### PR TITLE
[BO - Tableau de bord] Ajout widgets suivi 

### DIFF
--- a/assets/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -185,7 +185,6 @@ export default defineComponent({
       }
     },
     handleSignalementsNoSuivi (requestResponse: any) {
-      console.log(requestResponse)
       this.countTablesLoaded++
       this.sharedState.signalementsAcceptedNoSuivi = []
       for (const i in requestResponse.data) {

--- a/assets/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -185,7 +185,17 @@ export default defineComponent({
       }
     },
     handleSignalementsNoSuivi (requestResponse: any) {
+      console.log(requestResponse)
       this.countTablesLoaded++
+      this.sharedState.signalementsAcceptedNoSuivi = []
+      for (const i in requestResponse.data) {
+        const responseItem = requestResponse.data[i]
+        const item = [
+          responseItem.nom,
+          responseItem.count_no_suivi
+        ]
+        this.sharedState.signalementsAcceptedNoSuivi.push(item)
+      }
     },
     handleSignalementsPerTerritoire (requestResponse: any) {
       this.countTablesLoaded++

--- a/assets/vue/components/dashboard/TheHistoDashboardCards.vue
+++ b/assets/vue/components/dashboard/TheHistoDashboardCards.vue
@@ -66,7 +66,7 @@
         <div class="fr-card__body">
           <ul class="fr-badges-group">
             <li>
-                <p class="fr-badge fr-badge--no-icon fr-badge--info">{{ getBadgeText(sharedState.newSuivis.count, 'aucun', 'signalement', 'signalements') }}</p>
+                <p class="fr-badge fr-badge--no-icon fr-badge--info">{{ getBadgeText(sharedState.noSuivis.count, 'aucun', 'signalement', 'signalements') }}</p>
             </li>
           </ul>
           <div class="fr-card__content">

--- a/assets/vue/components/dashboard/TheHistoDashboardTables.vue
+++ b/assets/vue/components/dashboard/TheHistoDashboardTables.vue
@@ -21,7 +21,7 @@
     <div v-if="sharedState.user.isResponsableTerritoire" class="fr-col-12 fr-col-lg-6 fr-mb-3w">
       <HistoDataTable
         :headers=signalementsAcceptedNoSuiviHeaders
-        :items=[]
+        :items=sharedState.signalementsAcceptedNoSuivi
         >
         <template #title>Signalements acceptés mais sans suivi</template>
       </HistoDataTable>

--- a/assets/vue/components/dashboard/store.ts
+++ b/assets/vue/components/dashboard/store.ts
@@ -68,7 +68,8 @@ export const store = {
     },
     esaboraEvents: new Array<any>(),
     signalementsPerTerritoire: new Array<any>(),
-    affectationsPartenaires: new Array<any>()
+    affectationsPartenaires: new Array<any>(),
+    signalementsAcceptedNoSuivi: new Array<any>()
   },
   props: {
     ajaxurlSettings: '',

--- a/config/app/widgets.yaml
+++ b/config/app/widgets.yaml
@@ -42,6 +42,8 @@ parameters:
         label: "Nouvelles affectations"
         roles: [ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]
         link: 'back_index'
+        params:
+          statut: 1
       cardTousLesSignalements:
         label: "Tous les signalements"
         roles: [ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]

--- a/config/app/widgets.yaml
+++ b/config/app/widgets.yaml
@@ -9,19 +9,25 @@ parameters:
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY]
         link: 'back_index'
         params:
-          status_signalement: 1
+          statut: 1
       cardNouveauxSuivis:
         label: "Nouveaux suivis"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER]
+        link: 'back_index'
+        params:
+          nouveau_suivi: true
       cardSansSuivi:
         label: "Sans suivi"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER]
+        link: 'back_index'
+        params:
+          sans_suivi_periode: 30
       cardCloturesGlobales:
         label: "Clôtures globales"
         roles: [ROLE_ADMIN]
         link: 'back_index'
         params:
-          status_signalement: 6
+          statut: 6
       cardCloturesPartenaires:
         label: "Clotures partenaires"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY]

--- a/config/app/widgets.yaml
+++ b/config/app/widgets.yaml
@@ -31,6 +31,9 @@ parameters:
       cardCloturesPartenaires:
         label: "Clotures partenaires"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY]
+        link: 'back_index'
+        params:
+          closed_affectation: 'ONE_CLOSED'
       cardMesAffectations:
         label: "Mes affectations"
         roles: [ROLE_ADMIN_TERRITORY]

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -4,6 +4,8 @@ twig:
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr
+        feature:
+            dashboard_enable: '%env(bool:FEATURE_DASHBOARD_ENABLE)%'
     paths:
         # point this wherever your images live
         '%kernel.project_dir%/public/img': images

--- a/src/Controller/Back/BackSignalementController.php
+++ b/src/Controller/Back/BackSignalementController.php
@@ -14,12 +14,10 @@ use App\Form\ClotureType;
 use App\Form\SignalementType;
 use App\Manager\SignalementManager;
 use App\Repository\CritereRepository;
