### PR TITLE
[BO - Signalement] Rendre possible les affectations abonnées à ESABORA lorsque la réponse ESABORA est KO

### DIFF
--- a/.docker/php-worker/Dockerfile
+++ b/.docker/php-worker/Dockerfile
@@ -1,0 +1,42 @@
+FROM php:8.0-fpm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        curl \
+        wget \
+        zlib1g-dev \
+        libxml2-dev \
+        libzip-dev \
+        zip \
+        unzip \
+        libsqlite3-dev \
+        sqlite3 \
+        libxslt1-dev \
+        supervisor \
+        && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash \
+        && apt-get install -y  nodejs \
+         # Install intl
+        && docker-php-ext-configure intl \
+        && docker-php-ext-install -j2 intl \
+        # Install apcu
+        && pecl bundle -d /usr/src/php/ext apcu \
+        && docker-php-ext-install -j2 apcu \
+        # Install Xdebug
+        && pecl bundle -d /usr/src/php/ext xdebug-3.0.4 \
+        && docker-php-ext-install xdebug \
+        # Install others
+        && docker-php-ext-install -j2 bcmath ctype iconv pdo pdo_mysql pdo_sqlite zip xsl\
+        && docker-php-ext-enable opcache \
+        && rm /usr/src/php/ext/*.tgz \
+        && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer  \
+        && mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
+RUN sed -E -i -e 's/memory_limit = 128M/memory_limit = 512M/' "$PHP_INI_DIR/php.ini" \
+    && sed -E -i -e 's/post_max_size = 8M/post_max_size = 75M/' "$PHP_INI_DIR/php.ini" \
+    && sed -E -i -e 's/upload_max_filesize = 2M/upload_max_filesize = 75M/' "$PHP_INI_DIR/php.ini"
+
+RUN chmod a+rwx /var/log/supervisor/
+
+COPY ./supervisord.conf /etc/supervisor/conf.d/
+EXPOSE 8089
+
+ENTRYPOINT ["/usr/bin/supervisord"]

--- a/.docker/php-worker/supervisord.conf
+++ b/.docker/php-worker/supervisord.conf
@@ -1,0 +1,10 @@
+[supervisord]
+nodaemon=true
+
+[program:messenger-consume]
+command=php /app/bin/console messenger:consume async --time-limit=600 -vv
+user=root
+numprocs=1
+autostart=true
+autorestart=true
+process_name=%(program_name)s_%(process_num)02d

--- a/.slugignore
+++ b/.slugignore
@@ -1,2 +1,6 @@
-wiremock
+.docker
+docker-compose.yml
+.github
+tools
 cypress
+cypress.config.js

--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,21 @@ mysql: ## Log to mysql container
 	@echo -e '\e[1;32mLog to mysql container\032[0m'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_mysql mysql -u histologe -phistologe histologe_db'
 
-worker-status:
-	@echo -e '\e[1;32mLog to phpworker container\032'
+worker-status:## Gest status worker
+	@echo -e '\e[1;32mGet status worker\032'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker supervisorctl status all'
 
-worker-start:
-	@echo -e '\e[1;32mLog to phpworker container\032'
+worker-start: ## Start worker
+	@echo -e '\e[1;32mStart worker\032'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker supervisorctl start all'
 
-worker-stop:
-	@echo -e '\e[1;32mLog to phpworker container\032'
+worker-stop: ## Stop worker
+	@echo -e '\e[1;32mStop worker\032'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker supervisorctl stop all'
+
+worker-exec-failed: ## Consume failed queue
+	@echo -e '\e[1;32mConsume failed queue\032'
+	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker php bin/console messenger:consume failed -vvv'
 
 logs: ## Show container logs
 	@$(DOCKER_COMP) logs --follow
@@ -148,3 +152,15 @@ npm-build: ## Build the dependencies in the local node_modules folder
 
 .sleep:
 	@sleep 30
+
+.PHONY : cypress
+cypress:
+	docker run -it --rm -d -e DISPLAY \
+		-v $(shell pwd):/e2e \
+	 	-v /tmp/.X11-unix:/tmp/.X11-unix --net=host -w /e2e \
+		--entrypoint cypress cypress/included:6.6.0 open --project .
+
+cypress-run:
+	docker run -it --rm -w /e2e \
+		-v $(shell pwd):/e2e \
+		cypress/included:6.6.0

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ mysql: ## Log to mysql container
 	@echo -e '\e[1;32mLog to mysql container\032[0m'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_mysql mysql -u histologe -phistologe histologe_db'
 
-worker-status:## Gest status worker
+worker-status:## Get status worker
 	@echo -e '\e[1;32mGet status worker\032'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker supervisorctl status all'
 
@@ -152,15 +152,3 @@ npm-build: ## Build the dependencies in the local node_modules folder
 
 .sleep:
 	@sleep 30
-
-.PHONY : cypress
-cypress:
-	docker run -it --rm -d -e DISPLAY \
-		-v $(shell pwd):/e2e \
-	 	-v /tmp/.X11-unix:/tmp/.X11-unix --net=host -w /e2e \
-		--entrypoint cypress cypress/included:6.6.0 open --project .
-
-cypress-run:
-	docker run -it --rm -w /e2e \
-		-v $(shell pwd):/e2e \
-		cypress/included:6.6.0

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,9 @@ mock: ## Start Mock server
 	@${DOCKER_COMP} start histologe_wiremock && sleep 5
 	@${DOCKER_COMP} exec -it histologe_phpfpm sh -c "cd tools/wiremock/src/Mock && php AppMock.php"
 
+stop-mock: ## Stop Mock server
+	@${DOCKER_COMP} stop histologe_wiremock
+
 npm-install: ## Install the dependencies in the local node_modules folder
 	@$(DOCKER_COMP) exec -it histologe_phpfpm $(NPM) install
 

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,25 @@ sh: ## Log to phpfpm container
 	@echo -e '\e[1;32mLog to phpfpm container\032'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpfpm sh'
 
+worker: ## Log to php-worker container
+	@echo -e '\e[1;32mLog to phpworker container\032'
+	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker sh'
+
 mysql: ## Log to mysql container
 	@echo -e '\e[1;32mLog to mysql container\032[0m'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_mysql mysql -u histologe -phistologe histologe_db'
+
+worker-status:
+	@echo -e '\e[1;32mLog to phpworker container\032'
+	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker supervisorctl status all'
+
+worker-start:
+	@echo -e '\e[1;32mLog to phpworker container\032'
+	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker supervisorctl start all'
+
+worker-stop:
+	@echo -e '\e[1;32mLog to phpworker container\032'
+	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker supervisorctl stop all'
 
 logs: ## Show container logs
 	@$(DOCKER_COMP) logs --follow

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 postdeploy: ./scripts/postdeploy.sh
+worker: php bin/console messenger:consume async

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Une solution pour détecter et accélérer la prise en charge du “mal logement”.
 
-Histologe est une application web écrite en PHP et utilisant le framework Symfony, avec une base de données MySQL.
+## Environnement
 
 Cette application est déployé chez Scalingo, hébergé par Outscale.
 
@@ -71,7 +71,7 @@ $ make help
 La commande permet d'installer l'environnement de developpement avec un jeu de données
 
 ```
-make build
+$ make build
 ```
 
 2. Configurer les variables d'environnements du service object storage S3 d'OVH Cloud
@@ -108,19 +108,19 @@ Ain                    | Utilisateur Partenaire 01 | user-01-01@histologe.fr    
 > En tant qu'administrateur
 
 ```
-php bin/console app:add-user ROLE_ADMIN john.doe.1@histologe.fr John Doe
+$ php bin/console app:add-user ROLE_ADMIN john.doe.1@histologe.fr John Doe
 ```
 
 > En tant qu'administrateur territoire
 
 ```
-php bin/console app:add-user ROLE_ADMIN_TERRITORY joe.doe.2@histologe.fr John Doe Marseille 13
+$ php bin/console app:add-user ROLE_ADMIN_TERRITORY joe.doe.2@histologe.fr John Doe Marseille 13
 ```
 
 > En tant que partenaire
 > 
 ```
-php bin/console app:add-user ROLE_USER_PARTNER joe.doe.3@histologe.fr John Doe Marseille 13
+$ php bin/console app:add-user ROLE_USER_PARTNER joe.doe.3@histologe.fr John Doe Marseille 13
 ```
 
 Une activation de compte sera nécéssaire
@@ -149,12 +149,12 @@ Une fois le tunnel construit, à partir d'un autre terminal que celui du tunnel 
 `127.0.0.1:10000` et faire votre export de données.
 
 ```
-mysqldump --column-statistics=0 --no-tablespaces -u <database_user>  -h 127.0.0.1 -p <database_name> -P 10000 > data/dump.sql
+$ mysqldump --column-statistics=0 --no-tablespaces -u <database_user>  -h 127.0.0.1 -p <database_name> -P 10000 > data/dump.sql
 ```
 Vous pouvez ensuite executer la commande.
 
 ```
-make load-data  
+$ make load-data  
 ```
 
 ## Documentaton projet

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ git clone git@github.com:MTES-MCT/histologe.git
 
 [Génération d'une nouvelle clé SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 
-## Environnement
+## Environnement technique
 
 ### Versions des dépendances
 
@@ -68,7 +68,8 @@ Merci de vérifier que ces ports ne soient pas utilisés sur votre poste local
 Service| Hostname             |Port number
 -------|----------------------|-----------
 Nginx| histologe_nginx      | **8080**
-PHP-FPM| histologe_phpfpm     |**9000**
+php-fpm| histologe_phpfpm     |**9000**
+php-worker| histologe_phpworker  |**8089**
 MySQL| histologe_mysql      |**3307**
 PhpMyAdmin | histologe_phpmyadmin | **8081**
 Mailcatcher| histologe_mailer     | **1025** et **1080**
@@ -145,12 +146,6 @@ php bin/console app:add-user ROLE_USER_PARTNER joe.doe.3@histologe.fr John Doe M
 
 Une activation de compte sera nécéssaire
 
-### Compilation des fichiers Vue.js en cours de développement
-```
-npm install
-npm run watch
-```
-
 ## Bases de données scalingo
 
 ### Pré-requis
@@ -185,4 +180,4 @@ make load-data
 
 ## Documentaton projet
 
-[Wiki](https://github.com/MTES-MCT/histologe/wiki)
+[Consulter la documentation](https://github.com/MTES-MCT/histologe/wiki)

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Cette application est déployé chez Scalingo, hébergé par Outscale.
 
 - Staging: [histologe-staging.incubateur.net](https://histologe-staging.incubateur.net)
 
-Les ressources statiques telles que les images et documents sont hébergés par OVH Cloud à travers le service Object Storage.  
-
-- https://horizon.cloud.ovh.net
-
 ## Pré-requis
 
 Requirements|Release
@@ -24,23 +20,6 @@ AWS CLI OVH Object storage (optionnel) | [1.25](https://docs.ovh.com/fr/storage/
 PHP (optionnel)| [8.0.*](https://www.php.net/)
 Composer (optionnel) | [2.4.*](https://getcomposer.org/download/)
 Node (optionnel)| [16.*](https://nodejs.org/en/)
-
-
-## Clone du projet
-
-### HTTP
-```bash
-git clone https://github.com/MTES-MCT/histologe
-```
-
-### SSH
-```
-git clone git@github.com:MTES-MCT/histologe.git
-```
-
-[Vérification des clés SSH existantes](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys)
-
-[Génération d'une nouvelle clé SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 
 ## Environnement technique
 

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -14,11 +14,11 @@ framework:
             # Symfony\Component\Mailer\Messenger\SendEmailMessage: sync
             App\Messenger\Message\DossierMessage: async
 
-#
-#when@test:
-#    framework:
-#        messenger:
-#            transports:
-#                # replace with your transport name here (e.g., my_transport: 'in-memory://')
-#                # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
-#                sync: 'in-memory://'
+
+when@test:
+    framework:
+        messenger:
+            transports:
+                # replace with your transport name here (e.g., my_transport: 'in-memory://')
+                # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
+                async: 'in-memory://'

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,7 +1,7 @@
 framework:
     messenger:
         # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
-        # failure_transport: failed
+        failure_transport: failed
 
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
@@ -12,7 +12,7 @@ framework:
         routing:
             # Route your messages to the transports
             # Symfony\Component\Mailer\Messenger\SendEmailMessage: sync
-            App\Messenger\Message\DossierMessage: sync
+            App\Messenger\Message\DossierMessage: async
 
 #
 #when@test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     volumes:
       - .:/app/
 
-  php-worker:
+  histologe_phpworker:
     build: .docker/php-worker
     container_name: histologe_worker
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,20 @@ services:
       MAILER_DSN: ${MAILER_DSN}
       WIREMOCK_HOSTNAME: ${WIREMOCK_HOSTNAME}
       WIREMOCK_PORT: ${WIREMOCK_PORT}
+      MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN}
+    volumes:
+      - .:/app/
+
+  php-worker:
+    build: .docker/php-worker
+    container_name: histologe_worker
+    working_dir: /app
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      MAILER_DSN: ${MAILER_DSN}
+      WIREMOCK_HOSTNAME: ${WIREMOCK_HOSTNAME}
+      WIREMOCK_PORT: ${WIREMOCK_PORT}
+      MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN}
     volumes:
       - .:/app/
 

--- a/migrations/Version20221201010259.php
+++ b/migrations/Version20221201010259.php
@@ -21,13 +21,11 @@ final class Version20221201010259 extends AbstractMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE job_event (id INT AUTO_INCREMENT NOT NULL, signalement_id INT DEFAULT NULL, partner_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, title VARCHAR(255) NOT NULL, message LONGTEXT DEFAULT NULL, response LONGTEXT DEFAULT NULL, status VARCHAR(255) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(190) NOT NULL, created_at DATETIME NOT NULL, available_at DATETIME NOT NULL, delivered_at DATETIME DEFAULT NULL, INDEX IDX_75EA56E0FB7336F0 (queue_name), INDEX IDX_75EA56E0E3BD61CE (available_at), INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('DROP TABLE job_event');
-        $this->addSql('DROP TABLE messenger_messages');
     }
 }

--- a/src/Command/SynchronizeEsaboraCommand.php
+++ b/src/Command/SynchronizeEsaboraCommand.php
@@ -6,7 +6,6 @@ use App\Entity\JobEvent;
 use App\Manager\AffectationManager;
 use App\Manager\JobEventManager;
 use App\Repository\AffectationRepository;
-use App\Service\Esabora\DossierResponse;
 use App\Service\Esabora\EsaboraService;
 use App\Service\NotificationService;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -53,7 +52,6 @@ class SynchronizeEsaboraCommand extends Command
                 ],
             ];
 
-            /** @var DossierResponse $dossierResponse */
             $dossierResponse = $this->esaboraService->getStateDossier($affectation);
             if (Response::HTTP_OK === $dossierResponse->getStatusCode() && null !== $dossierResponse->getSasEtat()) {
                 $this->affectationManager->synchronizeAffectationFrom($dossierResponse, $affectation);
@@ -75,8 +73,8 @@ class SynchronizeEsaboraCommand extends Command
                 ++$countSyncFailed;
             }
             $this->jobEventManager->createJobEvent(
-                type: 'esabora',
-                title: 'sync_dossier',
+                type: EsaboraService::TYPE_SERVICE,
+                title: EsaboraService::ACTION_SYNC_DOSSIER,
                 message: json_encode($message),
                 response: $this->serializer->serialize($dossierResponse, 'json'),
                 status: Response::HTTP_OK === $dossierResponse->getStatusCode()

--- a/src/Command/SynchronizeEsaboraCommand.php
+++ b/src/Command/SynchronizeEsaboraCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\SerializerInterface;
 
 #[AsCommand(
@@ -74,7 +75,9 @@ class SynchronizeEsaboraCommand extends Command
                 title: 'sync_dossier',
                 message: json_encode($message, \JSON_THROW_ON_ERROR),
                 response: $this->serializer->serialize($dossierResponse, 'json'),
-                status: 200 === $dossierResponse->getStatusCode() ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED,
+                status: Response::HTTP_OK === $dossierResponse->getStatusCode()
+                    ? JobEvent::STATUS_SUCCESS
+                    : JobEvent::STATUS_FAILED,
                 signalementId: $affectation->getSignalement()->getId(),
                 partnerId: $affectation->getPartner()->getId()
             );

