### PR TITLE
[BO - signalements] corriger les signalements ayant null pour is_imported

### DIFF
--- a/migrations/Version20230411121503.php
+++ b/migrations/Version20230411121503.php
@@ -16,12 +16,10 @@ final class Version20230411121503 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('UPDATE signalement SET is_imported = 0 WHERE is_imported IS NULL');       
-
+        $this->addSql('UPDATE signalement SET is_imported = 0 WHERE is_imported IS NULL');
     }
 
     public function down(Schema $schema): void
     {
-
     }
 }

--- a/migrations/Version20230411121503.php
+++ b/migrations/Version20230411121503.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230411121503 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Define is_imported to false when null';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE signalement SET is_imported = 0 WHERE is_imported IS NULL');       
+
+    }
+
+    public function down(Schema $schema): void
+    {
+
+    }
+}


### PR DESCRIPTION
## Ticket

#1136    

## Description
Création d'une migration attribuant 0 pour is_imported quand celui-ci est null

## Changements apportés
* création d'une migration

## Tests
- [ ] Mettre is_imported à null pour un ou plusieurs signalements, puis jouer la migration. Vérifier que c'est bien défini à 0
