### PR TITLE
[BO - Suivis] Ne pas notifier les utilisateurs du même partenaire que l'utilisateur qui crée le suivi

### DIFF
--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -211,7 +211,7 @@ class ActivityListener implements EventSubscriberInterface
                 User::STATUS_ACTIVE === $user->getStatut()
                     && !$user->isSuperAdmin()
                     && !$user->isTerritoryAdmin()
-                    && $user !== $entity->getCreatedBy()
+                    && (!$entity instanceof Suivi || $user->getPartner() !== $entity->getCreatedBy()->getPartner())
             ) {
                 $this->createInAppNotification($user, $entity, $inAppType);
                 if ($user->getIsMailingActive()) {

--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -207,7 +207,12 @@ class ActivityListener implements EventSubscriberInterface
             $this->tos->add($partner->getEmail());
         }
         $partner->getUsers()->filter(function (User $user) use ($inAppType, $entity) {
-            if (User::STATUS_ACTIVE === $user->getStatut() && !$user->isSuperAdmin() && !$user->isTerritoryAdmin()) {
+            if (
+                User::STATUS_ACTIVE === $user->getStatut()
+                    && !$user->isSuperAdmin()
+                    && !$user->isTerritoryAdmin()
+                    && $user !== $entity->getCreatedBy()
+            ) {
                 $this->createInAppNotification($user, $entity, $inAppType);
                 if ($user->getIsMailingActive()) {
                     $this->tos->add($user->getEmail());


### PR DESCRIPTION
## Ticket

#1384    

## Description
Lorsqu'un agent crée un suivi, ne pas notifier l'agent lui-même, ni les agents du même partenaire.

## Tests
- [ ] Ajouter des suivis sur des signalements et vérifier les utilisateurs qui reçoivent les e-mails et les notifications
