### PR TITLE
  [BO - Cartographie] Ajout des désordres sur la cartographie

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -45,15 +45,14 @@ const popupTemplate = (options) => {
                             ${options.address} <br>
                             ${options.zip} ${options.city}</small></p>
                         </div>
-                        <div class="fr-col-4 fr-col--top fr-text--center">
-                        <canvas class="fr-col-12" id="gauge-signalement-${options.id}"></canvas>`;
+                        <div class="fr-col-4 fr-mt-1v fr-mb-0 fr-text--center">`;
     TEMPLATE += `<span class="fr-badge fr-badge--info fr-m-0">${parseInt(options.score).toFixed(2)}%</span></div>`;
     TEMPLATE += `<div class="fr-p-3v fr-rounded fr-background-alt--blue-france fr-col-12">${options.details}</div>`;
     TEMPLATE += `<ul class="fr-mt-5v">`;
     options.criteres.forEach(critere => {
-        TEMPLATE += `<li class="">${critere}</li></ul>`
+        TEMPLATE += `<li class="">${critere}</li>`
     })
-    TEMPLATE += `</div>`;
+    TEMPLATE += `</ul></div>`;
 
     return TEMPLATE;
 }
@@ -68,15 +67,16 @@ async function getMarkers(offset) {
         body: new FormData(document.querySelector('form#bo_filters_form'))
     }).then(r => r.json().then(res => {
         let marker;
+        console.log('signalements reçus '+res.signalements);
         if (res.signalements) {
             res.signalements.forEach(signalement => {
+                console.log(signalement);
                 if (!isNaN(parseFloat(signalement.geoloc?.lng)) && !isNaN(parseFloat(signalement.geoloc?.lat))) {
                     let crit = [];
-                    if (signalement.criteres instanceof Array) {
-                        signalement?.criteres?.map(c => {
-                            crit.push(c?.label);
-                        })
+                    if (null !== signalement.desordres){
+                        crit = signalement.desordres.split('|');
                     }
+                    
                     marker = L.marker([signalement.geoloc.lng, signalement.geoloc.lat], {
                         id: signalement.id,
                         status: signalement.statut,

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -52,7 +52,12 @@ class SignalementRepository extends ServiceEntityRepository
 
         $qb = $this->findSignalementAffectationQuery($user, $options);
 
-        $qb->addSelect('s.geoloc, s.details, s.cpOccupant, s.inseeOccupant');
+        $qb->addSelect('s.geoloc, s.details, s.cpOccupant, s.inseeOccupant, GROUP_CONCAT(DISTINCT c.label SEPARATOR :group_concat_separator_1) as desordres');
+        $qb->setParameter('group_concat_separator_1', SignalementExport::SEPARATOR_GROUP_CONCAT);
+
+        if (null === $options['criteres']) {
+            $qb->leftJoin('s.criteres', 'c');
+        }
 
         $qb->andWhere("JSON_EXTRACT(s.geoloc,'$.lat') != ''")
             ->andWhere("JSON_EXTRACT(s.geoloc,'$.lng') != ''")


### PR DESCRIPTION
## Ticket

#1218 
Suite de https://github.com/MTES-MCT/histologe/pull/1243   

## Description
Suite à la correction de la requête faite dans la PR 1243, les désordres avaient disparu. Je les ai remis dans la requête. 

## Changements apportés
* Ajout des désordres dans la requête (le join n'est fait qu' s'il n'y a pas de filtre sur les critères)
* Modification de la carte en JS pour prendre en compte les désordres

## Tests
- [ ] Tester la cartographie avec les différents profils en filtrant et en ne filtrant pas sur les critères
- [ ] Les critères doivent s'afficher, il ne doit pas y avoir d'erreur