--- a/src/Command/SynchronizeEsaboraCommand.php
+++ b/src/Command/SynchronizeEsaboraCommand.php
@@ -71,6 +71,7 @@ class SynchronizeEsaboraCommand extends Command
                 );
                 ++$countSyncSuccess;
             } else {
+                $io->error(sprintf('%s', $this->serializer->serialize($dossierResponse, 'json')));
                 ++$countSyncFailed;
             }
             $this->jobEventManager->createJobEvent(
@@ -98,7 +99,7 @@ class SynchronizeEsaboraCommand extends Command
                     ? 'signalements ont été synchronisés'
                     : 'signalement a été synchronisé',
                 'message_failed' => $countSyncFailed > 1
-                    ? 'signalements n\'ont été synchronisés'
+                    ? 'signalements n\'ont pas été synchronisés'
                     : 'signalement n\'a pas été synchronisé',
             ],
             null

--- a/src/Controller/Back/BackAssignmentController.php
+++ b/src/Controller/Back/BackAssignmentController.php
@@ -3,7 +3,6 @@
 namespace App\Controller\Back;
 
 use App\Entity\Affectation;
-use App\Entity\JobEvent;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Event\AffectationAnsweredEvent;
@@ -117,19 +116,7 @@ class BackAssignmentController extends AbstractController
         $partner = $affectation->getPartner();
         if ($partner->getEsaboraToken() && $partner->getEsaboraUrl()) {
             $dossierMessage = $this->dossierMessageFactory->createInstance($affectation);
-            try {
-                $this->messageBus->dispatch($dossierMessage);
-            } catch (\Throwable $exception) {
-                $this->jobEventManager->createJobEvent(
-                    type: 'esabora',
-                    title: 'push_dossier',
-                    message: json_encode($dossierMessage->preparePayload(), \JSON_THROW_ON_ERROR),
-                    response: $exception->getMessage(),
-                    status: JobEvent::STATUS_FAILED,
-                    signalementId: $affectation->getSignalement()->getId(),
-                    partnerId: $affectation->getPartner()->getId()
-                );
-            }
+            $this->messageBus->dispatch($dossierMessage);
         }
     }
 }

