### PR TITLE
[NDE][BO - Signalements] 3 petits bugs relevés pendant la démo

### DIFF
--- a/assets/controllers/form_nde.js
+++ b/assets/controllers/form_nde.js
@@ -29,8 +29,8 @@ formBtn?.addEventListener('click', evt => {
         _token: document.getElementById('signalement-edit-nde-token').value,
         dateEntree: document.querySelector('input[name=dateEntree]:checked').value,
         dpe: stringToBoolean(document.querySelector('input[name=dpe]:checked').value),
-        dateDernierBail: document.getElementById('signalement-edit-nde-dernier-bail').value,
-        dateDernierDPE: document.getElementById('signalement-edit-nde-dpe-date').value,
+        dateDernierBail: document.querySelector('input[name=dateDernierBail]:checked').value,
+        dateDernierDPE: document.querySelector('input[name=dateDernierDPE]:checked').value,
         consommationEnergie: Number(document.getElementById('signalement-edit-nde-conso-energie').value),
         superficie: Number(document.getElementById('signalement-edit-nde-superficie')?.value),
     };

--- a/src/Controller/Back/BackSignalementQualificationController.php
+++ b/src/Controller/Back/BackSignalementQualificationController.php
@@ -16,9 +16,11 @@ use Symfony\Component\Serializer\SerializerInterface;
 #[Route('/bo/signalements')]
 class BackSignalementQualificationController extends AbstractController
 {
-    #[Route('/{uuid}/qualification/{signalement_qualification}/editer',
+    #[Route(
+        '/{uuid}/qualification/{signalement_qualification}/editer',
         name: 'back_signalement_qualification_editer',
-        methods: 'POST')]
+        methods: 'POST'
+    )]
     public function editQualification(
         Request $request,
         Signalement $signalement,

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -22,6 +22,7 @@ use App\Repository\UserRepository;
 use App\Service\NotificationService;
 use App\Service\Signalement\CriticiteCalculatorService;
 use App\Service\Signalement\PostalCodeHomeChecker;
+use App\Service\Signalement\QualificationStatusService;
 use App\Service\Signalement\ReferenceGenerator;
 use App\Service\UploadHandlerService;
 use DateTimeImmutable;
@@ -110,7 +111,8 @@ class FrontSignalementController extends AbstractController
         EventDispatcherInterface $eventDispatcher,
         UrlGeneratorInterface $urlGenerator,
         CritereRepository $critereRepository,
-        SignalementQualificationFactory $signalementQualificationFactory
+        SignalementQualificationFactory $signalementQualificationFactory,
+        QualificationStatusService $qualificationStatusService
     ): Response {
         if ($this->isCsrfTokenValid('new_signalement', $request->request->get('_token'))
             && $data = $request->get('signalement')) {
@@ -252,6 +254,8 @@ class FrontSignalementController extends AbstractController
                     );
 
                     $signalement->addSignalementQualification($signalementQualification);
+                    // redéfinit le statut de la qualification après sa création
+                    $signalementQualification->setStatus($qualificationStatusService->getNDEStatus($signalementQualification));
                     $em->persist($signalementQualification);
                 }
             }

--- a/src/Dto/Request/Signalement/QualificationNDERequest.php
+++ b/src/Dto/Request/Signalement/QualificationNDERequest.php
@@ -2,14 +2,12 @@
 
 namespace App\Dto\Request\Signalement;
 
-use DateTimeImmutable;
-
 class QualificationNDERequest
 {
     public function __construct(
         private ?string $dateEntree = null,
-        private ?DateTimeImmutable $dateDernierBail = null,
-        private ?DateTimeImmutable $dateDernierDPE = null,
+        private ?string $dateDernierBail = null,
+        private ?string $dateDernierDPE = null,
         private ?int $superficie = null,
         private ?int $consommationEnergie = null,
         private ?bool $dpe = null,
@@ -26,12 +24,12 @@ class QualificationNDERequest
         return $this->superficie;
     }
 
-    public function getDateDernierBail(): ?DateTimeImmutable
+    public function getDateDernierBail(): ?string
     {
         return $this->dateDernierBail;
     }
 
-    public function getDateDernierDPE(): ?DateTimeImmutable
+    public function getDateDernierDPE(): ?string
     {
         return $this->dateDernierDPE;
     }
@@ -51,7 +49,7 @@ class QualificationNDERequest
         return [
             'consommation_energie' => $this->consommationEnergie,
             'DPE' => $this->dpe,
-            'date_dernier_dpe' => $this->dateDernierDPE?->format('Y-m-d'),
+            'date_dernier_dpe' => $this->dateDernierDPE,
         ];
     }
 }

