### PR TITLE
[BO - Dashboard] Correction de l'affichage des affectations des partenaires dans le tableau de bord

### DIFF
--- a/assets/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -176,7 +176,6 @@ export default defineComponent({
       for (const i in requestResponse.data) {
         const responseItem = requestResponse.data[i]
         const item = [
-          responseItem.zip,
           responseItem.nom,
           responseItem.waiting,
           responseItem.refused


### PR DESCRIPTION
## Ticket

[#988](https://github.com/MTES-MCT/histologe/issues/988) 

## Description
Correction de l'affichage des affectations des partenaires dans le tableau de bord pour les Responsables territoire

## Tests
- [ ] Affichage du tableau de bord pour un Resp. territoire
