### PR TITLE
[Signalement - NDE] Retirer le bloc "NDE" si on indique le bail avant 2023

### DIFF
--- a/src/Service/Signalement/QualificationStatusService.php
+++ b/src/Service/Signalement/QualificationStatusService.php
@@ -10,10 +10,15 @@ class QualificationStatusService
 {
     public function getNDEStatus(SignalementQualification $signalementQualification): ?QualificationStatus
     {
-        if (null == $signalementQualification->getDernierBailAt()) {
+        if (null === $signalementQualification->getDernierBailAt()) {
             return QualificationStatus::NDE_CHECK;
         }
-        if ('' == $signalementQualification->getDetails()['DPE']) {
+
+        if ($signalementQualification->getDernierBailAt()->format('Y') < '2023') {
+            return QualificationStatus::ARCHIVED;
+        }
+
+        if ('' === $signalementQualification->getDetails()['DPE'] || null === $signalementQualification->getDetails()['DPE']) {
             return QualificationStatus::NDE_CHECK;
         }
 

--- a/tests/Functional/Controller/BackSignalementQualificationControllerTest.php
+++ b/tests/Functional/Controller/BackSignalementQualificationControllerTest.php
@@ -61,6 +61,7 @@ class BackSignalementQualificationControllerTest extends WebTestCase
             [],
             json_encode([
                 'superficie' => 234,
+                'dpe' => null,
                 'consommationEnergie' => 545,
                 '_token' => $token,
             ])


### PR DESCRIPTION
## Ticket

#1113    

## Description
Dès que la date du bail est antérieure à 2023 on doit passer au statut Archived, quelles que soients les autres informations

## Changements apportés
* Changement du QualificationStatusService
* Adaptation d'un test

## Tests
- [ ] Recharger les fixtures
- [ ] Ouvrir le signalement 2023-7, éditer la NDE pour mettre "Non" ou "Je ne sais pas" au DPE
- [ ] Vérifier que l'encart NDE a bien disparu