--- a/src/Factory/SignalementQualificationFactory.php
+++ b/src/Factory/SignalementQualificationFactory.php
@@ -13,7 +13,7 @@ class SignalementQualificationFactory
 {
     public function __construct(
         private QualificationStatusService $qualificationStatusService
-        ) {
+    ) {
     }
 
     public function createInstanceFrom(
@@ -38,8 +38,8 @@ class SignalementQualificationFactory
             } elseif (!empty($dataDateBail)) {
                 $signalementQualification->setDernierBailAt(new DateTimeImmutable($dataDateBail));
             }
-            $dataDateBailToSave = $signalementQualification->getDernierBailAt();
-            if (empty($dataConsoSizeYear) && !empty($dataConsoYear) && !empty($dataConsoSize)) {
+            $dataDateBailToSave = $signalementQualification->getDernierBailAt()?->format('Y-m-d');
+            if (isset($dataDateDPE) && '1970-01-01' === $dataDateDPE && !empty($dataConsoYear) && !empty($dataConsoSize)) {
                 $dataConsoToSave = $dataConsoYear;
             } elseif (!empty($dataConsoSizeYear)) {
                 $dataConsoToSave = $dataConsoSizeYear;
@@ -50,7 +50,7 @@ class SignalementQualificationFactory
         $qualificationNDERequest = new QualificationNDERequest(
             dateEntree: $signalement->getDateEntree()->format('Y-m-d'),
             dateDernierBail: $dataDateBailToSave,
-            dateDernierDPE: isset($dataDateDPE) ? new DateTimeImmutable($dataDateDPE) : null,
+            dateDernierDPE: isset($dataDateDPE) ? $dataDateDPE : null,
             superficie: !empty($dataConsoSize) ? $dataConsoSize : null,
             consommationEnergie: $dataConsoToSave,
             dpe: $dataHasDPEToSave

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -224,14 +224,14 @@ class SignalementManager extends AbstractManager
     ) {
         $signalement = $signalementQualification->getSignalement();
         // // mise à jour du signalement
-        if ('after' === $qualificationNDERequest->getDateEntree()
-        && $signalement->getDateEntree()->format('Y') < '2023 '
+        if ('2023-01-02' === $qualificationNDERequest->getDateEntree()
+        && $signalement->getDateEntree()->format('Y') < '2023'
         ) {
             $signalement->setDateEntree(new DateTimeImmutable('2023-01-02'));
         }
 
-        if ('before' === $qualificationNDERequest->getDateEntree()
-        && $signalement->getDateEntree()->format('Y') >= '2023 '
+        if ('1970-01-01' === $qualificationNDERequest->getDateEntree()
+        && $signalement->getDateEntree()->format('Y') >= '2023'
         ) {
             $signalement->setDateEntree(new DateTimeImmutable('1970-01-01'));
         }
@@ -241,18 +241,26 @@ class SignalementManager extends AbstractManager
         ) {
             $signalement->setSuperficie($qualificationNDERequest->getSuperficie());
         }
+        $this->save($signalement);
 
         // // mise à jour du signalementqualification
-        if (null !== $qualificationNDERequest->getDateDernierBail()
-        && $signalementQualification->getDernierBailAt()->format('Y-m-d') !== $qualificationNDERequest->getDateDernierBail()
+        if ('2023-01-02' === $qualificationNDERequest->getDateDernierBail()
+        && $signalementQualification->getDernierBailAt()->format('Y') < '2023'
         ) {
-            $signalementQualification->setDernierBailAt($qualificationNDERequest->getDateDernierBail());
+            $signalementQualification->setDernierBailAt(new DateTimeImmutable('2023-01-02'));
+        }
+        if ('1970-01-01' === $qualificationNDERequest->getDateDernierBail()
+        && $signalementQualification->getDernierBailAt()->format('Y') >= '2023'
+        ) {
+            $signalementQualification->setDernierBailAt(new DateTimeImmutable('1970-01-01'));
         }
 
         $signalementQualification->setDetails($qualificationNDERequest->getDetails());
 
+        $this->save($signalementQualification);
+
         $signalementQualification->setStatus($this->qualificationStatusService->getNDEStatus($signalementQualification));
 
-        $this->save($signalement);
+        $this->save($signalementQualification);
     }
 }

--- a/src/Service/Statistics/MotifClotureStatisticProvider.php
+++ b/src/Service/Statistics/MotifClotureStatisticProvider.php
@@ -106,31 +106,6 @@ class MotifClotureStatisticProvider
                 'color' => '#FC5D00',
                 'count' => 0,
             ],
-            'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE' => [
-                'label' => 'Abandon de procédure / absence de réponse',
-                'color' => '#CACAFB',
-                'count' => 0,
-            ],
-            'PERIL' => [
-                'label' => 'Péril',
-                'color' => '#CACAFB',
-                'count' => 0,
-            ],
-            'REFUS_DE_VISITE' => [
-                'label' => 'Refus de visite',
-                'color' => '#CACAFB',
-                'count' => 0,
-            ],
-            'REFUS_DE_TRAVAUX' => [
-                'label' => 'Refus de travaux',
-                'color' => '#CACAFB',
-                'count' => 0,
-            ],
-            'RESPONSABILITE_DE_L_OCCUPANT' => [
-                'label' => "Responsabilité de l'occupant",
-                'color' => '#CACAFB',
-                'count' => 0,
-            ],
             'AUTRE' => [
                 'label' => 'Autre',
                 'color' => '#CECECE',

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -34,12 +34,12 @@
                                         </legend>
                                         <div class="fr-fieldset__content">
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="signalement-edit-nde-date-entree-before" name="dateEntree" value="before" {% if signalement.dateEntree and signalement.dateEntree|date('Y')<2023 %}checked{% endif %}>
+                                                <input type="radio" id="signalement-edit-nde-date-entree-before" name="dateEntree" value="1970-01-01" {% if signalement.dateEntree and signalement.dateEntree|date('Y')<2023 %}checked{% endif %}>
                                                 <label class="fr-label" for="signalement-edit-nde-date-entree-before">Avant 2023
                                                 </label>
                                             </div>
                                             <div class="fr-radio-group">
-                                                <input type="radio" id="signalement-edit-nde-date-entree-after" name="dateEntree" value="after" {% if signalement.dateEntree and signalement.dateEntree|date('Y')>=2023 %}checked{% endif %}>
+                                                <input type="radio" id="signalement-edit-nde-date-entree-after" name="dateEntree" value="2023-01-02" {% if signalement.dateEntree and signalement.dateEntree|date('Y')>=2023 %}checked{% endif %}>
                                                 <label class="fr-label" for="signalement-edit-nde-date-entree-after">A partir de 2023
                                                 </label>
                                             </div>
@@ -74,25 +74,42 @@
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"
                                 id="signalement-edit-nde-form-row">
                                 <div class="fr-col-6">
-                                    <div class="fr-input-group">
-                                        <label class="fr-label" for="dateDernierBail">
+                                    <fieldset class="fr-fieldset fr-fieldset--inline">
+                                        <legend class="fr-fieldset__legend fr-text--regular" id='signalement-edit-nde-dernier-bail-legend'>
                                             Date du dernier bail
-                                        </label>
-                                        <div class="fr-input-group">
-                                            <input class="fr-input fr-col-10" type="date" id="signalement-edit-nde-dernier-bail" name="dateDernierBail" value="{{ signalementQualificationNDE.dernierBailAt ? signalementQualificationNDE.dernierBailAt|date('Y-m-d') }}">
+                                        </legend>
+                                        <div class="fr-fieldset__content">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="signalement-edit-nde-dernier-bail-before" name="dateDernierBail" value="1970-01-01" {% if signalementQualificationNDE.dernierBailAt and signalementQualificationNDE.dernierBailAt|date('Y')<2023 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-dernier-bail-before">Avant 2023
+                                                </label>
+                                            </div>
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="signalement-edit-nde-dernier-bail-after" name="dateDernierBail" value="2023-01-02" {% if signalementQualificationNDE.dernierBailAt and signalementQualificationNDE.dernierBailAt|date('Y')>=2023 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-dernier-bail-after">A partir de 2023
+                                                </label>
+                                            </div>
                                         </div>
-
-                                    </div>
+                                    </fieldset>
                                 </div>
                                 <div class="fr-col-6">
-                                    <div class="fr-input-group">
-                                        <label class="fr-label" for="dateDernierDPE">
+                                    <fieldset class="fr-fieldset fr-fieldset--inline">
+                                        <legend class="fr-fieldset__legend fr-text--regular" id='signalement-edit-nde-dpe-date-legend'>
                                             Date du dernier DPE
-                                        </label>
-                                        <div class="fr-input-group">
-                                            <input class="fr-input fr-col-10" type="date" id="signalement-edit-nde-dpe-date" name="dateDernierDPE" value="{{ signalementQualificationNDE.details.date_dernier_dpe ? signalementQualificationNDE.details.date_dernier_dpe|date('Y-m-d') }}">
+                                        </legend>
+                                        <div class="fr-fieldset__content">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="signalement-edit-nde-dpe-date-before" name="dateDernierDPE" value="1970-01-01" {% if signalementQualificationNDE.details.date_dernier_dpe and signalementQualificationNDE.details.date_dernier_dpe|date('Y')<2023 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-dpe-date-before">Avant 2023
+                                                </label>
+                                            </div>
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="signalement-edit-nde-dpe-date-after" name="dateDernierDPE" value="2023-01-02" {% if signalementQualificationNDE.details.date_dernier_dpe and signalementQualificationNDE.details.date_dernier_dpe|date('Y')>=2023 %}checked{% endif %}>
+                                                <label class="fr-label" for="signalement-edit-nde-dpe-date-after">A partir de 2023
+                                                </label>
+                                            </div>
                                         </div>
-                                    </div>
+                                    </fieldset>
                                 </div>
                             </div>
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle"

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -12,7 +12,7 @@
     {% if signalement.statut is not same as(1) and not isClosed and not isClosedForMe and ((isAffected and isAccepted)) or is_granted('ROLE_ADMIN_TERRITORY') %}
         {% include '_partials/_modal_cloture.html.twig' %}
     {% endif %}
-    {% if isSignalementNDE %}
+    {% if isSignalementNDE and isUserNDE %}     
         {% include '_partials/_modal_edit_nde.html.twig' %}        
     {% endif %}
     <section
@@ -38,8 +38,8 @@
                     {% else %}
                         <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold{# fr-fi-information-fill fr-icon--sm #} fr-pr-3v">&nbsp;
                             Signalement par l'occupant</small>
-                    {% endif %}                    
-                    {% if isSignalementNDE %}
+                    {% endif %}                   
+                    {% if isSignalementNDE and isUserNDE %}     
                          <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold fr-pr-3v">&nbsp;
                             Non décence énergétique</small>
                     {% endif %}                               
@@ -449,7 +449,7 @@
                         {% else %}
                             {% set calcul = signalementQualificationNDE.details.consommation_energie %}
                         {% endif %}
-                       <strong>Consommation d'énergie :</strong> <span class="fr-badge fr-badge--info fr-badge--sm">{{ calcul }} kWh/m²/an</span>
+                       <strong>Consommation d'énergie :</strong> <span class="fr-badge fr-badge--info fr-badge--sm">{{ calcul|round(2) }} kWh/m²/an</span>
                     </div>
                     <div class="fr-col-12 fr-col-md-5">                    
                         <strong>Analyse :</strong> <span class="{{ signalementQualificationNDE.status|status_to_css }}">{{ signalementQualificationNDE.status.label }}</span>
@@ -472,7 +472,7 @@
                 </div>
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-6">
-                    <strong>Entrée dans le logement :</strong> {{ signalement.dateEntree ? signalement.dateEntree|date('d/m/Y') : ''}}
+                    <strong>Entrée dans le logement :</strong> {{ signalement.dateEntree  ? ( signalement.dateEntree|date('Y') < '2023' ? 'Avant 2023' : 'A partir de 2023' ) : ''}}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
                     <strong>DPE :</strong> {{ signalementQualificationNDE.details.DPE ? 'Oui' : (signalementQualificationNDE.details.DPE is same as null ? 'A vérifier' : 'Non') }} 
@@ -480,10 +480,10 @@
                 </div>
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-6">
-                    <strong>Dernier bail :</strong> {{ signalementQualificationNDE.dernierBailAt ? signalementQualificationNDE.dernierBailAt|date('d/m/Y') : ''}}
+                    <strong>Dernier bail :</strong> {{ signalementQualificationNDE.dernierBailAt  ? ( signalementQualificationNDE.dernierBailAt|date('Y') < '2023' ? 'Avant 2023' : 'A partir de 2023' ) : ''}}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
-                    <strong>Date dernier DPE :</strong> {{ signalementQualificationNDE.details.date_dernier_dpe ? signalementQualificationNDE.details.date_dernier_dpe|date('d/m/Y') : '' }} 
+                    <strong>Date dernier DPE :</strong> {{ signalementQualificationNDE.details.date_dernier_dpe  ? ( signalementQualificationNDE.details.date_dernier_dpe|date('Y') < '2023' ? 'Avant 2023' : 'A partir de 2023' ) : ''}}
                     </div>
                 </div>
             </div>

--- a/tests/Functional/Controller/BackSignalementQualificationControllerTest.php
+++ b/tests/Functional/Controller/BackSignalementQualificationControllerTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class BackSignalementQualificationControllerTest extends WebTestCase
 {
-    public function testSubmitQualificationNDESignalement()
+    public function testSubmitQualificationNDECheckSignalement()
     {
         $client = static::createClient();
 
@@ -63,7 +63,8 @@ class BackSignalementQualificationControllerTest extends WebTestCase
                 'superficie' => 234,
                 'consommationEnergie' => 545,
                 '_token' => $token,
-            ]));
+            ])
+        );
 
         /** @var Signalement $signalement */
         $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
@@ -72,7 +73,73 @@ class BackSignalementQualificationControllerTest extends WebTestCase
 
         $this->assertEquals(234, $signalement->getSuperficie());
         $this->assertEquals(545, $signalementQualification->getDetails()['consommation_energie']);
-        $this->assertEquals(QualificationStatus::NDE_AVEREE, $signalementQualification->getStatus());
+        $this->assertEquals(QualificationStatus::NDE_CHECK, $signalementQualification->getStatus());
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+    }
+
+    public function testSubmitQualificationNDEOKSignalement()
+    {
+        $client = static::createClient();
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+        $this->assertEquals(Qualification::NON_DECENCE_ENERGETIQUE, $signalementQualification->getQualification());
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate(
+            'back_signalement_qualification_editer',
+            ['uuid' => $signalement->getUuid(), 'signalement_qualification' => $signalementQualification->getId()]
+        );
+
+        $routeSignalementView = $router->generate(
+            'back_signalement_view',
+            ['uuid' => $signalement->getUuid()]
+        );
+
+        $crawler = $client->request('GET', $routeSignalementView);
+        $token = $crawler->filter('#signalement-edit-nde-form input[name=_token]')->attr('value');
+        $client->request('GET', $route);
+        $this->assertLessThan(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $client->getResponse()->getStatusCode(),
+            sprintf('Result value: %d', $client->getResponse()->getStatusCode())
+        );
+
+        $client->request(
+            'POST',
+            $route,
+            [],
+            [],
+            [],
+            json_encode([
+                'dpe' => true,
+                'superficie' => 234,
+                'dateDernierDPE' => '2023-01-08',
+                'consommationEnergie' => 120,
+                '_token' => $token,
+            ])
+        );
+
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+
+        $this->assertEquals(234, $signalement->getSuperficie());
+        $this->assertEquals(120, $signalementQualification->getDetails()['consommation_energie']);
+        $this->assertEquals(QualificationStatus::NDE_OK, $signalementQualification->getStatus());
 
         $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
     }
@@ -123,16 +190,90 @@ class BackSignalementQualificationControllerTest extends WebTestCase
             [],
             [],
             json_encode([
-                'dateDernierBail' => '2019-02-04',
+                'dpe' => true,
+                'superficie' => 234,
+                'dateDernierDPE' => '2023-01-02',
+                'dateDernierBail' => '1970-01-01',
+                'consommationEnergie' => 545,
                 '_token' => $token,
-            ]));
+            ])
+        );
 
         /** @var Signalement $signalement */
         $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
         /** @var SignalementQualification $signalementQualification */
         $signalementQualification = $signalement->getSignalementQualifications()[0];
 
