### PR TITLE
[Test][CI] Applique un mock pour la génération des références

### DIFF
--- a/tests/Functional/Signalement/ReferenceGeneratorTest.php
+++ b/tests/Functional/Signalement/ReferenceGeneratorTest.php
@@ -22,11 +22,15 @@ class ReferenceGeneratorTest extends KernelTestCase
 
     public function testGenerateReferenceFromExistingSignalement()
     {
-        /** @var SignalementRepository $signalementRepository */
-        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-
         $territoryRepository = $this->entityManager->getRepository(Territory::class);
         $territory = $territoryRepository->findOneBy(['zip' => 13]);
+
+        $signalementRepository = $this->createMock(SignalementRepository::class);
+        $signalementRepository
+            ->expects($this->once())
+            ->method('findLastReferenceByTerritory')
+            ->with($territory)
+            ->willReturn(['reference' => '2022-11']);
 
         $referenceGenerator = new ReferenceGenerator($signalementRepository);
 


### PR DESCRIPTION
Le test `testGenerateReferenceFromExistingSignalement` plante depuis 2023

![image](https://user-images.githubusercontent.com/5757116/210576090-93d0a67e-ba2d-4edf-a90a-09da615c8bf5.png)

![image](https://user-images.githubusercontent.com/5757116/210576317-4109f8c8-d694-4589-bee8-e4315cc62dbe.png)
