### PR TITLE
[QA] Contrainte de validation manquante formulaires

### DIFF
--- a/src/Controller/Back/BackSignalementFileController.php
+++ b/src/Controller/Back/BackSignalementFileController.php
@@ -4,7 +4,7 @@ namespace App\Controller\Back;
 
 use App\Entity\Signalement;
 use App\Entity\Suivi;
-use App\Exception\MaxUploadSizeExceededException;
+use App\Exception\File\MaxUploadSizeExceededException;
 use App\Service\Files\HeicToJpegConverter;
 use App\Service\UploadHandlerService;
 use DateTimeImmutable;

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -10,7 +10,6 @@ use App\Entity\Situation;
 use App\Entity\Suivi;
 use App\Entity\User;
 use App\Event\SignalementCreatedEvent;
-use App\Exception\MaxUploadSizeExceededException;
 use App\Factory\SignalementQualificationFactory;
 use App\Form\SignalementType;
 use App\Manager\UserManager;
@@ -33,7 +32,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -79,14 +77,17 @@ class FrontSignalementController extends AbstractController
     }
 
     #[Route('/signalement/handle', name: 'handle_upload', methods: 'POST')]
-    public function handleUpload(UploadHandlerService $uploadHandlerService, Request $request, RequestStack $requestStack, LoggerInterface $logger)
-    {
+    public function handleUpload(
+        UploadHandlerService $uploadHandlerService,
+        Request $request,
+        LoggerInterface $logger
+    ) {
         if (null !== ($files = $request->files->get('signalement'))) {
             try {
                 foreach ($files as $key => $file) {
                     return $this->json($uploadHandlerService->toTempFolder($file)->setKey($key));
                 }
-            } catch (MaxUploadSizeExceededException $exception) {
+            } catch (\Exception $exception) {
                 $logger->error($exception->getMessage());
 
                 return $this->json(['error' => $exception->getMessage()], 400);

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[Route('/')]
 class FrontSignalementController extends AbstractController
@@ -112,7 +113,8 @@ class FrontSignalementController extends AbstractController
         UrlGeneratorInterface $urlGenerator,
         CritereRepository $critereRepository,
         SignalementQualificationFactory $signalementQualificationFactory,
-        QualificationStatusService $qualificationStatusService
+        QualificationStatusService $qualificationStatusService,
+        ValidatorInterface $validator,
     ): Response {
         if ($this->isCsrfTokenValid('new_signalement', $request->request->get('_token'))
             && $data = $request->get('signalement')) {
@@ -202,6 +204,14 @@ class FrontSignalementController extends AbstractController
                         }
                 }
             }
+            $errors = $validator->validate($signalement);
+
+            if (\count($errors) > 0) {
+                return $this->json(
+                    ['response' => sprintf('Le formulaire comporte des erreurs: %s', $errors)],
+                    Response::HTTP_BAD_REQUEST);
+            }
+
             if (!$signalement->getIsNotOccupant()) {
                 $signalement->setNomDeclarant(null);
                 $signalement->setPrenomDeclarant(null);

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -209,7 +209,8 @@ class FrontSignalementController extends AbstractController
             if (\count($errors) > 0) {
                 return $this->json(
                     ['response' => sprintf('Le formulaire comporte des erreurs: %s', $errors)],
-                    Response::HTTP_BAD_REQUEST);
+                    Response::HTTP_BAD_REQUEST
+                );
             }
 
             if (!$signalement->getIsNotOccupant()) {

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -5,7 +5,6 @@ namespace App\Controller;
 use App\Form\ContactType;
 use App\Form\PostalCodeSearchType;
 use App\FormHandler\ContactFormHandler;
-use App\Repository\AffectationRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\PostalCodeHomeChecker;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -19,7 +18,6 @@ class HomepageController extends AbstractController
     public function index(
         Request $request,
         SignalementRepository $signalementRepository,
-        AffectationRepository $affectationRepository,
         PostalCodeHomeChecker $postalCodeHomeChecker
     ): Response {
         $title = 'Un service public pour les locataires et propriétaires';

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -94,6 +94,7 @@ class Signalement
     private $adresseProprio;
 
     #[ORM\Column(type: 'string', length: 15, nullable: true)]
+    #[Assert\Length(min: 10, max: 15)]
     private $telProprio;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
@@ -150,6 +151,7 @@ class Signalement
     private $adresseOccupant;
 
     #[ORM\Column(type: 'string', length: 5)]
+    #[Assert\NotBlank]
     private $cpOccupant;
 
     #[ORM\Column(type: 'string', length: 100)]
@@ -861,7 +863,7 @@ class Signalement
         return $this->cpOccupant;
     }
 
-    public function setCpOccupant(string $cpOccupant): self
+    public function setCpOccupant(?string $cpOccupant): self
     {
         $this->cpOccupant = $cpOccupant;
 

--- a/src/Exception/File/MaxUploadSizeExceededException.php
+++ b/src/Exception/File/MaxUploadSizeExceededException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Exception;
+namespace App\Exception\File;
 
 class MaxUploadSizeExceededException extends \Exception
 {

--- a/src/Exception/File/UnsupportedFileFormatException.php
+++ b/src/Exception/File/UnsupportedFileFormatException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception\File;
+
+class UnsupportedFileFormatException extends \Exception
+{
+    public function __construct(?string $mimeType = null)
+    {
+        parent::__construct(
+            sprintf('Le format %s n\'est pas supporté, merci d\'essayer avec un format JPEG ou PNG', $mimeType)
+        );
+    }
+}

--- a/src/Form/ContactType.php
+++ b/src/Form/ContactType.php
@@ -45,7 +45,7 @@ class ContactType extends AbstractType
                     'minlength' => 10,
                 ], 'label' => 'Votre message',
                 'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de renseigner votre message'),
+                    new Assert\NotBlank(message: 'Merci de renseigner votre message.'),
                     new Assert\Length(min: 10, minMessage: 'Votre message doit comporter au moins 10 caractères.'),
                 ],
             ]);

