### PR TITLE
[BO - Tableau Bord] Le filtre "sans suivi" prend en compte les suivis partenaires, usagers et automatiques

### DIFF
--- a/assets/vue/components/dashboard/TheHistoDashboardCards.vue
+++ b/assets/vue/components/dashboard/TheHistoDashboardCards.vue
@@ -74,7 +74,7 @@
               <a :href=getSanitizedUrl(sharedState.noSuivis.link)>Sans suivi</a>
             </h3>
             <p class="fr-card__desc">
-              Accédez aux signalements sans nouveau suivi depuis au moins 30 jours.
+              Accédez aux signalements sans nouveau suivi partenaire ou usager depuis au moins 30 jours.
             </p>
           </div>
         </div>

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -67,6 +67,7 @@ class SuiviRepository extends ServiceEntityRepository
             'day_period' => $period,
             'type_suivi_usager' => Suivi::TYPE_USAGER,
             'type_suivi_partner' => Suivi::TYPE_PARTNER,
+            'type_suivi_auto' => Suivi::TYPE_AUTO,
             'status_archived' => Signalement::STATUS_ARCHIVED,
             'status_closed' => Signalement::STATUS_CLOSED,
         ];
@@ -102,6 +103,7 @@ class SuiviRepository extends ServiceEntityRepository
             'day_period' => $period,
             'type_suivi_usager' => Suivi::TYPE_USAGER,
             'type_suivi_partner' => Suivi::TYPE_PARTNER,
+            'type_suivi_auto' => Suivi::TYPE_AUTO,
             'status_archived' => Signalement::STATUS_ARCHIVED,
             'status_closed' => Signalement::STATUS_CLOSED,
         ];
@@ -184,7 +186,7 @@ class SuiviRepository extends ServiceEntityRepository
                 FROM suivi su
                 INNER JOIN signalement s on s.id = su.signalement_id
                 '.$innerPartnerJoin.'
-                WHERE type in (:type_suivi_usager,:type_suivi_partner)
+                WHERE type in (:type_suivi_usager,:type_suivi_partner, :type_suivi_auto)
                 AND s.statut NOT IN (:status_closed, :status_archived)
                 '.$whereTerritory.'
                 '.$wherePartner.'


### PR DESCRIPTION
## Ticket

#743    

## Description
Dans la liste, si on active le filtre "sans suivi depuis x jours", on ne doit pas avoir les signalements qui ont des suivis dans cet intervalle, sauf si ce sont des suivis techniques. Pareil dans le widget du tableau de bord.

## Changements apportés
* Ajout du type Suivi Automatique dans la sous-requête d'exclusion

## Pré-requis

## Tests
- [ ] Avoir des signalements anciens avec des suivis anciens de différents types
- [ ] Vérifier que dans la liste ne s'affichent que les signalements pour lesquels il n'y a pas de suivis de moins de 30 jours hors suivis technique (commande `make console app="ask-feedback-usager"` pour ajouter un suivi technique récent)
- [ ] Sur le tableau de bord, vérifier que le nombre est cohérent
