### PR TITLE
[BO] Classement des listes de territoires et partenaires par ordre alphabétique

### DIFF
--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -76,7 +76,8 @@ class PartnerRepository extends ServiceEntityRepository
     public function findAllList(Territory|null $territory = null)
     {
         $qb = $this->createQueryBuilder('p')
-            ->where('p.isArchive != 1');
+            ->where('p.isArchive != 1')
+            ->orderBy('p.nom', 'ASC');
         if ($territory) {
             $qb->andWhere('p.territory = :territory')->setParameter('territory', $territory);
         }

--- a/src/Repository/TerritoryRepository.php
+++ b/src/Repository/TerritoryRepository.php
@@ -30,7 +30,8 @@ class TerritoryRepository extends ServiceEntityRepository
     public function findAllList()
     {
         $qb = $this->createQueryBuilder('t')
-            ->where('t.isActive = 1');
+            ->where('t.isActive = 1')
+            ->orderBy('t.name', 'ASC');
 
         return $qb->indexBy('t', 't.id')
             ->getQuery()

--- a/templates/_partials/_search_filter_form.html.twig
+++ b/templates/_partials/_search_filter_form.html.twig
@@ -117,8 +117,9 @@
                                 </div>
                                 {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                                     <div class="fr-col-12 fr-col-md-6">
-                                        <label class="fr-label" for="bo-filters-partners"><strong>Filtrer par
-                                                partenaire</strong></label>
+                                        <label class="fr-label" for="bo-filters-partners">
+                                            <strong>Filtrer par partenaire</strong>
+                                        </label>
                                         <select id="bo-filters-partners" class="fr-select" onchange="setBadge(this)">
                                             <option value="">TOUS</option>
                                             <option value="AUCUN">AUCUN</option>
@@ -128,7 +129,7 @@
                                                             class="{% if partner.id in filters.partners %}fr-hidden{% endif %}">{{ partner.nom|upper }}</option>
                                                 {% endfor %}
                                             </optgroup>
-                                            <optgroup label="PARTNERS">
+                                            <optgroup label="PARTENAIRES">
                                                 {% for partner in partners|filter(v=> v.isCommune == 0) %}
                                                     <option value="{{ partner.id }}"
                                                             class="{% if partner.id in filters.partners %}fr-hidden{% endif %}">{{ partner.nom|upper }}</option>


### PR DESCRIPTION
## Ticket

#713    

## Description
Tri des listes de territoires et partenaires par ordre alphabétique

## Pré-requis
`make clear-pool pool=cache.app`

## Tests
- [ ] En tant qu'admin : filtres dans la liste des signalements
- [ ] En tant qu'admin : interface de gestion de partenaires
- [ ] En tant qu'admin : interface de gestion des utilisateurs archivés
- [ ] En tant qu'utilisateur : filtres dans la liste des signalements
