### PR TITLE
Préparation gestion des flux esabora lors de l'affectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,27 +80,6 @@ Un [Makefile](Makefile) est disponible, qui sert de point d’entrée aux diffé
 
 ```
 $ make help
-
-build                          Install local environement
-run                            Start containers
-down                           Shutdown containers
-sh                             Log to phpfpm container
-mysql                          Log to mysql container
-logs                           Show container logs
-composer                       Install composer dependencies
-clear-cache                    Clear cache prod: make-clear-cache env=[dev|prod|test]
-create-db                      Create database
-drop-db                        Drop database
-load-data                      Load database from dump
-load-migrations                Play migrations
-load-fixtures                  Load database from fixtures
-create-db-test                 Create test database
-test                           Run all tests
-test-coverage                  Generate phpunit coverage report in html
-e2e                            Run E2E tests
-stan                           Run PHPStan
-cs-check                       Check source code with PHP-CS-Fixer
-cs-fix                         Fix source code with PHP-CS-Fixer
 ```
 
 ### Lancement
@@ -112,8 +91,6 @@ La commande permet d'installer l'environnement de developpement avec un jeu de d
 ```
 make build
 ```
-
-### Accès
 
 2. Configurer les variables d'environnements du service object storage S3 d'OVH Cloud
 
@@ -164,7 +141,7 @@ php bin/console app:add-user ROLE_ADMIN_TERRITORY joe.doe.2@histologe.fr John Do
 php bin/console app:add-user ROLE_USER_PARTNER joe.doe.3@histologe.fr John Doe Marseille 13
 ```
 
-[Une activation de compte sera nécéssaire](http://localhost:8080/activation)
+Une activation de compte sera nécéssaire
 
 ### Compilation des fichiers Vue.js en cours de développement
 ```

--- a/src/Controller/Back/BackAssignmentController.php
+++ b/src/Controller/Back/BackAssignmentController.php
@@ -4,15 +4,15 @@ namespace App\Controller\Back;
 
 use App\Entity\Affectation;
 use App\Entity\Signalement;
-use App\Entity\Suivi;
 use App\Entity\User;
+use App\Event\AffectationAnsweredEvent;
+use App\Manager\AffectationManager;
 use App\Repository\PartnerRepository;
 use App\Service\EsaboraService;
 use App\Service\NotificationService;
-use DateTimeImmutable;
 use Doctrine\Persistence\ManagerRegistry;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -71,37 +71,39 @@ class BackAssignmentController extends AbstractController
     }
 
     #[Route('/{signalement}/{affectation}/{user}/response', name: 'back_signalement_affectation_response', methods: 'POST')]
-    #[ParamConverter('signalement', class: Signalement::class)]
-    #[ParamConverter('affectation', class: Affectation::class)]
-    #[ParamConverter('user', class: User::class)]
-    public function affectationResponseSignalement(Signalement $signalement, Affectation $affectation, User $user, Request $request, ManagerRegistry $doctrine): Response
-    {
+    public function affectationResponseSignalement(
+        Signalement $signalement,
+        Affectation $affectation,
+        User $user,
+        Request $request,
+        AffectationManager $affectationManager,
+        EventDispatcherInterface $eventDispatcher,
+    ): Response {
         $this->denyAccessUnlessGranted('ASSIGN_ANSWER', $affectation);
         if ($this->isCsrfTokenValid('signalement_affectation_response_'.$signalement->getId(), $request->get('_token'))
-            && $response = $request->get('signalement-affectation-response')) {
-            if (isset($response['accept'])) {
-                $statut = Affectation::STATUS_ACCEPTED;
-            } else {
-                $motifRefus = $response['suivi'];
-                $statut = Affectation::STATUS_REFUSED;
-                $motifRefus = preg_replace('/<p[^>]*>/', '', $motifRefus); // Remove the start <p> or <p attr="">
-                $motifRefus = str_replace('</p>', '<br>', $motifRefus); // Replace the end
-                $suivi = new Suivi();
-                $suivi->setDescription('Le signalement à été refusé avec le motif suivant:<br> '.$motifRefus);
-                $suivi->setCreatedBy($user);
-                $suivi->setSignalement($signalement);
-                $doctrine->getManager()->persist($suivi);
-            }
-            $affectation->setStatut($statut);
-            $affectation->setAnsweredAt(new DateTimeImmutable());
-            $affectation->setAnsweredBy($user);
-            $doctrine->getManager()->persist($affectation);
-            $doctrine->getManager()->flush();
+            && $response = $request->get('signalement-affectation-response')
+        ) {
+            $status = isset($response['accept']) ? Affectation::STATUS_ACCEPTED : Affectation::STATUS_REFUSED;
+            $affectation = $affectationManager->updateAffection($affectation, $status);
             $this->addFlash('success', 'Affectation mise à jour avec succès !');
+            $this->dispatchAffectationAnsweredEvent($eventDispatcher, $affectation, $response);
         } else {
             $this->addFlash('error', "Une erreur est survenu lors de l'affectation");
         }
 
         return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+    }
+
+    private function dispatchAffectationAnsweredEvent(
+        EventDispatcherInterface $eventDispatcher,
+        Affectation $affectation,
+        array $response
+    ): void {
+        if (isset($response['suivi'])) {
+            $eventDispatcher->dispatch(
+                new AffectationAnsweredEvent($affectation, $response),
+                AffectationAnsweredEvent::NAME
+            );
+        }
     }
 }