-use App\Repository\PartnerRepository;
 use App\Repository\SituationRepository;
 use App\Repository\TagRepository;
 use App\Service\Signalement\CriticiteCalculatorService;
 use DateTimeImmutable;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -35,9 +33,7 @@ class BackSignalementController extends AbstractController
     public function viewSignalement(
         Signalement $signalement,
         Request $request,
-        EntityManagerInterface $entityManager,
         TagRepository $tagsRepository,
-        PartnerRepository $partnerRepository,
         SignalementManager $signalementManager,
         EventDispatcherInterface $eventDispatcher
     ): Response {

--- a/src/Controller/Back/BackSignalementController.php
+++ b/src/Controller/Back/BackSignalementController.php
@@ -5,11 +5,11 @@ namespace App\Controller\Back;
 use App\Entity\Affectation;
 use App\Entity\Critere;
 use App\Entity\Criticite;
-use App\Entity\Notification;
 use App\Entity\Signalement;
 use App\Entity\Situation;
 use App\Entity\Suivi;
 use App\Event\SignalementClosedEvent;
+use App\Event\SignalementViewedEvent;
 use App\Form\ClotureType;
 use App\Form\SignalementType;
 use App\Manager\SignalementManager;
@@ -48,14 +48,8 @@ class BackSignalementController extends AbstractController
             return $this->redirectToRoute('back_index');
         }
 
