### PR TITLE
[QA] formulaire de contact, possible d'avoir plusieurs signalements pour un déclarant

### DIFF
--- a/src/FormHandler/ContactFormHandler.php
+++ b/src/FormHandler/ContactFormHandler.php
@@ -40,35 +40,35 @@ class ContactFormHandler
         try {
             $signalementsByOccupants = $this->signalementRepository->findOneOpenedByMailOccupant($email);
             $signalementsByDeclarants = $this->signalementRepository->findOneOpenedByMailDeclarant($email);
-
-            if (null !== $signalementsByOccupants || null !== $signalementsByDeclarants) {
-                /** @var Signalement $signalement */
-                $signalement = (null !== $signalementsByOccupants)
-                    ? $signalementsByOccupants
-                    : $signalementsByDeclarants;
-                $params = [
-                    'description_contact_form' => nl2br($message).self::MENTION_SENT_BY_EMAIL,
-                ];
-                $userOccupant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::OCCUPANT);
-                $userDeclarant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::DECLARANT);
-
-                /** @var User $user */
-                $user = (null !== $signalementsByOccupants)
-                    ? $userOccupant
-                    : $userDeclarant;
-
-                if (null !== $user) {
-                    $suivi = $this->suiviFactory->createInstanceFrom(
-                        user: $user,
-                        signalement: $signalement,
-                        params: $params,
-                    );
-                    $this->suiviManager->save($suivi);
-                }
-                $hasNotificationToSend = false;
-            }
         } catch (NonUniqueResultException $exception) {
+            $signalementsByOccupants = $signalementsByDeclarants = null;
             $this->logger->error($exception->getMessage());
+        }
+        if (null !== $signalementsByOccupants || null !== $signalementsByDeclarants) {
+            /** @var Signalement $signalement */
+            $signalement = (null !== $signalementsByOccupants)
+                ? $signalementsByOccupants
+                : $signalementsByDeclarants;
+            $params = [
+                'description_contact_form' => nl2br($message).self::MENTION_SENT_BY_EMAIL,
+            ];
+            $userOccupant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::OCCUPANT);
+            $userDeclarant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::DECLARANT);
+
+            /** @var User $user */
+            $user = (null !== $signalementsByOccupants)
+                ? $userOccupant
+                : $userDeclarant;
+
+            if (null !== $user) {
+                $suivi = $this->suiviFactory->createInstanceFrom(
+                    user: $user,
+                    signalement: $signalement,
+                    params: $params,
+                );
+                $this->suiviManager->save($suivi);
+            }
+            $hasNotificationToSend = false;
         }
 
         if ($hasNotificationToSend) {

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -289,6 +289,9 @@ class SignalementRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * @throws NonUniqueResultException
+     */
     public function findOneOpenedByMailOccupant(string $email): ?Signalement
     {
         return $this->createQueryBuilder('s')
@@ -300,6 +303,9 @@ class SignalementRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * @throws NonUniqueResultException
+     */
     public function findOneOpenedByMailDeclarant(string $email): ?Signalement
     {
         return $this->createQueryBuilder('s')
@@ -346,7 +352,8 @@ class SignalementRepository extends ServiceEntityRepository
         $qb->orderBy(
             isset($options['sort']) && 'lastSuiviAt' === $options['sort']
                 ? 's.lastSuiviAt'
-                : 's.createdAt', 'DESC'
+                : 's.createdAt',
+            'DESC'
         );
         if (!$export) {
             $qb->setFirstResult($firstResult)
@@ -816,7 +823,8 @@ class SignalementRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select(
-            sprintf('NEW %s(
+            sprintf(
+                'NEW %s(
                 COUNT(s.id),
                 SUM(CASE WHEN s.statut = :new     THEN 1 ELSE 0 END),
                 SUM(CASE WHEN s.statut = :active OR s.statut =:waiting THEN 1 ELSE 0 END),

--- a/tests/Functional/FormHandler/ContactFormHandlerTest.php
+++ b/tests/Functional/FormHandler/ContactFormHandlerTest.php
@@ -45,7 +45,7 @@ class ContactFormHandlerTest extends KernelTestCase
             $suiviFactory,
             $suiviManager,
             $userManager,
-            $loggerInterface 
+            $loggerInterface
         );
     }
 

--- a/tests/Functional/FormHandler/ContactFormHandlerTest.php
+++ b/tests/Functional/FormHandler/ContactFormHandlerTest.php
@@ -13,6 +13,7 @@ use App\Repository\SignalementRepository;
 use App\Service\NotificationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Faker\Factory;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Mailer\MailerInterface;
@@ -36,13 +37,15 @@ class ContactFormHandlerTest extends KernelTestCase
         $suiviManager = self::getContainer()->get(SuiviManager::class);
         $this->signalementManager = self::getContainer()->get(SignalementManager::class);
         $userManager = self::getContainer()->get(UserManager::class);
+        $loggerInterface = self::getContainer()->get(LoggerInterface::class);
         $this->contactFormHandler = new ContactFormHandler(
             $notificationService,
             $parameterBag,
             $this->signalementRepository,
             $suiviFactory,
             $suiviManager,
-            $userManager
+            $userManager,
+            $loggerInterface 
         );
     }
 


### PR DESCRIPTION
## Ticket

#1031    

## Description
Si la personne qui envoie un message via le formulaire de contact a fait plusieurs signalements, on envoie un mail plutôt que d'ajouter un suivi au signalement car on ne sait pas quel signalement est concerné

## Changements apportés
* Ajout d'un try/catch sur le code d'ajout de suivi

## Tests
- [ ] Faire 2 signalements avec le même déclarant
- [ ] Avec ce même déclarant, envoyer un message via le formulaire de contact
- [ ] Vérifier qu'un mail a été envoyé et qu'il n'y a pas un nouveau suivi créé
