### PR TITLE
[QA] Problème de typage sur la récupération des emails (fiche suivi)

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -308,7 +308,7 @@ class FrontSignalementController extends AbstractController
     ) {
         if ($signalement = $signalementRepository->findOneByCodeForPublic($code)) {
             $requestEmail = $request->get('from');
-            $fromEmail = is_array($requestEmail) ? array_pop($requestEmail) : $requestEmail;
+            $fromEmail = \is_array($requestEmail) ? array_pop($requestEmail) : $requestEmail;
 
             /** @var User $userOccupant */
             $userOccupant = $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -307,7 +307,9 @@ class FrontSignalementController extends AbstractController
         UserManager $userManager
     ) {
         if ($signalement = $signalementRepository->findOneByCodeForPublic($code)) {
-            $fromEmail = $request->get('from');
+            $requestEmail = $request->get('from');
+            $fromEmail = is_array($requestEmail) ? array_pop($requestEmail) : $requestEmail;
+
             /** @var User $userOccupant */
             $userOccupant = $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
             /** @var User $userDeclarant */


### PR DESCRIPTION
## Ticket

#1178    

## Description
Un tableau est passé dans l'url de suivi
https://sentry.incubateur.net/share/issue/2e361c3ff86e4f5fb103cb988034cc33/


## Changements apportés
* Ajout d'une condition afin de récupérer une chaine si un tableau est passé en paramètre d'url

## Tests
- [ ] En tant qu'utilisateur, envoyer un suivi public
- [ ] En tant qu'usager cliquer sur le mail de suivi, vérifier que vous avez bien le paramètre from dans l'url `from=john@yopmail.com` et envoyer un suivi
- [ ] En tant qu'usager cliquer sur le mail de suivi, simuler l'envoi d'un tableau d'email avec from[] dans l'url `from[]=john@yopmail.com` et envoyer un suivi
- [ ] Aucune régression doit être constaté