### PR TITLE
[BO - Grille affectation] Amélioration de la commande de la grille affectation

### DIFF
--- a/config/app/competences.yaml
+++ b/config/app/competences.yaml
@@ -1,0 +1,65 @@
+parameters:
+  competence_per_type:
+    ADIL:
+    - !php/enum App\Entity\Enum\Qualification::ACCOMPAGNEMENT_JURIDIQUE
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE_ENERGETIQUE
+    ARS:
+    - !php/enum App\Entity\Enum\Qualification::ARRETES
+    - !php/enum App\Entity\Enum\Qualification::DIOGENE
+    - !php/enum App\Entity\Enum\Qualification::INSALUBRITE
+    - !php/enum App\Entity\Enum\Qualification::VISITES
+    BAILLEUR_SOCIAL:
+    - !php/enum App\Entity\Enum\Qualification::DIOGENE
+    - !php/enum App\Entity\Enum\Qualification::HEBERGEMENT_RELOGEMENT
+    - !php/enum App\Entity\Enum\Qualification::MISE_EN_SECURITE_PERIL
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE
+    - !php/enum App\Entity\Enum\Qualification::NUISIBLES
+    - !php/enum App\Entity\Enum\Qualification::RSD
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE_ENERGETIQUE
+    CAF_MSA:
+    - !php/enum App\Entity\Enum\Qualification::CONSIGNATION_AL
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE
+    - !php/enum App\Entity\Enum\Qualification::VISITES
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE_ENERGETIQUE
+    CCAS:
+    - !php/enum App\Entity\Enum\Qualification::ACCOMPAGNEMENT_SOCIAL
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    - !php/enum App\Entity\Enum\Qualification::DIOGENE
+    COMMUNE_SCHS:
+    - !php/enum App\Entity\Enum\Qualification::ARRETES
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    - !php/enum App\Entity\Enum\Qualification::DIOGENE
+    - !php/enum App\Entity\Enum\Qualification::INSALUBRITE
+    - !php/enum App\Entity\Enum\Qualification::MISE_EN_SECURITE_PERIL
+    - !php/enum App\Entity\Enum\Qualification::NUISIBLES
+    - !php/enum App\Entity\Enum\Qualification::RSD
+    - !php/enum App\Entity\Enum\Qualification::VISITES
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE_ENERGETIQUE
+    CONCILIATEURS:
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    CONSEIL_DEPARTEMENTAL:
+    - !php/enum App\Entity\Enum\Qualification::ACCOMPAGNEMENT_SOCIAL
+    - !php/enum App\Entity\Enum\Qualification::ACCOMPAGNEMENT_TRAVAUX
+    - !php/enum App\Entity\Enum\Qualification::FSL
+    DDETS:
+    - !php/enum App\Entity\Enum\Qualification::DALO
+    - !php/enum App\Entity\Enum\Qualification::HEBERGEMENT_RELOGEMENT
+    DDT_M:
+    - !php/enum App\Entity\Enum\Qualification::ARRETES
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    - !php/enum App\Entity\Enum\Qualification::DALO
+    - !php/enum App\Entity\Enum\Qualification::HEBERGEMENT_RELOGEMENT
+    DISPOSITIF_RENOVATION_HABITAT:
+    - !php/enum App\Entity\Enum\Qualification::ACCOMPAGNEMENT_TRAVAUX
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    - !php/enum App\Entity\Enum\Qualification::VISITES
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE_ENERGETIQUE
+    EPCI:
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    OPERATEUR_VISITES_ET_TRAVAUX:
+    - !php/enum App\Entity\Enum\Qualification::ACCOMPAGNEMENT_TRAVAUX
+    - !php/enum App\Entity\Enum\Qualification::CONCILIATION
+    - !php/enum App\Entity\Enum\Qualification::NON_DECENCE_ENERGETIQUE
+    PREFECTURE:
+    - !php/enum App\Entity\Enum\Qualification::DALO

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,6 +9,7 @@ imports:
     - { resource: 'app/insee.yaml'}
     - { resource: 'app/nondecence.yaml'}
     - { resource: 'app/documents.yaml'}
+    - { resource: 'app/competences.yaml'}
 parameters:
     container.dumper.inline_factories: true
     uploads_dir: '%kernel.project_dir%/uploaded_files/signalement/'

--- a/migrations/Version20230503082553.php
+++ b/migrations/Version20230503082553.php
@@ -16,11 +16,11 @@ final class Version20230503082553 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE partner ADD created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD modified_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE partner ADD created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE partner DROP created_at, DROP modified_at');
+        $this->addSql('ALTER TABLE partner DROP created_at, DROP updated_at');
     }
 }

--- a/migrations/Version20230503082553.php
+++ b/migrations/Version20230503082553.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230503082553 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add creation_date and modification_date to partners';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE partner ADD created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD modified_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE partner DROP created_at, DROP modified_at');
+    }
+}

--- a/src/Command/ImportGridAffectationCommand.php
+++ b/src/Command/ImportGridAffectationCommand.php
@@ -71,22 +71,21 @@ class ImportGridAffectationCommand extends Command
 
         $this->uploadHandlerService->createTmpFileFromBucket($fromFile, $toFile);
 
