### PR TITLE
[Intégration SISH] MAJ ARRETE WS

### DIFF
--- a/migrations/Version20230608131408.php
+++ b/migrations/Version20230608131408.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230608131408 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE intervention ADD additional_information JSON DEFAULT NULL');
+        $this->addSql('ALTER TABLE job_event CHANGE service service VARCHAR(255) NOT NULL, CHANGE action action VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE signalement CHANGE is_usager_abandon_procedure is_usager_abandon_procedure TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE intervention DROP additional_information');
+        $this->addSql('ALTER TABLE job_event CHANGE service service VARCHAR(255) DEFAULT NULL, CHANGE action action VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE signalement CHANGE is_usager_abandon_procedure is_usager_abandon_procedure TINYINT(1) DEFAULT 0');
+    }
+}

--- a/migrations/Version20230608131408.php
+++ b/migrations/Version20230608131408.php
@@ -7,29 +7,20 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20230608131408 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Add new field to intervention table';
     }
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE intervention ADD additional_information JSON DEFAULT NULL');
-        $this->addSql('ALTER TABLE job_event CHANGE service service VARCHAR(255) NOT NULL, CHANGE action action VARCHAR(255) NOT NULL');
-        $this->addSql('ALTER TABLE signalement CHANGE is_usager_abandon_procedure is_usager_abandon_procedure TINYINT(1) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE intervention DROP additional_information');
-        $this->addSql('ALTER TABLE job_event CHANGE service service VARCHAR(255) DEFAULT NULL, CHANGE action action VARCHAR(255) DEFAULT NULL');
-        $this->addSql('ALTER TABLE signalement CHANGE is_usager_abandon_procedure is_usager_abandon_procedure TINYINT(1) DEFAULT 0');
     }
 }

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -259,7 +259,7 @@ class Intervention
         return $this;
     }
 
-    public function getAdditionalInformation(): array
+    public function getAdditionalInformation(): ?array
     {
         return $this->additionalInformation;
     }

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -71,6 +71,9 @@ class Intervention
     #[ORM\Column(nullable: true, options: ['comment' => 'Unique id used by the provider'])]
     private ?int $providerId = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?array $additionalInformation = [];
+
     public function getId(): ?int
     {
         return $this->id;
@@ -252,6 +255,18 @@ class Intervention
     public function setProviderId(?int $providerId): self
     {
         $this->providerId = $providerId;
+
+        return $this;
+    }
+
+    public function getAdditionalInformation(): array
+    {
+        return $this->additionalInformation;
+    }
+
+    public function setAdditionalInformation(?array $additionalInformation): self
+    {
+        $this->additionalInformation = $additionalInformation;
 
         return $this;
     }

--- a/src/Factory/InterventionFactory.php
+++ b/src/Factory/InterventionFactory.php
@@ -18,6 +18,7 @@ class InterventionFactory
         ?int $providerId = null,
         ?string $doneBy = null,
         ?string $details = null,
+        ?array $additionalInformation = null,
     ): Intervention {
         return (new Intervention())
             ->setPartner($affectation->getPartner())
@@ -29,6 +30,8 @@ class InterventionFactory
             ->setProviderName($providerName)
             ->setProviderId($providerId)
             ->setDoneBy($doneBy)
-            ->setDetails($details);
+            ->setDetails($details)
+            ->setAdditionalInformation($additionalInformation)
+        ;
     }
 }

--- a/src/Service/Esabora/Response/Model/DossierArreteSISH.php
+++ b/src/Service/Esabora/Response/Model/DossierArreteSISH.php
@@ -10,6 +10,8 @@ class DossierArreteSISH
     public const ARRETE_DATE = 3;
     public const ARRETE_NUMERO = 4;
     public const ARRETE_TYPE = 5;
+    public const ARRETE_MAINLEVEE_DATE = 6;
+    public const ARRETE_MAINLEVEE_NUMERO = 7;
 
     private ?int $arreteId = null;
     private ?string $logicielProvenance = null;
@@ -18,6 +20,8 @@ class DossierArreteSISH
     private ?string $arreteDate = null;
     private ?string $arreteNumero = null;
     private ?string $arreteType = null;
+    private ?string $arreteMLDate = null;
+    private ?string $arreteMLNumero = null;
 
     public function __construct(array $item)
     {
@@ -31,6 +35,8 @@ class DossierArreteSISH
                 $this->arreteDate = $data[self::ARRETE_DATE];
                 $this->arreteNumero = $data[self::ARRETE_NUMERO];
                 $this->arreteType = $data[self::ARRETE_TYPE];
+                $this->arreteMLDate = $data[self::ARRETE_MAINLEVEE_DATE];
+                $this->arreteMLNumero = $data[self::ARRETE_MAINLEVEE_NUMERO];
             }
         }
     }
@@ -68,5 +74,15 @@ class DossierArreteSISH
     public function getArreteType(): ?string
     {
         return $this->arreteType;
+    }
+
+    public function getArreteMLDate(): ?string
+    {
+        return $this->arreteMLDate;
+    }
+
+    public function getArreteMLNumero(): ?string
+    {
+        return $this->arreteMLNumero;
     }
 }

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -96,4 +96,14 @@ trait FixturesHelper
             ->setCreatedAt(new \DateTimeImmutable())
             ->setCreatedBy(new User());
     }
+
+    public function getAdditionalInformationArrete(): array
+    {
+        return [
+            'arrete_numero' => '2023/DD13/00664',
+            'arrete_type' => 'Arrêté L.511-11 - Suroccupation',
+            'arrete_mainlevee_date' => '01/08/2023',
+            'arrete_mainlevee_numero' => '2023-DD13-00173',
+        ];
+    }
 }

