### PR TITLE
[BO - Esabora] Revoir la gestion des statuts retourné par l'API SAS_Etat ≠ Doss_Etat

### DIFF
--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -30,7 +30,7 @@ class JobEventRepository extends ServiceEntityRepository
         ?Territory $territory
     ): array {
         $qb = $this->createQueryBuilder('j')
-            ->select('MAX(j.createdAt) AS last_event, p.id, p.nom, s.reference, j.status, j.title')
+            ->select('MAX(j.createdAt) AS last_event, p.id, p.nom, s.reference, j.status, j.title, j.response')
             ->innerJoin(Signalement::class, 's', 'WITH', 's.id = j.signalementId')
             ->innerJoin(Partner::class, 'p', 'WITH', 'p.id = j.partnerId')
             ->where('j.type LIKE :type')
@@ -42,7 +42,7 @@ class JobEventRepository extends ServiceEntityRepository
 
         $qb->setParameter('type', '%'.$type.'%')
             ->setParameter('day_period', $dayPeriod)
-            ->groupBy('p.id, p.nom, s.reference,j.title, j.status')
+            ->groupBy('p.id, p.nom, s.reference,j.title, j.status, j.response')
             ->orderBy('last_event', 'DESC');
 
         return $qb->getQuery()->getArrayResult();

--- a/src/Service/Esabora/EsaboraService.php
+++ b/src/Service/Esabora/EsaboraService.php
@@ -15,8 +15,9 @@ class EsaboraService
 {
     public const ESABORA_WAIT = 'A traiter';
     public const ESABORA_ACCEPTED = 'Importé';
-    public const ESABORA_REFUSED = 'Non importé';
+    public const ESABORA_IN_PROGRESS = 'en cours';
     public const ESABORA_CLOSED = 'terminé';
+    public const ESABORA_REFUSED = 'Non importé';
 
     public const TYPE_SERVICE = 'esabora';
     public const ACTION_PUSH_DOSSIER = 'push_dossier';

--- a/tests/Unit/Service/Esabora/DossierResponseTest.php
+++ b/tests/Unit/Service/Esabora/DossierResponseTest.php
@@ -10,16 +10,16 @@ class DossierResponseTest extends TestCase
 {
     public function testDossierResponseSuccessfullyCreated(): void
     {
-        $filepath = __DIR__.'/../../../../tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_non_importe.json';
+        $filepath = __DIR__.'/../../../../tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_importe.json';
         $responseEsabora = json_decode(file_get_contents($filepath), true);
 
         $dossierResponse = new DossierResponse($responseEsabora, 200);
-        $this->assertEquals('00000000-0000-0000-2022-000000000002', $dossierResponse->getSasReference());
-        $this->assertEquals('Non importé', $dossierResponse->getSasEtat());
-        $this->assertEquals('20222', $dossierResponse->getId());
-        $this->assertEquals('2022-2', $dossierResponse->getNumero());
-        $this->assertNull($dossierResponse->getStatutAbrege());
-        $this->assertNull($dossierResponse->getStatut());
+        $this->assertEquals('00000000-0000-0000-2022-000000000001', $dossierResponse->getSasReference());
+        $this->assertEquals('Importé', $dossierResponse->getSasEtat());
+        $this->assertEquals('20221', $dossierResponse->getId());
+        $this->assertEquals('2022-1', $dossierResponse->getNumero());
+        $this->assertEquals('Traité', $dossierResponse->getStatutAbrege());
+        $this->assertEquals('Traité', $dossierResponse->getStatut());
         $this->assertEquals('en cours', $dossierResponse->getEtat());
         $this->assertNull($dossierResponse->getDateCloture());
         $this->assertEquals(200, $dossierResponse->getStatusCode());

--- a/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_a_traiter.json
+++ b/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_a_traiter.json
@@ -22,7 +22,7 @@
         "2022-8",
         null,
         null,
-        "en cours",
+        null,
         null
       ],
       "keyDataList": [

--- a/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_importe.json
+++ b/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_importe.json
@@ -20,8 +20,8 @@
         "Importé",
         "20221",
         "2022-1",
-        null,
-        null,
+        "Traité",
+        "Traité",
         "en cours",
         null
       ],

--- a/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_non_importe.json
+++ b/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_non_importe.json
@@ -18,11 +18,11 @@
       "columnDataList": [
         "00000000-0000-0000-2022-000000000002",
         "Non importé",
-        "20222",
-        "2022-2",
         null,
         null,
-        "en cours",
+        null,
+        null,
+        null,
         null
       ],
       "keyDataList": [

--- a/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/ws_etat_dossier_sas/etat_termine.json
@@ -8,7 +8,7 @@
     "Doss_Statut_Abrégé",
     "Doss_Statut",
     "Doss_Etat",
-    "DOss_Cloture"
+    "Doss_Cloture"
   ],
   "keyList": [
     "i1.iaff_id"
@@ -17,11 +17,11 @@
     {
       "columnDataList": [
         "00000000-0000-0000-2022-000000000010",
-        "terminé",
+        "Importé",
         "202210",
         "2022-10",
-        null,
-        null,
+        "Traité",
+        "Traité",
         "terminé",
         "30/11/2022"
       ],


### PR DESCRIPTION
## Ticket

#1185    

## Description
Des dossiers sont remis en attente car le service de mise à jour d'Histolloge s'appuie sur SAS_Etat alors qui faut le compléter par Doss_Etat. 
La mise à jour du statut par Esabora doit se faire à partir de deux champs renvoyé par l'API 
- SAS_Etat (A traiter / Non importé / Importé)
- Doss_Etat (en cours / terminé)

## Changements apportés
* Mise à jour des mock
* Mise à jour de l'algo prenant en compte les deux statuts pour le dossier cloturéé et en cours

## Tests
- [ ] Remise à zéro de la base de donnée `make create-db`
- [ ] Lancer `make mock`
- [ ] Aller sur le signalement #2022-10 http://localhost:8080/bo/signalements/00000000-0000-0000-2022-000000000010 et vérifier que le signalement est en cours avec des affectations en cours
- [ ] Lancer la commande ` make console app="sync-esabora"` afin que le service esabora puisse mettre à jour les statuts
- [ ] Retourner sur les signalements 2022-10 et vérifier que les affectations ont bien été cloturé

