### PR TITLE
Continuer à afficher les signalements avec des suivis déclarants (non utilisateur)

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -713,26 +713,49 @@
             <hr class=" fr-mt-5v">
         {% endif %}
         {% for suivi in signalement.suivis|reverse %}
-            <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if 'ROLE_USAGER' in suivi.createdBy.roles %}fr-background-alt--orange-terre-battue{% endif %}">
-                <div class="fr-col-2 {% if suivi.createdBy %}part-infos-hover{% endif %}"
-                     {% if suivi.createdBy %}data-user="{{ suivi.createdBy.nomComplet }}"
-                     data-mail="{{ suivi.createdBy.email }}"{% endif %}>
-                    <strong>{{ suivi.createdBy.nom|upper~' '~ suivi.createdBy.prenom|capitalize }}</strong>
-                    <br>
-                    <small>[{{ 'ROLE_USAGER' in suivi.createdBy.roles ? (suivi.createdBy.email is same as signalement.mailDeclarant ? 'DECLARANT' : 'OCCUPANT') : (suivi.createdBy.partner ? suivi.createdBy.partner.nom : 'Aucun')  }}]</small> <br>
-                    <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
+            {% if suivi.createdBy is not null %}
+                <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if 'ROLE_USAGER' in suivi.createdBy.roles %}fr-background-alt--orange-terre-battue{% endif %}">
+                    <div class="fr-col-2 {% if suivi.createdBy %}part-infos-hover{% endif %}"
+                         {% if suivi.createdBy %}data-user="{{ suivi.createdBy.nomComplet }}"
+                         data-mail="{{ suivi.createdBy.email }}"{% endif %}>
+                        <strong>{{ suivi.createdBy.nom|upper~' '~ suivi.createdBy.prenom|capitalize }}</strong>
+                        <br>
+                        <small>[{{ 'ROLE_USAGER' in suivi.createdBy.roles ? (suivi.createdBy.email is same as signalement.mailDeclarant ? 'DECLARANT' : 'OCCUPANT') : (suivi.createdBy.partner ? suivi.createdBy.partner.nom : 'Aucun')  }}]</small> <br>
+                        <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
+                    </div>
+                    <div class="fr-col-9 bloc-suivi-content-row fr-pl-3v">
+                        {{ suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|raw }}
+                    </div>
+                    <div class="fr-col-1 fr-text--right">
+                        {% if suivi.isPublic %}
+                            <span class="fr-fi-eye-fill" title="Visible par l'usager"></span>
+                        {% else %}
+                            <span class="fr-fi-eye-off-fill" title="Non visible par l'usager"></span>
+                        {% endif %}
+                    </div>
                 </div>
-                <div class="fr-col-9 bloc-suivi-content-row fr-pl-3v">
-                    {{ suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|raw }}
-                </div>
-                <div class="fr-col-1 fr-text--right">
-                    {% if suivi.isPublic %}
-                        <span class="fr-fi-eye-fill" title="Visible par l'usager"></span>
-                    {% else %}
-                        <span class="fr-fi-eye-off-fill" title="Non visible par l'usager"></span>
-                    {% endif %}
-                </div>
-            </div>
+                {% else %}
+                    <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if not suivi.createdBy %}fr-background-alt--orange-terre-battue{% endif %}">
+                        <div class="fr-col-2 {% if suivi.createdBy %}part-infos-hover{% endif %}"
+                             {% if suivi.createdBy %}data-user="{{ suivi.createdBy.nomComplet }}"
+                             data-mail="{{ suivi.createdBy.email }}"{% endif %}>
+                            <strong>{{ suivi.createdBy ? (suivi.createdBy.nom|upper~' '~ suivi.createdBy.prenom|capitalize) : (signalement.nomDeclarant ? signalement.nomDeclarant|upper~' '~signalement.prenomDeclarant|capitalize : signalement.nomOccupant|upper~' '~signalement.prenomOccupant|capitalize) }}</strong>
+                            <br>
+                            <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : 'Aucun') : 'DECLARANT' }}]</small> <br>
+                            <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
+                        </div>
+                        <div class="fr-col-9 bloc-suivi-content-row fr-pl-3v">
+                            {{ suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|raw }}
+                        </div>
+                        <div class="fr-col-1 fr-text--right">
+                            {% if suivi.isPublic %}
+                                <span class="fr-fi-eye-fill" title="Visible par l'usager"></span>
+                            {% else %}
+                                <span class="fr-fi-eye-off-fill" title="Non visible par l'usager"></span>
+                            {% endif %}
+                        </div>
+                    </div>
+            {% endif %}
         {% endfor %}
     </section>
 {% endblock %}

--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -39,14 +39,17 @@
         </td>
         <td>
             {% set suivi = (signalement.lastSuivi) %}
-            {% if suivi %}
+            {% if suivi and suivi.createdBy is not null %}
                 <strong>{{ suivi.createdAt|date('d.m.Y') }}</strong> <br>{% set classe = '' %}
                 {% if 'ROLE_USAGER' in suivi.createdBy.roles %}
                     {% set classe = 'fr-badge fr-badge--warning' %}
                 {% endif %}
                 <small class="{{ classe }}">{{ 'ROLE_USAGER' in suivi.createdBy.roles ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT')  : (suivi.createdBy.partner ? suivi.createdBy.partner.nom : 'Aucun')|upper   }}</small> <br>
                     
-            {% else %}
+            {% elseif suivi and suivi.createdBy is null %}
+                <strong>{{ suivi.createdAt|date('d.m.Y') }}</strong> <br>
+                <small>{{ suivi.createdBy ? suivi.createdBy.partner.nom|upper : '<small class="fr-badge fr-badge--warning">DECLARANT</small>'|raw }}</small>
+                {% else %}
                 Aucun
             {% endif %}
         </td>


### PR DESCRIPTION
## Ticket
#777 

## Description
Les signalements historiques doivent pouvoir s'afficher car la notion d’utilisateur usager n'est pas généralisé pour les suivi.
L'ancien fonctionnement doit continuer à fonctionné s'il n'ya pas d'utilisateur usager rattaché au suivi donc continuer à afficher `DECLARANT` ou `OCCUPANT`

![image](https://user-images.githubusercontent.com/5757116/214879344-9258670d-dae4-4f34-8e99-25b058000541.png)

## Changements apportés
- Mise à jour de la condition sur la liste des signalements
- Mise à jour de la condition sur la page de signalement