--- a/src/Controller/Back/BackAssignmentController.php
+++ b/src/Controller/Back/BackAssignmentController.php
@@ -112,10 +112,6 @@ class BackAssignmentController extends AbstractController
         }
     }
 
-    /** @todo: Enable Scalingo Worker for Messenger
-     * Task handled as sync way, check how scalingo manage messenger to manage handler as async task
-     * https://doc.scalingo.com/languages/php/symfony#symfony-messenger
-     */
     private function dispatchDossierEsabora(Affectation $affectation): void
     {
         $partner = $affectation->getPartner();

--- a/src/EventSubscriber/WorkerMessageEventSubscriber.php
+++ b/src/EventSubscriber/WorkerMessageEventSubscriber.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\JobEvent;
+use App\Manager\JobEventManager;
+use App\Messenger\Message\DossierMessage;
+use App\Service\Esabora\EsaboraService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+
+class WorkerMessageEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private JobEventManager $jobEventManager)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageFailedEvent::class => 'createJobEvent',
+        ];
+    }
+
+    public function createJobEvent(WorkerMessageFailedEvent $event)
+    {
+        if (!$event->willRetry()) {
+            $dossierMessage = $event->getEnvelope()->getMessage();
+            if ($dossierMessage instanceof DossierMessage) {
+                $error = [
+                  'message' => $event->getThrowable()->getMessage(),
+                  'stack_trace' => $event->getThrowable()->getTraceAsString(),
+                ];
+                $this->jobEventManager->createJobEvent(
+                    type: EsaboraService::TYPE_SERVICE,
+                    title: EsaboraService::ACTION_PUSH_DOSSIER,
+                    message: json_encode($dossierMessage->preparePayload()),
+                    response: json_encode($error),
+                    status: JobEvent::STATUS_FAILED,
+                    signalementId: $dossierMessage->getSignalementId(),
+                    partnerId: $dossierMessage->getPartnerId()
+                );
+            }
+        }
+    }
+}

