### PR TITLE
 [BO - Suivi] Distinguer les suivis automatiques des suivi utilisateurs 

### DIFF
--- a/migrations/Version20230206075100.php
+++ b/migrations/Version20230206075100.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230206075100 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add "type" to Suivi to differenciate suivi from partners, suivi from usagers and automatical suivi ';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE suivi ADD type INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE suivi DROP type');
+    }
+}

--- a/src/Command/UpdateSuiviTypeCommand.php
+++ b/src/Command/UpdateSuiviTypeCommand.php
@@ -56,39 +56,16 @@ class UpdateSuiviTypeCommand extends Command
     {
         $description = $suivi->getDescription();
 
-        if ('Signalement validé' === $description) {
-            return true;
-        }
-
-        if ('Le signalement a été accepté' === $description) {
-            return true;
-        }
-
-        if ('Modification du signalement par un partenaire' === $description) {
-            return true;
-        }
-
-        if (0 === strpos($description, 'Le signalement à été refusé avec le motif suivant:')) {
-            return true;
-        }
-
-        if (0 === strpos($description, 'Signalement rouvert pour ')) {
-            return true;
-        }
-
-        if (0 === strpos($description, 'Signalement cloturé car non-valide avec le motif suivant :')) {
-            return true;
-        }
-
-        if (preg_match('/Ajout de(.*)au signalement(.*)/', $description)) {
-            return true;
-        }
-
-        if (preg_match('/Le signalement à été cloturé pour (.*)avec le motif suivant (.*)/', $description)) {
-            return true;
-        }
-
-        if (preg_match('/Signalement (.*)via Esabora(.*)par(.*)/', $description)) {
+        if ('Signalement validé' === $description
+        || 'Le signalement a été accepté' === $description
+        || 'Modification du signalement par un partenaire' === $description
+        || 0 === strpos($description, 'Le signalement à été refusé avec le motif suivant:')
+        || 0 === strpos($description, 'Signalement rouvert pour ')
+        || 0 === strpos($description, 'Signalement cloturé car non-valide avec le motif suivant :')
+        || preg_match('/Ajout de(.*)au signalement(.*)/', $description)
+        || preg_match('/Le signalement à été cloturé pour (.*)avec le motif suivant (.*)/', $description)
+        || preg_match('/Signalement (.*)via Esabora(.*)par(.*)/', $description)
+        ) {
             return true;
         }
 

--- a/src/Command/UpdateSuiviTypeCommand.php
+++ b/src/Command/UpdateSuiviTypeCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Suivi;
+use App\Manager\SuiviManager;
+use App\Repository\SuiviRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:suivi-type-update',
+    description: 'Update Suivi type when null',
+)]
+class UpdateSuiviTypeCommand extends Command
+{
+    public function __construct(private SuiviManager $suiviManager)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var SuiviRepository $suiviRepository */
+        $suiviRepository = $this->suiviManager->getRepository();
+        $suivis = $suiviRepository->findBy([
+            'type' => 0,
+        ]);
+
+        $count = 0;
+        /** @var Suivi $suivi */
+        foreach ($suivis as $suivi) {
+            if (null === $suivi->getCreatedBy() || \in_array('ROLE_USAGER', $suivi->getCreatedBy()->getRoles())) {
+                $suivi->setType(Suivi::TYPE_USAGER);
+            } elseif ($this->isSuiviAuto($suivi)) {
+                $suivi->setType(Suivi::TYPE_AUTO);
+            } else {
+                $suivi->setType(Suivi::TYPE_PARTNER);
+            }
+            $this->suiviManager->save($suivi, false);
+            ++$count;
+        }
+        $this->suiviManager->flush();
+
+        $io->success(sprintf('%s suivis updated', $count));
+
+        return Command::SUCCESS;
+    }
+
+    private function isSuiviAuto(Suivi $suivi): bool
+    {
+        $description = $suivi->getDescription();
+
+        if ('Signalement validé' === $description) {
+            return true;
+        }
+
+        if ('Le signalement a été accepté' === $description) {
+            return true;
+        }
+
+        if ('Modification du signalement par un partenaire' === $description) {
+            return true;
+        }
+
+        if (0 === strpos($description, 'Le signalement à été refusé avec le motif suivant:')) {
+            return true;
+        }
+
+        if (0 === strpos($description, 'Signalement rouvert pour ')) {
+            return true;
+        }
+
+        if (0 === strpos($description, 'Signalement cloturé car non-valide avec le motif suivant :')) {
+            return true;
+        }
+
+        if (preg_match('/Ajout de(.*)au signalement(.*)/', $description)) {
+            return true;
+        }
+
+        if (preg_match('/Le signalement à été cloturé pour (.*)avec le motif suivant (.*)/', $description)) {
+            return true;
+        }
+
+        if (preg_match('/Signalement (.*)via Esabora(.*)par(.*)/', $description)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Controller/Back/BackSignalementActionController.php
+++ b/src/Controller/Back/BackSignalementActionController.php
@@ -71,6 +71,7 @@ class BackSignalementActionController extends AbstractController
             $suivi->setDescription('Signalement '.$description);
             $suivi->setCreatedBy($this->getUser());
             $suivi->setIsPublic(true);
+            $suivi->setType(SUIVI::TYPE_AUTO);
             $signalement->setStatut($statut);
             $doctrine->getManager()->persist($signalement);
             $doctrine->getManager()->persist($suivi);
@@ -98,6 +99,7 @@ class BackSignalementActionController extends AbstractController
             $suivi->setIsPublic($form['isPublic']);
             $suivi->setSignalement($signalement);
             $suivi->setCreatedBy($this->getUser());
+            $suivi->setType(SUIVI::TYPE_PARTNER);
             $doctrine->getManager()->persist($suivi);
             $doctrine->getManager()->flush();
             $this->addFlash('success', 'Suivi publié avec succès !');
@@ -137,6 +139,7 @@ class BackSignalementActionController extends AbstractController
             $suivi->setDescription('Signalement rouvert pour '.$reopenFor);
             $suivi->setCreatedBy($this->getUser());
             $suivi->setIsPublic(true);
+            $suivi->setType(SUIVI::TYPE_AUTO);
             $doctrine->getManager()->persist($suivi);
             $doctrine->getManager()->flush();
             $this->addFlash('success', 'Signalement rouvert avec succés !');

--- a/src/Controller/Back/BackSignalementController.php
+++ b/src/Controller/Back/BackSignalementController.php
@@ -31,13 +31,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class BackSignalementController extends AbstractController
 {
     #[Route('/{uuid}', name: 'back_signalement_view')]
-    public function viewSignalement(Signalement $signalement,
-                                    Request $request,
-                                    EntityManagerInterface $entityManager,
-                                    TagRepository $tagsRepository,
-                                    PartnerRepository $partnerRepository,
-                                    SignalementManager $signalementManager,
-                                    EventDispatcherInterface $eventDispatcher
+    public function viewSignalement(
+        Signalement $signalement,
+        Request $request,
+        EntityManagerInterface $entityManager,
+        TagRepository $tagsRepository,
+        PartnerRepository $partnerRepository,
+        SignalementManager $signalementManager,
+        EventDispatcherInterface $eventDispatcher
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_VIEW', $signalement);
         if (Signalement::STATUS_ARCHIVED === $signalement->getStatut()) {
@@ -171,6 +172,7 @@ class BackSignalementController extends AbstractController
                 $suivi->setSignalement($signalement);
                 $suivi->setIsPublic(false);
                 $suivi->setDescription('Modification du signalement par un partenaire');
+                $suivi->setType(SUIVI::TYPE_AUTO);
                 $doctrine->getManager()->persist($suivi);
                 $signalement->setGeoloc($form->getExtraData()['geoloc']);
                 $signalement->setInseeOccupant($form->getExtraData()['inseeOccupant']);

--- a/src/Controller/Back/BackSignalementFileController.php
+++ b/src/Controller/Back/BackSignalementFileController.php
@@ -60,8 +60,8 @@ class BackSignalementFileController extends AbstractController
         ManagerRegistry $doctrine,
         SluggerInterface $slugger,
         LoggerInterface $logger,
-        UploadHandlerService $uploadHandler): RedirectResponse
-    {
+        UploadHandlerService $uploadHandler
+    ): RedirectResponse {
         $this->denyAccessUnlessGranted('FILE_CREATE', $signalement);
         if ($this->isCsrfTokenValid('signalement_add_file_'.$signalement->getId(), $request->get('_token'))
             && $files = $request->files->get('signalement-add-file')) {
@@ -94,8 +94,10 @@ class BackSignalementFileController extends AbstractController
                     $this->addFlash('error', $exception->getMessage());
                 }
                 if (!empty($newFilename)) {
-                    $list[] = '<li><a class="fr-link" target="_blank" href="'.$this->generateUrl('show_uploaded_file',
-                        ['folder' => '_up', 'filename' => $newFilename]).'">'.$titre.'</a></li>';
+                    $list[] = '<li><a class="fr-link" target="_blank" href="'.$this->generateUrl(
+                        'show_uploaded_file',
+                        ['folder' => '_up', 'filename' => $newFilename]
+                    ).'">'.$titre.'</a></li>';
                     if (null === $type_list) {
                         $type_list = [];
                     }
@@ -114,6 +116,7 @@ class BackSignalementFileController extends AbstractController
                 $suivi->setCreatedBy($this->getUser());
                 $suivi->setDescription('Ajout de '.$type.' au signalement<ul>'.implode('', $list).'</ul>');
                 $suivi->setSignalement($signalement);
+                $suivi->setType(SUIVI::TYPE_AUTO);
                 $signalement->$setMethod($type_list);
                 $doctrine->getManager()->persist($suivi);
                 $doctrine->getManager()->persist($signalement);
@@ -134,8 +137,8 @@ class BackSignalementFileController extends AbstractController
         string $filename,
         Request $request,
         ManagerRegistry $doctrine,
-        FilesystemOperator $fileStorage): JsonResponse
-    {
+        FilesystemOperator $fileStorage
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('FILE_DELETE', $signalement);
         if ($this->isCsrfTokenValid('signalement_delete_file_'.$signalement->getId(), $request->get('_token'))) {
             $setMethod = 'set'.ucfirst($type);

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -257,6 +257,7 @@ class FrontSignalementController extends AbstractController
                 $email = $request->get('signalement_front_response')['email'];
                 $user = $userRepository->findOneBy(['email' => $email]);
                 $suivi->setCreatedBy($user);
+                $suivi->setType(Suivi::TYPE_USAGER);
 
                 $description = nl2br(filter_var($request->get('signalement_front_response')['content'], \FILTER_SANITIZE_STRING));
                 $files_array = [

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -4,33 +4,40 @@ suivis:
   description: "Signalement validé"
   is_public: 1
   signalement: "2022-1"
+  type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
   is_public: 1
   signalement: "2022-2"
+  type: 1
 -
   created_by: admin-territoire-13-01@histologe.fr
   description: "Signalement validé"
   is_public: 1
   signalement: "2022-3"
+  type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
   is_public: 1
   signalement: "2022-4"
+  type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
   is_public: 0
   signalement: "2022-5"
+  type: 1
 -
   created_by: admin-territoire-13-01@histologe.fr
   description: "Le signalement à été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
   is_public: 0
   signalement: "2022-3"
+  type: 1
 -
   created_by: null
   description: "Bonjour, j'ai toujours le problème, quand vais-je avoir une visite ?"
   is_public: 1
   signalement: "2022-4"
+  type: 2

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -34,7 +34,8 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
             ->setDescription($row['description'])
             ->setCreatedBy($this->userRepository->findOneBy(['email' => $row['created_by']]))
             ->setIsPublic($row['is_public'])
-            ->setCreatedAt(new \DateTimeImmutable());
+            ->setCreatedAt(new \DateTimeImmutable())
+            ->setType($row['type']);
 
         $manager->persist($suivi);
     }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -9,6 +9,10 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: SuiviRepository::class)]
 class Suivi
 {
+    public const TYPE_AUTO = 1;
+    public const TYPE_USAGER = 2;
+    public const TYPE_PARTNER = 3;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
@@ -26,6 +30,9 @@ class Suivi
 
     #[ORM\Column(type: 'boolean')]
     private $isPublic;
+
+    #[ORM\Column(type: 'integer')]
+    private $type;
 
     #[ORM\ManyToOne(targetEntity: Signalement::class, inversedBy: 'suivis')]
     #[ORM\JoinColumn(nullable: false)]
@@ -98,6 +105,18 @@ class Suivi
     public function setSignalement(?Signalement $signalement): self
     {
         $this->signalement = $signalement;
+
+        return $this;
+    }
+
+    public function getType(): ?int
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
 
         return $this;
     }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -114,7 +114,7 @@ class Suivi
         return $this->type;
     }
 
-    public function setType($type)
+    public function setType(int $type): self
     {
         $this->type = $type;
 

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -31,7 +31,10 @@ class SuiviFactory
             return SUIVI::TYPE_USAGER;
         }
 
-        if (isset($params['motif_cloture']) || isset($params['accept']) || isset($params['suivi']) || (isset($params['domain']) && 'esabora' === $params['domain'])) {
+        if (isset($params['motif_cloture'])
+        || isset($params['accept'])
+        || isset($params['suivi'])
+        || (isset($params['domain']) && 'esabora' === $params['domain'])) {
             return SUIVI::TYPE_AUTO;
         }
 

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -31,8 +31,7 @@ class SuiviFactory
             return SUIVI::TYPE_USAGER;
         }
 
-        if (isset($params['motif_cloture'])
-        || isset($params['accept'])
+        if (isset($params['accept'])
         || isset($params['suivi'])
         || (isset($params['domain']) && 'esabora' === $params['domain'])) {
             return SUIVI::TYPE_AUTO;

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -19,9 +19,23 @@ class SuiviFactory
             ->setCreatedBy($user)
             ->setSignalement($signalement)
             ->setDescription($this->buildDescription($params))
+            ->setType($this->buildType($user, $params))
             ->setIsPublic($isPublic);
 
         return $suivi;
+    }
+
+    private function buildType(?User $user, array $params): string
+    {
+        if ($user && \in_array('ROLE_USAGER', $user->getRoles())) {
+            return SUIVI::TYPE_USAGER;
+        }
+
+        if (isset($params['motif_cloture']) || isset($params['accept']) || isset($params['suivi']) || (isset($params['domain']) && 'esabora' === $params['domain'])) {
+            return SUIVI::TYPE_AUTO;
+        }
+
+        return SUIVI::TYPE_PARTNER;
     }
 
     private function buildDescription($params): string

--- a/tests/Functional/Controller/BackAssignmentControllerTest.php
+++ b/tests/Functional/Controller/BackAssignmentControllerTest.php
@@ -53,6 +53,7 @@ class BackAssignmentControllerTest extends WebTestCase
 
         $this->assertEmailCount(1);
         $this->assertTrue(str_contains($suivi->getDescription(), 'Cela ne me concerne pas, voir avec un autre organisme'));
+        $this->assertEquals(Suivi::TYPE_AUTO, $suivi->getType());
         $this->assertResponseRedirects('/bo/s/'.$signalement->getUuid());
     }
 

--- a/tests/Functional/FormHandler/ContactFormHandlerTest.php
+++ b/tests/Functional/FormHandler/ContactFormHandlerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\FormHandler;
 
 use App\Entity\Signalement;
+use App\Entity\Suivi;
 use App\Factory\SuiviFactory;
 use App\FormHandler\ContactFormHandler;
 use App\Manager\SignalementManager;
@@ -60,6 +61,7 @@ class ContactFormHandlerTest extends KernelTestCase
         $suivis = $signalement->getSuivis();
         $suivi = $suivis->last();
         $this->assertEquals($fakeMessage.ContactFormHandler::MENTION_SENT_BY_EMAIL, $suivi->getDescription());
+        $this->assertEquals(Suivi::TYPE_USAGER, $suivi->getType());
     }
 
     public function testHandleContactFormForDeclarant()
@@ -79,5 +81,6 @@ class ContactFormHandlerTest extends KernelTestCase
         $suivis = $signalement->getSuivis();
         $suivi = $suivis->last();
         $this->assertEquals($fakeMessage.ContactFormHandler::MENTION_SENT_BY_EMAIL, $suivi->getDescription());
+        $this->assertEquals(Suivi::TYPE_USAGER, $suivi->getType());
     }
 }

--- a/tests/Functional/Manager/AffectationManagerTest.php
+++ b/tests/Functional/Manager/AffectationManagerTest.php
@@ -116,6 +116,7 @@ class AffectationManagerTest extends KernelTestCase
         $suivi = $signalement->getSuivis()->last();
         $this->assertStringContainsString($suiviDescription, $suivi->getDescription());
         $this->assertFalse($suivi->getIsPublic());
+        $this->assertEquals(Suivi::TYPE_AUTO, $suivi->getType());
 
         /** @var Affectation $affectationUpdated */
         $affectationUpdated = $signalement->getAffectations()->get(0);

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -51,6 +51,7 @@ class SuiviManagerTest extends KernelTestCase
         $signalement->addSuivi($suivi);
         $countSuivisAfterCreate = $signalement->getSuivis()->count();
 
+        $this->assertEquals(Suivi::TYPE_AUTO, $suivi->getType());
         $this->assertNotEquals($countSuivisBeforeCreate, $countSuivisAfterCreate);
     }
 

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -51,7 +51,7 @@ class SuiviManagerTest extends KernelTestCase
         $signalement->addSuivi($suivi);
         $countSuivisAfterCreate = $signalement->getSuivis()->count();
 
-        $this->assertEquals(Suivi::TYPE_AUTO, $suivi->getType());
+        $this->assertEquals(Suivi::TYPE_PARTNER, $suivi->getType());
         $this->assertNotEquals($countSuivisBeforeCreate, $countSuivisAfterCreate);
     }
 

