### PR TITLE
[BO - Signalement] Informations clôture

### DIFF
--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -63,12 +63,16 @@ class AffectationManager extends Manager
             ->setTerritory($partner->getTerritory());
     }
 
-    public function closeAffectation(Affectation $affectation, User $user, MotifCloture $motif): Affectation
+    public function closeAffectation(Affectation $affectation, User $user, MotifCloture $motif, bool $flush = false): Affectation
     {
         $affectation
             ->setStatut(Affectation::STATUS_CLOSED)
+            ->setAnsweredAt(new \DateTimeImmutable())
             ->setMotifCloture($motif)
             ->setAnsweredBy($user);
+        if ($flush) {
+            $this->save($affectation);
+        }
 
         return $affectation;
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -205,19 +205,6 @@ class SignalementManager extends AbstractManager
         return $signalement;
     }
 
-    public function closeAffectation(Affectation $affectation, MotifCloture $motif): Affectation
-    {
-        $affectation
-            ->setStatut(Affectation::STATUS_CLOSED)
-            ->setAnsweredAt(new \DateTimeImmutable())
-            ->setMotifCloture($motif);
-
-        $this->managerRegistry->getManager()->persist($affectation);
-        $this->managerRegistry->getManager()->flush();
-
-        return $affectation;
-    }
-
     public function findEmailsAffectedToSignalement(Signalement $signalement): array
     {
         $sendTo = [];

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -117,20 +117,6 @@ class SignalementManagerTest extends KernelTestCase
         $this->assertTrue($signalementHasAllAffectationsClosed);
     }
 
-    public function testCloseAffectation()
-    {
-        $affectationRepository = $this->entityManager->getRepository(Affectation::class);
-        $affectationAccepted = $affectationRepository->findOneBy(['statut' => Affectation::STATUS_ACCEPTED]);
-        $affectationClosed = $this->signalementManager->closeAffectation(
-            $affectationAccepted,
-            MotifCloture::tryFrom('NON_DECENCE')
-        );
-
-        $this->assertEquals(Affectation::STATUS_CLOSED, $affectationClosed->getStatut());
-        $this->assertInstanceOf(\DateTimeInterface::class, $affectationClosed->getAnsweredAt());
-        $this->assertTrue(str_contains($affectationClosed->getMotifCloture()->label(), 'Non décence'));
-    }
-
     public function testFindEmailsAffectedToSignalement()
     {
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);


### PR DESCRIPTION
## Ticket

#1207    

## Description
Les infos diffèrent entre la partie suivi et l info dans le bloc partenaire lorsqu'un utilisateur cloture un signalement. 

## Changements apportés
* Utilisation de la fonction closeAffectation() de l'AffectationManager, et suppression de la fonction closeAffectation() du SignalementManager

## Pré-requis

## Tests
- [ ] Créer un signalement, ou ouvrir un signalement non validé
- [ ] Valider le signalement, et lui affecter un partenaire avec au moins 2 utilisateurs non-RT différents
- [ ] Se connecter avec un de ces utilisateurs, et accepter l'affectation
- [ ] Se connecter avec un autre utilisateur du m^me partenaire et clore le signalement
- [ ] Dans la partie Partenaires, le nom de l'utilisateur doit bien être celui de l'utilisateur ayant clos le signalement, et non pas celui qui a accepté l'affectation (comme dans la partie Suivi)
