### PR TITLE
Hotfix: Problème de pagination des signalements ajax

### DIFF
--- a/src/Controller/Back/BackController.php
+++ b/src/Controller/Back/BackController.php
@@ -23,6 +23,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 #[Route('/bo')]
 class BackController extends AbstractController
@@ -30,8 +31,21 @@ class BackController extends AbstractController
     private $req;
     private $iterator;
 
+    public function __construct(private CsrfTokenManagerInterface $csrfTokenManager)
+    {
+    }
+
     #[Route('/', name: 'back_index')]
-    public function index(EntityManagerInterface $em, CritereRepository $critereRepository, TerritoryRepository $territoryRepository, UserRepository $userRepository, SignalementRepository $signalementRepository, Request $request, AffectationRepository $affectationRepository, PartnerRepository $partnerRepository, TagRepository $tagsRepository): Response
+    public function index(
+        EntityManagerInterface $em,
+        CritereRepository $critereRepository,
+        TerritoryRepository $territoryRepository,
+        UserRepository $userRepository,
+        SignalementRepository $signalementRepository,
+        Request $request,
+        AffectationRepository $affectationRepository,
+        PartnerRepository $partnerRepository,
+        TagRepository $tagsRepository): Response
     {
         $title = 'Administration - Tableau de bord';
         $searchService = new SearchFilterService();
@@ -90,6 +104,7 @@ class BackController extends AbstractController
             'page' => (int) $filters['page'],
             'pages' => (int) ceil(\count($this->req) / 30),
             'counts' => $signalementsCount ?? [],
+            'csrfTokens' => $this->generateCsrfToken(),
         ];
 
         if ($request->get('pagination')) {
@@ -197,5 +212,22 @@ class BackController extends AbstractController
         }
 
         return new Response('<form method="POST" style="width: 100%;height: calc(100vh - 50px)"><textarea name="json" id="" style="width: 100%;height: calc(100% - 50px)"></textarea><hr><button style="width: 100%;height: 50px;">OK</button></form>');
+    }
+
+    /**
+     * Generate csrf token in side server for ajav request
+     * Fix Twig\Error\RuntimeError in order to do not generate csrf token (session) after the headers have been sent.
+     */
+    private function generateCsrfToken(): array
+    {
+        $csrfTokens = [];
+        /** @var Signalement $signalement */
+        foreach ($this->req as $signalement) {
+            $csrfTokens[$signalement->getUuid()] = $this->csrfTokenManager->getToken(
+                'signalement_delete_'.$signalement->getId()
+            )->getValue();
+        }
+
+        return $csrfTokens;
     }
 }

--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -64,7 +64,7 @@
                class="fr-btn fr-btn--secondary fr-btn--sm fr-fi-edit-fill"></a>
             {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                 <button data-delete="{{ path('back_signalement_delete',{uuid:signalement.uuid}) }}"
-                        data-token="{{ csrf_token('signalement_delete_'~signalement.id) }}"
+                        data-token="{{ signalements.csrfTokens[signalement.uuid] }}"
                         class="fr-btn fr-btn--sm fr-btn--danger fr-fi-delete-fill signalement-row-delete"></button>
             {% endif %}
         </td>


### PR DESCRIPTION
Impossible de paginer sur les signalements
Le hotfix appliqué, génération des csrf token coté serveur

https://sentry.io/share/issue/a49685a8b3e04f659442e57185861b99/
```
Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Failed to start the session because headers have already been sent by "/app/var/cache/prod/twig/28/28f8844d559a09b35b4f8f958e5e9aad9b7d0a6f207e8a5423dce957cf41cd48.php" at line 44.")." at /build/b02e0bef-0fea-472c-8039-6565c02fe925/templates/back/table_result.html.twig line 67
```

![image](https://user-images.githubusercontent.com/5757116/190560899-43490047-2826-4ea0-8cb3-f51e07d9417a.png)