--- a/tests/Unit/Entity/SuiviTest.php
+++ b/tests/Unit/Entity/SuiviTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Manager\UserManager;
+use Faker\Factory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+class SuiviTest extends KernelTestCase
+{
+    public function testCreateSuiviUsager(): void
+    {
+        self::bootKernel();
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+        $validator = self::getContainer()->get('validator');
+
+        // $territory = $entityManager->getRepository(Territory::class)->find(1);
+        $faker = Factory::create();
+
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->find(1);
+        $userManager = self::getContainer()->get(UserManager::class);
+
+        $userOccupant = $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
+
+        $suivi = (new Suivi())
+        ->setCreatedBy($userOccupant)
+        ->setSignalement($signalement)
+        ->setDescription($faker->text())
+        ->setType(Suivi::TYPE_USAGER)
+        ->setIsPublic(true);
+
+        /** @var ConstraintViolationList $errors */
+        $errors = $validator->validate($suivi);
+        $this->assertEquals(0, $errors->count());
+    }
+}

--- a/tests/Unit/Entity/SuiviTest.php
+++ b/tests/Unit/Entity/SuiviTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Signalement;
 use App\Entity\Suivi;
+use App\Entity\User;
 use App\Manager\UserManager;
 use Faker\Factory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -17,13 +18,13 @@ class SuiviTest extends KernelTestCase
         $entityManager = self::getContainer()->get('doctrine')->getManager();
         $validator = self::getContainer()->get('validator');
 
