### PR TITLE
[BO - Dashboard] Compteurs ne se mettent pas à jour (Clôtures global & partenaires)

### DIFF
--- a/src/Dto/CountSignalement.php
+++ b/src/Dto/CountSignalement.php
@@ -6,6 +6,7 @@ class CountSignalement
 {
     private ?array $percentage = null;
     private ?int $closedByAtLeastOnePartner = null;
+    private ?int $closedAllPartnersRecently = null;
 
     private ?int $affected = null;
 
@@ -74,6 +75,18 @@ class CountSignalement
     public function setAffected(?int $affected): self
     {
         $this->affected = $affected;
+
+        return $this;
+    }
+
+    public function getClosedAllPartnersRecently(): ?int
+    {
+        return $this->closedAllPartnersRecently;
+    }
+
+    public function setClosedAllPartnersRecently(?int $closedAllPartnersRecently): self
+    {
+        $this->closedAllPartnersRecently = $closedAllPartnersRecently;
 
         return $this;
     }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -14,6 +14,8 @@ class Suivi
     public const TYPE_PARTNER = 3;
     public const DEFAULT_PERIOD_INACTIVITY = 30;
 
+    public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'le signalement a été cloturé pour tous';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -14,7 +14,8 @@ class Suivi
     public const TYPE_PARTNER = 3;
     public const DEFAULT_PERIOD_INACTIVITY = 30;
 
-    public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'le signalement a été cloturé pour tous';
+    public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';
+    public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été cloturé pour';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -19,7 +19,6 @@ use Doctrine\ORM\Events;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ActivityListener implements EventSubscriberInterface
@@ -86,7 +85,7 @@ class ActivityListener implements EventSubscriberInterface
                                             'code' => $entity->getSignalement()->getCodeSuivi(),
                                             'from' => $toRecipient,
                                         ],
-                                        UrlGenerator::ABSOLUTE_URL
+                                        UrlGeneratorInterface::ABSOLUTE_URL
                                     ),
                                 ],
                                 $entity->getSignalement()->getTerritory()

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -140,4 +140,32 @@ class NotificationRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getSingleScalarResult();
     }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    public function countAffectationClosedNotSeen(?User $user, ?Territory $territory): int
+    {
+        $qb = $this->createQueryBuilder('n');
+        $qb
+            ->select('COUNT(DISTINCT n.signalement)')
+            ->innerJoin('n.signalement', 'si')
+            ->innerJoin('n.suivi', 'su')
+            ->where('n.isSeen = :is_seen')
+            ->andWhere('n.type = :type_notification')
+            ->andWhere('n.user = :user')
+            ->andWhere('su.description NOT LIKE :description_all AND su.description LIKE :description_partner')
+            ->setParameter('is_seen', 0)
+            ->setParameter('type_notification', Notification::TYPE_SUIVI)
+            ->setParameter('description_all', '%'.Suivi::DESCRIPTION_MOTIF_CLOTURE_ALL.'%')
+            ->setParameter('description_partner', '%'.Suivi::DESCRIPTION_MOTIF_CLOTURE_PARTNER.'%')
+            ->setParameter('user', $user);
+
+        if (null !== $territory) {
+            $qb->andWhere('si.territory = :territory')->setParameter('territory', $territory);
+        }
+
+        return $qb->getQuery()->getSingleScalarResult();
+    }
 }

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Notification;
+use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\Territory;
 use App\Entity\User;
