### PR TITLE
[Import de données] Evolution de la commande d'import - nouveau score et situations suspectées

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -187,6 +187,7 @@ class SignalementController extends AbstractController
         ManagerRegistry $doctrine,
         SituationRepository $situationRepository,
         CritereRepository $critereRepository,
+        CriticiteCalculator $criticiteCalculator,
         SignalementQualificationUpdater $signalementQualificationUpdater
     ): Response {
         $title = 'Administration - Edition signalement #'.$signalement->getReference();
@@ -198,8 +199,7 @@ class SignalementController extends AbstractController
             if ($form->isValid()) {
                 $signalement->setModifiedBy($this->getUser());
                 $signalement->setModifiedAt(new DateTimeImmutable());
-                $score = new CriticiteCalculator($signalement, $critereRepository);
-                $signalement->setScore($score->calculateNewCriticite());
+                $signalement->setScore($criticiteCalculator->calculate($signalement));
                 $data = [];
                 if (\array_key_exists('situation', $form->getExtraData())) {
                     $data['situation'] = $form->getExtraData()['situation'];

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -117,7 +117,8 @@ class FrontSignalementController extends AbstractController
         SignalementQualificationFactory $signalementQualificationFactory,
         QualificationStatusService $qualificationStatusService,
         ValidatorInterface $validator,
-        SignalementQualificationUpdater $signalementQualificationUpdater
+        SignalementQualificationUpdater $signalementQualificationUpdater,
+        CriticiteCalculator $criticiteCalculator,
     ): Response {
         if ($this->isCsrfTokenValid('new_signalement', $request->request->get('_token'))
             && $data = $request->get('signalement')) {
@@ -241,8 +242,7 @@ class FrontSignalementController extends AbstractController
             }
             $signalement->setReference($referenceGenerator->generate($signalement->getTerritory()));
 
-            $score = new CriticiteCalculator($signalement, $critereRepository);
-            $signalement->setScore($score->calculateNewCriticite());
+            $signalement->setScore($criticiteCalculator->calculate($signalement));
             $signalementQualificationUpdater->updateQualificationFromScore($signalement);
             $signalement->setCodeSuivi(md5(uniqid()));
 

--- a/src/Repository/CriticiteRepository.php
+++ b/src/Repository/CriticiteRepository.php
@@ -4,7 +4,6 @@ namespace App\Repository;
 
 use App\Entity\Criticite;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -21,15 +20,15 @@ class CriticiteRepository extends ServiceEntityRepository
     }
 
     /**
-     * @throws NonUniqueResultException
+     * @return Criticite[]
      */
-    public function findByLabel(string $label): ?Criticite
+    public function findByLabel(string $label): array
     {
         return $this->createQueryBuilder('c')
             ->where('c.label LIKE :label')
             ->setParameter('label', "%{$label}%")
             ->andWhere('c.isArchive = 0')
             ->getQuery()
-            ->getOneOrNullResult();
+            ->getResult();
     }
 }

--- a/src/Service/Signalement/CriticiteCalculator.php
+++ b/src/Service/Signalement/CriticiteCalculator.php
@@ -5,27 +5,22 @@ namespace App\Service\Signalement;
 use App\Entity\Critere;
 use App\Entity\Criticite;
 use App\Entity\Signalement;
-use App\Repository\CritereRepository;
 
 class CriticiteCalculator
 {
-    private Signalement $signalement;
     private float $scoreBatiment;
     private float $scoreLogement;
     private const MAX_SCORE_BATIMENT = 136;
     private const MAX_SCORE_LOGEMENT = 126;
 
-    public function __construct(Signalement $signalement, private CritereRepository $critereRepository)
+    public function __construct()
     {
-        $this->signalement = $signalement;
         $this->scoreBatiment = 0;
         $this->scoreLogement = 0;
     }
 
-    public function calculateNewCriticite(): float|int
+    public function calculate(Signalement $signalement): float|int
     {
-        $signalement = $this->signalement;
-
         $signalement->getCriticites()->map(function (Criticite $criticite) {
             if (Critere::TYPE_BATIMENT === $criticite->getCritere()->getType()) {
                 $this->scoreBatiment += ($criticite->getNewScore() * $criticite->getCritere()->getNewCoef());

--- a/src/Service/Signalement/CriticiteCalculator.php
+++ b/src/Service/Signalement/CriticiteCalculator.php
@@ -13,14 +13,10 @@ class CriticiteCalculator
     private const MAX_SCORE_BATIMENT = 136;
     private const MAX_SCORE_LOGEMENT = 126;
 
-    public function __construct()
+    public function calculate(Signalement $signalement): float|int
     {
         $this->scoreBatiment = 0;
         $this->scoreLogement = 0;
-    }
-
-    public function calculate(Signalement $signalement): float|int
-    {
         $signalement->getCriticites()->map(function (Criticite $criticite) {
             if (Critere::TYPE_BATIMENT === $criticite->getCritere()->getType()) {
                 $this->scoreBatiment += ($criticite->getNewScore() * $criticite->getCritere()->getNewCoef());

--- a/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
+++ b/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
@@ -10,6 +10,8 @@ use App\Manager\SuiviManager;
 use App\Manager\TagManager;
 use App\Service\Import\Signalement\SignalementImportLoader;
 use App\Service\Import\Signalement\SignalementImportMapper;
+use App\Service\Signalement\CriticiteCalculator;
+use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Faker\Factory;
@@ -28,6 +30,8 @@ class SignalementImportLoaderTest extends KernelTestCase
     private ParameterBagInterface $parameterBag;
     private LoggerInterface $logger;
     private SuiviCreatedSubscriber $suiviCreatedSubscriber;
+    private CriticiteCalculator $criticiteCalculator;
+    private SignalementQualificationUpdater $signalementQualificationUpdater;
 
     protected function setUp(): void
     {
@@ -40,6 +44,8 @@ class SignalementImportLoaderTest extends KernelTestCase
         $this->parameterBag = self::getContainer()->get(ParameterBagInterface::class);
         $this->logger = self::getContainer()->get(LoggerInterface::class);
         $this->suiviCreatedSubscriber = self::getContainer()->get(SuiviCreatedSubscriber::class);
+        $this->criticiteCalculator = self::getContainer()->get(CriticiteCalculator::class);
+        $this->signalementQualificationUpdater = self::getContainer()->get(SignalementQualificationUpdater::class);
 
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
     }
@@ -59,6 +65,8 @@ class SignalementImportLoaderTest extends KernelTestCase
             $this->entityManager,
             $this->parameterBag,
             $this->logger,
+            $this->criticiteCalculator,
+            $this->signalementQualificationUpdater,
         );
 
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '01']);

--- a/tests/Functional/Service/Signalement/CriticiteCalculatorTest.php
+++ b/tests/Functional/Service/Signalement/CriticiteCalculatorTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Tests\Functional\Service\Signalement;
 
-use App\Entity\Critere;
 use App\Entity\Signalement;
 use App\Service\Signalement\CriticiteCalculator;
 use Doctrine\ORM\EntityManagerInterface;
@@ -24,11 +23,9 @@ class CriticiteCalculatorTest extends KernelTestCase
     public function testCalculateBothScoreOnSignalement()
     {
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-        $critereRepository = $this->entityManager->getRepository(Critere::class);
         $signalement = $signalementRepository->find(1);
 
-        $score = new CriticiteCalculator($signalement, $critereRepository);
-        $newScore = $score->calculateNewCriticite();
+        $newScore = (new CriticiteCalculator())->calculate($signalement);
         $this->assertIsFloat($newScore);
         $this->assertLessThan(101, $newScore);
         $this->assertEquals(2.87, round($newScore, 2));


### PR DESCRIPTION
## Ticket

#1206    

## Description
Evolution de la commande d'import de signalement avec prise en compte des :
* Situation(s) suspectée(s)
* Nouvel algo de criticité dans l'import des signalement

## Changements apportés
* Modification de `CriticiteCalculator` afin de l'utiliser en tant que service via l'injection de dépendance
* Prise en compte des algo de calcul de score et situations suspectées dans la commande d'import
* CriticiteRepository::findByLabel plus permissif avec envoi d'un tableau de criticité au lieu d'un objet ou null

## Pré-requis
La commande `./scripts/upload-s3.sh signalement 07` a été exécuté, le fichier est déjà sur le bucket de dev

## Tests
- [ ] Créer un nouveau signalement
- [ ] Importer les signalement de l'Ardeche via `$ make console app="import-signalement 07"`