### PR TITLE
[Import partenaires] Ajout option pour désactiver les notifications pour certains partenaires

### DIFF
--- a/migrations/Version20230626144301.php
+++ b/migrations/Version20230626144301.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230626144301 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add activate account notification option for users';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD is_activate_account_notification_enabled TINYINT(1) NOT NULL DEFAULT 1');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP is_activate_account_notification_enabled');
+    }
+}

--- a/src/Command/Cron/RemindInactiveUserCommand.php
+++ b/src/Command/Cron/RemindInactiveUserCommand.php
@@ -54,17 +54,19 @@ class RemindInactiveUserCommand extends AbstractCronCommand
             $user = $this->userManager->loadUserToken($userItem['email']);
             $this->userManager->save($user);
 
-            $this->notificationMailerRegistry->send(
-                new NotificationMail(
-                    type: NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_REMINDER,
-                    to: $user->getEmail(),
-                    territory: $user->getTerritory(),
-                    user: $user,
-                    params: [
-                        'nb_signalements' => $userItem['nb_signalements'],
-                    ],
-                )
-            );
+            if ($user->isActivateAccountNotificationEnabled()) {
+                $this->notificationMailerRegistry->send(
+                    new NotificationMail(
+                        type: NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_REMINDER,
+                        to: $user->getEmail(),
+                        territory: $user->getTerritory(),
+                        user: $user,
+                        params: [
+                            'nb_signalements' => $userItem['nb_signalements'],
+                        ],
+                    )
+                );
+            }
         }
 
         $nbUsers = \count($userList);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -109,6 +109,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\JoinColumn(nullable: true)]
     private $territory;
 
+    #[ORM\Column]
+    private bool $isActivateAccountNotificationEnabled = true;
+
     public function __construct()
     {
         $this->suivis = new ArrayCollection();
@@ -440,6 +443,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setUuid(string $uuid): self
     {
         $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    public function isActivateAccountNotificationEnabled(): bool
+    {
+        return $this->isActivateAccountNotificationEnabled;
+    }
+
+    public function setIsActivateAccountNotificationEnabled(bool $isActivateAccountNotificationEnabled): self
+    {
+        $this->isActivateAccountNotificationEnabled = $isActivateAccountNotificationEnabled;
 
         return $this;
     }

--- a/src/EventSubscriber/UserCreatedSubscriber.php
+++ b/src/EventSubscriber/UserCreatedSubscriber.php
@@ -29,7 +29,7 @@ class UserCreatedSubscriber implements EventSubscriberInterface
         $unitOfWork = $args->getObjectManager()->getUnitOfWork();
 
         foreach ($unitOfWork->getScheduledEntityInsertions() as $entity) {
-            if ($entity instanceof User) {
+            if ($entity instanceof User && $entity->isActivateAccountNotificationEnabled()) {
                 $this->sendNotification($entity);
             }
         }

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -23,7 +23,8 @@ class UserFactory
         ?string $firstname,
         ?string $lastname,
         ?string $email,
-        ?bool $isMailActive = true
+        ?bool $isMailActive = true,
+        ?bool $isActivateAccountNotificationEnabled = true
     ): User {
         return (new User())
             ->setRoles(\in_array($roleLabel, User::ROLES) ? [$roleLabel] : [User::ROLES[$roleLabel]])
@@ -38,7 +39,8 @@ class UserFactory
             ->setToken($this->tokenGenerator->generateToken())
             ->setTokenExpiredAt(
                 (new \DateTimeImmutable())->modify($this->parameterBag->get('token_lifetime'))
-            );
+            )
+            ->setIsActivateAccountNotificationEnabled($isActivateAccountNotificationEnabled);
     }
 
     public function createInstanceFromArray(Partner $partner, array $data): User

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -14,7 +14,6 @@ use App\Manager\PartnerManager;
 use App\Manager\UserManager;
 use App\Service\Import\CsvParser;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Events;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -161,11 +160,6 @@ class GridAffectationLoader
                     $newPartnerNames[] = $partnerName;
                 }
 
-                if (\in_array($partnerType->name, $ignoreNotifPartnerTypes)) {
-                    $this->manager->flush();
-                    $this->entityManager->getEventManager()->removeEventSubscriber($this->userAddedSubscriber);
-                }
-
                 $roleLabel = $item[GridAffectationHeader::USER_ROLE];
                 $email = trim($item[GridAffectationHeader::USER_EMAIL]);
                 if (!empty($roleLabel) && !empty($email)) {
@@ -191,7 +185,8 @@ class GridAffectationLoader
                             partner: $partner,
                             firstname: trim($item[GridAffectationHeader::USER_FIRSTNAME]),
                             lastname: trim($item[GridAffectationHeader::USER_LASTNAME]),
-                            email: $email
+                            email: $email,
+                            isActivateAccountNotificationEnabled: !\in_array($partnerType->name, $ignoreNotifPartnerTypes)
                         );
 
                         $this->throwException($user);
@@ -203,11 +198,6 @@ class GridAffectationLoader
                         $this->logger->info(sprintf('in progress - %s users created or updated', $countUsers));
                         $this->manager->flush();
                     }
-                }
-
-                if (\in_array($partnerType, $ignoreNotifPartnerTypes)) {
-                    $this->manager->flush();
-                    $this->entityManager->getEventManager()->addEventListener(Events::onFlush, $this->userAddedSubscriber);
                 }
             }
         }


### PR DESCRIPTION
## Ticket

#1370    

## Description
Ajout d'une option pour désactiver les notifications pour certains partenaires

## Changements apportés
* Désactivation du subscriber lors de la création d'un utilisateur lorsque le type de partenaire correspond à ceux qui sont ignorés

## Tests
Partir d'une base neuve et ouvrir le mail catcher
- [ ] `make console app="import-grid-affectation 46` : tout s'importe normalement, les 19 utilisateurs sont notifiés
- [ ] `make console app="import-grid-affectation 46 --ignore-notification-partners=EPCI"` : les utilisateurs qui appartiennent à un partenaire EPCI ne sont pas notifiés
- [ ] `make console app="import-grid-affectation 46 --ignore-notification-partners=EPCI,ARS"` : les utilisateurs qui appartiennent à un partenaire EPCI ou ARS ne sont pas notifiés
