### PR TITLE
[BO - Signalement] Affichage des informations de non décence sur la fiche signalement

### DIFF
--- a/migrations/Version20230224152702.php
+++ b/migrations/Version20230224152702.php
@@ -16,7 +16,7 @@ final class Version20230224152702 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE signalement_qualification (id INT AUTO_INCREMENT NOT NULL, signalement_id INT NOT NULL, qualification VARCHAR(255) NOT NULL, desordres JSON DEFAULT NULL, dernier_bail_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', details JSON DEFAULT NULL, INDEX IDX_6617D77965C5E57E (signalement_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE signalement_qualification (id INT AUTO_INCREMENT NOT NULL, signalement_id INT NOT NULL, qualification VARCHAR(255) NOT NULL, criticites JSON DEFAULT NULL, dernier_bail_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', status VARCHAR(255) DEFAULT NULL, details JSON DEFAULT NULL, INDEX IDX_6617D77965C5E57E (signalement_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE signalement_qualification ADD CONSTRAINT FK_6617D77965C5E57E FOREIGN KEY (signalement_id) REFERENCES signalement (id)');
     }
 

--- a/src/Controller/Back/BackSignalementController.php
+++ b/src/Controller/Back/BackSignalementController.php
@@ -15,6 +15,7 @@ use App\Form\ClotureType;
 use App\Form\SignalementType;
 use App\Manager\SignalementManager;
 use App\Repository\CritereRepository;
+use App\Repository\CriticiteRepository;
 use App\Repository\SignalementQualificationRepository;
 use App\Repository\SituationRepository;
 use App\Repository\TagRepository;
@@ -40,7 +41,8 @@ class BackSignalementController extends AbstractController
         SignalementManager $signalementManager,
         EventDispatcherInterface $eventDispatcher,
         ParameterBagInterface $parameterBag,
-        SignalementQualificationRepository $signalementQualificationRepository
+        SignalementQualificationRepository $signalementQualificationRepository,
+        CriticiteRepository $criticiteRepository
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_VIEW', $signalement);
         if (Signalement::STATUS_ARCHIVED === $signalement->getStatut()) {
@@ -118,6 +120,8 @@ class BackSignalementController extends AbstractController
         $signalementQualification = $signalementQualificationRepository->findOneBy(['signalement' => $signalement]);
         $isSignalementNonDecence = Qualification::NON_DECENCE_ENERGETIQUE == $signalementQualification?->getQualification();
 
+        $signalementQualificationCriticites = $signalementQualification ? $criticiteRepository->findBy(['id' => $signalementQualification->getCriticites()]) : null;
+
         $partners = $signalementManager->findAllPartners($signalement, $isExperimentationTerritory && $isSignalementNonDecence);
 
         return $this->render('back/signalement/view.html.twig', [
@@ -138,6 +142,7 @@ class BackSignalementController extends AbstractController
             'isExperimentationTerritory' => $isExperimentationTerritory,
             'isSignalementNonDecence' => $isSignalementNonDecence,
             'signalementQualification' => $signalementQualification,
+            'signalementQualificationCriticite' => $signalementQualificationCriticites,
         ]);
     }
 

--- a/src/Controller/Back/BackSignalementController.php
+++ b/src/Controller/Back/BackSignalementController.php
@@ -114,6 +114,7 @@ class BackSignalementController extends AbstractController
 
         $experimentationTerritories = $parameterBag->get('experimentation_territory');
         $isExperimentationTerritory = \array_key_exists($signalement->getTerritory()->getZip(), $experimentationTerritories);
+        // TODO : à terme plusieurs qualifications possibles par signalement
         $signalementQualification = $signalementQualificationRepository->findOneBy(['signalement' => $signalement]);
         $isSignalementNonDecence = Qualification::NON_DECENCE_ENERGETIQUE == $signalementQualification?->getQualification();
 
@@ -135,6 +136,8 @@ class BackSignalementController extends AbstractController
             'clotureForm' => $clotureForm->createView(),
             'tags' => $tagsRepository->findAllActive($signalement->getTerritory()),
             'isExperimentationTerritory' => $isExperimentationTerritory,
+            'isSignalementNonDecence' => $isSignalementNonDecence,
+            'signalementQualification' => $signalementQualification,
         ]);
     }
 

--- a/src/Controller/Back/BackSignalementQualificationController.php
+++ b/src/Controller/Back/BackSignalementQualificationController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\Signalement;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/bo/signalements')]
+class BackSignalementQualificationController extends AbstractController
+{
+    #[Route('/{uuid}/qualification/{label}/editer', name: 'back_signalement_qualification_editer')]
+    public function editQualification(
+        Signalement $signalement,
+        EntityManagerInterface $entityManager
+    ) {
+    }
+}

--- a/src/Controller/Back/BackSignalementQualificationController.php
+++ b/src/Controller/Back/BackSignalementQualificationController.php
@@ -43,18 +43,18 @@ class BackSignalementQualificationController extends AbstractController
                 // $signalement->setDateEntree(new DateTimeImmutable($dataDateEntree));
             }
 
