### PR TITLE
[Performance] Revue de la checklist performance recommandation symfony

### DIFF
--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsqlite3-dev \
         sqlite3 \
         libxslt1-dev \
+        wkhtmltopdf \
         && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash \
         && apt-get install -y  nodejs \
          # Install intl

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "prefer-stable": true,
     "require": {
         "php": "~8.1",
-        "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-imagick": "*",
         "beberlei/doctrineextensions": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
         "paas": {
             "compile": [
                 "composer dump-autoload --no-dev --classmap-authoritative",
+                "php bin/console cache:clear",
                 "npm run build"
             ],
             "php-config": [

--- a/composer.json
+++ b/composer.json
@@ -148,6 +148,7 @@
                 "opcache.validate_timestamps=0",
                 "opcache.preload=/app/config/preload.php",
                 "opcache.preload_user=appsdeck",
+                "realpath_cache_size=4096K",
                 "realpath_cache_ttl=600"
             ]
         }

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
             "phpro/grumphp-shim": true
         },
         "optimize-autoloader": true,
+        "classmap-authoritative": true,
         "preferred-install": {
             "*": "dist"
         },
@@ -141,7 +142,13 @@
                 "npm run build"
             ],
             "php-config": [
-                "memory_limit=-1"
+                "memory_limit=-1",
+                "opcache.memory_consumption=256",
+                "opcache.max_accelerated_files=20000",
+                "opcache.validate_timestamps=0",
+                "opcache.preload=/app/config/preload.php",
+                "opcache.preload_user=appsdeck",
+                "realpath_cache_ttl=600"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,6 @@
         }
     },
     "replace": {
-        "symfony/polyfill-ctype": "*",
         "symfony/polyfill-iconv": "*",
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php73": "*",

--- a/composer.json
+++ b/composer.json
@@ -147,8 +147,6 @@
                 "opcache.memory_consumption=256",
                 "opcache.max_accelerated_files=20000",
                 "opcache.validate_timestamps=0",
-                "opcache.preload=/app/config/preload.php",
-                "opcache.preload_user=appsdeck",
                 "realpath_cache_ttl=600"
             ]
         }

--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,8 @@
                 "opcache.memory_consumption=256",
                 "opcache.max_accelerated_files=20000",
                 "opcache.validate_timestamps=0",
+                "opcache.preload=/app/config/preload.php",
+                "opcache.preload_user=appsdeck",
                 "realpath_cache_ttl=600"
             ]
         }

