### PR TITLE
[BO - Fiche signalement - NDE] Enlever le "0" de la consommation si pas calculée

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -452,7 +452,7 @@
                        <strong>Consommation d'énergie :</strong> 
                        <span class="fr-badge fr-badge--info fr-badge--sm">
                         {% if signalementQualificationNDE.details.DPE is same as null  %}
-                           A vérifier
+                           A renseigner
                         {% else %} 
                            {{calcul|round(2)}} kWh/m²/an
                         {% endif %} 

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -449,7 +449,14 @@
                         {% else %}
                             {% set calcul = signalementQualificationNDE.details.consommation_energie %}
                         {% endif %}
-                       <strong>Consommation d'énergie :</strong> <span class="fr-badge fr-badge--info fr-badge--sm">{{ calcul|round(2) }} kWh/m²/an</span>
+                       <strong>Consommation d'énergie :</strong> 
+                       <span class="fr-badge fr-badge--info fr-badge--sm">
+                        {% if signalementQualificationNDE.details.DPE is same as null  %}
+                           A vérifier
+                        {% else %} 
+                           {{calcul|round(2)}} kWh/m²/an
+                        {% endif %} 
+                        </span>
                     </div>
                     <div class="fr-col-12 fr-col-md-5">                    
                         <strong>Analyse :</strong> <span class="{{ signalementQualificationNDE.status|status_to_css }}">{{ signalementQualificationNDE.status.label }}</span>


### PR DESCRIPTION
## Ticket

#1077    

## Description
Sur les signalements NDE à vérifier, on n'a pas les info de consommation énergétique (vu que pas de DPE et / ou de bail).
Du coup, on indique la consommation énergétique à 0
Il faudrait supprimer le 0 et mettre "à renseigner" à la place du label.

## Changements apportés
* Changement du twig

## Tests
- [ ] Avoir un signalement NDE avérée et un signalement NDE à vérifier (répondre je ne sais pas pour le DPE)
- [ ] Vérifier dans la fiche signalement que l'affichage est bon pour ces deux signalements
