### PR TITLE
[BO - Dashboard] Filtre manquant widget Signalements acceptés mais sans suivi

### DIFF
--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -17,14 +17,11 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
     public function __construct(
         private SignalementRepository $signalementRepository,
         private UserRepository $userRepository,
-        private EntityManagerInterface $entityManager,
-        private SuiviCreatedSubscriber $suiviCreatedSubscriber,
     ) {
     }
 
     public function load(ObjectManager $manager): void
     {
-        $this->entityManager->getEventManager()->removeEventSubscriber($this->suiviCreatedSubscriber);
         $suiviRows = Yaml::parseFile(__DIR__.'/../Files/Suivi.yml');
         foreach ($suiviRows['suivis'] as $row) {
             $this->loadSuivi($manager, $row);

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -3,12 +3,10 @@
 namespace App\DataFixtures\Loader;
 
 use App\Entity\Suivi;
-use App\EventSubscriber\SuiviCreatedSubscriber;
 use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\Yaml\Yaml;
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -895,6 +895,10 @@ class SignalementRepository extends ServiceEntityRepository
                 ->from(Suivi::class, 'su')
                 ->innerJoin('su.signalement', 'sig')
                 ->where('sig.territory = :territory_1')
+                ->andWhere('sig.statut IN (:statut)')
+                ->andWhere('su.type IN (:suivi_type)')
+                ->setParameter('suivi_type', [Suivi::TYPE_USAGER, Suivi::TYPE_PARTNER])
+                ->setParameter('statut', [Signalement::STATUS_ACTIVE, Signalement::STATUS_NEED_PARTNER_RESPONSE])
                 ->setParameter('territory_1', $territory)
                 ->distinct();
 
@@ -902,10 +906,11 @@ class SignalementRepository extends ServiceEntityRepository
             ->select('COUNT(s.id) as count_no_suivi, p.nom')
             ->innerJoin('s.affectations', 'a')
             ->innerJoin('a.partner', 'p')
-            ->where('s.statut IN (:statut) AND s.id NOT IN (:subquery)')
+            ->where('s.statut IN (:statut)')
             ->andWhere('p.territory = :territory')
+            ->andWhere('s.id NOT IN (:subquery)')
             ->setParameter('statut', [Signalement::STATUS_ACTIVE, Signalement::STATUS_NEED_PARTNER_RESPONSE])
-            ->setParameter('subquery', $subquery)
+            ->setParameter('subquery', $subquery->getQuery()->getSingleColumnResult())
             ->setParameter('territory', $territory)
             ->groupBy('p.nom');
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -893,8 +893,8 @@ class SignalementRepository extends ServiceEntityRepository
         $subquery = $this->_em->createQueryBuilder()
                 ->select('IDENTITY(su.signalement)')
                 ->from(Suivi::class, 'su')
-                ->where('sig.territory = :territory_1')
                 ->innerJoin('su.signalement', 'sig')
+                ->where('sig.territory = :territory_1')
                 ->setParameter('territory_1', $territory)
                 ->distinct();
 

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -617,8 +617,8 @@
                                             class="part-infos-hover" data-user="{{ affectation.affectedBy.nomComplet }}"
                                             data-mail="{{ affectation.affectedBy.email }}">{{ affectation.affectedBy.nomComplet }}</span></span>
                                 <span class="fr-hint-text"><strong>Accepté le :</strong> {{ affectation.answeredAt|date('d/m/Y') }} <br>par <span
-                                            class="part-infos-hover" data-user="{{ affectation.answeredBy.nomComplet }}"
-                                            data-mail="{{ affectation.answeredBy.email }}">{{ affectation.answeredBy.nomComplet }}</span></span>
+                                            class="part-infos-hover" data-user="{{ affectation.answeredBy ? affectation.answeredBy.nomComplet : ''}}"
+                                            data-mail="{{ affectation.answeredBy ? affectation.answeredBy.email : '' }}">{{ affectation.answeredBy ? affectation.answeredBy.nomComplet : '' }}</span></span>
                             </div>
                         </div>
                     {% elseif affectation.statut is same as(2) %}


### PR DESCRIPTION
## Ticket

#785   

## Description
Filtre territoire manquant sur widget Signalements acceptés mais sans suivi

## Changements apportés
* Prise en compte du filtre

## Tests
- [ ] `make console app="update-signalement-lastsuivi"`
- [ ] Se connecter en tant qu'admin territoire et vérifier que les partenaires du territoire sont affichés
