### PR TITLE
[BO] Vérifier qu'il existe au moins un utilisateur à notifier, loguez le cas échéant

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,11 +89,3 @@ jobs:
         env:
           DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db
 
-      - name: Run tests
-        run: |
-          composer require --dev dama/doctrine-test-bundle
-          ./vendor/bin/phpunit --stop-on-failure --testdox -d memory_limit=-1
-        env:
-          DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db
-          HISTOLOGE_URL: http://localhost:8080
-          SERVER_NAME: localhost:8080

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       mysql:
         image: mysql:5.7
         env:
-          MYSQL_ROOT_PASSWORD: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: histologe
           MYSQL_DATABASE: histologe_db
         ports:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,5 +95,5 @@ jobs:
           ./vendor/bin/phpunit --stop-on-failure --testdox -d memory_limit=-1
         env:
           DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db
-          HISTOLOGE_URL: http://localhost
+          HISTOLOGE_URL: http://localhost:8080
           SERVER_NAME: localhost:8080

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,3 +95,5 @@ jobs:
           ./vendor/bin/phpunit --stop-on-failure --testdox -d memory_limit=-1
         env:
           DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db
+          HISTOLOGE_URL: http://localhost
+          SERVER_NAME: localhost:8080

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
         image: mysql:5.7
         env:
           MYSQL_ROOT_PASSWORD: root
+          MYSQL_ROOT_PASSWORD: histologe
+          MYSQL_DATABASE: histologe_db
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -77,3 +79,19 @@ jobs:
       # https://github.com/FriendsOfPHP/PHP-CS-Fixer
       - name: Check PHP coding standard (PHP-CS-Fixer)
         run: composer cs-check
+
+      - name: Load Doctrine fixtures
+        run: |
+          composer require --dev symfony/orm-pack
+          php bin/console --env=test doctrine:database:create --no-interaction
+          php bin/console --env=test doctrine:migrations:migrate --no-interaction
+          php bin/console --env=test doctrine:fixtures:load --no-interaction
+        env:
+          DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db
+
+      - name: Run tests
+        run: |
+          composer require --dev dama/doctrine-test-bundle
+          ./vendor/bin/phpunit --stop-on-failure --testdox -d memory_limit=-1
+        env:
+          DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db

--- a/src/Command/ClearNotificationCommand.php
+++ b/src/Command/ClearNotificationCommand.php
@@ -35,14 +35,17 @@ class ClearNotificationCommand extends Command
         }
         $this->entityManager->flush();
 
-        $io->success(\count($notifications).' notification(s) deleted !');
+        $nbNotifications = \count($notifications);
+        $io->success($nbNotifications.' notification(s) deleted !');
 
         $this->notificationService->send(
             NotificationService::TYPE_CRON,
             $this->parameterBag->get('admin_email'),
             [
                 'url' => $this->parameterBag->get('host_url'),
-                'cron_type' => 'SUPPRESSION DES NOTIFICATIONS',
+                'cron_label' => 'Suppression des notifications',
+                'count' => $nbNotifications,
+                'message' => $nbNotifications > 2 ? 'notifications ont été supprimées' : 'notification a été supprimée',
             ],
             null
         );

--- a/src/Command/ClearNotificationCommand.php
+++ b/src/Command/ClearNotificationCommand.php
@@ -45,7 +45,7 @@ class ClearNotificationCommand extends Command
                 'url' => $this->parameterBag->get('host_url'),
                 'cron_label' => 'Suppression des notifications',
                 'count' => $nbNotifications,
-                'message' => $nbNotifications > 2 ? 'notifications ont été supprimées' : 'notification a été supprimée',
+                'message' => $nbNotifications > 1 ? 'notifications ont été supprimées' : 'notification a été supprimée',
             ],
             null
         );

--- a/src/Command/ClearNotificationCommand.php
+++ b/src/Command/ClearNotificationCommand.php
@@ -3,12 +3,14 @@
 namespace App\Command;
 
 use App\Entity\Notification;
