### PR TITLE
 [BO - signalement] 1245 : hotfix - create suivi if there is no other affectation accepted

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -98,7 +98,12 @@ class AffectationController extends AbstractController
                 $signalement,
                 '<p>Suite à votre signalement, le ou les partenaires compétents'
             );
-            if (Affectation::STATUS_ACCEPTED === $affectation->getStatut()
+            $affectationAccepted = $signalement->getAffectations()->filter(function (Affectation $affectation) {
+                return Affectation::STATUS_ACCEPTED === $affectation->getStatut();
+            });
+
+            if (1 === $affectationAccepted->count()
+                && Affectation::STATUS_ACCEPTED === $affectation->getStatut()
                 && empty($suiviAffectationAccepted)
             ) {
                 $adminEmail = $parameterBag->get('user_system_email');


### PR DESCRIPTION
## Ticket

#1245    

## Description
Loupée lors de la correction précédente, des signalements avec des affectations ayant été acceptées avant cette nouvelle fonctionnalité se voient créer un suivi de première acceptation d'affectation

## Changements apportés
* Dans le controller, remise en place de la vérification du nombre d'affectation déjà acceptée

## Pré-requis

## Tests
- [ ] Ouvrir un signalement avec des affectations déjà acceptées (et sans ce suivi automatique), par exemple 2022-10
- [ ] Affecter des nouveaux partenaires
- [ ] Se connecter avec un de ces nouveaux partenaires, accepter l'affectation
- [ ] Aucun suivi automatique ne doit être créé, l'usager ne doit pas recevoir de mail