--- a/src/Messenger/Message/DossierMessage.php
+++ b/src/Messenger/Message/DossierMessage.php
@@ -4,45 +4,45 @@ namespace App\Messenger\Message;
 
 final class DossierMessage
 {
-    private ?string $url;
+    private ?string $url = null;
 
-    private ?string $token;
+    private ?string $token = null;
 
-    private ?int $signalementId;
+    private ?int $signalementId = null;
 
-    private ?int $partnerId;
+    private ?int $partnerId = null;
 
-    private ?string $reference;
+    private ?string $reference = null;
 
-    private ?string $prenomUsager;
+    private ?string $prenomUsager = null;
 
-    private ?string $nomUsager;
+    private ?string $nomUsager = null;
 
-    private ?string $mailUsager;
+    private ?string $mailUsager = null;
 
-    private ?string $telephoneUsager;
+    private ?string $telephoneUsager = null;
 
-    private ?string $numeroAdresseSignalement;
+    private ?string $numeroAdresseSignalement = null;
 
-    private ?string $adresseSignalement;
+    private ?string $adresseSignalement = null;
 
-    private ?string $etageSignalement;
+    private ?string $etageSignalement = null;
 
-    private ?string $numeroAppartementSignalement;
+    private ?string $numeroAppartementSignalement = null;
 
-    private ?string $codepostaleSignalement;
+    private ?string $codepostaleSignalement = null;
 
-    private ?string $villeSignalement;
+    private ?string $villeSignalement = null;
 
-    private ?float $latitudeSignalement;
+    private ?float $latitudeSignalement = null;
 
-    private ?float $longitudeSignalement;
+    private ?float $longitudeSignalement = null;
 
-    private ?string $dateOuverture;
+    private ?string $dateOuverture = null;
 
-    private ?string $dossierCommentaire;
+    private ?string $dossierCommentaire = null;
 
-    private ?string $piecesJointesObservation;
+    private ?string $piecesJointesObservation = null;
 
     private array $piecesJointes = [];
 

--- a/src/Messenger/MessageHandler/DossierMessageHandler.php
+++ b/src/Messenger/MessageHandler/DossierMessageHandler.php
@@ -22,8 +22,8 @@ final class DossierMessageHandler implements MessageHandlerInterface
     {
         $response = $this->esaboraService->pushDossier($dossierMessage);
         $this->jobEventManager->createJobEvent(
-            type: 'esabora',
-            title: 'push_dossier',
+            type: EsaboraService::TYPE_SERVICE,
+            title: EsaboraService::ACTION_PUSH_DOSSIER,
             message: $this->serializer->serialize($dossierMessage, 'json'),
             response: $response->getContent(),
             status: 200 === $response->getStatusCode() ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED,

--- a/src/Service/Esabora/DossierResponse.php
+++ b/src/Service/Esabora/DossierResponse.php
@@ -13,6 +13,7 @@ class DossierResponse
     private ?string $etat = null;
     private ?string $dateCloture = null;
     private ?int $statusCode = null;
+    private ?string $errorReason = null;
 
     public function __construct(array $response, ?int $statusCode)
     {
@@ -29,6 +30,7 @@ class DossierResponse
                 $this->dateCloture = $data[7];
             }
         }
+        $this->errorReason = json_encode($response);
         $this->statusCode = $statusCode;
     }
 

--- a/src/Service/Esabora/DossierResponse.php
+++ b/src/Service/Esabora/DossierResponse.php
@@ -28,9 +28,10 @@ class DossierResponse
                 $this->statut = $data[5];
                 $this->etat = $data[6];
                 $this->dateCloture = $data[7];
+            } else {
+                $this->errorReason = json_encode($response);
             }
         }
