### PR TITLE
[BO - Signalement] Compléter Motifs de cloture RT/Partenaires et Aucun motif sélectionné par défaut

### DIFF
--- a/migrations/Version20230313140816.php
+++ b/migrations/Version20230313140816.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230313140816 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update field motif_cloture of signalement and affectation';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE signalement SET motif_cloture = "RSD" WHERE motif_cloture="INFRACTION RSD"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "LOGEMENT_DECENT" WHERE motif_cloture="LOGEMENT DECENT"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "DEPART_OCCUPANT" WHERE motif_cloture="LOCATAIRE PARTI"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "LOGEMENT_VENDU" WHERE motif_cloture="LOGEMENT VENDU"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "TRAVAUX_FAITS_OU_EN_COURS" WHERE motif_cloture="RESOLU"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "RSD" WHERE motif_cloture="INFRACTION RSD"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "LOGEMENT_DECENT" WHERE motif_cloture="LOGEMENT DECENT"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "DEPART_OCCUPANT" WHERE motif_cloture="LOCATAIRE PARTI"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "LOGEMENT_VENDU" WHERE motif_cloture="LOGEMENT VENDU"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "TRAVAUX_FAITS_OU_EN_COURS" WHERE motif_cloture="RESOLU"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE signalement SET motif_cloture = "INFRACTION RSD" WHERE motif_cloture="RSD"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "LOGEMENT DECENT" WHERE motif_cloture="LOGEMENT_DECENT"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "LOCATAIRE PARTI" WHERE motif_cloture="DEPART_OCCUPANT"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "LOGEMENT VENDU" WHERE motif_cloture="LOGEMENT_VENDU"');
+        $this->addSql('UPDATE signalement SET motif_cloture = "RESOLU" WHERE motif_cloture="TRAVAUX_FAITS_OU_EN_COURS"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "INFRACTION RSD" WHERE motif_cloture="RSD"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "LOGEMENT DECENT" WHERE motif_cloture="LOGEMENT_DECENT"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "LOCATAIRE PARTI" WHERE motif_cloture="DEPART_OCCUPANT"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "LOGEMENT VENDU" WHERE motif_cloture="LOGEMENT_VENDU"');
+        $this->addSql('UPDATE affectation SET motif_cloture = "RESOLU" WHERE motif_cloture="TRAVAUX_FAITS_OU_EN_COURS"');
+    }
+}

--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -28,7 +28,7 @@ class BackStatistiquesController extends AbstractController
         private ListTagsStatisticProvider $listTagStatisticProvider,
         private GlobalBackAnalyticsProvider $globalBackAnalyticsProvider,
         private FilteredBackAnalyticsProvider $filteredBackAnalyticsProvider,
-        ) {
+    ) {
     }
 
     #[Route('/', name: 'back_statistiques')]

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -12,7 +12,7 @@ affectations:
     statut: 3
     answered_by: "admin-territoire-01-01@histologe.fr"
     affected_by: "admin-territoire-01-01@histologe.fr"
-    motif_cloture: "LOCATAIRE PARTI"
+    motif_cloture: "DEPART_OCCUPANT"
     territory: "Ain"
   -
     signalement: 2022-3
@@ -20,7 +20,7 @@ affectations:
     statut: 3
     answered_by: "admin-territoire-13-01@histologe.fr"
     affected_by: "admin-territoire-13-01@histologe.fr"
-    motif_cloture: "LOCATAIRE PARTI"
+    motif_cloture: "DEPART_OCCUPANT"
     territory: "Bouches-du-Rhône"
   -
     signalement: 2022-12

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -469,7 +469,7 @@ signalements:
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 6
-    motif_cloture: 'NON_DECENCE'
+    motif_cloture: 'TRAVAUX_FAITS_OU_EN_COURS'
     reference: "2022-12"
     geoloc: "[]"
     score_creation: 5.420054200542
@@ -512,7 +512,7 @@ signalements:
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 6
-    motif_cloture: 'NON_DECENCE'
+    motif_cloture: 'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE'
     reference: "2022-13"
     geoloc: "[]"
     score_creation: 5.420054200542
