### PR TITLE
[Intégration SISH] Mise à jour WS SISH_VISITES_DOSSIER_SAS / SISH_ARRETES_DOSSIER_SAS / SISH_ETAT_DOSSIER_SAS

### DIFF
--- a/src/Service/Esabora/Enum/EsaboraStatus.php
+++ b/src/Service/Esabora/Enum/EsaboraStatus.php
@@ -9,4 +9,5 @@ enum EsaboraStatus: string
     case ESABORA_IN_PROGRESS = 'en cours';
     case ESABORA_CLOSED = 'terminé';
     case ESABORA_REFUSED = 'Non importé';
+    case ESABORA_REJECTED = 'Rejeté';
 }

--- a/src/Service/Esabora/Enum/EsaboraStatus.php
+++ b/src/Service/Esabora/Enum/EsaboraStatus.php
@@ -8,6 +8,6 @@ enum EsaboraStatus: string
     case ESABORA_ACCEPTED = 'Importé';
     case ESABORA_IN_PROGRESS = 'en cours';
     case ESABORA_CLOSED = 'terminé';
-    case ESABORA_REFUSED = 'Non importé';
-    case ESABORA_REJECTED = 'Rejeté';
+    case ESABORA_REFUSED = 'Non importé'; // SCHS
+    case ESABORA_REJECTED = 'Rejeté'; // SISH
 }

--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -99,14 +99,11 @@ class EsaboraManager
                 affectation: $affectation,
                 type: InterventionType::fromLabel($dossierVisiteSISH->getVisiteType()),
                 scheduledAt: DateParser::parse($dossierVisiteSISH->getVisiteDate()),
-                registeredAt: DateParser::parse($dossierVisiteSISH->getVisiteDateEnreg()),
-                status: EsaboraStatus::ESABORA_IN_PROGRESS->value === $dossierVisiteSISH->getVisiteEtat()
-                    ? Intervention::STATUS_PLANNED
-                    : Intervention::STATUS_DONE,
+                registeredAt: new \DateTimeImmutable(),
+                status: Intervention::STATUS_DONE,
                 providerName: InterfacageType::ESABORA->value,
                 providerId: $dossierVisiteSISH->getVisiteId(),
                 doneBy: $dossierVisiteSISH->getVisitePar(),
-                details: $dossierVisiteSISH->getVisiteObservations()
             );
 
             $this->interventionRepository->save($newIntervention, true);
