### PR TITLE
[BO Signalement] Affichage de la qualification NDE sur la page signalement uniquement si avérée ou à vérifier

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -34,7 +34,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[Route('/bo/signalements')]
-class BackSignalementController extends AbstractController
+class SignalementController extends AbstractController
 {
     #[Route('/{uuid}', name: 'back_signalement_view')]
     public function viewSignalement(
@@ -149,12 +149,23 @@ class BackSignalementController extends AbstractController
             'clotureForm' => $clotureForm->createView(),
             'tags' => $tagsRepository->findAllActive($signalement->getTerritory()),
             'isExperimentationTerritory' => $isExperimentationTerritory,
-            'isSignalementNDE' => $isSignalementNDEActif,
+            'isQualificationNDEDisplayed' => $this->isQualificationNDEDisplayed($signalementQualificationNDE),
+            'isZoneNDEDisplayed' => $isSignalementNDEActif,
             'signalementQualificationNDE' => $signalementQualificationNDE,
             'signalementQualificationNDECriticite' => $signalementQualificationNDECriticites,
             'files' => $files,
             'canEditNDE' => $canEditNDE,
         ]);
+    }
+
+    private function isQualificationNDEDisplayed(?SignalementQualification $signalementQualification): bool
+    {
+        if (null !== $signalementQualification) {
+            return QualificationStatus::NDE_AVEREE == $signalementQualification->getStatus()
+                || QualificationStatus::NDE_CHECK == $signalementQualification->getStatus();
+        }
+
+        return false;
     }
 
     private function isSignalementNDEActif(?SignalementQualification $signalementQualification): bool

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -149,23 +149,11 @@ class SignalementController extends AbstractController
             'clotureForm' => $clotureForm->createView(),
             'tags' => $tagsRepository->findAllActive($signalement->getTerritory()),
             'isExperimentationTerritory' => $isExperimentationTerritory,
-            'isQualificationNDEDisplayed' => $this->isQualificationNDEDisplayed($signalementQualificationNDE),
-            'isZoneNDEDisplayed' => $isSignalementNDEActif,
             'signalementQualificationNDE' => $signalementQualificationNDE,
             'signalementQualificationNDECriticite' => $signalementQualificationNDECriticites,
             'files' => $files,
             'canEditNDE' => $canEditNDE,
         ]);
-    }
-
-    private function isQualificationNDEDisplayed(?SignalementQualification $signalementQualification): bool
-    {
-        if (null !== $signalementQualification) {
-            return QualificationStatus::NDE_AVEREE == $signalementQualification->getStatus()
-                || QualificationStatus::NDE_CHECK == $signalementQualification->getStatus();
-        }
-
-        return false;
     }
 
     private function isSignalementNDEActif(?SignalementQualification $signalementQualification): bool

--- a/src/Service/Signalement/QualificationStatusService.php
+++ b/src/Service/Signalement/QualificationStatusService.php
@@ -5,8 +5,9 @@ namespace App\Service\Signalement;
 use App\Entity\Enum\QualificationStatus;
 use App\Entity\SignalementQualification;
 use DateTimeImmutable;
+use Twig\Extension\RuntimeExtensionInterface;
 
-class QualificationStatusService
+class QualificationStatusService implements RuntimeExtensionInterface
 {
     public function getNDEStatus(SignalementQualification $signalementQualification): ?QualificationStatus
     {
@@ -56,6 +57,24 @@ class QualificationStatusService
         }
 
         return QualificationStatus::NDE_CHECK;
+    }
+
+    public function canSeenNDEQualification(?SignalementQualification $signalementQualification): bool
+    {
+        if (empty($signalementQualification)) {
+            return false;
+        }
+
+        return QualificationStatus::NDE_AVEREE == $signalementQualification->getStatus() || QualificationStatus::NDE_CHECK == $signalementQualification->getStatus();
+    }
+
+    public function canSeenNDEEditZone(?SignalementQualification $signalementQualification): bool
+    {
+        if (empty($signalementQualification)) {
+            return false;
+        }
+
+        return QualificationStatus::NDE_AVEREE == $signalementQualification->getStatus() || QualificationStatus::NDE_CHECK == $signalementQualification->getStatus() || QualificationStatus::NDE_OK == $signalementQualification->getStatus();
     }
 
     public function getList(): array

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -4,6 +4,7 @@ namespace App\Twig;
 
 use App\Entity\Enum\QualificationStatus;
 use App\Service\Notification\NotificationCounter;
