### PR TITLE
[BO - Statistiques] Partenaires

### DIFF
--- a/src/Command/UpdateSignalementLastSuiviAtCommand.php
+++ b/src/Command/UpdateSignalementLastSuiviAtCommand.php
@@ -34,7 +34,13 @@ class UpdateSignalementLastSuiviAtCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $queryBuilder = $this->signalementRepository->createQueryBuilderActiveSignalement(removeArchived: true);
         $progressBar = new ProgressBar($output);
-        $progressBar->start($this->signalementRepository->countAll(null, false, true));
+        $progressBar->start($this->signalementRepository->countAll(
+            territory: null,
+            partner: null,
+            removeImported: false,
+            removeArchived: true
+        ));
+
         $count = 0;
         /** @var Signalement $signalement */
         foreach ($queryBuilder->getQuery()->toIterable() as $signalement) {

--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\Annotation\Route;
 #[Route('/bo/statistiques')]
 class BackStatistiquesController extends AbstractController
 {
-    private array $ajaxResult;
+    private array $result;
 
     public function __construct(
         private ListTerritoryStatisticProvider $listTerritoryStatisticProvider,
@@ -49,7 +49,7 @@ class BackStatistiquesController extends AbstractController
     public function filter(Request $request, TerritoryRepository $territoryRepository): Response
     {
         if ($this->getUser()) {
-            $this->ajaxResult = [];
+            $this->result = [];
 
             $territory = $this->getSelectedTerritory($request, $territoryRepository);
             $partner = $this->getSelectedPartner();
@@ -57,29 +57,29 @@ class BackStatistiquesController extends AbstractController
             $this->buildFilterLists($territory);
 
             $globalStatistics = $this->globalBackAnalyticsProvider->getData($territory, $partner);
-            $this->ajaxResult['count_signalement'] = $globalStatistics['count_signalement'];
-            $this->ajaxResult['average_criticite'] = $globalStatistics['average_criticite'];
-            $this->ajaxResult['average_days_validation'] = $globalStatistics['average_days_validation'];
-            $this->ajaxResult['average_days_closure'] = $globalStatistics['average_days_closure'];
-            $this->ajaxResult['count_signalement_refuses'] = $globalStatistics['count_signalement_refuses'];
-            $this->ajaxResult['count_signalement_archives'] = $globalStatistics['count_signalement_archives'];
+            $this->result['count_signalement'] = $globalStatistics['count_signalement'];
+            $this->result['average_criticite'] = $globalStatistics['average_criticite'];
+            $this->result['average_days_validation'] = $globalStatistics['average_days_validation'];
+            $this->result['average_days_closure'] = $globalStatistics['average_days_closure'];
+            $this->result['count_signalement_refuses'] = $globalStatistics['count_signalement_refuses'];
+            $this->result['count_signalement_archives'] = $globalStatistics['count_signalement_archives'];
 
             $statisticsFilters = $this->createFilters($request, $territory, $partner);
             $filteredStatistics = $this->filteredBackAnalyticsProvider->getData($statisticsFilters);
-            $this->ajaxResult['count_signalement_filtered'] = $filteredStatistics['count_signalement_filtered'];
-            $this->ajaxResult['average_criticite_filtered'] = $filteredStatistics['average_criticite_filtered'];
-            $this->ajaxResult['countSignalementPerMonth'] = $filteredStatistics['count_signalement_per_month'];
-            $this->ajaxResult['countSignalementPerPartenaire'] = $filteredStatistics['count_signalement_per_partenaire'];
-            $this->ajaxResult['countSignalementPerSituation'] = $filteredStatistics['count_signalement_per_situation'];
-            $this->ajaxResult['countSignalementPerCriticite'] = $filteredStatistics['count_signalement_per_criticite'];
-            $this->ajaxResult['countSignalementPerStatut'] = $filteredStatistics['count_signalement_per_statut'];
-            $this->ajaxResult['countSignalementPerCriticitePercent'] = $filteredStatistics['count_signalement_per_criticite_percent'];
-            $this->ajaxResult['countSignalementPerVisite'] = $filteredStatistics['count_signalement_per_visite'];
-            $this->ajaxResult['countSignalementPerMotifCloture'] = $filteredStatistics['count_signalement_per_motif_cloture'];
+            $this->result['count_signalement_filtered'] = $filteredStatistics['count_signalement_filtered'];
+            $this->result['average_criticite_filtered'] = $filteredStatistics['average_criticite_filtered'];
+            $this->result['countSignalementPerMonth'] = $filteredStatistics['count_signalement_per_month'];
+            $this->result['countSignalementPerPartenaire'] = $filteredStatistics['count_signalement_per_partenaire'];
+            $this->result['countSignalementPerSituation'] = $filteredStatistics['count_signalement_per_situation'];
+            $this->result['countSignalementPerCriticite'] = $filteredStatistics['count_signalement_per_criticite'];
+            $this->result['countSignalementPerStatut'] = $filteredStatistics['count_signalement_per_statut'];
+            $this->result['countSignalementPerCriticitePercent'] = $filteredStatistics['count_signalement_per_criticite_percent'];
+            $this->result['countSignalementPerVisite'] = $filteredStatistics['count_signalement_per_visite'];
+            $this->result['countSignalementPerMotifCloture'] = $filteredStatistics['count_signalement_per_motif_cloture'];
 
-            $this->ajaxResult['response'] = 'success';
+            $this->result['response'] = 'success';
 
-            return $this->json($this->ajaxResult);
+            return $this->json($this->result);
         }
 
         return $this->json(['response' => 'error'], 400);
@@ -149,14 +149,14 @@ class BackStatistiquesController extends AbstractController
     private function buildFilterLists(?Territory $territory)
     {
         // Tells Vue component if a user can filter through Territoire
-        $this->ajaxResult['can_filter_territoires'] = $this->isGranted('ROLE_ADMIN') ? '1' : '0';
-        $this->ajaxResult['can_filter_archived'] = $this->isGranted('ROLE_ADMIN') ? '1' : '0';
-        $this->ajaxResult['can_see_per_partenaire'] = $this->isGranted('ROLE_ADMIN') || $this->isGranted('ROLE_ADMIN_TERRITORY') ? '1' : '0';
+        $this->result['can_filter_territoires'] = $this->isGranted('ROLE_ADMIN') ? '1' : '0';
+        $this->result['can_filter_archived'] = $this->isGranted('ROLE_ADMIN') ? '1' : '0';
+        $this->result['can_see_per_partenaire'] = $this->isGranted('ROLE_ADMIN') || $this->isGranted('ROLE_ADMIN_TERRITORY') ? '1' : '0';
 
         if ($this->isGranted('ROLE_ADMIN')) {
-            $this->ajaxResult['list_territoires'] = $this->listTerritoryStatisticProvider->getData();
+            $this->result['list_territoires'] = $this->listTerritoryStatisticProvider->getData();
         }
-        $this->ajaxResult['list_communes'] = $this->listCommunesStatisticProvider->getData($territory);
-        $this->ajaxResult['list_etiquettes'] = $this->listTagStatisticProvider->getData($territory);
+        $this->result['list_communes'] = $this->listCommunesStatisticProvider->getData($territory);
+        $this->result['list_etiquettes'] = $this->listTagStatisticProvider->getData($territory);
     }
 }

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -25,6 +25,7 @@ class HomepageController extends AbstractController
         $stats = [];
         $stats['total'] = $signalementRepository->countAll(
             territory: null,
+            partner: null,
             removeImported: true,
             removeArchived: true
         );

--- a/src/Dto/StatisticsFilters.php
+++ b/src/Dto/StatisticsFilters.php
@@ -2,6 +2,7 @@
 
 namespace App\Dto;
 
+use App\Entity\Partner;
 use App\Entity\Territory;
 use DateTime;
 
@@ -16,6 +17,7 @@ class StatisticsFilters
     private bool $countRefused;
     private bool $countArchived;
     private ?Territory $territory;
+    private ?Partner $partner;
 
     public function __construct(
         ?array $communes,
@@ -27,7 +29,8 @@ class StatisticsFilters
         bool $countRefused,
         bool $countArchived,
         ?Territory $territory,
-        ) {
+        ?Partner $partner,
+    ) {
         $this->communes = $communes;
         $this->statut = $statut;
         $this->etiquettes = $etiquettes;
@@ -37,6 +40,7 @@ class StatisticsFilters
         $this->countRefused = $countRefused;
         $this->countArchived = $countArchived;
         $this->territory = $territory;
+        $this->partner = $partner;
     }
 
     public function getCommunes(): ?array
@@ -143,6 +147,18 @@ class StatisticsFilters
     public function setTerritory(?Territory $territory): self
     {
         $this->territory = $territory;
+
+        return $this;
+    }
+
+    public function getPartner(): ?Partner
+    {
+        return $this->partner;
+    }
+
+    public function setPartner(?Partner $partner): self
+    {
+        $this->partner = $partner;
 
         return $this;
     }

--- a/src/Dto/StatisticsFilters.php
+++ b/src/Dto/StatisticsFilters.php
@@ -4,7 +4,6 @@ namespace App\Dto;
 
 use App\Entity\Partner;
 use App\Entity\Territory;
-use DateTime;
 
 class StatisticsFilters
 {
@@ -12,8 +11,8 @@ class StatisticsFilters
     private ?string $statut;
     private array $etiquettes;
     private ?string $type;
-    private DateTime $dateStart;
-    private DateTime $dateEnd;
+    private \DateTime $dateStart;
+    private \DateTime $dateEnd;
     private bool $countRefused;
     private bool $countArchived;
     private ?Territory $territory;
@@ -24,8 +23,8 @@ class StatisticsFilters
         ?string $statut,
         array $etiquettes,
         ?string $type,
-        DateTime $dateStart,
-        DateTime $dateEnd,
+        \DateTime $dateStart,
+        \DateTime $dateEnd,
         bool $countRefused,
         bool $countArchived,
         ?Territory $territory,
@@ -91,24 +90,24 @@ class StatisticsFilters
         return $this;
     }
 
-    public function getDateStart(): ?DateTime
+    public function getDateStart(): ?\DateTime
     {
         return $this->dateStart;
     }
 
-    public function setDateStart(DateTime $dateStart): self
+    public function setDateStart(\DateTime $dateStart): self
     {
         $this->dateStart = $dateStart;
 
         return $this;
     }
 
-    public function getDateEnd(): ?DateTime
+    public function getDateEnd(): ?\DateTime
     {
         return $this->dateEnd;
     }
 
-    public function setDateEnd(DateTime $dateEnd): self
+    public function setDateEnd(\DateTime $dateEnd): self
     {
         $this->dateEnd = $dateEnd;
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -70,7 +70,7 @@ class SignalementRepository extends ServiceEntityRepository
         return $qb->getQuery()->getArrayResult();
     }
 
-    public function countAll(Territory|null $territory, Partner|null $partner, bool $removeImported = false, bool $removeArchived = false): int
+    public function countAll(?Territory $territory, ?Partner $partner, bool $removeImported = false, bool $removeArchived = false): int
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id)');
@@ -109,7 +109,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
-    public function countByStatus(Territory|null $territory, Partner|null $partner, int|null $year = null, bool $removeImported = false, Qualification $qualification = null, array $qualificationStatuses = null): array
+    public function countByStatus(?Territory $territory, ?Partner $partner, ?int $year = null, bool $removeImported = false, Qualification $qualification = null, array $qualificationStatuses = null): array
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id) as count')
@@ -202,7 +202,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function countByMonth(Territory|null $territory, int|null $year, bool $removeImported = false): array
+    public function countByMonth(?Territory $territory, ?int $year, bool $removeImported = false): array
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id) AS count, MONTH(s.createdAt) AS month, YEAR(s.createdAt) AS year')
@@ -231,7 +231,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function countBySituation(Territory|null $territory, int|null $year, bool $removeImported = false): array
+    public function countBySituation(?Territory $territory, ?int $year, bool $removeImported = false): array
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id) AS count, sit.id, sit.menuLabel')
@@ -259,7 +259,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function countByMotifCloture(Territory|null $territory, int|null $year, bool $removeImported = false): array
+    public function countByMotifCloture(?Territory $territory, ?int $year, bool $removeImported = false): array
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id) AS count, s.motifCloture')
@@ -562,7 +562,7 @@ class SignalementRepository extends ServiceEntityRepository
         return $partnersEmail;
     }
 
