### PR TITLE
[Suivi usager] Désactivation du bouton du formulaire lors de l'envoi

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -19,4 +19,5 @@ import './vue/dashboard';
 import './controllers/form_partner';
 import './controllers/form_account';
 import './controllers/form_nde';
+import './controllers/form_helper';
 

--- a/assets/controllers/form_helper.js
+++ b/assets/controllers/form_helper.js
@@ -1,0 +1,9 @@
+document.querySelectorAll('.fr-disable-button-when-submit')?.forEach(element => {
+    element.addEventListener('submit', (event) => {
+        if (element.checkValidity()) {
+            element.querySelectorAll('button[type=submit]')?.forEach(element => {
+                element.setAttribute('disabled', true);
+            })
+        }
+    })
+})

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -29,7 +29,7 @@
                 <div class="fr-grid-row fr-grid-row--middle fr-rounded fr-p-5v">
                     <div class="fr-col-12">
                         <form action="{{ path('front_suivi_signalement_user_response',{code:signalement.codeSuivi}) }}"
-                                class="needs-validation" novalidate method="POST">
+                                class="needs-validation fr-disable-button-when-submit" novalidate method="POST">
                             <div class="fr-input-group">
                                 <label for="signalement_front_response_content" class="fr-label">Votre
                                     message:</label>
@@ -100,4 +100,8 @@
             {% endfor %}
         </section>
     </main>
+{% endblock %}
+
+{% block javascripts %}
+    {{ encore_entry_script_tags('app') }}
 {% endblock %}


### PR DESCRIPTION
## Ticket

#1074    

## Description
Désactivation du bouton du formulaire sur la page de suivi usager lors de la validation du formulaire, pour éviter des envois en doublon.

## Changements apportés
* Création d'un fichier générique JS qui peut être réutilisée sur d'autres formulaires au besoin (en injectant le JS)

## Tests
**Conditions de test :** utiliser le mode de limitation de réseau du navigateur pour avoir le temps de voir
- [ ] Vérifier que le bouton passe bien en désactivé lors de la soumission du formulaire
- [ ] Vérifier que le bouton reste actif si il y a une erreur dans le formulaire
