### PR TITLE
[Intégration SISH] envoyer heure française plutôt qu'heure UTC

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -4,6 +4,8 @@ twig:
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr
+    date:
+        timezone: 'Europe/Paris'
     paths:
         # point this wherever your images live
         '%kernel.project_dir%/public/img': images

--- a/src/Factory/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Esabora/DossierMessageSISHFactory.php
@@ -19,6 +19,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class DossierMessageSISHFactory extends AbstractDossierMessageFactory
 {
+    public const DEFAULT_TIMEZONE = 'Europe/Paris';
+
     public function __construct(
         private readonly SuiviRepository $suiviRepository,
         private readonly UploadHandlerService $uploadHandlerService,
@@ -67,7 +69,12 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ->setLocalisationLocalisationInsee($signalement->getInseeOccupant())
             ->setSasLogicielProvenance('H')
             ->setReferenceDossier($signalement->getUuid())
-            ->setSasDateAffectation($affectation->getCreatedAt()?->format($formatDateTime))
+            ->setSasDateAffectation(
+                $affectation
+                    ->getCreatedAt()
+                    ?->setTimezone(new \DateTimeZone(self::DEFAULT_TIMEZONE))
+                    ->format($formatDateTime)
+            )
             ->setLocalisationEtage($signalement->getEtageOccupant())
             ->setLocalisationEscalier($signalement->getEscalierOccupant())
             ->setLocalisationNumPorte($signalement->getNumAppartOccupant())

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -8,12 +8,4 @@ use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
-
-    public const DEFAULT_TIMEZONE = 'Europe/Paris';
-
-    public function boot(): void
-    {
-        parent::boot();
-        date_default_timezone_set(self::DEFAULT_TIMEZONE);
-    }
 }


### PR DESCRIPTION
## Ticket

#1290 

## Description
La fonction date de Twig est configuré par défaut sur Europe/Paris et envoi de la date  avec Timezone Europe/Paris à Esabora

## Changements apportés
* Suppression de l'instruction dans le Kernel (voir  #1302) 


## Pré-requis
```bash
$ make mock
$ make worker-start
```

## Tests
- [ ] Créer un signalement et valider le (vérifier que la date est bien sur une timezone FR)
- [ ] Affecter ou réaffecter le partenaire **PARTENAIRE 13-06 ESABORA ARS** au signalement **#2023-15**
- [ ] Vérifier que le dossier a bien été envoyé dans la table job_event
- [ ] Vérifier que le champs message concernant l'envoi du dossier 2023-15 contient bien l'heure FR

```json 
{
  "\\": "...."
  "sasDateAffectation": "02\/06\/2023 10:40",
   "\\": "...."
}