### PR TITLE
[Intégration SISH] Ajouter contrôle sur adresse proprio

### DIFF
--- a/public/js/const.min.js
+++ b/public/js/const.min.js
@@ -4,46 +4,79 @@ Node.prototype.addEventListeners=function(e,t){for(let r of e.split(" "))this.ad
 
 searchAddress=(e,t)=>{
     clearTimeout(idFetchTimeout);
-    idFetchTimeout = setTimeout( () => {
-        if(t.value.length>10)return t.removeEventListener("keyup",searchAddress),
-        fetch("https://api-adresse.data.gouv.fr/search/?q="+t.value).then(
-            (t=>{t.json().then((t=>{let r=e.querySelector("#signalement-adresse-suggestion");r.innerHTML="";for(let a of t.features){let t=document.createElement("div");t.classList.add("fr-col-12","fr-p-3v","fr-text-label--blue-france","fr-adresse-suggestion"),t.innerHTML=a.properties.label,t.addEventListener("click",(()=>{e.querySelector("#signalement_adresseOccupant").value=a.properties.name,e.querySelector("#signalement_cpOccupant").value=a.properties.postcode,e.querySelector("#signalement_villeOccupant").value=a.properties.city,e.querySelector("#signalement-insee-occupant").value=a.properties.citycode,e.querySelector("#signalement-geoloc-lat-occupant").value=a.geometry.coordinates[0],e.querySelector("#signalement-geoloc-lng-occupant").value=a.geometry.coordinates[1],r.innerHTML=""
 
-            let zipOccupant = a.properties.citycode.substr(0, 2)
-            // dirty change because we dont know how to minify this file ; will disappear when refacto
-            if (zipOccupant == '69') {
-                const METROPOLE_RHONES_AUTHORIZED_INSEE_CODES = [
-                    69091, 69096, 69123, 69149, 69199, 69205, 69290, 69259, 69266,
-                    69381, 69382, 69383, 69384, 69385, 69386, 69387, 69388, 69389,
-                    69003, 69029, 69033, 69034, 69040, 69044, 69046, 69271, 69063,
-                    69273, 69068, 69069, 69071, 69072, 69275, 69081, 69276, 69085,
-                    69087, 69088, 69089, 69100, 69279, 69142, 69250, 69116, 69117,
-                    69127, 69282, 69283, 69284, 69143, 69152, 69153, 69163, 69286,
-                    69168, 69191, 69194, 69204, 69207, 69202, 69292, 69293, 69296,
-                    69244, 69256, 69260, 69233, 69278 
-                ];
-                const COR_RHONES_AUTHORIZED_INSEE_CODES = [
-                    69001, 69006, 69008, 69037, 69054, 69060, 69066, 69070, 69075,
-                    69093, 69102, 69107, 69174, 69130, 69160, 69164, 69169, 69181,
-                    69183, 69188, 69200, 69214, 69217, 69225, 69229, 69234, 69240,
-                    69243, 69248, 69254, 69157
-                ];
+    if ("signalement_adresseOccupant" === t.id) {
+        idFetchTimeout = setTimeout( () => {
+            if(t.value.length>10)return t.removeEventListener("keyup",searchAddress),
+                fetch("https://api-adresse.data.gouv.fr/search/?q="+t.value).then(
+                    (t=>{t.json().then((t=>{let r=e.querySelector("#signalement-adresse-suggestion");r.innerHTML="";for(let a of t.features){let t=document.createElement("div");t.classList.add("fr-col-12","fr-p-3v","fr-text-label--blue-france","fr-adresse-suggestion"),t.innerHTML=a.properties.label,t.addEventListener("click",(()=>{e.querySelector("#signalement_adresseOccupant").value=a.properties.name,e.querySelector("#signalement_cpOccupant").value=a.properties.postcode,e.querySelector("#signalement_villeOccupant").value=a.properties.city,e.querySelector("#signalement-insee-occupant").value=a.properties.citycode,e.querySelector("#signalement-geoloc-lat-occupant").value=a.geometry.coordinates[0],e.querySelector("#signalement-geoloc-lng-occupant").value=a.geometry.coordinates[1],r.innerHTML=""
 
-                const RHONES_AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
-                    COR_RHONES_AUTHORIZED_INSEE_CODES
-                );
+                        let zipOccupant = a.properties.citycode.substr(0, 2)
+                        // dirty change because we dont know how to minify this file ; will disappear when refacto
+                        if (zipOccupant == '69') {
+                            const METROPOLE_RHONES_AUTHORIZED_INSEE_CODES = [
+                                69091, 69096, 69123, 69149, 69199, 69205, 69290, 69259, 69266,
+                                69381, 69382, 69383, 69384, 69385, 69386, 69387, 69388, 69389,
+                                69003, 69029, 69033, 69034, 69040, 69044, 69046, 69271, 69063,
+                                69273, 69068, 69069, 69071, 69072, 69275, 69081, 69276, 69085,
+                                69087, 69088, 69089, 69100, 69279, 69142, 69250, 69116, 69117,
+                                69127, 69282, 69283, 69284, 69143, 69152, 69153, 69163, 69286,
+                                69168, 69191, 69194, 69204, 69207, 69202, 69292, 69293, 69296,
+                                69244, 69256, 69260, 69233, 69278
+                            ];
+                            const COR_RHONES_AUTHORIZED_INSEE_CODES = [
+                                69001, 69006, 69008, 69037, 69054, 69060, 69066, 69070, 69075,
+                                69093, 69102, 69107, 69174, 69130, 69160, 69164, 69169, 69181,
+                                69183, 69188, 69200, 69214, 69217, 69225, 69229, 69234, 69240,
+                                69243, 69248, 69254, 69157
+                            ];
 
-                if (RHONES_AUTHORIZED_INSEE_CODES.indexOf(Number(a.properties.citycode)) == -1) {
-                    e.querySelector('#fr-error-text-insee')?.classList?.remove('fr-hidden');
-                } else {
-                    e.querySelector('#fr-error-text-insee')?.classList?.add('fr-hidden');
-                }
+                            const RHONES_AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
+                                COR_RHONES_AUTHORIZED_INSEE_CODES
+                            );
+
+                            if (RHONES_AUTHORIZED_INSEE_CODES.indexOf(Number(a.properties.citycode)) == -1) {
+                                e.querySelector('#fr-error-text-insee')?.classList?.remove('fr-hidden');
+                            } else {
+                                e.querySelector('#fr-error-text-insee')?.classList?.add('fr-hidden');
+                            }
+                        }
+
+                        // Zip codes available for Non Conformité Energétique
+                        isZipForNDE = (zipOccupant == '63' || zipOccupant == '89');
+
+                    })),r.appendChild(t)}}))})
+                ),!1
+        }, 300 );
+    }
+
+    if ("signalement_adresseProprio" === t.id) {
+        idFetchTimeout = setTimeout( () => {
+            if (t.value.length > 10) {
+                t.removeEventListener('keyup', searchAddress)
+                fetch('https://api-adresse.data.gouv.fr/search/?q=' + t.value).then((res) => {
+                    res.json().then((r) => {
+                        let container = e.querySelector('#signalement-adresse-pro-suggestion')
+                        container.innerHTML = '';
+                        for (let feature of r.features) {
+                            let suggestion = document.createElement('div');
+                            suggestion.classList.add(
+                                'fr-col-12',
+                                'fr-p-3v',
+                                'fr-text-label--blue-france',
+                                'fr-adresse-suggestion'
+                            );
+                            suggestion.innerHTML = feature.properties.label;
+                            suggestion.addEventListener('click', () => {
+                                e.querySelector('#signalement_adresseProprio').value = feature.properties.label;
+                                container.innerHTML = '';
+                            })
+                            container.appendChild(suggestion)
+                        }
+                    })
+                })
+                return false;
             }
-
-            // Zip codes available for Non Conformité Energétique
-            isZipForNDE = (zipOccupant == '63' || zipOccupant == '89');
-
-            })),r.appendChild(t)}}))})
-        ),!1
-    }, 300 );
+        }, 300 );
+    }
 };

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -320,7 +320,7 @@ class SignalementType extends AbstractType
                     'class' => 'fr-label',
                 ],
                 'label' => 'Adresse du logement',
