### PR TITLE
[FO - Signalement] Impossible de déposer des signalements

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -157,7 +157,7 @@ class FrontSignalementController extends AbstractController
                                     $criticite = $em->getRepository(Criticite::class)->find($data[$key][$idSituation]['critere'][$idCritere]['criticite']);
                                     $signalement->addCriticite($criticite);
                                     // TODO : replace getQualification with an array of enum
-                                    if (\in_array(Qualification::NON_DECENCE_ENERGETIQUE->value, $criticite->getQualification())) {
+                                    if (null !== $criticite->getQualification() && \in_array(Qualification::NON_DECENCE_ENERGETIQUE->value, $criticite->getQualification())) {
                                         $listNDECriticites[] = $criticite->getId();
                                     }
                                 }

--- a/src/Dto/SignalementAffectationListView.php
+++ b/src/Dto/SignalementAffectationListView.php
@@ -11,22 +11,22 @@ class SignalementAffectationListView
     public const MAX_LIST_PAGINATION = 30;
 
     public function __construct(
-      private ?int $id = null,
-      private ?string $uuid = null,
-      private ?string $reference = null,
-      private ?\DateTimeImmutable $createdAt = null,
-      private ?int $statut = null,
-      private ?string $scoreCreation = null,
-      private ?string $newScoreCreation = null,
-      private ?bool $isNotOccupant = null,
-      private ?string $nomOccupant = null,
-      private ?string $prenomOccupant = null,
-      private ?string $adresseOccupant = null,
-      private ?string $villeOccupant = null,
-      private \DateTimeImmutable|string|null $lastSuiviAt = null,
-      private ?string $lastSuiviBy = null,
-      private ?array $affectations = null,
-      private ?array $qualifications = null,
+        private ?int $id = null,
+        private ?string $uuid = null,
+        private ?string $reference = null,
+        private ?\DateTimeImmutable $createdAt = null,
+        private ?int $statut = null,
+        private ?string $scoreCreation = null,
+        private ?string $newScoreCreation = null,
+        private ?bool $isNotOccupant = null,
+        private ?string $nomOccupant = null,
+        private ?string $prenomOccupant = null,
+        private ?string $adresseOccupant = null,
+        private ?string $villeOccupant = null,
+        private \DateTimeImmutable|string|null $lastSuiviAt = null,
+        private ?string $lastSuiviBy = null,
+        private ?array $affectations = null,
+        private ?array $qualifications = null,
     ) {
     }
 
@@ -112,9 +112,11 @@ class SignalementAffectationListView
 
     public function hasNDE(): bool
     {
-        foreach ($this->qualifications as $qualification) {
-            if (Qualification::NON_DECENCE_ENERGETIQUE->name === $qualification) {
-                return true;
+        if (null !== $this->qualifications) {
+            foreach ($this->qualifications as $qualification) {
+                if (Qualification::NON_DECENCE_ENERGETIQUE->name === $qualification) {
+                    return true;
+                }
             }
         }
 

--- a/src/Factory/SignalementAffectationListViewFactory.php
+++ b/src/Factory/SignalementAffectationListViewFactory.php
@@ -18,6 +18,11 @@ class SignalementAffectationListViewFactory
         } else {
             $status = $data['statut'];
         }
+        if (null !== $data['qualifications']) {
+            $qualifications = explode(SignalementAffectationListView::SEPARATOR_GROUP_CONCAT, $data['qualifications']);
+        } else {
+            $qualifications = null;
+        }
 
         return new SignalementAffectationListView(
             id: $data['id'],
@@ -35,7 +40,7 @@ class SignalementAffectationListViewFactory
             lastSuiviAt: $data['lastSuiviAt'],
             lastSuiviBy: $data['lastSuiviBy'],
             affectations: $affectations,
-            qualifications: explode(SignalementAffectationListView::SEPARATOR_GROUP_CONCAT, $data['qualifications'])
+            qualifications: $qualifications
         );
     }
 


### PR DESCRIPTION
## Ticket

#1075    

## Description
Permet le dépôt de signalement avec des criticités non-NDE

## Changements apportés
* Vérification sur des null car en local, dans notre base, la migration sur la criticité a créé des tableaux vides pour toutes les criticités non NDE alors que sur la staging, la valeur est NULL conformément à la migration. C'est pour ça qu'on n'avait pas eu l'erreur.

## Tests
- [ ] En base, dans la table criticités, remplacer les [] par des null
- [ ] Déposer un signalement avec des criticités non NDE, vérifier qu'il n'y a pas d'erreur
