### PR TITLE
Correction pour l'affichage du nombre de filtres actifs quand on clique depuis le Dashboard

### DIFF
--- a/src/Controller/Back/BackCartographieController.php
+++ b/src/Controller/Back/BackCartographieController.php
@@ -25,7 +25,7 @@ class BackCartographieController extends AbstractController
     {
         $title = 'Cartographie';
         $filters = $this->searchFilterService->setRequest($request)->setFilters()->getFilters();
-        $countActiveFilters = $this->searchFilterService->getCountActiveFilters();
+        $countActiveFilters = $this->searchFilterService->getCountActive();
         if (!$this->isGranted('ROLE_ADMIN_TERRITORY')) {
             $user = $this->getUser();
         }

--- a/src/Controller/Back/BackController.php
+++ b/src/Controller/Back/BackController.php
@@ -51,7 +51,7 @@ class BackController extends AbstractController
     {
         $title = 'Administration - Tableau de bord';
         $filters = $searchFilterService->setRequest($request)->setFilters()->getFilters();
-        $countActiveFilters = $searchFilterService->getCountActiveFilters();
+        $countActiveFilters = $searchFilterService->getCountActive();
         /** @var User $user */
         $user = $this->getUser();
         $territory = $user->getTerritory(); // If user is not admin, he can only see his territory


### PR DESCRIPTION
## Ticket

#[941](https://github.com/MTES-MCT/histologe/issues/941)   

## Description
Correction pour l'affichage du nombre de filtres actifs quand on clique depuis le Dashboard

## Tests
- [ ] Vérifier que le nombre est bon si on applique des filtres depuis la modale ou depuis le dashboard
