### PR TITLE
Ajout étape "Avant de commencer" sur le formulaire de signalement

### DIFF
--- a/templates/_partials/_signalement_step_avantpropos.html.twig
+++ b/templates/_partials/_signalement_step_avantpropos.html.twig
@@ -1,0 +1,187 @@
+<div class="fr-callout">
+    <h3 class="fr-callout__title">Avant de commencer</h3>
+    <p class="fr-callout__text">
+        Vous allez pouvoir signaler votre problème de logement.
+        Après cette page, cela vous prendra environ 20 minutes.
+        Avant de commencer, <strong>lisez bien les conseils ci-dessous</strong>.
+    </p>
+</div>
+
+<h3 class="fr-mt-5w">Comment signaler mon problème de logement ?</h3>
+
+<p>
+    Pour déposer votre signalement, il faut remplir toutes les étapes du formulaire et répondre à des questions sur :
+    <ul>
+        <li>L’état de votre logement</li>
+        <li>L’adresse de votre logement</li>
+        <li>Le logement en général (taille en m², nombre de personnes vivant dans le logement, etc.)</li>
+    </ul>
+
+    Pour répondre à toutes les questions, préparez :
+    <ul>
+        <li>Des photos des dégâts dans votre logement</li>
+        <li>Les coordonnées de votre propriétaire (nom, téléphone, email)</li>
+        <li>Votre bail (si vous en avez un)</li>
+        <li>Si vous êtes allocataire CAF ou MSA : votre numéro d’allocataire</li>
+        <li>Si vous avez prévenu votre propriétaire : une copie de la lettre envoyée à votre propriétaire pour lui expliquer votre problème de logement</li>
+    </ul>
+
+    <div class="fr-alert fr-alert--info">
+        <p>Un signalement complet permet une meilleure prise en charge de votre dossier !</p>
+    </div>
+
+    <hr class="fr-mt-5w">
+
+    <h3>J'ai un problème de logement : qu'est-ce qui m'attend ?</h3>
+    <em>Cliquez sur les questions pour voir les réponses !</em>
+    
+    <section class="fr-accordion">
+        <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-quel-cas">
+                Dans quel cas déposer un signalement ?
+            </button>
+        </h3>
+        <div class="fr-collapse" id="accordion-quel-cas">
+            Histologe permet de signaler les <strong>logements non décents</strong>.
+            <br>
+            Un logement est décent s’il remplit toutes les conditions suivantes :
+            <ul>
+                <li>Il est sécurisé</li>
+                <li>Il ne met pas votre santé en danger</li>
+                <li>Il contient des équipements essentiels (eau froide et eau chaude, chauffage, coin cuisine, etc.)</li>
+                <li>Il est aéré correctement</li>
+                <li>Il n'a pas d'infiltrations d’air</li>
+                <li>Il n’a pas de parasites (cafards, punaises de lit…) ou nuisibles (rats…)</li>
+            </ul>
+            <em>
+                Si votre logement ne respecte pas un ou plusieurs critères ou si vous avez un doute,
+                déposez votre signalement sur Histologe !
+            </em>
+            <br>
+            <div class="fr-alert fr-alert--warning fr-mt-3v">
+                <p>
+                    L’entretien courant du logement est de votre responsabilité.
+                    Veillez à garder votre logement propre et ne pas casser ni abîmer les équipements.
+                    Contactez également votre assureur pour savoir si votre problème peut être pris en charge
+                    par l'assurance habitation.
+                </p>
+            </div>
+        </div>
+    </section>
+    <section class="fr-accordion">
+        <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-arret-payer">
+                Est-ce que je peux arrêter de payer mon loyer ?
+            </button>
+        </h3>
+        <div class="fr-collapse" id="accordion-arret-payer">
+            Non.
+            <br>
+            C’est très important ! Même si votre logement est indécent, vous n’avez pas le droit d’arrêter
+            de payer votre loyer ou une partie.
+            <br>
+            Si vous êtes allocataire, la CAF ou la MSA pourra par contre arrêter de 
+            verser l’allocation logement à votre propriétaire. De votre côté, 
+            <strong>vous devez continuer de payer votre loyer quoiqu’il arrive !</strong>
+        </div>
+    </section>
+    <section class="fr-accordion">
+        <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-prevenir-proprietaire">
+                Est-ce que je dois prévenir mon propriétaire que je dépose un signalement ?
+            </button>
+        </h3>
+        <div class="fr-collapse" id="accordion-prevenir-proprietaire">
+            Non.
+            <br>
+            Ce n’est pas obligatoire pour déposer un signalement, mais c’est recommandé !
+            <br>
+            Il est recommandé de prévenir votre propriétaire, bailleur ou agence immobilière par écrit. 
+            Le meilleur moyen est d’envoyer une lettre recommandée. 
+            Cette lettre doit contenir une description des problèmes dans votre logement 
+            et doit informer votre propriétaire qu’il a 2 mois pour vous répondre et commencer les travaux.
+            <div class="fr-alert fr-alert--success fr-mt-3v">
+                <p>
+                    Pour vous aider, vous pouvez 
+                    <a href="https://faq.histologe.beta.gouv.fr/usager/probleme-logement/avertir-proprietaire" target="_blank" rel="noreferrer">
+                        consulter un modèle de lettre en cliquant ici
+                    </a>.
+                </p>
+            </div>
+        </div>
+    </section>
+    <section class="fr-accordion">
+        <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-apres-depot">
+                Que se passe-t-il une fois que j'ai déposé mon signalement ?
+            </button>
+        </h3>
+        <div class="fr-collapse" id="accordion-apres-depot">
+            Une fois votre signalement déposé, voici les grandes étapes :
+            <br>
+            <ol>
+                <li>Vous recevrez un email de confirmation avec un lien vers une page pour suivre votre dossier</li>
+                <li>Un agent valide votre signalement et le qualifie. Nous déterminons à quelle procédure correspond votre situation parmi quatre procédures : la non décence, l'infraction au RSD (règlement sanitaire départemental), l'insalubrité et le péril.</li>
+                <li>Une visite sera programmée par le service compétent pour confirmer l’état de votre logement</li>
+                <li>Suite au rapport de visite, des mesures seront prises auprès de votre propriétaire pour améliorer votre logement, en fonction de la procédure !</li>
+            </ol>
+            <div class="fr-alert fr-alert--warning fr-mt-3v">
+                <p>
+                    <strong>Gardez bien votre email de confirmation :</strong>
+                    il contient le lien vers votre page de suivi. Tout au long de la procédure, 
+                    la page de suivi vous permettra de suivre l’avancement de votre dossier et de compléter vos informations.
+                </p>
+            </div>
+        </div>
+    </section>
+    <section class="fr-accordion">
+        <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-voir-signalement">
+                Qui pourra voir mon signalement ?
+            </button>
+        </h3>
+        <div class="fr-collapse" id="accordion-voir-signalement">
+            Les services publics en charge de votre dossier.
+            <br>
+            En déposant un signalement sur Histologe, les acteurs publics compétents pouvant
+            vous aider à trouver une solution auront accès à votre signalement. Les partenaires sont variés :
+            l’ADIL, la mairie de votre commune, la CAF, l’agence régionale de santé…
+            <br>
+            Les partenaires qui vont voir vos signalements vont dépendre des problèmes dans votre logement !
+        </div>
+    </section>
+    <section class="fr-accordion">
+        <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-proprietaire-prevenu">
+                Si je dépose un signalement, est-ce que mon propriétaire sera prévenu ?
+            </button>
+        </h3>
+        <div class="fr-collapse" id="accordion-proprietaire-prevenu">
+            Oui.
+            <br>
+            Si votre logement est indécent, le propriétaire est obligé de faire les travaux pour régler les problèmes.
+            Il sera donc prévenu par les services compétents.
+        </div>
+    </section>
+    <section class="fr-accordion">
+        <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-nouveau-logement">
+                Est-ce que Histologe va me permettre d'avoir un nouveau logement ?
+            </button>
+        </h3>
+        <div class="fr-collapse" id="accordion-nouveau-logement">
+            Non.
+            <br>
+            L’objectif du service Histologe et de (re)mettre votre logement aux normes.
+            Ce n’est pas un service de relogement ou de demande de logement social.
+        </div>
+    </section>
+
+    <div class="fr-grid-row fr-mt-5w">
+        <div class="fr-col-12 fr-text--center">
+            <form action="#" name="signalement" id="signalement-step-0" class="needs-validation" novalidate>
+                <button class="fr-btn fr-fi-arrow-right-line fr-btn--icon-right">Continuer</button>
+            </form>
+        </div>
+    </div>
+</p>

