### PR TITLE
[FO-Statistiques] Page Stat publique

### DIFF
--- a/src/Service/Statistics/GlobalAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalAnalyticsProvider.php
@@ -37,7 +37,10 @@ class GlobalAnalyticsProvider
         $countSignalementsResolus = 0;
         foreach ($countPerMotifsCloture as $countPerMotifCloture) {
             if ((MotifCloture::TRAVAUX_FAITS_OU_EN_COURS->value == $countPerMotifCloture['motifCloture']->value
-                || MotifCloture::RELOGEMENT_OCCUPANT->value == $countPerMotifCloture['motifCloture']->value)
+                || MotifCloture::RELOGEMENT_OCCUPANT->value == $countPerMotifCloture['motifCloture']->value
+                || MotifCloture::INSALUBRITE->value == $countPerMotifCloture['motifCloture']->value
+                || MotifCloture::RSD->value == $countPerMotifCloture['motifCloture']->value
+                || MotifCloture::PERIL->value == $countPerMotifCloture['motifCloture']->value)
                 && !empty($countPerMotifCloture['count'])
             ) {
                 $countSignalementsResolus += $countPerMotifCloture['count'];


### PR DESCRIPTION
## Ticket

#1312    

## Description
Dans le compteur Foyers sortis du mal logement intégrer les motifs:
-     travaux faits
-     insalubrite
-     RSD
-     Peril
-     Relogement occupant


## Changements apportés
Changement du GlobalAnalyticsProvide, ajout des motifs de cloture dans getCountSignalementResoluData

## Pré-requis

## Tests
- [ ] Aller fermer quelques signalements avec différents motifs de cloture, dont ces 5 là
- [ ] Sur la page statistiques, vérifier que le total est bon
