### PR TITLE
[BO - Cartographie] Erreur lors du choix d'un statut pour un partenaire

### DIFF
--- a/src/Controller/Back/CartographieController.php
+++ b/src/Controller/Back/CartographieController.php
@@ -43,8 +43,7 @@ class CartographieController extends AbstractController
                 'signalements' => $signalementRepository->findAllWithGeoData(
                     $user,
                     $filters,
-                    (int) $request->get('offset'),
-                    $user->getTerritory() ?? null
+                    (int) $request->get('offset')
                 ), ]
             );
         }

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -12,11 +12,12 @@ signalements:
     superficie: 40
     loyer: 500
     phone_number: 0621127284
-    cp_occupant: "13013"
+    adresse_occupant: "3 rue Mars"
+    cp_occupant: "13015"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-1"
-    geoloc: "{\"lat\":\"5.415151\",\"lng\":\"43.358246\"}"
+    geoloc: "{\"lng\":\"43.3426152\",\"lat\":\"5.3711848\"}"
     score: 100
     etage_occupant: "A"
     escalier_occupant: "1"
@@ -53,13 +54,14 @@ signalements:
     superficie: 100
     loyer: 1000
     phone_number: 0621127285
-    cp_occupant: "04700"
+    adresse_occupant: "380 Av. des Alpes"
+    cp_occupant: "01170"
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 6
     motif_cloture: 'NON_DECENCE'
     reference: "2022-2"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"46.3370155\",\"lat\":\"6.060438\"}"
     score: 5.420054200542
     insee_occupant: "01173"
     type_energie_logement: "Electrique"
@@ -97,12 +99,13 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "14 Pl. Sébastopol"
+    cp_occupant: "13004"
     ville_occupant: "Marseille"
     statut: 6
     motif_cloture: 'NON_DECENCE'
     reference: "2022-3"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2928291\",\"lat\":\"5.3695447\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -141,11 +144,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "5 rue Fauchier"
+    cp_occupant: "13002"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-4"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2928291\",\"lat\":\"5.3695447\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -183,11 +187,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "255 Av. du Prado"
+    cp_occupant: "13008"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-5"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2909138\",\"lat\":\"5.3719882\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -225,11 +230,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "13 Rue Chape"
+    cp_occupant: "13004"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-6"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2996767\",\"lat\":\"5.3876584\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -267,11 +273,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "65 Bd Longchamp"
+    cp_occupant: "13001"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-7"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2996767\",\"lat\":\"5.3876584\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -309,11 +316,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "50 Rue Monte Cristo"
+    cp_occupant: "13005"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-8"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2996767\",\"lat\":\"5.3876584\"}"
     created_at: "2022-03-08 17:06:33"
     score: 100
     etage_occupant: "0"
@@ -352,11 +360,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "87 Rue Saint-Savournin"
+    cp_occupant: "13005"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-9"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2996767\",\"lat\":\"5.3876584\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -394,11 +403,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
-    cp_occupant: "13003"
+    adresse_occupant: "Square Narvick, Esp. Saint-Charles"
+    cp_occupant: "13001"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-10"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.301004\",\"lat\":\"5.3798692\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -436,11 +446,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
+    adresse_occupant: "5 Av. Rostand"
     cp_occupant: "13003"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2022-11"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.3117791\",\"lat\":\"5.3755551\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -478,13 +489,14 @@ signalements:
     superficie: 100
     loyer: 1000
     phone_number: 0621127285
-    cp_occupant: "01700"
+    adresse_occupant: "333 Av. de la Gare"
+    cp_occupant: "01170"
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 6
     motif_cloture: 'TRAVAUX_FAITS_OU_EN_COURS'
     reference: "2022-12"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"46.3343579\",\"lat\":\"6.0549235\"}"
     score: 5.420054200542
     insee_occupant: "01173"
     type_energie_logement: "Electrique"
@@ -522,13 +534,14 @@ signalements:
     superficie: 100
     loyer: 1000
     phone_number: 0621127285
-    cp_occupant: "01700"
+    adresse_occupant: "214 Pl. Perdtemps"
+    cp_occupant: "01170"
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 6
     motif_cloture: 'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE'
     reference: "2022-13"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"46.3343579\",\"lat\":\"6.0549235\"}"
     score: 5.420054200542
     insee_occupant: "01173"
     type_energie_logement: "Electrique"
@@ -567,13 +580,14 @@ signalements:
     superficie: 100
     loyer: 1000
     phone_number: 0621127285
