### PR TITLE
Réinitialiser la liste des destinataires après chaque envoi de mail

### DIFF
--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -2,7 +2,7 @@ affectations:
   -
     signalement: 2022-1
     partner: "partenaire-13-01@histologe.fr"
-    statut: 1
+    statut: 0
     answered_by: "admin-03@histologe.fr"
     affected_by: "admin-03@histologe.fr"
     territory: "Bouches-du-Rhône"
@@ -16,12 +16,12 @@ affectations:
     territory: "Ain"
   -
     signalement: 2022-3
-    partner: "partenaire-01-01@histologe.fr"
+    partner: "partenaire-13-01@histologe.fr"
     statut: 3
-    answered_by: "admin-territoire-01-01@histologe.fr"
-    affected_by: "admin-territoire-01-01@histologe.fr"
+    answered_by: "admin-territoire-13-01@histologe.fr"
+    affected_by: "admin-territoire-13-01@histologe.fr"
     motif_cloture: "LOCATAIRE PARTI"
-    territory: "Ain"
+    territory: "Bouches-du-Rhône"
   -
     signalement: 2022-12
     partner: "partenaire-01-03@histologe.fr"
@@ -86,11 +86,3 @@ affectations:
     affected_by: "admin-territoire-13-01@histologe.fr"
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
-  -
-    signalement: 2022-14
-    partner: "partenaire-01-03@histologe.fr"
-    statut: 0
-    answered_by: ""
-    affected_by: "admin-territoire-01-01@histologe.fr"
-    motif_cloture: ""
-    territory: "Ain"

--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -7,88 +7,88 @@ partners:
     insee: "[\"\"]"
     territory: null
   -
-    nom: "Partenaire 1"
-    email: "partenaire-1@histologe.fr"
-    is_archive: 0
-    is_commune: 0
-    insee: "[\"\"]"
-    territory: "Ain"
-  -
-    nom: "Admin Histologe 13"
+    nom: "Partenaire 13-01"
     email: "partenaire-13-01@histologe.fr"
     is_archive: 0
     is_commune: 0
     insee: "[\"\"]"
     territory: "Bouches-du-Rhône"
   -
-    nom: "Marseille"
+    nom: "Partenaire 13-02"
     email: "partenaire-13-02@histologe.fr"
     is_archive: 0
     is_commune: 1
     insee: "[\"13215\", \"13205\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\", \"13001\"]"
     territory: "Bouches-du-Rhône"
   -
-    nom: "Istres"
+    nom: "Partenaire 13-03"
     email: "partenaire-13-03@histologe.fr"
     is_archive: 0
     is_commune: 1
     insee: "[\"13047\"]"
     territory: "Bouches-du-Rhône"
   -
-    nom: "Partenaire 13"
+    nom: "Partenaire 13-04"
     email: "partenaire-13-04@histologe.fr"
     is_archive: 0
     is_commune: 0
     insee: "[\"\"]"
     territory: "Bouches-du-Rhône"
   -
-    nom: "Admins Histologe Ain"
+    nom: "Partenaire 01-01"
     email: "partenaire-01-01@histologe.fr"
     is_archive: 0
     is_commune: 0
     insee: "[\"\"]"
     territory: "Ain"
   -
-    nom: "Gex"
+    nom: "Partenaire 01-02"
     email: "partenaire-01-02@histologe.fr"
     is_archive: 0
     is_commune: 1
     insee: "[\"01173\"]"
     territory: "Ain"
   -
-    nom: "Gex 2"
+    nom: "Partenaire 01-03"
     email: "partenaire-01-03@histologe.fr"
     is_archive: 0
     is_commune: 0
     insee: "[\"\"]"
     territory: "Ain"
   -
-    nom: "Vecchio Porto"
-    email: "partenaire-01-2A@histologe.fr"
+    nom: "Partenaire 01-04"
+    email: "partenaire-01-04@histologe.fr"
+    is_archive: 0
+    is_commune: 0
+    insee: "[\"\"]"
+    territory: "Ain"
+  -
+    nom: "Partenaire 2A-01"
+    email: "partenaire-2A-01@histologe.fr"
     is_archive: 0
     is_commune: 1
     insee: "[\"2A247\"]"
     territory: "Corse-du-Sud"
   -
-    nom: "Random partner 63"
+    nom: "Partenaire 63-01"
     is_archive: 0
     is_commune: 0
     insee: "[\"\"]"
     territory: "Puy-de-Dôme"
   -
-    nom: "Random partner 06"
+    nom: "Partenaire 06-01"
     is_archive: 0
     is_commune: 0
     insee: "[\"\"]"
     territory: "Alpes-Maritimes"
   -
-    nom: "Random partner 59"
+    nom: "Partenaire 59-01"
     is_archive: 0
     is_commune: 0
     insee: "[\"\"]"
     territory: "Nord"
   -
-    nom: "Partner La réunion"
+    nom: "Partenaire 974-01"
     email: "partenaire-01-974@histologe.fr"
     is_archive: 0
     is_commune: 0

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -11,7 +11,7 @@ signalements:
     phone_number: 0621127284
     cp_occupant: "13013"
     ville_occupant: "Marseille"
