### PR TITLE
[Affectation] Suivi automatique de type technique

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Back;
 
 use App\Entity\Affectation;
 use App\Entity\Signalement;
+use App\Entity\Suivi;
 use App\Entity\User;
 use App\Event\AffectationAnsweredEvent;
 use App\Manager\AffectationManager;
@@ -96,9 +97,12 @@ class AffectationController extends AbstractController
                 && Affectation::STATUS_ACCEPTED === $affectation->getStatut()
             ) {
                 $suiviManager->createSuivi(
-                    user: $user,
+                    user: null,
                     signalement: $signalement,
-                    params: ['description' => $parameterBag->get('suivi_message')['first_accepted_affectation']],
+                    params: [
+                        'description' => $parameterBag->get('suivi_message')['first_accepted_affectation'],
+                        'type' => Suivi::TYPE_TECHNICAL,
+                    ],
                     isPublic: true,
                     flush: true
                 );

--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -10,6 +10,7 @@ use App\Event\AffectationAnsweredEvent;
 use App\Manager\AffectationManager;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
+use App\Manager\UserManager;
 use App\Messenger\EsaboraBus;
 use App\Repository\PartnerRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -77,6 +78,7 @@ class AffectationController extends AbstractController
     #[Route('/{signalement}/{affectation}/{user}/response', name: 'back_signalement_affectation_response', methods: 'POST')]
     public function affectationResponseSignalement(
         SuiviManager $suiviManager,
+        UserManager $userManager,
         ParameterBagInterface $parameterBag,
         Signalement $signalement,
         Affectation $affectation,
@@ -96,12 +98,14 @@ class AffectationController extends AbstractController
             if (1 === $affectationAccepted->count()
                 && Affectation::STATUS_ACCEPTED === $affectation->getStatut()
             ) {
+                $adminEmail = $parameterBag->get('user_system_email');
+                $adminUser = $userManager->findOneBy(['email' => $adminEmail]);
                 $suiviManager->createSuivi(
-                    user: null,
+                    user: $adminUser,
                     signalement: $signalement,
                     params: [
                         'description' => $parameterBag->get('suivi_message')['first_accepted_affectation'],
-                        'type' => Suivi::TYPE_TECHNICAL,
+                        'type' => Suivi::TYPE_AUTO,
                     ],
                     isPublic: true,
                     flush: true

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -19,7 +19,7 @@ class SuiviManager extends Manager
     }
 
     public function createSuivi(
-        User $user,
+        ?User $user,
         Signalement $signalement,
         array $params,
         bool $isPublic = false,


### PR DESCRIPTION
## Ticket

#1245    

## Description
Mise en place du type technique pour les suivis automatiques créés lors de la première acceptation d'affectation

## Tests
- [ ] Faire un signalement, l'affecter à un partenaire, accepter via le partenaire, et vérifier l'émetteur du suivi