-    cp_occupant: "01700"
+    adresse_occupant: "31 Rue Georges Charpak"
+    cp_occupant: "01170"
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 1
     motif_cloture: 'RESPONSABILITE_DE_L_OCCUPANT'
     reference: "2022-14"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"46.3343579\",\"lat\":\"6.0549235\"}"
     score: 5.420054200542
     insee_occupant: "01173"
     type_energie_logement: "Electrique"
@@ -611,13 +625,14 @@ signalements:
     superficie: 100
     loyer: 1000
     phone_number: 0621127285
-    cp_occupant: "01700"
+    adresse_occupant: "1 Rue de Rogeland"
+    cp_occupant: "01170"
     ville_occupant: "Gex"
     etage_occupant: "5"
     statut: 6
     motif_cloture: 'NON_DECENCE'
     reference: "2023-1"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"46.3343579\",\"lat\":\"6.0549235\"}"
     score: 5.420054200542
     insee_occupant: "01173"
     type_energie_logement: "Electrique"
@@ -652,7 +667,7 @@ signalements:
     etage_occupant: "5"
     statut: 2
     reference: "2023-2"
-    geoloc: "{\"lat\":\"48.862725\", \"lng\":\"2.287592\"}"
+    geoloc: "{\"lng\":\"45.8448649\", \"lat\":\"4.4042316\"}"
     score: 5.420054200542
     insee_occupant: "69001"
     type_energie_logement: "Electrique"
@@ -686,7 +701,7 @@ signalements:
     etage_occupant: "5"
     statut: 2
     reference: "2023-3"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"45.7726408\", \"lat\":\"4.8332996\"}"
     score: 5.420054200542
     insee_occupant: "69381"
     type_energie_logement: "Electrique"
@@ -720,7 +735,7 @@ signalements:
     etage_occupant: "5"
     statut: 2
     reference: "2023-4"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"45.7549087\", \"lat\":\"4.7365062\"}"
     score: 5.420054200542
     insee_occupant: "69205"
     type_energie_logement: "Electrique"
@@ -754,7 +769,7 @@ signalements:
     etage_occupant: "5"
     statut: 2
     reference: "2023-5"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"46.1684594\", \"lat\":\"4.4857661\"}"
     score: 5.420054200542
     insee_occupant: "69054"
     type_energie_logement: "Electrique"
@@ -782,11 +797,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
+    adresse_occupant: "136 Rue Loubon"
     cp_occupant: "13003"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2023-6"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.3117791\", \"lat\":\"5.3755551\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -830,7 +846,7 @@ signalements:
     etage_occupant: "5"
     statut: 2
     reference: "2023-7"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"47.7948182\", \"lat\":\"3.5743749\"}"
     score: 43
     insee_occupant: "89024"
     type_energie_logement: "Electrique"
@@ -873,7 +889,7 @@ signalements:
     etage_occupant: "5"
     statut: 2
     reference: "2023-8"
-    geoloc: "[]"
+    geoloc: "{\"lng\":\"45.777271\", \"lat\":\"3.0812268\"}"
     score: 43
     insee_occupant: "63113"
     type_energie_logement: "Electrique"
@@ -910,11 +926,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
+    adresse_occupant: "147 Bd Baille"
     cp_occupant: "13005"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2023-9"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.2924995\", \"lat\":\"5.3904671\"}"
     score: 100
     etage_occupant: "0"
     escalier_occupant: ""
@@ -949,11 +966,12 @@ signalements:
     superficie: 30
     loyer: 300
     phone_number: 0621127286
+    adresse_occupant: "5 Imp. Madeleine Simon"
     cp_occupant: "13004"
     ville_occupant: "Marseille"
     statut: 2
     reference: "2023-10"
-    geoloc: "{\"lat\":\"5.371573\",\"lng\":\"43.313719\"}"
+    geoloc: "{\"lng\":\"43.3062255\", \"lat\":\"5.3898396\"}"
     score: 80
     etage_occupant: "0"
     escalier_occupant: ""

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -46,7 +46,7 @@ class SignalementRepository extends ServiceEntityRepository
         parent::__construct($registry, Signalement::class);
     }
 