-    public function getAverageCriticite(Territory|null $territory, Partner|null $partner, bool $removeImported = false): ?float
+    public function getAverageCriticite(?Territory $territory, ?Partner $partner, bool $removeImported = false): ?float
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('AVG(s.score)');
@@ -584,17 +584,17 @@ class SignalementRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
-    public function getAverageDaysValidation(Territory|null $territory, Partner|null $partner, bool $removeImported = false): ?float
+    public function getAverageDaysValidation(?Territory $territory, ?Partner $partner, bool $removeImported = false): ?float
     {
         return $this->getAverageDayResult('validatedAt', $territory, $partner, $removeImported);
     }
 
-    public function getAverageDaysClosure(Territory|null $territory, Partner|null $partner, bool $removeImported = false): ?float
+    public function getAverageDaysClosure(?Territory $territory, ?Partner $partner, bool $removeImported = false): ?float
     {
         return $this->getAverageDayResult('closedAt', $territory, $partner, $removeImported);
     }
 
-    private function getAverageDayResult(string $field, Territory|null $territory, Partner|null $partner, bool $removeImported = false): ?float
+    private function getAverageDayResult(string $field, ?Territory $territory, ?Partner $partner, bool $removeImported = false): ?float
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('AVG(datediff(s.'.$field.', s.createdAt))');

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -87,6 +87,7 @@ class WidgetDataKpiBuilder
             $countSignalementByStatus = $this->signalementRepository->countByStatus(
                 $this->territory,
                 null,
+                null,
                 false,
                 Qualification::NON_DECENCE_ENERGETIQUE,
                 [QualificationStatus::NDE_AVEREE, QualificationStatus::NDE_CHECK]

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -85,12 +85,12 @@ class WidgetDataKpiBuilder
 
         if ($this->user->isSuperAdmin() || $this->user->isTerritoryAdmin()) {
             $countSignalementByStatus = $this->signalementRepository->countByStatus(
-                $this->territory,
-                null,
-                null,
-                false,
-                Qualification::NON_DECENCE_ENERGETIQUE,
-                [QualificationStatus::NDE_AVEREE, QualificationStatus::NDE_CHECK]
+                territory: $this->territory,
+                partner: null,
+                year: null,
+                removeImported: false,
+                qualification: Qualification::NON_DECENCE_ENERGETIQUE,
+                qualificationStatuses: [QualificationStatus::NDE_AVEREE, QualificationStatus::NDE_CHECK]
             );
             $newNDE = isset($countSignalementByStatus[Signalement::STATUS_NEED_VALIDATION]) ? $countSignalementByStatus[Signalement::STATUS_NEED_VALIDATION]['count'] : 0;
             $currentNDE = isset($countSignalementByStatus[Signalement::STATUS_ACTIVE]) ? $countSignalementByStatus[Signalement::STATUS_ACTIVE]['count'] : 0;

--- a/src/Service/Statistics/GlobalAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalAnalyticsProvider.php
@@ -51,6 +51,7 @@ class GlobalAnalyticsProvider
     {
         return $this->signalementRepository->countAll(
             territory: null,
+            partner: null,
             removeImported: true,
             removeArchived: true
         );

--- a/src/Service/Statistics/GlobalBackAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalBackAnalyticsProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Statistics;
 
+use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
 use App\Repository\SignalementRepository;
@@ -12,20 +13,20 @@ class GlobalBackAnalyticsProvider
     public function __construct(
         private SignalementRepository $signalementRepository,
         private TerritoryRepository $territoryRepository
-        ) {
+    ) {
     }
 
-    public function getData(?Territory $territory): array
+    public function getData(?Territory $territory, ?Partner $partner): array
     {
         $data = [];
-        $data['count_signalement'] = $this->getCountSignalementData($territory);
-        $data['average_criticite'] = $this->getAverageCriticiteData($territory);
-        $data['average_days_validation'] = $this->getAverageDaysValidationData($territory);
-        $data['average_days_closure'] = $this->getAverageDaysClosureData($territory);
+        $data['count_signalement'] = $this->getCountSignalementData($territory, $partner);
+        $data['average_criticite'] = $this->getAverageCriticiteData($territory, $partner);
+        $data['average_days_validation'] = $this->getAverageDaysValidationData($territory, $partner);
+        $data['average_days_closure'] = $this->getAverageDaysClosureData($territory, $partner);
 
         $data['count_signalement_archives'] = 0;
         $data['count_signalement_refuses'] = 0;
-        $countByStatus = $this->signalementRepository->countByStatus($territory, null, true);
+        $countByStatus = $this->signalementRepository->countByStatus($territory, $partner, null, true);
         foreach ($countByStatus as $countByStatusItem) {
             switch ($countByStatusItem['statut']) {
                 case Signalement::STATUS_ARCHIVED:
@@ -42,23 +43,27 @@ class GlobalBackAnalyticsProvider
         return $data;
     }
 
-    private function getCountSignalementData(?Territory $territory): int
+    private function getCountSignalementData(?Territory $territory, ?Partner $partner): int
     {
-        return $this->signalementRepository->countAll($territory, true);
+        return $this->signalementRepository->countAll(
+            territory: $territory,
+            partner: $partner,
+            removeImported: true
+        );
     }
 
-    private function getAverageCriticiteData(?Territory $territory): float
+    private function getAverageCriticiteData(?Territory $territory, ?Partner $partner): float
     {
-        return round($this->signalementRepository->getAverageCriticite($territory, true) * 10) / 10;
+        return round($this->signalementRepository->getAverageCriticite($territory, $partner, true) * 10) / 10;
     }
 
-    private function getAverageDaysValidationData(?Territory $territory): float
+    private function getAverageDaysValidationData(?Territory $territory, ?Partner $partner): float
     {
-        return round($this->signalementRepository->getAverageDaysValidation($territory, true) * 10) / 10;
+        return round($this->signalementRepository->getAverageDaysValidation($territory, $partner, true) * 10) / 10;
     }
 
-    private function getAverageDaysClosureData(?Territory $territory): float
+    private function getAverageDaysClosureData(?Territory $territory, ?Partner $partner): float
     {
-        return round($this->signalementRepository->getAverageDaysClosure($territory, true) * 10) / 10;
+        return round($this->signalementRepository->getAverageDaysClosure($territory, $partner, true) * 10) / 10;
     }
 }

--- a/src/Service/Statistics/StatusStatisticProvider.php
+++ b/src/Service/Statistics/StatusStatisticProvider.php
@@ -22,7 +22,7 @@ class StatusStatisticProvider
 
     public function getData(Territory|null $territory, int|null $year): array
     {
-        $countPerStatuses = $this->signalementRepository->countByStatus($territory, $year, true);
+        $countPerStatuses = $this->signalementRepository->countByStatus($territory, null, $year, true);
 
         return $this->createFullArray($countPerStatuses);
     }

--- a/src/Service/Statistics/StatusStatisticProvider.php
+++ b/src/Service/Statistics/StatusStatisticProvider.php
@@ -20,9 +20,14 @@ class StatusStatisticProvider
         return $this->createFullArray($countPerSituations);
     }
 
-    public function getData(Territory|null $territory, int|null $year): array
+    public function getData(?Territory $territory, ?int $year): array
     {
-        $countPerStatuses = $this->signalementRepository->countByStatus($territory, null, $year, true);
+        $countPerStatuses = $this->signalementRepository->countByStatus(
+            territory: $territory,
+            partner: null,
+            year: $year,
+            removeImported: true
+        );
 
         return $this->createFullArray($countPerStatuses);
     }

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class BackStatistiquesControllerTest extends WebTestCase
+{
+    use SessionHelper;
+    private const USER_SUPER_ADMIN = 'admin-01@histologe.fr';
+    private const USER_ADMIN_TERRITOIRE = 'admin-territoire-13-01@histologe.fr';
+    private const USER_PARTNER = 'user-13-01@histologe.fr';
+
+    public function testStatistiquesFilterRouteNotLogged(): void
+    {
+        $client = static::createClient();
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques_filter',
+            )
+        );
+
+        $this->assertResponseRedirects('/connexion');
+    }
+
+    public function testStatistiquesRouteAdmin(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_SUPER_ADMIN]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques',
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testStatistiquesFilterRouteAdmin(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_SUPER_ADMIN]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques_filter',
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertEquals(27, $response['count_signalement']);
+        $this->assertEquals(66.3, $response['average_criticite']);
+        $this->assertEquals(48.1, $response['average_days_validation']);
+        $this->assertEquals(15, $response['average_days_closure']);
+    }
+
+    public function testStatistiquesRouteRT(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITOIRE]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques',
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testStatistiquesFilterRouteRT(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITOIRE]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques_filter',
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertEquals(17, $response['count_signalement']);
+        $this->assertEquals(97.6, $response['average_criticite']);
+        $this->assertEquals(60.6, $response['average_days_validation']);
+        $this->assertEquals(15, $response['average_days_closure']);
+    }
+
+    public function testStatistiquesFilterRouteRTArles(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITOIRE]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques_filter',
+                [
+                    'communes' => '["Arles"]',
+                ]
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertEquals(17, $response['count_signalement']);
+        $this->assertEquals(0, $response['count_signalement_filtered']);
+        $this->assertEquals(97.6, $response['average_criticite']);
+        $this->assertEquals(0, $response['average_criticite_filtered']);
+    }
+
+    public function testStatistiquesRoutePartner(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_PARTNER]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques',
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testStatistiquesFilterRoutePartner(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_PARTNER]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'back_statistiques_filter',
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertEquals(3, $response['count_signalement']);
+        $this->assertEquals(100, $response['average_criticite']);
+        $this->assertEquals(162.3, $response['average_days_validation']);
+        $this->assertEquals(0, $response['average_days_closure']);
+    }
+}


### PR DESCRIPTION
## Ticket

#845    

## Description
En tant qu'agent d'un partenaire (Rôle Utilisateur) lorsque je me rends dans l'onglet Statistiques de mon Tableau de Bord je visualise les données relatives à la Totalité des signalements du Territoire
Cette vue ne devrait être accessible qu'au Responsable Territoire
Pour les Partenaires de Type Partenaire ou Commune, et les rôles Utilisateurs je ne devrais avoir sur la page Statistiques que les données relatives à mon Partenaire

## Changements apportés
* Ajout du partenaire dans les provider de statistiques

## Pré-requis

## Tests
- [ ] Se connecter avec un partenaire, et vérifier que la page statistiques est bien filtrée sur les signalements affectés à ce partenaire
