### PR TITLE
[FO - Contenus] Corrections page de validation, après dépôt du signalement

### DIFF
--- a/templates/front/signalement.html.twig
+++ b/templates/front/signalement.html.twig
@@ -73,7 +73,7 @@
                     <thead>
                         <tr>
                             <th scope="col">Exemple de désordres</th>
-                            <th scope="col">Partenaires impliqués</th>
+                            <th scope="col">Partenaires éventuels</th>
                             <th scope="col">Propriétaire averti</th>
                             <th scope="col">Visite</th>
                             <th scope="col">Conciliation</th>
@@ -92,7 +92,7 @@
                                 </ul>
                             </td>
                             <td>
-                                <strong class="fr-hidden-md">Partenaires impliqués</strong>
+                                <strong class="fr-hidden-md">Partenaires éventuels</strong>
                                 <br>
                                 SCHS, Opérateur de visite
                                 <br>
@@ -116,8 +116,6 @@
                             <td>
                                 <strong class="fr-hidden-md">Mesures possibles</strong>
                                 <br>
-                                Lettre de mise en demeure
-                                <br>
                                 Recours à un conciliateur de justice
                                 <br>
                                 Intervention de l'assurance habitation
@@ -135,7 +133,7 @@
                     <thead>
                         <tr>
                             <th scope="col">Exemple de désordres</th>
-                            <th scope="col">Partenaires impliqués</th>
+                            <th scope="col">Partenaires éventuels</th>
                             <th scope="col">Propriétaire averti</th>
                             <th scope="col">Visite</th>
                             <th scope="col">Conciliation</th>
@@ -150,11 +148,11 @@
                                 <ul>
                                     <li>Il y a des insectes (cafards, punaises, ...) ou des rongeurs (rats, ...) dans le bâtiment</li>
                                     <li>Il y a très peu de lumière naturelle dans mon logement</li>
-                                    <li>La peinture est abimée et contient du plomb</li>
+                                    <li>Les plafonds sont trop bas (moins de 2.20 m)</li>
                                 </ul>
                             </td>
                             <td>
-                                <strong class="fr-hidden-md">Partenaires impliqués</strong>
+                                <strong class="fr-hidden-md">Partenaires éventuels</strong>
                                 <br>
                                 Mairie, DDT
                                 <br>
@@ -180,7 +178,7 @@
                                 <br>
                                 Recours à un conciliateur de justice
                                 <br>
-                                Arrêté municipal
+                                Lettre de mise en demeure
                                 <br>
                                 Injonction à réaliser les travaux
                                 <br>
@@ -199,7 +197,7 @@
                     <thead>
                         <tr>
                             <th scope="col">Exemple de désordres</th>
-                            <th scope="col">Partenaires impliqués</th>
+                            <th scope="col">Partenaires éventuels</th>
                             <th scope="col">Propriétaire averti</th>
                             <th scope="col">Visite</th>
                             <th scope="col">Conciliation</th>
@@ -212,13 +210,13 @@
                                 <strong class="fr-hidden-md">Exemple de désordres</strong>
                                 <br>
                                 <ul>
-                                    <li>Il n'y a pas de ventilation dans mon logement</li>
+                                    <li>Il n'y a pas de fenêtre ni de ventilation dans mon logement</li>
                                     <li>Mon logement est en sous-sol, sans fenêtre</li>
                                     <li>Mon logement est une pièce unique de moins de 9m²</li>
                                 </ul>
                             </td>
                             <td>
-                                <strong class="fr-hidden-md">Partenaires impliqués</strong>
+                                <strong class="fr-hidden-md">Partenaires éventuels</strong>
                                 <br>
                                 ARS, SCHS
                                 <br>
@@ -242,7 +240,7 @@
                             <td>
                                 <strong class="fr-hidden-md">Mesures possibles</strong>
                                 <br>
-                                Arrêté municipal
+                                Arrêté préfectoral
                                 <br>
                                 Travaux effectués d'office à rembourser
                                 <br>
@@ -263,7 +261,7 @@
                     <thead>
                         <tr>
                             <th scope="col">Exemple de désordres</th>
-                            <th scope="col">Partenaires impliqués</th>
+                            <th scope="col">Partenaires éventuels</th>
                             <th scope="col">Propriétaire averti</th>
                             <th scope="col">Visite</th>
                             <th scope="col">Conciliation</th>
@@ -282,11 +280,11 @@
                                 </ul>
                             </td>
                             <td>
-                                <strong class="fr-hidden-md">Partenaires impliqués</strong>
+                                <strong class="fr-hidden-md">Partenaires éventuels</strong>
                                 <br>
-                                ARS, SCHS
+                                SCHS
                                 <br>
-                                CAF ou MSA si allocataire
+                                Mairie
                             </td>
                             <td>
                                 <strong class="fr-hidden-md">Propriétaire averti</strong>


### PR DESCRIPTION
## Ticket

#1309    

## Description
Sur la page de validation, après dépôt du signalement. Modifier les contenus suivants : 

- Pour tous les types de procédure : modifier `Partenaires impliqués` en `Partenaires éventuels`
- Partie procédure de non décence
    - Dans les mesures possibles, retirer la mention `Lettre de mise en demeure`
- Partie procédure d'infraction au RSD
    - Dans les exemples de désordres : remplacer `La peinture est abîmée et contient du plomb` par `Les plafonds sont trop bas (moins de 2.20 m)`
    - Dans les mesures possibles : remplacer `Arrêté municipal` par `Lettre de mise en demeure`
- Partie procédure d'insalubrité
    - Dans les désordres : modifier le premier en `Il n'y a pas de fenêtre ni de ventilation dans mon logement`
    - Dans les mesures possibles : remplacer `Arrêté municipal` par `Arrêté préfectoral`
- Partie procédure de mise en sécurité
    - Dans les partenaires impliqués : remplacer les partenaires actuels par `SCHS` et `Mairie`




## Changements apportés
* Changement texte dans twig

## Pré-requis

## Tests
- [ ] Déposer un signalement, vérifier le texte des types de procédure sur la page "et maintenant?"