-        $this->errorReason = json_encode($response);
         $this->statusCode = $statusCode;
     }
 
@@ -77,5 +78,10 @@ class DossierResponse
     public function getStatusCode(): ?int
     {
         return $this->statusCode;
+    }
+
+    public function getErrorReason(): ?string
+    {
+        return $this->errorReason;
     }
 }

--- a/src/Service/Esabora/EsaboraService.php
+++ b/src/Service/Esabora/EsaboraService.php
@@ -78,18 +78,15 @@ class EsaboraService
             $statusCode = $response->getStatusCode();
 
             return new DossierResponse(
-                Response::HTTP_INTERNAL_SERVER_ERROR !== $statusCode ? $response->toArray() : [],
+                Response::HTTP_INTERNAL_SERVER_ERROR !== $statusCode
+                    ? $response->toArray()
+                    : [],
                 $statusCode
             );
         } catch (\Throwable $exception) {
             $this->logger->error($exception->getMessage());
         }
 
-        return new DossierResponse([
-            'message' => $exception->getMessage(),
-            'status_code' => $statusCode,
-        ],
-            $statusCode
-        );
+        return new DossierResponse(['message' => $exception->getMessage(), 'status_code' => $statusCode], $statusCode);
     }
 }

--- a/src/Service/Esabora/EsaboraService.php
+++ b/src/Service/Esabora/EsaboraService.php
@@ -17,6 +17,10 @@ class EsaboraService
     public const ESABORA_REFUSED = 'Non importé';
     public const ESABORA_CLOSED = 'terminé';
 
