### PR TITLE
[BO - Esabora] Prendre en compte la réponse pour déterminer le statut

### DIFF
--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -48,7 +48,7 @@ class JobEventRepository extends ServiceEntityRepository
         $results = $qb->getQuery()->getArrayResult();
 
         return array_map(function ($item) {
-            $response = json_decode($item['response'], true);
+            $response = json_decode($item['response']);
 
             return [
                 'reference' => $item['reference'],
@@ -56,7 +56,7 @@ class JobEventRepository extends ServiceEntityRepository
                 'title' => $item['title'],
                 'id' => $item['id'],
                 'nom' => $item['nom'],
-                'status' => null === $response['errorReason'] ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED,
+                'status' => null === $response?->errorReason ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED,
                 'response' => json_decode($item['response']),
             ];
         }, $results);


### PR DESCRIPTION
## Ticket

#1175    

## Description
En plus du code HTTP, inspecter la réponse de l'API esabora pour déterminer si c'est un succès ou un echec

## Changements apportés
* Ne plus seulement s'appuyer sur le code HTTP pour déterminer si un succès ou echec de la syncrhonisation
* Transformation du statut selon la réponse stocké en base
* apportés

## Tests
- [ ] Lancer la commande `make console app="sync-esabora"` 
- [ ] Vérifier en base de données que le statut est `failed` pour les evenements  qui ont une réponse avec un champs ErrorReason non vide et un code HTTTP 200
- [ ] Vérifier sur le tableau de bord que l'affichage est bien correcte