### PR TITLE
[BO - Carto] rendre possible l'affichage de la Martinique

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -22,16 +22,16 @@ const blueIcon = new L.Icon({
     popupAnchor: [1, -34],
     shadowSize: [41, 41]
 });
-const sudOuest = L.latLng(58, -5);
-const nordEst = L.latLng(41, 10);
+const sudOuest = L.latLng(8, -80);
+const nordEst = L.latLng(70, 20);
 const bounds = L.latLngBounds(sudOuest, nordEst);
 const markers = L.markerClusterGroup();
 let map = L.map('map-signalements-view', {
     center: [47.11, -0.01],
     maxBounds: bounds,
-    minZoom: 6,
+    minZoom: 5,
     maxZoom: 18,
-    zoom: 7
+    zoom: 5
 });
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {}).addTo(map);
 let offset = 0;


### PR DESCRIPTION
## Ticket

#1319    

## Description
Rendre possible l'affichage de la Martinique

## Changements apportés
* Changer les limites de la carte et le zoom minimal et par défaut pour inclure la Martinique

## Pré-requis

## Tests
- [ ] Se connecter en SA, et vérifier que la Martinique est inclue dans le zoom par défaut
- [ ] Se connecter avec divers RT et vérifier que la carte s'affiche bien comme il faut