-        // TODO REPLACE THIS
-        $this->getUser()->getNotifications()->filter(function (Notification $notification) use ($signalement, $entityManager) {
-            if ($notification->getSignalement()->getId() === $signalement->getId()) {
-                $notification->setIsSeen(true);
-                $entityManager->persist($notification);
-            }
-        });
-        $entityManager->flush();
+        $eventDispatcher->dispatch(new SignalementViewedEvent($signalement, $this->getUser()), SignalementViewedEvent::NAME);
+
         $isRefused = $isAccepted = $isClosedForMe = null;
         if ($isAffected = $signalement->getAffectations()->filter(function (Affectation $affectation) {
             return $affectation->getPartner() === $this->getUser()->getPartner();

--- a/src/Controller/Back/BackSignalementController.php
+++ b/src/Controller/Back/BackSignalementController.php
@@ -44,7 +44,10 @@ class BackSignalementController extends AbstractController
             return $this->redirectToRoute('back_index');
         }
 
-        $eventDispatcher->dispatch(new SignalementViewedEvent($signalement, $this->getUser()), SignalementViewedEvent::NAME);
+        $eventDispatcher->dispatch(
+            new SignalementViewedEvent($signalement, $this->getUser()),
+            SignalementViewedEvent::NAME
+        );
 
         $isRefused = $isAccepted = $isClosedForMe = null;
         if ($isAffected = $signalement->getAffectations()->filter(function (Affectation $affectation) {

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -86,3 +86,20 @@ affectations:
     affected_by: "admin-territoire-13-01@histologe.fr"
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
+  -
+    signalement: 2023-6
+    partner: "partenaire-13-02@histologe.fr"
+    statut: 1
+    answered_by: ""
+    affected_by: "admin-territoire-13-01@histologe.fr"
+    motif_cloture: ""
+    territory: "Bouches-du-Rhône"
+  -
+    signalement: 2023-6
+    partner: "partenaire-13-03@histologe.fr"
+    statut: 3
+    answered_by: ""
+    affected_by: "admin-territoire-13-01@histologe.fr"
+    motif_cloture: ""
+    territory: "Bouches-du-Rhône"
+

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -96,7 +96,8 @@ signalements:
     phone_number: 0621127286
     cp_occupant: "13003"
     ville_occupant: "Marseille"
-    statut: 2
+    statut: 6
+    motif_cloture: 'NON_DECENCE'
     reference: "2022-3"
     geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
     score_creation: 100
@@ -749,3 +750,44 @@ signalements:
     situations: []
     criteres: []
     criticites: []
+  -
+    uuid: "00000000-0000-0000-2023-000000000006"
+    details: "appartement insalubre avec des..."
+    is_proprio_averti: 1
+    nb_adultes: "2"
+    is_allocataire: ""
+    nature_logement: "Appartement"
+    type_logement: "T2"
+    superficie: 30
+    loyer: 300
+    phone_number: 0621127286
+    cp_occupant: "13003"
+    ville_occupant: "Marseille"
+    statut: 2
+    reference: "2023-6"
+    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    score_creation: 100
+    etage_occupant: "0"
+    escalier_occupant: ""
+    mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
+    insee_occupant: "13203"
+    is_rsa: 0
+    type_energie_logement: "Electrique"
+    origine_signalement: ""
+    nb_occupants_logement: 3
+    situation_occupant: "1"
+    territory: "Bouches-du-Rhône"
+    tags:
+      - "Urgent"
+    situations:
+      - "la vie commune et le voisinage"
+      - "la sécurité des occupants"
+      - "l'état et propreté du logement"
+    criteres:
+      - "Les déchets sont mal stockés."
+      - "La protection incendie n’est pas adaptée."
+      - "Les sols sont humides."
+    criticites:
+      - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
+      - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
+      - "le sol ou la base des murs est très humide."

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -30,6 +30,42 @@ suivis:
   signalement: "2022-5"
   type: 1
 -
+  created_by: admin-01@histologe.fr
+  description: "Signalement validé"
+  is_public: 0
+  signalement: "2022-6"
+  type: 1
+-
+  created_by: admin-01@histologe.fr
+  description: "Signalement validé"
+  is_public: 0
+  signalement: "2022-7"
+  type: 1
+-
+  created_by: admin-01@histologe.fr
+  description: "Signalement validé"
+  is_public: 0
+  signalement: "2022-8"
+  type: 1
+-
+  created_by: admin-01@histologe.fr
+  description: "Signalement validé"
+  is_public: 0
+  signalement: "2022-9"
+  type: 1
+-
+  created_by: admin-01@histologe.fr
+  description: "Signalement validé"
+  is_public: 0
+  signalement: "2022-10"
+  type: 1
+-
+  created_by: admin-01@histologe.fr
+  description: "Signalement validé"
+  is_public: 0
+  signalement: "2022-11"
+  type: 1
+-
   created_by: admin-territoire-13-01@histologe.fr
   description: "Le signalement à été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
   is_public: 0

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -48,6 +48,13 @@ suivis:
   signalement: "2022-8"
   type: 1
 -
+  created_by: admin-territoire-13-01@histologe.fr
+  description: "Ceci est vieux suivi de partenaire 13-01"
+  created_at: "2022-06-08 17:06:33"
+  is_public: 0
+  signalement: "2022-8"
+  type: 3
+-
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
   is_public: 0

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -34,7 +34,11 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
             ->setDescription($row['description'])
             ->setCreatedBy($this->userRepository->findOneBy(['email' => $row['created_by']]))
             ->setIsPublic($row['is_public'])
-            ->setCreatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(
+                isset($row['created_at'])
+                    ? new \DateTimeImmutable($row['created_at'])
+                    : new \DateTimeImmutable()
+            )
             ->setType($row['type']);
 
         $manager->persist($suivi);

--- a/src/Dto/CountSuivi.php
+++ b/src/Dto/CountSuivi.php
@@ -8,6 +8,8 @@ class CountSuivi
         private ?float $average = null,
         private ?int $partner = null,
         private ?int $usager = null,
+        private ?int $signalementNewSuivi = null,
+        private ?int $signalementNoSuivi = null,
     ) {
     }
 
@@ -24,5 +26,15 @@ class CountSuivi
     public function getUsager(): ?int
     {
         return $this->usager;
+    }
+
+    public function getSignalementNewSuivi(): ?int
+    {
+        return $this->signalementNewSuivi;
+    }
+
+    public function getSignalementNoSuivi(): ?int
+    {
+        return $this->signalementNoSuivi;
     }
 }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -12,6 +12,7 @@ class Suivi
     public const TYPE_AUTO = 1;
     public const TYPE_USAGER = 2;
     public const TYPE_PARTNER = 3;
+    public const DEFAULT_PERIOD_INACTIVITY = 30;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Event/SignalementViewedEvent.php
+++ b/src/Event/SignalementViewedEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Event;
+
+use App\Entity\Signalement;
+use App\Entity\User;
+
+class SignalementViewedEvent
+{
+    public const NAME = 'signalement.viewed';
+
+    public function __construct(private Signalement $signalement, private User $user)
+    {
+    }
+
+    public function getSignalement(): Signalement
+    {
+        return $this->signalement;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+}

--- a/src/EventSubscriber/SignalementViewedSubscriber.php
+++ b/src/EventSubscriber/SignalementViewedSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\Notification;
+use App\Event\SignalementViewedEvent;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SignalementViewedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SignalementViewedEvent::NAME => 'onSignalementViewed',
+        ];
+    }
+
+    public function onSignalementViewed(SignalementViewedEvent $event)
+    {
+        $signalement = $event->getSignalement();
+        $user = $event->getUser();
+
+        $notifications = $this->entityManager->getRepository(Notification::class)->findBy([
+            'signalement' => $signalement,
+            'user' => $user,
+            'isSeen' => false,
+        ]);
+
+        /** @var Notification $notification */
+        foreach ($notifications as $notification) {
+            $notification->setIsSeen(true);
+            $this->entityManager->persist($notification);
+        }
+
+        $this->entityManager->flush();
+    }
+}

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -3,9 +3,13 @@
 namespace App\Repository;
 
 use App\Entity\Notification;
+use App\Entity\Suivi;
+use App\Entity\Territory;
 use App\Entity\User;
 use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -52,5 +56,33 @@ class NotificationRepository extends ServiceEntityRepository
             ->setParameter('date', new DateTime('-'.$diff.' days'))
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    public function countSignalementNewSuivi(User $user, ?Territory $territory): int
+    {
+        $qb = $this->createQueryBuilder('n')
+            ->select('COUNT(DISTINCT n.signalement)')
+            ->innerJoin('n.suivi', 'su')
+            ->where('n.isSeen = :is_seen')
+            ->andWhere('n.type = :type')
+            ->andWhere('n.user = :user')
+            ->andWhere('su.type IN (:type_suivi_usager, :type_suivi_partner)')
+            ->setParameter('is_seen', 0)
+            ->setParameter('type', 1)
+            ->setParameter('user', $user)
+            ->setParameter('type_suivi_usager', Suivi::TYPE_USAGER)
+            ->setParameter('type_suivi_partner', Suivi::TYPE_PARTNER);
+
+        if (null !== $territory) {
+            $qb->innerJoin('n.signalement', 's')
+                ->andWhere('s.territory = :territory')
+                ->setParameter('territory', $territory);
+        }
+
+        return $qb->getQuery()->getSingleScalarResult();
     }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -861,7 +861,7 @@ class SignalementRepository extends ServiceEntityRepository
             AND a.statut = :affectation_closed'
             .$whereTerritory.
             ' GROUP BY s.uuid
-            HAVING nb_partner_closed > :nb_partner_closed) as count_partner_request';
+            HAVING nb_partner_closed >= :nb_partner_closed) as count_partner_request';
 
         $statement = $connection->prepare($sql);
 

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\Territory;
@@ -51,6 +52,52 @@ class SuiviRepository extends ServiceEntityRepository
         $statement = $connection->prepare($sql);
 
         return (float) $statement->executeQuery($parameters)->fetchOne();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function countSignalementNoSuiviSince(
+        int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
+        ?Territory $territory = null,
+        ?Partner $partner = null,
+    ): int {
+        $connection = $this->getEntityManager()->getConnection();
+        $whereTerritory = $wherePartner = '';
+        $innerSignalementJoin = $innerPartnerJoin = '';
+        $parameters['day_period'] = $period;
+        $parameters['type_suivi_usager'] = Suivi::TYPE_USAGER;
+        $parameters['type_suivi_partner'] = Suivi::TYPE_PARTNER;
+
+        if (null !== $territory) {
+            $whereTerritory = 'AND si.territory_id = :territory_id';
+            $innerSignalementJoin = 'INNER JOIN signalement si ON si.id = su.signalement_id ';
+            $parameters['territory_id'] = $territory->getId();
+        }
+
+        if (null !== $partner) {
+            $wherePartner = 'AND a.partner_id = :partner_id';
+            $innerPartnerJoin = 'INNER JOIN affectation a ON a.signalement_id = su.signalement_id';
+            $parameters['partner_id'] = $partner->getId();
+        }
+
+        $sql = 'SELECT COUNT(*) as count_signalement
+                FROM (
+                    SELECT su.signalement_id, MAX(su.created_at) as last_posted_at
+                    FROM suivi su
+                    '.$innerSignalementJoin.'
+                    '.$innerPartnerJoin.'
+                    WHERE type in (:type_suivi_usager,:type_suivi_partner)
+                    '.$whereTerritory.'
+                    '.$wherePartner.'
+                    GROUP BY su.signalement_id
+                    HAVING DATEDIFF(NOW(),last_posted_at) > :day_period
+                    ORDER BY last_posted_at
+                ) as countSignalementSuivi';
+
+        $statement = $connection->prepare($sql);
+
+        return (int) $statement->executeQuery($parameters)->fetchOne();
     }
 
     /**

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -6,7 +6,6 @@ use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\Territory;
-use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\NonUniqueResultException;
@@ -109,19 +108,10 @@ class SuiviRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s) as nb_suivi')
             ->innerJoin('s.signalement', 'sig')
-            ->innerJoin('s.createdBy', 'u')
             ->where('sig.statut != :statut')
-            ->andWhere(
-                $qb->expr()->orX(
-                    $qb->expr()->like('u.roles', ':role1'),
-                    $qb->expr()->like('u.roles', ':role2'),
-                    $qb->expr()->like('u.roles', ':role3')
-                )
-            )
-            ->setParameter('role1', '%'.User::ROLE_ADMIN_TERRITORY.'%')
-            ->setParameter('role2', '%'.User::ROLE_ADMIN_PARTNER.'%')
-            ->setParameter('role3', '%'.User::ROLE_USER_PARTNER.'%')
-            ->setParameter('statut', Signalement::STATUS_ARCHIVED);
+            ->andWhere('s.type = :type_suivi')
+            ->setParameter('statut', Signalement::STATUS_ARCHIVED)
+            ->setParameter('type_suivi', Suivi::TYPE_PARTNER);
 
         if ($territory instanceof Territory) {
             $qb->andWhere('sig.territory = :territory')->setParameter('territory', $territory);
@@ -141,13 +131,8 @@ class SuiviRepository extends ServiceEntityRepository
             ->innerJoin('s.signalement', 'sig')
             ->leftJoin('s.createdBy', 'u')
             ->where('sig.statut != :statut')
-            ->andWhere(
-                $qb->expr()->orX(
-                    $qb->expr()->like('u.roles', ':role'),
-                    $qb->expr()->isNull('s.createdBy')
-                )
-            )
-            ->setParameter('role', '%'.User::ROLE_USAGER.'%')
+            ->andWhere('s.type = :type_suivi')
+            ->setParameter('type_suivi', Suivi::TYPE_USAGER)
             ->setParameter('statut', Signalement::STATUS_ARCHIVED);
 
         if ($territory instanceof Territory) {

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -132,7 +132,7 @@ class WidgetDataKpiBuilder
             $widgetParams = $this->parameters[$key];
             $link = $widgetParams['link'] ?? null;
             $label = $widgetParams['label'] ?? null;
-            $widgetParams['params']['territory_id'] = $this->territory?->getId();
+            $widgetParams['params']['territoire_id'] = $this->territory?->getId();
             $parameters = array_merge($linkParameters, $widgetParams['params'] ?? []);
             $widgetCard = $this->widgetCardFactory->createInstance($label, $count, $link, $parameters);
             if (!$this->hasWidgetCard($key)) {

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -148,11 +148,6 @@ class WidgetDataKpiBuilder
         return \in_array($key, $this->widgetCards);
     }
 
-    /**
-     * @todo: cardNouveauxSuivis(fiiltre), cardSansSuivi(filtre), cardCloturesPartenaires(ayant été fermé par au moins 1 partenaire)
-     * [BO - Suivi] Qualification suivi: https://github.com/MTES-MCT/histologe/issues/867
-     * [BO - Filtre signalement] Cloture partiel: https://github.com/MTES-MCT/histologe/issues/869
-     */
     public function build(): WidgetDataKpi
     {
         $this

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -135,10 +135,17 @@ class WidgetDataKpiBuilder
             $widgetParams['params']['territory_id'] = $this->territory?->getId();
             $parameters = array_merge($linkParameters, $widgetParams['params'] ?? []);
             $widgetCard = $this->widgetCardFactory->createInstance($label, $count, $link, $parameters);
-            $this->widgetCards[$key] = $widgetCard;
+            if (!$this->hasWidgetCard($key)) {
+                $this->widgetCards[$key] = $widgetCard;
+            }
         }
 
         return $this;
