### PR TITLE
[CD] Echec déploiement depuis Node 19.6 

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "dev": "encore dev",
     "watch": "encore dev --watch",
     "build": "encore production --progress"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
## Description
La version de node js n'est pas fixé et viens de passer en 19.6 et plante le déploiement
https://dashboard.scalingo.com/apps/osc-fr1/histologe/deploy/5c899908-f38b-460e-aa2f-c5e9122cd8d1

Elle devrait être fixé avec la version LTS (version LTS 18.x)

## Test
https://dashboard.scalingo.com/apps/osc-fr1/histologe-staging-pr878/deploy/583664e1-27f1-48f6-a1d9-751c701276fd