### PR TITLE
[Tâche auto] Commande de demande de feedback usager, pas de demande si aucun suivi partenaire ou usager

### DIFF
--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -26,57 +26,57 @@ suivis:
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
-  is_public: 0
+  is_public: 1
   signalement: "2022-5"
   type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
-  is_public: 0
+  is_public: 1
   signalement: "2022-6"
   type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
-  is_public: 0
+  is_public: 1
   signalement: "2022-7"
   type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
   created_at: "2022-03-08 17:06:33"
-  is_public: 0
+  is_public: 1
   signalement: "2022-8"
   type: 1
 -
   created_by: admin-territoire-13-01@histologe.fr
   description: "Ceci est vieux suivi de partenaire 13-01"
   created_at: "2022-06-08 17:06:33"
-  is_public: 0
+  is_public: 1
   signalement: "2022-8"
   type: 3
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
-  is_public: 0
+  is_public: 1
   signalement: "2022-9"
   type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
-  is_public: 0
+  is_public: 1
   signalement: "2022-10"
   type: 1
 -
   created_by: admin-01@histologe.fr
   description: "Signalement validé"
-  is_public: 0
+  is_public: 1
   signalement: "2022-11"
   type: 1
 -
   created_by: admin-territoire-13-01@histologe.fr
   description: "Le signalement à été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
-  is_public: 0
+  is_public: 1
   signalement: "2022-3"
   type: 1
 -

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -195,8 +195,6 @@ class SuiviRepository extends ServiceEntityRepository
 
         $parameters = [
             'day_period' => $period,
-            'type_suivi_usager' => Suivi::TYPE_USAGER,
-            'type_suivi_partner' => Suivi::TYPE_PARTNER,
             'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
             'status_need_validation' => Signalement::STATUS_NEED_VALIDATION,
             'status_closed' => Signalement::STATUS_CLOSED,
@@ -207,7 +205,7 @@ class SuiviRepository extends ServiceEntityRepository
         $sql = 'SELECT su.signalement_id, MAX(su.created_at) as last_posted_at
         FROM suivi su
         INNER JOIN signalement s on s.id = su.signalement_id
-        WHERE type in (:type_suivi_usager,:type_suivi_partner,:type_suivi_technical)
+        WHERE (su.type = :type_suivi_technical OR su.is_public = 1)
         AND s.statut NOT IN (:status_need_validation, :status_closed, :status_archived, :status_refused)
         AND s.is_imported != 1
         GROUP BY su.signalement_id


### PR DESCRIPTION
## Ticket

#1135    

## Description
Changement du repo pour récupérer tous les signalements n'ayant pas eu de suivi public les 30 derniers jours

## Changements apportés
* Changement d'une fonction du repo
* Mise à jour des fixtures de suivi pour que les suivis "signalements validés" soient bien publics

## Tests
- [ ] Lancer la commande, vérifier qu'un mail a bien été envoyé.
- [ ] Décaler la date du suivi d'un signalement n'ayant eu qu'un seul suivi "signalement validé", vérifier que quand on lance la commande, ce signalement est bien pris en compte
