### PR TITLE
[QA] paramètre null deprecated sur un str_replace

### DIFF
--- a/src/Controller/Back/BackController.php
+++ b/src/Controller/Back/BackController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Back;
 
 use App\Entity\Affectation;
 use App\Entity\Criticite;
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Repository\AffectationRepository;
@@ -186,7 +187,9 @@ class BackController extends AbstractController
                     $data[] = $signalement->$method()->format('d.m.Y');
                 } elseif (\is_bool($signalement->$method())) {
                     $data[] = $signalement->$method() ? 'OUI' : 'NON';
-                } elseif (!\is_array($signalement->$method()) && !($signalement->$method() instanceof ArrayCollection)) {
+                } elseif ($signalement->$method() instanceof MotifCloture && null !== $signalement->$method()) {
+                    $data[] = str_replace(';', '', $signalement->$method()->label());
+                } elseif (!\is_array($signalement->$method()) && !($signalement->$method() instanceof ArrayCollection) && \is_string($signalement->$method())) {
                     $data[] = str_replace(';', '', $signalement->$method());
                 } elseif ('' == $signalement->$method()) {
                     $data[] = 'N/R';


### PR DESCRIPTION
## Ticket

#1034    

## Description
Vérifie le type de la donnée avant de faire un str_replace : https://sentry.incubateur.net/share/issue/bc581d6b6d704779917ab8a814c48239/
Récupère le label du motifCloture pour la liste des signalements

## Changements apportés
* Récupère le label du motifCloture pour l'export
* Ne fait un str_replace que sur les string pour éviter une erreur deprecated 

## Tests
- [ ] Avoir quelques signalements fermés
- [ ] Faire un export de la liste des signalements, vérifier que les motifs de cloture sont bien renseignés
