### PR TITLE
[CD] Forcer la version de node à 18.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "build": "encore production --progress"
   },
   "engines": {
-    "node": "18.x"
+    "node": "18.14.2"
   }
 }


### PR DESCRIPTION
## Ticket

NO-TICKET   

## Description
La version node 18.15 est sorti https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.15.0
mais le buildpack scaling ne le prend pas en charge
Tous les déploiements sont en echec depuis

https://dashboard.scalingo.com/apps/osc-fr1/histologe-staging/deploy/list

## Changements apportés
* Forcer la version de node dans le package.json
