### PR TITLE
[NDE] add 2 communes in zone parmis de louer

### DIFF
--- a/src/Command/UpdatePartnerAndCommuneNDECommand.php
+++ b/src/Command/UpdatePartnerAndCommuneNDECommand.php
@@ -41,7 +41,7 @@ class UpdatePartnerAndCommuneNDECommand extends Command
         $this->io = new SymfonyStyle($input, $output);
 
         $this->io->section('<info>Update communes in zone permis de louer in Puy de dôme</info>');
-        $communesInseePermisDeLouer63 = [63430, 63102, 63125];
+        $communesInseePermisDeLouer63 = [63430, 63102, 63125, 63231, 63291];
         $this->updateCommunes($communesInseePermisDeLouer63);
         $this->io->section('<info>Update communes in zone permis de louer in Yonne</info>');
         $communesInseePermisDeLouer89 = [89206, 89348, 89382, 89418];


### PR DESCRIPTION
## Description
Ajout des communes suivantes dans la liste des communes en zone permis de louer : 
|63650 | 63231 | La Monnerie-le-Montel | LA MONNERIE-LE MONTEL|
|63290 | 63291 | Puy-Guillaume | PUY-GUILLAUME|

## Changements apportés
* Ajout des codes insee dans la commande `app:update-partners-communes-nde`

## Tests
- [ ] Jouer la commande et vérifier le retour (il faut avoir joué la commande `app:commune-filler `avant)