+    }
+
+    public function hasWidgetCard(string $key): bool
+    {
+        return \in_array($key, $this->widgetCards);
     }
 
     /**

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -5,9 +5,11 @@ namespace App\Service\DashboardWidget;
 use App\Dto\CountSignalement;
 use App\Dto\CountSuivi;
 use App\Dto\CountUser;
+use App\Entity\Suivi;
 use App\Entity\Territory;
 use App\Entity\User;
 use App\Repository\AffectationRepository;
+use App\Repository\NotificationRepository;
 use App\Repository\SignalementRepository;
 use App\Repository\SuiviRepository;
 use App\Repository\UserRepository;
@@ -36,6 +38,7 @@ class WidgetDataKpiBuilder
         private AffectationRepository $affectationRepository,
         private SignalementRepository $signalementRepository,
         private UserRepository $userRepository,
+        private NotificationRepository $notificationRepository,
         private ParameterBagInterface $parameterBag,
         private Security $security,
     ) {
@@ -85,11 +88,28 @@ class WidgetDataKpiBuilder
      */
     public function withCountSuivi(): self
     {
+        /** @var User $user */
+        $user = $this->security->getUser();
         $averageSuivi = $this->suiviRepository->getAverageSuivi($this->territory);
         $countSuiviPartner = $this->suiviRepository->countSuiviPartner($this->territory);
         $countSuiviUsager = $this->suiviRepository->countSuiviUsager($this->territory);
+        $countSignalementNewSuivi = $this->notificationRepository->countSignalementNewSuivi(
+            $user,
+            $this->territory
+        );
+        $countSignalementNoSuivi = $this->suiviRepository->countSignalementNoSuiviSince(
+            Suivi::DEFAULT_PERIOD_INACTIVITY,
+            $this->territory,
+            \in_array(User::ROLE_USER_PARTNER, $user->getRoles()) ? $user->getPartner() : null
+        );
 
-        $this->countSuivi = new CountSuivi($averageSuivi, $countSuiviPartner, $countSuiviUsager);
+        $this->countSuivi = new CountSuivi(
+            $averageSuivi,
+            $countSuiviPartner,
+            $countSuiviUsager,
+            $countSignalementNewSuivi,
+            $countSignalementNoSuivi
+        );
 
         return $this;
     }
