### PR TITLE
[Tâche auto] Commande de demande de feedback usager, supprimer les signalements importés

### DIFF
--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -209,6 +209,7 @@ class SuiviRepository extends ServiceEntityRepository
         INNER JOIN signalement s on s.id = su.signalement_id
         WHERE type in (:type_suivi_usager,:type_suivi_partner,:type_suivi_technical)
         AND s.statut NOT IN (:status_need_validation, :status_closed, :status_archived, :status_refused)
+        AND s.is_imported != 1
         GROUP BY su.signalement_id
         HAVING DATEDIFF(NOW(),last_posted_at) > :day_period
         ORDER BY last_posted_at';


### PR DESCRIPTION
## Ticket

#1101   

## Description
N'envoie pas de demande de feedback à l'usager pour des signalements importés

## Changements apportés
* Ajout d'une condition sur la requête

## Tests
- [ ] Changer le signalement 8 en base pour mettre 1 à is_imported
- [ ] Tester la commande -> pas de suivi créé ni de mail envoyé
- [ ] Remettre 0 à is_imported pour ce signalement
- [ ] Tester la commande -> une demande de feedback est faite
