### PR TITLE
[Intégration SISH] envoyer heure française plutôt qu'heure UTC

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -8,4 +8,12 @@ use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
+
+    public const DEFAULT_TIMEZONE = 'Europe/Paris';
+
+    public function boot(): void
+    {
+        parent::boot();
+        date_default_timezone_set(self::DEFAULT_TIMEZONE);
+    }
 }


### PR DESCRIPTION
## Ticket

#1290   
#739

## Description
Toute l'application est configuré en heure UTC

## Changements apportés
* MAJ Kernel avec timezone par défaut

## Pré-requis
```bash
$ make mock
$ make worker-start
```

## Tests
- [ ] Créer un signalement et valider le (vérifier que la date est bien sur une timezone FR)
- [ ] Affecter ou réaffecter le partenaire **PARTENAIRE 13-06 ESABORA ARS** au signalement **#2023-15**
- [ ] Vérifier que le dossier a bien été envoyé dans la table job_event
- [ ] Vérifier que le champs message concernant l'envoi du dossier 2023-15 contient bien l'heure FR

```json 
{
  "\\": "...."
  "sasDateAffectation": "02\/06\/2023 10:40",
   "\\": "...."
}
