### PR TITLE
[Securité] Les utilisateurs archivés ne doivent pas recevoir de lien d'activation de compte ou récupération de mot de passe

### DIFF
--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -30,7 +30,7 @@ class UserAccountController extends AbstractController
         $title = 'Activation de votre compte';
         if ($request->isMethod('POST') && $email = $request->request->get('email')) {
             $user = $userRepository->findOneBy(['email' => $email]);
-            if ($user) {
+            if ($user && User::STATUS_ARCHIVE != $user->getStatut()) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_FROM_FO,
@@ -48,7 +48,6 @@ class UserAccountController extends AbstractController
             $this->addFlash('error', 'Cette adresse ne correspond à aucun compte, verifiez votre saisie');
         }
 
-        // if it's not submitted, render the "login" form
         return $this->render('security/login_activation.html.twig', [
             'title' => $title,
             'actionTitle' => 'Activation de votre compte',
@@ -73,7 +72,7 @@ class UserAccountController extends AbstractController
         $title = 'Récupération de votre mot de passe';
         if ($request->isMethod('POST') && $email = $request->request->get('email')) {
             $user = $userRepository->findOneBy(['email' => $email]);
-            if ($user) {
+            if ($user && User::STATUS_ARCHIVE != $user->getStatut()) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_LOST_PASSWORD,
@@ -105,8 +104,11 @@ class UserAccountController extends AbstractController
     }
 
     #[Route('/bo/nouveau-mot-de-passe', name: 'login_creation_pass')]
-    public function createPassword(Request $request, PasswordHasherFactoryInterface $hasherFactory, EntityManagerInterface $entityManager): RedirectResponse|Response
-    {
+    public function createPassword(
+        Request $request,
+        PasswordHasherFactoryInterface $hasherFactory,
+        EntityManagerInterface $entityManager
+    ): RedirectResponse|Response {
         $title = 'Création de votre mot de passe';
         if ($request->isMethod('POST') && $this->isCsrfTokenValid('create_password_'.$this->getUser()->getId(), $request->get('_csrf_token'))) {
             $user = $this->getUser();


### PR DESCRIPTION
## Ticket

#1181    

## Description
Les utilisateurs archivés ne doivent pas recevoir de lien d'activation de compte ou récupération de mot de passe

## Changements apportés
* Vérification du statut de l'utilisation avant d'envoyer un lien

## Tests
- [ ] En tant q'utilisateur archivé, je fais une demande de mot de passe oublié
- [ ] En tant qu'utilisateur archivé, je fais une demande d'activation
 