-        // $territory = $entityManager->getRepository(Territory::class)->find(1);
         $faker = Factory::create();
 
         /** @var Signalement $signalement */
         $signalement = $entityManager->getRepository(Signalement::class)->find(1);
         $userManager = self::getContainer()->get(UserManager::class);
 
+        /** @var User $userOccupant */
         $userOccupant = $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
 
         $suivi = (new Suivi())

--- a/tests/Unit/Factory/SuiviFactoryTest.php
+++ b/tests/Unit/Factory/SuiviFactoryTest.php
@@ -41,7 +41,8 @@ class SuiviFactoryTest extends KernelTestCase
         $signalement = $this->createMock(Signalement::class);
         $suivi = $suiviFactory->createInstanceFrom(
             $this->security->getUser(),
-            $signalement, [
+            $signalement,
+            [
                 'motif_suivi' => 'Lorem ipsum suivi sit amet, consectetur adipiscing elit.',
                 'motif_cloture' => MotifCloture::LABEL['INSALUBRITE'],
                 'subject' => 'tous les partenaires',
@@ -52,6 +53,7 @@ class SuiviFactoryTest extends KernelTestCase
 
         $this->assertInstanceOf(Suivi::class, $suivi);
         $this->assertTrue($suivi->getIsPublic());
+        $this->assertEquals(Suivi::TYPE_AUTO, $suivi->getType());
         $this->assertInstanceOf(UserInterface::class, $suivi->getCreatedBy());
         $this->assertTrue(str_contains($suivi->getDescription(), MotifCloture::LABEL['INSALUBRITE']));
         $this->assertTrue(str_contains($suivi->getDescription(), 'Le signalement à été cloturé pour'));

--- a/tests/Unit/Factory/SuiviFactoryTest.php
+++ b/tests/Unit/Factory/SuiviFactoryTest.php
@@ -53,7 +53,7 @@ class SuiviFactoryTest extends KernelTestCase
 
         $this->assertInstanceOf(Suivi::class, $suivi);
         $this->assertTrue($suivi->getIsPublic());
-        $this->assertEquals(Suivi::TYPE_AUTO, $suivi->getType());
+        $this->assertEquals(Suivi::TYPE_PARTNER, $suivi->getType());
         $this->assertInstanceOf(UserInterface::class, $suivi->getCreatedBy());
         $this->assertTrue(str_contains($suivi->getDescription(), MotifCloture::LABEL['INSALUBRITE']));
         $this->assertTrue(str_contains($suivi->getDescription(), 'Le signalement à été cloturé pour'));


### PR DESCRIPTION
## Ticket

#867    

## Description
Ajout d'un type sur les suivis. Ce type peut avoir 3 valeurs : 

-     suivi automatique
-     suivi usager
-     suivi partenaire

```
    public const TYPE_AUTO = 1;
    public const TYPE_USAGER = 2;
    public const TYPE_PARTNER = 3;
```

## Changements apportés
* Ajout d'une nouvelle colonne type sur la table Suivi, et création de la migration
* Définition de la valeur du type à tous les endroits où on créé un suivi (notamment dans le SuiviFactory)
* Création d'une commande pour mettre à jour le type pour tous les suivis existants `app:suivi-type-update`

## Tests
- [x] Mettre à jour la table en lançant la dernière migration, vérifier que la table a bien une nouvelle colonne
- [x] Lancer la commande  `app:suivi-type-update` et vérifier en base que les types des suivis ont été définis logiquement
- [x] Créer un suivi en tant que partenaire, et vérifier la valeur du type en base
- [x] Créer un suivi en tant qu'usager et vérifier la valeur du type en base
- [x] Rouvrir un signalement fermé et vérifier que le nouveau suivi a bien la valeur 1 correspondant à TYPE_AUTO
- 