### PR TITLE
[BO - Export] Revoir l'export des signalements

### DIFF
--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -3,9 +3,10 @@
 namespace App\Controller\Back;
 
 use App\Entity\User;
-use App\Manager\SignalementManager;
+use App\Service\Signalement\Export\SignalementExportLoader;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Annotation\Route;
@@ -16,22 +17,15 @@ class ExportSignalementController extends AbstractController
     #[Route('/export/signalement', name: 'back_signalement_list_export')]
     public function exportCsv(
         Request $request,
-        SignalementManager $signalementManager,
-    ) {
+        SignalementExportLoader $signalementExportLoader
+    ): RedirectResponse|StreamedResponse {
         /** @var User $user */
         $user = $this->getUser();
         if ($this->isCsrfTokenValid('export_token_'.$user->getId(), $request->get('_token'))) {
             $filters = $request->getSession()->get('filters');
             $response = new StreamedResponse();
-            $response->setCallback(function () use ($signalementManager, $filters, $user) {
-                $handle = fopen('php://output', 'w');
-                foreach ($signalementManager->findSignalementAffectationIterable($user, $filters) as $key => $signalementAffectationItem) {
-                    if (0 === $key) {
-                        fputcsv($handle, array_keys(get_object_vars($signalementAffectationItem)), ';');
-                    }
-                    fputcsv($handle, get_object_vars($signalementAffectationItem), ';');
-                }
-                fclose($handle);
+            $response->setCallback(function () use ($signalementExportLoader, $filters, $user) {
+                $signalementExportLoader->load($user, $filters);
             });
 
             $disposition = HeaderUtils::makeDisposition(
@@ -43,6 +37,7 @@ class ExportSignalementController extends AbstractController
 
             return $response->send();
         }
+        $this->addFlash('error', 'Le jeton CSRF n\'est pas valide. Veuillez réessayer.');
 
         return $this->redirectToRoute('back_index');
     }

--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -37,7 +37,7 @@ class ExportSignalementController extends AbstractController
 
             return $response->send();
         }
-        $this->addFlash('error', 'Le jeton CSRF n\'est pas valide. Veuillez réessayer.');
+        $this->addFlash('error', 'Problème d\'identification de votre demande. Merci de réessayer.');
 
         return $this->redirectToRoute('back_index');
     }

--- a/src/Dto/SignalementExport.php
+++ b/src/Dto/SignalementExport.php
@@ -45,7 +45,6 @@ class SignalementExport
         public ?string $nomDeclarant = null,
         public ?string $structureDeclarant = null,
         public ?string $lienDeclarantOccupant = null,
-        public ?string $isSituationHandicap = null,
         public ?string $scoreCreation = null,
         public ?string $dateVisite = null,
         public ?string $isOccupantPresentVisite = null,

--- a/src/Entity/Enum/AffectationStatus.php
+++ b/src/Entity/Enum/AffectationStatus.php
@@ -17,4 +17,19 @@ enum AffectationStatus: int
             self::STATUS_CLOSED, self::STATUS_REFUSED => SignalementStatus::CLOSED->value,
         };
     }
+
+    public function label(): string
+    {
+        return self::getLabel($this);
+    }
+
+    public static function getLabel(self $value): string
+    {
+        return match ($value) {
+            self::STATUS_WAIT => 'nouveau',
+            self::STATUS_ACCEPTED => 'en cours',
+            self::STATUS_CLOSED => 'fermé',
+            self::STATUS_REFUSED => 'refusé',
+        };
+    }
 }