--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,6 @@
         },
         "paas": {
             "compile": [
-                "composer dump-autoload --no-dev --classmap-authoritative",
                 "npm run build"
             ],
             "php-config": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "prefer-stable": true,
     "require": {
         "php": "~8.1",
-        "ext-iconv": "*",
         "ext-imagick": "*",
         "beberlei/doctrineextensions": "^1.3",
         "composer/package-versions-deprecated": "1.11.99.4",
@@ -102,7 +101,6 @@
         }
     },
     "replace": {
-        "symfony/polyfill-iconv": "*",
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php73": "*",
         "symfony/polyfill-php74": "*",

--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,6 @@
         "paas": {
             "compile": [
                 "composer dump-autoload --no-dev --classmap-authoritative",
-                "php bin/console cache:clear",
                 "npm run build"
             ],
             "php-config": [

--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
                 "opcache.memory_consumption=256",
                 "opcache.max_accelerated_files=20000",
                 "opcache.validate_timestamps=0",
-                "opcache.preload=/app/config/preload.php",
+                "opcache.preload=config/preload.php",
                 "opcache.preload_user=appsdeck",
                 "realpath_cache_size=4096K",
                 "realpath_cache_ttl=600"

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,8 @@
         }
     },
     "replace": {
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php73": "*",
         "symfony/polyfill-php74": "*",

--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
         },
         "paas": {
             "compile": [
+                "composer dump-autoload --no-dev --classmap-authoritative",
                 "npm run build"
             ],
             "php-config": [

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,7 @@ imports:
     - { resource: 'app/widgets.yaml'}
     - { resource: 'app/insee.yaml'}
 parameters:
+    container.dumper.inline_factories: true
     uploads_dir: '%kernel.project_dir%/uploaded_files/signalement/'
     uploads_tmp_dir: '%kernel.project_dir%/tmp/'
     url_bucket: '%env(resolve:S3_URL_BUCKET)%'

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -3,12 +3,6 @@
 echo "Executing migration..."
 php bin/console doctrine:migrations:migrate --no-interaction
 
-echo "Construction du contenu du fichier .user.ini"
-ini_contents="opcache.preload=/app/config/preload.php\nopcache.preload_user=appsdeck"
-
-echo "Écriture du contenu dans le fichier .user.ini"
-echo -e $ini_contents > .user.ini
-
 if [[ -z "${COMPOSER_DEV}" ]];
 then
     echo "No data fixtures to load!"

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -2,13 +2,15 @@
 
 echo "Executing migration..."
 php bin/console doctrine:migrations:migrate --no-interaction
-composer dump-autoload --no-dev --classmap-authoritative
-php bin/console c:c
 
 if [[ -z "${COMPOSER_DEV}" ]];
 then
     echo "No data fixtures to load!"
+    echo "Optimize Composer Autoloader"
+    composer dump-autoload --no-dev --classmap-authoritative
 else
     echo "Load data fixtures..."
     composer dump-env dev && php bin/console -e dev doctrine:fixtures:load --no-interaction
+    echo "Optimize Composer Autoloader with dev dependencies"
+    composer dump-autoload --classmap-authoritative
 fi

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -8,6 +8,7 @@ ini_contents="opcache.preload=/app/config/preload.php\nopcache.preload_user=apps
 
 echo "Écriture du contenu dans le fichier .user.ini"
 echo -e $ini_contents > .user.ini
+composer install --prefer-dist --no-scripts --no-dev -q -a
 
 if [[ -z "${COMPOSER_DEV}" ]];
 then

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -2,6 +2,8 @@
 
 echo "Executing migration..."
 php bin/console doctrine:migrations:migrate --no-interaction
+composer dump-autoload --no-dev --classmap-authoritative
+php bin/console c:c
 
 if [[ -z "${COMPOSER_DEV}" ]];
 then

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -8,7 +8,6 @@ ini_contents="opcache.preload=/app/config/preload.php\nopcache.preload_user=apps
 
 echo "Écriture du contenu dans le fichier .user.ini"
 echo -e $ini_contents > .user.ini
-composer install --prefer-dist --no-scripts --no-dev -q -a
 
 if [[ -z "${COMPOSER_DEV}" ]];
 then

--- a/scripts/postdeploy.sh
+++ b/scripts/postdeploy.sh
@@ -3,6 +3,12 @@
 echo "Executing migration..."
 php bin/console doctrine:migrations:migrate --no-interaction
 
+echo "Construction du contenu du fichier .user.ini"
+ini_contents="opcache.preload=/app/config/preload.php\nopcache.preload_user=appsdeck"
+
+echo "Écriture du contenu dans le fichier .user.ini"
+echo -e $ini_contents > .user.ini
+
 if [[ -z "${COMPOSER_DEV}" ]];
 then
     echo "No data fixtures to load!"


### PR DESCRIPTION
## Ticket

#969 

## Description
Revue de la check-list symfony pour vérifier que la plateforme et le serveur sont configurés pour des performances maximales.
https://symfony.com/doc/current/performance.html#:~:text=Production%20Server%20Checklist%3A

https://dashboard.scalingo.com/apps/osc-fr1/histologe-staging-pr983/deploy/list

## Changements apportés
* Ajout wkhtmltopdf en environnement de dev (on ne pouvait pas générer des pdf en local)
* MAJ composer.json afin de modifier la configuration par défaut du php.ini

- [x] [Dump the Service Container into a Single File](https://symfony.com/doc/current/performance.html#dump-the-service-container-into-a-single-file)
- [x] [Use the OPcache class preloading](https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading)
- [x] [Configure OPcache for Maximum Performance](https://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance)
- [x] [Don't Check PHP Files Timestamps](https://symfony.com/doc/current/performance.html#don-t-check-php-files-timestamps)
- [x] [Configure the PHP realpath Cache](https://symfony.com/doc/current/performance.html#configure-the-php-realpath-cache)
- [x] [Optimize Composer Autoloader](https://symfony.com/doc/current/performance.html#optimize-composer-autoloader)

## Tests
- [ ] CI OK
- [ ] CD OK

## Documentation
https://doc.scalingo.com/languages/php/start
https://github.com/Scalingo/php-buildpack

