### PR TITLE
[BO - Partenaires] Modifier nom de la colonne "emails" sur la fiche partenaire

### DIFF
--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -110,7 +110,7 @@
                 <th>Nom</th>
                 <th>Prénom</th>
                 <th>Courriel</th>
-                <th>Emails</th>
+                <th>Notif. emails</th>
                 <th>Statut</th>
                 <th>Rôle</th>
                 <th class="fr-text--right">Actions</th>


### PR DESCRIPTION
## Ticket

#1220    

## Description
Dans le BO, sur le détail d'un partenaire, il faudrait modifier l'en-tête de la colonne Emails en Notif. emails pour plus de clarté

## Changements apportés
* Changement d'un twig

## Tests
- [ ] Aller vérifier sur la page d'un partenaire que le nom de colonne a bien été renommé