--- a/tests/Unit/Entity/InterventionTest.php
+++ b/tests/Unit/Entity/InterventionTest.php
@@ -16,14 +16,14 @@ class InterventionTest extends TestCase
     {
         $affectation = $this->getSignalementAffectation(PartnerType::ARS);
         $visiteScheduledAt = new \DateTimeImmutable('2020-05-01 14:30');
-
         $intervention = (new Intervention())
             ->setSignalement($affectation->getSignalement())
             ->setPartner($affectation->getPartner())
             ->setDetails('Tout est OK')
             ->setType(InterventionType::VISITE)
             ->setScheduledAt($visiteScheduledAt)
-            ->setStatus(Intervention::STATUS_PLANNED);
+            ->setStatus(Intervention::STATUS_PLANNED)
+            ->setAdditionalInformation($this->getAdditionalInformationArrete());
 
         $this->assertEquals(Intervention::STATUS_PLANNED, $intervention->getStatus());
         $this->assertEquals($affectation->getSignalement(), $intervention->getSignalement());
@@ -31,5 +31,9 @@ class InterventionTest extends TestCase
         $this->assertEquals('Tout est OK', $intervention->getDetails());
         $this->assertEquals(InterventionType::VISITE, $intervention->getType());
         $this->assertEquals($visiteScheduledAt, $intervention->getScheduledAt());
+        $this->assertArrayHasKey('arrete_numero', $intervention->getAdditionalInformation());
+        $this->assertArrayHasKey('arrete_type', $intervention->getAdditionalInformation());
+        $this->assertArrayHasKey('arrete_mainlevee_date', $intervention->getAdditionalInformation());
+        $this->assertArrayHasKey('arrete_mainlevee_numero', $intervention->getAdditionalInformation());
     }
 }

--- a/tests/Unit/Factory/InterventionFactoryTest.php
+++ b/tests/Unit/Factory/InterventionFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\Unit\Factory;
+
+use App\Entity\Enum\InterventionType;
+use App\Entity\Enum\PartnerType;
+use App\Entity\Intervention;
+use App\Factory\InterventionFactory;
+use App\Service\Esabora\AbstractEsaboraService;
+use App\Tests\FixturesHelper;
+use PHPUnit\Framework\TestCase;
+
+class InterventionFactoryTest extends TestCase
+{
+    use FixturesHelper;
+
+    public function testCreateInstanceIntervention(): void
+    {
+        $intervention = (new InterventionFactory())->createInstanceFrom(
+            $affectation = $this->getAffectation(PartnerType::ARS),
+            InterventionType::ARRETE_PREFECTORAL,
+            new \DateTimeImmutable(),
+            new \DateTimeImmutable(),
+            Intervention::STATUS_DONE,
+            AbstractEsaboraService::TYPE_SERVICE,
+            1,
+            'ARS 13',
+            'Il existe 1 arrêté de n° 2023-DD13-00032 daté du 05/05/2023 dans le dossier de n° 2023/DD13/00001.',
+            $this->getAdditionalInformationArrete()
+        );
+        $this->assertEquals(InterventionType::ARRETE_PREFECTORAL, $intervention->getType());
+        $this->assertEquals('esabora', $intervention->getProviderName());
+        $this->assertEquals(1, $intervention->getProviderId());
+        $this->assertEquals('ARS 13', $intervention->getDoneBy());
+        $this->assertStringStartsWith('Il existe 1', $intervention->getDetails());
+        $this->assertCount(4, $intervention->getAdditionalInformation());
+        $this->assertNotNull($affectation->getSignalement());
+        $this->assertNotNull($affectation->getPartner());
+    }
+}

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas.json
@@ -7,7 +7,9 @@
     "SISH_DossNum",
     "SISH_ArreteDate",
     "SISH_ArreteNumero",
-    "SISH_ArreteType"
+    "SISH_ArreteType",
+    "SISH_ArreteMLDate",
+    "SISH_ArreteMLNumero"
   ],
   "keyList": [
     "i1.imdo_id",
@@ -21,7 +23,9 @@
         "2023/DD13/0010",
         "14/06/2023",
         "2023/DD13/00664",
-        "Arrêté L.511-11 - Suroccupation"
+        "Arrêté L.511-11 - Suroccupation",
+        "01/07/2023",
+        "2023-DD13-00172"
       ],
       "keyDataList": [
         29,

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
@@ -7,7 +7,9 @@
     "SISH_DossNum",
     "SISH_ArreteDate",
     "SISH_ArreteNumero",
-    "SISH_ArreteType"
+    "SISH_ArreteType",
+    "SISH_ArreteMLDate",
+    "SISH_ArreteMLNumero"
   ],
   "keyList": [
     "i1.imdo_id",
@@ -19,9 +21,11 @@
         "Histologe",
         "00000000-0000-0000-2023-000000000012",
         "2023/DD13/0011",
-        "5/06/2023",
+        "05/06/2023",
         "2023/DD13/00664",
-        "Arrêté L.511-11 - Suroccupation"
+        "Arrêté L.511-11 - Suroccupation",
+        "01/08/2023",
+        "2023-DD13-00173"
       ],
       "keyDataList": [
         30,


### PR DESCRIPTION
## Ticket

#1332    

## Description
Suite à la dernière version du document d’interface avec les modifications apportées au web service des arrêtés.

## Changements apportés
* Prise en compte des champs concernant les mains levées
* Transformation du statut en miscule pour le we SAS_ETAT
* Ajout champs dans la table intervention

## Pré-requis
```bash
make mock
make worker-start
```

## Tests
- [ ]  Test de regression sur les commandes `make console app="sync-esabora-sish"`
- [ ]  Test de regression sur les commandes `make console app=sync-intervention-esabora-sish`
- [ ] Vérifier que le champs additional_information est bien rempli pour les arretes