--- a/src/Entity/Enum/SignalementStatus.php
+++ b/src/Entity/Enum/SignalementStatus.php
@@ -15,8 +15,23 @@ enum SignalementStatus: int
     {
         return match ($this) {
             self::NEED_VALIDATION => AffectationStatus::STATUS_WAIT->value,
-            self::ACTIVE => AffectationStatus::STATUS_ACCEPTED->value,
+            self::ACTIVE, self::NEED_PARTNER_RESPONSE => AffectationStatus::STATUS_ACCEPTED->value,
             self::CLOSED, self::REFUSED => AffectationStatus::STATUS_CLOSED->value,
+        };
+    }
+
+    public function label(): string
+    {
+        return self::getLabel($this);
+    }
+
+    public static function getLabel(self $value): string
+    {
+        return match ($value) {
+            self::NEED_VALIDATION => 'nouveau',
+            self::ACTIVE, self::NEED_PARTNER_RESPONSE => 'en cours',
+            self::CLOSED => 'fermé',
+            self::REFUSED => 'refusé',
         };
     }
 }

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -17,10 +17,21 @@ class SignalementExportFactory
 
     public function createInstanceFrom(User $user, array $data): SignalementExport
     {
-        $createdAt = $data['createdAt'] instanceof \DateTimeImmutable ? $data['createdAt']->format(self::DATE_FORMAT) : null;
-        $modifiedAt = $data['modifiedAt'] instanceof \DateTimeImmutable ? $data['modifiedAt']->format(self::DATE_FORMAT) : null;
-        $closedAt = $data['closedAt'] instanceof \DateTimeImmutable ? $data['closedAt']->format(self::DATE_FORMAT) : null;
-        $dateVisite = $data['dateVisite'] instanceof \DateTimeImmutable ? $data['dateVisite']->format(self::DATE_FORMAT) : null;
+        $createdAt = $data['createdAt'] instanceof \DateTimeImmutable
+            ? $data['createdAt']->format(self::DATE_FORMAT)
+            : null;
+
+        $modifiedAt = $data['modifiedAt'] instanceof \DateTimeImmutable
+            ? $data['modifiedAt']->format(self::DATE_FORMAT)
+            : null;
+
+        $closedAt = $data['closedAt'] instanceof \DateTimeImmutable
+            ? $data['closedAt']->format(self::DATE_FORMAT)
+            : null;
+
+        $dateVisite = $data['dateVisite'] instanceof \DateTimeImmutable
+            ? $data['dateVisite']->format(self::DATE_FORMAT)
+            : null;
 
         $motifCloture = $data['motifCloture'] instanceof MotifCloture ? $data['motifCloture']->label() : null;
         $status = SignalementAffectationHelper::getStatusLabelFrom($user, $data);

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -13,13 +13,14 @@ class SignalementExportFactory
     public const NON = 'Non';
     public const NON_RENSEIGNE = 'Non renseigné';
     public const ALLOCATAIRE = ['CAF', 'MSA', 'Oui', 1];
+    public const DATE_FORMAT = 'd/m/Y';
 
     public function createInstanceFrom(User $user, array $data): SignalementExport
     {
-        $createdAt = $data['createdAt'] instanceof \DateTimeImmutable ? $data['createdAt']->format('d/m/y') : null;
-        $modifiedAt = $data['modifiedAt'] instanceof \DateTimeImmutable ? $data['modifiedAt']->format('d/m/y') : null;
-        $closedAt = $data['closedAt'] instanceof \DateTimeImmutable ? $data['closedAt']->format('d/m/y') : null;
-        $dateVisite = $data['dateVisite'] instanceof \DateTimeImmutable ? $data['dateVisite']->format('d/m/y') : null;
+        $createdAt = $data['createdAt'] instanceof \DateTimeImmutable ? $data['createdAt']->format(self::DATE_FORMAT) : null;
+        $modifiedAt = $data['modifiedAt'] instanceof \DateTimeImmutable ? $data['modifiedAt']->format(self::DATE_FORMAT) : null;
+        $closedAt = $data['closedAt'] instanceof \DateTimeImmutable ? $data['closedAt']->format(self::DATE_FORMAT) : null;
+        $dateVisite = $data['dateVisite'] instanceof \DateTimeImmutable ? $data['dateVisite']->format(self::DATE_FORMAT) : null;
 
         $motifCloture = $data['motifCloture'] instanceof MotifCloture ? $data['motifCloture']->label() : null;
         $status = SignalementAffectationHelper::getStatusLabelFrom($user, $data);
@@ -47,18 +48,18 @@ class SignalementExportFactory
             etiquettes: $data['etiquettes'] ?? null,
             photos: empty($data['photos']) ? self::NON : self::OUI,
             documents: empty($data['documents']) ? self::NON : self::OUI,
-            isProprioAverti: null === $data['isProprioAverti'] ? self::NON_RENSEIGNE : (1 == $data['isProprioAverti'] ? self::OUI : self::NON),
+            isProprioAverti: $this->mapData($data, 'isProprioAverti'),
             nbAdultes: $data['nbAdultes'],
             nbEnfantsM6: $data['nbEnfantsM6'] ?? self::NON_RENSEIGNE,
             nbEnfantsP6: $data['nbEnfantsP6'] ?? self::NON_RENSEIGNE,
-            isAllocataire: null === $data['isAllocataire'] ? self::NON_RENSEIGNE : (\in_array($data['isAllocataire'], self::ALLOCATAIRE) ? self::OUI : self::NON),
+            isAllocataire: $this->mapData($data, 'isAllocataire'),
             numAllocataire: $data['numAllocataire'] ?? self::NON_RENSEIGNE,
             natureLogement: $data['natureLogement'] ?? self::NON_RENSEIGNE,
             superficie: $data['superficie'] ?? self::NON_RENSEIGNE,
             nomProprio: $data['nomProprio'],
-            isLogementSocial: null === $data['isLogementSocial'] ? self::NON_RENSEIGNE : (1 == $data['isLogementSocial'] ? self::OUI : self::NON),
-            isPreavisDepart: null === $data['isPreavisDepart'] ? self::NON_RENSEIGNE : (1 == $data['isPreavisDepart'] ? self::OUI : self::NON),
-            isRelogement: null === $data['isRelogement'] ? self::NON_RENSEIGNE : (1 == $data['isRelogement'] ? self::OUI : self::NON),
+            isLogementSocial: $this->mapData($data, 'isLogementSocial'),
+            isPreavisDepart: $this->mapData($data, 'isPreavisDepart'),
+            isRelogement: $this->mapData($data, 'isRelogement'),
             isNotOccupant: 1 == $data['isNotOccupant'] ? self::OUI : self::NON,
             nomDeclarant: $data['nomDeclarant'] ?? '-',
             structureDeclarant: $data['structureDeclarant'] ?? '-',
@@ -71,5 +72,29 @@ class SignalementExportFactory
             motifCloture: $motifCloture,
             scoreCloture: $data['scoreCloture']
         );
+    }
+
+    private function mapData(array $data, string $keyColumn): ?string
+    {
+        $value = null;
+        switch ($keyColumn) {
+            case 'isProprioAverti':
+            case 'isLogementSocial':
+            case 'isPreavisDepart':
+            case 'isRelogement':
+                $value = null === $data[$keyColumn]
+                    ? self::NON_RENSEIGNE
+                    : (1 == $data[$keyColumn] ? self::OUI : self::NON);
+                break;
+            case 'isAllocataire':
+                $value = null === $data[$keyColumn]
+                    ? self::NON_RENSEIGNE
+                    : (\in_array($data[$keyColumn], self::ALLOCATAIRE) ? self::OUI : self::NON);
+                break;
+            default:
+                break;
+        }
+
+        return $value;
     }
 }

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -4,25 +4,30 @@ namespace App\Factory;
 
 use App\Dto\SignalementExport;
 use App\Entity\Enum\MotifCloture;