+    public const TYPE_SERVICE = 'esabora';
+    public const ACTION_PUSH_DOSSIER = 'push_dossier';
+    public const ACTION_SYNC_DOSSIER = 'sync_dossier';
+
     public function __construct(
         private HttpClientInterface $client,
         private LoggerInterface $logger,

--- a/src/Service/Esabora/EsaboraService.php
+++ b/src/Service/Esabora/EsaboraService.php
@@ -3,10 +3,10 @@
 namespace App\Service\Esabora;
 
 use App\Entity\Affectation;
-use App\Manager\AffectationManager;
 use App\Messenger\Message\DossierMessage;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -19,7 +19,6 @@ class EsaboraService
 
     public function __construct(
         private HttpClientInterface $client,
-        private AffectationManager $affectationManager,
         private LoggerInterface $logger,
     ) {
     }
@@ -46,7 +45,9 @@ class EsaboraService
             $this->logger->error($exception->getMessage());
         }
 
-        return (new JsonResponse(['message' => $exception->getMessage()]))->setStatusCode(500);
+        return (new JsonResponse([
+            'message' => $exception->getMessage(),
+        ]))->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     public function getStateDossier(Affectation $affectation): DossierResponse|JsonResponse
@@ -75,13 +76,15 @@ class EsaboraService
             );
 
             return new DossierResponse(
-                200 === $response->getStatusCode() ? $response->toArray() : [],
+                Response::HTTP_INTERNAL_SERVER_ERROR !== $response->getStatusCode() ? $response->toArray() : [],
                 $response->getStatusCode()
             );
         } catch (\Throwable $exception) {
             $this->logger->error($exception->getMessage());
         }
 
-        return (new JsonResponse(['message' => $exception->getMessage()]))->setStatusCode(500);
+        return (new JsonResponse([
+            'message' => $exception->getMessage(),
+        ]))->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/Service/Esabora/EsaboraService.php
+++ b/src/Service/Esabora/EsaboraService.php
@@ -47,7 +47,7 @@ class EsaboraService
 
         return (new JsonResponse([
             'message' => $exception->getMessage(),
-        ]))->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+        ]))->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE);
     }
 
     public function getStateDossier(Affectation $affectation): DossierResponse|JsonResponse
@@ -85,6 +85,6 @@ class EsaboraService
 
         return (new JsonResponse([
             'message' => $exception->getMessage(),
-        ]))->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+        ]))->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE);
     }
 }

--- a/templates/emails/cron_email.html.twig
+++ b/templates/emails/cron_email.html.twig
@@ -5,9 +5,9 @@
     <p>La tache planifiée <strong>{{ cron_label }}</strong> s'est éxécutée avec succès.</p>
     <p> {{ count is defined ? count : ' '}} {{ message is defined ? message : ' ' }}</p>
     {% if count_success is defined and message_success is defined %}
-        <p><span>&#9989;</span> {{ count_success ~ message_success }}</p>
+        <p><span>&#9989;</span> {{ count_success }} {{ message_success }}</p>
     {% endif %}
     {% if count_failed is defined and message_failed is defined %}
-        <p><span>&#10060;</span> {{ count_failed ~ message_failed }}</p>
+        <p><span>&#10060;</span> {{ count_failed }}  {{ message_failed }}</p>
     {% endif %}
 {% endblock %}

--- a/templates/emails/cron_email.html.twig
+++ b/templates/emails/cron_email.html.twig
@@ -3,5 +3,11 @@
 {% block body %}
     <p>Plateforme: {{ url }}</p>
     <p>La tache planifiée <strong>{{ cron_label }}</strong> s'est éxécutée avec succès.</p>
-    <p> {{ count is defined ? count : ' '}} {{ message }}.</p>
+    <p> {{ count is defined ? count : ' '}} {{ message is defined ? message : ' ' }}</p>
+    {% if count_success is defined and message_success is defined %}
+        <p><span>&#9989;</span> {{ count_success ~ message_success }}</p>
+    {% endif %}
+    {% if count_failed is defined and message_failed is defined %}
+        <p><span>&#10060;</span> {{ count_failed ~ message_failed }}</p>
+    {% endif %}
 {% endblock %}

--- a/tests/Functional/Manager/JobEventManagerTest.php
+++ b/tests/Functional/Manager/JobEventManagerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests\Functional\Manager;
+
+use App\Entity\JobEvent;
+use App\Manager\JobEventManager;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class JobEventManagerTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        self::bootKernel();
+    }
+
+    public function testCreateJobEvent(): void
+    {
+        $managerRegistry = static::getContainer()->get(ManagerRegistry::class);
+
+        $jobEventManager = new JobEventManager($managerRegistry, JobEvent::class);
+        $jobEvent = $jobEventManager->createJobEvent(
+            'esabora',
+            'push_dossier',
+            '',
+            '',
+            JobEvent::STATUS_SUCCESS,
+            10,
+            10
+        );
+
+        $this->assertInstanceOf(JobEvent::class, $jobEvent);
+        $this->assertEquals('success', $jobEvent->getStatus());
+    }
+}

