### PR TITLE
Add Data in fixtures criticites and signalements

### DIFF
--- a/src/DataFixtures/Files/Criticite.yml
+++ b/src/DataFixtures/Files/Criticite.yml
@@ -439,6 +439,8 @@ criticites:
     score: 1
     new_score: 0.5
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "De l’air s’infiltre dans mon logement."
     label: "Infiltration ou fuite d'air dans deux des éléments suivants : toit, charpente, façades, murs extérieurs. Sensation de courant d'air régulièrement ou ponctuellement."
@@ -447,6 +449,8 @@ criticites:
     score: 2
     new_score: 1
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "De l’air s’infiltre dans mon logement."
     label: "Infiltration ou fuite d'air dans plus de deux des éléments suivants : toit, charpente, façades, murs extérieurs. Sensation de courant d'air régulière ou très fréquente."
@@ -479,6 +483,8 @@ criticites:
     score: 3
     new_score: 1
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "Mon logement est mal isolé."
     label: "Le DPE indique une étiquette énergie B ou C. J’ai rarement ou parfois la sensation d'avoir froid en hiver et/ou très chaud en été."
@@ -495,6 +501,8 @@ criticites:
     score: 2
     new_score: 1
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "Mon logement est mal isolé."
     label: "Le DPE indique une étiquette énergie F ou G ou n’a pas été fait. J’ai tout le temps la sensation d'avoir froid en hiver et/ou très chaud en été."
@@ -503,6 +511,8 @@ criticites:
     score: 3
     new_score: 1
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "De l'eau s’infiltre dans mon logement."
     label: "Il y a de l'humidité mais pas de traces de d'eau."
@@ -919,6 +929,8 @@ criticites:
     score: 2
     new_score: 2
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "Le chauffage ne fonctionne pas bien."
     label: "il fait très chaud dans mon logement l’été (ex : baies vitrées avec forte exposition au soleil, absence de stores…) ou le système de chauffage ne fonctionne pas en hiver."
@@ -927,6 +939,8 @@ criticites:
     score: 3
     new_score: 1
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "J'ai un problème avec l’eau potable."
     label: "j'ai accès à l’eau potable et à l’eau chaude dans le logement mais avec débit limité."
@@ -1015,6 +1029,8 @@ criticites:
     score: 2
     new_score: 1
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "J’utilise un appareil d'appoint pour le chauffage."
     label: "J’utilise plusieurs chauffages d'appoint et/ou des pièces principales ne possèdent pas de moyen de chauffage."
@@ -1023,6 +1039,8 @@ criticites:
     score: 3
     new_score: 1
     is_danger: 0
+    qualifications:
+      - "Non décence énergétique"
   -
     critere: "L'installation de gaz n’est pas en bon état"
     label: "L’installation de gaz est ancienne mais fonctionne sans danger."

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -832,6 +832,7 @@ signalements:
       - "J’utilise plusieurs chauffages d'appoint et/ou des pièces principales ne possèdent pas de moyen de chauffage."
     qualifications: 
       - "Non décence énergétique"
+    date_entree: "2022-06-08 17:06:33"
   -
     uuid: "00000000-0000-0000-2023-0000000008"
     details: "Signalement Non-Décence dans le Puy de dôme"
@@ -873,3 +874,4 @@ signalements:
       - "J’utilise plusieurs chauffages d'appoint et/ou des pièces principales ne possèdent pas de moyen de chauffage."
     qualifications: 
       - "Non décence énergétique"
+    date_entree: "2023-01-08 17:06:33"

--- a/src/DataFixtures/Loader/LoadCriticiteData.php
+++ b/src/DataFixtures/Loader/LoadCriticiteData.php
@@ -3,6 +3,7 @@
 namespace App\DataFixtures\Loader;
 
 use App\Entity\Criticite;
+use App\Entity\Enum\Qualification;
 use App\Repository\CritereRepository;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -35,6 +36,16 @@ class LoadCriticiteData extends Fixture implements OrderedFixtureInterface
             ->setScore($row['score'])
             ->setNewScore($row['new_score'])
             ->setIsDanger($row['is_danger']);
+
+        if (isset($row['qualifications'])) {
+            $qualification = [];
+            foreach ($row['qualifications'] as $qualificationLabel) {
+                $qualification[] = Qualification::from($qualificationLabel);
+                $criticite
+                ->setQualification($qualification)
+                ->setModifiedAt(new \DateTimeImmutable());
+            }
+        }
 
         $manager->persist($criticite);
     }

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -109,6 +109,10 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 ->setModifiedAt(null);
         }
 
+        if (isset($row['date_entree'])) {
+            $signalement->setDateEntree(new \DateTimeImmutable($row['date_entree']));
+        }
+
         if (Signalement::STATUS_CLOSED === $row['statut']) {
             $signalement
                 ->setMotifCloture($row['motif_cloture'])
@@ -139,6 +143,11 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 $signalementQualification = (new SignalementQualification())
                 ->setSignalement($signalement)
                 ->setQualification(Qualification::from($qualificationLabel))
+                ->setDernierBailAt(
+                    isset($row['date_entree'])
+                        ? new \DateTimeImmutable($row['date_entree'])
+                        : new \DateTimeImmutable()
+                )
                 ->setDesordres($signalement->getCriticites()->map(function (Criticite $criticite) {
                     return $criticite->getId();
                 })->toArray());


### PR DESCRIPTION
## Description
Ajout de la qualification dans les fixtures des criticites, car elles sont faites en migration (pour la prod) et étaient écrasées par les fixtures. Ajout aussi d'une date d'entrée et de bail pour les 2 signalements NDE

## Changements apportés
* Liste
* des changements techniques
* apportés

## Tests
- [ ] Jouer les fixtures, vérifier les tables criticite, signalement et signalement_qualification
