### PR TITLE
UserAddedSubscriber impacte l'import de la grille d'affectation

### DIFF
--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -6,11 +6,14 @@ use App\Entity\Partner;
 use App\Entity\Territory;
 use App\Entity\User;
 use App\Service\Token\TokenGeneratorInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class UserFactory
 {
-    public function __construct(private TokenGeneratorInterface $tokenGenerator)
-    {
+    public function __construct(
+        private TokenGeneratorInterface $tokenGenerator,
+        private ParameterBagInterface $parameterBag,
+    ) {
     }
 
     public function createInstanceFrom(
@@ -32,7 +35,11 @@ class UserFactory
             ->setIsGenerique(false)
             ->setStatut(User::STATUS_INACTIVE)
             ->setIsMailingActive($isMailActive)
-            ->setPassword($this->tokenGenerator->generateToken());
+            ->setPassword($this->tokenGenerator->generateToken())
+            ->setToken($this->tokenGenerator->generateToken())
+            ->setTokenExpiredAt(
+                (new \DateTimeImmutable())->modify($this->parameterBag->get('token_lifetime'))
+            );
     }
 
     public function createInstanceFromArray(Partner $partner, array $data): User

--- a/src/Service/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/GridAffectation/GridAffectationLoader.php
@@ -80,7 +80,7 @@ class GridAffectationLoader
         $errors = $this->validator->validate($user);
         if (\count($errors) > 0) {
             foreach ($errors as $error) {
-                throw new \Exception($error->getMessage());
+                throw new \Exception(sprintf('%s (%s)', $error->getMessage(), $user->getEmail()));
             }
         }
     }


### PR DESCRIPTION
Envoyer le nouveau lien d'activation de compte qui arrivent directement sur la saisie du mot de passe et non sur le formulaire d'oubli du mot de passe