+use App\Service\NotificationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[AsCommand(
     name: 'app:clear-notification',
@@ -16,8 +18,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class ClearNotificationCommand extends Command
 {
-    public function __construct(private EntityManagerInterface $entityManager)
-    {
+    public function __construct(private EntityManagerInterface $entityManager,
+                                private NotificationService $notificationService,
+                                private ParameterBagInterface $parameterBag
+    ) {
         parent::__construct();
     }
 
@@ -32,6 +36,16 @@ class ClearNotificationCommand extends Command
         $this->entityManager->flush();
 
         $io->success(\count($notifications).' notification(s) deleted !');
+
+        $this->notificationService->send(
+            NotificationService::TYPE_CRON,
+            $this->parameterBag->get('admin_email'),
+            [
+                'url' => $this->parameterBag->get('host_url'),
+                'cron_type' => 'SUPPRESSION DES NOTIFICATIONS',
+            ],
+            null
+        );
 
         return Command::SUCCESS;
     }

--- a/src/Command/FixUserPasswordInactiveCommand.php
+++ b/src/Command/FixUserPasswordInactiveCommand.php
@@ -28,7 +28,7 @@ class FixUserPasswordInactiveCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $users = $this->userManager->findBy(['statut' => User::STATUS_INACTIVE, 'password' => null]);
+        $users = $this->userManager->findBy(['password' => null]);
 
         /** @var User $user */
         foreach ($users as $user) {

--- a/src/Command/RemindInactiveUserCommand.php
+++ b/src/Command/RemindInactiveUserCommand.php
@@ -67,14 +67,17 @@ class RemindInactiveUserCommand extends Command
             );
         }
 
-        $io->success(sprintf('%s users has been notified', \count($userList)));
+        $nbUsers = \count($userList);
+        $io->success(sprintf('%s users has been notified', $nbUsers));
 
         $this->notificationService->send(
             NotificationService::TYPE_CRON,
             $this->parameterBag->get('admin_email'),
             [
                 'url' => $this->parameterBag->get('host_url'),
-                'cron_type' => 'DEMANDE ACTIVATION DE COMPTE',
+                'cron_label' => 'demande d\'activation de compte',
+                'count' => $nbUsers,
+                'message' => $nbUsers > 2 ? 'utilisateurs ont été notifiées' : 'utilisateur a été notifiée',
             ],
             null
         );

--- a/src/Command/RemindInactiveUserCommand.php
+++ b/src/Command/RemindInactiveUserCommand.php
@@ -77,7 +77,7 @@ class RemindInactiveUserCommand extends Command
                 'url' => $this->parameterBag->get('host_url'),
                 'cron_label' => 'demande d\'activation de compte',
                 'count' => $nbUsers,
-                'message' => $nbUsers > 2 ? 'utilisateurs ont été notifiées' : 'utilisateur a été notifiée',
+                'message' => $nbUsers > 1 ? 'utilisateurs ont été notifiées' : 'utilisateur a été notifiée',
             ],
             null
         );

--- a/src/Command/RemindInactiveUserCommand.php
+++ b/src/Command/RemindInactiveUserCommand.php
@@ -69,6 +69,16 @@ class RemindInactiveUserCommand extends Command
 
         $io->success(sprintf('%s users has been notified', \count($userList)));
 