--- a/templates/_partials/_signalement_steps_tabs.html.twig
+++ b/templates/_partials/_signalement_steps_tabs.html.twig
@@ -1,9 +1,16 @@
 <div class="fr-tabs" id="signalement-tabs">
     <ul class="fr-tabs__list" role="tablist" aria-label="Etapes signalement">
         <li role="presentation">
-            <button id="signalement-step-1-btn"
+            <button id="signalement-step-0-btn"
                     class="fr-tabs__tab fr-fi-checkbox-circle-line fr-tabs__tab--icon-left" tabindex="0"
-                    role="tab" aria-selected="true" aria-controls="signalement-step-1-panel">1.
+                    role="tab" aria-selected="true" aria-controls="signalement-step-0-panel">
+                0. Avant-propos
+            </button>
+        </li>
+        <li role="presentation">
+            <button id="signalement-step-1-btn"
+                    class="fr-tabs__tab fr-fi-checkbox-circle-line fr-tabs__tab--icon-left" tabindex="-1"
+                    role="tab" aria-selected="false" aria-controls="signalement-step-1-panel">1.
                 Identité
             </button>
         </li>
@@ -49,8 +56,12 @@
             </li>
         {% endif %}
     </ul>
-    <section id="signalement-step-1-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel"
-             aria-labelledby="signalement-step-1-btn" tabindex="0">
+    <section id="signalement-step-0-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel"
+             aria-labelledby="signalement-step-0-btn" tabindex="0">
+        {% include '_partials/_signalement_step_avantpropos.html.twig' %}
+    </section>
+    <section id="signalement-step-1-panel" class="fr-tabs__panel" role="tabpanel"
+             aria-labelledby="signalement-step-1-btn" tabindex="-1">
         {% if 'back_' not in app.request.get('_route') %}
             <header class="fr-callout bg-light fr-mb-5v">
                 <p class="fr-callout__title">Je renseigne mes coordonnées</p>


### PR DESCRIPTION
## Ticket

#794 

## Description
Ajout étape "Avant de commencer" sur le formulaire de signalement

## Tests
- [ ] Vérifier que la nouvelle étape s'affiche
- [ ] Vérifier que les boutons précédent/continuer du formulaires fonctionnent toujours