@@ -109,5 +110,34 @@ class NotificationRepository extends ServiceEntityRepository
         }
 
         return $qb->getQuery()->getResult(AbstractQuery::HYDRATE_SCALAR_COLUMN);
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    public function countSignalementClosedNotSeen(?User $user, ?Territory $territory): int
+    {
+        $qb = $this->createQueryBuilder('n');
+        $qb
+            ->select('COUNT(DISTINCT n.signalement)')
+            ->innerJoin('n.signalement', 'si')
+            ->innerJoin('n.suivi', 'su')
+            ->where('n.isSeen = :is_seen')
+            ->andWhere('n.type = :type_notification')
+            ->andWhere('n.user = :user')
+            ->andWhere('si.statut = :statut')
+            ->andWhere('su.description LIKE :description')
+            ->setParameter('is_seen', 0)
+            ->setParameter('type_notification', Notification::TYPE_SUIVI)
+            ->setParameter('statut', Signalement::STATUS_CLOSED)
+            ->setParameter('description', '%'.Suivi::DESCRIPTION_MOTIF_CLOTURE_ALL.'%')
+            ->setParameter('user', $user);
+
+        if (null !== $territory) {
+            $qb->andWhere('si.territory = :territory')->setParameter('territory', $territory);
+        }
+
+        return $qb->getQuery()->getSingleScalarResult();
     }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -4,7 +4,6 @@ namespace App\Repository;
 
 use App\Dto\CountSignalement;
 use App\Dto\StatisticsFilters;
-use App\Entity\Affectation;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
@@ -835,36 +834,5 @@ class SignalementRepository extends ServiceEntityRepository
         }
 
         return $qb->getQuery()->getOneOrNullResult();
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function countSignalementClosedByAtLeast(int $numberPartner = 1, ?Territory $territory = null): int
-    {
-        $connection = $this->getEntityManager()->getConnection();
-        $whereTerritory = $territory instanceof Territory ? ' AND s.territory_id = :territory_id ' : null;
-        $parameters = [
-            'signalement_closed' => Signalement::STATUS_CLOSED,
-            'affectation_closed' => Affectation::STATUS_CLOSED,
-            'nb_partner_closed' => $numberPartner,
-        ];
-        if (null !== $whereTerritory) {
-            $parameters['territory_id'] = $territory->getId();
-        }
-
-        $sql = 'SELECT COUNT(uuid) AS count_partner FROM (
-            SELECT s.uuid, count(s.uuid) as nb_partner_closed
-            FROM signalement s
-            INNER JOIN affectation a on a.signalement_id = s.id
-            WHERE s.statut != :signalement_closed
-            AND a.statut = :affectation_closed'
-            .$whereTerritory.
-            ' GROUP BY s.uuid
-            HAVING nb_partner_closed >= :nb_partner_closed) as count_partner_request';
-
-        $statement = $connection->prepare($sql);
-
-        return (int) $statement->executeQuery($parameters)->fetchOne();
     }
 }

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -71,12 +71,10 @@ class WidgetDataKpiBuilder
             ? $this->affectationRepository->countSignalementByPartner($this->user->getPartner())
             : $this->signalementRepository->countSignalementByStatus($this->territory);
 
-        $this->countSignalement->setClosedByAtLeastOnePartner(
-            $this->signalementRepository->countSignalementClosedByAtLeast(1, $this->territory)
-        )
-            ->setAffected(
-                $this->affectationRepository->countAffectationByPartner($this->user->getPartner())
-            );
+        $this->countSignalement
+            ->setClosedByAtLeastOnePartner($this->signalementRepository->countSignalementClosedByAtLeast(1, $this->territory))
+            ->setAffected($this->affectationRepository->countAffectationByPartner($this->user->getPartner()))
+            ->setClosedAllPartnersRecently($this->notificationRepository->countSignalementClosedNotSeen($this->user, $this->territory));
 
         return $this;
     }
@@ -155,7 +153,7 @@ class WidgetDataKpiBuilder
             ->addWidgetCard('cardCloturesPartenaires', $this->countSignalement->getClosedByAtLeastOnePartner())
             ->addWidgetCard('cardMesAffectations')
             ->addWidgetCard('cardTousLesSignalements', $this->countSignalement->getTotal())