-    statut: 1
+    statut: 2
     reference: "2022-1"
     geoloc: "{\"lat\":\"5.415151\",\"lng\":\"43.358246\"}"
     score_creation: 100

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -8,19 +8,24 @@ suivis:
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
   is_public: 1
-  signalement: "2022-1"
--
-  created_by: admin-01@histologe.fr
-  description: "Signalement validé"
-  is_public: 1
   signalement: "2022-2"
 -
-  created_by: admin-01@histologe.fr
+  created_by: admin-territoire-13-01@histologe.fr
   description: "Signalement validé"
   is_public: 1
   signalement: "2022-3"
 -
   created_by: admin-01@histologe.fr
-  description: "Signalement validé par l'équipe Histologe"
+  description: "Signalement validé"
+  is_public: 1
+  signalement: "2022-4"
+-
+  created_by: admin-01@histologe.fr
+  description: "Signalement validé"
+  is_public: 0
+  signalement: "2022-5"
+-
+  created_by: admin-territoire-13-01@histologe.fr
+  description: "Le signalement à été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
   is_public: 0
   signalement: "2022-3"

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -26,7 +26,7 @@ users:
   -
     email: admin-territoire-13-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
-    partner: "Admin Histologe 13"
+    partner: "Partenaire 13-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -34,7 +34,7 @@ users:
   -
     email: admin-territoire-01-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
-    partner: "Admins Histologe Ain"
+    partner: "Partenaire 01-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 0
@@ -42,7 +42,7 @@ users:
   -
     email: admin-territoire-63-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
-    partner: "Random partner 63"
+    partner: "Partenaire 63-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -50,7 +50,7 @@ users:
   -
     email: admin-territoire-06-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
-    partner: "Random partner 06"
+    partner: "Partenaire 06-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -58,7 +58,7 @@ users:
   -
     email: admin-territoire-59-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
-    partner: "Random partner 59"
+    partner: "Partenaire 59-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -66,7 +66,7 @@ users:
   -
     email: user-13-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Marseille"
+    partner: "Partenaire 13-02"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -74,7 +74,7 @@ users:
   -  
     email: user-13-02@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Istres"
+    partner: "Partenaire 13-03"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -82,7 +82,7 @@ users:
   -
     email: user-13-03@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Partenaire 13"
+    partner: "Partenaire 13-04"
     statut: 0
     is_generique: 0
     is_mailing_active: 1
@@ -90,7 +90,7 @@ users:
   -
     email: user-13-04@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Istres"
+    partner: "Partenaire 13-03"
     statut: 0
     is_generique: 0
     is_mailing_active: 0
@@ -98,7 +98,7 @@ users:
   -
     email: user-2A-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Vecchio Porto"
+    partner: "Partenaire 2A-01"
     statut: 0
     is_generique: 0
     is_mailing_active: 0
@@ -106,7 +106,7 @@ users:
   -
     email: user-974-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Partner La réunion"
+    partner: "Partenaire 974-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -114,7 +114,7 @@ users:
   -
     email: user-01-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Partenaire 1"
+    partner: "Partenaire 01-04"
     statut: 1
     is_generique: 0
     is_mailing_active: 0
@@ -122,7 +122,7 @@ users:
   -
     email: user-01-02@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Gex 2"
+    partner: "Partenaire 01-03"
     statut: 0
     is_generique: 0
     is_mailing_active: 1
@@ -131,7 +131,7 @@ users:
   -
     email: user-01-03@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Admins Histologe Ain"
+    partner: "Partenaire 01-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 1
@@ -139,7 +139,7 @@ users:
   -
     email: user-01-04@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Gex 2"
+    partner: "Partenaire 01-03"
     statut: 0
     is_generique: 0
     is_mailing_active: 1
@@ -147,7 +147,7 @@ users:
   -
     email: user-01-05@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Gex 2"
+    partner: "Partenaire 01-03"
     statut: 0
     is_generique: 0
     is_mailing_active: 1
@@ -155,7 +155,7 @@ users:
   -
     email: user-01-06@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Gex"
+    partner: "Partenaire 01-02"
     statut: 1
     is_generique: 0
     is_mailing_active: 0

--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -162,6 +162,7 @@ class ActivityListener implements EventSubscriberInterface
                 );
             } else {
                 $this->notifier->send($mailType, array_unique($this->tos->toArray()), $options, $signalement->getTerritory());
+                $this->tos->clear();
             }
         }
     }

