### PR TITLE
[BO - Signalement] Suivi automatique clôture signalement - faute d'orthographe

### DIFF
--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -75,7 +75,7 @@ suivis:
   type: 1
 -
   created_by: admin-territoire-13-01@histologe.fr
-  description: "Le signalement à été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
+  description: "Le signalement a été refusé avec le motif suivant: <br>Ne me concerne pas, voir avec la DDT."
   is_public: 1
   signalement: "2022-3"
   type: 1

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -75,7 +75,7 @@ class SuiviFactory
         $motifSuivi = Sanitizer::sanitize($params['motif_suivi']);
 
         return sprintf(
-            'Le signalement à été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
+            'Le signalement a été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
             $params['subject'],
             $params['motif_cloture']->label(),
             $motifSuivi
@@ -89,7 +89,7 @@ class SuiviFactory
             $description = 'Le signalement a été accepté';
         } elseif (isset($params['suivi'])) {
             $motifRejected = Sanitizer::sanitize($params['suivi']);
-            $description = 'Le signalement à été refusé avec le motif suivant:<br> '.$motifRejected;
+            $description = 'Le signalement a été refusé avec le motif suivant:<br> '.$motifRejected;
         }
 
         return $description;

--- a/tests/Unit/Factory/SuiviFactoryTest.php
+++ b/tests/Unit/Factory/SuiviFactoryTest.php
@@ -56,6 +56,6 @@ class SuiviFactoryTest extends KernelTestCase
         $this->assertEquals(Suivi::TYPE_PARTNER, $suivi->getType());
         $this->assertInstanceOf(UserInterface::class, $suivi->getCreatedBy());
         $this->assertTrue(str_contains($suivi->getDescription(), MotifCloture::tryFrom('INSALUBRITE')->label()));
-        $this->assertTrue(str_contains($suivi->getDescription(), 'Le signalement à été cloturé pour'));
+        $this->assertTrue(str_contains($suivi->getDescription(), 'Le signalement a été cloturé pour'));
     }
 }


### PR DESCRIPTION
## Ticket

#1019    

## Description
Correction d'une faute d'orthographe sur le suivi automatique de cloture

## Changements apportés
* correction d'une faute

## Pré-requis

## Tests
- [ ] Cloturer le signalement
- [ ] Vérifier le suivi
