### PR TITLE
[Intégration SISH] envoyer premier suivi partenaire #1291

### DIFF
--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -157,8 +157,15 @@ suivis:
   type: 1
 -
   created_by: admin-territoire-13-01@histologe.fr
-  description: "Ceci est vieux suivi de partenaire 13-01"
+  description: "Ceci est le premier suivi de partenaire 13-01"
   created_at: "2023-01-10 17:06:33"
+  is_public: 1
+  signalement: "2023-15"
+  type: 3
+-
+  created_by: admin-territoire-13-01@histologe.fr
+  description: "Ceci est le dernier suivi de partenaire 13-01"
+  created_at: "2023-02-10 17:06:33"
   is_public: 1
   signalement: "2023-15"
   type: 3

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -321,4 +321,20 @@ class SuiviRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    public function findFirstSuiviBy(Signalement $signalement, string $typeSuivi): ?Suivi
+    {
+        $qb = $this->createQueryBuilder('s');
+        $qb->where('s.signalement = :signalement')
+            ->andWhere('s.type = :type')
+            ->orderBy('s.createdAt', 'ASC')
+            ->setMaxResults(1)
+            ->setParameter('signalement', $signalement)
+            ->setParameter('type', $typeSuivi);
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
 }

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -77,11 +77,7 @@ trait FixturesHelper
                     'date' => '02.12.2022',
                 ],
             ])
-            ->addSuivi((new Suivi())
-                ->setType(Suivi::TYPE_AUTO)
-                ->setDescription('Signalement validé')
-                ->setCreatedBy(new User())
-            );
+            ->addSuivi($this->getSuiviPartner());
 
         $partner = (new Partner())
             ->setNom($faker->company())
@@ -90,5 +86,14 @@ trait FixturesHelper
             ->setType($partnerType);
 
         return (new Affectation())->setSignalement($signalement)->setPartner($partner);
+    }
+
+    public function getSuiviPartner(): Suivi
+    {
+        return (new Suivi())
+            ->setType(Suivi::TYPE_PARTNER)
+            ->setDescription('Problèmes de condensation et de moisissures')
+            ->setCreatedAt(new \DateTimeImmutable())
+            ->setCreatedBy(new User());
     }
 }

--- a/tests/Functional/Repository/SuiviRepositoryTest.php
+++ b/tests/Functional/Repository/SuiviRepositoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\Functional\Repository;
+
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Repository\SuiviRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SuiviRepositoryTest extends KernelTestCase
+{
+    private SuiviRepository $suiviRepository;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $this->suiviRepository = $this->entityManager->getRepository(Suivi::class);
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    public function testFindFirstSuiviBy(): void
+    {
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-15']);
+        $firstSuivi = $this->suiviRepository->findFirstSuiviBy($signalement, Suivi::TYPE_PARTNER);
+
+        $this->assertStringContainsString('le premier suivi de partenaire 13-01', $firstSuivi->getDescription());
+    }
+}

--- a/tests/Functional/Service/Notification/NotificationCounterTest.php
+++ b/tests/Functional/Service/Notification/NotificationCounterTest.php
@@ -25,6 +25,6 @@ class NotificationCounterTest extends KernelTestCase
 
         $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
         $notificationCount = (new NotificationCounter($notificationRepository))->countUnseenNotification($user);
-        $this->assertEquals(6, $notificationCount);
+        $this->assertEquals(7, $notificationCount);
     }
 }

--- a/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Factory\Esabora;
 
 use App\Entity\Enum\PartnerType;
 use App\Factory\Esabora\DossierMessageSISHFactory;
+use App\Repository\SuiviRepository;
 use App\Service\Esabora\AbstractEsaboraService;
 use App\Service\UploadHandlerService;
 use App\Tests\FixturesHelper;
@@ -18,6 +19,12 @@ class DossierMessageSISHFactoryTest extends TestCase
 
     public function testDossierMessageFactoryIsFullyCreated()
     {
+        $suiviRepositoryMock = $this->createMock(SuiviRepository::class);
+        $suiviRepositoryMock
+            ->expects($this->once())
+            ->method('findFirstSuiviBy')
+            ->willReturn($this->getSuiviPartner());
+
         $uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
         $uploadHandlerServiceMock
             ->expects($this->exactly(2))
@@ -38,6 +45,7 @@ class DossierMessageSISHFactoryTest extends TestCase
             ->willReturn('/bo/signalements/00000000-0000-0000-2022-000000000001');
 
         $dossierMessageFactory = new DossierMessageSISHFactory(
+            $suiviRepositoryMock,
             $uploadHandlerServiceMock,
             $parameterBagMock,
             $urlGeneratorMock


### PR DESCRIPTION
## Ticket

#1291    

## Description
Le premier suivi d'un signalement après acceptation est toujours "Signalement validé" qui n'a très peu de valeurs pour l'ARS.
Il faudrait donc envoyer le premier suivi partenaire s'il existe. 

## Changements apportés
* Ajout de méthode dans SuiviRepository qui envoi le premier suivi selon le type 

## Pré-requis
```bash
$ make mock
$ make worker-start
```

## Tests
- [ ] Affecter ou réaffecter le partenaire **PARTENAIRE 13-06 ESABORA ARS** au signalement **#2023-15**
- [ ] Vérifier que le dossier a bien été envoyé dans la table job_event
- [ ] Vérifier que le champs message concernant l'envoi du dossier 2023-15 contient bien le premier suivi dans le paramètre 
```json 
{
  "\\": "...."
  "signalementCommentaire": "Ceci est le premier suivi de partenaire 13-01",
   "\\": "...."
}
```