### PR TITLE
[BO - Cartographie] Ajout des désordres sur la cartographie

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -37,6 +37,7 @@ class SignalementRepository extends ServiceEntityRepository
 {
     public const ARRAY_LIST_PAGE_SIZE = 30;
     public const MARKERS_PAGE_SIZE = 9000; // @todo: is high cause duplicate result, the query findAllWithGeoData should be reviewed
+    public const SEPARATOR_GROUP_CONCAT = '|'; // | used in maps.js
 
     public function __construct(
         ManagerRegistry $registry,
@@ -53,7 +54,7 @@ class SignalementRepository extends ServiceEntityRepository
         $qb = $this->findSignalementAffectationQuery($user, $options);
 
         $qb->addSelect('s.geoloc, s.details, s.cpOccupant, s.inseeOccupant, GROUP_CONCAT(DISTINCT c.label SEPARATOR :group_concat_separator_1) as desordres');
-        $qb->setParameter('group_concat_separator_1', SignalementExport::SEPARATOR_GROUP_CONCAT);
+        $qb->setParameter('group_concat_separator_1', self::SEPARATOR_GROUP_CONCAT);
 
         if (null === $options['criteres']) {
             $qb->leftJoin('s.criteres', 'c');


### PR DESCRIPTION
## Ticket

#1218 
#1044 
Suite de https://github.com/MTES-MCT/histologe/pull/1243   

## Description
Suite à la correction de la requête faite dans la PR 1243, les désordres avaient disparu. Je les ai remis dans la requête. 

## Changements apportés
* Ajout des désordres dans la requête (le join n'est fait qu' s'il n'y a pas de filtre sur les critères)
* Modification de la carte en JS pour prendre en compte les désordres

## Tests
- [ ] Tester la cartographie avec les différents profils en filtrant et en ne filtrant pas sur les critères
- [ ] Les critères doivent s'afficher, il ne doit pas y avoir d'erreur
- [ ] Vérifier l'amélioration de performance (#1044 )