+use App\Entity\User;
+use App\Service\Signalement\SignalementAffectationHelper;
 
 class SignalementExportFactory
 {
     public const OUI = 'Oui';
     public const NON = 'Non';
     public const NON_RENSEIGNE = 'Non renseigné';
+    public const ALLOCATAIRE = ['CAF', 'MSA', 'Oui', 1];
 
-    public function createInstanceFrom(array $data): SignalementExport
+    public function createInstanceFrom(User $user, array $data): SignalementExport
     {
         $createdAt = $data['createdAt'] instanceof \DateTimeImmutable ? $data['createdAt']->format('d/m/y') : null;
         $modifiedAt = $data['modifiedAt'] instanceof \DateTimeImmutable ? $data['modifiedAt']->format('d/m/y') : null;
         $closedAt = $data['closedAt'] instanceof \DateTimeImmutable ? $data['closedAt']->format('d/m/y') : null;
         $dateVisite = $data['dateVisite'] instanceof \DateTimeImmutable ? $data['dateVisite']->format('d/m/y') : null;
-        $motifCloture = $data['motifCloture'] instanceof MotifCloture ? $data['motifCloture']->value : null;
+
+        $motifCloture = $data['motifCloture'] instanceof MotifCloture ? $data['motifCloture']->label() : null;
+        $status = SignalementAffectationHelper::getStatusLabelFrom($user, $data);
 
         return new SignalementExport(
             reference: $data['reference'],
             createdAt: $createdAt,
-            statut: $data['statut'],
+            statut: $status,
             description: $data['details'],
             nomOccupant: $data['nomOccupant'],
             prenomOccupant: $data['prenomOccupant'],
@@ -42,21 +47,21 @@ class SignalementExportFactory
             etiquettes: $data['etiquettes'] ?? null,
             photos: empty($data['photos']) ? self::NON : self::OUI,
             documents: empty($data['documents']) ? self::NON : self::OUI,
-            isProprioAverti: 1 == $data['isProprioAverti'] ? self::OUI : self::NON,
+            isProprioAverti: null === $data['isProprioAverti'] ? self::NON_RENSEIGNE : (1 == $data['isProprioAverti'] ? self::OUI : self::NON),
             nbAdultes: $data['nbAdultes'],
             nbEnfantsM6: $data['nbEnfantsM6'] ?? self::NON_RENSEIGNE,
             nbEnfantsP6: $data['nbEnfantsP6'] ?? self::NON_RENSEIGNE,
-            isAllocataire: 1 == $data['isAllocataire'] ? self::OUI : self::NON,
+            isAllocataire: null === $data['isAllocataire'] ? self::NON_RENSEIGNE : (\in_array($data['isAllocataire'], self::ALLOCATAIRE) ? self::OUI : self::NON),
             numAllocataire: $data['numAllocataire'] ?? self::NON_RENSEIGNE,
             natureLogement: $data['natureLogement'] ?? self::NON_RENSEIGNE,
             superficie: $data['superficie'] ?? self::NON_RENSEIGNE,
             nomProprio: $data['nomProprio'],
-            isLogementSocial: 1 == $data['isLogementSocial'] ? self::OUI : self::NON,
-            isPreavisDepart: 1 == $data['isPreavisDepart'] ? self::OUI : self::NON,
-            isRelogement: 1 == $data['isRelogement'] ? self::OUI : self::NON,
+            isLogementSocial: null === $data['isLogementSocial'] ? self::NON_RENSEIGNE : (1 == $data['isLogementSocial'] ? self::OUI : self::NON),
+            isPreavisDepart: null === $data['isPreavisDepart'] ? self::NON_RENSEIGNE : (1 == $data['isPreavisDepart'] ? self::OUI : self::NON),
+            isRelogement: null === $data['isRelogement'] ? self::NON_RENSEIGNE : (1 == $data['isRelogement'] ? self::OUI : self::NON),
             isNotOccupant: 1 == $data['isNotOccupant'] ? self::OUI : self::NON,
-            nomDeclarant: $data['nomDeclarant'],
-            structureDeclarant: $data['structureDeclarant'],
+            nomDeclarant: $data['nomDeclarant'] ?? '-',
+            structureDeclarant: $data['structureDeclarant'] ?? '-',
             lienDeclarantOccupant: $data['lienDeclarantOccupant'],
             scoreCreation: $data['scoreCreation'],
             dateVisite: $dateVisite,

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -305,8 +305,10 @@ class SignalementManager extends AbstractManager
     public function findSignalementAffectationIterable(User|UserInterface|null $user, ?array $options = null): \Generator
     {
         $options['authorized_codes_insee'] = $this->parameterBag->get('authorized_codes_insee');
+
         foreach ($this->getRepository()->findSignalementAffectationIterable($user, $options) as $row) {
             yield $this->signalementExportFactory->createInstanceFrom(
+                $user,
                 $row
             );
         }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -461,9 +461,9 @@ class SignalementRepository extends ServiceEntityRepository
             s.closedAt,
             s.motifCloture,
             s.scoreCloture,
-            GROUP_CONCAT(situations.label SEPARATOR :group_concat_separator_1) as familleSituation,
-            GROUP_CONCAT(criteres.label SEPARATOR :group_concat_separator_1) as desordres,
-            GROUP_CONCAT(tags.label SEPARATOR :group_concat_separator_1) as etiquettes
+            GROUP_CONCAT(DISTINCT situations.label SEPARATOR :group_concat_separator_1) as familleSituation,
+            GROUP_CONCAT(DISTINCT criteres.label SEPARATOR :group_concat_separator_1) as desordres,
+            GROUP_CONCAT(DISTINCT tags.label SEPARATOR :group_concat_separator_1) as etiquettes
             '
         )->leftJoin('s.situations', 'situations')
             ->leftJoin('s.criteres', 'criteres')

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -88,17 +88,6 @@ class SignalementRepository extends ServiceEntityRepository
             ->getQuery()->getArrayResult();
     }
 
-    public function findAllWithAffectations($year): array
-    {
-        return $this->createQueryBuilder('s')
-            ->where('s.statut != 7')
-            ->andWhere('YEAR(s.createdAt) = '.$year)
-            ->leftJoin('s.affectations', 'affectations')
-            ->addSelect('affectations', 's')
-            ->getQuery()
-            ->getResult();
-    }
-
     public function countAll(Territory|null $territory, bool $removeImported = false, bool $removeArchived = false): int
     {
         $qb = $this->createQueryBuilder('s');

--- a/src/Service/Signalement/Export/SignalementExportHeader.php
+++ b/src/Service/Signalement/Export/SignalementExportHeader.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Service\Signalement\Export;
+
+class SignalementExportHeader
+{
+    public const SEPARATOR = ';';
+
+    public static function getHeaders(): array
+    {
+        return [
+            'Référence',
+            'Déposé le',
+            'Statut',
+            'Description',
+            'Nom',
+            'Prénom',
+            'Téléphone',
+            'Téléphone',
+            'Email',
+            'Adresse',
+            'Code postal',
+            'Commmune',
+            'Code INSEE',
+            'Étage',
+            'Escalier',
+            'Appartement',
+            'Complément',
+            'Situations',
+            'Désordres',
+            'Étiquettes',
+            'Photos',
+            'Documents',
+            'Propriétaire averti',
+            'Nb adultes',
+            'Nb enfants -6 ans',
+            'Nb enfants +6 ans',
+            'Allocataire',
+            'Numéro allocataire',
+            'Nature du logement',
+            'Superficie',
+            'Nom bailleur',
+            'Logement social',
+            'Préavis de départ',
+            'Demande de relogement',
+            'Déclarant tiers',
+            'Nom tiers',
+            'Structure tiers',
+            'Lien tiers occupant',
+            'Criticité au dépôt',
+            'Visité le',
+            'Occupant présent visite',
+            'Dernière MAJ le',
+            'Clôturé le',
+            'Motif de clôture',
+            'Criticité à la clôture',
+        ];
+    }
+}

--- a/src/Service/Signalement/Export/SignalementExportLoader.php
+++ b/src/Service/Signalement/Export/SignalementExportLoader.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Service\Signalement\Export;
+
+use App\Entity\User;
+use App\Manager\SignalementManager;
+
+class SignalementExportLoader
+{
+    public function __construct(private readonly SignalementManager $signalementManager)
+    {
+    }
+
+    public function load(User $user, array $filters): void
+    {
+        $handle = fopen('php://output', 'w');
+        fputcsv($handle, SignalementExportHeader::getHeaders(), SignalementExportHeader::SEPARATOR);
+        foreach ($this->signalementManager->findSignalementAffectationIterable($user, $filters) as $signalementExportItem) {
+            fputcsv($handle, get_object_vars($signalementExportItem), SignalementExportHeader::SEPARATOR);
+        }
+        fclose($handle);
+    }
+}

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Service\Signalement;
+
+use App\Dto\SignalementAffectationListView;
+use App\Entity\Enum\AffectationStatus;
+use App\Entity\Enum\SignalementStatus;
+use App\Entity\User;
+
+class SignalementAffectationHelper
+{
+    public static function getStatusLabelFrom(User $user, array $data): string
+    {
+        $affectations = self::parseAffectations($data['rawAffectations']);
+        if (empty($affectations) || ($user->isSuperAdmin() || $user->isTerritoryAdmin())) {
+            return SignalementStatus::tryFrom($data['statut'])->label();
+        }
+
+        $statusAffectation = $affectations[$user->getPartner()->getNom()]['statut'];
+
+        return AffectationStatus::tryFrom($statusAffectation)?->label();
+    }
+
+    public static function getStatusAndAffectationFrom(User $user, array $data): array
+    {
+        $affectations = self::parseAffectations($data['rawAffectations']);
+        if (empty($affectations) || ($user->isSuperAdmin() || $user->isTerritoryAdmin())) {
+            return [$data['statut'], $affectations];
+        }
+
+        $statusAffectation = $affectations[$user->getPartner()->getNom()]['statut'];
+
+        return [AffectationStatus::tryFrom($statusAffectation)?->mapSignalementStatus(), $affectations];
+    }
+
+    public static function getQualificationFrom(array $data): ?array
+    {
+        if (null !== $data['qualifications']) {
+            return explode(SignalementAffectationListView::SEPARATOR_GROUP_CONCAT, $data['qualifications']);
+        }
+
+        return null;
+    }
+
+    public static function parseAffectations(?string $rawAffectations): ?array
+    {
+        if (empty($rawAffectations)) {
+            return [];
+        }
+
+        $affectations = [];
+        $affectationsList = explode(SignalementAffectationListView::SEPARATOR_GROUP_CONCAT, $rawAffectations);
+        foreach ($affectationsList as $affectationItem) {
+            list($partner, $status) = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $affectationItem);
+            $statusAffectation = AffectationStatus::from($status)->value;
+            $affectations[$partner] = [
+                'partner' => $partner,
+                'statut' => $statusAffectation,
+            ];
+        }
+
+        return $affectations;
+    }
+}

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -31,8 +31,10 @@ class SignalementExportFactoryTest extends TestCase
             'prenomOccupant' => $faker->firstName(),
             'adresseOccupant' => $faker->streetAddress(),
             'villeOccupant' => $faker->city(),
-            'rawAffectations' => 'DDETS-PS-DL PE - Mission Logement indigne||0;M.A.M.P. - CT1 / EAH Marseille||0;MARSEILLE||1',
-            'affectationPartnerName' => 'DDETS-PS-DL PE - Mission Logement indigne;M.A.M.P. - CT1 / EAH Marseille;MARSEILLE',
+            'rawAffectations' =>
+                'DDETS-PS-DL PE - Mission Logement indigne||0;M.A.M.P. - CT1 / EAH Marseille||0;MARSEILLE||1',
+            'affectationPartnerName' =>
+                'DDETS-PS-DL PE - Mission Logement indigne;M.A.M.P. - CT1 / EAH Marseille;MARSEILLE',
             'affectationStatus' => '0;1',
             'affectationPartnerId' => '636;645;708',
             'details' => $faker->text(),
@@ -69,7 +71,9 @@ class SignalementExportFactoryTest extends TestCase
             'motifCloture' => MotifCloture::INSALUBRITE,
             'scoreCloture' => null,
             'familleSituation' => "l'état et propreté du logement|l'état et propreté du logement|",
-            'desordres' => "Les sols sont humides.|Les installations électriques ne sont pas en bon état.|Les murs ont des fissures.|De l'eau s’infiltre dans mon logement.|Il y a des trace ",
+            'desordres' =>
+                "Les sols sont humides.|Les installations électriques ne sont pas en bon état.|
+                Les murs ont des fissures.|De l'eau s’infiltre dans mon logement.|Il y a des trace ",
             'etiquettes' => null,
         ];
 
@@ -80,10 +84,11 @@ class SignalementExportFactoryTest extends TestCase
         $this->assertEquals('en cours', $signalementExportFactory->statut);
         $this->assertEquals(MotifCloture::INSALUBRITE->label(), $signalementExportFactory->motifCloture);
 
-        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->createdAt);
-        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->modifiedAt);
-        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->closedAt);
-        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->dateVisite);
+        $dateFormatted =(new \DateTimeImmutable())->format(SignalementExportFactory::DATE_FORMAT);
+        $this->assertEquals($dateFormatted, $signalementExportFactory->createdAt);
+        $this->assertEquals($dateFormatted, $signalementExportFactory->modifiedAt);
+        $this->assertEquals($dateFormatted, $signalementExportFactory->closedAt);
+        $this->assertEquals($dateFormatted, $signalementExportFactory->dateVisite);
 
         $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->telephoneOccupantBis);
         $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->etageOccupant);

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -31,10 +31,8 @@ class SignalementExportFactoryTest extends TestCase
             'prenomOccupant' => $faker->firstName(),
             'adresseOccupant' => $faker->streetAddress(),
             'villeOccupant' => $faker->city(),
