### PR TITLE
[Notification] en cas d absence de suivi partagé sur 30 jours, envoyer mail de suivi automatique / demander feedback à l usager

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -10,7 +10,7 @@
       "command": "0 8,18 * * * php bin/console app:sync-esabora"
     },
     {
-      "command": "0 9 * * * php bin/console app:ask-feeback-usager"
+      "command": "0 6 * * * php bin/console app:ask-feedback-usager"
     }
   ]
 }

--- a/cron.json
+++ b/cron.json
@@ -8,6 +8,9 @@
     },
     {
       "command": "0 8,18 * * * php bin/console app:sync-esabora"
+    },
+    {
+      "command": "0 9 * * * php bin/console app:ask-feeback-usager"
     }
   ]
 }

--- a/src/Command/AskFeedbackUsagerCommand.php
+++ b/src/Command/AskFeedbackUsagerCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Command;
+
+use App\Manager\SignalementManager;
+use App\Repository\SuiviRepository;
+use App\Service\NotificationService;
+use App\Service\Token\TokenGenerator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[AsCommand(
+    name: 'app:ask-feeback-usager',
+    description: 'Ask feedback to usager if no suivi from 30 days',
+)]
+class AskFeedbackUsagerCommand extends Command
+{
+    public function __construct(
+        private SignalementManager $signalementManager,
+        private NotificationService $notificationService,
+        private UrlGeneratorInterface $urlGenerator,
+        private TokenGenerator $tokenGenerator,
+        private ParameterBagInterface $parameterBag,
+        private SuiviRepository $suiviRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('--debug', null, InputOption::VALUE_NONE, 'Check how many emails will be send')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        // $signalementsList = $this->signalementManager->getRepository()->findSignalementWithSuiviOlderThan30();
+
+        // TODO : revoir la récupération de la liste
+        $signalements = $this->suiviRepository->findSignalementNoSuiviSince(30);
+
+        $nbSignalements = \count($signalements);
+        if ($input->getOption('debug')) {
+            $io->info(sprintf('%s signalement without suivi from more than 30 days', $nbSignalements));
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($signalements as $signalement) {
+            $toRecipients = $signalement->getMailUsagers();
+            if (!empty($toRecipients)) {
+                foreach ($toRecipients as $toRecipient) {
+                    $this->notificationService->send(
+                        NotificationService::TYPE_SIGNALEMENT_FEEDBACK_USAGER,
+                        [$toRecipient],
+                        [
+                            'link' => $this->generateLinkCodeSuivi($signalement->getCodeSuivi(), $toRecipient),
+                        ],
+                        $signalement->getTerritory()
+                    );
+                }
+            }
+        }
+        // TODO : comment prendre en compte cet envoi pour qu'il n'y en ait pas un autre avant 30 jours ?
+
+        $io->success(sprintf('%s signalement without suivi from more than 30 days', $nbSignalements));
+
+        $this->notificationService->send(
+            NotificationService::TYPE_CRON,
+            $this->parameterBag->get('admin_email'),
+            [
+                'url' => $this->parameterBag->get('host_url'),
+                'cron_label' => 'demande de feedback à l\'usager',
+                'count' => $nbSignalements,
+                'message' => 'signalement(s) pour lesquels une demande de feedback a été envoyée à l\'usager',
+            ],
+            null
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function generateLinkCodeSuivi(string $codeSuivi, string $email): string
+    {
+        return $this->parameterBag->get('host_url').$this->urlGenerator->generate(
+            'front_suivi_signalement',
+            [
+                'code' => $codeSuivi,
+                'from' => $email,
+            ]
+        );
+    }
+}

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -314,6 +314,7 @@ signalements:
     statut: 2
     reference: "2022-8"
     geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    created_at: "2022-03-08 17:06:33"
     score_creation: 100
     etage_occupant: "0"
     escalier_occupant: ""

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -44,6 +44,7 @@ suivis:
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
+  created_at: "2022-03-08 17:06:33"
   is_public: 0
   signalement: "2022-8"
   type: 1

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -89,8 +89,11 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             ->setSituationOccupant($row['situation_occupant'])
             ->setValidatedAt(Signalement::STATUS_ACTIVE === $row['statut'] ? new \DateTimeImmutable() : null)
             ->setOrigineSignalement($row['origine_signalement'])
-            ->setCreatedAt((new \DateTimeImmutable())->modify('-15 days'));
-
+            ->setCreatedAt(
+                isset($row['created_at'])
+                    ? new \DateTimeImmutable($row['created_at'])
+                    : (new \DateTimeImmutable())->modify('-15 days')
+            );
         if (isset($row['is_not_occupant'])) {
             $signalement
                 ->setIsNotOccupant($row['is_not_occupant'])

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -12,6 +12,7 @@ class Suivi
     public const TYPE_AUTO = 1;
     public const TYPE_USAGER = 2;
     public const TYPE_PARTNER = 3;
+    public const TYPE_TECHNICAL = 4;
     public const DEFAULT_PERIOD_INACTIVITY = 30;
 
     public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';

--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -60,6 +60,11 @@ class ActivityListener implements EventSubscriberInterface
                 $this->notifyPartner($partner, $entity, Notification::TYPE_AFFECTATION);
                 $this->sendMail($entity, NotificationService::TYPE_ASSIGNMENT_NEW);
             } elseif ($entity instanceof Suivi) {
+                // pas de notification pour un suivi technique
+                if (Suivi::TYPE_TECHNICAL === $entity->getType()) {
+                    continue;
+                }
+
                 $this->notifyAdmins($entity, Notification::TYPE_SUIVI, $entity->getSignalement()->getTerritory());
                 $entity->getSignalement()->getAffectations()->filter(function (Affectation $affectation) use ($entity) {
                     $partner = $affectation->getPartner();

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -37,6 +37,8 @@ class SuiviFactory
             return SUIVI::TYPE_AUTO;
         }
 
+        // TODO : type technical
+
         return SUIVI::TYPE_PARTNER;
     }
 

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -27,6 +27,10 @@ class SuiviFactory
 
     private function buildType(?User $user, array $params): string
     {
+        if (isset($params['type'])) {
+            return $params['type'];
+        }
+
         if ($user && \in_array('ROLE_USAGER', $user->getRoles())) {
             return SUIVI::TYPE_USAGER;
         }
@@ -36,8 +40,6 @@ class SuiviFactory
         || (isset($params['domain']) && 'esabora' === $params['domain'])) {
             return SUIVI::TYPE_AUTO;
         }
-
-        // TODO : type technical
 
         return SUIVI::TYPE_PARTNER;
     }
@@ -61,8 +63,8 @@ class SuiviFactory
             return 'Signalement <b>'.$params['description'].'</b> par '.$params['name_partner'];
         }
 
-        if (isset($params['description_contact_form'])) {
-            return $params['description_contact_form'];
+        if (isset($params['description'])) {
+            return $params['description'];
         }
 
         return $description;

--- a/src/FormHandler/ContactFormHandler.php
+++ b/src/FormHandler/ContactFormHandler.php
@@ -50,7 +50,7 @@ class ContactFormHandler
                 ? $signalementsByOccupants
                 : $signalementsByDeclarants;
             $params = [
-                'description_contact_form' => nl2br($message).self::MENTION_SENT_BY_EMAIL,
+                'description' => nl2br($message).self::MENTION_SENT_BY_EMAIL,
             ];
             $userOccupant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::OCCUPANT);
             $userDeclarant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::DECLARANT);

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -973,4 +973,22 @@ class SignalementRepository extends ServiceEntityRepository
 
         return $qb;
     }