@@ -122,7 +142,7 @@ class WidgetDataKpiBuilder
     }
 
     /**
-     * @todo: cardNouveauxSuivis, cardSansSuivi, cardCloturesPartenaires(ayant été fermé par au moins 1 partenaire)
+     * @todo: cardNouveauxSuivis(fiiltre), cardSansSuivi(filtre), cardCloturesPartenaires(ayant été fermé par au moins 1 partenaire)
      * [BO - Suivi] Qualification suivi: https://github.com/MTES-MCT/histologe/issues/867
      * [BO - Filtre signalement] Cloture partiel: https://github.com/MTES-MCT/histologe/issues/869
      */
@@ -134,7 +154,9 @@ class WidgetDataKpiBuilder
             ->addWidgetCard('cardMesAffectations')
             ->addWidgetCard('cardTousLesSignalements', $this->countSignalement->getTotal())
             ->addWidgetCard('cardCloturesGlobales', $this->countSignalement->getClosed())
-            ->addWidgetCard('cardNouvellesAffectations', $this->countSignalement->getNew());
+            ->addWidgetCard('cardNouvellesAffectations', $this->countSignalement->getNew())
+            ->addWidgetCard('cardNouveauxSuivis', $this->countSuivi->getSignalementNewSuivi())
+            ->addWidgetCard('cardSansSuivi', $this->countSuivi->getSignalementNoSuivi());
 
         return new WidgetDataKpi(
             $this->widgetCards,

--- a/src/Service/DashboardWidget/WidgetDataManager.php
+++ b/src/Service/DashboardWidget/WidgetDataManager.php
@@ -56,9 +56,9 @@ class WidgetDataManager implements WidgetDataManagerInterface
     /**
      * @throws Exception
      */
-    public function findLastJobEventByType(string $type, array $params): array
+    public function findLastJobEventByType(string $type, array $params, ?Territory $territory = null): array
     {
-        return $this->jobEventRepository->findLastJobEventByType($type, $params['period']);
+        return $this->jobEventRepository->findLastJobEventByType($type, $params['period'], $territory);
     }
 
     /**

--- a/src/Service/DashboardWidget/WidgetDataManagerCache.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerCache.php
@@ -77,14 +77,14 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function findLastJobEventByType(string $type, array $params): array
+    public function findLastJobEventByType(string $type, array $params, ?Territory $territory = null): array
     {
         return $this->dashboardCache->get(
             __FUNCTION__.'-'.$this->key,
-            function (ItemInterface $item) use ($type, $params) {
+            function (ItemInterface $item) use ($type, $params, $territory) {
                 $item->expiresAfter($params['expired_after'] ?? null);
 
-                return $this->widgetDataManager->findLastJobEventByType($type, $params);
+                return $this->widgetDataManager->findLastJobEventByType($type, $params, $territory);
             }
         );
     }

--- a/src/Service/DashboardWidget/WidgetDataManagerCache.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerCache.php
@@ -80,7 +80,7 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     public function findLastJobEventByType(string $type, array $params, ?Territory $territory = null): array
     {
         return $this->dashboardCache->get(
-            __FUNCTION__.'-'.$this->key,
+            __FUNCTION__.'-'.$this->key.'-zip-'.$territory?->getZip(),
             function (ItemInterface $item) use ($type, $params, $territory) {
                 $item->expiresAfter($params['expired_after'] ?? null);
 

--- a/src/Service/DashboardWidget/WidgetDataManagerInterface.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerInterface.php
@@ -12,7 +12,7 @@ interface WidgetDataManagerInterface
 
     public function countAffectationPartner(?Territory $territory = null, ?array $params = null): array;
 
-    public function findLastJobEventByType(string $type, array $params): array;
+    public function findLastJobEventByType(string $type, array $params, ?Territory $territory = null): array;
 
     public function countDataKpi(?Territory $territory = null, ?array $params = null): WidgetDataKpi;
 }

--- a/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
+++ b/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
@@ -25,7 +25,8 @@ class EsaboraEventWidgetLoader extends AbstractWidgetLoader
         $widget->setData(
             $this->widgetDataManager->findLastJobEventByType(
                 JobEvent::TYPE_JOB_EVENT_ESABORA,
-                $this->widgetParameter['data']
+                $this->widgetParameter['data'],
+                $widget->getTerritory()
             )
         );
     }

--- a/src/Service/SearchFilterService.php
+++ b/src/Service/SearchFilterService.php
@@ -97,13 +97,13 @@ class SearchFilterService
             }
         }
 
-        if (null !== $this->filters['delays']
+        if (!empty($this->filters['delays'])
             || $request->isMethod('GET') && null !== $request->query->get('sans_suivi_periode')
         ) {
             $period = $this->filters['delays'] ?? $request->query->get('sans_suivi_periode');
             $territory = $user->getTerritory();
             $partner = \in_array(User::ROLE_USER_PARTNER, $user->getRoles()) ? $user->getPartner() : null;
-            $signalementIds = $this->suiviRepository->findSignalementNoSuiviSince($period, $territory, $partner);
+            $signalementIds = $this->suiviRepository->findSignalementNoSuiviSince((int) $period, $territory, $partner);
             $this->filters['delays'] = (int) $period;
             $this->filters['delays_signalement_id'] = $signalementIds;
         }

--- a/src/Service/SearchFilterService.php
+++ b/src/Service/SearchFilterService.php
@@ -2,11 +2,17 @@
 
 namespace App\Service;
 
+use App\Entity\User;
+use App\Repository\NotificationRepository;
+use App\Repository\SuiviRepository;
 use App\Entity\Affectation;
 use App\Entity\Signalement;
 use DateInterval;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,8 +22,12 @@ class SearchFilterService
     private array $filters;
     private Request $request;
 
-    public function __construct(private Security $security, private EntityManagerInterface $entityManager)
-    {
+    public function __construct(
+        private Security $security,
+        private NotificationRepository $notificationRepository,
+        private SuiviRepository $suiviRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
     }
 
     public function setRequest(Request $request): static
@@ -32,9 +42,16 @@ class SearchFilterService
         return $this->filters ?? null;
     }
 
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     * @throws Exception
+     */
     public function setFilters(): self
     {
         $request = $this->getRequest();
+        /** @var User $user */
+        $user = $this->security->getUser();
 
         $this->filters = [
             'searchterms' => $request->get('bo-filters-searchterms') ?? null,
@@ -60,17 +77,35 @@ class SearchFilterService
             'page' => $request->get('page') ?? 1,
         ];
 
-        if (null !== $statusSignalement = $request->query->get('status_signalement')) {
-            $this->filters['statuses'] = [$statusSignalement];
+        if ($request->isMethod('GET')) {
+            if (null !== $statusSignalement = $request->query->get('statut')) {
+                $this->filters['statuses'] = [$statusSignalement];
+            }
+
+            if (null !== $partners = $request->query->get('partenaires')) {
+                $this->filters['partners'] = [$partners];
+            }
+
+            if ($request->query->get('nouveau_suivi')) {
+                $signalementIds = $this->notificationRepository->findSignalementNewSuivi($user, $user->getTerritory());
+                $this->filters['signalement_ids'] = $signalementIds;
+            }
+
+            if ($this->security->isGranted('ROLE_ADMIN')
+                && null !== $territory = $request->query->get('territoire_id')) {
+                $this->filters['territories'] = [$territory];
+            }
         }
 
-        if (null !== $partners = $request->query->get('partners')) {
-            $this->filters['partners'] = [$partners];
-        }
-
-        if ($this->security->isGranted('ROLE_ADMIN')
-            && null !== $territory = $request->query->get('territory_id')) {
-            $this->filters['territories'] = [$territory];
+        if (null !== $this->filters['delays']
+            || $request->isMethod('GET') && null !== $request->query->get('sans_suivi_periode')
+        ) {
+            $period = $this->filters['delays'] ?? $request->query->get('sans_suivi_periode');
+            $territory = $user->getTerritory();
+            $partner = \in_array(User::ROLE_USER_PARTNER, $user->getRoles()) ? $user->getPartner() : null;
+            $signalementIds = $this->suiviRepository->findSignalementNoSuiviSince($period, $territory, $partner);
+            $this->filters['delays'] = (int) $period;
+            $this->filters['delays_signalement_id'] = $signalementIds;
         }
 
         return $this;
@@ -262,8 +297,8 @@ class SearchFilterService
                 ->setParameter('interventions', $filters['interventions']);
         }
         if (!empty($filters['delays'])) {
-            $qb->andWhere('DATEDIFF(NOW(),suivis.createdAt) >= :delays')
-                ->setParameter('delays', $filters['delays']);
+            $qb->andWhere('s.id IN (:id)')
+                ->setParameter('id', $filters['delays_signalement_id']);
         }
         if (!empty($filters['scores'])) {
             if (!empty($filters['scores']['on'])) {
@@ -277,6 +312,11 @@ class SearchFilterService
         if (!empty($filters['territories'])) {
             $qb->andWhere('s.territory IN (:territories)')
                 ->setParameter('territories', $filters['territories']);
+        }
+
+        if (!empty($filters['signalement_ids'])) {
+            $qb->andWhere('s.id IN (:reference)')
+                ->setParameter('reference', $filters['signalement_ids']);
         }
 
         return $qb;

--- a/src/Service/SearchFilterService.php
+++ b/src/Service/SearchFilterService.php
@@ -316,6 +316,11 @@ class SearchFilterService
                 ->setParameter('territories', $filters['territories']);
         }
 
+        if (!empty($filters['signalement_ids'])) {
+            $qb->andWhere('s.id IN (:signalement_ids)')
+                ->setParameter('signalement_ids', $filters['signalement_ids']);
+        }
+
         return $qb;
     }
 }

--- a/templates/_partials/_search_filter_form.html.twig
+++ b/templates/_partials/_search_filter_form.html.twig
@@ -378,19 +378,6 @@
                                                 <small>(jours)</small></label>
                                             <input type="number" min="0" max="9999" step="1" id="bo-filters-delays" name="bo-filters-delays"
                                                    class="fr-input" value="{{ filters.delays ?? '' }}">
-                                            <div class="selected__value">
-                                                <div class="fr-pb-1v fr-border--bottom--orange"></div>
-                                                {% set visible = 'fr-hidden' %}
-                                                {% if filters.delays %}
-                                                    <input type="hidden" name="bo-filters-delays" value="{{ filters.delays }}">
-                                                    <span class="fr-badge fr-badge--success fr-m-1v" data-value="{{ filters.delays }}"
-                                                          data-removable="true">PLUS {{ filters.delays }} JOUR(S)</span>
-                                                {% else %}
-                                                    {% set visible = 0 %}
-                                                {% endif %}
-                                                <span class="fr-badge fr-badge--info fr-m-1v {{ visible ?? '' }}">TOUS</span>
-                                            </div>
-
                                         </div>
                                     </div>
                                 </div>

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -3,7 +3,6 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block body %}
-    {# {{ dump(signalements) }} #}
     <main class="fr-container-fluid">
         <div class="fr-grid-row">
             {% include 'back/nav_bo.html.twig' %}

--- a/templates/back/dashboard/index.html.twig
+++ b/templates/back/dashboard/index.html.twig
@@ -13,7 +13,7 @@
         data-ajaxurl-settings="{{ path('back_widget_settings') }}"
         data-ajaxurl-KPI="{{ path('back_dashboard_widget', {widgetType: 'data-kpi'}) }}"
         data-ajaxurl-partners="{{ path('back_dashboard_widget', {widgetType: 'affectations-partenaires'}) }}"
-        data-ajaxurl-signalements-nosuivi="{{ path('back_dashboard_widget', {widgetType: 'signalements-accepte-sans-suivi'}) }}"
+        data-ajaxurl-signalements-nosuivi="{{ path('back_dashboard_widget', {widgetType: 'signalements-acceptes-sans-suivi'}) }}"
         data-ajaxurl-signalements-per-territoire="{{ path('back_dashboard_widget', {widgetType: 'signalements-territoires'}) }}"
         data-ajaxurl-connections-esabora="{{ path('back_dashboard_widget', {widgetType: 'esabora-evenements'}) }}"
         ></div>

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -21,7 +21,9 @@
             </div>
             <ul class="fr-sidemenu__list">
                 <li class="fr-sidemenu__item">
-                    <a class="fr-sidemenu__link" href="{{ path('back_dashboard') }}">Tableau de bord</a>
+                    <a class="fr-sidemenu__link" href="{{ path('back_dashboard') }}">
+                       {{ feature.dashboard_enable ? 'Tableau de bord' : 'Accueil' }}
+                    </a>
                 </li>
                 <li class="fr-sidemenu__item">
                     <a class="fr-sidemenu__link" href="{{ path('back_news_activities') }}">Notifications<span

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -22,7 +22,7 @@ class AffectationRepositoryTest extends KernelTestCase
         /** @var AffectationRepository $affectationRepository */
         $affectationRepository = $this->entityManager->getRepository(Affectation::class);
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora();
-        $this->assertCount(9, $affectationsSubscribedToEsabora);
+        $this->assertCount(11, $affectationsSubscribedToEsabora);
         foreach ($affectationsSubscribedToEsabora as $affectationSubscribedToEsabora) {
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }

--- a/tests/Unit/Dto/CountSuiviTest.php
+++ b/tests/Unit/Dto/CountSuiviTest.php
@@ -9,17 +9,21 @@ class CountSuiviTest extends TestCase
 {
     public function testGetValidCountSuivi(): void
     {
-        $countSuivi = new CountSuivi(20.6, 123, 70);
+        $countSuivi = new CountSuivi(20.6, 123, 70, 10, 12);
         $this->assertEquals(20.6, $countSuivi->getAverage());
         $this->assertEquals(123, $countSuivi->getPartner());
         $this->assertEquals(70, $countSuivi->getUsager());
+        $this->assertEquals(10, $countSuivi->getSignalementNewSuivi());
+        $this->assertEquals(12, $countSuivi->getSignalementNoSuivi());
     }
 
     public function testEmptyCountSuivi(): void
     {
-        $countSuivi = new CountSuivi(0, 0, 0);
+        $countSuivi = new CountSuivi(0, 0, 0, 0, 0);
         $this->assertEquals(0, $countSuivi->getAverage());
         $this->assertEquals(0, $countSuivi->getPartner());
         $this->assertEquals(0, $countSuivi->getUsager());
+        $this->assertEquals(0, $countSuivi->getSignalementNewSuivi());
+        $this->assertEquals(0, $countSuivi->getSignalementNoSuivi());
     }
 }

--- a/tests/Unit/Manager/WidgetDataManagerTest.php
+++ b/tests/Unit/Manager/WidgetDataManagerTest.php
@@ -12,28 +12,28 @@ use App\Repository\JobEventRepository;
 use App\Repository\SignalementRepository;
 use App\Service\DashboardWidget\WidgetDataKpiBuilder;
 use App\Service\DashboardWidget\WidgetDataManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class WidgetDataManagerTest extends TestCase
 {
     private WidgetDataManager $widgetDataManager;
-    private $signalementRepositoryMock;
-    private $jobEventRepositoryMock;
-    private $affectationRepositoryMock;
-    private $widgetDataKpiBuilderMock;
+    private SignalementRepository|MockObject $signalementRepositoryMock;
+    private JobEventRepository|MockObject $jobEventRepositoryMock;
+    private MockObject|AffectationRepository $affectationRepositoryMock;
 
     protected function setUp(): void
     {
         $this->signalementRepositoryMock = $this->createMock(SignalementRepository::class);
         $this->jobEventRepositoryMock = $this->createMock(JobEventRepository::class);
         $this->affectationRepositoryMock = $this->createMock(AffectationRepository::class);
-        $this->widgetDataKpiBuilderMock = $this->createMock(WidgetDataKpiBuilder::class);
+        $widgetDataKpiBuilderMock = $this->createMock(WidgetDataKpiBuilder::class);
 
         $this->widgetDataManager = new WidgetDataManager(
             $this->signalementRepositoryMock,
             $this->jobEventRepositoryMock,
             $this->affectationRepositoryMock,
-            $this->widgetDataKpiBuilderMock,
+            $widgetDataKpiBuilderMock,
         );
     }
 


### PR DESCRIPTION
## Ticket
Les tickets #867 et #869 permettent de terminer le tableau de bord
#785 
#743   

## Description
A la suite des différents tickets transverses, ce ticket complète le tableau de bord avec l'ajout des différents widget de suivi et des différents filtres

## Changements apportés
* [Back] Récupération des données pour le widgets `Nouveau suivis`
* [Back] Récupération des données pour le widgets `Sans suivs`
* [Front] Récupération des données pour le widget `Sans suivi`
* [Back] Ajout des différents filtres dans la configuration du widget
* [Back] Prise en compte des filtre dans `src/Service/SearchFilterService.php`
* [Back] Notification - Optimisation sur la confirmation de visualisation du suivi
* [Back] Ajout d'un filtre de territoire pour les événements esabora


## Tests
- [ ] Vérifier que le widgetCard `Nouveaux suivis` s'affiche et que la carte est cliquable pour tous les utilisateurs
- [ ] Vérifier que le widgetCard `Sans suivis` s'affiche et que la carte est cliquable pour tous les utilisateurs
- [ ] Vérifier que le widgetCard `Clotudes partenaires` s'affiche et que la carte est cliquable les admin territoire et super admin

## Tests de non régressions
https://github.com/MTES-MCT/histologe/pull/863
https://github.com/MTES-MCT/histologe/pull/915