### PR TITLE
[Signalement] Ajout de message d'erreur quand un fichier est vide

### DIFF
--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -32,6 +32,9 @@ class UploadHandlerService
     public function toTempFolder(UploadedFile $file): self|array
     {
         $originalFilename = pathinfo($file->getClientOriginalName(), \PATHINFO_FILENAME);
+        if (empty($originalFilename) || !$file->isValid()) {
+            return ['error' => 'Erreur lors du téléversement.', 'message' => 'Fichier vide', 'status' => 500];
+        }
         $titre = $originalFilename.'.'.$file->guessExtension();
         // this is needed to safely include the file name as part of the URL
         $safeFilename = $this->slugger->slug($originalFilename);


### PR DESCRIPTION
## Ticket

#899    

## Description
Correction d'erreur Sentry : Ajout de message d'erreur quand un fichier est vide
(je n'ai pas réussi à reproduire l'erreur, donc c'est juste un ajout d'erreur pour éviter que ça plante)

## Tests
- [ ] Vérifier que les fichiers s'envoient toujours dans le formulaire front