--- a/tests/Unit/EventSubscriber/WorkerMessageEventSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/WorkerMessageEventSubscriberTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\Unit\EventSubscriber;
+
+use App\Entity\JobEvent;
+use App\EventSubscriber\WorkerMessageEventSubscriber;
+use App\Manager\JobEventManager;
+use App\Messenger\Message\DossierMessage;
+use App\Service\Esabora\EsaboraService;
+use App\Tests\Unit\Messenger\DossierMessageTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+
+class WorkerMessageEventSubscriberTest extends TestCase
+{
+    use DossierMessageTrait;
+
+    public function testEventSubscription(): void
+    {
+        $this->assertArrayHasKey(
+            WorkerMessageFailedEvent::class,
+            WorkerMessageEventSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function testOnWorkerMessageFailedEvent(): void
+    {
+        $jobEventManagerMock = $this->createMock(JobEventManager::class);
+        $subscriber = new WorkerMessageEventSubscriber($jobEventManagerMock);
+
+        $dossierMessage = new DossierMessage();
+        $envelope = new Envelope($dossierMessage, [
+            new DelayStamp(0),
+            new ReceivedStamp('async'),
+        ]);
+        $event = new WorkerMessageFailedEvent($envelope, 'async', new \Exception('custom error'));
+
+        /** @var DossierMessage $dossierMessageFromEnvelope */
+        $dossierMessageFromEnvelope = $event->getEnvelope()->getMessage();
+
+        $jobEventManagerMock
+            ->expects($this->atLeast(1))
+            ->method('createJobEvent')
+            ->with(
+                EsaboraService::TYPE_SERVICE,
+                EsaboraService::ACTION_PUSH_DOSSIER,
+                json_encode($dossierMessageFromEnvelope->preparePayload()),
+                json_encode(['message' => 'custom error', 'stack_trace' => $event->getThrowable()->getTraceAsString()]),
+                JobEvent::STATUS_FAILED,
+                null,
+                null
+            );
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($subscriber);
+        $dispatcher->dispatch($event, WorkerMessageFailedEvent::class);
+    }
+}

--- a/tests/Unit/Factory/DossierMessageFactoryTest.php
+++ b/tests/Unit/Factory/DossierMessageFactoryTest.php
@@ -79,7 +79,7 @@ class DossierMessageFactoryTest extends TestCase
         $dossierMessageFactory = new DossierMessageFactory($uploadHandlerServiceMock);
         $dossierMessage = $dossierMessageFactory->createInstance($affectation);
 
-        $this->assertEquals(2, \count($dossierMessage->getPiecesJointes()));
+        $this->assertCount(2, $dossierMessage->getPiecesJointes());
         $this->assertStringContainsString('Doc', $dossierMessage->getPiecesJointesObservation());
         $this->assertStringContainsString('Points signalés', $dossierMessage->getDossierCommentaire());
         $this->assertStringContainsString('Etat grave', $dossierMessage->getDossierCommentaire());

--- a/tests/Unit/Messenger/DossierMessageTrait.php
+++ b/tests/Unit/Messenger/DossierMessageTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Tests\Unit\Messenger;
+
+use App\Messenger\Message\DossierMessage;
+use Faker\Factory;
+
+trait DossierMessageTrait
+{
+    protected function getDossierMessage(): DossierMessage
+    {
+        $faker = Factory::create();
+
+        return (new DossierMessage())
+            ->setUrl($faker->url())
+            ->setToken($faker->password(20))
+            ->setPartnerId($faker->randomDigit())
+            ->setSignalementId($faker->randomDigit())
+            ->setReference($faker->uuid())
+            ->setNomUsager($faker->lastName())
+            ->setPrenomUsager($faker->firstName())
+            ->setMailUsager($faker->email())
+            ->setTelephoneUsager($faker->phoneNumber())
+            ->setAdresseSignalement($faker->address())
+            ->setCodepostaleSignalement($faker->postcode())
+            ->setVilleSignalement($faker->city())
+            ->setEtageSignalement('1')
+            ->setNumeroAppartementSignalement('2')
+            ->setNumeroAdresseSignalement('10')
+            ->setLatitudeSignalement(0)
+            ->setLongitudeSignalement(0)
+            ->setDateOuverture('01/01/2022')
+            ->setDossierCommentaire(null)
+            ->setPiecesJointesObservation(null);
+    }
+}

--- a/tests/Unit/Messenger/MessageHandler/DossierMessageHandlerTest.php
+++ b/tests/Unit/Messenger/MessageHandler/DossierMessageHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Tests\Unit\Messenger\MessageHandler;
+
+use App\Manager\JobEventManager;
+use App\Messenger\MessageHandler\DossierMessageHandler;
+use App\Service\Esabora\EsaboraService;
+use App\Tests\Unit\Messenger\DossierMessageTrait;
+use Faker\Factory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+class DossierMessageHandlerTest extends TestCase
+{
+    use DossierMessageTrait;
+
+    /**
+     * @throws TransportExceptionInterface
+     */
+    public function testProcessDossierMessage(): void
+    {
+        $faker = Factory::create();
+        $dossierMessage = $this->getDossierMessage();
+        $filepath = __DIR__.'/../../../../tools/wiremock/src/Resources/Esabora/ws_import.json';
+        $mockResponse = new MockResponse(file_get_contents($filepath));
+        $mockHttpClient = new MockHttpClient($mockResponse);
+        $response = $mockHttpClient->request('POST', $faker->url());
+
+        $esaboraServiceMock = $this->createMock(EsaboraService::class);
+        $esaboraServiceMock
+            ->expects($this->once())
+            ->method('pushDossier')
+            ->willReturn($response);
+
+        $jobEventManagerMock = $this->createMock(JobEventManager::class);
+
+        $serializerMock = $this->createMock(SerializerInterface::class);
+        $serializerMock
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($dossierMessage, 'json')
+            ->willReturn(json_encode([]));
+
+        $dossierMessageHandler = new DossierMessageHandler(
+            $esaboraServiceMock,
+            $jobEventManagerMock,
+            $serializerMock
+        );
+
+        $dossierMessageHandler($dossierMessage);
+    }
+}

--- a/tests/Unit/Service/Esabora/DossierResponseTest.php
+++ b/tests/Unit/Service/Esabora/DossierResponseTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Service\Esabora;
 
 use App\Service\Esabora\DossierResponse;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 class DossierResponseTest extends TestCase
 {
@@ -22,5 +23,23 @@ class DossierResponseTest extends TestCase
         $this->assertEquals('en cours', $dossierResponse->getEtat());
         $this->assertNull($dossierResponse->getDateCloture());
         $this->assertEquals(200, $dossierResponse->getStatusCode());
+        $this->assertNull($dossierResponse->getErrorReason());
+    }
+
+    public function testDossierResponseFailed(): void
+    {
+        $responseEsabora = ['message' => 'Lorem ipsum', 'statusCode' => Response::HTTP_BAD_REQUEST];
+
+        $dossierResponse = new DossierResponse($responseEsabora, Response::HTTP_BAD_REQUEST);
+        $this->assertNull($dossierResponse->getSasReference());
+        $this->assertNull($dossierResponse->getSasEtat());
+        $this->assertNull($dossierResponse->getId());
+        $this->assertNull($dossierResponse->getNumero());
+        $this->assertNull($dossierResponse->getStatutAbrege());
+        $this->assertNull($dossierResponse->getStatut());
+        $this->assertNull($dossierResponse->getEtat());
+        $this->assertNull($dossierResponse->getDateCloture());
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $dossierResponse->getStatusCode());
+        $this->assertNotNull($dossierResponse->getErrorReason());
     }
 }

