### PR TITLE
[Tâche auto] Commande de demande de feedback usager, Vérifie qu'il existe un code de suivi 

### DIFF
--- a/src/Command/AskFeedbackUsagerCommand.php
+++ b/src/Command/AskFeedbackUsagerCommand.php
@@ -63,7 +63,10 @@ class AskFeedbackUsagerCommand extends Command
         foreach ($signalements as $signalement) {
             ++$totalRead;
             $toRecipients = $signalement->getMailUsagers();
-            if (!empty($toRecipients) && null !== $signalement->getCodeSuivi()) {
+            if (!empty($toRecipients)) {
+                if (null !== $signalement->getCodeSuivi()) {
+                    $signalement->setCodeSuivi(md5(uniqid()));
+                }
                 foreach ($toRecipients as $toRecipient) {
                     $this->notificationService->send(
                         NotificationService::TYPE_SIGNALEMENT_FEEDBACK_USAGER,

--- a/src/Command/AskFeedbackUsagerCommand.php
+++ b/src/Command/AskFeedbackUsagerCommand.php
@@ -63,7 +63,7 @@ class AskFeedbackUsagerCommand extends Command
         foreach ($signalements as $signalement) {
             ++$totalRead;
             $toRecipients = $signalement->getMailUsagers();
-            if (!empty($toRecipients)) {
+            if (!empty($toRecipients) && null !== $signalement->getCodeSuivi()) {
                 foreach ($toRecipients as $toRecipient) {
                     $this->notificationService->send(
                         NotificationService::TYPE_SIGNALEMENT_FEEDBACK_USAGER,


### PR DESCRIPTION
## Ticket

#1098 

## Description
Vérifie qu'il existe un code de suivi pour le signalement avant d'envoyer une demande de feedback à l'usager (erreur sentry https://sentry.incubateur.net/share/issue/1caa9c43ce4542cda7a606996e0ad7b9/)

## Changements apportés
* idem

## Tests
- [ ] Vérifier que la commande fonctionne