+        $this->assertEquals(234, $signalement->getSuperficie());
+        $this->assertEquals(545, $signalementQualification->getDetails()['consommation_energie']);
         $this->assertEquals(QualificationStatus::ARCHIVED, $signalementQualification->getStatus());
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+    }
+
+    public function testSubmitQualificationNDEAvereeSignalement()
+    {
+        $client = static::createClient();
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+        $this->assertEquals(Qualification::NON_DECENCE_ENERGETIQUE, $signalementQualification->getQualification());
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate(
+            'back_signalement_qualification_editer',
+            ['uuid' => $signalement->getUuid(), 'signalement_qualification' => $signalementQualification->getId()]
+        );
+
+        $routeSignalementView = $router->generate(
+            'back_signalement_view',
+            ['uuid' => $signalement->getUuid()]
+        );
+
+        $crawler = $client->request('GET', $routeSignalementView);
+        $token = $crawler->filter('#signalement-edit-nde-form input[name=_token]')->attr('value');
+        $client->request('GET', $route);
+        $this->assertLessThan(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $client->getResponse()->getStatusCode(),
+            sprintf('Result value: %d', $client->getResponse()->getStatusCode())
+        );
+
+        $client->request(
+            'POST',
+            $route,
+            [],
+            [],
+            [],
+            json_encode([
+                'dpe' => true,
+                'superficie' => 234,
+                'dateDernierDPE' => '2023-01-02',
+                'dateDernierBail' => '2023-01-02',
+                'consommationEnergie' => 545,
+                '_token' => $token,
+            ])
+        );
+
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
+        /** @var SignalementQualification $signalementQualification */
+        $signalementQualification = $signalement->getSignalementQualifications()[0];
+
+        $this->assertEquals(234, $signalement->getSuperficie());
+        $this->assertEquals(545, $signalementQualification->getDetails()['consommation_energie']);
+        $this->assertEquals(QualificationStatus::NDE_AVEREE, $signalementQualification->getStatus());
 
         $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
     }


