### PR TITLE
Rendre les suivis publics quand ils sont ajoutés par le formulaire de contact

### DIFF
--- a/src/FormHandler/ContactFormHandler.php
+++ b/src/FormHandler/ContactFormHandler.php
@@ -65,6 +65,7 @@ class ContactFormHandler
                     user: $user,
                     signalement: $signalement,
                     params: $params,
+                    isPublic: true
                 );
                 $this->suiviManager->save($suivi);
             }


### PR DESCRIPTION
## Ticket

#1001    

## Description
Rendre les suivis publics quand ils sont ajoutés par le formulaire de contact

## Tests
- [ ] Utiliser le formulaire de contact avec l'adresse mail d'un occupant/déclarant d'un signalement existant
- [ ] Vérifier si le suivi créé automatiquement est bien public