-            'rawAffectations' =>
-                'DDETS-PS-DL PE - Mission Logement indigne||0;M.A.M.P. - CT1 / EAH Marseille||0;MARSEILLE||1',
-            'affectationPartnerName' =>
-                'DDETS-PS-DL PE - Mission Logement indigne;M.A.M.P. - CT1 / EAH Marseille;MARSEILLE',
+            'rawAffectations' => 'DDETS-PS-DL PE - Mission Logement indigne||0;M.A.M.P. - CT1 / EAH Marseille||0;MARSEILLE||1',
+            'affectationPartnerName' => 'DDETS-PS-DL PE - Mission Logement indigne;M.A.M.P. - CT1 / EAH Marseille;MARSEILLE',
             'affectationStatus' => '0;1',
             'affectationPartnerId' => '636;645;708',
             'details' => $faker->text(),
@@ -71,8 +69,7 @@ class SignalementExportFactoryTest extends TestCase
             'motifCloture' => MotifCloture::INSALUBRITE,
             'scoreCloture' => null,
             'familleSituation' => "l'état et propreté du logement|l'état et propreté du logement|",
-            'desordres' =>
-                "Les sols sont humides.|Les installations électriques ne sont pas en bon état.|
+            'desordres' => "Les sols sont humides.|Les installations électriques ne sont pas en bon état.|
                 Les murs ont des fissures.|De l'eau s’infiltre dans mon logement.|Il y a des trace ",
             'etiquettes' => null,
         ];