--- a/src/Controller/Back/BackAssignmentController.php
+++ b/src/Controller/Back/BackAssignmentController.php
@@ -47,9 +47,9 @@ class BackAssignmentController extends AbstractController
                         $esaboraService->post($affectation);
                     }
                 }
-                $affectationManager->removeAffectationsBy($signalement, $partnersIdToRemove);
+                $affectationManager->removeAffectationsFrom($signalement, $partnersIdToRemove);
             } else {
-                $affectationManager->removeAffectationsBy($signalement);
+                $affectationManager->removeAffectationsFrom($signalement);
             }
             $affectationManager->flush();
             $this->addFlash('success', 'Les affectations ont bien été effectuées.');

--- a/src/Event/AffectationAnsweredEvent.php
+++ b/src/Event/AffectationAnsweredEvent.php
@@ -9,7 +9,7 @@ class AffectationAnsweredEvent extends Event
 {
     public const NAME = 'affectation.answered';
 
-    public function __construct(private Affectation $affectation, private array $answer)
+    public function __construct(private Affectation $affectation, private array $params)
     {
     }
 
@@ -18,8 +18,8 @@ class AffectationAnsweredEvent extends Event
         return $this->affectation;
     }
 
-    public function getAnswer(): array
+    public function getParams(): array
     {
-        return $this->answer;
+        return $this->params;
     }
 }

--- a/src/Event/AffectationAnsweredEvent.php
+++ b/src/Event/AffectationAnsweredEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Event;
+
+use App\Entity\Affectation;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class AffectationAnsweredEvent extends Event
+{
+    public const NAME = 'affectation.answered';
+
+    public function __construct(private Affectation $affectation, private array $answer)
+    {
+    }
+
+    public function getAffectation(): ?Affectation
+    {
+        return $this->affectation;
+    }
+
+    public function getAnswer(): array
+    {
+        return $this->answer;
+    }
+}

--- a/src/EventSubscriber/AffectationAnsweredSubscriber.php
+++ b/src/EventSubscriber/AffectationAnsweredSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Event\AffectationAnsweredEvent;
+use App\Manager\SuiviManager;
+use App\Service\Sanitizer;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class AffectationAnsweredSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private SuiviManager $suiviManager)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            AffectationAnsweredEvent::NAME => 'onAffectationAnswered',
+        ];
+    }
+
+    public function onAffectationAnswered(AffectationAnsweredEvent $event)
+    {
+        $affectation = $event->getAffectation();
+        $answer = $event->getAnswer();
+        $signalement = $affectation->getSignalement();
+        $suivi = $this->suiviManager->createSuivi($this->buildDescriptionFrom($answer));
+        $suivi
+            ->setCreatedBy($affectation->getAnsweredBy())
+            ->setSignalement($signalement);
+
+        $this->suiviManager->save($suivi);
+    }
+
+    private function buildDescriptionFrom(array $answer): string
+    {
+        $description = '';
+        if (isset($answer['accept'])) {
+            $description = 'Le signalement a été accepté';
+        } else {
+            $motifRejected = Sanitizer::sanitize($answer['suivi']);
+            $description = 'Le signalement à été refusé avec le motif suivant:<br> '.$motifRejected;
+        }
+
+        return $description;
+    }
+}

