### PR TITLE
[BO - Cloture signalement] Renommer des motifs de clôture

### DIFF
--- a/src/Entity/Enum/MotifCloture.php
+++ b/src/Entity/Enum/MotifCloture.php
@@ -30,10 +30,10 @@ enum MotifCloture: string
             'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE' => 'Abandon de procédure / absence de réponse',
             'DEPART_OCCUPANT' => 'Départ occupant', // renommage de locataire parti
             'INSALUBRITE' => 'Insalubrité',
-            'LOGEMENT_DECENT' => 'Logement décent',
+            'LOGEMENT_DECENT' => "Logement décent / Pas d'infraction",
             'LOGEMENT_VENDU' => 'Logement vendu',
             'NON_DECENCE' => 'Non décence',
-            'PERIL' => 'Péril',
+            'PERIL' => 'Mise en sécurité / Péril',
             'REFUS_DE_VISITE' => 'Refus de visite',
             'REFUS_DE_TRAVAUX' => 'Refus de travaux',
             'RELOGEMENT_OCCUPANT' => 'Relogement occupant', // précise Problème résolu

--- a/src/Service/Statistics/MotifClotureStatisticProvider.php
+++ b/src/Service/Statistics/MotifClotureStatisticProvider.php
@@ -67,7 +67,7 @@ class MotifClotureStatisticProvider
                 'count' => 0,
             ],
             'LOGEMENT_DECENT' => [
-                'label' => 'Logement décent',
+                'label' => "Logement décent / Pas d'infraction",
                 'color' => '#C3FAD5',
                 'count' => 0,
             ],
@@ -87,7 +87,7 @@ class MotifClotureStatisticProvider
                 'count' => 0,
             ],
             'PERIL' => [
-                'label' => 'Péril',
+                'label' => 'Mise en sécurité / Péril',
                 'color' => '#313178',
                 'count' => 0,
             ],


### PR DESCRIPTION
## Ticket

#1251    

## Description
Dans le BO, renommer les motifs de clôture suivants : 
- `Péril` devient `Mise en sécurité / Péril`
- `Logement décent` devient `Logement décent / Pas d'infraction` 


## Changements apportés
* Changement de l'enum MotifCloture, et du MotifClotureStatisticProvider

## Tests
- [ ] Cloturer un signalement, vérifier la liste des motifs de cloture
- [ ] Afficher les statistiques, vérifier la légende des motifs de cloture
