### PR TITLE
[BO - Fiche signalement] Modifier phrase photo

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -583,7 +583,7 @@
         <div class="fr-grid-row fr-grid-row--middle" style="position: relative;z-index: 1001">
             <div class="fr-col-12 fr-col-md-6">
                 <strong class="fr-fi-upload-2-fill fr-icon--sm fr-text-label--blue-france"> Photos et documents</strong>
-                <span class="fr-hint-text">Ci-dessous les photos et documents fournis par le déclarant et/ou les partenaires.</span>
+                <span class="fr-hint-text">Pour ajouter plusieurs photos ou documents à la fois, sélectionnez vos fichiers en maintenant la touche CTRL enfoncée.</span>
             </div>
             {% if (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted)) and signalement.statut is not same as(1) %}
                 <div class="fr-col-12 fr-col-md-6 fr-text--right">


### PR DESCRIPTION
## Ticket

#1315    

## Description
Dans la partie "photos et documents", modifier la phrase de sous-titre pour :
Pour ajouter plusieurs photos ou documents à la fois, sélectionnez vos fichiers en maintenant la touche CTRL enfoncée.

## Changements apportés
* changement d'une phrase sur la fiche signalement

## Pré-requis

## Tests
- [ ] check une fiche signalement
