### PR TITLE
[BO - Carto] Les signalements sur la carto ne sont pas cliquables

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -70,28 +70,30 @@ async function getMarkers(offset) {
         let marker;
         if (res.signalements) {
             res.signalements.forEach(signalement => {
-                let crit = [];
-                if (signalement.criteres instanceof Array) {
-                    signalement?.criteres?.map(c => {
-                        crit.push(c?.label);
+                if (!isNaN(parseFloat(signalement.geoloc?.lng)) && !isNaN(parseFloat(signalement.geoloc?.lat))) {
+                    let crit = [];
+                    if (signalement.criteres instanceof Array) {
+                        signalement?.criteres?.map(c => {
+                            crit.push(c?.label);
+                        })
+                    }
+                    marker = L.marker([signalement.geoloc.lng, signalement.geoloc.lat], {
+                        id: signalement.id,
+                        status: signalement.statut,
+                        address: signalement.adresseOccupant,
+                        zip: signalement.cpOccupant,
+                        city: signalement.villeOccupant,
+                        reference: signalement.reference,
+                        score: signalement.scoreCreation,
+                        newScore: signalement.newScoreCreation,
+                        name: signalement.nomOccupant.toUpperCase() +' '+ signalement.prenomOccupant,
+                        danger: signalement.scoreCreation > 66 ? 1 : 0,
+                        url: `/bo/signalements/${signalement.uuid}`,
+                        criteres: crit,
+                        details: `${signalement.details}`
                     })
+                    markers.addLayer(marker);
                 }
-                marker = L.marker([signalement.geoloc.lng, signalement.geoloc.lat], {
-                    id: signalement.id,
-                    status: signalement.statut,
-                    address: signalement.adresseOccupant,
-                    zip: signalement.cpOccupant,
-                    city: signalement.villeOccupant,
-                    reference: signalement.reference,
-                    score: signalement.scoreCreation,
-                    newScore: signalement.newScoreCreation,
-                    name: signalement.nomOccupant.toUpperCase() +' '+ signalement.prenomOccupant,
-                    danger: signalement.scoreCreation > 66 ? 1 : 0,
-                    url: `/bo/signalements/${signalement.uuid}`,
-                    criteres: crit,
-                    details: `${signalement.details}`
-                })
-                markers.addLayer(marker);
             })
             map.addLayer(markers);
             // console.log(offset,res.signalements.length)


### PR DESCRIPTION
## Ticket

#1059    

## Description
Vérification de la latitude et la longitude d'un signalement au moment de l'affichage sur la carto

## Changements apportés
* Ajout d'une contrainte dans le js pour être sûrs que ce sont des nombres

## Tests
- [ ] En base, sur un signalement, changer la valeur de geoloc pour {"lat": "..","lng": ".."}
- [ ] Vérifier que les signalements sont cliquables sur la carto