-                'help' => "Commencez à entrer votre adresse et cliquez sur l'une des suggestion. Si vous ne trouvez pas votre adresse entrez-la manuellement",
+                'help' => "Commencez à entrer votre adresse et cliquez sur l'une des suggestions. Si vous ne trouvez pas votre adresse, entrez-la manuellement.",
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],
@@ -430,7 +430,7 @@ class SignalementType extends AbstractType
                     'class' => 'fr-label',
                 ],
                 'label' => 'Adresse du propriétaire',
-                'help' => "Commencez à entrer votre adresse et cliquez sur l'une des suggestion. Si vous ne trouvez pas votre adresse entrez-la manuellement",
+                'help' => "Commencez à entrer votre adresse et cliquez sur l'une des suggestions. Si vous ne trouvez pas votre adresse, entrez-la manuellement.",
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -424,16 +424,21 @@ class SignalementType extends AbstractType
                 'attr' => [
                     'class' => 'fr-input',
                     'maxlength' => '200',
+                    'data-fr-adresse-autocomplete' => 'true',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
                 ],
                 'label' => 'Adresse du propriétaire',
+                'help' => "Commencez à entrer votre adresse et cliquez sur l'une des suggestion. Si vous ne trouvez pas votre adresse entrez-la manuellement",
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
                 'required' => false,
             ])
             ->add('telProprio', TelType::class, [
                 'row_attr' => [
-                    'class' => 'fr-input-group',
+                    'class' => 'fr-input-group fr-mt-2w',
                 ],
                 'attr' => [
                     'class' => 'fr-input',

--- a/templates/_partials/_signalement_steps_tabs.html.twig
+++ b/templates/_partials/_signalement_steps_tabs.html.twig
@@ -314,7 +314,12 @@
                                 Merci de renseigner le nom ou la raison sociale du propriétaire du logement.
                             </p>
                         </div>
-                        {{ form_row(form.adresseProprio) }}
+                        {{ form_label(form.adresseProprio) }}
+                        {{ form_help(form.adresseProprio) }}
+                        {{ form_widget(form.adresseProprio) }}
+                        <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france"
+                             id="signalement-adresse-pro-suggestion">
+                        </div>
                         {{ form_row(form.telProprio) }}
                         {{ form_row(form.mailProprio) }}
                     </div>


### PR DESCRIPTION
## Ticket

#1292    

## Description
Esabora a besoin d'avoir des adresses de proprio valide. Jusqu'à maintenant aucune suggestion d’adresse n'est faite sur le champ adresse du propriétaire, il faut donc permettre au formulaire de suggérer des adresses lors l'auto-complétion de ce champs.

## Changements apportés
* Conditionnement de la méthode searchAddress afin de permettre le remplissage sur 1 seul champs au lieu de 3

## Tests
- [ ] Déposer un formulaire avec saisie adresse pro