-    public function findAllWithGeoData($user, $options, int $offset, Territory|null $territory): array
+    public function findAllWithGeoData($user, $options, int $offset): array
     {
         $firstResult = $offset;
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -49,42 +49,19 @@ class SignalementRepository extends ServiceEntityRepository
     public function findAllWithGeoData($user, $options, int $offset, Territory|null $territory): array
     {
         $firstResult = $offset;
-        $qb = $this->createQueryBuilder('s');
-        $qb->select('PARTIAL s.{id,details,uuid,reference,nomOccupant,prenomOccupant,adresseOccupant,cpOccupant,
-        inseeOccupant, villeOccupant,score,statut,createdAt,geoloc,territory},
-            PARTIAL a.{id,partner,createdAt},
-            PARTIAL criteres.{id,label},
-            PARTIAL partner.{id,nom}');
 
-        $qb->leftJoin('s.affectations', 'a')
-            ->leftJoin('s.criteres', 'criteres')
-            ->leftJoin('a.partner', 'partner');
-        if ($user) {
-            $qb->andWhere('partner = :partner')->setParameter('partner', $user->getPartner());
-        }
-        if ($territory) {
-            $qb->andWhere('s.territory = :territory')->setParameter('territory', $territory);
+        $qb = $this->findSignalementAffectationQuery($user, $options);
 
-            if (\array_key_exists($territory->getZip(), $options['authorized_codes_insee'])
-            ) {
-                $qb = $this->filterForSpecificAgglomeration(
-                    $qb,
-                    $territory->getZip(),
-                    $options['partner_name'],
-                    $options['authorized_codes_insee']
-                );
-            }
-        }
+        $qb->addSelect('s.geoloc, s.details, s.cpOccupant, s.inseeOccupant');
 
-        $qb = $this->searchFilterService->applyFilters($qb, $options);
-        $qb->addSelect('a', 'partner', 'criteres');
-
-        return $qb->andWhere("JSON_EXTRACT(s.geoloc,'$.lat') != ''")
+        $qb->andWhere("JSON_EXTRACT(s.geoloc,'$.lat') != ''")
             ->andWhere("JSON_EXTRACT(s.geoloc,'$.lng') != ''")
-            ->andWhere('s.statut != 7')
-            ->setFirstResult($firstResult)
-            ->setMaxResults(self::MARKERS_PAGE_SIZE)
-            ->getQuery()->getArrayResult();
+            ->andWhere('s.statut != 7');
+
+        $qb->setFirstResult($firstResult)
+            ->setMaxResults(self::MARKERS_PAGE_SIZE);
+
+        return $qb->getQuery()->getArrayResult();
     }
 
     public function countAll(Territory|null $territory, bool $removeImported = false, bool $removeArchived = false): int
@@ -363,13 +340,13 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(DISTINCT p.id SEPARATOR :group_concat_separator) as affectationPartnerId,
             GROUP_CONCAT(DISTINCT sq.qualification SEPARATOR :group_concat_separator) as qualifications,
             GROUP_CONCAT(DISTINCT sq.status SEPARATOR :group_concat_separator) as qualificationsStatuses')
-            ->leftJoin('s.affectations', 'a')
-            ->leftJoin('a.partner', 'p')
-            ->leftJoin('s.signalementQualifications', 'sq', 'WITH', 'sq.status LIKE \'%AVEREE%\' OR sq.status LIKE \'%CHECK%\'')
-            ->where('s.statut != :status')
-            ->groupBy('s.id')
-            ->setParameter('concat_separator', SignalementAffectationListView::SEPARATOR_CONCAT)
-            ->setParameter('group_concat_separator', SignalementAffectationListView::SEPARATOR_GROUP_CONCAT);
+             ->leftJoin('s.affectations', 'a')
+             ->leftJoin('a.partner', 'p')
+             ->leftJoin('s.signalementQualifications', 'sq', 'WITH', 'sq.status LIKE \'%AVEREE%\' OR sq.status LIKE \'%CHECK%\'')
+             ->where('s.statut != :status')
+             ->groupBy('s.id')
+             ->setParameter('concat_separator', SignalementAffectationListView::SEPARATOR_CONCAT)
+             ->setParameter('group_concat_separator', SignalementAffectationListView::SEPARATOR_GROUP_CONCAT);
 
         if ($user->isTerritoryAdmin()) {
             $qb->andWhere('s.territory = :territory')->setParameter('territory', $user->getTerritory());

--- a/tests/Functional/Controller/CartographieControllerTest.php
+++ b/tests/Functional/Controller/CartographieControllerTest.php
@@ -10,6 +10,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CartographieControllerTest extends WebTestCase
 {
+    private const SUPER_ADMIN = 'admin-01@histologe.fr';
+    private const ADMIN_TERRITOIRE = 'admin-territoire-13-01@histologe.fr';
+    private const PARTNER = 'user-13-01@histologe.fr';
+
     protected function setUp(): void
     {
         self::ensureKernelShutdown();
@@ -66,7 +70,7 @@ class CartographieControllerTest extends WebTestCase
         $user = $userRepository->findOneBy(['email' => $email]);
         $client->loginUser($user);
         $route = $generatorUrl->generate('back_cartographie');
-        $crawler = $client->request('POST', $route, [
+        $client->request('POST', $route, [
             $filter => $terms,
         ]);
 
@@ -75,75 +79,57 @@ class CartographieControllerTest extends WebTestCase
 
     public function provideFilterSearch(): \Generator
     {
-        yield 'Super Admin by statut Nouveau' => ['admin-01@histologe.fr', 'bo-filters-statuses', ['1']];
-        yield 'Resp territoire by statut Nouveau' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-statuses', ['1']];
-        yield 'Partenaire by statut Nouveau' => ['user-13-01@histologe.fr', 'bo-filters-statuses', ['1']];
-
-        yield 'Super Admin by Parc public/prive' => ['admin-01@histologe.fr', 'bo-filters-housetypes', ['1']];
-        yield 'Resp territoire by Parc public/prive' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-housetypes', ['1']];
-        yield 'Partenaire by Parc public/prive' => ['user-13-01@histologe.fr', 'bo-filters-housetypes', ['1']];
-
-        yield 'Super Admin by affectation closed' => ['admin-01@histologe.fr', 'bo-filters-closed_affectation', ['ONE_CLOSED']];
-        yield 'Resp territoire by affectation closed' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-closed_affectation', ['ONE_CLOSED']];
-
-        yield 'Super Admin by city' => ['admin-01@histologe.fr', 'bo-filters-cities', ['Marseille']];
-        yield 'Resp territoire by city' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-cities', ['Marseille']];
-        yield 'Partenaire by city' => ['user-13-01@histologe.fr', 'bo-filters-cities', ['Marseille']];
-
-        yield 'Super Admin by partenaire' => ['admin-01@histologe.fr', 'bo-filters-partners', ['5']];
-        yield 'Resp territoire by partenaire' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-partners', ['5']];
-
-        yield 'Super Admin by critère' => ['admin-01@histologe.fr', 'bo-filters-criteres', ['17']];
-        yield 'Resp territoire by critère' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-criteres', ['17']];
-        yield 'Partenaire by critère' => ['user-13-01@histologe.fr', 'bo-filters-criteres', ['17']];
-
-        yield 'Super Admin by territory' => ['admin-01@histologe.fr', 'bo-filters-territories', ['1']];
-
-        yield 'Super Admin by Search Terms with Reference' => ['admin-01@histologe.fr', 'bo-filters-searchterms', '2022-1'];
-        yield 'Resp territoire by Search Terms with cp Occupant' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-searchterms', '13003'];
-        yield 'Partenaire by Search Terms with cp Occupant 13005' => ['user-13-01@histologe.fr', 'bo-filters-searchterms', '13005'];
-        yield 'Partenaire by Search Terms with city Occupant' => ['user-13-01@histologe.fr', 'bo-filters-searchterms', 'Gex'];
-
-        yield 'Super Admin by Tags' => ['admin-01@histologe.fr', 'bo-filters-tags', ['3']];
-        yield 'Resp territoire by Tags' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-tags', ['3']];
-        yield 'Partenaire by Tags' => ['user-13-01@histologe.fr', 'bo-filters-tags', ['3']];
-
-        yield 'Super Admin by scores' => ['admin-01@histologe.fr', 'bo-filters-scores', ['on' => '3', 'off' => '20']];
-        yield 'Resp territoire by scores' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-scores', ['on' => '3', 'off' => '20']];
-        yield 'Partenaire by scores' => ['user-13-01@histologe.fr', 'bo-filters-scores', ['on' => '3', 'off' => '20']];
-
-        yield 'Super Admin by allocs' => ['admin-01@histologe.fr', 'bo-filters-allocs', ['CAF']];
-        yield 'Resp territoire by allocs' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-allocs', ['CAF']];
-        yield 'Partenaire by allocs' => ['user-13-01@histologe.fr', 'bo-filters-allocs', ['CAF']];
-
-        yield 'Super Admin by avant1949' => ['admin-01@histologe.fr', 'bo-filters-avant1949', ['1']];
-        yield 'Resp territoire by avant1949' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-avant1949', ['1']];
-        yield 'Partenaire by avant1949' => ['user-13-01@histologe.fr', 'bo-filters-avant1949', ['1']];
-
-        yield 'Super Admin by dates' => ['admin-01@histologe.fr', 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
-        yield 'Resp territoire by dates' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
-        yield 'Partenaire by dates' => ['user-13-01@histologe.fr', 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
-
-        yield 'Super Admin by declarants' => ['admin-01@histologe.fr', 'bo-filters-declarants', '15'];
-        yield 'Resp territoire by declarants' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-declarants', '15'];
-        yield 'Partenaire by declarants' => ['user-13-01@histologe.fr', 'bo-filters-declarants', '15'];
-
-        yield 'Super Admin by enfantsM6' => ['admin-01@histologe.fr', 'bo-filters-enfantsM6', ['1']];
-        yield 'Resp territoire by enfantsM6' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-enfantsM6', ['1']];
-        yield 'Partenaire by enfantsM6' => ['user-13-01@histologe.fr', 'bo-filters-enfantsM6', ['1']];
-
-        yield 'Super Admin by interventions' => ['admin-01@histologe.fr', 'bo-filters-interventions', ['0']];
-        yield 'Resp territoire by interventions' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-interventions', ['0']];
-        yield 'Partenaire by interventions' => ['user-13-01@histologe.fr', 'bo-filters-interventions', ['0']];
-
-        yield 'Super Admin by nde' => ['admin-01@histologe.fr', 'bo-filters-nde', ['NDE_AVEREE']];
-
-        yield 'Super Admin by proprios' => ['admin-01@histologe.fr', 'bo-filters-proprios', ['0']];
-        yield 'Resp territoire by proprios' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-proprios', ['0']];
-        yield 'Partenaire by proprios' => ['user-13-01@histologe.fr', 'bo-filters-proprios', ['0']];
-
-        yield 'Super Admin by visites' => ['admin-01@histologe.fr', 'bo-filters-visites', ['0']];
-        yield 'Resp territoire by visites' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-visites', ['0']];
-        yield 'Partenaire by visites' => ['user-13-01@histologe.fr', 'bo-filters-visites', ['0']];
+        yield 'Super Admin by statut Nouveau' => [self::SUPER_ADMIN, 'bo-filters-statuses', ['1']];
+        yield 'Resp territoire by statut Nouveau' => [self::ADMIN_TERRITOIRE, 'bo-filters-statuses', ['1']];
+        yield 'Partenaire by statut Nouveau' => [self::PARTNER, 'bo-filters-statuses', ['1']];
+        yield 'Super Admin by Parc public/prive' => [self::SUPER_ADMIN, 'bo-filters-housetypes', ['1']];
+        yield 'Resp territoire by Parc public/prive' => [self::ADMIN_TERRITOIRE, 'bo-filters-housetypes', ['1']];
+        yield 'Partenaire by Parc public/prive' => [self::PARTNER, 'bo-filters-housetypes', ['1']];
+        yield 'Super Admin by affectation closed' => [self::SUPER_ADMIN, 'bo-filters-closed_affectation', ['ONE_CLOSED']];
+        yield 'Resp territoire by affectation closed' => [self::ADMIN_TERRITOIRE, 'bo-filters-closed_affectation', ['ONE_CLOSED']];
+        yield 'Super Admin by city' => [self::SUPER_ADMIN, 'bo-filters-cities', ['Marseille']];
+        yield 'Resp territoire by city' => [self::ADMIN_TERRITOIRE, 'bo-filters-cities', ['Marseille']];
+        yield 'Partenaire by city' => [self::PARTNER, 'bo-filters-cities', ['Marseille']];
+        yield 'Super Admin by partenaire' => [self::SUPER_ADMIN, 'bo-filters-partners', ['5']];
+        yield 'Resp territoire by partenaire' => [self::ADMIN_TERRITOIRE, 'bo-filters-partners', ['5']];
+        yield 'Super Admin by critère' => [self::SUPER_ADMIN, 'bo-filters-criteres', ['17']];
+        yield 'Resp territoire by critère' => [self::ADMIN_TERRITOIRE, 'bo-filters-criteres', ['17']];
+        yield 'Partenaire by critère' => [self::PARTNER, 'bo-filters-criteres', ['17']];
+        yield 'Super Admin by territory' => [self::SUPER_ADMIN, 'bo-filters-territories', ['1']];
+        yield 'Super Admin by Search Terms with Reference' => [self::SUPER_ADMIN, 'bo-filters-searchterms', '2022-1'];
+        yield 'Resp territoire by Search Terms with cp Occupant' => [self::ADMIN_TERRITOIRE, 'bo-filters-searchterms', '13003'];
+        yield 'Partenaire by Search Terms with cp Occupant 13005' => [self::PARTNER, 'bo-filters-searchterms', '13005'];
+        yield 'Partenaire by Search Terms with city Occupant' => [self::PARTNER, 'bo-filters-searchterms', 'Gex'];
+        yield 'Super Admin by Tags' => [self::SUPER_ADMIN, 'bo-filters-tags', ['3']];
+        yield 'Resp territoire by Tags' => [self::ADMIN_TERRITOIRE, 'bo-filters-tags', ['3']];
+        yield 'Partenaire by Tags' => [self::PARTNER, 'bo-filters-tags', ['3']];
+        yield 'Super Admin by scores' => [self::SUPER_ADMIN, 'bo-filters-scores', ['on' => '3', 'off' => '20']];
+        yield 'Resp territoire by scores' => [self::ADMIN_TERRITOIRE, 'bo-filters-scores', ['on' => '3', 'off' => '20']];
+        yield 'Partenaire by scores' => [self::PARTNER, 'bo-filters-scores', ['on' => '3', 'off' => '20']];
+        yield 'Super Admin by allocs' => [self::SUPER_ADMIN, 'bo-filters-allocs', ['CAF']];
+        yield 'Resp territoire by allocs' => [self::ADMIN_TERRITOIRE, 'bo-filters-allocs', ['CAF']];
+        yield 'Partenaire by allocs' => [self::PARTNER, 'bo-filters-allocs', ['CAF']];
+        yield 'Super Admin by avant1949' => [self::SUPER_ADMIN, 'bo-filters-avant1949', ['1']];
+        yield 'Resp territoire by avant1949' => [self::ADMIN_TERRITOIRE, 'bo-filters-avant1949', ['1']];
+        yield 'Partenaire by avant1949' => [self::PARTNER, 'bo-filters-avant1949', ['1']];
+        yield 'Super Admin by dates' => [self::SUPER_ADMIN, 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
+        yield 'Resp territoire by dates' => [self::ADMIN_TERRITOIRE, 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
+        yield 'Partenaire by dates' => [self::PARTNER, 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
+        yield 'Super Admin by declarants' => [self::SUPER_ADMIN, 'bo-filters-declarants', '15'];
+        yield 'Resp territoire by declarants' => [self::ADMIN_TERRITOIRE, 'bo-filters-declarants', '15'];
+        yield 'Partenaire by declarants' => [self::PARTNER, 'bo-filters-declarants', '15'];
+        yield 'Super Admin by enfantsM6' => [self::SUPER_ADMIN, 'bo-filters-enfantsM6', ['1']];
+        yield 'Resp territoire by enfantsM6' => [self::ADMIN_TERRITOIRE, 'bo-filters-enfantsM6', ['1']];
+        yield 'Partenaire by enfantsM6' => [self::PARTNER, 'bo-filters-enfantsM6', ['1']];
+        yield 'Super Admin by interventions' => [self::SUPER_ADMIN, 'bo-filters-interventions', ['0']];
+        yield 'Resp territoire by interventions' => [self::ADMIN_TERRITOIRE, 'bo-filters-interventions', ['0']];
+        yield 'Partenaire by interventions' => [self::PARTNER, 'bo-filters-interventions', ['0']];
+        yield 'Super Admin by nde' => [self::SUPER_ADMIN, 'bo-filters-nde', ['NDE_AVEREE']];
+        yield 'Super Admin by proprios' => [self::SUPER_ADMIN, 'bo-filters-proprios', ['0']];
+        yield 'Resp territoire by proprios' => [self::ADMIN_TERRITOIRE, 'bo-filters-proprios', ['0']];
+        yield 'Partenaire by proprios' => [self::PARTNER, 'bo-filters-proprios', ['0']];
+        yield 'Super Admin by visites' => [self::SUPER_ADMIN, 'bo-filters-visites', ['0']];
+        yield 'Resp territoire by visites' => [self::ADMIN_TERRITOIRE, 'bo-filters-visites', ['0']];
+        yield 'Partenaire by visites' => [self::PARTNER, 'bo-filters-visites', ['0']];
     }
 }

--- a/tests/Functional/Controller/CartographieControllerTest.php
+++ b/tests/Functional/Controller/CartographieControllerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class CartographieControllerTest extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+    }
+
+    /**
+     * @dataProvider provideUserEmail
+     */
+    public function testCartographieSuccessfullyOrRedirectWithoutError500(string $email): void
+    {
+        $client = static::createClient();
+        /** @var UrlGeneratorInterface $generatorUrl */
+        $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => $email]);
+        $client->loginUser($user);
+        $route = $generatorUrl->generate('back_cartographie');
+        $client->request('GET', $route, [
+            'load_markers' => true,
+        ]);
+        $this->assertLessThan(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $client->getResponse()->getStatusCode(),
+            sprintf('Result value: %d', $client->getResponse()->getStatusCode())
+        );
+    }
+
+    public function provideUserEmail(): \Generator
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $users = $userRepository->findAll();
+        /** @var User $user */
+        foreach ($users as $user) {
+            if ($user->getTerritory()) {
+                yield $user->getEmail() => [$user->getEmail()];
+            }
+        }
+    }
+
+    /**
+     * @dataProvider provideFilterSearch
+     */
+    public function testCartographieWithFilter(string $email, string $filter, string|array $terms)
+    {
+        $client = static::createClient();
+        /** @var UrlGeneratorInterface $generatorUrl */
+        $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => $email]);
+        $client->loginUser($user);
+        $route = $generatorUrl->generate('back_cartographie');
+        $crawler = $client->request('POST', $route, [
+            $filter => $terms,
+        ]);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function provideFilterSearch(): \Generator
+    {
+        yield 'Super Admin by statut Nouveau' => ['admin-01@histologe.fr', 'bo-filters-statuses', ['1']];
+        yield 'Resp territoire by statut Nouveau' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-statuses', ['1']];
+        yield 'Partenaire by statut Nouveau' => ['user-13-01@histologe.fr', 'bo-filters-statuses', ['1']];
+
+        yield 'Super Admin by Parc public/prive' => ['admin-01@histologe.fr', 'bo-filters-housetypes', ['1']];
+        yield 'Resp territoire by Parc public/prive' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-housetypes', ['1']];
+        yield 'Partenaire by Parc public/prive' => ['user-13-01@histologe.fr', 'bo-filters-housetypes', ['1']];
+
+        yield 'Super Admin by affectation closed' => ['admin-01@histologe.fr', 'bo-filters-closed_affectation', ['ONE_CLOSED']];
+        yield 'Resp territoire by affectation closed' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-closed_affectation', ['ONE_CLOSED']];
+
+        yield 'Super Admin by city' => ['admin-01@histologe.fr', 'bo-filters-cities', ['Marseille']];
+        yield 'Resp territoire by city' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-cities', ['Marseille']];
+        yield 'Partenaire by city' => ['user-13-01@histologe.fr', 'bo-filters-cities', ['Marseille']];
+
+        yield 'Super Admin by partenaire' => ['admin-01@histologe.fr', 'bo-filters-partners', ['5']];
+        yield 'Resp territoire by partenaire' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-partners', ['5']];
+
+        yield 'Super Admin by critère' => ['admin-01@histologe.fr', 'bo-filters-criteres', ['17']];
+        yield 'Resp territoire by critère' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-criteres', ['17']];
+        yield 'Partenaire by critère' => ['user-13-01@histologe.fr', 'bo-filters-criteres', ['17']];
+
+        yield 'Super Admin by territory' => ['admin-01@histologe.fr', 'bo-filters-territories', ['1']];
+
+        yield 'Super Admin by Search Terms with Reference' => ['admin-01@histologe.fr', 'bo-filters-searchterms', '2022-1'];
+        yield 'Resp territoire by Search Terms with cp Occupant' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-searchterms', '13003'];
+        yield 'Partenaire by Search Terms with cp Occupant 13005' => ['user-13-01@histologe.fr', 'bo-filters-searchterms', '13005'];
+        yield 'Partenaire by Search Terms with city Occupant' => ['user-13-01@histologe.fr', 'bo-filters-searchterms', 'Gex'];
+
+        yield 'Super Admin by Tags' => ['admin-01@histologe.fr', 'bo-filters-tags', ['3']];
+        yield 'Resp territoire by Tags' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-tags', ['3']];
+        yield 'Partenaire by Tags' => ['user-13-01@histologe.fr', 'bo-filters-tags', ['3']];
+
+        yield 'Super Admin by scores' => ['admin-01@histologe.fr', 'bo-filters-scores', ['on' => '3', 'off' => '20']];
+        yield 'Resp territoire by scores' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-scores', ['on' => '3', 'off' => '20']];
+        yield 'Partenaire by scores' => ['user-13-01@histologe.fr', 'bo-filters-scores', ['on' => '3', 'off' => '20']];
+
+        yield 'Super Admin by allocs' => ['admin-01@histologe.fr', 'bo-filters-allocs', ['CAF']];
+        yield 'Resp territoire by allocs' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-allocs', ['CAF']];
+        yield 'Partenaire by allocs' => ['user-13-01@histologe.fr', 'bo-filters-allocs', ['CAF']];
+
+        yield 'Super Admin by avant1949' => ['admin-01@histologe.fr', 'bo-filters-avant1949', ['1']];
+        yield 'Resp territoire by avant1949' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-avant1949', ['1']];
+        yield 'Partenaire by avant1949' => ['user-13-01@histologe.fr', 'bo-filters-avant1949', ['1']];
+
+        yield 'Super Admin by dates' => ['admin-01@histologe.fr', 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
+        yield 'Resp territoire by dates' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
+        yield 'Partenaire by dates' => ['user-13-01@histologe.fr', 'bo-filters-dates', ['on' => '2023-05-01', 'off' => '2023-05-16']];
+
+        yield 'Super Admin by declarants' => ['admin-01@histologe.fr', 'bo-filters-declarants', '15'];
+        yield 'Resp territoire by declarants' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-declarants', '15'];
+        yield 'Partenaire by declarants' => ['user-13-01@histologe.fr', 'bo-filters-declarants', '15'];
+
+        yield 'Super Admin by enfantsM6' => ['admin-01@histologe.fr', 'bo-filters-enfantsM6', ['1']];
+        yield 'Resp territoire by enfantsM6' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-enfantsM6', ['1']];
+        yield 'Partenaire by enfantsM6' => ['user-13-01@histologe.fr', 'bo-filters-enfantsM6', ['1']];
+
+        yield 'Super Admin by interventions' => ['admin-01@histologe.fr', 'bo-filters-interventions', ['0']];
+        yield 'Resp territoire by interventions' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-interventions', ['0']];
+        yield 'Partenaire by interventions' => ['user-13-01@histologe.fr', 'bo-filters-interventions', ['0']];
+
+        yield 'Super Admin by nde' => ['admin-01@histologe.fr', 'bo-filters-nde', ['NDE_AVEREE']];
+
+        yield 'Super Admin by proprios' => ['admin-01@histologe.fr', 'bo-filters-proprios', ['0']];
+        yield 'Resp territoire by proprios' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-proprios', ['0']];
+        yield 'Partenaire by proprios' => ['user-13-01@histologe.fr', 'bo-filters-proprios', ['0']];
+
+        yield 'Super Admin by visites' => ['admin-01@histologe.fr', 'bo-filters-visites', ['0']];
+        yield 'Resp territoire by visites' => ['admin-territoire-13-01@histologe.fr', 'bo-filters-visites', ['0']];
+        yield 'Partenaire by visites' => ['user-13-01@histologe.fr', 'bo-filters-visites', ['0']];
+    }
+}

--- a/tests/Functional/Controller/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/SignalementListControllerTest.php
@@ -169,7 +169,8 @@ class SignalementListControllerTest extends WebTestCase
     public function provideFilterSearch(): \Generator
     {
         yield 'Search Terms with Reference' => ['bo-filters-searchterms', '2022-1', '1 signalement(s)'];
-        yield 'Search Terms with cp Occupant' => ['bo-filters-searchterms', '13003', '10 signalement(s)'];
+        yield 'Search Terms with cp Occupant' => ['bo-filters-searchterms', '13003', '2 signalement(s)'];
+        yield 'Search Terms with cp Occupant 13005' => ['bo-filters-searchterms', '13005', '3 signalement(s)'];
         yield 'Search Terms with city Occupant' => ['bo-filters-searchterms', 'Gex', '5 signalement(s)'];
         yield 'Search by Territory' => ['bo-filters-territories', ['1'], '5 signalement(s)'];
         yield 'Search by Partner' => ['bo-filters-partners', ['5'], '2 signalement(s)'];


### PR DESCRIPTION
## Ticket

#1218    

## Description
Pour un utilisateur partenaire (pas resp territoire), la carto ne fonctionnait plus lors de l'application d'un filtre sur les statuts. En effet, on utilisait dans le searchFilterService `affectationStatus` (ligne 325) qui n'était pas défini dans la requête initiale de la liste des signalements pour la carto (`SignalementRepository.findAllWithGeoData()`). Cela générait une erreur : https://sentry.incubateur.net/share/issue/e100e4309f7b409dbac74465cd54bff7/
Pour éviter cela, et parce que la requête générée dans `SignalementRepository.findAllWithGeoData()` était en partie dépréciée (PARTIAL), on passe maintenant par `SignalementRepository.findSignalementAffectationQuery()` qui génère la requête de la liste des signalements et qui est compatible avec le searchFilterService. 

## Changements apportés
* Mise à jour des fixtures de signalements pour avoir des vraies adresses et des vraies coordonnées GPS. Attention, partout dans Histologe les latitudes et longitudes semblent être inversées, mais les remettre dans le "bon ordre" implique de modifier tout ce qui se trouve en base cf https://mattermost.incubateur.net/betagouv/pl/3sq175cohj8x5mjcydrxy87kcw
* Simplification de la fonction `findAllWithGeodata` pour passer par `findSignalementAffectationQuery`
* Renommage et légères adaptations du BackCartographieController

## Tests
- [ ] Se connecter en super admin ou en responsable territoire. Afficher la cartographie et faire quelques filtrages dessus, vérifier que l'affichage est cohérent et qu'il n'y a aucune erreur dans le profiler
- [ ] Se connecter avec un utilisateur partenaire auquel sont affectés quelques signalements avec différents statuts
- [ ] Vérifier que la carto s'affiche bien.
- [ ] Utiliser différents filtres (notamment les statuts), vérifier que les résultats affichés sont cohérents et qu'il n'y a pas d'erreur dans le profiler