--- a/tests/Functional/Controller/BackAssignmentControllerTest.php
+++ b/tests/Functional/Controller/BackAssignmentControllerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class BackAssignmentControllerTest extends WebTestCase
+{
+    public function testRejectAffectationSignalement(): void
+    {
+        $client = static::createClient();
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy(['reference' => '2022-1']);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $routeSignalementView = $router->generate('back_signalement_view', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+
+        $crawler = $client->request('GET', $routeSignalementView);
+        $token = $crawler->filter('#signalement-affectation-response-form input[name=_token]')->attr('value');
+        $routeAffectationResponse = $router->generate('back_signalement_affectation_response', [
+            'signalement' => $signalement->getId(),
+            'affectation' => $signalement->getAffectations()->first()->getId(),
+            'user' => $user->getId(),
+        ]);
+
+        $client->request('POST', $routeAffectationResponse, [
+            'signalement-affectation-response' => [
+                'suivi' => 'Cela ne me concerne pas, voir avec un autre organisme',
+            ],
+            '_token' => $token,
+        ]);
+
+        /** @var Suivi $suivi */
+        $suivi = $entityManager->getRepository(Suivi::class)->findOneBy(
+            ['signalement' => $signalement],
+            ['createdAt' => 'DESC']
+        );
+
+        $this->assertEmailCount(1);
+        $this->assertTrue(str_contains($suivi->getDescription(), 'Cela ne me concerne pas, voir avec un autre organisme'));
+        $this->assertResponseRedirects('/bo/s/'.$signalement->getUuid());
+    }
+
+    public function testCheckingNoDuplicatedMailSentWhenPartnerAffectationIsMultiple(): void
+    {
+        $client = static::createClient();
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy(['reference' => '2022-1']);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $routeSignalementView = $router->generate('back_signalement_view', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+
+        $crawler = $client->request('GET', $routeSignalementView);
+        $token = $crawler->filter('#signalement-affectation-form input[name=_token]')->attr('value');
+
+        $routeAffectationResponse = $router->generate('back_signalement_toggle_affectation', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+
+        $client->request('POST', $routeAffectationResponse, [
+            'signalement-affectation' => [
+                'partners' => [3, 4, 5],
+            ],
+            '_token' => $token,
+        ]);
+
+        $this->assertEmailCount(3);
+        $tos = [];
+        foreach ($this->getMailerMessages() as $message) {
+            foreach ($message->getTo() as $to) {
+                $tos[] = $to->getAddress();
+            }
+        }
+        $this->assertEquals(\count($tos), \count(array_unique($tos)));
+    }
+}

--- a/tests/Functional/Manager/UserManagerTest.php
+++ b/tests/Functional/Manager/UserManagerTest.php
@@ -57,7 +57,7 @@ class UserManagerTest extends KernelTestCase
 
         /** @var PartnerRepository $partnerRepository */
         $partnerRepository = $this->entityManager->getRepository(Partner::class);
-        $partner = $partnerRepository->findOneBy(['nom' => 'Gex']);
+        $partner = $partnerRepository->findOneBy(['nom' => 'Partenaire 01-02']);
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => 'user-01-01@histologe.fr']);
@@ -67,7 +67,7 @@ class UserManagerTest extends KernelTestCase
         /** @var User $userNewPartner */
         $userNewPartner = $userRepository->findOneBy(['email' => 'user-01-01@histologe.fr']);
 
-        $this->assertEquals('Gex', $userNewPartner->getPartner()->getNom());
+        $this->assertEquals('Partenaire 01-02', $userNewPartner->getPartner()->getNom());
         $this->assertEmailCount(1);
         $email = $this->getMailerMessage();
         $this->assertEmailHtmlBodyContains($email, ' Cliquez ci-dessous pour vous connecter à votre compte');
@@ -87,7 +87,7 @@ class UserManagerTest extends KernelTestCase
 
         /** @var PartnerRepository $partnerRepository */
         $partnerRepository = $this->entityManager->getRepository(Partner::class);
-        $partner = $partnerRepository->findOneBy(['nom' => 'Istres']);
+        $partner = $partnerRepository->findOneBy(['nom' => 'Partenaire 13-03']);
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => 'user-13-03@histologe.fr']);
@@ -97,7 +97,7 @@ class UserManagerTest extends KernelTestCase
         /** @var User $userNewPartner */
         $userNewPartner = $userRepository->findOneBy(['email' => 'user-13-03@histologe.fr']);
 
-        $this->assertEquals('Istres', $userNewPartner->getPartner()->getNom());
+        $this->assertEquals('Partenaire 13-03', $userNewPartner->getPartner()->getNom());
         $this->assertEmailCount(1);
         $email = $this->getMailerMessage();
         $this->assertEmailHtmlBodyContains($email, 'Cliquez ci-dessous pour vous activer votre compte et définir votre mot de passe');

--- a/tests/Unit/Factory/UserFactoryTest.php
+++ b/tests/Unit/Factory/UserFactoryTest.php
@@ -85,7 +85,7 @@ class UserFactoryTest extends KernelTestCase
     public function testCreateUserFromArray(): void
     {
         /** @var Partner $partner */
-        $partner = $this->partnerManager->findOneBy(['nom' => 'Random partner 63']);
+        $partner = $this->partnerManager->findOneBy(['nom' => 'Partenaire 63-01']);
         $data = [
             'roles' => 'ROLE_USER_PARTNER',
             'email' => 'john.doe-1@example.com',


### PR DESCRIPTION
Lié  à #741 

## Remarque fixtures:
- MAJ des noms de partenaires, les rendre générique en rapport avec leur mails (facilite les tests)
- MAJ des affectations (+ cohérent)
