### PR TITLE
[FO - Signalement] Permettre les dépôts de signalement pour le territoire Haute Corse

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -173,7 +173,7 @@ class FrontSignalementController extends AbstractController
             if (!empty($signalement->getCpOccupant())) {
                 $signalement->setTerritory(
                     $territoryRepository->findOneBy([
-                    'zip' => $postalCodeHomeChecker->mapZip($signalement->getCpOccupant()), 'isActive' => 1, ])
+                    'zip' => $postalCodeHomeChecker->getZipCode($signalement->getCpOccupant()), 'isActive' => 1, ])
                 );
             }
 

--- a/src/DataFixtures/Files/Territory.yml
+++ b/src/DataFixtures/Files/Territory.yml
@@ -102,7 +102,7 @@ territories:
   -
     zip: "2B"
     name: "Haute-Corse"
-    is_active: 0
+    is_active: 1
     bbox: "{\"n\":\"43.027678\",\"e\":\"9.560096\",\"s\":\"41.832168\",\"w\":\"8.573307\"}"
   -
     zip: "21"

--- a/src/Service/Signalement/PostalCodeHomeChecker.php
+++ b/src/Service/Signalement/PostalCodeHomeChecker.php
@@ -7,8 +7,8 @@ use App\Repository\TerritoryRepository;
 
 class PostalCodeHomeChecker
 {
-    public const CDRSE_DU_SUD_CODE_DEPARTMENT_2A = '2A';
-    public const HAUTE_CDRSE_CODE_DEPARTMENT_2B = '2B';
+    public const CORSE_DU_SUD_CODE_DEPARTMENT_2A = '2A';
+    public const HAUTE_CORSE_CODE_DEPARTMENT_2B = '2B';
     public const LA_REUNION_CODE_DEPARTMENT_974 = '974';
 
     public function __construct(private TerritoryRepository $territoryRepository)
@@ -38,8 +38,8 @@ class PostalCodeHomeChecker
         $zipChunk = substr($postalCode, 0, 3);
 
         return match ($zipChunk) {
-            '200', '201' => self::CDRSE_DU_SUD_CODE_DEPARTMENT_2A,
-            '202', '206' => self::HAUTE_CDRSE_CODE_DEPARTMENT_2B,
+            '200', '201' => self::CORSE_DU_SUD_CODE_DEPARTMENT_2A,
+            '202', '206' => self::HAUTE_CORSE_CODE_DEPARTMENT_2B,
             '974' => self::LA_REUNION_CODE_DEPARTMENT_974,
             default => substr($postalCode, 0, 2),
         };

--- a/src/Service/Signalement/PostalCodeHomeChecker.php
+++ b/src/Service/Signalement/PostalCodeHomeChecker.php
@@ -7,9 +7,9 @@ use App\Repository\TerritoryRepository;
 
 class PostalCodeHomeChecker
 {
-    public const CORSE_DEPARTMENT = ['20' => '2A'];
-
-    public const DOM_TOM_START_WITH_97 = '97';
+    public const CDRSE_DU_SUD_CODE_DEPARTMENT_2A = '2A';
+    public const HAUTE_CDRSE_CODE_DEPARTMENT_2B = '2B';
+    public const LA_REUNION_CODE_DEPARTMENT_974 = '974';
 
     public function __construct(private TerritoryRepository $territoryRepository)
     {
@@ -18,7 +18,7 @@ class PostalCodeHomeChecker
     public function isActive(string $postalCode, string $inseeCode = ''): bool
     {
         $territoryItem = $this->territoryRepository->findOneBy([
-            'zip' => $this->mapZip($postalCode),
+            'zip' => $this->getZipCode($postalCode),
             'isActive' => 1,
         ]);
 
@@ -33,11 +33,16 @@ class PostalCodeHomeChecker
         return false;
     }
 
-    public function mapZip(string $postalCode): string
+    public function getZipCode(string $postalCode): string
     {
-        $zip = substr($postalCode, 0, str_starts_with($postalCode, self::DOM_TOM_START_WITH_97) ? 3 : 2);
+        $zipChunk = substr($postalCode, 0, 3);
 
-        return \array_key_exists($zip, self::CORSE_DEPARTMENT) ? self::CORSE_DEPARTMENT[$zip] : $zip;
+        return match ($zipChunk) {
+            '200', '201' => self::CDRSE_DU_SUD_CODE_DEPARTMENT_2A,
+            '202', '206' => self::HAUTE_CDRSE_CODE_DEPARTMENT_2B,
+            '974' => self::LA_REUNION_CODE_DEPARTMENT_974,
+            default => substr($postalCode, 0, 2),
+        };
     }
 
     public function isAuthorizedInseeCode(Territory $territory, string $inseeCode)

--- a/tests/Functional/Controller/FrontSignalementControllerTest.php
+++ b/tests/Functional/Controller/FrontSignalementControllerTest.php
@@ -93,6 +93,13 @@ class FrontSignalementControllerTest extends WebTestCase
                 'geoloc' => ['lat' => 47.324467, 'lng' => 5.039006],
                 'inseeOccupant' => '21231',
             ]],
+            'Bastia' => [[
+                'adresseOccupant' => '2 rue de la marine',
+                'villeOccupant' => 'Bastia',
+                'cpOccupant' => '20200',
+                'geoloc' => ['lat' => 42.70278, 'lng' => 9.45],
+                'inseeOccupant' => '2B033',
+            ]],
         ];
     }
 

