### PR TITLE
Correction de l'envoi du champ Adresse à Esabora

### DIFF
--- a/src/Factory/DossierMessageFactory.php
+++ b/src/Factory/DossierMessageFactory.php
@@ -28,7 +28,7 @@ class DossierMessageFactory
             ->setPrenomUsager($signalement->getPrenomOccupant())
             ->setMailUsager($signalement->getMailOccupant())
             ->setTelephoneUsager($signalement->getTelOccupant())
-            ->setAdresseSignalement($signalement->getAdresseOccupant())
+            ->setAdresseSignalement($this->getAdresseWithoutNumero($signalement->getAdresseOccupant()))
             ->setCodepostaleSignalement($signalement->getCpOccupant())
             ->setVilleSignalement($signalement->getVilleOccupant())
             ->setEtageSignalement($signalement->getEtageOccupant())
@@ -47,6 +47,14 @@ class DossierMessageFactory
         preg_match('!\d+!', $adresse, $matches);
 
         return $matches[0] ?? '';
+    }
+
+    private function getAdresseWithoutNumero(string $adresse): string
+    {
+        $numero = $this->getNumeroAdresse($adresse);
+        $adresse = trim(substr($adresse, \strlen($numero)));
+
+        return $adresse;
     }
 
     private function buildCommentaire(Signalement $signalement): string

--- a/tests/Unit/Factory/DossierMessageFactoryTest.php
+++ b/tests/Unit/Factory/DossierMessageFactoryTest.php
@@ -46,7 +46,7 @@ class DossierMessageFactoryTest extends TestCase
             ->setNbEnfantsP6(1)
             ->setNbEnfantsM6(1)
             ->setTelOccupant($faker->phoneNumber())
-            ->setAdresseOccupant($faker->address())
+            ->setAdresseOccupant('25 rue du test')
             ->setEtageOccupant(2)
             ->setVilleOccupant($faker->city())
             ->setCpOccupant($faker->postcode())
@@ -83,5 +83,7 @@ class DossierMessageFactoryTest extends TestCase
         $this->assertStringContainsString('Doc', $dossierMessage->getPiecesJointesObservation());
         $this->assertStringContainsString('Points signalés', $dossierMessage->getDossierCommentaire());
         $this->assertStringContainsString('Etat grave', $dossierMessage->getDossierCommentaire());
+        $this->assertStringContainsString('25', $dossierMessage->getNumeroAdresseSignalement());
+        $this->assertStringContainsString('rue du test', $dossierMessage->getAdresseSignalement());
     }
 }


### PR DESCRIPTION
## Ticket

#1204    

## Description
Suppression du numéro de rue lors de l'envoi du champ Adresse à Esabora

## Changements apportés
* Modification de la fonction d'envoi de champ
* Modification du test associé

## Tests
J'avoue que j'ai testé qu'avec le test unitaire :o