+
+    public function findSignalementWithSuiviOlderThan30()
+    {
+        $subquery = $this->createQueryBuilder('su')
+                ->select('su.signalement.id')
+                ->from(Suivi::class, 'su')
+                ->distinct();
+
+        $queryBuilder = $this->createQueryBuilder('s')
+            // ->select('s.')
+            // ->innerJoin('s.affectations', 'a')
+            // ->innerJoin('a.partner', 'p')
+            ->where('s.statut IN (:statut) AND s.id NOT IN (:subquery)')
+            ->setParameter('statut', [Signalement::STATUS_ACTIVE, Signalement::STATUS_NEED_PARTNER_RESPONSE])
+            ->setParameter('subquery', $subquery);
+
+        return $queryBuilder->getQuery()->getResult();
+    }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -974,21 +974,12 @@ class SignalementRepository extends ServiceEntityRepository
         return $qb;
     }
 
-    public function findSignalementWithSuiviOlderThan30()
+    public function findAllByIds(array $ids): array
     {
-        $subquery = $this->createQueryBuilder('su')
-                ->select('su.signalement.id')
-                ->from(Suivi::class, 'su')
-                ->distinct();
-
-        $queryBuilder = $this->createQueryBuilder('s')
-            // ->select('s.')
-            // ->innerJoin('s.affectations', 'a')
-            // ->innerJoin('a.partner', 'p')
-            ->where('s.statut IN (:statut) AND s.id NOT IN (:subquery)')
-            ->setParameter('statut', [Signalement::STATUS_ACTIVE, Signalement::STATUS_NEED_PARTNER_RESPONSE])
-            ->setParameter('subquery', $subquery);
-
-        return $queryBuilder->getQuery()->getResult();
+        return $this->createQueryBuilder('s')
+            ->where('s.id IN (:ids)')
+            ->setParameter('ids', $ids)
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -198,6 +198,7 @@ class SuiviRepository extends ServiceEntityRepository
             'type_suivi_usager' => Suivi::TYPE_USAGER,
             'type_suivi_partner' => Suivi::TYPE_PARTNER,
             'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
+            'status_need_validation' => Signalement::STATUS_NEED_VALIDATION,
             'status_closed' => Signalement::STATUS_CLOSED,
             'status_archived' => Signalement::STATUS_ARCHIVED,
             'status_refused' => Signalement::STATUS_REFUSED,
@@ -207,7 +208,7 @@ class SuiviRepository extends ServiceEntityRepository
         FROM suivi su
         INNER JOIN signalement s on s.id = su.signalement_id
         WHERE type in (:type_suivi_usager,:type_suivi_partner,:type_suivi_technical)
-        AND s.statut NOT IN (:status_closed, :status_archived, :status_refused)
+        AND s.statut NOT IN (:status_need_validation, :status_closed, :status_archived, :status_refused)
         GROUP BY su.signalement_id
         HAVING DATEDIFF(NOW(),last_posted_at) > :day_period
         ORDER BY last_posted_at';

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -198,15 +198,16 @@ class SuiviRepository extends ServiceEntityRepository
             'type_suivi_usager' => Suivi::TYPE_USAGER,
             'type_suivi_partner' => Suivi::TYPE_PARTNER,
             'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
-            'status_archived' => Signalement::STATUS_ARCHIVED,
             'status_closed' => Signalement::STATUS_CLOSED,
+            'status_archived' => Signalement::STATUS_ARCHIVED,
+            'status_refused' => Signalement::STATUS_REFUSED,
         ];
 
         $sql = 'SELECT su.signalement_id, MAX(su.created_at) as last_posted_at
         FROM suivi su
         INNER JOIN signalement s on s.id = su.signalement_id
         WHERE type in (:type_suivi_usager,:type_suivi_partner,:type_suivi_technical)
