### PR TITLE
[Signalement] Ajout d'un champ facultatif Date de naissance

### DIFF
--- a/migrations/Version20230619151717.php
+++ b/migrations/Version20230619151717.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230619151717 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add field date_naissance_occupant to signalement table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement ADD date_naissance_occupant DATE DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP date_naissance_occupant');
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -67,6 +67,15 @@ forms.forEach((form) => {
             })
         })
     })
+    form?.querySelectorAll('input[name="signalement[isAllocataire]"]')?.forEach((input) => {
+        input.addEventListener('change', (event) => {
+            if (event.target.value === 'CAF' || event.target.value === 'MSA') {
+                form.querySelector('#signalement-date-naissance-bloc')?.classList.remove('fr-hidden')
+            } else {
+                form.querySelector('#signalement-date-naissance-bloc')?.classList.add('fr-hidden')
+            }
+        })
+    })
     form?.querySelectorAll('#signalement_cpOccupant')?.forEach((element) => {
         element.addEventListener('change', (event) => {
             let cpOccupant = form.querySelector('#signalement_cpOccupant').value;
@@ -577,6 +586,29 @@ forms.forEach((form) => {
                     if (form.id === "signalement-step-3b") {
                         if (superficieNDE > -1) {
                             document.querySelector('#signalement_superficie').value = superficieNDE;
+                        }
+                    }
+                    
+                    if (form.id === "signalement-step-4") {
+                        document.querySelector('#signalement-date-naissance-bloc .fr-error-text').classList.add('fr-hidden')
+                        let isOccupant = false
+                        let isAllocataire = false
+                        document.querySelectorAll('input[name="signalement[isNotOccupant]"]').forEach((element) => {
+                            if (element.value == '0' && element.checked) {
+                                isOccupant = true
+                            }
+                        })
+                        document.querySelectorAll('input[name="signalement[isAllocataire]"]').forEach((element) => {
+                            if ((element.value == 'CAF' || element.value == 'MSA') && element.checked) {
+                                isAllocataire = true
+                            }
+                        })
+                        if (isOccupant && isAllocataire) {
+                            if (document.querySelector('input[name="signalement[dateNaissanceOccupant]"]').value == '') {
+                                document.querySelector('#signalement-date-naissance-bloc .fr-error-text').classList.remove('fr-hidden')
+                                event.stopPropagation();
+                                return
+                            }
                         }
                     }
 

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -174,8 +174,11 @@ class FrontSignalementController extends AbstractController
                         break;
 
                     case 'dateEntree':
-                        $value = new DateTimeImmutable($value);
-                        $signalement->$method($value);
+                    case 'dateNaissanceOccupant':
+                        if (!empty($value)) {
+                            $value = new DateTimeImmutable($value);
+                            $signalement->$method($value);
+                        }
                         break;
 
                     case 'geoloc':

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -67,7 +67,7 @@ class HomepageController extends AbstractController
         Request $request,
         ContactFormHandler $contactFormHandler,
     ): Response {
-        $title = "Conditions Générales d'Utilisation";
+        $title = 'Contact';
         $form = $this->createForm(ContactType::class, []);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -1665,12 +1665,12 @@ class Signalement
         return $this;
     }
 
-    public function getDateNaissanceOccupant(): ?DateTimeInterface
+    public function getDateNaissanceOccupant(): ?DateTimeImmutable
     {
         return $this->dateNaissanceOccupant;
     }
 
-    public function setDateNaissanceOccupant(?DateTimeInterface $dateNaissanceOccupant): self
+    public function setDateNaissanceOccupant(?DateTimeImmutable $dateNaissanceOccupant): self
     {
         $this->dateNaissanceOccupant = $dateNaissanceOccupant;
 

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -323,6 +323,9 @@ class Signalement
     #[ORM\Column(type: 'boolean', nullable: true)]
     private ?bool $isUsagerAbandonProcedure;
 
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $dateNaissanceOccupant = null;
+
     public function __construct()
     {
         $this->situations = new ArrayCollection();
@@ -1658,6 +1661,18 @@ class Signalement
                 $intervention->setSignalement(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getDateNaissanceOccupant(): ?DateTimeInterface
+    {
+        return $this->dateNaissanceOccupant;
+    }
+
+    public function setDateNaissanceOccupant(?DateTimeInterface $dateNaissanceOccupant): self
+    {
+        $this->dateNaissanceOccupant = $dateNaissanceOccupant;
 
         return $this;
     }

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -205,6 +205,23 @@ class SignalementType extends AbstractType
                 ],
                 'required' => false,
             ])
+            ->add('dateNaissanceOccupant', TextType::class, [
+                'attr' => [
+                    'class' => 'fr-input',
+                ],
+                'label_attr' => [
+                    'class' => 'fr-label',
+                ],
+                'row_attr' => [
+                    'class' => 'fr-form-group fr-col-2',
+                ],
+                'label' => 'Date de naissance',
+                'help' => 'Merci de préciser la date de naissance de l\'occupant.',
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
+                'required' => false,
+            ])
             ->add('isLogementSocial', ChoiceType::class, [
                 'choices' => [
                     'Oui' => 1,

--- a/templates/_partials/_signalement_steps_tabs.html.twig
+++ b/templates/_partials/_signalement_steps_tabs.html.twig
@@ -494,7 +494,7 @@
                     (*) sont obligatoires.</em>
             </header>
         {% endif %}
-        <form action="#" name="signalement" class="needs-validation" novalidate>
+        <form action="#" name="signalement" class="needs-validation" id="signalement-step-4" novalidate>
             <div class="fr-form-group">
                 <fieldset class="fr-fieldset fr-fieldset--inline">
                     <legend class="fr-fieldset__legend fr-text--regular" id='signalement-proprio-averti'>
@@ -586,6 +586,18 @@
                         </p>
                     </div>
                 </div>
+            </div>
+            <div class="fr-form-group fr-hidden" id="signalement-date-naissance-bloc">
+                <fieldset class="fr-fieldset fr-fieldset--inline">
+                    <legend class="fr-fieldset__legend fr-text--regular">
+                        Date de naissance
+                    </legend>
+                    {{ form_help(form.dateNaissanceOccupant) }}
+                    <input type="date" class="fr-input" name="signalement[dateNaissanceOccupant]">
+                    <p class="fr-error-text fr-hidden">
+                        Veuillez préciser votre date de naissance.
+                    </p>
+                </fieldset>
             </div>
             <div class="fr-form-group">
                 <fieldset class="fr-fieldset fr-fieldset--inline">

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -72,6 +72,14 @@
                         <strong>Tél. sec. :</strong>
                         <a href="tel:{{ signalement.telOccupantBis }}">{{ signalement.telOccupantBis }}</a>
                     </div>
+                    <div class="fr-col-12">
+                        <strong>Date de naissance :</strong>
+                        {% if (signalement.dateNaissanceOccupant) %}
+                            {{ signalement.dateNaissanceOccupant.format('d/m/Y') }}
+                        {% else %}
+                            {{ signalement.naissanceOccupants ?? '-' }}
+                        {% endif %}
+                    </div>
                 </div>
             </div>
             


### PR DESCRIPTION
## Ticket

#1269    

## Description
Ajout d'un champ facultatif Date de naissance sur les signalements
La PR se base sur les visites pour ne pas faire deux fois le travail dans le BO

## Changements apportés
* Ajout du champ dans la base de données
* Ajout d'un champ facultatif dans le formulaire de signalement : obligatoire si l'occupant déclare ET qu'il est allocataire
* Affichage de la date de naissance dans le BO

## Tests
Différents scénarii de signalements :
- [ ] Occupant = PAS allocataire => comme avant
- [ ] Occupant = PAS déclarant && Allocataire => date de naissance visible mais pas obligatoire
- [ ] Occupant = déclarant && Allocataire => date de naissance visible et obligatoire
