### PR TITLE
[QA] Gérer le code déprécié de la commande d'import de signalement

### DIFF
--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -539,7 +539,7 @@ class Signalement
 
     public function setNatureLogement(?string $natureLogement): self
     {
-        $this->natureLogement = mb_strtolower($natureLogement);
+        $this->natureLogement = null !== $natureLogement ? mb_strtolower($natureLogement) : null;
 
         return $this;
     }

--- a/src/Factory/SignalementFactory.php
+++ b/src/Factory/SignalementFactory.php
@@ -93,7 +93,10 @@ class SignalementFactory
             ->setNbChambresLogement((int) $data['nbChambresLogement'])
             ->setNbNiveauxLogement((int) $data['nbNiveauxLogement'])
             ->setNbOccupantsLogement((int) $data['nbOccupantsLogement'])
-            ->setMotifCloture(MotifCloture::tryFrom($data['motifCloture']))
+            ->setMotifCloture(
+                null !== $data['motifCloture']
+                ? MotifCloture::tryFrom($data['motifCloture'])
+                : null)
             ->setClosedAt($data['closedAt'])
             ->setIsFondSolidariteLogement((bool) $data['isFondSolidariteLogement']);
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -146,7 +146,11 @@ class SignalementManager extends AbstractManager
             ->setNbChambresLogement((int) $data['nbChambresLogement'])
             ->setNbNiveauxLogement((int) $data['nbNiveauxLogement'])
             ->setNbOccupantsLogement((int) $data['nbOccupantsLogement'])
-            ->setMotifCloture(MotifCloture::tryFrom($data['motifCloture']))
+            ->setMotifCloture(
+                null !== $data['motifCloture']
+                    ? MotifCloture::tryFrom($data['motifCloture'])
+                    : null
+            )
             ->setClosedAt($data['closedAt'])
             ->setIsFondSolidariteLogement((bool) $data['isFondSolidariteLogement']);
     }

--- a/src/Service/Import/Signalement/SignalementImportMapper.php
+++ b/src/Service/Import/Signalement/SignalementImportMapper.php
@@ -130,7 +130,7 @@ class SignalementImportMapper
         $situations = [];
         foreach ($this->getMapping() as $fileColumn => $fieldColumn) {
             if (\in_array($fileColumn, $columns)) {
-                $fieldValue = 'NSP' !== $data[$fileColumn] ? $data[$fileColumn] : null;
+                $fieldValue = 'NSP' !== $data[$fileColumn] ? $data[$fileColumn] : '';
                 $fieldValue = trim($fieldValue, '"');
                 switch ($fieldColumn) {
                     case 'reference':


### PR DESCRIPTION
## Ticket

#1293    

## Description
Il existe du code déprécié dans l’exécution de la commande `app:import-signalement`

## Changements apportés
* Ne plus passer null dans les fonctions suivantes `mb_strtolower`, `trim` , `Enum::tryFrom`

## Pré-requis
Dans une autre branche, éxécuter la commande `make console app="import-signalement 07 -vv"` afin de constater les warning en local

## Tests
- [ ] Partez d'une base vierge `make create-db`
- [ ] Exécuter une première fois pour la création `make console app="import-signalement 07 -vv"`
- [ ] Exécuter une seconde fois pour les mises à jour `make console app="import-signalement 07 -vv"`