-            ->addWidgetCard('cardCloturesGlobales', $this->countSignalement->getClosed())
+            ->addWidgetCard('cardCloturesGlobales', $this->countSignalement->getClosedAllPartnersRecently())
             ->addWidgetCard('cardNouvellesAffectations', $this->countSignalement->getNew())
             ->addWidgetCard('cardNouveauxSuivis', $this->countSuivi->getSignalementNewSuivi())
             ->addWidgetCard('cardSansSuivi', $this->countSuivi->getSignalementNoSuivi());

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -72,7 +72,7 @@ class WidgetDataKpiBuilder
             : $this->signalementRepository->countSignalementByStatus($this->territory);
 
         $this->countSignalement
-            ->setClosedByAtLeastOnePartner($this->signalementRepository->countSignalementClosedByAtLeast(1, $this->territory))
+            ->setClosedByAtLeastOnePartner($this->notificationRepository->countAffectationClosedNotSeen($this->user, $this->territory))
             ->setAffected($this->affectationRepository->countAffectationByPartner($this->user->getPartner()))
             ->setClosedAllPartnersRecently($this->notificationRepository->countSignalementClosedNotSeen($this->user, $this->territory));
 

--- a/src/Service/DashboardWidget/WidgetDataManagerCache.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerCache.php
@@ -4,6 +4,10 @@ namespace App\Service\DashboardWidget;
 
 use App\Entity\Territory;
 use App\Entity\User;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Query\QueryException;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -90,17 +94,13 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @throws QueryException
+     * @throws NonUniqueResultException
+     * @throws Exception
+     * @throws NoResultException
      */
     public function countDataKpi(?Territory $territory = null, ?array $params = null): WidgetDataKpi
     {
-        return $this->dashboardCache->get(
-            __FUNCTION__.'-'.$this->key.'-zip-'.$territory?->getZip(),
-            function (ItemInterface $item) use ($territory, $params) {
-                $item->expiresAfter($params['expired_after'] ?? null);
-
-                return $this->widgetDataManager->countDataKpi($territory);
-            }
-        );
+        return $this->widgetDataManager->countDataKpi($territory);
     }
 }

--- a/templates/back/index.html.twig
+++ b/templates/back/index.html.twig
@@ -1,8 +1,8 @@
 {% extends 'back/base_bo.html.twig' %}
 
 {% block content %}
-
-    <section class="fr-background-alt--blue-france fr-p-2v">
+    {% if not feature.dashboard_enable %}
+        <section class="fr-background-alt--blue-france fr-p-2v">
         <div class="fr-badge fr-p-2v fr-border--bottom--orange fr-background--white fr-m-1v">
             <span class="fr-text-default--info">{{ signalements.counts.total }}</span>
             <strong class="fr-hint-text">&nbsp;SIGNALEMENTS</strong>
@@ -45,6 +45,8 @@
             </div>
         {% endif %}
     </section>
+    {% endif %}
+
     {% include '_partials/_search_filter_form.html.twig' %}
     <section class="fr-col-12 fr-table fr-table--bordered fr-background-alt--blue-france">
         <table class="fr-display-inline-table fr-display-md-block sortable fr-mb-0">

--- a/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
@@ -29,7 +29,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
     }
 
-    public function testEventSubcription(): void
+    public function testEventSubscription(): void
     {
         $this->assertArrayHasKey(SignalementClosedEvent::NAME, SignalementClosedSubscriber::getSubscribedEvents());
     }

--- a/tests/Functional/EventSubscriber/SignalementViewedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementViewedSubscriberTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\Functional\EventSubscriber;
+
+use App\Entity\Notification;
+use App\Entity\Signalement;
+use App\Entity\User;
+use App\Event\SignalementViewedEvent;
+use App\EventSubscriber\SignalementViewedSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class SignalementViewedSubscriberTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+    }
+
+    public function testEventSubscription(): void
+    {
+        $this->assertArrayHasKey(SignalementViewedEvent::NAME, SignalementViewedSubscriber::getSubscribedEvents());
+    }
+
+    public function testOnSignalementViewed(): void
+    {
+        $signalement = $this->entityManager->getRepository(Signalement::class)->findOneBy([
+            'uuid' => '00000000-0000-0000-2023-000000000006',
+        ]);
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $signalementViewedEvent = new SignalementViewedEvent($signalement, $user);
+
+        /** @var Notification $notification */
+        $notification = $this->entityManager->getRepository(Notification::class)->findOneBy(['signalement' => $signalement]);
+        $isSeenBefore = $notification->getIsSeen();
+        $this->assertFalse($isSeenBefore);
+
+        $signalementViewedSubscriber = new SignalementViewedSubscriber($this->entityManager);
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($signalementViewedSubscriber);
+        $dispatcher->dispatch($signalementViewedEvent, SignalementViewedEvent::NAME);
+
+        /** @var Notification $notification */
+        $notification = $this->entityManager->getRepository(Notification::class)->findOneBy(['signalement' => $signalement]);
+        $isSeenAfter = $notification->getIsSeen();
+        $this->assertTrue($isSeenAfter);
+    }
+}

