### PR TITLE
[BO - notifications] Investiguer sur le doublons de mails "aucun utilisateur notifiable pour le signalement ..."

### DIFF
--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -209,8 +209,9 @@ class ActivityListener implements EventSubscriberInterface
                 [
                     'url' => $this->parameterBag->get('host_url'),
                     'error' => sprintf(
-                        'Aucun utilisateur est notifiable pour le signalement #%s',
+                        'Aucun utilisateur est notifiable pour le signalement #%s, notification prévue %s (2 = nouveau signalement, 1 = suivi, 0 = affectation)',
                         $signalement->getReference(),
+                        $mailType,
                     ),
                 ],
                 $signalement->getTerritory()


### PR DESCRIPTION
## Ticket

#957    

## Description
Ajout du type de notification originale dans le mail "Aucun utilisateur notifiable pour le signalement" pour vérifier que ce ne sont pas des doublons purs, mais plusieurs cas différents sur un même signalement

## Changements apportés
* Ajout du type de notification dans le mail

## Tests
- [ ] 