--- a/tests/Unit/Service/Esabora/EsaboraServiceTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraServiceTest.php
@@ -5,7 +5,6 @@ namespace App\Tests\Unit\Service\Esabora;
 use App\Entity\Affectation;
 use App\Entity\Partner;
 use App\Entity\Signalement;
-use App\Manager\AffectationManager;
 use App\Messenger\Message\DossierMessage;
 use App\Service\Esabora\DossierResponse;
 use App\Service\Esabora\EsaboraService;
@@ -18,7 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EsaboraServiceTest extends KernelTestCase
 {
-    private AffectationManager $affectationManager;
     private LoggerInterface $logger;
 
     protected function setUp(): void


### PR DESCRIPTION
## Ticket 
#773
> Déployé sur https://histologe-staging-pr839.osc-fr1.scalingo.io/

## Description
Jusqu’à maintenant l'envoi des dossiers vers ESABORA lors dune affectation se faisait en synchrone. Des retours d'affectations impossible ont été remontés, il faut permettre l'affectation peu importe si l'envoi des dossiers vers ESABORA échoue ou réussit

> Une refonte a été effectué afin de permettre à terme l'envoi de dossier en asynchrone (voir PR #753) 

## Changements apportés
- Activation du mode asynchrone via le composant messenger 
- Ajout d'un nouveau service docker phpworker afin de dépiler les messages de queue
- Ajout de tache au Makefile afin de gérer le worker
- Mentionner le nombre de signalement synchronisé et non synchronisé dans le mail 
- Meilleure gestion des erreurs
- Activation du worker scalingo 

## Envionnement technique
> Lancer `make build` pour prise en charge du nouveau service docker

### Transport
Queue de message est la table `messenger_messages`

### Worker
```
$ docker compose ps | grep worker
histologe_worker       histologe-histologe_phpworker   "/usr/bin/supervisord"   histologe_phpworker    3 days ago          Up 2 hours               8089/tcp, 9000/tcp
```

Description| Commande
-------|-------
Statut worker | make worker-status
Démarrer worker | make worker-start
Stopper worker | make worker-stop
Consommer les messages dans la pile d'erreur | make worker-exec-failed

### Mock server (ESABORA API)
Description| Commande
-------|-------
Démarrer mock server | make mock
Stopper mock server | make stop-mock


### 

## Tests
- [x] Je peut affecter un partenaire `esabora` à un signalement  peu importe la réponse du service ESABORA
- [x] J'arrete le serveur de mock,  je peut affecter un partenaire `esabora` à un signalement  peu importe la réponse du service ESABORA
- [x] J’arrête le worker, je peut affecter un partenaire `esabora` à un signalement  peu importe la réponse du service ESABORA
- [x] La commande `make console app="sync-esabora"` s’exécute et je reçois bien un e-mail de confirmation
- [x] J’arrête le serveur de mock, la commande `make console app="sync-esabora"` s’exécute et je reçois bien un e-mail de confirmation
- [x] Je vérifie que les événements http succès ou echec sont bien enregistré dans la table `job_event`
- [x] Je vérifie que les messages sont  bien dépilé dans la table `messenger_messages` lorsqu'un message est traité
- [x] Je vérifie que les messages sont bien présent dans la table `messenger_messages` lorsqu'un message est en erreur