### PR TITLE
rollback add filter to select if partner is commune or not commune

### DIFF
--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -25,7 +25,7 @@ class PartnerRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('p')
             ->where('p.isArchive != 1');
         if ($insee) {
-            $qb->andWhere('p.insee LIKE :insee')
+            $qb->andWhere('p.isCommune = 0 OR p.isCommune = 1 AND p.insee LIKE :insee')
                 ->setParameter('insee', '%'.$insee.'%');
         }
         if ($territory) {

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -24,6 +24,10 @@ class PartnerRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('p')
             ->where('p.isArchive != 1');
+        /*
+         * @todo: necessary to clean data and add some constraint in partner creation to know
+         * if partner should have `is_commune` 0 or 1 depends if code insee exists
+         */
         if ($insee) {
             $qb->andWhere('p.isCommune = 0 OR p.isCommune = 1 AND p.insee LIKE :insee')
                 ->setParameter('insee', '%'.$insee.'%');

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -53,11 +53,14 @@ class PartnerRepositoryTest extends KernelTestCase
         /** @var PartnerRepository $partnerRepository */
         $partnerRepository = $this->entityManager->getRepository(Partner::class);
         $partners = $partnerRepository->findAllOrByInseeIfCommune(13215, $territory);
-
         /** @var Partner $partner */
+        $inseeList = [];
         foreach ($partners as $partner) {
-            $this->assertContains('13215', $partner->getInsee());
+            foreach ($partner->getInsee() as $insee) {
+                $inseeList[] = $insee;
+            }
         }
+        $this->assertContains('13215', $inseeList);
     }
 
     public function testFindPartnersByStringInseeWithTerritory(): void


### PR DESCRIPTION
https://github.com/MTES-MCT/histologe/issues/566

Comme il n' y a pas de contrôle sur la création de partenaire qui vérifie si un partenaire est une commune c'est à dire présence de code insee donc il faut rajouter ce filtre pour avoir tous les partenaires génériques. 

A terme il faudra nettoyer les données et mettre `is_commune = 0` uniquement au partenaire générique et mettre les contrôles nécessaires niveau UI