### PR TITLE
[QA] Correction code déprécié

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -266,7 +266,6 @@ class FrontSignalementController extends AbstractController
         string $code,
         SignalementRepository $signalementRepository,
         UserRepository $userRepository,
-        NotificationService $notificationService,
         UploadHandlerService $uploadHandlerService,
         Request $request,
         EntityManagerInterface $entityManager
@@ -280,7 +279,12 @@ class FrontSignalementController extends AbstractController
                 $suivi->setCreatedBy($user);
                 $suivi->setType(Suivi::TYPE_USAGER);
 
-                $description = nl2br(filter_var($request->get('signalement_front_response')['content'], \FILTER_SANITIZE_STRING));
+                $description = htmlspecialchars(
+                    nl2br($request->get('signalement_front_response')['content']),
+                    \ENT_QUOTES,
+                    'UTF-8'
+                );
+
                 $files_array = [
                     'documents' => $signalement->getDocuments(),
                     'photos' => $signalement->getPhotos(),

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -115,7 +115,7 @@ class PartnerType extends AbstractType
             },
             function ($tagsAsString) {
                 // transform the string back to an array
-                return explode(',', $tagsAsString);
+                return null !== $tagsAsString ? explode(',', $tagsAsString) : [];
             }
         ));
 


### PR DESCRIPTION
## Ticket

#1087    

## Description
Beaucoup d’événements sentry à ce jour sur ces dépréciations

## Changements apportés
* La constante `FILTER_SANITIZE_STRING` est obsolète, la remplacer par 
https://www.php.net/manual/en/filter.filters.sanitize.php#:~:text=flags%20to%200.-,FILTER_SANITIZE_STRING,-%22string%22

## Tests
- [ ] Déposer un suivi en tant qu'utilisateur
- [ ] En tant qu'usager accéder à la page de suivi et déposer un suivi et vérifier qu'il n'y est pas de régression sur l'affichage
- [ ] En tant qu'admin territoire, éditer une fiche partenaire