-        AND s.statut NOT IN (:status_closed, :status_archived)
+        AND s.statut NOT IN (:status_closed, :status_archived, :status_refused)
         GROUP BY su.signalement_id
         HAVING DATEDIFF(NOW(),last_posted_at) > :day_period
         ORDER BY last_posted_at';

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -187,4 +187,32 @@ class SuiviRepository extends ServiceEntityRepository
                 HAVING DATEDIFF(NOW(),last_posted_at) > :day_period
                 ORDER BY last_posted_at';
     }
+
+    public function findSignalementsNoSuiviUsagerFrom(
+        int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
+    ): array {
+        $connection = $this->getEntityManager()->getConnection();
+
+        $parameters = [
+            'day_period' => $period,
+            'type_suivi_usager' => Suivi::TYPE_USAGER,
+            'type_suivi_partner' => Suivi::TYPE_PARTNER,
+            'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
+            'status_archived' => Signalement::STATUS_ARCHIVED,
+            'status_closed' => Signalement::STATUS_CLOSED,
+        ];
+
+        $sql = 'SELECT su.signalement_id, MAX(su.created_at) as last_posted_at
+        FROM suivi su
+        INNER JOIN signalement s on s.id = su.signalement_id
+        WHERE type in (:type_suivi_usager,:type_suivi_partner,:type_suivi_technical)
+        AND s.statut NOT IN (:status_closed, :status_archived)
+        GROUP BY su.signalement_id
+        HAVING DATEDIFF(NOW(),last_posted_at) > :day_period
+        ORDER BY last_posted_at';
+
+        $statement = $connection->prepare($sql);
+
+        return $statement->executeQuery($parameters)->fetchFirstColumn();
+    }
 }

