### PR TITLE
[BO - Affectation] Différencier visuellement les refus / clôture par partenaire

### DIFF
--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -38,8 +38,10 @@
                     {% set classe = 'fr-badge fr-badge--info' %}
                 {% elseif affectation.statut is same as (1) %}
                     {% set classe = 'fr-badge fr-badge--success' %}
-                {% elseif affectation.statut is same as (2) or affectation.statut is same as (3) %}
-                    {% set classe = 'fr-badge fr-badge--error' %}
+                {% elseif affectation.statut is same as (2) %}
+                    {% set classe = 'fr-badge fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line' %}
+                {% elseif affectation.statut is same as (3) %}
+                    {% set classe = 'fr-badge fr-fi-close-circle-fill' %}
                 {% endif %}
                 <small class="{{ classe }} fr-ws-nowrap fr-badge--sm fr-my-1v fr-text--bold fr-display-block"><span
                     > {{ affectation.partner.nom }}</span></small>


### PR DESCRIPTION
## Ticket

#949    

## Description
Différencier les partenaires ayant refusés une affectation de ceux ayant clôturés le signalement pour leur partenaire.

## Changements apportés
* Changement de style des affectations partenaires dans la liste des signalements

## Tests
- [ ] Aller dans la liste des signalements, vérifier que les affectations fermées sont bien grises avec une croix pleine, et les affectations refusées sont rouges avec une croix sans fond