@@ -556,7 +556,7 @@ signalements:
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 1
-    motif_cloture: 'NON_DECENCE'
+    motif_cloture: 'RESPONSABILITE_DE_L_OCCUPANT'
     reference: "2022-14"
     geoloc: "[]"
     score_creation: 5.420054200542

--- a/src/DataFixtures/Loader/LoadAffectationData.php
+++ b/src/DataFixtures/Loader/LoadAffectationData.php
@@ -3,6 +3,7 @@
 namespace App\DataFixtures\Loader;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\MotifCloture;
 use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Repository\TerritoryRepository;
@@ -43,6 +44,11 @@ class LoadAffectationData extends Fixture implements OrderedFixtureInterface
             ->setAnsweredBy($this->userRepository->findOneBy(['email' => $row['affected_by']]))
             ->setAnsweredAt(new \DateTimeImmutable())
         ;
+
+        if (Affectation::STATUS_CLOSED === $row['statut'] && '' !== $row['motif_cloture']) {
+            $affectation
+                ->setMotifCloture(MotifCloture::tryFrom($row['motif_cloture']));
+        }
 
         $manager->persist($affectation);
     }

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -2,6 +2,7 @@
 
 namespace App\DataFixtures\Loader;
 
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Form\SignalementType;
@@ -108,7 +109,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
 
         if (Signalement::STATUS_CLOSED === $row['statut']) {
             $signalement
-                ->setMotifCloture($row['motif_cloture'])
+                ->setMotifCloture(MotifCloture::tryFrom($row['motif_cloture']))
                 ->setClosedAt(new \DateTimeImmutable())
                 ->setClosedBy($this->userRepository->findOneBy(['statut' => User::STATUS_ACTIVE]));
         }

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Entity\Enum\MotifCloture;
 use App\Repository\AffectationRepository;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -43,8 +44,8 @@ class Affectation
     #[ORM\ManyToOne(targetEntity: User::class)]
     private ?User $affectedBy;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    private ?string $motifCloture;
+    #[ORM\Column(type: 'string', enumType: MotifCloture::class, nullable: true)]
+    private ?MotifCloture $motifCloture;
 
     #[ORM\OneToMany(mappedBy: 'affectation', targetEntity: Notification::class)]
     private $notifications;
@@ -149,12 +150,12 @@ class Affectation
         return $this;
     }
 
-    public function getMotifCloture(): ?string
+    public function getMotifCloture(): ?MotifCloture
     {
         return $this->motifCloture;
     }
 