--- a/src/Form/ContactType.php
+++ b/src/Form/ContactType.php
@@ -8,6 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ContactType extends AbstractType
 {
@@ -20,6 +21,9 @@ class ContactType extends AbstractType
                 ], 'attr' => [
                     'class' => 'fr-input',
                 ], 'label' => 'Votre nom',
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de renseigner votre nom complet.'),
+                ],
             ])
             ->add('email', EmailType::class, [
                 'row_attr' => [
@@ -27,6 +31,10 @@ class ContactType extends AbstractType
                 ], 'attr' => [
                     'class' => 'fr-input',
                 ], 'label' => 'Votre adresse courriel',
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de renseigner votre email.'),
+                    new Assert\Email(),
+                ],
             ])
             ->add('message', TextareaType::class, [
                 'row_attr' => [
@@ -36,6 +44,10 @@ class ContactType extends AbstractType
                     'rows' => 10,
                     'minlength' => 10,
                 ], 'label' => 'Votre message',
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de renseigner votre message'),
+                    new Assert\Length(min: 10, minMessage: 'Votre message doit comporter au moins 10 caractères.'),
+                ],
             ]);
     }
 
@@ -47,7 +59,6 @@ class ContactType extends AbstractType
                 'class' => 'needs-validation',
                 'novalidate' => 'true',
             ],
-            // Configure your form options here
         ]);
     }
 }

--- a/src/Form/PostalCodeSearchType.php
+++ b/src/Form/PostalCodeSearchType.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class PostalCodeSearchType extends AbstractType
 {
@@ -23,6 +24,9 @@ class PostalCodeSearchType extends AbstractType
                     'maxlength' => 5,
                 ],
                 'label' => 'Votre code postal',
+                'constraints' => [
+                    new Assert\NotBlank(),
+                ],
             ])
         ;
     }

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -2,7 +2,8 @@
 
 namespace App\Service;
 
-use App\Exception\MaxUploadSizeExceededException;
+use App\Exception\File\MaxUploadSizeExceededException;
+use App\Exception\File\UnsupportedFileFormatException;
 use App\Service\Files\HeicToJpegConverter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -38,6 +39,11 @@ class UploadHandlerService
         if ($file->getSize() > self::MAX_FILESIZE) {
             throw new MaxUploadSizeExceededException(self::MAX_FILESIZE);
         }
+
+        if (\in_array($file->getMimeType(), HeicToJpegConverter::HEIC_FORMAT)) {
+            throw new UnsupportedFileFormatException($file->getMimeType());
+        }
+
         try {
             $distantFolder = $this->parameterBag->get('bucket_tmp_dir');
             $fileResource = fopen($file->getPathname(), 'r');

--- a/tests/Functional/Controller/FrontSignalementControllerTest.php
+++ b/tests/Functional/Controller/FrontSignalementControllerTest.php
@@ -21,7 +21,7 @@ class FrontSignalementControllerTest extends WebTestCase
         $crawler = $client->request('GET', $routeSignalementSend);
         $token = $crawler->filter('input[name=_token]')->attr('value');
 
-        $payload = $this->getCommonPayload();
+        $payload = $this->getCommonValidPayload();
         $payloadSignalement = [
             'signalement' => array_merge($payload, $adressSignalement),
             '_token' => $token,
@@ -50,7 +50,7 @@ class FrontSignalementControllerTest extends WebTestCase
 
         $urlPostSignalement = $router->generate('envoi_signalement');
 
-        $payload = $this->getCommonPayload();
+        $payload = $this->getCommonValidPayload();
         $payloadSignalement = [
             'signalement' => array_merge($payload, $adressSignalement),
             '_token' => $token,
@@ -60,6 +60,32 @@ class FrontSignalementControllerTest extends WebTestCase
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
         $bodyContent = $client->getResponse()->getContent();
         $this->assertEquals(json_decode($bodyContent, true)['response'], 'Territory is inactive');
+    }
+
+    public function testConstraintValidationSignalement()
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $routeSignalementSend = $router->generate('front_signalement');
+        $crawler = $client->request('GET', $routeSignalementSend);
+        $token = $crawler->filter('input[name=_token]')->attr('value');
+
+        $payloadSignalement = [
+            'signalement' => $this->getErrorPayload(),
+            '_token' => $token,
+        ];
+
+        $urlPostSignalement = $router->generate('envoi_signalement');
+        $client->request('POST', $urlPostSignalement, $payloadSignalement);
+
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $bodyContent = $client->getResponse()->getContent();
+        $this->assertStringContainsString(
+            'Le formulaire comporte des erreurs',
+            json_decode($bodyContent, true)['response']
+        );
     }
 
     public function provideAdressSignalementWithTerritoryActive(): array
@@ -137,7 +163,7 @@ class FrontSignalementControllerTest extends WebTestCase
         ];
     }
 
