### PR TITLE
[BO - Signalement] Ne pas notifier la première acceptation d'affectation si le signalement est importé

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -102,7 +102,8 @@ class AffectationController extends AbstractController
                 return Affectation::STATUS_ACCEPTED === $affectation->getStatut();
             });
 
-            if (1 === $affectationAccepted->count()
+            if (!$signalement->getIsImported()
+                && 1 === $affectationAccepted->count()
                 && Affectation::STATUS_ACCEPTED === $affectation->getStatut()
                 && empty($suiviAffectationAccepted)
             ) {


### PR DESCRIPTION
## Ticket

#1245    

## Description
Ne pas notifier la première acceptation d'affectation si le signalement est importé

## Changements apportés
* Test si le signalement est importé

## Tests
- [ ] Tester une première acceptation d'affectation sur un signalement "classique" (le suivi est créé)
- [ ] Tester une première acceptation d'affectation sur un signalement importé (le suivi n'est pas créé)
