### PR TITLE
1245 : change existing first_acceptation_suivi

### DIFF
--- a/migrations/Version20230531140303.php
+++ b/migrations/Version20230531140303.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Suivi;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+final class Version20230531140303 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription(): string
+    {
+        return 'Set user_system and type auto to first_accepted_affectation suivis';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $adminEmail = $this->container->getParameter('user_system_email');
+        $user = $this->connection->fetchAssociative('SELECT id FROM user WHERE email = \''.$adminEmail.'\'');
+        if ($user) {
+            $request = 'UPDATE suivi SET created_by_id = \''.$user['id'].'\' AND type = \''.Suivi::TYPE_AUTO
+            .'\' WHERE description LIKE \'%<p>Suite à votre signalement, le ou les partenaires compétents%\'';
+            $this->addSql($request);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -90,6 +90,7 @@ class AffectationController extends AbstractController
             && $response = $request->get('signalement-affectation-response')
         ) {
             $status = isset($response['accept']) ? Affectation::STATUS_ACCEPTED : Affectation::STATUS_REFUSED;
+            $oldAffectationStatut = $affectation->getStatut();
             $affectation = $this->affectationManager->updateAffectation($affectation, $user, $status);
             $affectationAccepted = $signalement->getAffectations()->filter(function (Affectation $affectation) {
                 return Affectation::STATUS_ACCEPTED === $affectation->getStatut();
@@ -97,6 +98,7 @@ class AffectationController extends AbstractController
 
             if (1 === $affectationAccepted->count()
                 && Affectation::STATUS_ACCEPTED === $affectation->getStatut()
+                && Affectation::STATUS_WAIT === $oldAffectationStatut
             ) {
                 $adminEmail = $parameterBag->get('user_system_email');
                 $adminUser = $userManager->findOneBy(['email' => $adminEmail]);


### PR DESCRIPTION
## Ticket

#1245    

## Description
Création d'un suivi public si aucune affectation acceptée auparavant, **seulement si le statut précédent de l'affectation était "en attente".**
Migration pour passer au type auto et à l'utilisateur système pour les suivis "première acceptation d'affectation" déjà existants 

## Changements apportés
* Conditionner la création de suivi selon le nombre d'affectation acceptée avant si 0 lors de l'affectation envoyer le mail et au statut "wait" précédemment
* Création d'une migration

## Tests
- [ ] En tant que partenaire, lors de l'acceptation d'une affectation, si c'est la première acceptation, un suivi public est crée 
- [ ] En tant qu'usager, Un mail de `Nouvelle mise à jour de votre signalement !` doit être receptionné, l'usager doit voir le message de suivi sur sa fiche
- [ ] Un mail `Nouvelle mise à jour de votre signalement !` ne doit pas être envoyé lorsque le signalement a déjà des affectations acceptées ou lorsque le statut de l'affectation passe de refusé à accepté
- [ ] Une fois que des suivis de première acceptation sont créés, les changer en base pour les attribuer à des utilisateurs partenaires, et avec un type de suivi 3  (TYPE_PARTNER)
- [ ] Rejouer la migration, vérifier qu'elle s'éxécute bien et que ces suivis sont réattribués à l'utilisateur système et au type auto 1
`symfony console doctrine:migrations:execute --down 'DoctrineMigrations\Version20230531140303'
symfony console doctrine:migrations:execute --up 'DoctrineMigrations\Version20230531140303'`