-    public function setMotifCloture(?string $motifCloture): self
+    public function setMotifCloture(?MotifCloture $motifCloture): self
     {
         $this->motifCloture = $motifCloture;
 

--- a/src/Entity/Enum/MotifCloture.php
+++ b/src/Entity/Enum/MotifCloture.php
@@ -2,17 +2,45 @@
 
 namespace App\Entity\Enum;
 
-/** Should be replaced by enum with php 8.1 */
-class MotifCloture
+enum MotifCloture: string
 {
-    public const LABEL = [
-        'RESOLU' => 'Problème résolu',
-        'NON_DECENCE' => 'Non décence',
-        'INFRACTION RSD' => 'Infraction RSD',
-        'INSALUBRITE' => 'Insalubrité',
-        'LOGEMENT DECENT' => 'Logement décent',
-        'LOCATAIRE PARTI' => 'Locataire parti',
-        'LOGEMENT VENDU' => 'Logement vendu',
-        'AUTRE' => 'Autre',
-    ];
+    case ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE = 'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE';
+    case DEPART_OCCUPANT = 'DEPART_OCCUPANT';
+    case INSALUBRITE = 'INSALUBRITE';
+    case LOGEMENT_DECENT = 'LOGEMENT_DECENT';
+    case LOGEMENT_VENDU = 'LOGEMENT_VENDU';
+    case NON_DECENCE = 'NON_DECENCE';
+    case PERIL = 'PERIL';
+    case REFUS_DE_VISITE = 'REFUS_DE_VISITE';
+    case REFUS_DE_TRAVAUX = 'REFUS_DE_TRAVAUX';
+    case RELOGEMENT_OCCUPANT = 'RELOGEMENT_OCCUPANT';
+    case RESPONSABILITE_DE_L_OCCUPANT = 'RESPONSABILITE_DE_L_OCCUPANT';
+    case RSD = 'RSD';
+    case TRAVAUX_FAITS_OU_EN_COURS = 'TRAVAUX_FAITS_OU_EN_COURS';
+    case AUTRE = 'AUTRE';
+
+    public function label(): string
+    {
+        return self::getLabelList()[$this->name];
+    }
+
+    public static function getLabelList(): array
+    {
+        return [
+            'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE' => 'Abandon de procédure / absence de réponse',
+            'DEPART_OCCUPANT' => 'Départ occupant', // renommage de locataire parti
+            'INSALUBRITE' => 'Insalubrité',
+            'LOGEMENT_DECENT' => 'Logement décent',
+            'LOGEMENT_VENDU' => 'Logement vendu',
+            'NON_DECENCE' => 'Non décence',
+            'PERIL' => 'Péril',
+            'REFUS_DE_VISITE' => 'Refus de visite',
+            'REFUS_DE_TRAVAUX' => 'Refus de travaux',
+            'RELOGEMENT_OCCUPANT' => 'Relogement occupant', // précise Problème résolu
+            'RESPONSABILITE_DE_L_OCCUPANT' => "Responsabilité de l'occupant",
+            'RSD' => 'RSD',
+            'TRAVAUX_FAITS_OU_EN_COURS' => 'Travaux faits ou en cours', // précise Problème résolu
+            'AUTRE' => 'Autre',
+        ];
+    }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Entity\Enum\MotifCloture;
 use App\Repository\SignalementRepository;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -298,8 +299,8 @@ class Signalement
     #[ORM\OneToMany(mappedBy: 'signalement', targetEntity: Affectation::class, cascade: ['persist'], orphanRemoval: true)]
     private $affectations;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    private $motifCloture;
+    #[ORM\Column(type: 'string', enumType: MotifCloture::class, nullable: true)]
+    private ?MotifCloture $motifCloture;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $closedAt;
@@ -1497,12 +1498,12 @@ class Signalement
         return $this;
     }
 
-    public function getMotifCloture(): ?string
+    public function getMotifCloture(): ?MotifCloture
     {
         return $this->motifCloture;
     }
 
-    public function setMotifCloture(?string $motifCloture): self
+    public function setMotifCloture(?MotifCloture $motifCloture): self
     {
         $this->motifCloture = $motifCloture;
 

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -3,7 +3,6 @@
 namespace App\EventSubscriber;
 
 use App\Entity\Affectation;
-use App\Entity\Enum\MotifCloture;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Event\SignalementClosedEvent;
@@ -102,7 +101,7 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
                     NotificationService::TYPE_SIGNALEMENT_CLOSED_TO_USAGER,
                     [$toRecipient],
                     [
-                        'motif_cloture' => MotifCloture::LABEL[$signalement->getMotifCloture()],
+                        'motif_cloture' => $signalement->getMotifCloture()->label(),
                         'link' => $this->generateLinkCodeSuivi($signalement->getCodeSuivi(), $toRecipient),
                     ],
                     $signalement->getTerritory()
@@ -123,7 +122,7 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
             $sendTo,
             [
                 'ref_signalement' => $signalement->getReference(),
-                'motif_cloture' => MotifCloture::LABEL[$signalement->getMotifCloture()],
+                'motif_cloture' => $signalement->getMotifCloture()->label(),
                 'closed_by' => $signalement->getClosedBy()->getNomComplet(),
                 'partner_name' => $signalement->getClosedBy()->getPartner()->getNom(),
                 'link' => $this->generateLinkSignalementView($signalement->getUuid()),

--- a/src/Factory/SignalementFactory.php
+++ b/src/Factory/SignalementFactory.php
@@ -2,6 +2,7 @@
 
 namespace App\Factory;
 
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Signalement;
 use App\Entity\Territory;
 
@@ -92,7 +93,7 @@ class SignalementFactory
             ->setNbChambresLogement((int) $data['nbChambresLogement'])
             ->setNbNiveauxLogement((int) $data['nbNiveauxLogement'])
             ->setNbOccupantsLogement((int) $data['nbOccupantsLogement'])
-            ->setMotifCloture($data['motifCloture'])
+            ->setMotifCloture(MotifCloture::tryFrom($data['motifCloture']))
             ->setClosedAt($data['closedAt'])
             ->setIsFondSolidariteLogement((bool) $data['isFondSolidariteLogement']);
     }

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -73,7 +73,7 @@ class SuiviFactory
         return sprintf(
             'Le signalement à été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
             $params['subject'],
-            $params['motif_cloture'],
+            $params['motif_cloture']->label(),
             $motifSuivi
         );
     }

--- a/src/Form/ClotureType.php
+++ b/src/Form/ClotureType.php
@@ -2,33 +2,27 @@
 
 namespace App\Form;
 
+use App\Entity\Enum\MotifCloture;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ClotureType extends AbstractType
 {
-    public const CHOICES = [
-        'Problème résolu' => 'RESOLU',
-        'Non décence' => 'NON_DECENCE',
-        'Infraction RSD' => 'INFRACTION RSD',
-        'Insalubrité' => 'INSALUBRITE',
-        'Logement décent' => 'LOGEMENT DECENT',
-        'Locataire parti' => 'LOCATAIRE PARTI',
-        'Logement vendu' => 'LOGEMENT VENDU',
-        'Autre' => 'AUTRE',
-    ];
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('motif', ChoiceType::class, [
-                'choices' => self::CHOICES,
+            ->add('motif', EnumType::class, [
+                'class' => MotifCloture::class,
+                'choice_label' => function ($choice) {
+                    return $choice->label();
+                },
                 'row_attr' => [
                     'class' => 'fr-select-group',
                 ],
+                'placeholder' => 'Sélectionner un motif',
                 'attr' => [
                     'class' => 'fr-select',
                 ],

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -3,6 +3,7 @@
 namespace App\Manager;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -64,7 +65,7 @@ class AffectationManager extends Manager
             ->setTerritory($partner->getTerritory());
     }
 
-    public function closeAffectation(Affectation $affectation, User $user, string $motif): Affectation
+    public function closeAffectation(Affectation $affectation, User $user, MotifCloture $motif): Affectation
     {
         $affectation
             ->setStatut(Affectation::STATUS_CLOSED)
@@ -91,7 +92,8 @@ class AffectationManager extends Manager
                         if ($affectation->getPartner()->getId() === $partner->getId()) {
                             $this->remove($affectation);
                         }
-                    });
+                    }
+                );
             }
         }
     }
