### PR TITLE
[FO - Stat] Foyers sorti du mal logement : ajoute les relogements aux travaux faits

### DIFF
--- a/src/Service/Statistics/GlobalAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalAnalyticsProvider.php
@@ -11,7 +11,7 @@ class GlobalAnalyticsProvider
     public function __construct(
         private SignalementRepository $signalementRepository,
         private TerritoryRepository $territoryRepository
-        ) {
+    ) {
     }
 
     public function getData(): array
@@ -34,15 +34,17 @@ class GlobalAnalyticsProvider
             year: null,
             removeImported: true
         );
+        $countSignalementsResolus = 0;
         foreach ($countPerMotifsCloture as $countPerMotifCloture) {
-            if (MotifCloture::TRAVAUX_FAITS_OU_EN_COURS->value == $countPerMotifCloture['motifCloture']->value
+            if ((MotifCloture::TRAVAUX_FAITS_OU_EN_COURS->value == $countPerMotifCloture['motifCloture']->value
+                || MotifCloture::RELOGEMENT_OCCUPANT->value == $countPerMotifCloture['motifCloture']->value)
                 && !empty($countPerMotifCloture['count'])
             ) {
-                return $countPerMotifCloture['count'];
+                $countSignalementsResolus += $countPerMotifCloture['count'];
             }
         }
 
-        return 0;
+        return $countSignalementsResolus;
     }
 
     public function getCountSignalementData(): int


### PR DESCRIPTION
## Ticket

[#Discussion mattermost liée   ](https://mattermost.incubateur.net/betagouv/pl/y1zhsemji7g5bp4e56kntasf6y)

## Description
Prends en compte les deux motifs de clotures : TRAVAUX_FAITS_OU_EN_COURS et RELOGEMENT_OCCUPANT

## Changements apportés
* Ajoute un motif dans le provider de stats

## Tests
- [ ] Faire en sorte d'avoir des signalements fermés avec chacun de ces types de cloture
- [ ] sur la page signalement, vérifier qu'on prend bien en compte les signalements fermés avec ces deux motifs