--- a/tests/Unit/Dto/CountSignalementTest.php
+++ b/tests/Unit/Dto/CountSignalementTest.php
@@ -10,11 +10,25 @@ class CountSignalementTest extends TestCase
     public function testGetValidCountSignalement(): void
     {
         $countSignalement = new CountSignalement(20, 3, 7, 6, 4);
+        $countSignalement
+            ->setClosedByAtLeastOnePartner(4)
+            ->setAffected(2);
+
         $this->assertEquals(20, $countSignalement->getTotal());
         $this->assertEquals(3, $countSignalement->getNew());
         $this->assertEquals(7, $countSignalement->getActive());
         $this->assertEquals(6, $countSignalement->getClosed());
         $this->assertEquals(4, $countSignalement->getRefused());
+        $this->assertEquals(4, $countSignalement->getClosedByAtLeastOnePartner());
+        $this->assertEquals(2, $countSignalement->getAffected());
+        $this->assertEquals([
+            'new' => 15.0,
+            'active' => 35.0,
+            'closed' => 30.0,
+            'refused' => 20.0,
+            ],
+            $countSignalement->getPercentage()
+        );
     }
 
     public function testEmptyCountSignalement(): void
@@ -24,5 +38,13 @@ class CountSignalementTest extends TestCase
         $this->assertEquals(0, $countSignalement->getNew());
         $this->assertEquals(0, $countSignalement->getActive());
         $this->assertEquals(0, $countSignalement->getClosed());
+        $this->assertEquals([
+            'new' => 0,
+            'active' => 0,
+            'closed' => 0,
+            'refused' => 0,
+            ],
+            $countSignalement->getPercentage()
+        );
     }
 }


### PR DESCRIPTION
## Ticket

#963  

## Description
Les compteurs des cartes clôturés globales et  partenaires doivent être mise à jour  selon les le signalement a été vu par l'utilisateur

## Changements apportés
* Mise à jour requête compteur clôtures globales
* Mise à jour requête compteur clôtures partenaires
* Mise à jour DTO CountSIgnalement
* Bandeau statistique liste de signalement caché

## Tests

### Clôtures globales
- [ ] En tant que super-admin, je clôture un signalement, le widget "Clôtures globales" se met à jour
- [ ] En tant que responsable territoire,  je clôture un signalement, le widget "Clôtures globales" pour un responsable admin se met à jour
- [ ]  En tant que super admin, j'ai 2 nouveaux signalement en "Clôtures globales"
- [ ] En tant que super admin, je clique sur la carte du Widget "Clôtures globales" afin de visualiser un des signalement qui a été fermé récemment. J'ai donc 1 signalement en clôtures globales

### Clôtures partenaires
- [ ] En tant qu’utilisateur partenaire, je clôture un signalement pour mon partenaire.
- [ ] En tant que responsable territoire, je remarque que le tableau de bord s'est mis à jour avec 1 Clôture partenaire et je clique sur la carte afin de visualiser le signalement récemment clôturé pour le partenaire
- [ ] En tant que super admin, je remarque que le tableau de bord s'est mis à jour avec 1 Clôture partenaire et je clique sur la carte afin de visualiser le signalement récemment clôturé pour le partenaire