--- a/src/EventSubscriber/AffectationAnsweredSubscriber.php
+++ b/src/EventSubscriber/AffectationAnsweredSubscriber.php
@@ -4,7 +4,6 @@ namespace App\EventSubscriber;
 
 use App\Event\AffectationAnsweredEvent;
 use App\Manager\SuiviManager;
-use App\Service\Sanitizer;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class AffectationAnsweredSubscriber implements EventSubscriberInterface
@@ -20,29 +19,16 @@ class AffectationAnsweredSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function onAffectationAnswered(AffectationAnsweredEvent $event)
+    public function onAffectationAnswered(AffectationAnsweredEvent $event): void
     {
         $affectation = $event->getAffectation();
-        $answer = $event->getAnswer();
+        $params = $event->getParams();
         $signalement = $affectation->getSignalement();
-        $suivi = $this->suiviManager->createSuivi($this->buildDescriptionFrom($answer));
+        $suivi = $this->suiviManager->createSuivi($params);
         $suivi
             ->setCreatedBy($affectation->getAnsweredBy())
             ->setSignalement($signalement);
 
         $this->suiviManager->save($suivi);
-    }
-
-    private function buildDescriptionFrom(array $answer): string
-    {
-        $description = '';
-        if (isset($answer['accept'])) {
-            $description = 'Le signalement a été accepté';
-        } else {
-            $motifRejected = Sanitizer::sanitize($answer['suivi']);
-            $description = 'Le signalement à été refusé avec le motif suivant:<br> '.$motifRejected;
-        }
-
-        return $description;
     }
 }

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -7,8 +7,8 @@ use App\Entity\Enum\MotifCloture;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Event\SignalementClosedEvent;
-use App\Factory\SuiviFactory;
 use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
 use App\Repository\UserRepository;
 use App\Service\NotificationService;
 use App\Service\Token\TokenGeneratorInterface;
@@ -25,7 +25,7 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
                                 private UrlGeneratorInterface $urlGenerator,
                                 private ParameterBagInterface $parameterBag,
                                 private TokenGeneratorInterface $tokenGenerator,
-                                private SuiviFactory $suiviFactory,
+                                private SuiviManager $suiviManager,
                                 private Security $security,
     ) {
     }
