### PR TITLE
Mise en place d'une version de cache paramétrable pour les fichiers JS dépréciés

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -4,7 +4,6 @@ twig:
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr
-        deprecated_js_cache_version: '202303271647'
     paths:
         # point this wherever your images live
         '%kernel.project_dir%/public/img': images

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -94,8 +94,8 @@
 <script type="text/javascript" nomodule src={{ asset('dsfr/dsfr.nomodule.min.js') }}></script>
 <script type="text/javascript" src={{ asset('js/screencapture.js') }}></script>
 <script src="{{ asset('js/tinymce/tinymce.min.js') }}"></script>
-<script src="{{ asset('js/const.min.js?v='~deprecated_js_cache_version) }}"></script>
-<script src="{{ asset('js/app.js?v='~deprecated_js_cache_version) }}"></script>
+<script src="{{ asset('js/const.min.js?v='~''|date('YmdH')) }}"></script>
+<script src="{{ asset('js/app.js?v='~''|date('YmdH')) }}"></script>
 <script src={{ asset('js/img_box.js') }}></script>
 <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>


### PR DESCRIPTION
## Description
Mise en place d'une version de cache paramétrable pour les fichiers JS dépréciés

## Tests
- [ ] Les fichiers js app et const se chargent toujours
