### PR TITLE
[BO - Dashboard] Cartes inactives pour admin partenaire

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ S3_URL_BUCKET=
 Territoire             | Partenaire                | Email                               | Rôle       
 -----------------------|---------------------------|-------------------------------------|----------------------
 N/A                    | Admin Histologe           | admin-01@histologe.fr               | ROLE_ADMIN 
-Bouches-du-Rhône       | Admin Histologe 13        | admin-territoire-13-01@histologe.fr | ROLE_ADMIN_TERRITORY
-Ain                    | Admin Histologe 01        | admin-territoire-01-01@histologe.fr | ROLE_ADMIN_TERRITORY
+Bouches-du-Rhône       | Admin Territoire 13       | admin-territoire-13-01@histologe.fr | ROLE_ADMIN_TERRITORY
+Ain                    | Admin Territoire 01       | admin-territoire-01-01@histologe.fr | ROLE_ADMIN_TERRITORY
+Bouches-du-Rhône       | Admin Partenaire 13       | admin-partenaire-13-01@histologe.fr | ROLE_ADMIN_PARTNER
+Ain                    | Admin Partenaire 01       | admin-partenaire-01-01@histologe.fr | ROLE_ADMIN_PARTNER
 Bouches-du-Rhône       | Utilisateur Partenaire 13 | user-13-01@histologe.fr             | ROLE_USER_PARTNER
 Ain                    | Utilisateur Partenaire 01 | user-01-01@histologe.fr             | ROLE_USER_PARTNER
 

--- a/assets/vue/components/dashboard/TheHistoDashboardTables.vue
+++ b/assets/vue/components/dashboard/TheHistoDashboardTables.vue
@@ -73,7 +73,6 @@ export default defineComponent({
     affectationsOfPartnersHeaders () {
       if (store.state.user.isAdmin) {
         return [
-          'Dpt',
           'Partenaire',
           'En attente',
           'Refusés'

--- a/config/app/widgets.yaml
+++ b/config/app/widgets.yaml
@@ -12,13 +12,13 @@ parameters:
           statut: 1
       cardNouveauxSuivis:
         label: "Nouveaux suivis"
-        roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER]
+        roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]
         link: 'back_index'
         params:
           nouveau_suivi: true
       cardSansSuivi:
         label: "Sans suivi"
-        roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER]
+        roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]
         link: 'back_index'
         params:
           sans_suivi_periode: 30

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -100,8 +100,8 @@ services:
     App\Service\DashboardWidget\WidgetDataManagerInterface:
         alias: App\Service\DashboardWidget\WidgetDataManager
 
-    App\Service\DashboardWidget\WidgetDataManagerCache:
-        decorates: App\Service\DashboardWidget\WidgetDataManager
+#    App\Service\DashboardWidget\WidgetDataManagerCache:
+#        decorates: App\Service\DashboardWidget\WidgetDataManager
 
 when@test:
     parameters:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -100,8 +100,8 @@ services:
     App\Service\DashboardWidget\WidgetDataManagerInterface:
         alias: App\Service\DashboardWidget\WidgetDataManager
 
-#    App\Service\DashboardWidget\WidgetDataManagerCache:
-#        decorates: App\Service\DashboardWidget\WidgetDataManager
+    App\Service\DashboardWidget\WidgetDataManagerCache:
+        decorates: App\Service\DashboardWidget\WidgetDataManager
 
 when@test:
     parameters:

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -112,6 +112,22 @@ users:
     is_mailing_active: 1
     territory: "Rhône"
   -
+    email: admin-partenaire-13-01@histologe.fr
+    roles: "[\"ROLE_ADMIN_PARTNER\"]"
+    partner: "Partenaire 13-01"
+    statut: 1
+    is_generique: 0
+    is_mailing_active: 1
+    territory: "Bouches-du-Rhône"
+  -
+    email: admin-partenaire-01-01@histologe.fr
+    roles: "[\"ROLE_ADMIN_PARTNER\"]"
+    partner: "Partenaire 01-01"
+    statut: 1
+    is_generique: 0
+    is_mailing_active: 0
+    territory: "Ain"
+  -
     email: user-13-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-02"

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -5,6 +5,7 @@ namespace App\Service\DashboardWidget;
 use App\Dto\CountSignalement;
 use App\Dto\CountSuivi;
 use App\Dto\CountUser;
+use App\Entity\Partner;
 use App\Entity\Suivi;
 use App\Entity\Territory;
 use App\Entity\User;
@@ -100,7 +101,7 @@ class WidgetDataKpiBuilder
         $countSignalementNoSuivi = $this->suiviRepository->countSignalementNoSuiviSince(
             Suivi::DEFAULT_PERIOD_INACTIVITY,
             $this->territory,
-            \in_array(User::ROLE_USER_PARTNER, $user->getRoles()) ? $user->getPartner() : null
+            $this->getPartnerForPartner($user)
         );
 
         $this->countSuivi = new CountSuivi(
@@ -166,5 +167,12 @@ class WidgetDataKpiBuilder
             $this->countSuivi,
             $this->countUser,
         );
+    }
+
+    private function getPartnerForPartner(User $user): ?Partner
+    {
+        return 1 === \count(array_diff([User::ROLE_USER_PARTNER, User::ROLE_ADMIN_PARTNER], $user->getRoles()))
+            ? $user->getPartner()
+            : null;
     }
 }

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -101,7 +101,7 @@ class WidgetDataKpiBuilder
         $countSignalementNoSuivi = $this->suiviRepository->countSignalementNoSuiviSince(
             Suivi::DEFAULT_PERIOD_INACTIVITY,
             $this->territory,
-            $this->getPartnerForPartner($user)
+            $this->getPartnerFromUser($user)
         );
 
         $this->countSuivi = new CountSuivi(
@@ -169,7 +169,7 @@ class WidgetDataKpiBuilder
         );
     }
 
-    private function getPartnerForPartner(User $user): ?Partner
+    private function getPartnerFromUser(User $user): ?Partner
     {
         return 1 === \count(array_diff([User::ROLE_USER_PARTNER, User::ROLE_ADMIN_PARTNER], $user->getRoles()))
             ? $user->getPartner()


### PR DESCRIPTION
## Ticket

#964

## Description
Activer les cartes cardSansSuivi et cardNouveauxSuivis pour les admin partenaires 

## Changements apportés
* Mise à jour des fixtures pour ajout utilisateurs avec le rôle ROLE_ADMIN_PARTNER
* Prise en compte du partenaire pour les utilisateurs avec le role ROLE_ADMIN_PARTNER

## Tests
- [ ] Se connecter en tant qu'admin partenaires et vérifier que l'on peut cliquer sur les cartes  de suivi