### PR TITLE
[FO - suivi usager] Lorsqu'un usager ajoute un suivi (via contact ou formulaire suivi) il ne reçoit plus de notification pour son propre suivi

### DIFF
--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -76,8 +76,9 @@ class ActivityListener implements EventSubscriberInterface
                 }
 
                 if ($entity->getIsPublic() && Signalement::STATUS_REFUSED !== $entity->getSignalement()->getStatut()) {
-                    $toRecipients = $entity->getSignalement()->getMailUsagers();
-                    if (!empty($toRecipients) && Signalement::STATUS_CLOSED !== $entity->getSignalement()->getStatut()) {
+                    $toRecipients = new ArrayCollection($entity->getSignalement()->getMailUsagers());
+                    if (!$toRecipients->isEmpty() && Signalement::STATUS_CLOSED !== $entity->getSignalement()->getStatut()) {
+                        $toRecipients->removeElement($entity->getCreatedBy()?->getEmail());
                         foreach ($toRecipients as $toRecipient) {
                             $this->notifier->send(
                                 NotificationService::TYPE_NEW_COMMENT_FRONT,


### PR DESCRIPTION
## Ticket

#1100    

## Description
Lorsqu'un usager ajoute un suivi (via contact ou formulaire suivi) il ne reçoit plus de notification pour son propre suivi

## Changements apportés
* On retire l'adresse mail de l'usager du tableau des adresses mails si elle correspond à l'adresse mail du créateur du Suivi

## Tests
- [ ] Ajouter un suivi via le formulaire de suivi usager, vérifier que l'usager ne reçoit pas de notification par mail
- [ ] Ajouter un suivi via le formulaire de contact, vérifier que l'usager ne reçoit pas de notification par mail