@@ -105,7 +107,8 @@ class AffectationManager extends Manager
         if (!empty($description)) {
             $suivi = $this->suiviManager->createSuivi(
                 $user,
-                $signalement, [
+                $signalement,
+                [
                     'domain' => 'esabora',
                     'action' => 'synchronize',
                     'description' => $description,

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -3,6 +3,7 @@
 namespace App\Manager;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
@@ -127,7 +128,7 @@ class SignalementManager extends AbstractManager
             ->setNbChambresLogement((int) $data['nbChambresLogement'])
             ->setNbNiveauxLogement((int) $data['nbNiveauxLogement'])
             ->setNbOccupantsLogement((int) $data['nbOccupantsLogement'])
-            ->setMotifCloture($data['motifCloture'])
+            ->setMotifCloture(MotifCloture::tryFrom($data['motifCloture']))
             ->setClosedAt($data['closedAt'])
             ->setIsFondSolidariteLogement((bool) $data['isFondSolidariteLogement']);
     }
@@ -158,7 +159,7 @@ class SignalementManager extends AbstractManager
         return $affectation->toArray();
     }
 
-    public function closeSignalementForAllPartners(Signalement $signalement, string $motif): Signalement
+    public function closeSignalementForAllPartners(Signalement $signalement, MotifCloture $motif): Signalement
     {
         $signalement
             ->setStatut(Signalement::STATUS_CLOSED)
@@ -178,7 +179,7 @@ class SignalementManager extends AbstractManager
         return $signalement;
     }
 
-    public function closeAffectation(Affectation $affectation, string $motif): Affectation
+    public function closeAffectation(Affectation $affectation, MotifCloture $motif): Affectation
     {
         $affectation
             ->setStatut(Affectation::STATUS_CLOSED)

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -5,6 +5,7 @@ namespace App\Service\Import\Signalement;
 use App\Entity\Affectation;
 use App\Entity\Critere;
 use App\Entity\Criticite;
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
@@ -61,7 +62,8 @@ class SignalementImportLoader
     {
         $countSignalement = 0;
 
-        $this->userSystem = $this->entityManager->getRepository(User::class)->findOneBy([
+        $this->userSystem = $this->entityManager->getRepository(User::class)->findOneBy(
+            [
                 'email' => $this->parameterBag->get('user_system_email'), ]
         );
 
@@ -139,7 +141,7 @@ class SignalementImportLoader
                             $affectation = $this->affectationManager->closeAffectation(
                                 $affectation,
                                 $this->userSystem,
-                                $dataMapped['motifCloture']
+                                MotifCloture::tryFrom($dataMapped['motifCloture'])
                             );
                         } else {
                             $affectation->setStatut(Affectation::STATUS_ACCEPTED);

--- a/src/Service/Import/Signalement/SignalementImportMapper.php
+++ b/src/Service/Import/Signalement/SignalementImportMapper.php
@@ -191,7 +191,8 @@ class SignalementImportMapper
                         break;
                     case 'motifCloture':
                         $fieldValue = mb_strtoupper($fieldValue);
-                        $fieldValue = \array_key_exists($fieldValue, MotifCloture::LABEL) ? $fieldValue : null;
+                        // TODO  : faire un mapping ?
+                        $fieldValue = \array_key_exists($fieldValue, MotifCloture::getLabelList()) ? $fieldValue : null;
                         break;
                     case self::SITUATION_SECURITE_OCCUPANT:
                     case self::SITUATION_ETAT_PROPRETE_LOGEMENT:

--- a/src/Service/Statistics/FilteredBackAnalyticsProvider.php
+++ b/src/Service/Statistics/FilteredBackAnalyticsProvider.php
@@ -19,7 +19,7 @@ class FilteredBackAnalyticsProvider
         private CriticitePercentStatisticProvider $criticitePercentStatisticProvider,
         private VisiteStatisticProvider $visiteStatisticProvider,
         private MotifClotureStatisticProvider $motifClotureStatisticProvider,
-        ) {
+    ) {
     }
 
     public function getData(StatisticsFilters $statisticsFilters): array

--- a/src/Service/Statistics/MotifClotureStatisticProvider.php
+++ b/src/Service/Statistics/MotifClotureStatisticProvider.php
@@ -43,72 +43,72 @@ class MotifClotureStatisticProvider
         return [
             'TRAVAUX_FAITS_OU_EN_COURS' => [
                 'label' => 'Travaux faits ou en cours',
-                'color' => '#21AB8E',
+                'color' => '#18753C',
                 'count' => 0,
             ],
             'RELOGEMENT_OCCUPANT' => [
                 'label' => 'Relogement occupant',
-                'color' => '#21AB8E',
+                'color' => '#27A658',
                 'count' => 0,
             ],
             'NON_DECENCE' => [
                 'label' => 'Non décence',
-                'color' => '#E4794A',
+                'color' => '#8585F6',
                 'count' => 0,
             ],
             'RSD' => [
                 'label' => 'RSD',
-                'color' => '#A558A0',
+                'color' => '#CACAFB',
                 'count' => 0,
             ],
             'INSALUBRITE' => [
                 'label' => 'Insalubrité',
-                'color' => '#CE0500',
+                'color' => '#000091',
                 'count' => 0,
             ],
             'LOGEMENT_DECENT' => [
                 'label' => 'Logement décent',
-                'color' => '#00A95F',
+                'color' => '#C3FAD5',
                 'count' => 0,
             ],
             'DEPART_OCCUPANT' => [
                 'label' => 'Départ occupant',
-                'color' => '#000091',
+                'color' => '#FF8E77',
                 'count' => 0,
             ],
             'LOGEMENT_VENDU' => [
                 'label' => 'Logement vendu',
-                'color' => '#417DC4',
+                'color' => '#DDE5FF',
                 'count' => 0,
             ],
             'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE' => [
                 'label' => 'Abandon de procédure / absence de réponse',
-                'color' => '#CACAFB',
+                'color' => '#FF5655',
                 'count' => 0,
             ],
             'PERIL' => [
                 'label' => 'Péril',
-                'color' => '#CACAFB',
+                'color' => '#313178',
                 'count' => 0,
             ],
             'REFUS_DE_VISITE' => [
                 'label' => 'Refus de visite',
-                'color' => '#CACAFB',
+                'color' => '#CE0500',
                 'count' => 0,
             ],
             'REFUS_DE_TRAVAUX' => [
                 'label' => 'Refus de travaux',
-                'color' => '#CACAFB',
+                'color' => '#CB5555',
                 'count' => 0,
             ],
             'RESPONSABILITE_DE_L_OCCUPANT' => [
                 'label' => "Responsabilité de l'occupant",
-                'color' => '#CACAFB',
+                'color' => '#FC5D00',
                 'count' => 0,
             ],
             'AUTRE' => [
                 'label' => 'Autre',
-                'color' => '#CACAFB',
+                'color' => '#CECECE',
                 'count' => 0,
             ],
         ];

--- a/src/Service/Statistics/MotifClotureStatisticProvider.php
+++ b/src/Service/Statistics/MotifClotureStatisticProvider.php
@@ -30,8 +30,8 @@ class MotifClotureStatisticProvider
     {
         $data = self::initMotifPerValue();
         foreach ($countPerMotifsCloture as $countPerMotifCloture) {
-            if ($data[$countPerMotifCloture['motifCloture']]) {
-                $data[$countPerMotifCloture['motifCloture']]['count'] = $countPerMotifCloture['count'];
+            if ($data[$countPerMotifCloture['motifCloture']->name]) {
+                $data[$countPerMotifCloture['motifCloture']->name]['count'] = $countPerMotifCloture['count'];
             }
         }
 
@@ -41,8 +41,13 @@ class MotifClotureStatisticProvider
     private static function initMotifPerValue(): array
     {
         return [
-            'RESOLU' => [
-                'label' => 'Problème résolu',
+            'TRAVAUX_FAITS_OU_EN_COURS' => [
+                'label' => 'Travaux faits ou en cours',
+                'color' => '#21AB8E',
+                'count' => 0,
+            ],
+            'RELOGEMENT_OCCUPANT' => [
+                'label' => 'Relogement occupant',
                 'color' => '#21AB8E',
                 'count' => 0,
             ],
@@ -51,8 +56,8 @@ class MotifClotureStatisticProvider
                 'color' => '#E4794A',
                 'count' => 0,
             ],
-            'INFRACTION RSD' => [
-                'label' => 'Infraction RSD',
+            'RSD' => [
+                'label' => 'RSD',
                 'color' => '#A558A0',
                 'count' => 0,
             ],
@@ -61,19 +66,44 @@ class MotifClotureStatisticProvider
                 'color' => '#CE0500',
                 'count' => 0,
             ],
-            'LOGEMENT DECENT' => [
+            'LOGEMENT_DECENT' => [
                 'label' => 'Logement décent',
                 'color' => '#00A95F',
                 'count' => 0,
             ],
-            'LOCATAIRE PARTI' => [
+            'DEPART_OCCUPANT' => [
                 'label' => 'Départ occupant',
                 'color' => '#000091',
                 'count' => 0,
             ],
-            'LOGEMENT VENDU' => [
+            'LOGEMENT_VENDU' => [
                 'label' => 'Logement vendu',
                 'color' => '#417DC4',
+                'count' => 0,
+            ],
+            'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE' => [
+                'label' => 'Abandon de procédure / absence de réponse',
+                'color' => '#CACAFB',
+                'count' => 0,
+            ],
+            'PERIL' => [
+                'label' => 'Péril',
+                'color' => '#CACAFB',
+                'count' => 0,
+            ],
+            'REFUS_DE_VISITE' => [
+                'label' => 'Refus de visite',
+                'color' => '#CACAFB',
+                'count' => 0,
+            ],
+            'REFUS_DE_TRAVAUX' => [
+                'label' => 'Refus de travaux',
+                'color' => '#CACAFB',
+                'count' => 0,
+            ],
+            'RESPONSABILITE_DE_L_OCCUPANT' => [
+                'label' => "Responsabilité de l'occupant",
+                'color' => '#CACAFB',
                 'count' => 0,
             ],
             'AUTRE' => [

--- a/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
@@ -61,7 +61,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
                     NotificationService::TYPE_SIGNALEMENT_CLOSED_TO_USAGER,
                     $signalementClosed->getMailUsagers(),
                     [
-                        'motif_cloture' => MotifCloture::LABEL[$signalementClosed->getMotifCloture()],
+                        'motif_cloture' => $signalementClosed->getMotifCloture()->label(),
                         'link' => '',
                     ],
                     $signalementClosed->getTerritory(),
@@ -71,7 +71,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
                     $sendToPartners,
                     [
                         'ref_signalement' => $signalementClosed->getReference(),
-                        'motif_cloture' => MotifCloture::LABEL[$signalementClosed->getMotifCloture()],
+                        'motif_cloture' => $signalementClosed->getMotifCloture()->label(),
                         'closed_by' => $signalementClosed->getClosedBy()->getNomComplet(),
                         'partner_name' => $signalementClosed->getClosedBy()->getPartner()->getNom(),
                         'link' => '',
@@ -104,7 +104,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
             $signalementClosed,
             [
                 'motif_suivi' => 'Lorem ipsum suivi sit amet, consectetur adipiscing elit.',
-                'motif_cloture' => 'Non décence',
+                'motif_cloture' => MotifCloture::tryFrom('NON_DECENCE'),
                 'subject' => 'tous les partenaires',
                 'closed_for' => 'all',
             ]

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -60,18 +60,18 @@ class SignalementManagerTest extends KernelTestCase
         $signalementManager = new SignalementManager($this->managerRegistry, $this->security, $this->signalementFactory, $this->eventDispatcher);
         $signalementClosed = $signalementManager->closeSignalementForAllPartners(
             $signalementActive,
-            MotifCloture::LABEL['RESOLU']
+            MotifCloture::tryFrom('TRAVAUX_FAITS_OU_EN_COURS')
         );
 
         $this->assertInstanceOf(Signalement::class, $signalementClosed);
         $this->assertEquals(Signalement::STATUS_CLOSED, $signalementClosed->getStatut());
-        $this->assertEquals('Problème résolu', $signalementClosed->getMotifCloture());
+        $this->assertEquals('Travaux faits ou en cours', $signalementClosed->getMotifCloture()->label());
         $this->assertInstanceOf(\DateTimeInterface::class, $signalementClosed->getClosedAt());
 
         $signalementHasAllAffectationsClosed = $signalementClosed->getAffectations()
             ->forAll(function (int $index, Affectation $affectation) {
                 return Affectation::STATUS_CLOSED === $affectation->getStatut()
-                && str_contains($affectation->getMotifCloture(), 'Problème résolu');
+                && str_contains($affectation->getMotifCloture()->label(), 'Travaux faits ou en cours'); // TODO ??
             });
 
         $this->assertTrue($signalementHasAllAffectationsClosed);
@@ -84,12 +84,12 @@ class SignalementManagerTest extends KernelTestCase
         $signalementManager = new SignalementManager($this->managerRegistry, $this->security, $this->signalementFactory, $this->eventDispatcher);
         $affectationClosed = $signalementManager->closeAffectation(
             $affectationAccepted,
-            MotifCloture::LABEL['NON_DECENCE']
+            MotifCloture::tryFrom('NON_DECENCE')
         );
 
         $this->assertEquals(Affectation::STATUS_CLOSED, $affectationClosed->getStatut());
         $this->assertInstanceOf(\DateTimeInterface::class, $affectationClosed->getAnsweredAt());
-        $this->assertTrue(str_contains($affectationClosed->getMotifCloture(), 'Non décence'));
+        $this->assertTrue(str_contains($affectationClosed->getMotifCloture()->label(), 'Non décence'));
     }
 
     public function testFindEmailsAffectedToSignalement()

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Manager;
 
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
@@ -43,7 +44,7 @@ class SuiviManagerTest extends KernelTestCase
         $countSuivisBeforeCreate = $signalement->getSuivis()->count();
         $suivi = $suiviManager->createSuivi($user, $signalement, [
                     'motif_suivi' => 'Lorem ipsum suivi sit amet, consectetur adipiscing elit.',
-                    'motif_cloture' => 'NON_DECENCE',
+                    'motif_cloture' => MotifCloture::tryFrom('NON_DECENCE'),
                     'subject' => 'test',
                 ], true);
 

--- a/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
+++ b/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Tests\Functional\Service\Import\Signalement;
 
-use App\Entity\Enum\MotifCloture;
 use App\Entity\Territory;
 use App\EventSubscriber\SuiviCreatedSubscriber;
 use App\Manager\AffectationManager;
@@ -79,7 +78,7 @@ class SignalementImportLoaderTest extends KernelTestCase
                 'Ref signalement' => (0 === $i % 2) ? $faker->randomNumber(4) : date('Y').'-'.$faker->randomNumber(4),
                 'Date de creation signalement' => date('d/m/Y'),
                 'Date cloture' => null,
-                'motif_cloture' => (0 === $i % 2) ? MotifCloture::LABEL['AUTRE'] : null,
+                'motif_cloture' => (0 === $i % 2) ? 'AUTRE' : null,
                 'ref des photos' => null,
                 'ref des documents' => null,
                 'details' => $faker->realText(),

--- a/tests/Unit/Factory/SignalementFactoryTest.php
+++ b/tests/Unit/Factory/SignalementFactoryTest.php
@@ -175,7 +175,7 @@ class SignalementFactoryTest extends KernelTestCase
             $signalement->getCreatedAt()->getTimestamp()
         )
         ;
-        $this->assertEquals($data['motifCloture'], $signalement->getMotifCloture());
+        $this->assertEquals($data['motifCloture'], $signalement->getMotifCloture()?->label());
         $this->assertEquals($data['closedAt'], $signalement->getClosedAt());
         $this->assertEquals($data['numeroInvariant'], $signalement->getNumeroInvariant());
         $this->assertEquals($data['dateEntree'], $signalement->getDateEntree());

--- a/tests/Unit/Factory/SuiviFactoryTest.php
+++ b/tests/Unit/Factory/SuiviFactoryTest.php
@@ -44,7 +44,7 @@ class SuiviFactoryTest extends KernelTestCase
             $signalement,
             [
                 'motif_suivi' => 'Lorem ipsum suivi sit amet, consectetur adipiscing elit.',
-                'motif_cloture' => MotifCloture::LABEL['INSALUBRITE'],
+                'motif_cloture' => MotifCloture::tryFrom('INSALUBRITE'),
                 'subject' => 'tous les partenaires',
                 'closed_for' => 'all',
             ],
@@ -55,7 +55,7 @@ class SuiviFactoryTest extends KernelTestCase
         $this->assertTrue($suivi->getIsPublic());
         $this->assertEquals(Suivi::TYPE_PARTNER, $suivi->getType());
         $this->assertInstanceOf(UserInterface::class, $suivi->getCreatedBy());
-        $this->assertTrue(str_contains($suivi->getDescription(), MotifCloture::LABEL['INSALUBRITE']));
+        $this->assertTrue(str_contains($suivi->getDescription(), MotifCloture::tryFrom('INSALUBRITE')->label()));
         $this->assertTrue(str_contains($suivi->getDescription(), 'Le signalement à été cloturé pour'));
     }
 }


### PR DESCRIPTION
## Tickets
#810 
#631

## Description
Ajout d'option pour les motifs de cloture.
Par défaut, aucun motif ne soit sélectionné et qu'on mette "Sélectionner un motif" en placeholder dans le champ

## Changements apportés
* Transformation de MotifCloture en vrai enum
* Modification du form pour utiliser l'enumType Symfony
* Modification du form pour ne pas avoir de motif sélectionné par défaut
* Migration pour changer les motifs de cloture existants pour les signalements et affectations

## Tests
- [ ] Affecter un signalement à différents partenaires
- [ ] Prendre un des partenaires, ouvrir et accepter le signalement, puis le cloturer. Vérifier que le formulaire n'a pas une option choisie par défaut et que les options possibles sont correctes. Cloturer le signalement.
- [ ] Vérifier que le suivi est ok avec description et label de l'enum
- [ ] Revenir en admin, cloturer le signalement pour tous et faire les mêmes vérifications.
- [ ] Vérifier les mails reçus par l'usager.
- [ ] Vérifier les données en base
