### PR TITLE
[Esabora - Intégration SISH] Envoi du nom image

### DIFF
--- a/src/Factory/Esabora/AbstractDossierMessageFactory.php
+++ b/src/Factory/Esabora/AbstractDossierMessageFactory.php
@@ -25,7 +25,7 @@ abstract class AbstractDossierMessageFactory implements DossierMessageFactoryInt
         foreach ($signalement->getPhotos() as $photo) {
             $filepath = $this->uploadHandlerService->getTmpFilepath($photo['file']);
             $piecesJointes[] = [
-                'documentName' => 'Image téléversée',
+                'documentName' => $photo['titre'],
                 'documentSize' => filesize($filepath),
                 'documentContent' => $photo['file'],
             ];

--- a/src/Service/Esabora/EsaboraSISHService.php
+++ b/src/Service/Esabora/EsaboraSISHService.php
@@ -175,8 +175,6 @@ class EsaboraSISHService extends AbstractEsaboraService
             $piecesJointes = array_map(function ($pieceJointe) {
                 $filepath = $this->uploadHandlerService->getTmpFilepath($pieceJointe['documentContent']);
                 $pieceJointe['documentContent'] = base64_encode(file_get_contents($filepath));
-                $pieceJointe['documentSize'] = $pieceJointe['documentSize'];
-                $pieceJointe['documentName'] = $pieceJointe['documentName'];
 
                 return $pieceJointe;
             }, $dossierMessageSISH->getPiecesJointesDocuments());

--- a/src/Service/Esabora/EsaboraSISHService.php
+++ b/src/Service/Esabora/EsaboraSISHService.php
@@ -175,6 +175,8 @@ class EsaboraSISHService extends AbstractEsaboraService
             $piecesJointes = array_map(function ($pieceJointe) {
                 $filepath = $this->uploadHandlerService->getTmpFilepath($pieceJointe['documentContent']);
                 $pieceJointe['documentContent'] = base64_encode(file_get_contents($filepath));
+                $pieceJointe['documentSize'] = $pieceJointe['documentSize'];
+                $pieceJointe['documentName'] = $pieceJointe['documentName'];
 
                 return $pieceJointe;
             }, $dossierMessageSISH->getPiecesJointesDocuments());


### PR DESCRIPTION
## Ticket

#1254    

## Description
Les noms des documents sont manquant à  l'envoi du dossier vers le SAS SISH 

## Changements apportés
* Ajout des informations manquantes dans la construction des pièces jointes
* Remplacement Image téléversé par le vrai nom du fichier 

## Pré-requis

## Tests
- [ ] Créer un signalement dans les bouche du Rhone avec un vrai adresse
- [ ] Affecter le partenaire Partenaire 13-06 ESABORA ARS au signalement
- [ ] Vérifier que le dossier est présent dans le SAS (Identifiant dans matermost)
- [ ] Vérifier le statut du dossier sur le tableau de bord `make clear-pool pool=dashboard.cache`
`

