### PR TITLE
[Intégration SISH] Tagger les signalements affectés (sync avec esabora) afin de les cibler lors de la sync

### DIFF
--- a/migrations/Version20230606161945.php
+++ b/migrations/Version20230606161945.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230606161945 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add filed in order to select which signalement need to be sync';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE affectation ADD is_synchronized TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE affectation DROP is_synchronized');
+    }
+}

--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -147,6 +147,8 @@ class AffectationController extends AbstractController
     {
         $partner = $affectation->getPartner();
         if ($partner->getEsaboraToken() && $partner->getEsaboraUrl() && $partner->isEsaboraActive()) {
+            $affectation->setIsSynchronized(true);
+            $this->affectationManager->save($affectation);
             $this->esaboraBus->dispatch($affectation);
         }
     }

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -126,6 +126,7 @@ affectations:
     affected_by: "admin-territoire-13-01@histologe.fr"
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
+    is_synchronized: true
   -
     signalement: 2023-12
     partner: "partenaire-13-05@histologe.fr"
@@ -134,3 +135,4 @@ affectations:
     affected_by: "admin-territoire-13-01@histologe.fr"
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
+    is_synchronized: true

--- a/src/DataFixtures/Loader/LoadAffectationData.php
+++ b/src/DataFixtures/Loader/LoadAffectationData.php
@@ -43,6 +43,7 @@ class LoadAffectationData extends Fixture implements OrderedFixtureInterface
             ->setAffectedBy($this->userRepository->findOneBy(['email' => $row['affected_by']]))
             ->setAnsweredBy($this->userRepository->findOneBy(['email' => $row['affected_by']]))
             ->setAnsweredAt(new \DateTimeImmutable())
+            ->setIsSynchronized($row['is_synchronized'] ?? false)
         ;
 
         if (Affectation::STATUS_CLOSED === $row['statut'] && '' !== $row['motif_cloture']) {

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -38,6 +38,9 @@ class Affectation
     #[ORM\Column(type: 'integer')]
     private int $statut;
 
+    #[ORM\Column(type: 'boolean')]
+    private bool $isSynchronized = false;
+
     #[ORM\ManyToOne(targetEntity: User::class)]
     private ?User $answeredBy;
 
@@ -200,6 +203,18 @@ class Affectation
     public function setTerritory(?Territory $territory): self
     {
         $this->territory = $territory;
+
+        return $this;
+    }
+
+    public function isSynchronized(): bool
+    {
+        return $this->isSynchronized;
+    }
+
+    public function setIsSynchronized(bool $isSynchronized): self
+    {
+        $this->isSynchronized = $isSynchronized;
 
         return $this;
     }

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -81,7 +81,9 @@ class AffectationRepository extends ServiceEntityRepository
         $qb = $qb->innerJoin('a.partner', 'p')
             ->where('p.esaboraUrl IS NOT NULL AND p.esaboraToken IS NOT NULL AND p.isEsaboraActive = 1')
             ->andWhere('p.type = :partner_type')
-            ->setParameter('partner_type', $partnerType);
+            ->andWhere('a.isSynchronized = :is_synchronized')
+            ->setParameter('partner_type', $partnerType)
+            ->setParameter('is_synchronized', true);
 
         if (null !== $uuidSignalement) {
             $qb->innerJoin('a.signalement', 's')

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -23,13 +23,13 @@ class AffectationRepositoryTest extends KernelTestCase
         /** @var AffectationRepository $affectationRepository */
         $affectationRepository = $this->entityManager->getRepository(Affectation::class);
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::ARS);
-        $this->assertCount(2, $affectationsSubscribedToEsabora);
+        $this->assertCount(1, $affectationsSubscribedToEsabora);
         foreach ($affectationsSubscribedToEsabora as $affectationSubscribedToEsabora) {
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }
 
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::COMMUNE_SCHS);
-        $this->assertCount(2, $affectationsSubscribedToEsabora);
+        $this->assertCount(1, $affectationsSubscribedToEsabora);
         foreach ($affectationsSubscribedToEsabora as $affectationSubscribedToEsabora) {
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }


### PR DESCRIPTION
## Ticket

#1321   

## Description
Afin de distinguer les signalements affectés à un partenaire esabora avant ou après la MEP, il est nécessaire de rajouter un tag à la table Affectation

## Changements apportés
* Mise à jour de ta table affectation

## Pré-requis
```bash
make mock
make worker-start
```

## Tests
- [ ]  Test de regression sur les commandes `make console app="sync-esabora-sish"`
- [ ]  Test de regression sur les commandes `make console app="sync-esabora-schs"`
- [ ]  Test de regression sur les commandes `make console app=sync-intervention-esabora-sish`
