### PR TITLE
Stockage des fichiers directement sur le cloud lors de la saisie d'un signalement

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,7 @@ parameters:
     container.dumper.inline_factories: true
     uploads_dir: '%kernel.project_dir%/uploaded_files/signalement/'
     uploads_tmp_dir: '%kernel.project_dir%/tmp/'
+    bucket_tmp_dir: 'tmp/'
     url_bucket: '%env(resolve:S3_URL_BUCKET)%'
     capture_dir: '%kernel.project_dir%/uploaded_files/capture/'
     images_dir: '%kernel.project_dir%/public/img/'

--- a/tests/Functional/Service/UploadHandlerServiceTest.php
+++ b/tests/Functional/Service/UploadHandlerServiceTest.php
@@ -66,7 +66,6 @@ class UploadHandlerServiceTest extends KernelTestCase
         $this->assertIsArray($fileResult);
         $this->assertArrayHasKey('file', $fileResult);
         $this->assertArrayHasKey('titre', $fileResult);
-        $this->assertFileExists($parameterBag->get('uploads_tmp_dir').$fileResult['file']);
     }
 
     public function testUploadBigFileShouldThrowsException(): void


### PR DESCRIPTION
## Ticket

#979 

## Description
Lors de la saisie d'un signalement, si l'usager envoie des fichiers, on stocke ces fichiers directement dans le dossier /tmp du cloud plutôt que sur le serveur.

## Changements apportés
* Stockage sur cloud direct à l'envoi
* Déplacement dans le bon dossier quand le signalement est validé

## Tests
- [ ] Créer un signalement avec fichier
- [ ] Le fichier s'affiche bien dans le parcours
- [ ] Après validation du signalement, le fichier s'affiche bien dans le back-office
- [ ] On peut supprimer et ajouter des fichiers dans le back-office