@@ -122,11 +119,9 @@ class EsaboraManager
             $intervention = $this->interventionFactory->createInstanceFrom(
                 affectation: $affectation,
                 type: InterventionType::ARRETE_PREFECTORAL,
-                scheduledAt: DateParser::parse($dossierArreteSISH->getArreteDatePresc()),
-                registeredAt: DateParser::parse($dossierArreteSISH->getArreteDate()),
-                status: EsaboraStatus::ESABORA_IN_PROGRESS->value === $dossierArreteSISH->getArreteEtat()
-                    ? Intervention::STATUS_PLANNED
-                    : Intervention::STATUS_DONE,
+                scheduledAt: DateParser::parse($dossierArreteSISH->getArreteDate()),
+                registeredAt: new \DateTimeImmutable(),
+                status: Intervention::STATUS_DONE,
                 providerName: InterfacageType::ESABORA->value,
                 providerId: $dossierArreteSISH->getArreteId(),
                 details: $this->buildDetailArrete($dossierArreteSISH)
@@ -140,12 +135,7 @@ class EsaboraManager
     {
         $intervention
             ->setScheduledAt(DateParser::parse($dossierVisiteSISH->getVisiteDate()))
-            ->setRegisteredAt(DateParser::parse($dossierVisiteSISH->getVisiteDateEnreg()))
-            ->setStatus(EsaboraStatus::ESABORA_IN_PROGRESS->value === $dossierVisiteSISH->getVisiteEtat()
-                ? Intervention::STATUS_PLANNED
-                : Intervention::STATUS_DONE)
-            ->setDoneBy($dossierVisiteSISH->getVisitePar())
-            ->setDetails($dossierVisiteSISH->getVisiteObservations());
+            ->setDoneBy($dossierVisiteSISH->getVisitePar());
 
         $this->interventionRepository->save($intervention, true);
     }
@@ -153,12 +143,9 @@ class EsaboraManager
     private function updateFromDossierArrete(Intervention $intervention, DossierArreteSISH $dossierArreteSISH): void
     {
         $intervention
-            ->setScheduledAt(DateParser::parse($dossierArreteSISH->getArreteDatePresc()))
+            ->setScheduledAt(DateParser::parse($dossierArreteSISH->getArreteDate()))
             ->setDetails($this->buildDetailArrete($dossierArreteSISH))
-            ->setRegisteredAt(DateParser::parse($dossierArreteSISH->getArreteDate()))
-            ->setStatus(EsaboraStatus::ESABORA_IN_PROGRESS->value === $dossierArreteSISH->getArreteEtat()
-                ? Intervention::STATUS_PLANNED
-                : Intervention::STATUS_DONE)
+            ->setStatus(Intervention::STATUS_DONE)
             ->setDetails($this->buildDetailArrete($dossierArreteSISH));
 
         $this->interventionRepository->save($intervention, true);
@@ -166,11 +153,7 @@ class EsaboraManager
 
     private function buildDetailArrete(DossierArreteSISH $dossierArreteSISH): string
     {
-        return sprintf('Commentaire: %s<br>Type arrêté: %s<br>Statut arrêté: %s',
-            $dossierArreteSISH->getArreteCommentaire(),
-            $dossierArreteSISH->getArreteType(),
-            $dossierArreteSISH->getArreteStatut()
-        );
+        return sprintf('Type arrêté: %s', $dossierArreteSISH->getArreteType());
     }
 
     private function shouldBeAcceptedViaEsabora(string $esaboraDossierStatus, int $currentStatus): bool

--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -84,6 +84,15 @@ class EsaboraManager
                     $description = 'refusé via Esabora';
                 }
                 break;
+            case EsaboraStatus::ESABORA_REJECTED->value:
+                if (Affectation::STATUS_REFUSED !== $currentStatus) {
+                    $this->affectationManager->updateAffectation($affectation, $user, Affectation::STATUS_REFUSED);
+                    $description = sprintf(
+                        'refusé via Esabora pour motif suivant: %s',
+                        $dossierResponse->getSasCauseRefus()
+                    );
+                }
+                break;
         }
 
         return $description;

--- a/src/Service/Esabora/Response/DossierPushSISHResponse.php
+++ b/src/Service/Esabora/Response/DossierPushSISHResponse.php
@@ -40,4 +40,9 @@ class DossierPushSISHResponse implements DossierResponseInterface
     {
         return null;
     }
+
+    public function getSasCauseRefus(): ?string
+    {
+        return null;
+    }
 }

--- a/src/Service/Esabora/Response/DossierResponseInterface.php
+++ b/src/Service/Esabora/Response/DossierResponseInterface.php
@@ -9,4 +9,6 @@ interface DossierResponseInterface
     public function getErrorReason(): ?string;
 
     public function getSasEtat(): ?string;
+
+    public function getSasCauseRefus(): ?string;
 }

--- a/src/Service/Esabora/Response/DossierStateSCHSResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSCHSResponse.php
@@ -87,6 +87,6 @@ class DossierStateSCHSResponse implements DossierResponseInterface
 
     public function getSasCauseRefus(): ?string
     {
-        return $this->errorReason;
+        return null;
     }
 }

--- a/src/Service/Esabora/Response/DossierStateSCHSResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSCHSResponse.php
@@ -84,4 +84,9 @@ class DossierStateSCHSResponse implements DossierResponseInterface
     {
         return $this->errorReason;
     }
+
+    public function getSasCauseRefus(): ?string
+    {
+        return $this->errorReason;
+    }
 }

--- a/src/Service/Esabora/Response/Model/DossierArreteSISH.php
+++ b/src/Service/Esabora/Response/Model/DossierArreteSISH.php
@@ -8,24 +8,16 @@ class DossierArreteSISH
     public const REFERENCE_DOSSIER = 1;
     public const DOSS_NUM = 2;
     public const ARRETE_DATE = 3;
