### PR TITLE
[Security] Empêcher les spams envoyés chaque matin

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -75,8 +75,9 @@ describe('Simple test for the Signalement interface', () => {
     cy.get('#signalement-step-last-panel').should('be.visible')
     cy.window().scrollTo('top')
 
+    cy.get('label[for=signalement-accept-visite]').click()
     cy.get('label[for=signalement-accept-cgu]').click()
-    
+
     cy.get('#signalement-step-last-panel #form_finish_submit').should('be.visible')
   })
 

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -99,7 +99,8 @@ class FrontSignalementController extends AbstractController
         ReferenceGenerator $referenceGenerator,
         PostalCodeHomeChecker $postalCodeHomeChecker): Response
     {
-        if ($data = $request->get('signalement')) {
+        if ($this->isCsrfTokenValid('new_signalement', $request->request->get('_token'))
+            && $data = $request->get('signalement')) {
             $em = $doctrine->getManager();
             $signalement = new Signalement();
             $files_array = [];

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -163,9 +163,11 @@ class FrontSignalementController extends AbstractController
                 $signalement->setTelDeclarant(null);
             }
 
-            $signalement->setTerritory($territoryRepository->findOneBy([
-                'zip' => $postalCodeHomeChecker->mapZip($signalement->getCpOccupant()), 'isActive' => 1, ])
-            );
+            if (!empty($signalement->getCpOccupant())) {
+                $signalement->setTerritory($territoryRepository->findOneBy([
+                    'zip' => $postalCodeHomeChecker->mapZip($signalement->getCpOccupant()), 'isActive' => 1, ])
+                );
+            }
 
             if (null === $signalement->getTerritory() || !$postalCodeHomeChecker->isAuthorizedInseeCode($signalement->getTerritory(), $signalement->getInseeOccupant())) {
                 return $this->json(['response' => 'Territory is inactive'], Response::HTTP_BAD_REQUEST);

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -6,16 +6,20 @@ use App\Entity\Signalement;
 use App\Service\NotificationService;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 class ExceptionListener
 {
-    public function __construct(private NotificationService $notificationService, private ParameterBagInterface $params)
-    {
+    public function __construct(
+        private NotificationService $notificationService,
+        private ParameterBagInterface $params,
+    ) {
     }
 
     public function onKernelException(ExceptionEvent $event)
     {
-        if (null !== $event->getRequest()->get('signalement')) {
+        if (!$event->getThrowable() instanceof MethodNotAllowedException &&
+            null !== $event->getRequest()->get('signalement')) {
             $attachment = ['documents' => 0, 'photos' => 0];
             if ($files = $event->getRequest()->files->get('signalement')) {
                 foreach ($files as $k => $file) {

--- a/tests/Functional/Controller/FrontSignalementControllerTest.php
+++ b/tests/Functional/Controller/FrontSignalementControllerTest.php
@@ -17,11 +17,17 @@ class FrontSignalementControllerTest extends WebTestCase
 
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
-        $urlPostSignalement = $router->generate('envoi_signalement');
+        $routeSignalementSend = $router->generate('front_signalement');
+        $crawler = $client->request('GET', $routeSignalementSend);
+        $token = $crawler->filter('input[name=_token]')->attr('value');
 
         $payload = $this->getCommonPayload();
-        $payloadSignalement = ['signalement' => array_merge($payload, $adressSignalement)];
+        $payloadSignalement = [
+            'signalement' => array_merge($payload, $adressSignalement),
+            '_token' => $token,
+        ];
 
+        $urlPostSignalement = $router->generate('envoi_signalement');
         $client->request('POST', $urlPostSignalement, $payloadSignalement);
 
         $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
@@ -38,11 +44,17 @@ class FrontSignalementControllerTest extends WebTestCase
 
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
+        $routeSignalementSend = $router->generate('front_signalement');
+        $crawler = $client->request('GET', $routeSignalementSend);
+        $token = $crawler->filter('input[name=_token]')->attr('value');
+
         $urlPostSignalement = $router->generate('envoi_signalement');
 
         $payload = $this->getCommonPayload();
-        $payloadSignalement = ['signalement' => array_merge($payload, $adressSignalement)];
-
+        $payloadSignalement = [
+            'signalement' => array_merge($payload, $adressSignalement),
+            '_token' => $token,
+        ];
         $client->request('POST', $urlPostSignalement, $payloadSignalement);
 
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());


### PR DESCRIPTION
#754 

## Modifications apportées

- Prise en compte du `csrf_token` dans le formulaire usager
- Ne pas envoyer d'email lors d'une erreur 405 
- Vérification du code postal occupant
- Mise à jour des tests