-            if ($signalement->getSuperficie() !== $dataSuperficie) {
+            if (null !== $dataSuperficie && $signalement->getSuperficie() !== $dataSuperficie) {
                 $signalement->setSuperficie($dataSuperficie);
             }
 
-            if ($signalementQualification->getDernierBailAt()->format('Y-m-d') !== $dataDernierBail) {
+            if (null !== $dataDernierBail && $signalementQualification->getDernierBailAt()->format('Y-m-d') !== $dataDernierBail) {
                 $signalementQualification->setDernierBailAt(new DateTimeImmutable($dataDernierBail));
             }
 
             $qualificationDetails = $signalementQualification->getDetails();
-            if ($qualificationDetails['consommation_energie'] !== $dataConsoEnergie
-            || $qualificationDetails['DPE'] !== $dataDpe
-            || $qualificationDetails['date_dernier_dpe'] !== $dataDpeDate) {
+            if ((null !== $dataConsoEnergie && $qualificationDetails['consommation_energie'] !== $dataConsoEnergie)
+            || (null !== $dataDpe && $qualificationDetails['DPE'] !== $dataDpe)
+            || (null !== $dataDpeDate && $qualificationDetails['date_dernier_dpe'] !== $dataDpeDate)) {
                 $qualificationDetails['consommation_energie'] = $dataConsoEnergie;
                 $qualificationDetails['DPE'] = $dataDpe;
                 $qualificationDetails['date_dernier_dpe'] = $dataDpeDate;

--- a/src/Controller/Back/BackSignalementQualificationController.php
+++ b/src/Controller/Back/BackSignalementQualificationController.php
@@ -3,17 +3,74 @@
 namespace App\Controller\Back;
 
 use App\Entity\Signalement;
+use App\Entity\SignalementQualification;
+use App\Service\Signalement\SignalementQualificationService;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route('/bo/signalements')]
 class BackSignalementQualificationController extends AbstractController
 {
-    #[Route('/{uuid}/qualification/{label}/editer', name: 'back_signalement_qualification_editer')]
+    #[Route('/{uuid}/qualification/{signalement_qualification}/editer', name: 'back_signalement_qualification_editer')]
     public function editQualification(
+        Request $request,
         Signalement $signalement,
+        SignalementQualification $signalementQualification,
         EntityManagerInterface $entityManager
-    ) {
+    ): RedirectResponse|JsonResponse {
+        $this->denyAccessUnlessGranted('SIGN_EDIT_NDE', $signalement);
+        if ($this->isCsrfTokenValid('signalement_edit_nde_'.$signalement->getId(), $request->get('_token'))) {
+            $dataDateEntree = $request->get('signalement-edit-nde-date-entree');
+            $dataSuperficie = $request->get('signalement-edit-nde-superficie');
+
+            $dataDernierBail = $request->get('signalement-edit-nde-dernier-bail');
+            $dataConsoEnergie = $request->get('signalement-edit-nde-conso-energie');
+            $dataDpe = 'null' === $request->get('signalement-edit-nde-dpe') ? null : (int) $request->get('signalement-edit-nde-dpe');
+            $dataDpeDate = $request->get('signalement-edit-nde-dpe-date');
+
+            if ('after' === $dataDateEntree && $signalement->getDateEntree()->format('Y') < '2023 ') {
+                // TODO :  voir avec Emilien les dates qu'on met en fonction des différents cas : ici date du jour ?
+                // $signalement->setDateEntree(new DateTimeImmutable($dataDateEntree));
+            }
+
+            if ('before' === $dataDateEntree && $signalement->getDateEntree()->format('Y') >= '2023 ') {
+                // TODO :  voir avec Emilien les dates qu'on met en fonction des différents cas : ici 01/01/1970
+                // $signalement->setDateEntree(new DateTimeImmutable($dataDateEntree));
+            }
+
+            if ($signalement->getSuperficie() !== $dataSuperficie) {
+                $signalement->setSuperficie($dataSuperficie);
+            }
+
+            if ($signalementQualification->getDernierBailAt()->format('Y-m-d') !== $dataDernierBail) {
+                $signalementQualification->setDernierBailAt(new DateTimeImmutable($dataDernierBail));
+            }
+
+            $qualificationDetails = $signalementQualification->getDetails();
+            if ($qualificationDetails['consommation_energie'] !== $dataConsoEnergie
+            || $qualificationDetails['DPE'] !== $dataDpe
+            || $qualificationDetails['date_dernier_dpe'] !== $dataDpeDate) {
+                $qualificationDetails['consommation_energie'] = $dataConsoEnergie;
+                $qualificationDetails['DPE'] = $dataDpe;
+                $qualificationDetails['date_dernier_dpe'] = $dataDpeDate;
+                $signalementQualification->setDetails($qualificationDetails);
+            }
+
+            $qualificationService = new SignalementQualificationService($signalement, $signalementQualification);
+            $signalementQualification->setStatus($qualificationService->updateNDEStatus());
+
+            $entityManager->persist($signalement);
+            $entityManager->persist($signalementQualification);
+            $entityManager->flush();
+        } else {
+            $this->addFlash('error', "Une erreur est survenu lors de l'édition");
+        }
+
+        return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
     }
 }

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -4,6 +4,7 @@ namespace App\DataFixtures\Loader;
 
 use App\Entity\Criticite;
 use App\Entity\Enum\Qualification;
+use App\Entity\Enum\QualificationStatus;
 use App\Entity\Signalement;
 use App\Entity\SignalementQualification;
 use App\Entity\User;
@@ -148,9 +149,19 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                         ? new \DateTimeImmutable($row['date_entree'])
                         : new \DateTimeImmutable()
                 )
-                ->setDesordres($signalement->getCriticites()->map(function (Criticite $criticite) {
+                ->setCriticites($signalement->getCriticites()->map(function (Criticite $criticite) {
                     return $criticite->getId();
                 })->toArray());
+                if ('Non décence énergétique' == $qualificationLabel) {
+                    $qualificationDetails = [];
+                    $qualificationDetails['consommation_energie'] = $faker->numberBetween(450, 700);
+                    $qualificationDetails['DPE'] = 1;
+                    $qualificationDetails['date_dernier_dpe'] = $faker->dateTimeThisYear()->format('Y-m-d');
+                    $signalementQualification
+                    ->setStatus(QualificationStatus::NDE_AVEREE)
+                    ->setDetails($qualificationDetails);
+                }
+
                 $manager->persist($signalementQualification);
 
                 $signalement->addSignalementQualification($signalementQualification);

--- a/src/Entity/Criticite.php
+++ b/src/Entity/Criticite.php
@@ -209,6 +209,7 @@ class Criticite
 
     public function getScoreLabel(): string
     {
+        // TODO à revoir avec le nouvel algo de criticité (les scores ne sont plus forcément 1, 2, 3)
         return match ($this->score) {
             1 => self::ETAT_MOYEN,
             2 => self::ETAT_GRAVE,

--- a/src/Entity/Enum/QualificationStatus.php
+++ b/src/Entity/Enum/QualificationStatus.php
@@ -4,6 +4,7 @@ namespace App\Entity\Enum;
 
 enum QualificationStatus: string
 {
+    case ARCHIVED = 'archived';
     case NDE_AVEREE = 'Non décence énergétique avérée';
     case NDE_OK = 'Décence énergétique OK';
     case NDE_CHECK = 'Non décence énergétique à vérifier';

--- a/src/Entity/Enum/QualificationStatus.php
+++ b/src/Entity/Enum/QualificationStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum QualificationStatus: string
+{
+    case NDE_AVEREE = 'Non décence énergétique avérée';
+    case NDE_OK = 'Décence énergétique OK';
+    case NDE_CHECK = 'Non décence énergétique à vérifier';
+}

--- a/src/Entity/SignalementQualification.php
+++ b/src/Entity/SignalementQualification.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Enum\Qualification;
+use App\Entity\Enum\QualificationStatus;
 use App\Repository\SignalementQualificationRepository;
 use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
@@ -24,13 +25,16 @@ class SignalementQualification
     private ?Qualification $qualification = null;
 
     #[ORM\Column(nullable: true)]
-    private array $desordres = [];
+    private array $criticites = [];
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $dernierBailAt = null;
 
     #[ORM\Column(nullable: true)]
     private array $details = [];
+
+    #[ORM\Column(type: 'string', enumType: QualificationStatus::class, nullable: true)]
+    private ?QualificationStatus $status = null;
 
     public function getId(): ?int
     {
@@ -61,14 +65,14 @@ class SignalementQualification
         return $this;
     }
 
-    public function getDesordres(): array
+    public function getCriticites(): array
     {
-        return $this->desordres;
+        return $this->criticites;
     }
 
-    public function setDesordres(?array $desordres): self
+    public function setCriticites(?array $criticites): self
     {
-        $this->desordres = $desordres;
+        $this->criticites = $criticites;
 
         return $this;
     }
@@ -93,6 +97,18 @@ class SignalementQualification
     public function setDetails(?array $details): self
     {
         $this->details = $details;
+
+        return $this;
+    }
+
+    public function getStatus(): ?QualificationStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(QualificationStatus $status): self
+    {
+        $this->status = $status;
 
         return $this;
     }

--- a/src/Service/Signalement/SignalementQualificationService.php
+++ b/src/Service/Signalement/SignalementQualificationService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Service\Signalement;
+
+use App\Entity\Enum\QualificationStatus;
+use App\Entity\Signalement;
+use App\Entity\SignalementQualification;
+
+class SignalementQualificationService
+{
+    public function __construct(private Signalement $signalement, private SignalementQualification $signalementQualification)
+    {
+    }
+
+    public function updateNDEStatus(): ?QualificationStatus
+    {
+        if ($this->signalementQualification->getDernierBailAt()->format('Y') >= '2023' && $this->signalementQualification->getDetails()['consommation_energie'] > 450) {
+            return QualificationStatus::NDE_AVEREE;
+        }
+
+        if ($this->signalementQualification->getDernierBailAt()->format('Y') >= '2023' && $this->signalementQualification->getDetails()['consommation_energie'] <= 450) {
+            return QualificationStatus::NDE_OK;
+        }
+
+        if ($this->signalementQualification->getDernierBailAt()->format('Y') >= '2023') {
+            return QualificationStatus::NDE_CHECK;
+        }
+
+        return null;
+    }
+}

--- a/src/Service/Signalement/SignalementQualificationService.php
+++ b/src/Service/Signalement/SignalementQualificationService.php
@@ -26,6 +26,7 @@ class SignalementQualificationService
             return QualificationStatus::NDE_CHECK;
         }
 
-        return null;
+        // si avant 2023, on archive la qualification
+        return QualificationStatus::ARCHIVED;
     }
 }

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -1,0 +1,131 @@
+<dialog aria-labelledby="fr-modal-edit-nde-title" id="fr-modal-edit-nde" class="fr-modal" role="dialog">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-10 fr-col-lg-10">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                            <h1 id="fr-modal-edit-nde-title" class="fr-modal__title">
+                                Non décence énergétique
+                            </h1>
+                            <button class="fr-link--close fr-link" aria-controls="fr-modal-edit-nde">Fermer</button>
+                     </div>
+                    <div class="fr-modal__content">
+                       <div class="fr-grid-row fr-grid-row--gutters fr-alert fr-alert--info fr-alert--sm">Valider les informations pour savoir si le logement dépasse le seuil de non décence énergétique ou non.</div>
+                    
+                        <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-h-100 fr-hidden fr-mt-5w"
+                             id="signalement-edit-nde-loader-row">
+                            <div class="fr-col-12 fr-text--center">
+                                <div class="lds-histologe">
+                                    <div></div>
+                                    <div></div>
+                                    <div></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
+                             id="signalement-edit-nde-form-row">
+                            {# <form method="POST" name="signalement-edit-nde" id="signalement-edit-nde-form"> #}
+                                <div class="fr-col-6">
+                                    {# <label for="signalement-edit-nde-select-disponible" class="fr-label fr-text--bold">Entrée dans le logement</label> #}
+                                    <fieldset class="fr-fieldset fr-fieldset--inline">
+                                        <legend class="fr-fieldset__legend fr-text--regular" id='radio-inline-legend'>
+                                            Entrée dans le logement
+                                        </legend>
+                                        <div class="fr-fieldset__content">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="radio-inline-1" name="radio-inline">
+                                                <label class="fr-label" for="radio-inline-1">Avant 2023
+                                                </label>
+                                            </div>
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="radio-inline-2" name="radio-inline">
+                                                <label class="fr-label" for="radio-inline-2">A partir de 2023
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </fieldset>
+
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="text-input-calendar">
+                                            Date du dernier bail
+                                        </label>
+                                        <div class="fr-input-wrap fr-fi-calendar-line">
+                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar">
+                                        </div>
+                                    </div>
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="text-input-number">
+                                            Consommation énergétique
+                                        </label>
+                                        <input class="fr-input" pattern="[0-9]*" inputmode="numeric" type="number" id="text-input-number" name="text-input-number"> kWh/an
+                                    </div>
+                                </div>
+                                <div class="fr-col-6">
+                                    {# <label for="signalement-edit-nde-select-affecte" class="fr-label fr-text--bold">Partenaire(s)
+                                        affecté(s)</label> #}
+                                    <fieldset class="fr-fieldset fr-fieldset--inline">
+                                        <legend class="fr-fieldset__legend fr-text--regular" id='radio-inline-legend'>
+                                            DPE Disponible ?
+                                        </legend>
+                                        <div class="fr-fieldset__content">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="radio-inline-1" name="radio-dpe">
+                                                <label class="fr-label" for="radio-inline-1">Oui
+                                                </label>
+                                            </div>
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="radio-inline-2" name="radio-dpe">
+                                                <label class="fr-label" for="radio-inline-2">Non
+                                                </label>
+                                            </div>
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="radio-inline-2" name="radio-dpe">
+                                                <label class="fr-label" for="radio-inline-2">Ne sais pas
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </fieldset>
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="text-input-calendar">
+                                            Date du dernier DPE
+                                        </label>
+                                        <div class="fr-input-wrap fr-fi-calendar-line">
+                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar">
+                                        </div>
+                                    </div>
+                                    {# TODO Si date de DPE à partir du 01/01/2023 -> On affiche un champ unique kWh/m²/an sur toute la largeur #}
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="text-input-number">
+                                            Superficie du logement
+                                        </label>
+                                        <input class="fr-input" pattern="[0-9]*" type="number" id="text-input-number" name="text-input-number"> m2
+                                    </div>
+
+                                    <input type="hidden" name="_token"
+                                            value="{{ csrf_token('signalement_affectation_'~signalement.id) }}">
+                                </div>
+                            {# </form> #}
+                        </div>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button class="fr-btn fr-fi-checkbox-line" type="submit"
+                                        form="signalement-edit-nde-form" id="signalement-edit-nde-form-submit"
+                                        formaction="{{ path('back_signalement_qualification_editer',{uuid:signalement.uuid, label:signalementQualification.qualification.name}) }}">
+                                    Valider
+                                </button>
+                            </li>
+                            <li>
+                                <button class="fr-btn fr-fi-checkbox-line fr-btn--secondary"
+                                        aria-controls="fr-modal-edit-nde">
+                                    Annuler
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -11,7 +11,6 @@
                      </div>
                     <div class="fr-modal__content">
                        <p class="fr-grid-row fr-grid-row--gutters fr-alert fr-alert--info fr-alert--sm">Valider les informations pour savoir si le logement dépasse le seuil de non décence énergétique ou non.</p>
-                    {# <p class="fr-badge fr-badge--info fr-badge--sm">Valider les informations pour savoir si le logement dépasse le seuil de non décence énergétique ou non.</p> #}
                         <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-h-100 fr-hidden fr-mt-5w"
                              id="signalement-edit-nde-loader-row">
                             <div class="fr-col-12 fr-text--center">
@@ -22,6 +21,8 @@
                                 </div>
                             </div>
                         </div>
+                        </br>
+                        </br>
                         <form method="POST" name="signalement-edit-nde" id="signalement-edit-nde-form">
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
                                 id="signalement-edit-nde-form-row">
@@ -43,21 +44,6 @@
                                             </div>
                                         </div>
                                     </fieldset>
-                                    <div class="fr-input-group">
-                                        <label class="fr-label" for="signalement-edit-nde-dernier-bail">
-                                            Date du dernier bail
-                                        </label>
-                                        <div class="fr-input-wrap">
-                                            <input class="fr-input" type="date" id="signalement-edit-nde-dernier-bail" name="signalement-edit-nde-dernier-bail" value="{{ signalementQualificationNDE.dernierBailAt|date('Y-m-d') }}">
-                                        </div>
-
-                                    </div>
-                                    <div class="fr-input-group">
-                                        <label class="fr-label" for="signalement-edit-nde-conso-energie">
-                                            Consommation énergétique
-                                        </label>
-                                        <input class="fr-input" pattern="[0-9]*" inputmode="numeric" type="number" id="signalement-edit-nde-conso-energie" name="signalement-edit-nde-conso-energie" value="{{ signalementQualificationNDE.details.consommation_energie }}"> kWh/an
-                                    </div>
                                 </div>
                                 <div class="fr-col-6">
                                     <fieldset class="fr-fieldset fr-fieldset--inline">
@@ -82,26 +68,65 @@
                                             </div>
                                         </div>
                                     </fieldset>
+                                </div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
+                                id="signalement-edit-nde-form-row">
+                                <div class="fr-col-6">
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="signalement-edit-nde-dernier-bail">
+                                            Date du dernier bail
+                                        </label>
+                                        <div class="fr-input-group">
+                                            <input class="fr-input fr-col-10" type="date" id="signalement-edit-nde-dernier-bail" name="signalement-edit-nde-dernier-bail" value="{{ signalementQualificationNDE.dernierBailAt|date('Y-m-d') }}">
+                                        </div>
+
+                                    </div>
+                                </div>
+                                <div class="fr-col-6">
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="signalement-edit-nde-dpe-date">
                                             Date du dernier DPE
                                         </label>
-                                        <div class="fr-input-wrap fr-fi-calendar-line">
-                                            <input class="fr-input" type="date" id="signalement-edit-nde-dpe-date" name="signalement-edit-nde-dpe-date" value="{{ signalementQualificationNDE.details.date_dernier_dpe|date('Y-m-d') }}">
+                                        <div class="fr-input-group">
+                                            <input class="fr-input fr-col-10" type="date" id="signalement-edit-nde-dpe-date" name="signalement-edit-nde-dpe-date" value="{{ signalementQualificationNDE.details.date_dernier_dpe|date('Y-m-d') }}">
                                         </div>
                                     </div>
-                                    {# TODO Si date de DPE à partir du 01/01/2023 -> On affiche un champ unique kWh/m²/an sur toute la largeur #}
-                                    <div class="fr-input-group">
-                                        <label class="fr-label" for="signalement-edit-nde-superficie">
-                                            Superficie du logement
-                                        </label>
-                                        <input class="fr-input" pattern="[0-9]*" type="number" id="signalement-edit-nde-superficie" name="signalement-edit-nde-superficie" value="{{signalement.superficie}}"> m²
-                                    </div>
-
-                                    <input type="hidden" name="_token"
-                                            value="{{ csrf_token('signalement_edit_nde_'~signalement.id) }}">
                                 </div>
                             </div>
+                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
+                                id="signalement-edit-nde-form-row">
+                                {# Si date de DPE à partir du 01/01/2023 -> On affiche un champ unique kWh/m²/an sur toute la largeur #}
+                                {% if signalementQualificationNDE.details.date_dernier_dpe|date('Y') >= '2023' %}
+                                    <div class="fr-col-12">
+                                        <div class="fr-input-group">
+                                            <label class="fr-label" for="signalement-edit-nde-conso-energie">
+                                                Consommation énergétique
+                                            </label>
+                                            <input class="fr-input fr-col-10" style="display: inline;" pattern="[0-9]*" inputmode="numeric" type="number" id="signalement-edit-nde-conso-energie" name="signalement-edit-nde-conso-energie" value="{{ signalementQualificationNDE.details.consommation_energie }}"> kWh/m²/an
+                                        </div>
+                                    </div>
+
+                                {% else %}
+                                    <div class="fr-col-6">
+                                        <div class="fr-input-group">
+                                            <label class="fr-label" for="signalement-edit-nde-conso-energie">
+                                                Consommation énergétique
+                                            </label>
+                                            <input class="fr-input fr-col-10" style="display: inline;" pattern="[0-9]*" inputmode="numeric" type="number" id="signalement-edit-nde-conso-energie" name="signalement-edit-nde-conso-energie" value="{{ signalementQualificationNDE.details.consommation_energie }}"> kWh/an
+                                        </div>
+                                    </div>
+                                    <div class="fr-col-6">
+                                        <div class="fr-input-group">
+                                            <label class="fr-label" for="signalement-edit-nde-superficie">
+                                                Superficie du logement
+                                            </label>
+                                            <input class="fr-input fr-col-10" style="display: inline;" pattern="[0-9]*" type="number" id="signalement-edit-nde-superficie" name="signalement-edit-nde-superficie" value="{{signalement.superficie}}"> m²
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            </div>                            
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_nde_'~signalement.id) }}">
                         </form>
                     </div>
                     <div class="fr-modal__footer">

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -10,8 +10,8 @@
                             <button class="fr-link--close fr-link" aria-controls="fr-modal-edit-nde">Fermer</button>
                      </div>
                     <div class="fr-modal__content">
-                       <div class="fr-grid-row fr-grid-row--gutters fr-alert fr-alert--info fr-alert--sm">Valider les informations pour savoir si le logement dépasse le seuil de non décence énergétique ou non.</div>
-                    
+                       <p class="fr-grid-row fr-grid-row--gutters fr-alert fr-alert--info fr-alert--sm">Valider les informations pour savoir si le logement dépasse le seuil de non décence énergétique ou non.</p>
+                    {# <p class="fr-badge fr-badge--info fr-badge--sm">Valider les informations pour savoir si le logement dépasse le seuil de non décence énergétique ou non.</p> #}
                         <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-h-100 fr-hidden fr-mt-5w"
                              id="signalement-edit-nde-loader-row">
                             <div class="fr-col-12 fr-text--center">
@@ -33,31 +33,31 @@
                                         </legend>
                                         <div class="fr-fieldset__content">
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-1" name="radio-inline">
+                                                <input type="radio" id="radio-inline-1" name="radio-inline" {% if signalement.dateEntree|date('Y')<2023 %}checked{% endif %}>
                                                 <label class="fr-label" for="radio-inline-1">Avant 2023
                                                 </label>
                                             </div>
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-2" name="radio-inline">
+                                                <input type="radio" id="radio-inline-2" name="radio-inline" {% if signalement.dateEntree|date('Y')>=2023 %}checked{% endif %}>
                                                 <label class="fr-label" for="radio-inline-2">A partir de 2023
                                                 </label>
                                             </div>
                                         </div>
                                     </fieldset>
-
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="text-input-calendar">
                                             Date du dernier bail
                                         </label>
-                                        <div class="fr-input-wrap fr-fi-calendar-line">
-                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar">
+                                        <div class="fr-input-wrap">
+                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar" value="{{ signalementQualification.dernierBailAt|date('Y-m-d') }}">
                                         </div>
+
                                     </div>
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="text-input-number">
                                             Consommation énergétique
                                         </label>
-                                        <input class="fr-input" pattern="[0-9]*" inputmode="numeric" type="number" id="text-input-number" name="text-input-number"> kWh/an
+                                        <input class="fr-input" pattern="[0-9]*" inputmode="numeric" type="number" id="text-input-number" name="text-input-number" value="{{ signalementQualification.details.consommation_energie }}"> kWh/an
                                     </div>
                                 </div>
                                 <div class="fr-col-6">
@@ -69,17 +69,17 @@
                                         </legend>
                                         <div class="fr-fieldset__content">
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-1" name="radio-dpe">
+                                                <input type="radio" id="radio-inline-1" name="radio-dpe" {% if signalementQualification.details.DPE == 1 %}checked{% endif %}>
                                                 <label class="fr-label" for="radio-inline-1">Oui
                                                 </label>
                                             </div>
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-2" name="radio-dpe">
+                                                <input type="radio" id="radio-inline-2" name="radio-dpe" {% if signalementQualification.details.DPE == 0 %}checked{% endif %}>
                                                 <label class="fr-label" for="radio-inline-2">Non
                                                 </label>
                                             </div>
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-2" name="radio-dpe">
+                                                <input type="radio" id="radio-inline-2" name="radio-dpe" {% if signalementQualification.details.DPE is null %}checked{% endif %}>
                                                 <label class="fr-label" for="radio-inline-2">Ne sais pas
                                                 </label>
                                             </div>
@@ -90,7 +90,7 @@
                                             Date du dernier DPE
                                         </label>
                                         <div class="fr-input-wrap fr-fi-calendar-line">
-                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar">
+                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar" value="{{ signalementQualification.details.date_dernier_dpe|date('Y-m-d') }}">
                                         </div>
                                     </div>
                                     {# TODO Si date de DPE à partir du 01/01/2023 -> On affiche un champ unique kWh/m²/an sur toute la largeur #}
@@ -98,7 +98,7 @@
                                         <label class="fr-label" for="text-input-number">
                                             Superficie du logement
                                         </label>
-                                        <input class="fr-input" pattern="[0-9]*" type="number" id="text-input-number" name="text-input-number"> m2
+                                        <input class="fr-input" pattern="[0-9]*" type="number" id="text-input-number" name="text-input-number" value="{{signalement.superficie}}"> m²
                                     </div>
 
                                     <input type="hidden" name="_token"

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -22,97 +22,94 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
-                             id="signalement-edit-nde-form-row">
-                            {# <form method="POST" name="signalement-edit-nde" id="signalement-edit-nde-form"> #}
+                        <form method="POST" name="signalement-edit-nde" id="signalement-edit-nde-form">
+                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
+                                id="signalement-edit-nde-form-row">
                                 <div class="fr-col-6">
-                                    {# <label for="signalement-edit-nde-select-disponible" class="fr-label fr-text--bold">Entrée dans le logement</label> #}
                                     <fieldset class="fr-fieldset fr-fieldset--inline">
-                                        <legend class="fr-fieldset__legend fr-text--regular" id='radio-inline-legend'>
+                                        <legend class="fr-fieldset__legend fr-text--regular" id='signalement-edit-nde-date-entree-legend'>
                                             Entrée dans le logement
                                         </legend>
                                         <div class="fr-fieldset__content">
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-1" name="radio-inline" {% if signalement.dateEntree|date('Y')<2023 %}checked{% endif %}>
-                                                <label class="fr-label" for="radio-inline-1">Avant 2023
+                                                <input type="radio" id="signalement-edit-nde-date-entree-before" name="signalement-edit-nde-date-entree" value="before" {% if signalement.dateEntree|date('Y')<2023 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-date-entree-before">Avant 2023
                                                 </label>
                                             </div>
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-2" name="radio-inline" {% if signalement.dateEntree|date('Y')>=2023 %}checked{% endif %}>
-                                                <label class="fr-label" for="radio-inline-2">A partir de 2023
+                                                <input type="radio" id="signalement-edit-nde-date-entree-after" name="signalement-edit-nde-date-entree" value="after" {% if signalement.dateEntree|date('Y')>=2023 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-date-entree-after">A partir de 2023
                                                 </label>
                                             </div>
                                         </div>
                                     </fieldset>
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="text-input-calendar">
+                                        <label class="fr-label" for="signalement-edit-nde-dernier-bail">
                                             Date du dernier bail
                                         </label>
                                         <div class="fr-input-wrap">
-                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar" value="{{ signalementQualification.dernierBailAt|date('Y-m-d') }}">
+                                            <input class="fr-input" type="date" id="signalement-edit-nde-dernier-bail" name="signalement-edit-nde-dernier-bail" value="{{ signalementQualificationNDE.dernierBailAt|date('Y-m-d') }}">
                                         </div>
 
                                     </div>
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="text-input-number">
+                                        <label class="fr-label" for="signalement-edit-nde-conso-energie">
                                             Consommation énergétique
                                         </label>
-                                        <input class="fr-input" pattern="[0-9]*" inputmode="numeric" type="number" id="text-input-number" name="text-input-number" value="{{ signalementQualification.details.consommation_energie }}"> kWh/an
+                                        <input class="fr-input" pattern="[0-9]*" inputmode="numeric" type="number" id="signalement-edit-nde-conso-energie" name="signalement-edit-nde-conso-energie" value="{{ signalementQualificationNDE.details.consommation_energie }}"> kWh/an
                                     </div>
                                 </div>
                                 <div class="fr-col-6">
-                                    {# <label for="signalement-edit-nde-select-affecte" class="fr-label fr-text--bold">Partenaire(s)
-                                        affecté(s)</label> #}
                                     <fieldset class="fr-fieldset fr-fieldset--inline">
-                                        <legend class="fr-fieldset__legend fr-text--regular" id='radio-inline-legend'>
+                                        <legend class="fr-fieldset__legend fr-text--regular" id='signalement-edit-nde-dpe-legend'>
                                             DPE Disponible ?
                                         </legend>
                                         <div class="fr-fieldset__content">
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-1" name="radio-dpe" {% if signalementQualification.details.DPE == 1 %}checked{% endif %}>
-                                                <label class="fr-label" for="radio-inline-1">Oui
+                                                <input type="radio" id="signalement-edit-nde-dpe-1" name="signalement-edit-nde-dpe" value='1' {% if signalementQualificationNDE.details.DPE == 1 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-dpe-1">Oui
                                                 </label>
                                             </div>
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-2" name="radio-dpe" {% if signalementQualification.details.DPE == 0 %}checked{% endif %}>
-                                                <label class="fr-label" for="radio-inline-2">Non
+                                                <input type="radio" id="signalement-edit-nde-dpe-0" name="signalement-edit-nde-dpe" value='0' {% if signalementQualificationNDE.details.DPE == 0 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-dpe-0">Non
                                                 </label>
                                             </div>
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="radio-inline-2" name="radio-dpe" {% if signalementQualification.details.DPE is null %}checked{% endif %}>
-                                                <label class="fr-label" for="radio-inline-2">Ne sais pas
+                                                <input type="radio" id="signalement-edit-nde-dpe-2" name="signalement-edit-nde-dpe" value='null' {% if signalementQualificationNDE.details.DPE is null %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-dpe-2">Ne sais pas
                                                 </label>
                                             </div>
                                         </div>
                                     </fieldset>
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="text-input-calendar">
+                                        <label class="fr-label" for="signalement-edit-nde-dpe-date">
                                             Date du dernier DPE
                                         </label>
                                         <div class="fr-input-wrap fr-fi-calendar-line">
-                                            <input class="fr-input" type="date" id="text-input-calendar" name="text-input-calendar" value="{{ signalementQualification.details.date_dernier_dpe|date('Y-m-d') }}">
+                                            <input class="fr-input" type="date" id="signalement-edit-nde-dpe-date" name="signalement-edit-nde-dpe-date" value="{{ signalementQualificationNDE.details.date_dernier_dpe|date('Y-m-d') }}">
                                         </div>
                                     </div>
                                     {# TODO Si date de DPE à partir du 01/01/2023 -> On affiche un champ unique kWh/m²/an sur toute la largeur #}
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="text-input-number">
+                                        <label class="fr-label" for="signalement-edit-nde-superficie">
                                             Superficie du logement
                                         </label>
-                                        <input class="fr-input" pattern="[0-9]*" type="number" id="text-input-number" name="text-input-number" value="{{signalement.superficie}}"> m²
+                                        <input class="fr-input" pattern="[0-9]*" type="number" id="signalement-edit-nde-superficie" name="signalement-edit-nde-superficie" value="{{signalement.superficie}}"> m²
                                     </div>
 
                                     <input type="hidden" name="_token"
-                                            value="{{ csrf_token('signalement_affectation_'~signalement.id) }}">
+                                            value="{{ csrf_token('signalement_edit_nde_'~signalement.id) }}">
                                 </div>
-                            {# </form> #}
-                        </div>
+                            </div>
+                        </form>
                     </div>
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
                                 <button class="fr-btn fr-fi-checkbox-line" type="submit"
                                         form="signalement-edit-nde-form" id="signalement-edit-nde-form-submit"
-                                        formaction="{{ path('back_signalement_qualification_editer',{uuid:signalement.uuid, label:signalementQualification.qualification.name}) }}">
+                                        formaction="{{ path('back_signalement_qualification_editer',{uuid:signalement.uuid, signalement_qualification:signalementQualificationNDE.id}) }}">
                                     Valider
                                 </button>
                             </li>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -12,7 +12,7 @@
     {% if signalement.statut is not same as(1) and not isClosed and not isClosedForMe and ((isAffected and isAccepted)) or is_granted('ROLE_ADMIN_TERRITORY') %}
         {% include '_partials/_modal_cloture.html.twig' %}
     {% endif %}
-    {% if isSignalementNonDecence %}
+    {% if isSignalementNDE %}
         {% include '_partials/_modal_edit_nde.html.twig' %}        
     {% endif %}
     <section
@@ -39,7 +39,7 @@
                         <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold{# fr-fi-information-fill fr-icon--sm #} fr-pr-3v">&nbsp;
                             Signalement par l'occupant</small>
                     {% endif %}                    
-                    {% if isSignalementNonDecence %}
+                    {% if isSignalementNDE %}
                          <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold fr-pr-3v">&nbsp;
                             Non décence énergétique</small>
                     {% endif %}                               
@@ -436,20 +436,7 @@
                 </ul>
             </div>
         </div>
-        
-        {% if isSignalementNonDecence %}
-        
-                {# {% if is_granted('ROLE_ADMIN_TERRITORY') and signalement.statut is not same as(6) and not needValidation %} #}
-        {# TODO : Les infos sur la non décence énergétique sont affichés sur les signalements concernés, pour 
-Les super admin
-Les responsables territoire sur les territoires d'expérimentation
-Les partenaires affectés au signalement ET ayant la compétence "Non décence énergétique" #}
-
-        {# <div class="fr-grid-row fr-grid-row--middle fr-mb-3v"> #}
-    {# <div class="fr-grid-row">
-                <strong class="fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france"> Non décence énergétique</strong>#}
-                {# <span class="fr-hint-text">Ci-dessous le détail du signalement tel que rapporté par l'usager</span> #}
-            {# </div>  #}
+        {% if isSignalementNDE and (is_granted('ROLE_ADMIN_TERRITORY') or 'Non décence énergétique' in app.user.partner.competence)  %}
         <section class="fr-accordion">
             <h3 class="fr-accordion__title ">
                 <button class="fr-accordion__btn fr-btn--icon-left fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france" aria-expanded="true" aria-controls="accordion-nde">Non décence énergétique</button>
@@ -457,18 +444,18 @@ Les partenaires affectés au signalement ET ayant la compétence "Non décence �
             <div class="fr-collapse" id="accordion-nde">
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-5">
-                    <strong>Consommation d'énergie :</strong> <span class="fr-badge fr-badge--info fr-badge--sm">{{ signalementQualification.details.consommation_energie }} kWh/m²/an</span>
+                    <strong>Consommation d'énergie :</strong> <span class="fr-badge fr-badge--info fr-badge--sm">{{ signalementQualificationNDE.details.consommation_energie }} kWh/m²/an</span>
                     </div>
                     <div class="fr-col-12 fr-col-md-5">                    
                         {% set classe = '' %}
-                        {% if signalementQualification.status.name == 'NDE_CHECK' %}
+                        {% if signalementQualificationNDE.status.name == 'NDE_CHECK' %}
                             {% set classe = 'fr-badge fr-badge--info fr-badge--sm' %}
-                        {% elseif signalementQualification.status.name == 'NDE_OK' %}
+                        {% elseif signalementQualificationNDE.status.name == 'NDE_OK' %}
                             {% set classe = 'fr-badge fr-badge--success fr-badge--sm' %}
-                        {% elseif signalementQualification.status.name == 'NDE_AVEREE' %}
+                        {% elseif signalementQualificationNDE.status.name == 'NDE_AVEREE' %}
                             {% set classe = 'fr-badge fr-badge--error fr-badge--sm' %}
                         {% endif %}
-                    <strong>Analyse :</strong> <span class="{{ classe }}">{{ signalementQualification.status.value }}</span>
+                    <strong>Analyse :</strong> <span class="{{ classe }}">{{ signalementQualificationNDE.status.value }}</span>
                     </div>
                     
                     <div class="fr-col-12 fr-col-md-2 fr-text--right">
@@ -481,7 +468,7 @@ Les partenaires affectés au signalement ET ayant la compétence "Non décence �
                 <div class="fr-grid-row">
                     <strong>Désordre(s) concerné(s) :</strong> 
                     <ul class="fr-list">
-                        {% for criticite in signalementQualificationCriticite %}
+                        {% for criticite in signalementQualificationNDECriticite %}
                             <li> {{ criticite.critere.label}} - Etat {{criticite.scoreLabel}} : {{criticite.label}}</li>
                         {% endfor %}
                     </ul>
@@ -491,15 +478,15 @@ Les partenaires affectés au signalement ET ayant la compétence "Non décence �
                     <strong>Entrée dans le logement :</strong> {{ signalement.dateEntree|date('d/m/Y') }}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
-                    <strong>DPE :</strong> {{ signalementQualification.details.DPE ? 'Oui' : 'Non' }} 
+                    <strong>DPE :</strong> {{ signalementQualificationNDE.details.DPE ? 'Oui' : 'Non' }} 
                     </div>
                 </div>
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-6">
-                    <strong>Dernier bail :</strong> {{ signalementQualification.dernierBailAt|date('d/m/Y') }}
+                    <strong>Dernier bail :</strong> {{ signalementQualificationNDE.dernierBailAt|date('d/m/Y') }}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
-                    <strong>Date dernier DPE :</strong> {{ signalementQualification.details.date_dernier_dpe|date('d/m/Y') }} 
+                    <strong>Date dernier DPE :</strong> {{ signalementQualificationNDE.details.date_dernier_dpe|date('d/m/Y') }} 
                     </div>
                 </div>
             </div>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -12,6 +12,9 @@
     {% if signalement.statut is not same as(1) and not isClosed and not isClosedForMe and ((isAffected and isAccepted)) or is_granted('ROLE_ADMIN_TERRITORY') %}
         {% include '_partials/_modal_cloture.html.twig' %}
     {% endif %}
+    {% if isSignalementNonDecence %}
+        {% include '_partials/_modal_edit_nde.html.twig' %}        
+    {% endif %}
     <section
             class="fr-p-5v {{ isClosedForMe or signalement.statut is same as(6) or signalement.statut is same as(8) ? 'signalement-invalid':'' }}"
             id="signalement-{{ signalement.id }}-content">
@@ -35,7 +38,11 @@
                     {% else %}
                         <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold{# fr-fi-information-fill fr-icon--sm #} fr-pr-3v">&nbsp;
                             Signalement par l'occupant</small>
-                    {% endif %}
+                    {% endif %}                    
+                    {% if isSignalementNonDecence %}
+                         <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold fr-pr-3v">&nbsp;
+                            Non décence énergétique</small>
+                    {% endif %}                               
                     <text><strong>Déposé le:</strong> {{ signalement.createdAt|format_datetime(locale='fr') }}</text>
                 </div>
                 <div class="fr-col-12 fr-col-md-6 fr-text--right">
@@ -428,6 +435,69 @@
                 </ul>
             </div>
         </div>
+        
+        {% if isSignalementNonDecence %}
+        {# TODO : Les infos sur la non décence énergétique sont affichés sur les signalements concernés, pour 
+Les super admin
+Les responsables territoire sur les territoires d'expérimentation
+Les partenaires affectés au signalement ET ayant la compétence "Non décence énergétique" #}
+
+        {# <div class="fr-grid-row fr-grid-row--middle fr-mb-3v"> #}
+    {# <div class="fr-grid-row">
+                <strong class="fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france"> Non décence énergétique</strong>#}
+                {# <span class="fr-hint-text">Ci-dessous le détail du signalement tel que rapporté par l'usager</span> #}
+            {# </div>  #}
+        <section class="fr-accordion">
+            <h3 class="fr-accordion__title ">
+                <button class="fr-accordion__btn fr-btn--icon-left fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france" aria-expanded="true" aria-controls="accordion-nde">Non décence énergétique</button>
+            </h3>
+            <div class="fr-collapse" id="accordion-nde">
+                <!-- données de test -->
+                <div class="fr-grid-row">
+                    <div class="fr-col-12 fr-col-md-5">
+                    Consommation d'énergie :
+                    </div>
+                    <div class="fr-col-12 fr-col-md-5">
+                    Analyse :
+                    </div>
+                    
+                {# {% if is_granted('ROLE_ADMIN_TERRITORY') and signalement.statut is not same as(6) and not needValidation %} #}
+                    <div class="fr-col-12 fr-col-md-2 fr-text--right">
+                        <button class="fr-btn fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" data-fr-opened="false"
+                                aria-controls="fr-modal-edit-nde">
+                            Modifier
+                        </button>
+                    </div>
+                {# {% endif %} #}
+
+                </div>
+                <div class="fr-grid-row">
+                    Désordre(s) concerné(s) : {{ signalementQualification.desordres|join(', ')}}
+                </div>
+                <div class="fr-grid-row">
+                    <div class="fr-col-12 fr-col-md-6">
+                    Entrée dans le logement : {{ signalement.dateEntree}}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                    DPE :
+                    </div>
+                </div>
+                <div class="fr-grid-row">
+                    <div class="fr-col-12 fr-col-md-6">
+                    Dernier bail : {{ signalementQualification.dernierBailAt}}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                    Date dernier DPE :
+                    </div>
+                </div>
+            </div>
+        </section>
+
+
+        {# </div> #}
+
+        {% endif %}
+
         <hr>
         <div class="fr-grid-row">
             <div class="fr-col-12 fr-col-md-6">

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -405,6 +405,7 @@
                             <strong>{{ situation|capitalize }}</strong>
                             <ul class="fr-list--icon-img fr-collapse" id="situation-collapse-{{ loop.index }}">
                                 {% for critere,criticite in criteres %}
+                                    {# TODO à revoir avec le nouvel algo de criticité (les scores ne sont plus forcément 1, 2, 3, et le isDanger est au niveau de la criticité) #}
                                     {% if criticite.score is same as(1) %}
                                         {% set icon = 'moyen' %}
                                     {% elseif criticite.score is same as(2) %}
@@ -437,6 +438,8 @@
         </div>
         
         {% if isSignalementNonDecence %}
+        
+                {# {% if is_granted('ROLE_ADMIN_TERRITORY') and signalement.statut is not same as(6) and not needValidation %} #}
         {# TODO : Les infos sur la non décence énergétique sont affichés sur les signalements concernés, pour 
 Les super admin
 Les responsables territoire sur les territoires d'expérimentation
@@ -452,42 +455,51 @@ Les partenaires affectés au signalement ET ayant la compétence "Non décence �
                 <button class="fr-accordion__btn fr-btn--icon-left fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france" aria-expanded="true" aria-controls="accordion-nde">Non décence énergétique</button>
             </h3>
             <div class="fr-collapse" id="accordion-nde">
-                <!-- données de test -->
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-5">
-                    Consommation d'énergie :
+                    <strong>Consommation d'énergie :</strong> <span class="fr-badge fr-badge--info fr-badge--sm">{{ signalementQualification.details.consommation_energie }} kWh/m²/an</span>
                     </div>
-                    <div class="fr-col-12 fr-col-md-5">
-                    Analyse :
+                    <div class="fr-col-12 fr-col-md-5">                    
+                        {% set classe = '' %}
+                        {% if signalementQualification.status.name == 'NDE_CHECK' %}
+                            {% set classe = 'fr-badge fr-badge--info fr-badge--sm' %}
+                        {% elseif signalementQualification.status.name == 'NDE_OK' %}
+                            {% set classe = 'fr-badge fr-badge--success fr-badge--sm' %}
+                        {% elseif signalementQualification.status.name == 'NDE_AVEREE' %}
+                            {% set classe = 'fr-badge fr-badge--error fr-badge--sm' %}
+                        {% endif %}
+                    <strong>Analyse :</strong> <span class="{{ classe }}">{{ signalementQualification.status.value }}</span>
                     </div>
                     
-                {# {% if is_granted('ROLE_ADMIN_TERRITORY') and signalement.statut is not same as(6) and not needValidation %} #}
                     <div class="fr-col-12 fr-col-md-2 fr-text--right">
                         <button class="fr-btn fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" data-fr-opened="false"
                                 aria-controls="fr-modal-edit-nde">
                             Modifier
                         </button>
                     </div>
-                {# {% endif %} #}
-
                 </div>
                 <div class="fr-grid-row">
-                    Désordre(s) concerné(s) : {{ signalementQualification.desordres|join(', ')}}
-                </div>
-                <div class="fr-grid-row">
-                    <div class="fr-col-12 fr-col-md-6">
-                    Entrée dans le logement : {{ signalement.dateEntree}}
-                    </div>
-                    <div class="fr-col-12 fr-col-md-6">
-                    DPE :
-                    </div>
+                    <strong>Désordre(s) concerné(s) :</strong> 
+                    <ul class="fr-list">
+                        {% for criticite in signalementQualificationCriticite %}
+                            <li> {{ criticite.critere.label}} - Etat {{criticite.scoreLabel}} : {{criticite.label}}</li>
+                        {% endfor %}
+                    </ul>
                 </div>
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-6">
-                    Dernier bail : {{ signalementQualification.dernierBailAt}}
+                    <strong>Entrée dans le logement :</strong> {{ signalement.dateEntree|date('d/m/Y') }}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
-                    Date dernier DPE :
+                    <strong>DPE :</strong> {{ signalementQualification.details.DPE ? 'Oui' : 'Non' }} 
+                    </div>
+                </div>
+                <div class="fr-grid-row">
+                    <div class="fr-col-12 fr-col-md-6">
+                    <strong>Dernier bail :</strong> {{ signalementQualification.dernierBailAt|date('d/m/Y') }}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                    <strong>Date dernier DPE :</strong> {{ signalementQualification.details.date_dernier_dpe|date('d/m/Y') }} 
                     </div>
                 </div>
             </div>

--- a/tests/Functional/Controller/BackPartnerControllerTest.php
+++ b/tests/Functional/Controller/BackPartnerControllerTest.php
@@ -13,6 +13,43 @@ class BackPartnerControllerTest extends WebTestCase
 {
     use SessionHelper;
 
+    public function testPartnersSuccessfullyDisplay()
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('back_partner_index');
+        $client->request('GET', $route);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testPartnersExperimentalTerritorySuccessfullyDisplay()
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-63-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('back_partner_index');
+        $client->request('GET', $route);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('.fr-display-inline-table',
+            'Compétences',
+        );
+    }
+
     public function testPartnerFormSubmit(): void
     {
         $faker = Factory::create();

--- a/tests/Functional/Controller/BackSignalementControllerTest.php
+++ b/tests/Functional/Controller/BackSignalementControllerTest.php
@@ -51,6 +51,31 @@ class BackSignalementControllerTest extends WebTestCase
         }
     }
 
+    public function testSignalementNDESuccessfullyDisplay()
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+
+        $client->loginUser($user);
+        $client->request('GET', $route);
+        $this->assertResponseIsSuccessful($signalement->getId());
+        $this->assertSelectorTextContains('#accordion-nde',
+            'Consommation'
+        );
+    }
+
     public function testSubmitClotureSignalementWihEmailSentToPartnersAndUsager()
     {
         $client = static::createClient();

--- a/tests/Functional/Controller/BackSignalementQualificationControllerTest.php
+++ b/tests/Functional/Controller/BackSignalementQualificationControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Enum\Qualification;
+use App\Entity\Enum\QualificationStatus;
+use App\Entity\Signalement;
+use App\Entity\SignalementQualification;
+use App\Repository\SignalementRepository;
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+class BackSignalementQualificationControllerTest extends WebTestCase
+{
+    public function testSubmitQualificationNDESignalement()
+    {
+        $client = static::createClient();
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+        $this->assertEquals(Qualification::NON_DECENCE_ENERGETIQUE, $signalementQualification->getQualification());
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('back_signalement_qualification_editer', ['uuid' => $signalement->getUuid(), 'signalement_qualification' => $signalementQualification->getId()]);
+
+        $routeSignalementView = $router->generate('back_signalement_view', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+
+        $crawler = $client->request('GET', $routeSignalementView);
+        $token = $crawler->filter('#signalement-edit-nde-form input[name=_token]')->attr('value');
+        $client->request('GET', $route);
+        $this->assertLessThan(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $client->getResponse()->getStatusCode(),
+            sprintf('Result value: %d', $client->getResponse()->getStatusCode())
+        );
+
+        $client->request('POST', $route, [
+            'signalement-edit-nde-superficie' => 234,
+            'signalement-edit-nde-conso-energie' => 545,
+            '_token' => $token,
+        ]);
+
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+
+        $this->assertEquals(234, $signalement->getSuperficie());
+        $this->assertEquals(545, $signalementQualification->getDetails()['consommation_energie']);
+        $this->assertEquals(QualificationStatus::NDE_AVEREE, $signalementQualification->getStatus());
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+    }
+
+    public function testSubmitQualificationNDEArchivedSignalement()
+    {
+        $client = static::createClient();
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+        $this->assertEquals(Qualification::NON_DECENCE_ENERGETIQUE, $signalementQualification->getQualification());
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('back_signalement_qualification_editer', ['uuid' => $signalement->getUuid(), 'signalement_qualification' => $signalementQualification->getId()]);
+
+        $routeSignalementView = $router->generate('back_signalement_view', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+
+        $crawler = $client->request('GET', $routeSignalementView);
+        $token = $crawler->filter('#signalement-edit-nde-form input[name=_token]')->attr('value');
+        $client->request('GET', $route);
+        $this->assertLessThan(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $client->getResponse()->getStatusCode(),
+            sprintf('Result value: %d', $client->getResponse()->getStatusCode())
+        );
+
+        $client->request('POST', $route, [
+            'signalement-edit-nde-dernier-bail' => '2019-02-04',
+            '_token' => $token,
+        ]);
+
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+
+        $this->assertEquals(QualificationStatus::ARCHIVED, $signalementQualification->getStatus());
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+    }
+}

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -52,6 +52,22 @@ class SignalementManagerTest extends KernelTestCase
         $this->assertCount(3, $partners['not_affected'], 'Three partners should not be affected');
     }
 
+    public function testFindAllPartnersWithCompetences()
+    {
+        $signalementManager = new SignalementManager($this->managerRegistry, $this->security, $this->signalementFactory, $this->eventDispatcher);
+        $signalement = $signalementManager->findOneBy(['reference' => '2023-8']);
+
+        $partners = $signalementManager->findAllPartners($signalement, true);
+
+        $this->assertArrayHasKey('affected', $partners);
+        $this->assertArrayHasKey('not_affected', $partners);
+
+        $this->assertCount(0, $partners['affected'], '0 partner should be affected');
+        $this->assertCount(19, $partners['not_affected'], '19 partners should not be affected');
+        $firstPartner = $partners['not_affected'][0];
+        $this->assertArrayHasKey('competence', $firstPartner);
+    }
+
     public function testCloseSignalementForAllPartners()
     {
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -49,6 +49,20 @@ class PartnerRepositoryTest extends KernelTestCase
         $this->assertCount(3, $partners);
     }
 
+    public function testFindPartnersWithCompetences(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+
+        $partners = $this->partnerRepository->findByLocalization($signalement, false, true);
+        $this->assertCount(19, $partners);
+        $firstPartner = $partners[0];
+        $this->assertArrayHasKey('competence', $firstPartner);
+    }
+
     public function testFindPossiblePartnersForCOR69(): void
     {
         /** @var SignalementRepository $signalementRepository */

--- a/tests/Functional/Service/Signalement/SignalementQualificationServiceTest.php
+++ b/tests/Functional/Service/Signalement/SignalementQualificationServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tests\Functional\Service\Signalement;
+
+use App\Entity\Enum\QualificationStatus;
+use App\Entity\Signalement;
+use App\Entity\SignalementQualification;
+use App\Service\Signalement\SignalementQualificationService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SignalementQualificationServiceTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    protected ManagerRegistry $managerRegistry;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
+    }
+
+    public function testUpdateNonDecenceEnergetiqueStatus()
+    {
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+
+        $qualificationService = new SignalementQualificationService($signalement, $signalementQualification);
+        $signalementQualification->setStatus($qualificationService->updateNDEStatus());
+
+        $status = $qualificationService->updateNDEStatus();
+
+        $this->assertEquals(QualificationStatus::NDE_AVEREE, $status);
+    }
+}

--- a/tests/Unit/Factory/CommuneFactoryTest.php
+++ b/tests/Unit/Factory/CommuneFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Tests\Unit\Factory;
+
+use App\Entity\Commune;
+use App\Entity\Territory;
+use App\Factory\CommuneFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CommuneFactoryTest extends KernelTestCase
+{
+    public function testCreateCommune(): void
+    {
+        self::bootKernel();
+        /** @var ValidatorInterface $validator */
+        $validator = static::getContainer()->get(ValidatorInterface::class);
+
+        $territory = new Territory();
+
+        $itemNomCommune = 'Saint-Mars-du-Désert';
+        $itemCodePostal = '44850';
+        $itemCodeCommune = '44179';
+
+        $commune = (new CommuneFactory())->createInstanceFrom(
+            territory: $territory,
+            nom: $itemNomCommune,
+            codePostal: $itemCodePostal,
+            codeInsee: $itemCodeCommune
+        );
+
+        $errors = $validator->validate($commune);
+        $this->assertEmpty($errors, (string) $errors);
+
+        $this->assertInstanceOf(Commune::class, $commune);
+
+        $this->assertEquals('44850', $commune->getCodePostal());
+        $this->assertFalse($commune->getIsZonePermisLouer());
+    }
+
+    public function testCreateCommuneZonePermisDeLouer(): void
+    {
+        self::bootKernel();
+        /** @var ValidatorInterface $validator */
+        $validator = static::getContainer()->get(ValidatorInterface::class);
+
+        $territory = new Territory();
+
+        $itemNomCommune = 'Tonnerre';
+        $itemCodePostal = '89700';
+        $itemCodeCommune = '89418';
+
+        $commune = (new CommuneFactory())->createInstanceFrom(
+            territory: $territory,
+            nom: $itemNomCommune,
+            codePostal: $itemCodePostal,
+            codeInsee: $itemCodeCommune,
+            isZonePermisLouer: true
+        );
+
+        $errors = $validator->validate($commune);
+        $this->assertEmpty($errors, (string) $errors);
+
+        $this->assertInstanceOf(Commune::class, $commune);
+
+        $this->assertEquals('89418', $commune->getCodeInsee());
+        $this->assertTrue($commune->getIsZonePermisLouer());
+    }
+}


### PR DESCRIPTION
## Ticket

#932   

## Description
-     L'ajout d'une partie dédiée à la non décence énergétique dans la fiche signalement
-     Ouverture d'une modale pour éditer les informations

Spécs : https://github.com/MTES-MCT/histologe/wiki/Gestion-NDE/
[Maquette](https://xd.adobe.com/view/3fe7a859-dfae-4bc6-99a6-650ce6a179d5-6ab4/) fiche signalement avec infos non décence énergétique

## Changements apportés
* renommer desordres en criticites dans la table signalement_qualification
* création des signalement_qualification pour les signalements en fixtures
* création d'un enum QualificationStatus
* Dans BackSignalementController, récupération de la qualification et envoi des informations à la vue pour afficher la nouvelle partie sur la NDE
* Création d'une modale pour éditer ces informations
* Création de BackSignalementQualificationController pour enregistrer les changements
* Création de SignalementQualificationService pour mettre à jour le status de la qualification en fonction des données

## Tests
- [ ] Rejouer les fixtures, et la commande symfony console app:commune-filler et symfony console app:update-partners-communes-nde pour avoir les bonnes données
- [ ] Se connecter en admin, ouvrir le signalement du Puy de Dôme, le valider (2023-8)
- [ ] Vérifier que la partie Non Décence énergétique s'affiche bien, que l'édition des informations et leur enregistrement se passe bien (ne tester que la consommation énergétique pour l'instant, le reste est plus loin, essayer des valeurs sous et au-dessus de 450 pour vérifier que le statut du signalement change selon)
- [ ] Affecter des partenaires avec et sans la compétence Non Décence énergétique (ADIL avec la compétence ALF (OPAH) sans)
- [ ] Se connecter avec ALF (OPAH) (user-63-02@histologe.fr) vérifier qu'on a accès au signalement, mais qu'on ne voit pas la partie non décence énergétique
- [ ] Se connecter avec ADIL (user-63-01@histologe.fr) vérifier qu'on a accès au signalement, et qu'on voit la partie non décence énergétique. Changer la date du DPE avant/après 2023 pour vérifier qu'en 2023 le champ superficie ne s'affiche plus. Changer la date du bail, pour vérifier que si le dernier bail est antérieur à 2023, le signalement n'est plus en non décence énergétique, la partie ne s'affiche plus, et en base il est Archivé. 
