### PR TITLE
[Territoire 69] Filtrer les notifications par e-mail

### DIFF
--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -98,7 +98,7 @@ class ActivityListener implements EventSubscriberInterface
         }
     }
 
-    private function getPartnerFromSignalement(mixed $entity, Territory|null $territory): ?Partner
+    private function getPartnerFromSignalementInsee(mixed $entity, Territory|null $territory): ?Partner
     {
         if ($entity instanceof Signalement) {
             $signalement = $entity;
@@ -130,7 +130,7 @@ class ActivityListener implements EventSubscriberInterface
             ->setParameter('role2', '"ROLE_ADMIN_TERRITORY"')
             ->setParameter('territory', $territory);
 
-        if (null !== $partner = $this->getPartnerFromSignalement($entity, $territory)) {
+        if (null !== $partner = $this->getPartnerFromSignalementInsee($entity, $territory)) {
             $qb->andWhere('u.partner = :partner')->setParameter('partner', $partner);
         }
 

--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -197,7 +197,6 @@ class ActivityListener implements EventSubscriberInterface
                 $sendErrorMail = true;
             } else {
                 $this->notifier->send($mailType, array_unique($this->tos->toArray()), $options, $signalement->getTerritory());
-
                 $this->tos->clear();
             }
         } else {


### PR DESCRIPTION
## Pré-requis
Repasser en PHP 8.0 / SF 6.0
```
$ mail build 
```
## Ticket

#841    

## Description
Les responsables territoires COR sont notifiés par e-mail des signalements MDL et ceux de la MDL sont notifiés par les signalements COR.

## Changements apportés
* Ajout d'une fonction qui récupère le partenaire selon le code INSEE du signalement, seul le territoire 69 est impactés (présence des codes INSEE dans le fichier de configuration)

## Tests
- [ ] Je crée un signalement COR  avec l'adresse 26 Rue Georges Clemenceau - 69470 Cours, le responsable MDL `admin-territoire-69-mdl@histologe.fr` ne doit pas être notifié par mail
- [ ] Je crée un signalement MDL avec l'adresse  1 Place de la Comédie 69001 Lyon, le responsable COR `admin-territoire-69-cor@histologe.fr`ne doit pas être notifié par mail