-    public const ARRETE_DATE_PRESC = 4;
-    public const ARRETE_COMMENTAIRE = 5;
-    public const ARRETE_NUMERO = 6;
-    public const ARRETE_TYPE = 7;
-    public const ARRETE_ETAT = 8;
-    public const ARRETE_STATUT = 9;
+    public const ARRETE_NUMERO = 4;
+    public const ARRETE_TYPE = 5;
 
     private ?int $arreteId = null;
     private ?string $logicielProvenance = null;
     private ?string $referenceDossier = null;
     private ?string $dossNum = null;
     private ?string $arreteDate = null;
-    private ?string $arreteDatePresc = null;
-    private ?string $arreteCommentaire = null;
     private ?string $arreteNumero = null;
     private ?string $arreteType = null;
-    private ?string $arreteEtat = null;
-    private ?string $arreteStatut = null;
 
     public function __construct(array $item)
     {
@@ -37,12 +29,8 @@ class DossierArreteSISH
                 $this->referenceDossier = $data[self::REFERENCE_DOSSIER];
                 $this->dossNum = $data[self::DOSS_NUM];
                 $this->arreteDate = $data[self::ARRETE_DATE];
-                $this->arreteDatePresc = $data[self::ARRETE_DATE_PRESC];
-                $this->arreteCommentaire = $data[self::ARRETE_COMMENTAIRE];
                 $this->arreteNumero = $data[self::ARRETE_NUMERO];
                 $this->arreteType = $data[self::ARRETE_TYPE];
-                $this->arreteEtat = strtolower($data[self::ARRETE_ETAT]);
-                $this->arreteStatut = $data[self::ARRETE_STATUT];
             }
         }
     }
@@ -72,16 +60,6 @@ class DossierArreteSISH
         return $this->arreteDate;
     }
 
-    public function getArreteDatePresc(): ?string
-    {
-        return $this->arreteDatePresc;
-    }
-
-    public function getArreteCommentaire(): ?string
-    {
-        return $this->arreteCommentaire;
-    }
-
     public function getArreteNumero(): ?string
     {
         return $this->arreteNumero;
@@ -90,15 +68,5 @@ class DossierArreteSISH
     public function getArreteType(): ?string
     {
         return $this->arreteType;
-    }
-
-    public function getArreteEtat(): ?string
-    {
-        return $this->arreteEtat;
-    }
-
-    public function getArreteStatut(): ?string
-    {
-        return $this->arreteStatut;
     }
 }

--- a/src/Service/Esabora/Response/Model/DossierVisiteSISH.php
+++ b/src/Service/Esabora/Response/Model/DossierVisiteSISH.php
@@ -7,26 +7,18 @@ class DossierVisiteSISH
     public const SAS_LOGICIEL_PROVENANCE = 0;
     public const REFERENCE_DOSSIER = 1;
     public const DOSS_NUM = 2;
-    public const VISITE_DATE_ENREG = 3;
-    public const VISITE_DATE = 4;
-    public const VISITE_OBSERVATIONS = 5;
-    public const VISITE_NUM = 6;
-    public const VISITE_TYPE = 7;
-    public const VISITE_STATUT = 8;
-    public const VISITE_ETAT = 9;
-    public const VISITE_PAR = 10;
+    public const VISITE_DATE = 3;
+    public const VISITE_NUM = 4;
+    public const VISITE_TYPE = 5;
+    public const VISITE_PAR = 6;
 
     private ?int $visiteId = null;
     private ?string $sasLogicielProvenance = null;
     private ?string $referenceDossier = null;
     private ?string $dossNum = null;
-    private ?string $visiteDateEnreg = null;
     private ?string $visiteDate = null;
-    private ?string $visiteObservations = null;
     private ?string $visiteNum = null;
     private ?string $visiteType = null;
-    private ?string $visiteStatut = null;
-    private ?string $visiteEtat = null;
     private ?string $visitePar = null;
 
     public function __construct(array $item)
@@ -38,13 +30,9 @@ class DossierVisiteSISH
                 $this->sasLogicielProvenance = $data[self::SAS_LOGICIEL_PROVENANCE];
                 $this->referenceDossier = $data[self::REFERENCE_DOSSIER];
                 $this->dossNum = $data[self::DOSS_NUM];