+        $this->notificationService->send(
+            NotificationService::TYPE_CRON,
+            $this->parameterBag->get('admin_email'),
+            [
+                'url' => $this->parameterBag->get('host_url'),
+                'cron_type' => 'DEMANDE ACTIVATION DE COMPTE',
+            ],
+            null
+        );
+
         return Command::SUCCESS;
     }
 

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -183,7 +183,7 @@ class PartnerType extends AbstractType
             }
 
             $canBeNotified = $usersActive->exists(function (int $i, User $user) {
-                return $user->getIsMailingActive() && User::STATUS_ACTIVE === $user->getStatut();
+                return $user->getIsMailingActive();
             });
 
             if (!$canBeNotified) {

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -174,13 +174,16 @@ class PartnerType extends AbstractType
     {
         if ($value instanceof Partner) {
             $partner = $value;
-            if (!empty($partner->getEmail()) || $partner->getUsers()->isEmpty()) {
+            $usersActive = $partner->getUsers()->filter(function (User $user) {
+                return User::STATUS_ACTIVE === $user->getStatut();
+            });
+
+            if (!empty($partner->getEmail()) || $usersActive->isEmpty()) {
                 return;
             }
 
-            $users = $partner->getUsers();
-            $canBeNotified = $users->exists(function (int $i, User $user) {
-                return $user->getIsMailingActive();
+            $canBeNotified = $usersActive->exists(function (int $i, User $user) {
+                return $user->getIsMailingActive() && User::STATUS_ACTIVE === $user->getStatut();
             });
 
             if (!$canBeNotified) {

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -31,6 +31,7 @@ class NotificationService
     public const TYPE_CONTACT_FORM = 8;
     public const TYPE_ERROR_SIGNALEMENT = 9;
     public const TYPE_MIGRATION_PASSWORD = 13;
+    public const TYPE_CRON = 100;
 
     private MailerInterface $mailer;
 
@@ -161,6 +162,10 @@ class NotificationService
             self::TYPE_ERROR_SIGNALEMENT => [
                 'template' => 'erreur_signalement_email',
                 'subject' => 'Une erreur est survenue lors de la création d\'un signalement !',
+            ],
+            self::TYPE_CRON => [
+                'template' => 'cron_email',
+                'subject' => 'La tache planifiée s\'est bien éxécutée.',
             ]
         };
     }

--- a/templates/emails/cron_email.html.twig
+++ b/templates/emails/cron_email.html.twig
@@ -1,0 +1,6 @@
+{% extends 'emails/base_email.html.twig' %}
+
+{% block body %}
+    <p>Plateforme: {{ url }}</p>
+    <p>La tache planifiée <strong>{{ cron_type }}</strong> s'est éxécuté avec succès </p>
+{% endblock %}

--- a/templates/emails/cron_email.html.twig
+++ b/templates/emails/cron_email.html.twig
@@ -2,5 +2,6 @@
 
 {% block body %}
     <p>Plateforme: {{ url }}</p>
-    <p>La tache planifiée <strong>{{ cron_type }}</strong> s'est éxécuté avec succès </p>
+    <p>La tache planifiée <strong>{{ cron_label }}</strong> s'est éxécutée avec succès.</p>
+    <p>{{ count }} {{ message }}.</p>
 {% endblock %}

--- a/templates/emails/erreur_signalement_email.html.twig
+++ b/templates/emails/erreur_signalement_email.html.twig
@@ -3,10 +3,20 @@
 {% block body %}
 
     <p>Plateforme: {{ url }}</p>
-    <p>Code erreur: {{ code }}</p>
-    <p>Message erreur: {{ error }}</p>
-    <p>Documents: {{ attachment.documents }}</p>
-    <p>Photos: {{ attachment.photos }}</p>
-    <p>{{ req|json_encode() }}</p>
-    <p>{{ signalement|json_encode()|replace({',':',<br>'})|raw }}</p>
+    {% if code is defined %}
+        <p>Code erreur: {{ code }}</p>
+    {% endif %}
+    {% if error is defined %}
+        <p>Message erreur: {{ error }}</p>
+    {% endif %}
+    {% if attachment is defined %}
+        <p>Documents: {{ attachment.documents }}</p>
+        <p>Photos: {{ attachment.photos }}</p>
+    {% endif %}
+    {% if req is defined %}
+        <p>{{ req|json_encode() }}</p>
+    {% endif %}
+    {% if signalement is defined %}
+        <p>{{ signalement|json_encode()|replace({',':',<br>'})|raw }}</p>
+    {% endif %}
 {% endblock %}

--- a/tests/Functional/Command/ClearNotificationCommandTest.php
+++ b/tests/Functional/Command/ClearNotificationCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Tests\Functional\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ClearNotificationCommandTest extends KernelTestCase
+{
+    public function testDisplayMessageSuccessfully(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:clear-notification');
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('notification(s) deleted', $output);
+        $this->assertEmailCount(1);
+    }
+}

--- a/tests/Functional/Command/RemindInactiveUserCommandTest.php
+++ b/tests/Functional/Command/RemindInactiveUserCommandTest.php
@@ -23,6 +23,6 @@ class RemindInactiveUserCommandTest extends KernelTestCase
 
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('6 users has been notified', $output);
-        $this->assertEmailCount(6);
+        $this->assertEmailCount(7); // with cron notification email (6+1)
     }
 }


### PR DESCRIPTION
## Lié à une alerte sentry
https://sentry.incubateur.net/share/issue/797fa3a26fb74d3581c8d9f1dcffdbc7/

Suite à l'évolution de ne plus notifier l'utilisateur courant et de rendre le mail partenaire obligatoire
2 signalements n'ont pas trouvé d'utilisateur à notifier

## Solution appliquée
Avant d'envoyer le mail, vérifier la présence d'utilisateur à notifier, logger en erreur le cas échéant afin de rentrer en contact avec le partenaire.


## Autre
* Envoi mail notification pour les commandes exécuté via un cron
* Mise à jour du validateur partenaire (ignorer es utilisateurs inactifs)
* Mettre un mot de passe par défaut à tous les utilisateurs inactifs