--- a/src/Service/NotificationService.php
+++ b/src/Service/NotificationService.php
@@ -28,6 +28,7 @@ class NotificationService
     public const TYPE_SIGNALEMENT_CLOSED_TO_USAGER = 98;
     public const TYPE_SIGNALEMENT_CLOSED_TO_PARTNERS = 97;
     public const TYPE_SIGNALEMENT_CLOSED_TO_PARTNER = 96;
+    public const TYPE_SIGNALEMENT_FEEDBACK_USAGER = 95;
     public const TYPE_CONFIRM_RECEPTION = 6;
     public const TYPE_NEW_COMMENT_FRONT = 7;
     public const TYPE_NEW_COMMENT_BACK = 10;
@@ -166,6 +167,11 @@ class NotificationService
                 'template' => 'nouveau_suivi_signalement_email',
                 'subject' => 'Nouvelle mise à jour de votre signalement !',
                 'btnText' => 'Accéder à mon signalement',
+            ],
+            self::TYPE_SIGNALEMENT_FEEDBACK_USAGER => [
+                'template' => 'demande_feedback_usager_email',
+                'subject' => 'Histologe : faites le point sur votre problème de logement !',
+                'btntext' => 'Mettre à jour ma situation',
             ],
             self::TYPE_NEW_COMMENT_BACK => [
                 'template' => 'nouveau_suivi_signalement_back_email',

--- a/src/Service/Signalement/SuiviHelper.php
+++ b/src/Service/Signalement/SuiviHelper.php
@@ -25,6 +25,9 @@ class SuiviHelper
     public function getLastLabel(Suivi $suivi, Signalement $signalement): string
     {
         $user = $suivi->getCreatedBy();
+        if (null === $user && Suivi::TYPE_TECHNICAL === $suivi->getType()) {
+            return 'MESSAGE AUTOMATIQUE';
+        }
         if (null !== $user && \in_array('ROLE_USAGER', $user->getRoles())) {
             return $user->getEmail() === $signalement->getMailOccupant() ? 'OCCUPANT' : 'DECLARANT';
         }

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -707,11 +707,30 @@
             <hr class=" fr-mt-5v">
         {% endif %}
         {% for suivi in signalement.suivis|reverse %}            
-            {% if suivi.createdBy is not null %}
+            {% if suivi.type is same as 4 %}
+                <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v">
+                    <div class="fr-col-2">
+                        <strong>Message automatique</strong>
+                        <br>
+                        <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
+                    </div>
+                    <div class="fr-col-9 bloc-suivi-content-row fr-pl-3v">
+                        {{ suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|raw }}
+                    </div>
+                    <div class="fr-col-1 fr-text--right">
+                        {% if suivi.isPublic %}
+                            <span class="fr-fi-eye-fill" title="Visible par l'usager"></span>
+                        {% else %}
+                            <span class="fr-fi-eye-off-fill" title="Non visible par l'usager"></span>
+                        {% endif %}
+                    </div>
+                </div>
+
+            {% elseif suivi.createdBy is not null %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if 'ROLE_USAGER' in suivi.createdBy.roles %}fr-background-alt--orange-terre-battue{% endif %}">
-                    <div class="fr-col-2 {% if suivi.createdBy %}part-infos-hover{% endif %}"
-                        {% if suivi.createdBy %}data-user="{{ suivi.createdBy.nomComplet }}"
-                        data-mail="{{ suivi.createdBy.email }}"{% endif %}>
+                    <div class="fr-col-2 part-infos-hover"
+                        data-user="{{ suivi.createdBy.nomComplet }}"
+                        data-mail="{{ suivi.createdBy.email }}">
                         <strong>{{ suivi.createdBy.nom|upper~' '~ suivi.createdBy.prenom|capitalize }}</strong>
                         <br>
                         <small>[{{ 'ROLE_USAGER' in suivi.createdBy.roles ? (suivi.createdBy.email is same as signalement.mailDeclarant ? 'DECLARANT' : 'OCCUPANT') : (suivi.createdBy.partner ? suivi.createdBy.partner.nom : 'Aucun')  }}]</small> <br>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -707,7 +707,7 @@
             <hr class=" fr-mt-5v">
         {% endif %}
         {% for suivi in signalement.suivis|reverse %}            
-            {% if suivi.type is same as 4 %}
+            {% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v">
                     <div class="fr-col-2">
                         <strong>Message automatique</strong>

--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -50,6 +50,8 @@
                     {% set classe = 'fr-badge fr-badge--warning' %}
                 {% endif %}
                 <small class="{{ classe }}">{{ signalement.lastSuiviBy }}</small> <br>
+            {% else %}
+                Aucun
             {% endif %}
         </td>
         <td>

--- a/templates/emails/demande_feedback_usager_email.html.twig
+++ b/templates/emails/demande_feedback_usager_email.html.twig
@@ -1,0 +1,29 @@
+{% extends 'emails/base_email.html.twig' %}
+
+{% block body %}
+    <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    <p>
+        Vous avez signalé un problème dans le logement au <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>. <br>
+        La situation a-t-elle évolué ? Les travaux ont commencé ? Un agent a visité le logement ? Vous avez quitté ou prévoyez de quitter le logement ?.
+    </p>
+    
+    <p>Cliquez sur le bouton ci-dessous pour nous envoyer un message de mise à jour !</p>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
+           style="text-align: center">
+        <tbody>
+        <tr>
+            <td align="left">
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                    <tbody>
+                    <tr style="text-align: center;width: 100%">
+                        <td>
+                            <a href="{{ lien_suivi|raw }}" target="_blank">{{ btntext|capitalize }}</a></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    <p>Si le bouton ne fonctionne pas <a href="{{ lien_suivi|raw }}">cliquez ici</a></p>
+{% endblock %}

--- a/templates/emails/demande_feedback_usager_email.html.twig
+++ b/templates/emails/demande_feedback_usager_email.html.twig
@@ -4,7 +4,7 @@
     <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
     <p>
         Vous avez signalé un problème dans le logement au <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>. <br>
-        La situation a-t-elle évolué ? Les travaux ont commencé ? Un agent a visité le logement ? Vous avez quitté ou prévoyez de quitter le logement ?.
+        La situation a évolué ? Les travaux ont commencé ? Un agent a visité le logement ? Vous avez quitté ou prévoyez de quitter le logement ?.
     </p>
     
     <p>Cliquez sur le bouton ci-dessous pour nous envoyer un message de mise à jour !</p>

--- a/templates/emails/demande_feedback_usager_email.html.twig
+++ b/templates/emails/demande_feedback_usager_email.html.twig
@@ -17,7 +17,7 @@
                     <tbody>
                     <tr style="text-align: center;width: 100%">
                         <td>
-                            <a href="{{ lien_suivi|raw }}" target="_blank">{{ btntext|capitalize }}</a></td>
+                            <a href="{{ lien_suivi|raw }}" target="_blank" rel="noopener">{{ btntext|capitalize }}</a></td>
                     </tr>
                     </tbody>
                 </table>

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -24,46 +24,48 @@
                 </div>
             </header>
             <hr>
-            {% for suivi in signalement.suivis|reverse %}
-                {% if loop.first and suivi.createdBy and signalement.statut != 6 %}
-                    <div class="fr-grid-row fr-grid-row--middle fr-rounded fr-p-5v">
-                        <div class="fr-col-12">
-                            <form action="{{ path('front_suivi_signalement_user_response',{code:signalement.codeSuivi}) }}"
-                                  class="needs-validation" novalidate method="POST">
-                                <div class="fr-input-group">
-                                    <label for="signalement_front_response_content" class="fr-label">Votre
-                                        message:</label>
-                                    <p class="fr-hint-text">Dix (10) caractères minimum</p>
-                                    <input type="hidden" name="signalement_front_response[email]" value="{{ email }}">
-                                    <input type="hidden" name="signalement_front_response[type]" value="{{ type }}">
-                                    <textarea name="signalement_front_response[content]"
-                                              id="signalement_front_response_content" rows="10" class="fr-input"
-                                              required minlength="10"></textarea>
-                                    <p class="fr-error-text fr-hidden">Veuillez composer un message d'au moins 10
-                                        caractères.</p>
+            
+            {% if signalement.statut != 6 %}
+                <div class="fr-grid-row fr-grid-row--middle fr-rounded fr-p-5v">
+                    <div class="fr-col-12">
+                        <form action="{{ path('front_suivi_signalement_user_response',{code:signalement.codeSuivi}) }}"
+                                class="needs-validation" novalidate method="POST">
+                            <div class="fr-input-group">
+                                <label for="signalement_front_response_content" class="fr-label">Votre
+                                    message:</label>
+                                <p class="fr-hint-text">Dix (10) caractères minimum</p>
+                                <input type="hidden" name="signalement_front_response[email]" value="{{ email }}">
+                                <input type="hidden" name="signalement_front_response[type]" value="{{ type }}">
+                                <textarea name="signalement_front_response[content]"
+                                            id="signalement_front_response_content" rows="10" class="fr-input"
+                                            required minlength="10"></textarea>
+                                <p class="fr-error-text fr-hidden">Veuillez composer un message d'au moins 10
+                                    caractères.</p>
+                            </div>
+                            {% include '_partials/_signalement_upload.html.twig' with {
+                                limit:1
+                            } %}
+                            <div class="fr-grid-row">
+                                <div class="fr-col-12 fr-text--center">
+                                    <progress max="100" id="form_global_file_progress" value="0"
+                                                class="final-progress fr-hidden"></progress>
                                 </div>
-                                {% include '_partials/_signalement_upload.html.twig' with {
-                                    limit:1
-                                } %}
-                                <div class="fr-grid-row">
-                                    <div class="fr-col-12 fr-text--center">
-                                        <progress max="100" id="form_global_file_progress" value="0"
-                                                  class="final-progress fr-hidden"></progress>
-                                    </div>
+                            </div>
+                            <div class="fr-grid-row">
+                                <div class="fr-col-12 fr-text--center">
+                                    <button class="fr-btn fr-fi-checkbox-circle-fill fr-btn--icon-right"
+                                            type="submit" id="form_finish_submit">Confirmer
+                                    </button>
                                 </div>
-                                <div class="fr-grid-row">
-                                    <div class="fr-col-12 fr-text--center">
-                                        <button class="fr-btn fr-fi-checkbox-circle-fill fr-btn--icon-right"
-                                                type="submit" id="form_finish_submit">Confirmer
-                                        </button>
-                                    </div>
-                                </div>
-                                <input type="hidden" name="_token"
-                                       value="{{ csrf_token('signalement_front_response_'~signalement.uuid) }}">
-                            </form>
-                        </div>
+                            </div>
+                            <input type="hidden" name="_token"
+                                    value="{{ csrf_token('signalement_front_response_'~signalement.uuid) }}">
+                        </form>
                     </div>
-                {% endif %}
+                </div>
+            {% endif %}
+
+            {% for suivi in signalement.suivis|reverse %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if not suivi.createdBy %}fr-background-alt--orange-terre-battue{% endif %}">
                     <div class="fr-col-12 fr-col-md-2">
                         <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): 'Vous' }}

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -25,7 +25,7 @@
             </header>
             <hr>
             
