### PR TITLE
count only affectation with waiting and open status #1035

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,9 @@ create-db: ## Create database
 drop-db: ## Drop database
 	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:database:drop --force --no-interaction"
 
-load-data: ## Load database from dump
+load-data: ## Load database from
+	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:database:drop --force --no-interaction || true"
+	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:database:create --no-interaction"
 	@$(DOCKER_COMP) exec -T histologe_mysql mysql -u $(DATABASE_USER) -phistologe $(DATABASE_NAME) < $(PATH_DUMP_SQL)
 	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:migrations:migrate --no-interaction"
 

--- a/src/Factory/NotificationFactory.php
+++ b/src/Factory/NotificationFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Factory;
+
+use App\Entity\Notification;
+use App\Entity\Suivi;
+use App\Entity\User;
+
+class NotificationFactory
+{
+    public function createInstanceFrom(User $user, Suivi $suivi): Notification
+    {
+        return (new Notification())
+            ->setUser($user)
+            ->setSuivi($suivi)
+            ->setSignalement($suivi->getSignalement())
+            ->setType(Notification::TYPE_SUIVI);
+    }
+}

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Enum\AffectationStatus;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
@@ -75,6 +76,8 @@ class SuiviRepository extends ServiceEntityRepository
         }
         if (null !== $partner) {
             $parameters['partner_id'] = $partner->getId();
+            $parameters['status_wait'] = AffectationStatus::STATUS_WAIT->value;
+            $parameters['status_accepted'] = AffectationStatus::STATUS_ACCEPTED->value;
         }
 
         $sql = 'SELECT COUNT(*) as count_signalement
@@ -109,6 +112,8 @@ class SuiviRepository extends ServiceEntityRepository
 
         if (null != $partner) {
             $parameters['partner_id'] = $partner->getId();
+            $parameters['status_wait'] = AffectationStatus::STATUS_WAIT->value;
+            $parameters['status_accepted'] = AffectationStatus::STATUS_ACCEPTED->value;
         }
 
         $sql = $this->getSignalementsQuery($territory, $partner);
@@ -172,7 +177,7 @@ class SuiviRepository extends ServiceEntityRepository
 
         if (null != $partner) {
             $wherePartner = 'AND a.partner_id = :partner_id';
-            $innerPartnerJoin = 'INNER JOIN affectation a ON a.signalement_id = su.signalement_id';
+            $innerPartnerJoin = 'INNER JOIN affectation a ON a.signalement_id = su.signalement_id AND a.statut IN (:status_wait, :status_accepted)';
         }
 
         return 'SELECT su.signalement_id, MAX(su.created_at) as last_posted_at

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -92,9 +92,6 @@ class WidgetDataKpiBuilder
             );
             $newNDE = isset($countSignalementByStatus[Signalement::STATUS_NEED_VALIDATION]) ? $countSignalementByStatus[Signalement::STATUS_NEED_VALIDATION]['count'] : 0;
             $currentNDE = isset($countSignalementByStatus[Signalement::STATUS_ACTIVE]) ? $countSignalementByStatus[Signalement::STATUS_ACTIVE]['count'] : 0;
-            $this->countSignalement
-                ->setNewNDE($newNDE)
-                ->setCurrentNDE($currentNDE);
         } else {
             $countAffectationByStatus = $this->affectationRepository->countByStatusForUser(
                 $this->user,
@@ -104,11 +101,9 @@ class WidgetDataKpiBuilder
             );
             $newNDE = isset($countAffectationByStatus[Affectation::STATUS_WAIT]) ? $countAffectationByStatus[Affectation::STATUS_WAIT]['count'] : 0;
             $currentNDE = isset($countAffectationByStatus[Affectation::STATUS_ACCEPTED]) ? $countAffectationByStatus[Affectation::STATUS_ACCEPTED]['count'] : 0;
-
-            $this->countSignalement
-                ->setNewNDE($newNDE)
-                ->setCurrentNDE($currentNDE);
         }
+
+        $this->countSignalement->setNewNDE($newNDE)->setCurrentNDE($currentNDE);
 
         return $this;
     }

--- a/tests/Unit/Factory/NotificationFactoryTest.php
+++ b/tests/Unit/Factory/NotificationFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tests\Unit\Factory;
+
+use App\Entity\Notification;
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Entity\User;
+use App\Factory\NotificationFactory;
+use App\Tests\UserHelper;
+use PHPUnit\Framework\TestCase;
+
+class NotificationFactoryTest extends TestCase
+{
+    use UserHelper;
+
+    public function testCreateInstanceNotification(): void
+    {
+        $user = $this->getUserFromRole(User::ROLE_USER_PARTNER);
+        $suivi = (new Suivi())
+            ->setType(Suivi::TYPE_PARTNER)
+            ->setCreatedBy($user)
+            ->setDescription('Hello world')
+            ->setSignalement(new Signalement());
+
+        $notification = (new NotificationFactory())->createInstanceFrom($user, $suivi);
+
+        $this->assertEquals(Notification::TYPE_SUIVI, $notification->getType());
+        $this->assertEquals('Hello world', $notification->getSuivi()->getDescription());
+    }
+}


### PR DESCRIPTION
## Ticket

#1035    

## Description
Comptabiliser uniquement les signalements en attente ou accepté pour les cartes du dashboard `Sans Suivi` et `Nouveau Suivi`
 
## Changements apportés
* Filtrer les signalements en ne gardant uniquement que les signalement en attente et accepté pour les partenaires (admn et user)
* Possibilité de créer une notification de manière autonome

## Tests
- [ ] En tant qu'utilisateur partenaire je laisse un suivi sur un signalement afin que tous les utilisateurs partenaires affectés reçoivent une notification. [Email + Notif + Tableau de bord (Nouveau Suivi + 1)]
- [ ] En tant qu'utilisateur avec un partenaire différent mais affecté à ce même signalement, je confirme que j'ai bien recu un email si j'accepte de les recevoir, je confirme que j'ai bien une nouvelle notification et j'ai bien mon compteur nouveau suivi qui s'incrémente.
- [ ]  Avec ce même utilisateur, je clôture le signalement pour mon partenaire afin que les utilisateurs du partenaire ne reçoivent aucune notification [Email + Notif + Tableau de bord (Nouveau Suivi + 1)]

