### PR TITLE
[BO Notifications] Mise en place d'une largeur max pour les tableaux

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -461,3 +461,7 @@ div.procedure-items {
         }
     }
 }
+
+table tr.partner-row table {
+    max-width: 500px;
+}


### PR DESCRIPTION
## Ticket

#1050    

## Description
Mise en place d'une largeur max pour les tableaux pour éviter des dépassements en largeur lors de copier-coller.

## Changements apportés
* Ajout d'une règle css sur les tableaux concernés

## Tests
- [ ] Copier coller un tableau dans un suivi avec une largeur définie assez large, et vérifier que l'affichage reste correct dans les notifications
