### PR TITLE
[BO - Tableau de bord][Backend] Liens avec le filtre territoire pour les widget card - ROLE_ADMIN

### DIFF
--- a/src/Controller/Back/BackCartographieController.php
+++ b/src/Controller/Back/BackCartographieController.php
@@ -16,12 +16,15 @@ use Symfony\Component\Routing\Annotation\Route;
 #[Route('/bo/cartographie')]
 class BackCartographieController extends AbstractController
 {
+    public function __construct(private SearchFilterService $searchFilterService)
+    {
+    }
+
     #[Route('/', name: 'back_cartographie')]
     public function index(SignalementRepository $signalementRepository, TagRepository $tagsRepository, Request $request, CritereRepository $critereRepository, TerritoryRepository $territoryRepository, PartnerRepository $partnerRepository): Response
     {
         $title = 'Cartographie';
-        $searchService = new SearchFilterService();
-        $filters = $searchService->setRequest($request)->setFilters()->getFilters();
+        $filters = $this->searchFilterService->setRequest($request)->setFilters()->getFilters();
         if (!$this->isGranted('ROLE_ADMIN_TERRITORY')) {
             $user = $this->getUser();
         }

--- a/src/Controller/Back/BackController.php
+++ b/src/Controller/Back/BackController.php
@@ -46,11 +46,11 @@ class BackController extends AbstractController
         Request $request,
         AffectationRepository $affectationRepository,
         PartnerRepository $partnerRepository,
+        SearchFilterService $searchFilterService,
         TagRepository $tagsRepository): Response
     {
         $title = 'Administration - Tableau de bord';
-        $searchService = new SearchFilterService();
-        $filters = $searchService->setRequest($request)->setFilters()->getFilters();
+        $filters = $searchFilterService->setRequest($request)->setFilters()->getFilters();
         /** @var User $user */
         $user = $this->getUser();
         $territory = $user->getTerritory(); // If user is not admin, he can only see his territory

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -25,12 +25,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class AffectationRepository extends ServiceEntityRepository
 {
     public const ARRAY_LIST_PAGE_SIZE = 30;
-    private SearchFilterService $searchFilterService;
 
-    public function __construct(ManagerRegistry $registry)
+    public function __construct(ManagerRegistry $registry, private SearchFilterService $searchFilterService)
     {
         parent::__construct($registry, Affectation::class);
-        $this->searchFilterService = new SearchFilterService();
     }
 
     public function countByStatusForUser($user, Territory|null $territory)

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -34,12 +34,12 @@ class SignalementRepository extends ServiceEntityRepository
     public const ARRAY_LIST_PAGE_SIZE = 30;
     public const MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result, the query findAllWithGeoData should be reviewed
 
-    private SearchFilterService $searchFilterService;
-
-    public function __construct(ManagerRegistry $registry, private array $params)
-    {
+    public function __construct(
+        ManagerRegistry $registry,
+        private SearchFilterService $searchFilterService,
+        private array $params
+    ) {
         parent::__construct($registry, Signalement::class);
-        $this->searchFilterService = new SearchFilterService();
     }
 
     public function findAllWithGeoData($user, $options, int $offset, Territory|null $territory): array

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -115,6 +115,7 @@ class WidgetDataKpiBuilder
             $widgetParams = $this->parameters[$key];
             $link = $widgetParams['link'] ?? null;
             $label = $widgetParams['label'] ?? null;
+            $widgetParams['params']['territory_id'] = $this->territory?->getId();
             $parameters = array_merge($linkParameters, $widgetParams['params'] ?? []);
             $widgetCard = $this->widgetCardFactory->createInstance($label, $count, $link, $parameters);
             $this->widgetCards[$key] = $widgetCard;

--- a/src/Service/SearchFilterService.php
+++ b/src/Service/SearchFilterService.php
@@ -6,11 +6,16 @@ use DateInterval;
 use DateTime;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Security;
 
 class SearchFilterService
 {
     private array $filters;
     private Request $request;
+
+    public function __construct(private Security $security)
+    {
+    }
 
     public function setRequest(Request $request): static
     {
@@ -58,6 +63,11 @@ class SearchFilterService
 
         if (null !== $partners = $request->query->get('partners')) {
             $this->filters['partners'] = [$partners];
+        }
+
+        if ($this->security->isGranted('ROLE_ADMIN')
+            && null !== $territory = $request->query->get('territory_id')) {
+            $this->filters['territories'] = [$territory];
         }
 
         return $this;


### PR DESCRIPTION
## Ticket

#785    

## Description
L'API doit pouvoir fournir des liens qui permettent de filtrer les signalements par territoires
Voir commentaire https://github.com/MTES-MCT/histologe/pull/875#discussion_r1102624544

## Changements apportés
* Prise en charge de l'injection de dépendance pour le service SearchFilterService
* Ajout du territoire_id dans les paramètre du widget

## Tests
- [ ] Se connecter en tant qu'admin et se rendre vous sur l'url http://localhost:8080/bo/widget/data-kpi?territory=1
- [ ] Cliquer sur le lien d'un des widget afin de vérifier que les signalement soient bien filtré par territoire

```json
{
  "type": "data-kpi",
  "territory": {
    "id": 1,
    "zip": "01",
    "name": "Ain"
  },
  "parameters": null,
  "data": {
    "widgetCards": {
      "cardNouveauxSignalements": {
        "label": "Nouveaux signalements",
        "count": 1,
        "link": "http://localhost:8080/bo/?status_signalement=1&territory_id=1"
      },
      "cardCloturesPartenaires": {
        "label": "Clotures partenaires",
        "count": 0,
        "link": null
      },
      "cardCloturesGlobales": {
        "label": "Clôtures globales",
        "count": 4,
        "link": "http://localhost:8080/bo/?status_signalement=6&territory_id=1"
      }
    },
    "countSignalement": {
      "total": 5,
      "new": 1,
      "active": 0,
      "closed": 4,
      "refused": 0,
      "percentage": {
        "new": 20,
        "active": 0,
        "closed": 80,
        "refused": 0
      },
      "closedByAtLeastOnePartner": 0,
      "affected": 0
    },
    "countSuivi": {
      "average": 1,
      "partner": 0,
      "usager": 0
    },
    "countUser": {
      "active": 4,
      "inactive": 3,
      "percentage": {
        "active": 57.1,
        "inactive": 42.9
      }
    }
  }
}

```
