### PR TITLE
[BO - Fiche signalement NDE] Correction pour laisser la zone NDE visible sur les signalements même si l'affectation est clôturée

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -438,7 +438,7 @@
         </div>
         {% if isSignalementNDE and is_granted('USER_SEE_NDE', app.user) %}       
         <section class="fr-accordion">
-            <h3 class="fr-accordion__title ">
+            <h3 class="fr-accordion__title">
                 <button class="fr-accordion__btn fr-btn--icon-left fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france" aria-expanded="true" aria-controls="accordion-nde">Non décence énergétique</button>
             </h3>
             <div class="fr-collapse" id="accordion-nde">
@@ -906,7 +906,7 @@
     </script>
     <script>
         {% if isClosedForMe or signalement.statut is same as(6) %}
-        document?.querySelector('#signalement-{{ signalement.id }}-content').querySelectorAll('button:not(.reopen,.reaffect,.img-box),.fr-btn:not(.reopen,.reaffect,.img-box,.fr-fi-file-pdf-fill)').forEach(input => {
+        document?.querySelector('#signalement-{{ signalement.id }}-content').querySelectorAll('button:not(.reopen,.reaffect,.img-box,.fr-accordion__btn),.fr-btn:not(.reopen,.reaffect,.img-box,.fr-fi-file-pdf-fill)').forEach(input => {
             input.remove()
         })
         {% endif %}


### PR DESCRIPTION
## Ticket

#1084    

## Description
Correction pour laisser la zone NDE visible sur les signalements même si l'affectation est clôturée

## Tests
Affecter un signalement NDE à différents partenaires
Utiliser un utilisateur dans un partenaire avec la compétence NDE
Accepter puis clôturer l'affectation

- [ ] Vérifier que la zone NDE de la fiche signalement BO apparait toujours du point de vue de l'utilisateur partenaire
