### PR TITLE
Cartographie: affichage des clusters de points des territoires

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -57,7 +57,7 @@ const popupTemplate = (options) => {
 
     return TEMPLATE;
 }
-const MAP_MARKERS_PAGE_SIZE = 9000; // @todo: is high cause the query findAllWithGeoData should be reviewed
+const MAP_MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result the query findAllWithGeoData should be reviewed
 
 async function getMarkers(offset) {
     await fetch('?load_markers=true&offset=' + offset, {

--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -57,7 +57,7 @@ const popupTemplate = (options) => {
 
     return TEMPLATE;
 }
-const MAP_MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result the query findAllWithGeoData should be reviewed
+const MAP_MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result, the query findAllWithGeoData should be reviewed
 
 async function getMarkers(offset) {
     await fetch('?load_markers=true&offset=' + offset, {

--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -57,7 +57,7 @@ const popupTemplate = (options) => {
 
     return TEMPLATE;
 }
-const MAP_MARKERS_PAGE_SIZE = 300;
+const MAP_MARKERS_PAGE_SIZE = 9000; // @todo: is high cause the query findAllWithGeoData should be reviewed
 
 async function getMarkers(offset) {
     await fetch('?load_markers=true&offset=' + offset, {
@@ -94,9 +94,9 @@ async function getMarkers(offset) {
             })
             map.addLayer(markers);
             // console.log(offset,res.signalements.length)
-            if (res.signalements.length === MAP_MARKERS_PAGE_SIZE)
+            if (res.signalements.length !== 0) { // As long as we have signalement getMarkers is calling
                 getMarkers(offset + MAP_MARKERS_PAGE_SIZE)
-            else {
+            } else {
                 markers.getLayers().forEach((layer, index) => {
                     let type;
                     switch (layer.options.status) {
@@ -126,10 +126,12 @@ async function getMarkers(offset) {
                 })
             }
             let bound = markers.getBounds();
-            map.fitBounds([
-                [bound._northEast.lat, bound._northEast.lng],
-                [bound._southWest.lat, bound._southWest.lng]
-            ]);
+            if (Object.keys(bound).length !== 0) {
+                map.fitBounds([
+                    [bound._northEast.lat, bound._northEast.lng],
+                    [bound._southWest.lat, bound._southWest.lng]
+                ]);
+            }
             document?.querySelector('#container.signalement-invalid')?.classList?.remove('signalement-invalid')
         } else {
             alert('Erreur lors du chargement des signalements...')

--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -62,3 +62,21 @@ partners:
     is_commune: 1
     insee: "[\"2A247\"]"
     territory: "Corse-du-Sud"
+  -
+    nom: "Random partner 63"
+    is_archive: 0
+    is_commune: 0
+    insee: "[\"\"]"
+    territory: "Puy-de-Dôme"
+  -
+    nom: "Random partner 06"
+    is_archive: 0
+    is_commune: 0
+    insee: "[\"\"]"
+    territory: "Alpes-Maritimes"
+  -
+    nom: "Random partner 59"
+    is_archive: 0
+    is_commune: 0
+    insee: "[\"\"]"
+    territory: "Nord"

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -40,6 +40,30 @@ users:
     is_mailing_active: 0
     territory: "Ain"
   -
+    email: admin-territoire-63@histologe.fr
+    roles: "[\"ROLE_ADMIN_TERRITORY\"]"
+    partner: "Random partner 63"
+    statut: 1
+    is_generique: 0
+    is_mailing_active: 1
+    territory: "Puy-de-Dôme"
+  -
+    email: admin-territoire-06@histologe.fr
+    roles: "[\"ROLE_ADMIN_TERRITORY\"]"
+    partner: "Random partner 06"
+    statut: 1
+    is_generique: 0
+    is_mailing_active: 1
+    territory: "Alpes-Maritimes"
+  -
+    email: admin-territoire-59@histologe.fr
+    roles: "[\"ROLE_ADMIN_TERRITORY\"]"
+    partner: "Random partner 59"
+    statut: 1
+    is_generique: 0
+    is_mailing_active: 1
+    territory: "Nord"
+  -
     email: partenaire-13-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Marseille"

--- a/src/DataFixtures/Loader/LoadPartnerData.php
+++ b/src/DataFixtures/Loader/LoadPartnerData.php
@@ -28,7 +28,7 @@ class LoadPartnerData extends Fixture implements OrderedFixtureInterface
     {
         $partner = (new Partner())
             ->setNom($row['nom'])
-            ->setEmail($row['email'])
+            ->setEmail($row['email'] ?? null)
             ->setIsArchive($row['is_archive'])
             ->setIsCommune($row['is_commune'])
             ->setInsee(json_decode($row['insee'], true))

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class SignalementRepository extends ServiceEntityRepository
 {
     public const ARRAY_LIST_PAGE_SIZE = 30;
-    public const MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result the query findAllWithGeoData should be reviewed
+    public const MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result, the query findAllWithGeoData should be reviewed
 
     private SearchFilterService $searchFilterService;
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class SignalementRepository extends ServiceEntityRepository
 {
     public const ARRAY_LIST_PAGE_SIZE = 30;
-    public const MARKERS_PAGE_SIZE = 300;
+    public const MARKERS_PAGE_SIZE = 9000; // @todo: is high cause the query findAllWithGeoData should be reviewed
 
     private SearchFilterService $searchFilterService;
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class SignalementRepository extends ServiceEntityRepository
 {
     public const ARRAY_LIST_PAGE_SIZE = 30;
-    public const MARKERS_PAGE_SIZE = 9000; // @todo: is high cause the query findAllWithGeoData should be reviewed
+    public const MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result the query findAllWithGeoData should be reviewed
 
     private SearchFilterService $searchFilterService;
 


### PR DESCRIPTION
## Problème connu 

Sur les objets partielles au niveau de la récupération des résultats, différence entre le nombre d'objets récupérés et le nombre de résultats.
> The partial object problem in general does not apply to methods or queries where you do not retrieve the query result as objects. Examples are: Query#getArrayResult(), Query#getScalarResult(), Query#getSingleScalarResult(), etc.

Source : https://www.doctrine-project.org/projects/doctrine-orm/en/2.13/reference/partial-objects.html

## Version
La fonctionnalité a été dépréciée depuis la 2.9 `(doctrine/orm)`, la DQL devra donc être réécrite.

Sur le projet nous sommes en 2.12
```
$ composer show | grep doctrine/orm
doctrine/orm                         2.12.2    Object-Relational-Mapper for PHP
```
## Solution temporaire 
Etant donné qu'on ne récupère jamais 300 objets max `MAP_MARKERS_PAGE_SIZE`, augmenter la taille de la pagination et modifier la condition d’arrêt de l'appel récursif.

L'appel récursif se fera tant qu'on aura des résultats
```res.signalements.length !== 0```

## Test
https://histologe-staging-pr568.osc-fr1.scalingo.io/