@@ -84,7 +81,7 @@ class SignalementExportFactoryTest extends TestCase
         $this->assertEquals('en cours', $signalementExportFactory->statut);
         $this->assertEquals(MotifCloture::INSALUBRITE->label(), $signalementExportFactory->motifCloture);
 
-        $dateFormatted =(new \DateTimeImmutable())->format(SignalementExportFactory::DATE_FORMAT);
+        $dateFormatted = (new \DateTimeImmutable())->format(SignalementExportFactory::DATE_FORMAT);
         $this->assertEquals($dateFormatted, $signalementExportFactory->createdAt);
         $this->assertEquals($dateFormatted, $signalementExportFactory->modifiedAt);
         $this->assertEquals($dateFormatted, $signalementExportFactory->closedAt);

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Tests\Unit\Factory;
+
+use App\Dto\SignalementExport;
+use App\Entity\Enum\MotifCloture;
+use App\Entity\User;
+use App\Factory\SignalementExportFactory;
+use App\Tests\UserHelper;
+use Faker\Factory;
+use PHPUnit\Framework\TestCase;
+
+class SignalementExportFactoryTest extends TestCase
+{
+    use UserHelper;
+
+    public function testCreateSignalementExportFactory(): void
+    {
+        $faker = Factory::create();
+
+        $data = [
+            'id' => 21081,
+            'uuid' => '661c23e9-8abb-4840-ab9d-4880f475ccfb',
+            'reference' => '2023-542',
+            'createdAt' => new \DateTimeImmutable(),
+            'statut' => 2,
+            'scoreCreation' => 100.0,
+            'newScoreCreation' => 0.0,
+            'isNotOccupant' => false,
+            'nomOccupant' => $faker->lastName(),
+            'prenomOccupant' => $faker->firstName(),
+            'adresseOccupant' => $faker->streetAddress(),
+            'villeOccupant' => $faker->city(),
+            'rawAffectations' => 'DDETS-PS-DL PE - Mission Logement indigne||0;M.A.M.P. - CT1 / EAH Marseille||0;MARSEILLE||1',
+            'affectationPartnerName' => 'DDETS-PS-DL PE - Mission Logement indigne;M.A.M.P. - CT1 / EAH Marseille;MARSEILLE',
+            'affectationStatus' => '0;1',
+            'affectationPartnerId' => '636;645;708',
+            'details' => $faker->text(),
+            'telOccupant' => $faker->phoneNumber(),
+            'telOccupantBis' => null,
+            'mailOccupant' => $faker->email(),
+            'cpOccupant' => $faker->postcode(),
+            'inseeOccupant' => $faker->postcode(),
+            'etageOccupant' => null,
+            'escalierOccupant' => null,
+            'numAppartOccupant' => null,
+            'adresseAutreOccupant' => null,
+            'photos' => [],
+            'documents' => [],
+            'isProprioAverti' => true,
+            'nbAdultes' => '2',
+            'nbEnfantsM6' => null,
+            'nbEnfantsP6' => null,
+            'isAllocataire' => 'CAF',
+            'numAllocataire' => null,
+            'natureLogement' => null,
+            'superficie' => null,
+            'nomProprio' => $faker->company(),
+            'isLogementSocial' => null,
+            'isPreavisDepart' => false,
+            'isRelogement' => null,
+            'nomDeclarant' => null,
+            'structureDeclarant' => null,
+            'lienDeclarantOccupant' => null,
+            'dateVisite' => new \DateTimeImmutable(),
+            'isOccupantPresentVisite' => false,
+            'modifiedAt' => new \DateTimeImmutable(),
+            'closedAt' => new \DateTimeImmutable(),
+            'motifCloture' => MotifCloture::INSALUBRITE,
+            'scoreCloture' => null,
+            'familleSituation' => "l'état et propreté du logement|l'état et propreté du logement|",
+            'desordres' => "Les sols sont humides.|Les installations électriques ne sont pas en bon état.|Les murs ont des fissures.|De l'eau s’infiltre dans mon logement.|Il y a des trace ",
+            'etiquettes' => null,
+        ];
+
+        $user = $this->getUserFromRole(User::ROLE_ADMIN);
+
+        $signalementExportFactory = (new SignalementExportFactory())->createInstanceFrom($user, $data);
+        $this->assertInstanceOf(SignalementExport::class, $signalementExportFactory);
+        $this->assertEquals('en cours', $signalementExportFactory->statut);
+        $this->assertEquals(MotifCloture::INSALUBRITE->label(), $signalementExportFactory->motifCloture);
+
+        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->createdAt);
+        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->modifiedAt);
+        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->closedAt);
+        $this->assertEquals((new \DateTimeImmutable())->format('d/m/y'), $signalementExportFactory->dateVisite);
+
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->telephoneOccupantBis);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->etageOccupant);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->escalierOccupant);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->numAppartOccupant);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->adresseAutreOccupant);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->nbEnfantsM6);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->nbEnfantsP6);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->numAllocataire);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->natureLogement);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->superficie);
+
+        $this->assertEquals(SignalementExportFactory::NON, $signalementExportFactory->photos);
+        $this->assertEquals(SignalementExportFactory::NON, $signalementExportFactory->documents);
+        $this->assertEquals(SignalementExportFactory::OUI, $signalementExportFactory->isProprioAverti);
+        $this->assertEquals(SignalementExportFactory::OUI, $signalementExportFactory->isProprioAverti);
+        $this->assertEquals(SignalementExportFactory::OUI, $signalementExportFactory->isAllocataire);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->isLogementSocial);
+        $this->assertEquals(SignalementExportFactory::NON, $signalementExportFactory->isPreavisDepart);
+        $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->isRelogement);
+        $this->assertEquals(SignalementExportFactory::NON, $signalementExportFactory->isNotOccupant);
+        $this->assertEquals(SignalementExportFactory::NON, $signalementExportFactory->isOccupantPresentVisite);
+    }
+}