--- a/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
+++ b/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
@@ -63,19 +63,19 @@ class PostalCodeHomeCheckerTest extends KernelTestCase
     public function testGetZipCodeTerritory(): void
     {
         $this->assertEquals(
-            PostalCodeHomeChecker::CDRSE_DU_SUD_CODE_DEPARTMENT_2A,
+            PostalCodeHomeChecker::CORSE_DU_SUD_CODE_DEPARTMENT_2A,
             $this->postalCodeHomeChecker->getZipCode('20167'),
         );
         $this->assertEquals(
-            PostalCodeHomeChecker::CDRSE_DU_SUD_CODE_DEPARTMENT_2A,
+            PostalCodeHomeChecker::CORSE_DU_SUD_CODE_DEPARTMENT_2A,
             $this->postalCodeHomeChecker->getZipCode('20000'),
         );
         $this->assertEquals(
-            PostalCodeHomeChecker::HAUTE_CDRSE_CODE_DEPARTMENT_2B,
+            PostalCodeHomeChecker::HAUTE_CORSE_CODE_DEPARTMENT_2B,
             $this->postalCodeHomeChecker->getZipCode('20200')
         );
         $this->assertEquals(
-            PostalCodeHomeChecker::HAUTE_CDRSE_CODE_DEPARTMENT_2B,
+            PostalCodeHomeChecker::HAUTE_CORSE_CODE_DEPARTMENT_2B,
             $this->postalCodeHomeChecker->getZipCode('20600')
         );
         $this->assertEquals(

--- a/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
+++ b/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class PostalCodeHomeCheckerTest extends KernelTestCase
 {
-    private $postalCodeHomeChecker;
+    private ?PostalCodeHomeChecker $postalCodeHomeChecker;
 
     protected function setUp(): void
     {
@@ -58,5 +58,33 @@ class PostalCodeHomeCheckerTest extends KernelTestCase
         $territory = $territoryRepository->findOneBy(['id' => 70]);
         $territory->setAuthorizedCodesInsee(['69091']);
         $this->assertFalse($this->postalCodeHomeChecker->isAuthorizedInseeCode($territory, '69092'));
+    }
+
+    public function testGetZipCodeTerritory(): void
+    {
+        $this->assertEquals(
+            PostalCodeHomeChecker::CDRSE_DU_SUD_CODE_DEPARTMENT_2A,
+            $this->postalCodeHomeChecker->getZipCode('20167'),
+        );
+        $this->assertEquals(
+            PostalCodeHomeChecker::CDRSE_DU_SUD_CODE_DEPARTMENT_2A,
+            $this->postalCodeHomeChecker->getZipCode('20000'),
+        );
+        $this->assertEquals(
+            PostalCodeHomeChecker::HAUTE_CDRSE_CODE_DEPARTMENT_2B,
+            $this->postalCodeHomeChecker->getZipCode('20200')
+        );
+        $this->assertEquals(
+            PostalCodeHomeChecker::HAUTE_CDRSE_CODE_DEPARTMENT_2B,
+            $this->postalCodeHomeChecker->getZipCode('20600')
+        );
+        $this->assertEquals(
+            PostalCodeHomeChecker::LA_REUNION_CODE_DEPARTMENT_974,
+            $this->postalCodeHomeChecker->getZipCode('97400')
+        );
+        $this->assertEquals(
+            '13',
+            $this->postalCodeHomeChecker->getZipCode('13002')
+        );
     }
 }


### PR DESCRIPTION
## Ticket

#890    

## Description
Modification nécessaire afin d'ouvrir le territoire de la haute corse.

La Haute corse et la corse du sud ont des code postaux qui commencent par 20. 
https://www.annuaire-administration.com/code-postal/departement/haute-corse.html
https://www.annuaire-administration.com/code-postal/departement/corse-du-sud.html

## Changements apportés
* Modification de l'algorithme permettant de retourner le code zip territoire.

## Tests
- [ ] Créer un signalement avec un code postal de la Haute corse
- [ ] Créer un signalement avec un code postal de la Corse du sud 
- [ ] Créer un signalement avec un code postal de la Réunion
- [ ] Créer un signalement avec un code postal d'un territoire ouvert 