-        // first check datas
-        $checkErrors = $this->gridAffectationLoader->check(
-            $this->csvParser->parseAsDict($toFile),
+        $csvData = $this->csvParser->parseAsDict($toFile);
+        $checkErrors = $this->gridAffectationLoader->validate(
+            $csvData,
         );
 
-        if (null !== $checkErrors) {
+        if (\count($checkErrors) > 0) {
             $io->error($checkErrors);
 
             return Command::FAILURE;
         }
         $io->success('No error detected in file');
 
-        // then create partners and users
         $this->gridAffectationLoader->load(
             $territory,
-            $this->csvParser->parseAsDict($toFile)
+            $csvData
         );
 
         $metadata = $this->gridAffectationLoader->getMetadata();

--- a/src/Command/ImportGridAffectationCommand.php
+++ b/src/Command/ImportGridAffectationCommand.php
@@ -70,10 +70,27 @@ class ImportGridAffectationCommand extends Command
         }
 
         $this->uploadHandlerService->createTmpFileFromBucket($fromFile, $toFile);
-        $this->gridAffectationLoader->load($this->csvParser->parse($toFile), $territory);
+
+        // first check datas
+        $checkErrors = $this->gridAffectationLoader->check(
+            $this->csvParser->parseAsDict($toFile),
+        );
+
+        if (null !== $checkErrors) {
+            $io->error($checkErrors);
+
+            return Command::FAILURE;
+        }
+        $io->success('No error detected in file');
+
+        // then create partners and users
+        $this->gridAffectationLoader->load(
+            $territory,
+            $this->csvParser->parseAsDict($toFile)
+        );
 
         $metadata = $this->gridAffectationLoader->getMetadata();
-        $io->success($metadata['nb_partners'].' partner(s) created, '.$metadata['nb_users'].' user(s) created');
+        $io->success($metadata['nb_partners'].' partner(s) created, '.$metadata['nb_users_created'].' user(s) created, '.$metadata['nb_users_updated'].' user(s) updated');
 
         $territory->setIsActive(true);
         $this->territoryManager->save($territory);
@@ -83,10 +100,12 @@ class ImportGridAffectationCommand extends Command
             new NotificationMail(
                 type: NotificationMailerType::TYPE_CRON,
                 to: $this->parameterBag->get('admin_email'),
-                message: sprintf('Félicitation, le térritoire %s est ouvert: %s partenaires et %s utilsateurs ont été crées',
+                message: sprintf(
+                    'Félicitation, le territoire %s est ouvert: %s partenaires, %s utilisateurs ont été crées et %s utilisateurs ont été mis à jour',
                     $territory->getName(),
                     $metadata['nb_partners'],
-                    $metadata['nb_users']
+                    $metadata['nb_users_created'],
+                    $metadata['nb_users_updated']
                 ),
                 cronLabel: 'Ouverture de territoire',
             )

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\Qualification;
 use App\Repository\PartnerRepository;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -59,10 +60,14 @@ class Partner
     #[ORM\Column(type: 'string', enumType: PartnerType::class, nullable: true)]
     private ?PartnerType $type = null;
 
-    private $isCommune;
-
     #[ORM\Column(type: Types::SIMPLE_ARRAY, length: 255, nullable: true, enumType: Qualification::class)]
     private array $competence = [];
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?DateTimeImmutable $modifiedAt;
 
     public function __construct()
     {
@@ -281,6 +286,30 @@ class Partner
     public function setCompetence(?array $competence): self
     {
         $this->competence = $competence;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getModifiedAt(): ?DateTimeImmutable
+    {
+        return $this->modifiedAt;
+    }
+
+    public function setModifiedAt(?DateTimeImmutable $modifiedAt): self
+    {
+        $this->modifiedAt = $modifiedAt;
 
         return $this;
     }

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -2,10 +2,10 @@
 
 namespace App\Entity;
 
+use App\Entity\Behaviour\TimestampableTrait;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\Qualification;
 use App\Repository\PartnerRepository;
-use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -17,6 +17,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[UniqueEntity('email', ignoreNull: true)]
 class Partner
 {
+    use TimestampableTrait;
+
     public const DEFAULT_PARTNER = 'Administrateurs Histologe ALL';
     public const MAX_LIST_PAGINATION = 50;
 
@@ -62,12 +64,6 @@ class Partner
 
     #[ORM\Column(type: Types::SIMPLE_ARRAY, length: 255, nullable: true, enumType: Qualification::class)]
     private array $competence = [];
-
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
-    private ?DateTimeImmutable $createdAt;
-
-    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
-    private ?DateTimeImmutable $modifiedAt;
 
     public function __construct()
     {
@@ -286,30 +282,6 @@ class Partner
     public function setCompetence(?array $competence): self
     {
         $this->competence = $competence;
-
-        return $this;
-    }
-
-    public function getCreatedAt(): ?DateTimeImmutable
-    {
-        return $this->createdAt;
-    }
-
-    public function setCreatedAt(?DateTimeImmutable $createdAt): self
-    {
-        $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
-    public function getModifiedAt(): ?DateTimeImmutable
-    {
-        return $this->modifiedAt;
-    }
-
-    public function setModifiedAt(?DateTimeImmutable $modifiedAt): self
-    {
-        $this->modifiedAt = $modifiedAt;
 
         return $this;
     }

--- a/src/EventSubscriber/UserUpdatedSubscriber.php
+++ b/src/EventSubscriber/UserUpdatedSubscriber.php
@@ -35,9 +35,7 @@ class UserUpdatedSubscriber implements EventSubscriberInterface
         foreach ($unitOfWork->getScheduledEntityUpdates() as $entity) {
             $changes = $unitOfWork->getEntityChangeSet($entity);
 
-            if ($entity instanceof User &&
-            (\array_key_exists('email', $changes) // if email has changed
-            || (\array_key_exists('roles', $changes) && \in_array('ROLE_USAGER', $changes['roles'][0])))) { // if usager becomes user
+            if ($entity instanceof User && $this->shouldChangePassword($changes)) {
                 $entity->setPassword($this->tokenGenerator->generateToken())
                 ->setToken($this->tokenGenerator->generateToken())
                 ->setTokenExpiredAt(
@@ -61,5 +59,16 @@ class UserUpdatedSubscriber implements EventSubscriberInterface
                 )
             );
         }
+    }
+
+    private function shouldChangePassword(array $changes): bool
+    {
+        if (\array_key_exists('email', $changes) // if email has changed
+            || (\array_key_exists('roles', $changes) && \in_array('ROLE_USAGER', $changes['roles'][0]))// if usager becomes user
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/EventSubscriber/UserUpdatedSubscriber.php
+++ b/src/EventSubscriber/UserUpdatedSubscriber.php
@@ -37,7 +37,7 @@ class UserUpdatedSubscriber implements EventSubscriberInterface
 
             if ($entity instanceof User &&
             (\array_key_exists('email', $changes) // if email has changed
-            || (\array_key_exists('roles', $changes) && \in_array('ROLE_USAGER', $changes['roles'][0])))) { // is usager becomes user
+            || (\array_key_exists('roles', $changes) && \in_array('ROLE_USAGER', $changes['roles'][0])))) { // if usager becomes user
                 $entity->setPassword($this->tokenGenerator->generateToken())
                 ->setToken($this->tokenGenerator->generateToken())
                 ->setTokenExpiredAt(

--- a/src/EventSubscriber/UserUpdatedSubscriber.php
+++ b/src/EventSubscriber/UserUpdatedSubscriber.php
@@ -34,7 +34,10 @@ class UserUpdatedSubscriber implements EventSubscriberInterface
 
         foreach ($unitOfWork->getScheduledEntityUpdates() as $entity) {
             $changes = $unitOfWork->getEntityChangeSet($entity);
-            if ($entity instanceof User && \array_key_exists('email', $changes)) {
+
+            if ($entity instanceof User &&
+            (\array_key_exists('email', $changes) // if email has changed
+            || (\array_key_exists('roles', $changes) && \in_array('ROLE_USAGER', $changes['roles'][0])))) { // is usager becomes user
                 $entity->setPassword($this->tokenGenerator->generateToken())
                 ->setToken($this->tokenGenerator->generateToken())
                 ->setTokenExpiredAt(

--- a/src/Factory/PartnerFactory.php
+++ b/src/Factory/PartnerFactory.php
@@ -3,6 +3,7 @@
 namespace App\Factory;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\Qualification;
 use App\Entity\Partner;
 use App\Entity\Territory;
 
@@ -17,19 +18,109 @@ class PartnerFactory
         string $name = null,
         string $email = null,
         PartnerType $type = null,
-        string $insee = null): Partner
-    {
+        string $insee = null
+    ): Partner {
         $partner = (new Partner())
             ->setTerritory($territory)
             ->setNom($name)
             ->setEmail($email)
             ->setType($type)
-            ->setIsArchive(false);
+            ->setCompetence($this->buildCompetences($type))
+            ->setIsArchive(false)
+            ->setCreatedAt(new \DateTimeImmutable());
 
         if (!empty($insee)) {
             $partner->setInsee(array_map('trim', explode(',', $insee)));
         }
 
         return $partner;
+    }
+
+    // build default competences according to partner type
+    public function buildCompetences(PartnerType $type): ?array
+    {
+        $competences = [];
+        switch ($type) {
+            case PartnerType::ADIL:
+                $competences[] = Qualification::ACCOMPAGNEMENT_JURIDIQUE;
+                $competences[] = Qualification::CONCILIATION;
+                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
+
+                break;
+            case PartnerType::ARS:
+                $competences[] = Qualification::ARRETES;
+                $competences[] = Qualification::DIOGENE;
+                $competences[] = Qualification::INSALUBRITE;
+                $competences[] = Qualification::VISITES;
+                break;
+            case PartnerType::BAILLEUR_SOCIAL:
+                $competences[] = Qualification::DIOGENE;
+                $competences[] = Qualification::HEBERGEMENT_RELOGEMENT;
+                $competences[] = Qualification::MISE_EN_SECURITE_PERIL;
+                $competences[] = Qualification::NON_DECENCE;
+                $competences[] = Qualification::NUISIBLES;
+                $competences[] = Qualification::RSD;
+                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
+                break;
+            case PartnerType::CAF_MSA:
+                $competences[] = Qualification::CONSIGNATION_AL;
+                $competences[] = Qualification::NON_DECENCE;
+                $competences[] = Qualification::VISITES;
+                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
+                break;
+            case PartnerType::CCAS:
+                $competences[] = Qualification::ACCOMPAGNEMENT_SOCIAL;
+                $competences[] = Qualification::CONCILIATION;
+                $competences[] = Qualification::DIOGENE;
+                break;
+            case PartnerType::COMMUNE_SCHS:
+                $competences[] = Qualification::ARRETES;
+                $competences[] = Qualification::CONCILIATION;
+                $competences[] = Qualification::DIOGENE;
+                $competences[] = Qualification::INSALUBRITE;
+                $competences[] = Qualification::MISE_EN_SECURITE_PERIL;
+                $competences[] = Qualification::NUISIBLES;
+                $competences[] = Qualification::RSD;
+                $competences[] = Qualification::VISITES;
+                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
+                break;
+            case PartnerType::CONCILIATEURS:
+                $competences[] = Qualification::CONCILIATION;
+                break;
+            case PartnerType::CONSEIL_DEPARTEMENTAL:
+                $competences[] = Qualification::ACCOMPAGNEMENT_SOCIAL;
+                $competences[] = Qualification::ACCOMPAGNEMENT_TRAVAUX;
+                $competences[] = Qualification::FSL;
+                break;
+            case PartnerType::DDETS:
+                $competences[] = Qualification::DALO;
+                $competences[] = Qualification::HEBERGEMENT_RELOGEMENT;
+                break;
+            case PartnerType::DDT_M:
+                $competences[] = Qualification::ARRETES;
+                $competences[] = Qualification::CONCILIATION;
+                $competences[] = Qualification::DALO;
+                $competences[] = Qualification::HEBERGEMENT_RELOGEMENT;
+                break;
+            case PartnerType::DISPOSITIF_RENOVATION_HABITAT:
+                $competences[] = Qualification::ACCOMPAGNEMENT_TRAVAUX;
+                $competences[] = Qualification::CONCILIATION;
+                $competences[] = Qualification::VISITES;
+                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
+                break;
+            case PartnerType::EPCI:
+                $competences[] = Qualification::CONCILIATION;
+                break;
+            case PartnerType::OPERATEUR_VISITES_ET_TRAVAUX:
+                $competences[] = Qualification::ACCOMPAGNEMENT_TRAVAUX;
+                $competences[] = Qualification::CONCILIATION;
+                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
+                break;
+            case PartnerType::PREFECTURE:
+                $competences[] = Qualification::DALO;
+                break;
+        }
+
+        return $competences;
     }
 }

--- a/src/Factory/PartnerFactory.php
+++ b/src/Factory/PartnerFactory.php
@@ -3,14 +3,15 @@
 namespace App\Factory;
 
 use App\Entity\Enum\PartnerType;
-use App\Entity\Enum\Qualification;
 use App\Entity\Partner;
 use App\Entity\Territory;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class PartnerFactory
 {
-    public function __construct()
-    {
+    public function __construct(
+        private ParameterBagInterface $parameterBag
+    ) {
     }
 
     public function createInstanceFrom(
@@ -26,8 +27,7 @@ class PartnerFactory
             ->setEmail($email)
             ->setType($type)
             ->setCompetence($this->buildCompetences($type))
-            ->setIsArchive(false)
-            ->setCreatedAt(new \DateTimeImmutable());
+            ->setIsArchive(false);
 
         if (!empty($insee)) {
             $partner->setInsee(array_map('trim', explode(',', $insee)));
@@ -39,86 +39,12 @@ class PartnerFactory
     // build default competences according to partner type
     public function buildCompetences(PartnerType $type): ?array
     {
+        $types = $this->parameterBag->get('competence_per_type');
         $competences = [];
-        switch ($type) {
-            case PartnerType::ADIL:
-                $competences[] = Qualification::ACCOMPAGNEMENT_JURIDIQUE;
-                $competences[] = Qualification::CONCILIATION;
-                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
-
-                break;
-            case PartnerType::ARS:
-                $competences[] = Qualification::ARRETES;
-                $competences[] = Qualification::DIOGENE;
-                $competences[] = Qualification::INSALUBRITE;
-                $competences[] = Qualification::VISITES;
-                break;
-            case PartnerType::BAILLEUR_SOCIAL:
-                $competences[] = Qualification::DIOGENE;
-                $competences[] = Qualification::HEBERGEMENT_RELOGEMENT;
-                $competences[] = Qualification::MISE_EN_SECURITE_PERIL;
-                $competences[] = Qualification::NON_DECENCE;
-                $competences[] = Qualification::NUISIBLES;
-                $competences[] = Qualification::RSD;
-                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
-                break;
-            case PartnerType::CAF_MSA:
-                $competences[] = Qualification::CONSIGNATION_AL;
-                $competences[] = Qualification::NON_DECENCE;
-                $competences[] = Qualification::VISITES;
-                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
-                break;
-            case PartnerType::CCAS:
-                $competences[] = Qualification::ACCOMPAGNEMENT_SOCIAL;
-                $competences[] = Qualification::CONCILIATION;
-                $competences[] = Qualification::DIOGENE;
-                break;
-            case PartnerType::COMMUNE_SCHS:
-                $competences[] = Qualification::ARRETES;
-                $competences[] = Qualification::CONCILIATION;
-                $competences[] = Qualification::DIOGENE;
-                $competences[] = Qualification::INSALUBRITE;
-                $competences[] = Qualification::MISE_EN_SECURITE_PERIL;
-                $competences[] = Qualification::NUISIBLES;
-                $competences[] = Qualification::RSD;
-                $competences[] = Qualification::VISITES;
-                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
-                break;
-            case PartnerType::CONCILIATEURS:
-                $competences[] = Qualification::CONCILIATION;
-                break;
-            case PartnerType::CONSEIL_DEPARTEMENTAL:
-                $competences[] = Qualification::ACCOMPAGNEMENT_SOCIAL;
-                $competences[] = Qualification::ACCOMPAGNEMENT_TRAVAUX;
-                $competences[] = Qualification::FSL;
-                break;
-            case PartnerType::DDETS:
-                $competences[] = Qualification::DALO;
-                $competences[] = Qualification::HEBERGEMENT_RELOGEMENT;
-                break;
-            case PartnerType::DDT_M:
-                $competences[] = Qualification::ARRETES;
-                $competences[] = Qualification::CONCILIATION;
-                $competences[] = Qualification::DALO;
-                $competences[] = Qualification::HEBERGEMENT_RELOGEMENT;
-                break;
-            case PartnerType::DISPOSITIF_RENOVATION_HABITAT:
-                $competences[] = Qualification::ACCOMPAGNEMENT_TRAVAUX;
-                $competences[] = Qualification::CONCILIATION;
-                $competences[] = Qualification::VISITES;
-                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
-                break;
-            case PartnerType::EPCI:
-                $competences[] = Qualification::CONCILIATION;
-                break;
-            case PartnerType::OPERATEUR_VISITES_ET_TRAVAUX:
-                $competences[] = Qualification::ACCOMPAGNEMENT_TRAVAUX;
-                $competences[] = Qualification::CONCILIATION;
-                $competences[] = Qualification::NON_DECENCE_ENERGETIQUE;
-                break;
-            case PartnerType::PREFECTURE:
-                $competences[] = Qualification::DALO;
-                break;
+        if (\array_key_exists($type->name, $types)) {
+            foreach ($types[$type->name] as $competence) {
+                $competences[] = $competence;
+            }
         }
 
         return $competences;

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -41,7 +41,15 @@ class UserManager extends AbstractManager
             ->setRoles([$data['roles']])
             ->setEmail($data['email'])
             ->setIsMailingActive($data['isMailingActive']);
-
+        if (\array_key_exists('territory', $data)) {
+            $user->setTerritory($data['territory']);
+        }
+        if (\array_key_exists('partner', $data)) {
+            $user->setPartner($data['partner']);
+        }
+        if (\array_key_exists('statut', $data)) {
+            $user->setStatut($data['statut']);
+        }
         $this->save($user);
 
         return $user;

--- a/src/Service/Import/CsvParser.php
+++ b/src/Service/Import/CsvParser.php
@@ -51,7 +51,7 @@ class CsvParser
             $dataList[] = $dataItem;
         }
 
-        if (1 === \count(end($dataList))) {
+        if (1 <= \count(end($dataList))) {
             array_pop($dataList);
         }
 

--- a/src/Service/Import/CsvParser.php
+++ b/src/Service/Import/CsvParser.php
@@ -51,10 +51,6 @@ class CsvParser
             $dataList[] = $dataItem;
         }
 
-        if (1 <= \count(end($dataList))) {
-            array_pop($dataList);
-        }
-
         return $dataList;
     }
 

--- a/src/Service/Import/GridAffectation/GridAffectationHeader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationHeader.php
@@ -5,7 +5,7 @@ namespace App\Service\Import\GridAffectation;
 class GridAffectationHeader
 {
     public const PARTNER_NAME_INSTITUTION = 'Institution';
-    public const PARTNER_TYPE = 'TYPE';
+    public const PARTNER_TYPE = 'Type';
     public const PARTNER_CODE_INSEE = 'Codes insee';
     public const PARTNER_EMAIL = 'E-mail d\'équipe';
     public const USER_ROLE = 'Rôle';

--- a/src/Service/Import/GridAffectation/GridAffectationHeader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationHeader.php
@@ -4,12 +4,12 @@ namespace App\Service\Import\GridAffectation;
 
 class GridAffectationHeader
 {
-    public const PARTNER_NAME_INSTITUTION = 0;
-    public const PARTNER_TYPE = 1;
-    public const PARTNER_CODE_INSEE = 2;
-    public const PARTNER_EMAIL = 3;
-    public const USER_ROLE = 4;
-    public const USER_FIRSTNAME = 5;
-    public const USER_LASTNAME = 6;
-    public const USER_EMAIL = 7;
+    public const PARTNER_NAME_INSTITUTION = 'Institution';
+    public const PARTNER_TYPE = 'TYPE';
+    public const PARTNER_CODE_INSEE = 'Codes insee';
+    public const PARTNER_EMAIL = 'E-mail d\'équipe';
+    public const USER_ROLE = 'Rôle';
+    public const USER_FIRSTNAME = 'Prénom';
+    public const USER_LASTNAME = 'Nom';
+    public const USER_EMAIL = 'E-mail';
 }

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -39,105 +39,92 @@ class GridAffectationLoader
     ) {
     }
 
-    public function check(array $data): ?array
+    public function validate(array $data): array
     {
         $errors = [];
         $mailPartners = [];
         $mailUsers = [];
 
         $emailConstraint = new Email(['mode' => 'strict'], true);
+        $numLine = 1;
 
         foreach ($data as $item) {
-            // partner must have a name
-            if (empty($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION])) {
-                $errors[] = 'Nom de partenaire manquant';
-            }
-            // partner must have correct PartnerType
-            if (!\in_array($item[GridAffectationHeader::PARTNER_TYPE], PartnerType::getLabelList())) {
-                $errors[] = 'Type incorrect pour '.$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION].' --> '.$item[GridAffectationHeader::PARTNER_TYPE];
-            }
-            // if partner has an email, it should be valid and not existing for another partner
-            $emailPartner = trim($item[GridAffectationHeader::PARTNER_EMAIL]);
-            if (!empty($emailPartner)) {
-                $violations = $this->validator->validate($emailPartner, $emailConstraint);
-                if (\count($violations) > 0) {
-                    $errors[] = 'Email incorrect pour un partenaire : '.$emailPartner;
+            ++$numLine;
+            if (\count($item) > 1) {
+                if (empty($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION])) {
+                    $errors[] = 'line '.$numLine.' : Nom de partenaire manquant';
+                }
+                if (!\in_array($item[GridAffectationHeader::PARTNER_TYPE], PartnerType::getLabelList())) {
+                    $errors[] = 'line '.$numLine.' : Type incorrect pour '.$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION].' --> '.$item[GridAffectationHeader::PARTNER_TYPE];
+                }
+                // if partner has an email, it should be valid and not existing for another partner
+                $emailPartner = trim($item[GridAffectationHeader::PARTNER_EMAIL]);
+                if (!empty($emailPartner)) {
+                    $violations = $this->validator->validate($emailPartner, $emailConstraint);
+                    if (\count($violations) > 0) {
+                        $errors[] = 'line '.$numLine.' : Email incorrect pour un partenaire : '.$emailPartner;
+                    }
+
+                    /** @var Partner $partnerToCreate */
+                    $partnerToCreate = $this->partnerManager->findOneBy(['email' => $emailPartner]);
+                    if (null !== $partnerToCreate) {
+                        $errors[] = 'line '.$numLine.' : Il existe déjà un partenaire avec cette adresse mail : '
+                        .$emailPartner.' dans le territoire '
+                        .$partnerToCreate->getTerritory()->getName().' avec le nom '.$partnerToCreate->getNom();
+                    }
+                    // store partner mail to check duplicates
+                    $mailPartners[$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]] = $item[GridAffectationHeader::PARTNER_EMAIL];
                 }
 
-                /** @var Partner $partnerToCreate */
-                $partnerToCreate = $this->partnerManager->findOneBy(['email' => $emailPartner]);
-                if (null !== $partnerToCreate) {
-                    $errors[] = 'Il existe déjà un partenaire avec cette adresse mail : '
-                    .$emailPartner.' dans le territoire '
-                    .$partnerToCreate->getTerritory()->getName().' avec le nom '.$partnerToCreate->getNom();
-                }
-                // store partner mail to check duplicates
-                $mailPartners[$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]] = $item[GridAffectationHeader::PARTNER_EMAIL];
-            }
+                $emailUser = trim($item[GridAffectationHeader::USER_EMAIL]);
+                if (empty($emailUser)) {
+                    $errors[] = 'line '.$numLine.' : Email manquant pour '.$item[GridAffectationHeader::USER_FIRSTNAME].' '
+                    .$item[GridAffectationHeader::USER_LASTNAME].', partenaire '.$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION];
+                } else {
+                    // email must be valid and not used by another user of another partner
+                    $violations = $this->validator->validate($emailUser, $emailConstraint);
+                    if (\count($violations) > 0) {
+                        $errors[] = 'line '.$numLine.' : Email incorrect pour un utilisateur : '.$emailUser;
+                    }
 
-            // user must have an email
-            $emailUser = trim($item[GridAffectationHeader::USER_EMAIL]);
-            if (empty($emailUser)) {
-                $errors[] = 'Email manquant pour '.$item[GridAffectationHeader::USER_FIRSTNAME].' '
-                .$item[GridAffectationHeader::USER_LASTNAME].', partenaire '.$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION];
-            } else {
-                // email must be valid and not used by another user of another partner
-                $violations = $this->validator->validate($emailUser, $emailConstraint);
-                if (\count($violations) > 0) {
-                    $errors[] = 'Email incorrect pour un utilisateur : '.$emailUser;
-                }
+                    /** @var User $userToCreate */
+                    $userToCreate = $this->userManager->findOneBy(['email' => $emailUser]);
 
-                /** @var User $userToCreate */
-                $userToCreate = $this->userManager->findOneBy(['email' => $emailUser]);
-
-                if (null !== $userToCreate && !\in_array('ROLE_USAGER', $userToCreate->getRoles())) {
-                    $errors[] = 'Il existe déjà un utilisateur avec cette adresse mail : '
-                    .$emailUser.' dans le territoire '.$userToCreate->getTerritory()->getName()
-                    .' et dans le partenaire '.$userToCreate->getPartner()->getNom()
-                    .' avec le rôle '.$userToCreate->getRoleLabel();
+                    if (null !== $userToCreate && !\in_array('ROLE_USAGER', $userToCreate->getRoles())) {
+                        $errors[] = 'line '.$numLine.' : Il existe déjà un utilisateur avec cette adresse mail : '
+                        .$emailUser.' dans le territoire '.$userToCreate->getTerritory()->getName()
+                        .' et dans le partenaire '.$userToCreate->getPartner()->getNom()
+                        .' avec le rôle '.$userToCreate->getRoleLabel();
+                    }
+                    // store user mail to check duplicates
+                    $mailUsers[] = $item[GridAffectationHeader::USER_EMAIL];
                 }
-                // store user mail to check duplicates
-                $mailUsers[] = $item[GridAffectationHeader::USER_EMAIL];
-            }
-            // user must have correct Role
-            if (!\in_array($item[GridAffectationHeader::USER_ROLE], array_keys(User::ROLES))) {
-                $errors[] = 'Rôle incorrect pour '.$item[GridAffectationHeader::USER_EMAIL].' --> '.$item[GridAffectationHeader::USER_ROLE];
+                if (!\in_array($item[GridAffectationHeader::USER_ROLE], array_keys(User::ROLES))) {
+                    $errors[] = 'line '.$numLine.' : Rôle incorrect pour '.$item[GridAffectationHeader::USER_EMAIL].' --> '.$item[GridAffectationHeader::USER_ROLE];
+                }
             }
         }
 
         // check if there are no duplicate email between partners
-        $occurrencesMailPartners = array_count_values($mailPartners);
-        $duplicatesMailPartners = array_filter($occurrencesMailPartners, function ($value) {
-            return $value > 1;
-        });
+        $duplicatesMailPartners = $this->checkIfDuplicates($mailPartners);
         if (\count($duplicatesMailPartners) > 0) {
             $errors[] = 'Certains partenaires ont un mail en commun '.implode(',', array_keys($duplicatesMailPartners));
         }
 
         // check if there are no duplicate email between users
-        $occurrencesMailUsers = array_count_values($mailUsers);
-        $duplicatesMailUsers = array_filter($occurrencesMailUsers, function ($value) {
-            return $value > 1;
-        });
+        $duplicatesMailUsers = $this->checkIfDuplicates($mailUsers);
         if (\count($duplicatesMailUsers) > 0) {
             $errors[] = 'Certains utilisateurs ont un mail en commun '.implode(',', array_keys($duplicatesMailUsers));
         }
 
         // check if there are no duplicate email between partners and users
         $mails = array_merge($mailPartners, $mailUsers);
-        $occurrencesMails = array_count_values($mails);
-        $duplicatesMails = array_filter($occurrencesMails, function ($value) {
-            return $value > 1;
-        });
+        $duplicatesMails = $this->checkIfDuplicates($mails);
         if (\count($duplicatesMails) > 0) {
             $errors[] = 'Certains utilisateurs ont un mail en commun avec un partenaire '.implode(',', array_keys($duplicatesMails));
         }
 
-        if ($errors) {
-            return $errors;
-        }
-
-        return null;
+        return $errors;
     }
 
     public function load(Territory $territory, array $data): void
@@ -149,54 +136,59 @@ class GridAffectationLoader
         $userToCreate = null;
         $newPartnerName = [];
         foreach ($data as $item) {
-            $partnerName = trim($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]);
+            if (\count($item) > 1) {
+                $partnerName = trim($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]);
 
-            if (!\in_array($partnerName, $newPartnerName)) {
-                $partner = $this->partnerFactory->createInstanceFrom(
-                    territory: $territory,
-                    name: $partnerName,
-                    email: !empty($item[GridAffectationHeader::PARTNER_EMAIL]) ? trim($item[GridAffectationHeader::PARTNER_EMAIL]) : null,
-                    type: PartnerType::tryFromLabel($item[GridAffectationHeader::PARTNER_TYPE]),
-                    insee: $item[GridAffectationHeader::PARTNER_CODE_INSEE]
-                );
-                $this->partnerManager->save($partner, false);
-                ++$this->metadata['nb_partners'];
-                $newPartnerName[] = $partnerName;
-            }
-
-            $roleLabel = $item[GridAffectationHeader::USER_ROLE];
-            $email = trim($item[GridAffectationHeader::USER_EMAIL]);
-            if (!empty($roleLabel) && !empty($email)) {
-                ++$countUsers;
-                /** @var User $userToCreate */
-                $userToCreate = $this->userManager->findOneBy(['email' => $email]);
-                if (null !== $userToCreate && \in_array('ROLE_USAGER', $userToCreate->getRoles())) {
-                    // if there is already an usager with this mail, change role, and set territory, partner, ...
-                    $userToCreate->setRoles(\in_array($roleLabel, User::ROLES) ? [$roleLabel] : [User::ROLES[$roleLabel]]);
-                    $userToCreate->setTerritory($territory);
-                    $userToCreate->setPartner($partner);
-                    $userToCreate->setStatut(User::STATUS_INACTIVE);
-                    $userToCreate->setIsMailingActive(true);
-                    $this->userManager->save($userToCreate, false);
-                    ++$this->metadata['nb_users_updated'];
-                } else {
-                    $user = $this->userFactory->createInstanceFrom(
-                        roleLabel: $roleLabel,
+                if (!\in_array($partnerName, $newPartnerName)) {
+                    $partner = $this->partnerFactory->createInstanceFrom(
                         territory: $territory,
-                        partner: $partner,
-                        firstname: trim($item[GridAffectationHeader::USER_FIRSTNAME]),
-                        lastname: trim($item[GridAffectationHeader::USER_LASTNAME]),
-                        email: $email
+                        name: $partnerName,
+                        email: !empty($item[GridAffectationHeader::PARTNER_EMAIL]) ? trim($item[GridAffectationHeader::PARTNER_EMAIL]) : null,
+                        type: PartnerType::tryFromLabel($item[GridAffectationHeader::PARTNER_TYPE]),
+                        insee: $item[GridAffectationHeader::PARTNER_CODE_INSEE]
                     );
-
-                    $this->throwException($user);
-                    $this->userManager->save($user, false);
-                    ++$this->metadata['nb_users_created'];
+                    $this->partnerManager->save($partner, false);
+                    ++$this->metadata['nb_partners'];
+                    $newPartnerName[] = $partnerName;
                 }
 
-                if (0 === $countUsers % self::FLUSH_COUNT) {
-                    $this->logger->info(sprintf('in progress - %s users created or updated', $countUsers));
-                    $this->manager->flush();
+                $roleLabel = $item[GridAffectationHeader::USER_ROLE];
+                $email = trim($item[GridAffectationHeader::USER_EMAIL]);
+                if (!empty($roleLabel) && !empty($email)) {
+                    ++$countUsers;
+                    /** @var User $userToCreate */
+                    $userToCreate = $this->userManager->findOneBy(['email' => $email]);
+                    if (null !== $userToCreate && \in_array('ROLE_USAGER', $userToCreate->getRoles())) {
+                        $data = [];
+                        $data['nom'] = $userToCreate->getNom();
+                        $data['prenom'] = $userToCreate->getPrenom();
+                        $data['roles'] = \in_array($roleLabel, User::ROLES) ? [$roleLabel] : [User::ROLES[$roleLabel]];
+                        $data['email'] = $userToCreate->getEmail();
+                        $data['isMailingActive'] = true;
+                        $data['territory'] = $territory;
+                        $data['partner'] = $partner;
+                        $data['statut'] = User::STATUS_INACTIVE;
+                        $this->userManager->updateUserFromData($userToCreate, $data);
+                        ++$this->metadata['nb_users_updated'];
+                    } else {
+                        $user = $this->userFactory->createInstanceFrom(
+                            roleLabel: $roleLabel,
+                            territory: $territory,
+                            partner: $partner,
+                            firstname: trim($item[GridAffectationHeader::USER_FIRSTNAME]),
+                            lastname: trim($item[GridAffectationHeader::USER_LASTNAME]),
+                            email: $email
+                        );
+
+                        $this->throwException($user);
+                        $this->userManager->save($user, false);
+                        ++$this->metadata['nb_users_created'];
+                    }
+
+                    if (0 === $countUsers % self::FLUSH_COUNT) {
+                        $this->logger->info(sprintf('in progress - %s users created or updated', $countUsers));
+                        $this->manager->flush();
+                    }
                 }
             }
         }
@@ -207,6 +199,16 @@ class GridAffectationLoader
     public function getMetadata(): array
     {
         return $this->metadata;
+    }
+
+    private function checkIfDuplicates(array $emails): array
+    {
+        $occurrencesEmails = array_count_values($emails);
+        $duplicatesEmails = array_filter($occurrencesEmails, function ($value) {
+            return $value > 1;
+        });
+
+        return $duplicatesEmails;
     }
 
     private function throwException(User $user): void

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -2,6 +2,8 @@
 
 namespace App\Service\Import\GridAffectation;
 
+use App\Entity\Enum\PartnerType;
+use App\Entity\Partner;
 use App\Entity\Territory;
 use App\Entity\User;
 use App\Factory\PartnerFactory;
@@ -10,13 +12,18 @@ use App\Manager\ManagerInterface;
 use App\Manager\PartnerManager;
 use App\Manager\UserManager;
 use App\Service\Import\CsvParser;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class GridAffectationLoader
 {
+    private const FLUSH_COUNT = 250;
+
     private array $metadata = [
-        'nb_users' => 0,
+        'nb_users_created' => 0,
+        'nb_users_updated' => 0,
         'nb_partners' => 0,
     ];
 
@@ -28,41 +35,169 @@ class GridAffectationLoader
         private UserManager $userManager,
         private ManagerInterface $manager,
         private ValidatorInterface $validator,
+        private LoggerInterface $logger,
     ) {
     }
 
-    public function load(array $data, Territory $territory): void
+    public function check(array $data): ?array
     {
+        $errors = [];
+        $mailPartners = [];
+        $mailUsers = [];
+
+        $emailConstraint = new Email(['mode' => 'strict'], true);
+
+        foreach ($data as $item) {
+            // partner must have a name
+            if (empty($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION])) {
+                $errors[] = 'Nom de partenaire manquant';
+            }
+            // partner must have correct PartnerType
+            if (!\in_array($item[GridAffectationHeader::PARTNER_TYPE], PartnerType::getLabelList())) {
+                $errors[] = 'Type incorrect pour '.$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION].' --> '.$item[GridAffectationHeader::PARTNER_TYPE];
+            }
+            // if partner has an email, it should be valid and not existing for another partner
+            $emailPartner = trim($item[GridAffectationHeader::PARTNER_EMAIL]);
+            if (!empty($emailPartner)) {
+                $violations = $this->validator->validate($emailPartner, $emailConstraint);
+                if (\count($violations) > 0) {
+                    $errors[] = 'Email incorrect pour un partenaire : '.$emailPartner;
+                }
+
+                /** @var Partner $partnerToCreate */
+                $partnerToCreate = $this->partnerManager->findOneBy(['email' => $emailPartner]);
+                if (null !== $partnerToCreate) {
+                    $errors[] = 'Il existe déjà un partenaire avec cette adresse mail : '
+                    .$emailPartner.' dans le territoire '
+                    .$partnerToCreate->getTerritory()->getName().' avec le nom '.$partnerToCreate->getNom();
+                }
+                // store partner mail to check duplicates
+                $mailPartners[$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]] = $item[GridAffectationHeader::PARTNER_EMAIL];
+            }
+
+            // user must have an email
+            $emailUser = trim($item[GridAffectationHeader::USER_EMAIL]);
+            if (empty($emailUser)) {
+                $errors[] = 'Email manquant pour '.$item[GridAffectationHeader::USER_FIRSTNAME].' '
+                .$item[GridAffectationHeader::USER_LASTNAME].', partenaire '.$item[GridAffectationHeader::PARTNER_NAME_INSTITUTION];
+            } else {
+                // email must be valid and not used by another user of another partner
+                $violations = $this->validator->validate($emailUser, $emailConstraint);
+                if (\count($violations) > 0) {
+                    $errors[] = 'Email incorrect pour un utilisateur : '.$emailUser;
+                }
+
+                /** @var User $userToCreate */
+                $userToCreate = $this->userManager->findOneBy(['email' => $emailUser]);
+
+                if (null !== $userToCreate && !\in_array('ROLE_USAGER', $userToCreate->getRoles())) {
+                    $errors[] = 'Il existe déjà un utilisateur avec cette adresse mail : '
+                    .$emailUser.' dans le territoire '.$userToCreate->getTerritory()->getName()
+                    .' et dans le partenaire '.$userToCreate->getPartner()->getNom()
+                    .' avec le rôle '.$userToCreate->getRoleLabel();
+                }
+                // store user mail to check duplicates
+                $mailUsers[] = $item[GridAffectationHeader::USER_EMAIL];
+            }
+            // user must have correct Role
+            if (!\in_array($item[GridAffectationHeader::USER_ROLE], array_keys(User::ROLES))) {
+                $errors[] = 'Rôle incorrect pour '.$item[GridAffectationHeader::USER_EMAIL].' --> '.$item[GridAffectationHeader::USER_ROLE];
+            }
+        }
+
+        // check if there are no duplicate email between partners
+        $occurrencesMailPartners = array_count_values($mailPartners);
+        $duplicatesMailPartners = array_filter($occurrencesMailPartners, function ($value) {
+            return $value > 1;
+        });
+        if (\count($duplicatesMailPartners) > 0) {
+            $errors[] = 'Certains partenaires ont un mail en commun '.implode(',', array_keys($duplicatesMailPartners));
+        }
+
+        // check if there are no duplicate email between users
+        $occurrencesMailUsers = array_count_values($mailUsers);
+        $duplicatesMailUsers = array_filter($occurrencesMailUsers, function ($value) {
+            return $value > 1;
+        });
+        if (\count($duplicatesMailUsers) > 0) {
+            $errors[] = 'Certains utilisateurs ont un mail en commun '.implode(',', array_keys($duplicatesMailUsers));
+        }
+
+        // check if there are no duplicate email between partners and users
+        $mails = array_merge($mailPartners, $mailUsers);
+        $occurrencesMails = array_count_values($mails);
+        $duplicatesMails = array_filter($occurrencesMails, function ($value) {
+            return $value > 1;
+        });
+        if (\count($duplicatesMails) > 0) {
+            $errors[] = 'Certains utilisateurs ont un mail en commun avec un partenaire '.implode(',', array_keys($duplicatesMails));
+        }
+
+        if ($errors) {
+            return $errors;
+        }
+
+        return null;
+    }
+
+    public function load(Territory $territory, array $data): void
+    {
+        // TODO LATER : command should be usable several times (update partners and users)
+        $countUsers = 0;
         $partner = null;
-        foreach ($data as $lineNumber => $row) {
-            if (0 === $lineNumber || $data[$lineNumber][0] !== $data[$lineNumber - 1][0]) {
+        $user = null;
+        $userToCreate = null;
+        $newPartnerName = [];
+        foreach ($data as $item) {
+            $partnerName = trim($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]);
+
+            if (!\in_array($partnerName, $newPartnerName)) {
                 $partner = $this->partnerFactory->createInstanceFrom(
                     territory: $territory,
-                    name: $row[GridAffectationHeader::PARTNER_NAME_INSTITUTION],
-                    email: !empty($row[GridAffectationHeader::PARTNER_EMAIL]) ? $row[GridAffectationHeader::PARTNER_EMAIL] : null,
-                    type: !empty($row[GridAffectationHeader::PARTNER_TYPE]) ? $row[GridAffectationHeader::PARTNER_TYPE] : null,
-                    insee: $row[GridAffectationHeader::PARTNER_CODE_INSEE]
+                    name: $partnerName,
+                    email: !empty($item[GridAffectationHeader::PARTNER_EMAIL]) ? trim($item[GridAffectationHeader::PARTNER_EMAIL]) : null,
+                    type: PartnerType::tryFromLabel($item[GridAffectationHeader::PARTNER_TYPE]),
+                    insee: $item[GridAffectationHeader::PARTNER_CODE_INSEE]
                 );
                 $this->partnerManager->save($partner, false);
                 ++$this->metadata['nb_partners'];
+                $newPartnerName[] = $partnerName;
             }
 
-            $roleLbal = $row[GridAffectationHeader::USER_ROLE];
-            $email = $row[GridAffectationHeader::USER_EMAIL];
-            if (!empty($roleLbal) && !empty($email)) {
-                $user = $this->userFactory->createInstanceFrom(
-                    roleLabel: $row[GridAffectationHeader::USER_ROLE],
-                    territory: $territory,
-                    partner: $partner,
-                    firstname: $row[GridAffectationHeader::USER_FIRSTNAME],
-                    lastname: $row[GridAffectationHeader::USER_LASTNAME],
-                    email: $row[GridAffectationHeader::USER_EMAIL]
-                );
+            $roleLabel = $item[GridAffectationHeader::USER_ROLE];
+            $email = trim($item[GridAffectationHeader::USER_EMAIL]);
+            if (!empty($roleLabel) && !empty($email)) {
+                ++$countUsers;
+                /** @var User $userToCreate */
+                $userToCreate = $this->userManager->findOneBy(['email' => $email]);
+                if (null !== $userToCreate && \in_array('ROLE_USAGER', $userToCreate->getRoles())) {
+                    // if there is already an usager with this mail, change role, and set territory, partner, ...
+                    $userToCreate->setRoles(\in_array($roleLabel, User::ROLES) ? [$roleLabel] : [User::ROLES[$roleLabel]]);
+                    $userToCreate->setTerritory($territory);
+                    $userToCreate->setPartner($partner);
+                    $userToCreate->setStatut(User::STATUS_INACTIVE);
+                    $userToCreate->setIsMailingActive(true);
+                    $this->userManager->save($userToCreate, false);
+                    ++$this->metadata['nb_users_updated'];
+                } else {
+                    $user = $this->userFactory->createInstanceFrom(
+                        roleLabel: $roleLabel,
+                        territory: $territory,
+                        partner: $partner,
+                        firstname: trim($item[GridAffectationHeader::USER_FIRSTNAME]),
+                        lastname: trim($item[GridAffectationHeader::USER_LASTNAME]),
+                        email: $email
+                    );
 
-                $this->throwException($user);
+                    $this->throwException($user);
+                    $this->userManager->save($user, false);
+                    ++$this->metadata['nb_users_created'];
+                }
 
-                $this->userManager->save($user, false);
-                ++$this->metadata['nb_users'];
+                if (0 === $countUsers % self::FLUSH_COUNT) {
+                    $this->logger->info(sprintf('in progress - %s users created or updated', $countUsers));
+                    $this->manager->flush();
+                }
             }
         }
 

--- a/tests/Functional/Service/Import/CsvParserTest.php
+++ b/tests/Functional/Service/Import/CsvParserTest.php
@@ -49,9 +49,11 @@ class CsvParserTest extends KernelTestCase
         $dataList = $csvParser->parseAsDict($this->projectDir.self::FILEPATH);
 
         foreach ($dataList as $dataItem) {
-            $this->assertArrayHasKey('Lastname', $dataItem);
-            $this->assertArrayHasKey('Firstname', $dataItem);
-            $this->assertArrayHasKey('Email', $dataItem);
+            if (\count($dataItem) > 1) {
+                $this->assertArrayHasKey('Lastname', $dataItem);
+                $this->assertArrayHasKey('Firstname', $dataItem);
+                $this->assertArrayHasKey('Email', $dataItem);
+            }
         }
     }
 

--- a/tests/Unit/Command/ImportGridAffectationCommandTest.php
+++ b/tests/Unit/Command/ImportGridAffectationCommandTest.php
@@ -42,7 +42,7 @@ class ImportGridAffectationCommandTest extends KernelTestCase
         $gridAffectationLoader
             ->expects($this->once())
             ->method('getMetaData')
-            ->willReturn(['nb_partners' => 10, 'nb_users' => 55]);
+            ->willReturn(['nb_partners' => 10, 'nb_users_created' => 55, 'nb_users_updated' => 0]);
 
         $uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
         $uploadHandlerServiceMock

--- a/tests/Unit/Factory/PartnerFactoryTest.php
+++ b/tests/Unit/Factory/PartnerFactoryTest.php
@@ -7,24 +7,33 @@ use App\Entity\Partner;
 use App\Entity\Territory;
 use App\Factory\PartnerFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class PartnerFactoryTest extends KernelTestCase
 {
-    public function testCreatePartnerInstanceWhenIsNotCommune(): void
+    private ParameterBagInterface $parameterBag;
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
     {
         self::bootKernel();
-        /** @var ValidatorInterface $validator */
-        $validator = static::getContainer()->get(ValidatorInterface::class);
-        $territory = new Territory();
-        $partner = (new PartnerFactory())->createInstanceFrom(
+        /* @var ParameterBagInterface parameterBag */
+        $this->parameterBag = static::getContainer()->get(ParameterBagInterface::class);
+        /* @var ValidatorInterface validator */
+        $this->validator = static::getContainer()->get(ValidatorInterface::class);
+    }
+
+    public function testCreatePartnerInstanceWhenIsNotCommune(): void
+    {
+        $partner = (new PartnerFactory($this->parameterBag))->createInstanceFrom(
             territory: new Territory(),
             name: 'HTL',
             email: 'htl@example.com',
             type: PartnerType::ADIL,
         );
 
-        $errors = $validator->validate($partner);
+        $errors = $this->validator->validate($partner);
         $this->assertEmpty($errors, (string) $errors);
 
         $this->assertInstanceOf(Partner::class, $partner);
@@ -36,11 +45,7 @@ class PartnerFactoryTest extends KernelTestCase
 
     public function testCreatePartnerInstanceWhenIsCommune(): void
     {
-        self::bootKernel();
-        /** @var ValidatorInterface $validator */
-        $validator = static::getContainer()->get(ValidatorInterface::class);
-        $territory = new Territory();
-        $partner = (new PartnerFactory())->createInstanceFrom(
+        $partner = (new PartnerFactory($this->parameterBag))->createInstanceFrom(
             territory: new Territory(),
             name: 'HTL',
             email: 'htl@example.com',
@@ -48,7 +53,7 @@ class PartnerFactoryTest extends KernelTestCase
             insee: '99000, 99001'
         );
 
-        $errors = $validator->validate($partner);
+        $errors = $this->validator->validate($partner);
         $this->assertEmpty($errors, (string) $errors);
 
         $this->assertInstanceOf(Partner::class, $partner);


### PR DESCRIPTION
## Ticket

#842   

## Description
Avoir le même implémentation technique que l'import de signalement.
Faire les vérifications avant de faire l'import.
Lister tous les pbs et ne pas faire de création. Liste de problèmes à copier-coller à l'équipe impact.
Sinon, processer le fichier, en prenant en compte les nouveaux types et en ajoutant les compétences par défaut

## Changements apportés
* Migration : ajout d'une date de modification et création pour les partenaires
* Changement de la commande import-grid-affectation , du loader lié, et de la définition des header pour prendre en compte tous les changements du ticket #842 
* Changement de la PartnerFactory pour prendre en compte les compétences par défaut

## Pré-requis
Créer un signalement sur la plateforme et récupérer le mail du déclarant ou de l'occupant

Dans l'idéal faire sa propre grille avec ou sans erreurs, mais j'en fournis 2.
La grille 78, correspond à une grille sans erreur.
La grille 44 correspond à une grille avec des erreurs qui doivent être remontées.
[grille_affectation_44.csv](https://github.com/MTES-MCT/histologe/files/11435355/grille_affectation_44.csv)
[grille_affectation_78.csv](https://github.com/MTES-MCT/histologe/files/11435356/grille_affectation_78.csv)


Modifier la grille d'affectation 78 et mettre ce mail à la place du mail d'un des derniers utilisateurs
Définir la variable d'export puis envoyer les 2 fichiers d'exemple sur le bucket

```
export BUCKET_URL=dev.xxxxxxxxxxxxxxxxx
./scripts/upload-s3.sh grid 78
./scripts/upload-s3.sh grid 44
```

## Tests
- [ ] **Jouer la commande `make console app="import-grid-affectation 44"` et vérifier que les erreurs suivantes sont remontées**
- [ ] Un partenaire sans nom --> erreur
- [ ] Deux partenaires avec le même mail --> erreur
- [ ] Deux utilisateurs avec le même mail --> erreur
- [ ] Un utilisateur avec le même mail qu'un partenaire --> erreur
- [ ] Un partenaire avec un mail non valide --> erreur
- [ ] Un partenaire avec un mail de partenaire déjà présent en base --> erreur
- [ ] Un utilisateur avec un mail non valide --> erreur
- [ ] Un utilisateur avec un mail déjà utilisé par un autre utilisateur partenaire --> erreur
- [ ] Un partenaire avec un type pas du tout correct  --> erreur
- [ ] Un utilisateur avec un rôle pas correct  --> erreur
- [ ] Les erreurs doivent être remontées, et rien ne doit avoir été modifié en base
- [ ] **Jouer la commande `make console app="import-grid-affectation 78"` et vérifier les choses suivantes**
- [ ] Le territoire est activé en base. 
- [ ] Les partenaires sont créés. (vérifier le nombre)
- [ ] les partenaires ont une date de création, un type et des compétences par défaut cohérentes
- [ ] Les utilisateurs sont créés. (vérifier le nombre)
- [ ] Les utilisateurs ont reçu des mails d'activation de compte.
- [ ] L'activation de compte marche
- [ ] L'utilisateur correspondant à un mail Usager (cf signalement créé en pré-requis) a bien été transformé en utilisateur partenaire, avec le rôle défini dans le csv. Il a été rattaché au partenaire et au territoire. Il a reçu un mail d'activation de compte, et l'activation fonctionne.
- [ ] Si fichier personnalisé de plus de 250 lignes, vérifier qu'il y a bien des flush() intermédiaires