-                $this->visiteDateEnreg = $data[self::VISITE_DATE_ENREG];
                 $this->visiteDate = $data[self::VISITE_DATE];
-                $this->visiteObservations = $data[self::VISITE_OBSERVATIONS];
                 $this->visiteNum = $data[self::VISITE_NUM];
                 $this->visiteType = $data[self::VISITE_TYPE];
-                $this->visiteStatut = $data[self::VISITE_STATUT];
-                $this->visiteEtat = strtolower($data[self::VISITE_ETAT]);
                 $this->visitePar = $data[self::VISITE_PAR];
             }
         }
@@ -70,19 +58,9 @@ class DossierVisiteSISH
         return $this->dossNum;
     }
 
-    public function getVisiteDateEnreg(): ?string
-    {
-        return $this->visiteDateEnreg;
-    }
-
     public function getVisiteDate(): ?string
     {
         return $this->visiteDate;
-    }
-
-    public function getVisiteObservations(): ?string
-    {
-        return $this->visiteObservations;
     }
 
     public function getVisiteNum(): ?string
@@ -93,16 +71,6 @@ class DossierVisiteSISH
     public function getVisiteType(): ?string
     {
         return $this->visiteType;
-    }
-
-    public function getVisiteStatut(): ?string
-    {
-        return $this->visiteStatut;
-    }
-
-    public function getVisiteEtat(): ?string
-    {
-        return $this->visiteEtat;
     }
 
     public function getVisitePar(): ?string

--- a/tests/Unit/Service/Esabora/Response/DossierArreteSISHCollectionResponseTest.php
+++ b/tests/Unit/Service/Esabora/Response/DossierArreteSISHCollectionResponseTest.php
@@ -19,12 +19,8 @@ class DossierArreteSISHCollectionResponseTest extends TestCase
         $this->assertEquals('00000000-0000-0000-2023-000000000010', $dossiersArreteSISH[0]->getReferenceDossier());
         $this->assertEquals('2023/DD13/0010', $dossiersArreteSISH[0]->getDossNum());
         $this->assertEquals('14/06/2023', $dossiersArreteSISH[0]->getArreteDate());
-        $this->assertEquals('13/06/2023 10:16', $dossiersArreteSISH[0]->getArreteDatePresc());
-        $this->assertStringStartsWith('De nombreuses personnes', $dossiersArreteSISH[0]->getArreteCommentaire());
         $this->assertEquals('2023/DD13/00664', $dossiersArreteSISH[0]->getArreteNumero());
         $this->assertEquals('Arrêté L.511-11 - Suroccupation', $dossiersArreteSISH[0]->getArreteType());
-        $this->assertEquals('en cours', $dossiersArreteSISH[0]->getArreteEtat());
-        $this->assertEquals('A rédiger', $dossiersArreteSISH[0]->getArreteStatut());
 
         $this->assertEquals(200, $dossierArreteSISHCollectionResponse->getStatusCode());
         $this->assertNull($dossierArreteSISHCollectionResponse->getErrorReason());

--- a/tests/Unit/Service/Esabora/Response/DossierVisiteSISHCollectionResponseTest.php
+++ b/tests/Unit/Service/Esabora/Response/DossierVisiteSISHCollectionResponseTest.php
@@ -22,20 +22,10 @@ class DossierVisiteSISHCollectionResponseTest extends TestCase
             $this->assertEquals('2023/DD13/0010', $dossierVisiteSISH->getDossNum());
             $this->assertInstanceOf(
                 \DateTimeImmutable::class,
-                \DateTimeImmutable::createFromFormat('d/m/Y', $dossierVisiteSISH->getVisiteDateEnreg())
-            );
-            $this->assertInstanceOf(
-                \DateTimeImmutable::class,
                 \DateTimeImmutable::createFromFormat('d/m/Y H:i', $dossierVisiteSISH->getVisiteDate())
-            );
-            $this->assertTrue(
-                'Tout est OK' === $dossierVisiteSISH->getVisiteObservations()
-                || null === $dossierVisiteSISH->getVisiteObservations()
             );
             $this->assertNotNull($dossierVisiteSISH->getVisiteNum());
             $this->assertStringContainsString('Visite', $dossierVisiteSISH->getVisiteType());
