### PR TITLE
Modification du texte d'un motif de cloture

### DIFF
--- a/src/Entity/Enum/MotifCloture.php
+++ b/src/Entity/Enum/MotifCloture.php
@@ -37,7 +37,7 @@ enum MotifCloture: string
             'REFUS_DE_VISITE' => 'Refus de visite',
             'REFUS_DE_TRAVAUX' => 'Refus de travaux',
             'RELOGEMENT_OCCUPANT' => 'Relogement occupant', // précise Problème résolu
-            'RESPONSABILITE_DE_L_OCCUPANT' => "Responsabilité de l'occupant",
+            'RESPONSABILITE_DE_L_OCCUPANT' => "Responsabilité de l'occupant / assurantiel",
             'RSD' => 'RSD',
             'TRAVAUX_FAITS_OU_EN_COURS' => 'Travaux faits ou en cours', // précise Problème résolu
             'AUTRE' => 'Autre',

--- a/src/Service/Statistics/MotifClotureStatisticProvider.php
+++ b/src/Service/Statistics/MotifClotureStatisticProvider.php
@@ -102,7 +102,7 @@ class MotifClotureStatisticProvider
                 'count' => 0,
             ],
             'RESPONSABILITE_DE_L_OCCUPANT' => [
-                'label' => "Responsabilité de l'occupant",
+                'label' => "Responsabilité de l'occupant / assurantiel",
                 'color' => '#FC5D00',
                 'count' => 0,
             ],


### PR DESCRIPTION
## Ticket

#1066    

## Description
Modification du texte d'un motif de cloture.
On remplace `Responsabilité de l'occupant` par `Responsabilité de l'occupant / assurantiel`

## Tests
- [ ] Le nouveau texte s'affiche bien 