-    private function getCommonPayload()
+    private function getCommonValidPayload(): array
     {
         return [
             'isNotOccupant' => '0',
@@ -172,6 +198,49 @@ class FrontSignalementControllerTest extends WebTestCase
             'isPreavisDepart' => '0',
             'isRelogement' => '0',
             'isCguAccepted' => 'on',
+        ];
+    }
+
+    private function getErrorPayload(): array
+    {
+        return [
+            'isNotOccupant' => '0',
+            'nomDeclarant' => 'John',
+            'prenomDeclarant' => 'Doe',
+            'telDeclarant' => '',
+            'mailDeclarant' => 'admin-01@histologe.fr',
+            'nomOccupant' => 'Doe',
+            'prenomOccupant' => 'Jenifer',
+            'telOccupant' => '0611571631',
+            'telOccupantBis' => '',
+            'mailOccupant' => 'john.doe@yopmail.com',
+            'etageOccupant' => '',
+            'escalierOccupant' => '',
+            'numAppartOccupant' => '',
+            'adresseAutreOccupant' => '',
+            'nomProprio' => 'Arnold Doe',
+            'adresseProprio' => '',
+            'telProprio' => '+331123456987854521452145245',
+            'mailProprio' => '',
+            'situation' => [8 => ['critere' => [10 => ['criticite' => 11]]]],
+            'details' => 'Trés problématique de vivre ici, pas mal de fssure dans le séjour et de l\'humidité dans la chambre des enfants',
+            'isProprioAverti' => '0',
+            'nbAdultes' => '2',
+            'nbEnfantsM6' => '1',
+            'nbEnfantsP6' => '2',
+            'natureLogement' => 'maison',
+            'superficie' => '1000',
+            'isAllocataire' => '0',
+            'numAllocataire' => '0',
+            'isLogementSocial' => '0',
+            'isPreavisDepart' => '0',
+            'isRelogement' => '0',
+            'isCguAccepted' => 'on',
+            'adresseOccupant' => '45 Rue du Général de Gaulle',
+            'villeOccupant' => 'Saint-Denis',
+            'cpOccupant' => '',
+            'geoloc' => ['lat' => 55.452091, 'lng' => -20.885586],
+            'inseeOccupant' => '97411',
         ];
     }
 }

--- a/tests/Functional/Controller/HomepageControllerTest.php
+++ b/tests/Functional/Controller/HomepageControllerTest.php
@@ -76,12 +76,10 @@ class HomepageControllerTest extends WebTestCase
 
     public function testSubmitContactWithEmptyMessage(): void
     {
-        $faker = Factory::create();
-
         $client = static::createClient();
         /** @var UrlGeneratorInterface $generatorUrl */
         $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
-        $crawler = $client->request('GET', $generatorUrl->generate('front_contact'));
+        $client->request('GET', $generatorUrl->generate('front_contact'));
 
         $client->submitForm('Envoyer le message', [
                 'contact[nom]' => 'John Doe',
@@ -90,7 +88,8 @@ class HomepageControllerTest extends WebTestCase
             ]
         );
 
-        $this->assertSelectorTextContains('[for="contact_message"] + ul',
+        $this->assertSelectorTextContains(
+            '[for="contact_message"] + ul',
             'Merci de renseigner votre message',
             $client->getResponse()->getContent()
         );


### PR DESCRIPTION
## Ticket

#902    

## Description
Suite aux erreurs Sentry, ajout de quelques contraintes de validation sur les formulaires suivants:
- [Homepage] Formulaire de saisie de code postal
- [Contact] Formulaire de contact
- [Signalement] Formulaire de signalement

## Changements apportés
* Ajout de contrainte de validation sur l'entité Signalement (cpOccupant, telProprio)
* Ajout de contrainte de validation sur le formulaire de contact 
* Ajout de contrainte de validation sur le formulaire de code postal
* Renvoie une exception si le format de fichier est HEIF/HEIC

## Tests
- [ ] Après avoir désactiver javascript, je ne dois passer à l'étape suivante si je soumet le formulaire sans code postal
- [ ] Après avoir désactiver javascript, je ne peux pas envoyer de message via le formulaire de contact
- [ ] Test de régression  sur la soumission de formulaire car sans JS le formulaire ne fonctionne pas
- [ ] Test de regression sur l'upload de photo et la fiche suivi 