### PR DESCRIPTION
## Ticket

#1049    

## Description
Correction de bugs et comportement inadéquats repérés pendant la démo

## Changements apportés
* Changements des champs dates en champs radiobutton avant/après pour dateDernierBail et dateDernierDPE
* Passages des valeurs des 3 champs dates pour '1970-01-01' et '2023-01-02'
* Correction du calcul du statut dans QualificationStatusService
* Correction de doublons dans MotifClotureStatisticProvider.php

## Prérequis

- Mettre à jour la base de données et les fixtures
- `symfony console app:commune-filler`
- `symfony console app:update-partners-communes-nde`
- `npm run build`

## Tests
- [ ] Créer un signalement dans un des territoires d'expérimentation, avec un critère NDE, sans donner de date de DPE. Vérifier que le résumé est bon à la fin du dépôt de signalement (tout est "à vérifier")
- [ ] Se connecter en admin, Vérifier que dans la liste des signalements ce signalement a bien le label "NDE"
- [ ] Dans la fiche signalement, vérifier que le statut NDE est bien "a vérifier"
- [ ] Toujours dans la fiche signalement, vérifier qu'on n'affiche plus de dates pour le dernier bail, le dpe etc., mais seulement des infos "avant / après 2023) (en lecture et en édition)
- [ ] Attribuer ce signalement à plusieurs partenaires, qui ont ET qui n'ont pas la compétence NDE (par exemple ADIL et ALF - OPAH)
- [ ] Se connecter avec un partenaire NDE, vérifier que la liste signalement et la fiche signalement ont bien toutes les infos NDE
- [ ] Editer la NDE du signalement, modifier des informations (avant/après 2023) et vérifier que le comportement est bien approprié
- [ ] Se connecter avec un partenaire non-NDE, vérifier que la liste signalement et la fiche signalement n'ont aucune info NDE (notamment le label "non-décence énergétique" tout en haut de la fiche signalement)
- [ ] Recréer un signalement en territoire d'expé avec des critères NDE. Au moment de l'étape NDE, commencer par mettre un DPE 2023, et indiquer une valeur de kwh/m2/an ... puis changer pour mettre DPE avant 2023. Mettre des valeurs de kwh/an et de superficie très différentes. Passer à la suite, valider le signalement. 
- [ ] Se connecter en admin, et vérifier que dans le signalement on a bien les dernières valeurs rentrées et le bon statut. Et pas un mix tout bizarre entre les différentes valeurs.
