### PR TITLE
[BO - utilisateurs] reprise de données : ajout des territoires aux utilisateurs sans territoires via partenaires

### DIFF
--- a/migrations/Version20230407115407.php
+++ b/migrations/Version20230407115407.php
@@ -11,19 +11,17 @@ final class Version20230407115407 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Affect territoryof partner to all user without territory (except admin and usager)';
+        return 'Affect partner\'s territory to all users without territory (except admin and usager)';
     }
 
     public function up(Schema $schema): void
     {
-        $users = $this->connection->fetchAllAssociative('SELECT id, email, partner_id, roles FROM user WHERE territory_id IS NULL AND roles NOT LIKE \'%"ROLE_USAGER"%\' AND roles NOT LIKE  \'%"ROLE_ADMIN"%\'');
+        $users = $this->connection->fetchAllAssociative('SELECT id, email, partner_id, roles FROM user WHERE territory_id IS NULL AND partner_id IS NOT NULL AND roles NOT LIKE \'%"ROLE_USAGER"%\' AND roles NOT LIKE  \'%"ROLE_ADMIN"%\'');
 
         foreach ($users as $user) {
-            if (null !== $user['partner_id']) {
-                $partner = $this->connection->fetchAssociative('SELECT id, territory_id, nom FROM partner WHERE id = '.$user['partner_id']);
-                if ($partner && $partner['territory_id']) {
-                    $this->addSql('UPDATE user SET territory_id = '.$partner['territory_id'].' WHERE id ='.$user['id']);
-                }
+            $partner = $this->connection->fetchAssociative('SELECT id, territory_id, nom FROM partner WHERE id = '.$user['partner_id']);
+            if ($partner && $partner['territory_id']) {
+                $this->addSql('UPDATE user SET territory_id = '.$partner['territory_id'].' WHERE id ='.$user['id']);
             }
         }
     }

--- a/migrations/Version20230407115407.php
+++ b/migrations/Version20230407115407.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230407115407 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Affect territoryof partner to all user without territory (except admin and usager)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $users = $this->connection->fetchAllAssociative('SELECT id, email, partner_id, roles FROM user WHERE territory_id IS NULL AND roles NOT LIKE \'%"ROLE_USAGER"%\' AND roles NOT LIKE  \'%"ROLE_ADMIN"%\'');
+
+        foreach ($users as $user) {
+            if (null !== $user['partner_id']) {
+                $partner = $this->connection->fetchAssociative('SELECT id, territory_id, nom FROM partner WHERE id = '.$user['partner_id']);
+                if ($partner && $partner['territory_id']) {
+                    $this->addSql('UPDATE user SET territory_id = '.$partner['territory_id'].' WHERE id ='.$user['id']);
+                }
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#993    

## Description
Migration pour ajouter les territoires des partenaires des utilisateurs qui n'ont pas de territoire. Ceci pour permettre de voir si à nouveau des utilisateurs perdent leur territoire quand on aura sorti la nouvelle page partenaire
Aujourd'hui 295 utilisateurs concernés : https://histologe-metabase.osc-fr1.scalingo.io/question/103-user-non-usager-sans-territoire

## Changements apportés
* Ajout d'une migration

## Tests
- [ ] Mettre à jour la base de données, vérifier que l'utilisateur user-974-01@histologe.fr est bien relié à un territoire correspondant à son partenaire
