### PR TITLE
[BO - Signalement]  Régression mise à jour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "webpack-notifier": "^1.15.0"
       },
       "engines": {
-        "node": "18.x"
+        "node": "18.14.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -29,7 +29,8 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
                 $signalement->setLastSuiviAt($entity->getCreatedAt());
                 $metaData = $entityManager->getClassMetadata(Signalement::class);
                 $entityManager->persist($signalement);
-                $unitOfWork->computeChangeSet($metaData, $signalement);
+                //  used to recompute the changes of a specific signalement entity
+                $unitOfWork->recomputeSingleEntityChangeSet($metaData, $signalement);
             }
         }
     }


### PR DESCRIPTION
## Ticket

#996    

## Description
Suite à `SuiviCreatedSubscriber` qui écoute les ajout de suivi en mettant à jour la date de dernier suivi dans la table signalement, une régression a été constaté sur les mises à jour de signalements. Plus aucune mise à jour est possible
 
## Changements apportés
Il faut garder en tête que les modifications d'un signalement entraîne la création d'un nouveau suivi,
```php
$signalement = $entity->getSignalement(); // deja persisté et en cours de flush
$signalement->setLastSuiviAt($entity->getCreatedAt());
````
Sur l’événement onFlush, le subscriber va récupérer un signalement déjà modifié et doit rajouter la date de dernier suivi. 
En gros pour faire simple je demande à doctrine de merger le signalement dans l'état avec la mise à jour effectué dans le onFlush donc ce n'est pas `computeChangeSet` mais `recomputeSingleEntityChangeSet`, comme ça lorsque le flush sera effectué on aura un objet complet.

**C'est une particularité de l’événement onFlush de doctrine, on ne fait pas de flush sur l'evenement onFlush**

* Utiliser la méthode `recomputeSingleEntityChangeSet` au lieu de `computeChangeSet`

## Tests
- [ ] Créer un signalement
- [ ] Vailder un signalement
- [ ] Mise à jour du signalement (photo et info signalement)