--- a/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
+++ b/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests\Unit\Service\Signalement\Export;
+
+use App\Dto\SignalementExport;
+use App\Entity\User;
+use App\Manager\SignalementManager;
+use App\Service\Signalement\Export\SignalementExportHeader;
+use App\Service\Signalement\Export\SignalementExportLoader;
+use App\Tests\UserHelper;
+use PHPUnit\Framework\TestCase;
+
+class SignalementExportLoaderTest extends TestCase
+{
+    use UserHelper;
+
+    public function testLoad()
+    {
+        $signalementManager = $this->createMock(SignalementManager::class);
+        $filters = ['foo' => 'bar'];
+        $user = $this->getUserFromRole(User::ROLE_ADMIN);
+
+        $signalementExports = [
+            new SignalementExport('2023-01', '31-03-2023', 'nouveau'),
+            new SignalementExport('2023-02', '31-03-2023', 'nouveau'),
+        ];
+
+        $signalementManager->expects($this->once())
+            ->method('findSignalementAffectationIterable')
+            ->with($user, $filters)
+            ->willReturn($this->getSignalementExportGenerator($signalementExports));
+
+        $expectedOutput = $this->getHeaderAsString()."2023-01;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n2023-02;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n";
+
+        $loader = new SignalementExportLoader($signalementManager);
+        ob_start();
+        $loader->load($user, $filters);
+        $output = ob_get_clean();
+        $this->assertEquals($expectedOutput, $output);
+    }
+
+    private function getSignalementExportGenerator(array $signalements): \Generator
+    {
+        foreach ($signalements as $signalement) {
+            yield $signalement;
+        }
+    }
+
+    private function getHeaderAsString(): string
+    {
+        $headers = SignalementExportHeader::getHeaders();
+        $headers = array_map(function ($header) {
+            if (str_contains($header, ' ')) {
+                $header = str_replace('"', '""', $header);
+                $header = '"'.$header.'"';
+            }
+
+            return $header;
+        }, $headers);
+
+        return implode(SignalementExportHeader::SEPARATOR, $headers)."\n";
+    }
+}