-            {% if signalement.statut != 6 %}
+            {% if signalement.statut != constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
                 <div class="fr-grid-row fr-grid-row--middle fr-rounded fr-p-5v">
                     <div class="fr-col-12">
                         <form action="{{ path('front_suivi_signalement_user_response',{code:signalement.codeSuivi}) }}"

--- a/tests/Functional/Command/AskFeedbackUsagerCommandTest.php
+++ b/tests/Functional/Command/AskFeedbackUsagerCommandTest.php
@@ -13,7 +13,7 @@ class AskFeedbackUsagerCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
 
-        $command = $application->find('app:ask-feeback-usager');
+        $command = $application->find('app:ask-feedback-usager');
 
         $commandTester = new CommandTester($command);
 

--- a/tests/Functional/Command/AskFeedbackUsagerCommandTest.php
+++ b/tests/Functional/Command/AskFeedbackUsagerCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Tests\Functional\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AskFeedbackUsagerCommandTest extends KernelTestCase
+{
+    public function testDisplayMessageSuccessfully(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:ask-feeback-usager');
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('1 signalement without suivi from more than 30 days', $output);
+        $this->assertEmailCount(2); // with cron notification email (1+1)
+    }
+}


### PR DESCRIPTION
## Ticket

#800    

## Description
Envoyer un mail à l'occupant tous les mois pour savoir s'il est toujours dans le logement ou non

-     Signalement ouvert & validé
-     Au bout de 30 jours après validation du signalement, si pas de suivi partagé à l'usager
-     Puis tous les 30 jours, si pas de suivi partagé à l'usager


## Changements apportés
* Création d'un nouveau type de suivi, TECHNICAL, qui n'a pas d'auteur, et qui ne créé pas de notification
* Création d'une commande `app:ask-feeback-usager` qui récupère tous les signalements ouverts et validés, n'ayant eu aucun suivi technique, usager ou partenaire depuis 30 jours. Pour chacun de ces signalements, envoi du mail aux usagers et création d'un suivi technique 
* Ajout d'un job cron, tous les jours à 9h pour faire tourner cette commande
* Mise en forme différente de ces suivis techniques dans la fiche signalement (pas visibles en front)

## Tests
- [ ] Recharger les fixtures et jouer la commande `make console app="ask-feedback-usager"`
- [ ] Vérifier qu'un mail est bien envoyé à l'occupant du signalemenet 2022-8, et un autre mail envoyé à notifications pour récap
- [ ] Rejouer la commande, et vérifier qu'un deuxième mail n'est pas envoyé
- [ ] Changer des dates de suivis et/ou des statuts de signalement et vérifier que le comportement est bon