-            $this->assertStringContainsString('Effectuée', $dossierVisiteSISH->getVisiteStatut());
-            $this->assertEquals('terminé', $dossierVisiteSISH->getVisiteEtat());
             $this->assertTrue(\in_array($dossierVisiteSISH->getVisitePar(), ['ARS', 'SCHS', 'SH', 'STH']));
         }
 

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas.json
@@ -6,12 +6,8 @@
     "Reference_Dossier",
     "SISH_DossNum",
     "SISH_ArreteDate",
-    "SISH_ArreteDatePresc",
-    "SISH_ArreteCommentaire",
     "SISH_ArreteNumero",
-    "SISH_ArreteType",
-    "SISH_ArreteEtat",
-    "SISH_ArreteStatut"
+    "SISH_ArreteType"
   ],
   "keyList": [
     "i1.imdo_id",
@@ -24,12 +20,8 @@
         "00000000-0000-0000-2023-000000000010",
         "2023/DD13/0010",
         "14/06/2023",
-        "13/06/2023 10:16",
-        "De nombreuses personnes vivent dans des conditions de logement précaires, insalubres et indécentes.",
         "2023/DD13/00664",
-        "Arrêté L.511-11 - Suroccupation",
-        "En cours",
-        "A rédiger"
+        "Arrêté L.511-11 - Suroccupation"
       ],
       "keyDataList": [
         29,

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
@@ -21,7 +21,7 @@
         "2023/DD13/0011",
         "5/06/2023",
         "2023/DD13/00664",
-        "Arrêté L.511-11 - Suroccupation",
+        "Arrêté L.511-11 - Suroccupation"
       ],
       "keyDataList": [
         30,

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
@@ -6,12 +6,8 @@
     "Reference_Dossier",
     "SISH_DossNum",
     "SISH_ArreteDate",
-    "SISH_ArreteDatePresc",
-    "SISH_ArreteCommentaire",
     "SISH_ArreteNumero",
-    "SISH_ArreteType",
-    "SISH_ArreteEtat",
-    "SISH_ArreteStatut"
+    "SISH_ArreteType"
   ],
   "keyList": [
     "i1.imdo_id",
@@ -24,12 +20,8 @@
         "00000000-0000-0000-2023-000000000012",
         "2023/DD13/0011",
         "5/06/2023",
-        "14/06/2023 10:16",
-        "De nombreuses personnes vivent dans des conditions de logement précaires, insalubres et indécentes.",
         "2023/DD13/00664",
         "Arrêté L.511-11 - Suroccupation",
-        "Terminé",
-        ""
       ],
       "keyDataList": [
         30,

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas.json
@@ -5,13 +5,9 @@
     "Sas_LogicielProvenance",
     "Reference_Dossier",
     "SISH_DossNum",
-    "SISH_VisiteDateEnreg",
     "SISH_VisiteDate",
-    "SISH_VisiteObservations",
     "SISH_VisiteNum",
     "SISH_VisiteType",
-    "SISH_VisiteStatut",
-    "SISH_VisiteEtat",
     "SISH_VisitePar"
   ],
   "keyList": [
@@ -24,13 +20,9 @@
         "Histologe",
         "00000000-0000-0000-2023-000000000010",
         "2023/DD13/0010",
-        "04/05/2023",
         "03/05/2023 10:16",
-        "Tout est OK",
         "2023/DD13/00664-03/05/2023 10:16",
         "Visite de contrôle",
-        "Effectuée",
-        "Terminé",
         "SH"
       ],
       "keyDataList": [
@@ -43,13 +35,9 @@
         "Histologe",
         "00000000-0000-0000-2023-000000000010",
         "2023/DD13/0010",
-        "14/05/2023",
         "13/05/2023 10:16",
-        null,
         "2023/DD13/00664-13/05/2023 10:16",
         "Visite",
-        "Effectuée",
-        "Terminé",
         "ARS"
       ],
       "keyDataList": [

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas_en_cours.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas_en_cours.json
@@ -5,13 +5,9 @@
     "Sas_LogicielProvenance",
     "Reference_Dossier",
     "SISH_DossNum",
-    "SISH_VisiteDateEnreg",
     "SISH_VisiteDate",
-    "SISH_VisiteObservations",
     "SISH_VisiteNum",
     "SISH_VisiteType",
-    "SISH_VisiteStatut",
-    "SISH_VisiteEtat",
     "SISH_VisitePar"
   ],
   "keyList": [
@@ -25,12 +21,8 @@
         "00000000-0000-0000-2023-000000000012",
         "2023/DD13/0011",
         "05/05/2023",
-        "04/05/2023 10:16",
-        "Tout est OK",
         "2023/DD13/00664-03/05/2023 10:16",
         "Visite de contrôle",
-        "",
-        "En cours",
         "SH"
       ],
       "keyDataList": [
@@ -44,12 +36,8 @@
         "00000000-0000-0000-2023-000000000012",
         "2023/DD13/0011",
         "14/05/2023",
-        "13/05/2023 10:16",
-        null,
         "2023/DD13/00665-13/05/2023 10:16",
         "Visite",
-        "Effectuée",
-        "En cours",
         "ARS"
       ],
       "keyDataList": [


### PR DESCRIPTION
## Ticket

#1289    
#1286 

## Description
Voir spec: [Histologe/Santé Habitat] - Contrat d'interface - version 1.4
> Le web service "SISH_VISITES_DOSSIER_SAS" appelle la multicritère "SISH_VISITES_DOSSIER_SAS". 
Il permet d’obtenir la liste des visites enregistrées et en statut "Effectuée" sur un dossier importé par le sas.
Seules les visites avec le statut "Effectuée" sont retournées.
Si un dossier SISH a été créé depuis le sas mais qu'il ne contient aucune visite effectuée, la liste retournée sera vide.

Nom des colonnes renvoyées : 
    • Sas_LogicielProvenance
    • Reference_Dossier
    • SISH_DossNum
    • ~~SISH_VisiteDateEnreg~~
    • SISH_VisiteDate 
    • ~~SISH_VisiteObservations~~
    • SISH_VisiteNum
    • SISH_VisiteType
    • ~~SISH_VisiteStatut~~
    • ~~SISH_VisiteEtat~~
    • SISH_VisitePar

> Le web service "SISH_ARRETES_DOSSIER_SAS" appelle la multicritère "SISH_ARRETES_DOSSIER_SAS". 
Il permet d’obtenir la liste des arrêtés enregistrés (hors astreinte) sur un dossier importé par le sas.
Si un dossier SISH a été créé depuis le sas mais qu'il ne contient aucun arrêté (ou juste des arrêtés d'astreinte), la liste retournée sera vide.