--- a/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
+++ b/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
@@ -17,7 +17,7 @@ class SignalementExportLoaderTest extends TestCase
     public function testLoad()
     {
         $signalementManager = $this->createMock(SignalementManager::class);
-        $filters = ['foo' => 'bar'];
+        $filters = ['territories' => ['1']];
         $user = $this->getUserFromRole(User::ROLE_ADMIN);
 
         $signalementExports = [
@@ -30,7 +30,7 @@ class SignalementExportLoaderTest extends TestCase
             ->with($user, $filters)
             ->willReturn($this->getSignalementExportGenerator($signalementExports));
 
-        $expectedOutput = $this->getHeaderAsString()."2023-01;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n2023-02;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n";
+        $expectedOutput = $this->getHeaderAsString() . "2023-01;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n2023-02;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n";
 
         $loader = new SignalementExportLoader($signalementManager);
         ob_start();
@@ -52,12 +52,12 @@ class SignalementExportLoaderTest extends TestCase
         $headers = array_map(function ($header) {
             if (str_contains($header, ' ')) {
                 $header = str_replace('"', '""', $header);
-                $header = '"'.$header.'"';
+                $header = '"' . $header . '"';
             }
 
             return $header;
         }, $headers);
 
-        return implode(SignalementExportHeader::SEPARATOR, $headers)."\n";
+        return implode(SignalementExportHeader::SEPARATOR, $headers) . "\n";
     }
 }

