### PR TITLE
Correction du zoom sur les parties extrêmes de la cartographie

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -22,8 +22,8 @@ const blueIcon = new L.Icon({
     popupAnchor: [1, -34],
     shadowSize: [41, 41]
 });
-const sudOuest = L.latLng(58, -2);
-const nordEst = L.latLng(41, 9);
+const sudOuest = L.latLng(58, -5);
+const nordEst = L.latLng(41, 10);
 const bounds = L.latLngBounds(sudOuest, nordEst);
 const markers = L.markerClusterGroup();
 let map = L.map('map-signalements-view', {


### PR DESCRIPTION
## Ticket

#1203    

## Description
Ajustement des limites de la cartographie pour pouvoir zoomer sur les parties plus extrêmes (pas de correction sur les DOM TOM pour l'instant...)

## Tests
- [ ] Zoomer aux 4 coins de la métropole (+ Corse)