Nom des colonnes renvoyées : 
    • Sas_LogicielProvenance
    • Reference_Dossier
    • SISH_DossNum
    • SISH_ArreteDate
    • ~~SISH_ArreteDatePresc~~
    • ~~SISH_ArreteCommentaire~~
    • SISH_ArreteNumero
    • SISH_ArreteType
    • ~~SISH_ArreteEtat~~
    • ~~SISH_ArreteStatut~~

## Changements apportés
* Gestion du cas rejeté pour mise à jour affectation depuis SISH
* Mise à jour des mock response selon les specs
* Suppression des attributs obsolètes dans la classe `src/Service/Esabora/Response/Model/DossierArreteSISH.php`
* Suppression des attributs obsolètes dans la classe `src/Service/Esabora/Response/Model/DossierVisiteSISH.php`

## Tests #1289 
- [ ] Créer un signalement avec une adresse de Marseille
- [ ] Mettre à jour le partenaire SISH avec les identifiant de test esabora (voir mattermost)
- [ ] Affecter le partenaire au signalement 
- [ ] Se connecter au SAS et rejeter le dossier avec un motif
- [ ] Lancer la commande ` 2054  make console app="sync-esabora-sish [uuid_signalement]"
 
## Tests #1286 

### Pré-requis
(Je ne sas pas créer de visite dans le SAS donc maj `make create-db`)

```bash
$ make mock
$ make worker-start
```
- [ ] Executer `make console app="sync-intervention-esabora-sish"`
- [ ] Vérifier la table invention s'est bien remplie avec arrête et visite