--- a/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
+++ b/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
@@ -30,7 +30,7 @@ class SignalementExportLoaderTest extends TestCase
             ->with($user, $filters)
             ->willReturn($this->getSignalementExportGenerator($signalementExports));
 
-        $expectedOutput = $this->getHeaderAsString() . "2023-01;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n2023-02;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n";
+        $expectedOutput = $this->getHeaderAsString()."2023-01;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n2023-02;31-03-2023;nouveau;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n";
 
         $loader = new SignalementExportLoader($signalementManager);
         ob_start();
@@ -52,12 +52,12 @@ class SignalementExportLoaderTest extends TestCase
         $headers = array_map(function ($header) {
             if (str_contains($header, ' ')) {
                 $header = str_replace('"', '""', $header);
-                $header = '"' . $header . '"';
+                $header = '"'.$header.'"';
             }
 
             return $header;
         }, $headers);
 
-        return implode(SignalementExportHeader::SEPARATOR, $headers) . "\n";
+        return implode(SignalementExportHeader::SEPARATOR, $headers)."\n";
     }
 }

--- a/tests/UserHelper.php
+++ b/tests/UserHelper.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Partner;
+use App\Entity\Territory;
+use App\Entity\User;
+
+trait UserHelper
+{
+    public function getUserFromRole(string $role): User
+    {
+        $territory = (new Territory())
+            ->setName('Ain')
+            ->setZip('01')
+            ->setBbox([])
+            ->setIsActive(true);
+
+        $partner = (new Partner())
+            ->setNom('Partner')
+            ->setTerritory($territory);
+
+        return (new User())
+            ->setNom('Doe')
+            ->setPrenom('John')
+            ->setRoles([$role])
+            ->setPartner($partner)->setTerritory($territory);
+    }
+}


### PR DESCRIPTION
## Ticket

#666 

## Description
Refactorisation de l'export des signalement avec mises à jour des colonnes et normalisation des valeurs des données

## Changements apportés
* Mise à jour des noms de colonnes
* MIse à jour des status, motif de cloture, date au bon format
* Création d'un service `SignalementExportLoader`

## Tests
- [ ]  Se connecter en tant qu'utilisateur et appliquer des filtres et cliquer sur `Exporter les résultats`
- [ ] Se connecter en tant qu'utilisateur  et cliquer sur `Exporter les résultats`
- [ ] Vérifier que les colonnes ont bien été renommé conformément au ticket #666 
- [ ] Vérifier que les dates soient au bon format
- [ ] Vérifier que le statut a bien un libellé
- [ ] Vérifier que le motif de clôture a bien été libellé 