+use App\Service\Signalement\QualificationStatusService;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -35,6 +36,8 @@ class AppExtension extends AbstractExtension
     {
         return [
             new TwigFunction('count_notification', [NotificationCounter::class, 'countUnseenNotification']),
+            new TwigFunction('can_see_nde_qualification', [QualificationStatusService::class, 'canSeenNDEQualification']),
+            new TwigFunction('can_see_nde_edit_zone', [QualificationStatusService::class, 'canSeenNDEEditZone']),
         ];
     }
 }

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -39,7 +39,7 @@
                         <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold{# fr-fi-information-fill fr-icon--sm #} fr-pr-3v">&nbsp;
                             Signalement par l'occupant</small>
                     {% endif %}                   
-                    {% if isQualificationNDEDisplayed and is_granted('USER_SEE_NDE', app.user) %}     
+                    {% if can_see_nde_qualification(signalementQualificationNDE) and is_granted('USER_SEE_NDE', app.user) %}     
                          <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold fr-pr-3v">&nbsp;
                             Non décence énergétique</small>
                     {% endif %}                               
@@ -436,7 +436,7 @@
                 </ul>
             </div>
         </div>
-        {% if isZoneNDEDisplayed and is_granted('USER_SEE_NDE', app.user) %}       
+        {% if can_see_nde_edit_zone(signalementQualificationNDE) and is_granted('USER_SEE_NDE', app.user) %}       
         <section class="fr-accordion">
             <h3 class="fr-accordion__title">
                 <button class="fr-accordion__btn fr-btn--icon-left fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france" aria-expanded="true" aria-controls="accordion-nde">Non décence énergétique</button>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -39,7 +39,7 @@
                         <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold{# fr-fi-information-fill fr-icon--sm #} fr-pr-3v">&nbsp;
                             Signalement par l'occupant</small>
                     {% endif %}                   
-                    {% if isSignalementNDE and is_granted('USER_SEE_NDE', app.user) %}     
+                    {% if isQualificationNDEDisplayed and is_granted('USER_SEE_NDE', app.user) %}     
                          <small class="fr-background-alt--blue-france fr-text-label--blue-france fr-rounded fr-p-1v fr-text--bold fr-pr-3v">&nbsp;
                             Non décence énergétique</small>
                     {% endif %}                               
@@ -436,7 +436,7 @@
                 </ul>
             </div>
         </div>
-        {% if isSignalementNDE and is_granted('USER_SEE_NDE', app.user) %}       
+        {% if isZoneNDEDisplayed and is_granted('USER_SEE_NDE', app.user) %}       
         <section class="fr-accordion">
             <h3 class="fr-accordion__title">
                 <button class="fr-accordion__btn fr-btn--icon-left fr-fi-chat-quote-fill fr-icon--sm fr-text-label--blue-france" aria-expanded="true" aria-controls="accordion-nde">Non décence énergétique</button>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -141,7 +141,7 @@
                         {% endfor %}
                     ];
              
-                    {% if isZoneNDEDisplayed and is_granted('USER_SEE_NDE', app.user) and files is defined and files.documents is defined %}  
+                    {% if can_see_nde_edit_zone(signalementQualificationNDE) and is_granted('USER_SEE_NDE', app.user) and files is defined and files.documents is defined %}  
                        {% for doc in files.documents %}
                             {% if enum('App\\Entity\\Enum\\Qualification').NON_DECENCE_ENERGETIQUE.name in doc.params.qualification|joinEnumKeys(',') %}
                                 items.push({

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -141,7 +141,7 @@
                         {% endfor %}
                     ];
              
-                    {% if isSignalementNDE and is_granted('USER_SEE_NDE', app.user) and files is defined and files.documents is defined %}  
+                    {% if isZoneNDEDisplayed and is_granted('USER_SEE_NDE', app.user) and files is defined and files.documents is defined %}  
                        {% for doc in files.documents %}
                             {% if enum('App\\Entity\\Enum\\Qualification').NON_DECENCE_ENERGETIQUE.name in doc.params.qualification|joinEnumKeys(',') %}
                                 items.push({


### PR DESCRIPTION
## Ticket

#1118    

## Description
Affichage de la qualification NDE sur la page signalement uniquement si avérée ou à vérifier

## Changements apportés
* Renommage controller BackSignalementController en SignalementController
* Ajout d'une variable pour tester si on affiche la zone / si on affiche la qualification

## Tests
- [ ] L'affichage de la qualification NDE correspond à la réalité sur la page Signalement
- [ ] L'affichage de la zone d'édition NDE correspond à la réalité sur la page Signalement
