### PR TITLE
[BO Signalement] Correction informations survol sur documents

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -617,8 +617,7 @@
             {% endfor %}
         </div>
         {% for doc in signalement.documents %}
-            <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-3v signalement-file-item"
-                 style="position: relative;z-index: 1001">
+            <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-3v signalement-file-item">
                 <div class="fr-col-10">
                     <a href="{{ asset('_up/'~doc.file) }}" target="_blank" class="fr-link part-infos-hover"
                        data-user="{{ doc.username ?? 'N/R' }}" data-mail="{{ doc.date ?? 'N/R' }}">{{ doc.titre }}</a>


### PR DESCRIPTION
## Ticket

#627    

## Description
Correction de l'affichage des informations au survol des documents dans la page signalement

## Tests
- [ ] Ajouter des documents et photos et vérifier que l'information au survol s'affiche bien