@@ -44,7 +44,7 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
         $params = $event->getParams();
 
         if ($signalement instanceof Signalement) {
-            $suivi = $this->suiviFactory->createInstance(
+            $suivi = $this->suiviManager->createSuivi(
                 params: $params,
                 isPublic: true
             );
@@ -58,7 +58,7 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
         }
 
         if ($affectation instanceof Affectation) {
-            $suivi = $this->suiviFactory->createInstance(params: $params);
+            $suivi = $this->suiviManager->createSuivi($params);
             $signalement = $affectation->getSignalement();
             $signalement->addSuivi($suivi);
             $this->sendMailToPartner(

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -45,7 +45,7 @@ class SuiviFactory
         $motifSuivi = Sanitizer::sanitize($params['motif_suivi']);
 
         return sprintf(
-            'Le signalement à été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc.:</strong>%s',
+            'Le signalement à été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
             $params['subject'],
             $params['motif_cloture'],
             $motifSuivi

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -22,7 +22,7 @@ class SuiviFactory
         return $suivi;
     }
 
-    private function buildDescription($params): ?string
+    private function buildDescription($params): string
     {
         $description = '';
         if (empty($params)) {

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Manager;
+
+use App\Entity\Affectation;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Security\Core\Security;
+
+class AffectationManager extends Manager
+{
+    public function __construct(
+        private Security $security,
+        protected ManagerRegistry $managerRegistry,
+        string $entityName = '')
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->entityName = $entityName;
+    }
+
+    public function updateAffection(Affectation $affectation, string $status): Affectation
+    {
+        $affectation->setStatut($status);
+        $affectation->setAnsweredAt(new \DateTimeImmutable());
+        $affectation->setAnsweredBy($this->security->getUser());
+
+        $this->save($affectation);
+
+        return $affectation;
+    }
+}

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -39,7 +39,7 @@ class AffectationManager extends Manager
             ->setTerritory($partner->getTerritory());
     }
 
-    public function removeAffectationsBy(Signalement $signalement, array $partnersIdToRemove = [])
+    public function removeAffectationsBy(Signalement $signalement, array $partnersIdToRemove = []): void
     {
         if (empty($partnersIdToRemove)) {
             $signalement->getAffectations()->filter(function (Affectation $affectation) {

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -3,6 +3,8 @@
 namespace App\Manager;
 
 use App\Entity\Affectation;
+use App\Entity\Partner;
+use App\Entity\Signalement;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Security;
 
@@ -26,5 +28,33 @@ class AffectationManager extends Manager
         $this->save($affectation);
 
         return $affectation;
+    }
+
+    public function createAffectationFrom(Signalement $signalement, Partner $partner): Affectation
+    {
+        return (new Affectation())
+            ->setSignalement($signalement)
+            ->setPartner($partner)
+            ->setAffectedBy($this->security->getUser())
+            ->setTerritory($partner->getTerritory());
+    }
+
+    public function removeAffectationsBy(Signalement $signalement, array $partnersIdToRemove = [])
+    {
+        if (empty($partnersIdToRemove)) {
+            $signalement->getAffectations()->filter(function (Affectation $affectation) {
+                $this->remove($affectation);
+            });
+        } else {
+            foreach ($partnersIdToRemove as $partnerIdToRemove) {
+                $partner = $this->managerRegistry->getRepository(Partner::class)->find($partnerIdToRemove);
+                $signalement->getAffectations()->filter(
+                    function (Affectation $affectation) use ($partner) {
+                        if ($affectation->getPartner()->getId() === $partner->getId()) {
+                            $this->remove($affectation);
+                        }
+                    });
+            }
+        }
     }
 }

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -39,7 +39,7 @@ class AffectationManager extends Manager
             ->setTerritory($partner->getTerritory());
     }
 
-    public function removeAffectationsBy(Signalement $signalement, array $partnersIdToRemove = []): void
+    public function removeAffectationsFrom(Signalement $signalement, array $partnersIdToRemove = []): void
     {
         if (empty($partnersIdToRemove)) {
             $signalement->getAffectations()->filter(function (Affectation $affectation) {

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -11,8 +11,8 @@ class AffectationManager extends Manager
     public function __construct(
         private Security $security,
         protected ManagerRegistry $managerRegistry,
-        string $entityName = '')
-    {
+        string $entityName = ''
+    ) {
         $this->managerRegistry = $managerRegistry;
         $this->entityName = $entityName;
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -32,6 +32,16 @@ class SignalementManager extends AbstractManager
         return $partners;
     }
 
+    public function findPartners(Signalement $signalement): array
+    {
+        $affectation = $signalement->getAffectations()->map(
+            function (Affectation $affectation) {
+                return $affectation->getPartner()->getId();
+            });
+
+        return $affectation->toArray();
+    }
+
     public function closeSignalementForAllPartners(Signalement $signalement, string $motif): Signalement
     {
         $signalement

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -5,13 +5,11 @@ namespace App\Manager;
 use App\Entity\Suivi;
 use App\Factory\SuiviFactory;
 use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Component\Security\Core\Security;
 
 class SuiviManager extends Manager
 {
     public function __construct(
         private SuiviFactory $suiviFactory,
-        private Security $security,
         protected ManagerRegistry $managerRegistry,
         string $entityName = Suivi::class
     ) {
@@ -19,11 +17,8 @@ class SuiviManager extends Manager
         $this->entityName = $entityName;
     }
 
-    public function createSuivi(string $description)
+    public function createSuivi(array $params, bool $isPublic = false)
     {
-        $suivi = $this->suiviFactory->createInstance();
-        $suivi->setDescription($description);
-
-        return $suivi;
+        return $this->suiviFactory->createInstanceFrom($params, $isPublic);
     }
 }

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -9,10 +9,11 @@ use Symfony\Component\Security\Core\Security;
 
 class SuiviManager extends Manager
 {
-    public function __construct(private SuiviFactory $suiviFactory,
-                                private Security $security,
-                                protected ManagerRegistry $managerRegistry,
-                                string $entityName = Suivi::class
+    public function __construct(
+        private SuiviFactory $suiviFactory,
+        private Security $security,
+        protected ManagerRegistry $managerRegistry,
+        string $entityName = Suivi::class
     ) {
         $this->managerRegistry = $managerRegistry;
         $this->entityName = $entityName;

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Manager;
+
+use App\Entity\Suivi;
+use App\Factory\SuiviFactory;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Security\Core\Security;
+
+class SuiviManager extends Manager
+{
+    public function __construct(private SuiviFactory $suiviFactory,
+                                private Security $security,
+                                protected ManagerRegistry $managerRegistry,
+                                string $entityName = Suivi::class
+    ) {
+        $this->managerRegistry = $managerRegistry;
+        $this->entityName = $entityName;
+    }
+
+    public function createSuivi(string $description)
+    {
+        $suivi = $this->suiviFactory->createInstance();
+        $suivi->setDescription($description);
+
+        return $suivi;
+    }
+}

--- a/src/Service/Sanitizer.php
+++ b/src/Service/Sanitizer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Service;
+
+class Sanitizer
+{
+    public static function sanitize($text): string
+    {
+        $textSanitized = preg_replace('/<p[^>]*>/', '', $text); // Remove the start <p> or <p attr="">
+
+        return str_replace('</p>', '<br>', $textSanitized); // Replace the end
+    }
+}

--- a/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
@@ -7,8 +7,8 @@ use App\Entity\Signalement;
 use App\Entity\User;
 use App\Event\SignalementClosedEvent;
 use App\EventSubscriber\SignalementClosedSubscriber;
-use App\Factory\SuiviFactory;
 use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
 use App\Repository\UserRepository;
 use App\Service\NotificationService;
 use App\Service\Token\TokenGeneratorInterface;
@@ -85,7 +85,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
         $securityMock->expects($this->once())->method('getUser')->willReturn($user);
 
         $signalementManager = static::getContainer()->get(SignalementManager::class);
-        $suiviFactory = static::getContainer()->get(SuiviFactory::class);
+        $suiviManager = static::getContainer()->get(SuiviManager::class);
 
         $signalementClosedSubscriber = new SignalementClosedSubscriber(
             $notitificationServiceMock,
@@ -94,7 +94,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
             $urlGeneratorMock,
             $parameterBagMock,
             $tokenGeneratorMock,
-            $suiviFactory,
+            $suiviManager,
             $securityMock
         );
 

--- a/tests/Functional/Manager/AffectationManagerTest.php
+++ b/tests/Functional/Manager/AffectationManagerTest.php
@@ -29,7 +29,7 @@ class AffectationManagerTest extends KernelTestCase
         $signalement = $this->managerRegistry->getRepository(Signalement::class)->findOneBy(['reference' => '2022-8']);
 
         $countAffectationBeforeRemove = $signalement->getAffectations()->count();
-        $affectationManager->removeAffectationsBy($signalement);
+        $affectationManager->removeAffectationsFrom($signalement);
         $countAffectationAfterRemove = $signalement->getAffectations()->count();
 
         $this->assertNotEquals($countAffectationBeforeRemove, $countAffectationAfterRemove);
@@ -46,7 +46,7 @@ class AffectationManagerTest extends KernelTestCase
         $partnersIdToRemove[] = $signalement->getAffectations()->get(0)->getPartner()->getId();
         $partnersIdToRemove[] = $signalement->getAffectations()->get(1)->getPartner()->getId();
         $countAffectationBeforeRemove = $signalement->getAffectations()->count();
-        $affectationManager->removeAffectationsBy(signalement: $signalement, partnersIdToRemove: $partnersIdToRemove);
+        $affectationManager->removeAffectationsFrom(signalement: $signalement, partnersIdToRemove: $partnersIdToRemove);
         $countAffectationAfterRemove = $signalement->getAffectations()->count();
         $this->assertNotEquals($countAffectationBeforeRemove, $countAffectationAfterRemove);
         $this->assertEquals(1, $countAffectationAfterRemove);

--- a/tests/Functional/Manager/AffectationManagerTest.php
+++ b/tests/Functional/Manager/AffectationManagerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Tests\Functional\Manager;
+
+use App\Entity\Affectation;
+use App\Entity\Signalement;
+use App\Manager\AffectationManager;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Security\Core\Security;
+
+class AffectationManagerTest extends KernelTestCase
+{
+    private ManagerRegistry $managerRegistry;
+    private Security $security;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->managerRegistry = self::getContainer()->get(ManagerRegistry::class);
+        $this->security = self::getContainer()->get('security.helper');
+    }
+
+    public function testRemoveAllPartnersFromAffectation(): void
+    {
+        $affectationManager = new AffectationManager($this->security, $this->managerRegistry, Affectation::class);
+
+        /** @var Signalement $signalement */
+        $signalement = $this->managerRegistry->getRepository(Signalement::class)->findOneBy(['reference' => '2022-8']);
+
+        $countAffectationBeforeRemove = $signalement->getAffectations()->count();
+        $affectationManager->removeAffectationsBy($signalement);
+        $countAffectationAfterRemove = $signalement->getAffectations()->count();
+
+        $this->assertNotEquals($countAffectationBeforeRemove, $countAffectationAfterRemove);
+        $this->assertEquals(0, $countAffectationAfterRemove);
+    }
+
+    public function testRemoveSomePartnersFromAffectation(): void
+    {
+        $affectationManager = new AffectationManager($this->security, $this->managerRegistry, Affectation::class);
+
+        /** @var Signalement $signalement */
+        $signalement = $this->managerRegistry->getRepository(Signalement::class)->findOneBy(['reference' => '2022-8']);
+
+        $partnersIdToRemove[] = $signalement->getAffectations()->get(0)->getPartner()->getId();
+        $partnersIdToRemove[] = $signalement->getAffectations()->get(1)->getPartner()->getId();
+        $countAffectationBeforeRemove = $signalement->getAffectations()->count();
+        $affectationManager->removeAffectationsBy(signalement: $signalement, partnersIdToRemove: $partnersIdToRemove);
+        $countAffectationAfterRemove = $signalement->getAffectations()->count();
+        $this->assertNotEquals($countAffectationBeforeRemove, $countAffectationAfterRemove);
+        $this->assertEquals(1, $countAffectationAfterRemove);
+    }
+}

--- a/tests/Unit/Factory/SuiviFactoryTest.php
+++ b/tests/Unit/Factory/SuiviFactoryTest.php
@@ -24,9 +24,10 @@ class SuiviFactoryTest extends KernelTestCase
     public function testCreateSuiviInstance(): void
     {
         $suiviFactory = new SuiviFactory($this->security);
-        $suivi = $suiviFactory->createInstance();
+        $suivi = $suiviFactory->createInstanceFrom();
 
         $this->assertInstanceOf(Suivi::class, $suivi);
+        $this->assertEquals('', $suivi->getDescription());
         $this->assertFalse($suivi->getIsPublic());
         $this->assertInstanceOf(UserInterface::class, $suivi->getCreatedBy());
     }
@@ -34,7 +35,7 @@ class SuiviFactoryTest extends KernelTestCase
     public function testCreateSuiviInstanceWithClosedSignalementParameters(): void
     {
         $suiviFactory = new SuiviFactory($this->security);
-        $suivi = $suiviFactory->createInstance([
+        $suivi = $suiviFactory->createInstanceFrom([
             'motif_suivi' => 'Lorem ipsum suivi sit amet, consectetur adipiscing elit.',
             'motif_cloture' => MotifCloture::LABEL['INSALUBRITE'],
             'subject' => 'tous les partenaires',


### PR DESCRIPTION
## Routes impactés

|Noms des routes  | Remarque         |
|------------------------|-----------------------|
| back_signalement_toggle_affectation |   Appelle Esabora |
| back_signalement_affectation_response |   - |


## Changements effectuées
- Création et suppression des affectations délégué à `AffectationManager`.
- Création des suivi délégué aux classes `SuiviFactory`  et `SuiviManager`.
- Création d'une classe statique `Santizer` qui permet de nettoyer les messages de suivi.
- Ajout d'un `AffectationAnsweredEventSubscriber` qui va écouter l’événement `AffectationAnsweredEvent` correspondant aux réponses d'affectations.

## Tests
- Ajout d'un test `AffectationManagerTest` qui couvre la suppression des affectations pour tous les partenaires ou plusieurs
