### PR TITLE
[BO - Utilisateur] Création utilisateur pour un déclarant partenaire déjà existant

### DIFF
--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -105,7 +105,7 @@ class AddUserCommand extends Command
             $question = new ChoiceQuestion(
                 'Please select a role (default: ROLE_USER_PARTNER)',
                 User::ROLES,
-                User::ROLES['Super Admin']
+                User::ROLES['Utilisateur']
             );
 
             $role = $helper->ask($input, $output, $question);
@@ -170,7 +170,6 @@ class AddUserCommand extends Command
 
         if (null !== $user && \in_array('ROLE_USAGER', $user->getRoles())) {
             $this->io->text(' > <info>'.$input->getArgument('email').' existe déjà avec le rôle </info>: '.implode(',', $user->getRoles()));
-            $data = [];
             $data['nom'] = $input->getArgument('lastname');
             $data['prenom'] = $input->getArgument('firstname');
             $data['roles'] = \in_array($input->getArgument('role'), User::ROLES) ? $input->getArgument('role') : User::ROLES[$input->getArgument('role')];

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -178,7 +178,6 @@ class AddUserCommand extends Command
             $data['isMailingActive'] = true;
             $data['territory'] = $territory;
             $data['partner'] = $partner;
-            $data['statut'] = User::STATUS_INACTIVE;
             $this->userManager->updateUserFromData($user, $data);
         } else {
             $user = $this->userFactory->createInstanceFrom(

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -165,14 +165,31 @@ class AddUserCommand extends Command
 
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => $territory]);
 
-        $user = $this->userFactory->createInstanceFrom(
-            roleLabel: $input->getArgument('role'),
-            partner: $partner,
-            territory: $territory,
-            firstname: $input->getArgument('firstname'),
-            lastname: $input->getArgument('lastname'),
-            email: $input->getArgument('email')
-        );
+        /** @var User $user */
+        $user = $this->userManager->findOneBy(['email' => $input->getArgument('email')]);
+
+        if (null !== $user && \in_array('ROLE_USAGER', $user->getRoles())) {
+            $this->io->text(' > <info>'.$input->getArgument('email').' existe déjà avec le rôle </info>: '.implode(',', $user->getRoles()));
+            $data = [];
+            $data['nom'] = $input->getArgument('lastname');
+            $data['prenom'] = $input->getArgument('firstname');
+            $data['roles'] = \in_array($input->getArgument('role'), User::ROLES) ? $input->getArgument('role') : User::ROLES[$input->getArgument('role')];
+            $data['email'] = $input->getArgument('email');
+            $data['isMailingActive'] = true;
+            $data['territory'] = $territory;
+            $data['partner'] = $partner;
+            $data['statut'] = User::STATUS_INACTIVE;
+            $this->userManager->updateUserFromData($user, $data);
+        } else {
+            $user = $this->userFactory->createInstanceFrom(
+                roleLabel: $input->getArgument('role'),
+                partner: $partner,
+                territory: $territory,
+                firstname: $input->getArgument('firstname'),
+                lastname: $input->getArgument('lastname'),
+                email: $input->getArgument('email')
+            );
+        }
 
         $password = $this->hasher->hashPassword($user, 'histologe');
 
@@ -189,7 +206,8 @@ class AddUserCommand extends Command
         $this->entityManager->persist($user);
         $this->entityManager->flush();
 
-        $this->io->success(sprintf('%s was successfully created: %s',
+        $this->io->success(sprintf(
+            '%s was successfully created: %s',
             $user->getNomComplet(),
             $user->getEmail()
         ));


### PR DESCRIPTION
## Ticket

#1173    

## Description
Dans la page partenaire, et dans la commande add-user, si un utilisateur existe déjà en tant qu'usager, on peut "l'ajouter" en tant que partenaire, c'est-à-dire changer son rôle et lui attribuer territoire et partenaire. 

## Changements apportés
* Changement du PartnerController
* Changement de AddUserCommand

## Tests
- [ ] Créer un signalement en tant qu'occupant ou déclarant, retenir son adresse mail
- [ ] Se connecter sur le BO, et dans la page Partenaire, ajouter un utilisateur avec cette adresse mail
- [ ] Vérifier que l'utilisateur peut être ajouté, qu'il reçoit un mail, que dans la base son rôle, statut etc. soient bons
- [ ] Recréer un signalement avec une nouvelle adresse mail
- [ ] Ajouter cet usager en utilisateur partenaire grâce à la commande `make console app="add-user"`
- [ ] Faire les mêmes vérifications
