### PR TITLE
[Contenu] Mise en variable du nom de la plateforme pour simplifier le changement de nom prochain

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,6 +1,13 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
     globals:
+        platform:
+            name: 'Histologe'
+            logo: 'Logohistologe.png'
+            logo145: 'logo_145.png'
+            logosvg: 'logo-histologe.svg'
+            url: 'https://histologe.beta.gouv.fr'
+            demo: 'https://app.livestorm.co/incubateur-des-territoires/demonstration-histologe?type=detailed'
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,6 +29,7 @@ parameters:
     cron_enable: '%env(bool:CRON_ENABLE)%'
     mail_enable: '%env(bool:MAIL_ENABLE)%'
     feature_ask_visite: '%env(FEATURE_ASK_VISITE_ENABLE)%'
+    platform_name: 'Histologe'
 
 services:
     # default configuration for services in *this* file

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -63,7 +63,7 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
         $message->from(
             new Address(
                 $this->parameterBag->get('notifications_email'),
-                'HISTOLOGE - '.mb_strtoupper($territoryName)
+                mb_strtoupper($this->parameterBag->get('platform_name').' - '.$territoryName)
             )
         );
 
@@ -125,9 +125,11 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
         return $notification->htmlTemplate('emails/'.$this->mailerTemplate.'.html.twig')
             ->context(array_merge($params, $config))
             ->subject(
-                'HISTOLOGE '.mb_strtoupper((!empty($territory) && null !== $territory->getName())
-                    ? $territory->getName()
-                    : 'ALERTE').' - '.$this->mailerSubject
+                mb_strtoupper($this->parameterBag->get('platform_name'))
+                .' '
+                .mb_strtoupper((!empty($territory) && null !== $territory->getName()) ? $territory->getName() : 'ALERTE')
+                .' - '.
+                str_replace('%param.platform_name%', $this->parameterBag->get('platform_name'), $this->mailerSubject)
             );
     }
 }

--- a/src/Service/Mailer/Mail/Account/AccountActivationBoMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountActivationBoMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class AccountActivationBoMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_FROM_BO;
-    protected ?string $mailerSubject = 'Activez votre compte sur Histologe';
+    protected ?string $mailerSubject = 'Activez votre compte sur %param.platform_name%';
     protected ?string $mailerButtonText = 'Activer mon compte';
     protected ?string $mailerTemplate = 'login_link_email';
 

--- a/src/Service/Mailer/Mail/Account/AccountActivationFoMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountActivationFoMailer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 class AccountActivationFoMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_FROM_FO;
-    protected ?string $mailerSubject = 'Activez votre compte sur Histologe';
+    protected ?string $mailerSubject = 'Activez votre compte sur %param.platform_name%';
     protected ?string $mailerButtonText = 'Activer mon compte';
     protected ?string $mailerTemplate = 'login_link_email';
 

--- a/src/Service/Mailer/Mail/Account/AccountActivationReminderMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountActivationReminderMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class AccountActivationReminderMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_REMINDER;
-    protected ?string $mailerSubject = 'Activez votre compte sur Histologe';
+    protected ?string $mailerSubject = 'Activez votre compte sur %param.platform_name%';
     protected ?string $mailerButtonText = 'Activer mon compte';
     protected ?string $mailerTemplate = 'login_link_email';
 

--- a/src/Service/Mailer/Mail/Account/AccountDeleteMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountDeleteMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class AccountDeleteMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ACCOUNT_DELETE;
-    protected ?string $mailerSubject = 'Suppression de votre compte Histologe';
+    protected ?string $mailerSubject = 'Suppression de votre compte %param.platform_name%';
     protected ?string $mailerTemplate = 'delete_account_email';
 
     public function __construct(

--- a/src/Service/Mailer/Mail/Account/AccountLostPasswordMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountLostPasswordMailer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 class AccountLostPasswordMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_LOST_PASSWORD;
-    protected ?string $mailerSubject = 'Nouveau mot de passe sur Histologe';
+    protected ?string $mailerSubject = 'Nouveau mot de passe sur %param.platform_name%';
     protected ?string $mailerButtonText = 'Définir mon mot de passe';
     protected ?string $mailerTemplate = 'lost_pass_email';
 

--- a/src/Service/Mailer/Mail/Account/AccountReactivationMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountReactivationMailer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class AccountReactivationMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ACCOUNT_REACTIVATION;
-    protected ?string $mailerSubject = 'Votre compte Histologe est activé !';
+    protected ?string $mailerSubject = 'Votre compte %param.platform_name% est activé !';
     protected ?string $mailerButtonText = 'Accéder à mon compte';
     protected ?string $mailerTemplate = 'reactive_account_email';
 

--- a/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 class AccountTransferMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ACCOUNT_TRANSFER;
-    protected ?string $mailerSubject = 'Transfert de votre compte Histologe';
+    protected ?string $mailerSubject = 'Transfert de votre compte %param.platform_name%';
     protected ?string $mailerTemplate = 'transfer_account_email';
 
     public function __construct(

--- a/src/Service/Mailer/Mail/Contact/ContactFormMailer.php
+++ b/src/Service/Mailer/Mail/Contact/ContactFormMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class ContactFormMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_CONTACT_FORM;
-    protected ?string $mailerSubject = 'Vous avez reçu un message depuis la page Histologe';
+    protected ?string $mailerSubject = 'Vous avez reçu un message depuis la page %param.platform_name%';
     protected ?string $mailerTemplate = 'nouveau_mail_front';
 
     public function __construct(

--- a/src/Service/Mailer/Mail/Signalement/AssignementNewMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/AssignementNewMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class AssignementNewMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ASSIGNMENT_NEW;
-    protected ?string $mailerSubject = 'Un nouveau signalement vous attend sur Histologe.';
+    protected ?string $mailerSubject = 'Un nouveau signalement vous attend sur %param.platform_name%.';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'affectation_email';
 

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToUsagerMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SignalementClosedToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_USAGER;
-    protected ?string $mailerSubject = 'Votre signalement sur Histologe est terminé.';
+    protected ?string $mailerSubject = 'Votre signalement sur %param.platform_name% est terminé.';
     protected ?string $mailerButtonText = 'Accéder à mon signalement';
     protected ?string $mailerTemplate = 'closed_to_usager_signalement_email';
 

--- a/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SignalementFeedbackUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_FEEDBACK_USAGER;
-    protected ?string $mailerSubject = 'Histologe : faites le point sur votre problème de logement !';
+    protected ?string $mailerSubject = '%param.platform_name% : faites le point sur votre problème de logement !';
     protected ?string $mailerButtonText = 'Mettre à jour ma situation';
     protected ?string $mailerTemplate = 'demande_feedback_usager_email';
 

--- a/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerThirdMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerThirdMailer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SignalementFeedbackUsagerThirdMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_FEEDBACK_USAGER_THIRD;
-    protected ?string $mailerSubject = 'Histologe : faites le point sur votre problème de logement !';
+    protected ?string $mailerSubject = '%param.platform_name% : faites le point sur votre problème de logement !';
     protected ?string $mailerTemplate = 'demande_feedback_usager_third_email';
 
     public function __construct(

--- a/templates/_partials/_modal_closed_territory.html.twig
+++ b/templates/_partials/_modal_closed_territory.html.twig
@@ -14,7 +14,7 @@
                         <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-h-100 fr-mt-5w">
                             <div class="fr-col-12">
                                <p>Nous ne pouvons malheureusement pas traiter votre demande. <br>
-                                   Le service Histologe n'est pas encore ouvert dans votre département... Nous faisons tout pour le rendre disponible dès que possible !
+                                   Le service {{ platform.name }} n'est pas encore ouvert dans votre département... Nous faisons tout pour le rendre disponible dès que possible !
                                    <br>
                                    En attendant, nous vous invitons à contacter gratuitement le service "Info logement indigne" au numéro suivant :</p>
                             </div>

--- a/templates/_partials/_modal_user_delete.html.twig
+++ b/templates/_partials/_modal_user_delete.html.twig
@@ -16,7 +16,7 @@
                             <div class="fr-select-group">
                                 Vous êtes sur le point de supprimer le compte utilisateur de <span class="fr-modal-user-delete_username"></span> (<span class="fr-modal-user-delete_useremail"></span>). Une fois le compte supprimé :
                                 <ul class="fr-list">
-                                    <li><span class="fr-modal-user-delete_username"></span> ne pourra plus se connecter à la plateforme Histologe pour traiter des signalements.</li>
+                                    <li><span class="fr-modal-user-delete_username"></span> ne pourra plus se connecter à la plateforme {{ platform.name }} pour traiter des signalements.</li>
                                     <li>S'il s'agit du dernier compte utilisateur du partenaire, les signalements affectés ne pourrons plus être pris en charge par le partenaire.</li>
                                     <li>Vous ne pourrez plus re-créer un compte avec cette adresse email : <span class="fr-modal-user-delete_useremail"></span>.</li>
                                 </ul>

--- a/templates/_partials/_signalement_step_avantpropos.html.twig
+++ b/templates/_partials/_signalement_step_avantpropos.html.twig
@@ -42,7 +42,7 @@
             </button>
         </h3>
         <div class="fr-collapse" id="accordion-quel-cas">
-            Histologe permet de signaler les <strong>logements non décents</strong>.
+            {{ platform.name }} permet de signaler les <strong>logements non décents</strong>.
             <br>
             Un logement est décent s’il remplit toutes les conditions suivantes :
             <ul>
@@ -55,7 +55,7 @@
             </ul>
             <em>
                 Si votre logement ne respecte pas un ou plusieurs critères ou si vous avez un doute,
-                déposez votre signalement sur Histologe !
+                déposez votre signalement sur {{ platform.name }} !
             </em>
             <br>
             <div class="fr-alert fr-alert--warning fr-mt-3v">
@@ -103,7 +103,7 @@
             <div class="fr-alert fr-alert--success fr-mt-3v">
                 <p>
                     Pour vous aider, vous pouvez 
-                    <a href="https://faq.histologe.beta.gouv.fr/usager/probleme-logement/avertir-proprietaire" target="_blank" rel="noopener">
+                    <a href="{{ gitbook.faq }}/usager/probleme-logement/avertir-proprietaire" target="_blank" rel="noopener">
                         consulter un modèle de lettre en cliquant ici
                     </a>.
                 </p>
@@ -143,7 +143,7 @@
         <div class="fr-collapse" id="accordion-voir-signalement">
             Les services publics en charge de votre dossier.
             <br>
-            En déposant un signalement sur Histologe, les acteurs publics compétents pouvant
+            En déposant un signalement sur {{ platform.name }}, les acteurs publics compétents pouvant
             vous aider à trouver une solution auront accès à votre signalement. Les services sont variés :
             l’ADIL, la mairie de votre commune, la CAF, l’agence régionale de santé…
             <br>
@@ -166,13 +166,13 @@
     <section class="fr-accordion">
         <h3 class="fr-accordion__title">
             <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-nouveau-logement">
-                Est-ce que Histologe va me permettre d'avoir un nouveau logement ?
+                Est-ce que {{ platform.name }} va me permettre d'avoir un nouveau logement ?
             </button>
         </h3>
         <div class="fr-collapse" id="accordion-nouveau-logement">
             Non.
             <br>
-            L’objectif du service Histologe et de (re)mettre votre logement aux normes.
+            L’objectif du service {{ platform.name }} et de (re)mettre votre logement aux normes.
             Ce n’est pas un service de relogement ou de demande de logement social.
         </div>
     </section>

--- a/templates/_partials/_signalement_step_nde.html.twig
+++ b/templates/_partials/_signalement_step_nde.html.twig
@@ -198,25 +198,25 @@
 
         <p class="fr-hidden display-if-bail-before-2023 fr-mt-3w">
             Votre logement n'est pas concerné par les changements de législation concernant la consommation énergétique.
-            Cliquez sur le bouton "Continuer" pour compléter votre signalement sur Histologe !
+            Cliquez sur le bouton "Continuer" pour compléter votre signalement sur {{ platform.name }} !
         </p>
 
         <p class="fr-hidden display-if-missing-info fr-mt-3w">
             Il nous manque des informations pour déterminer la consommation énergétique de votre logement !
             Ces informations pourront vous être demandées plus tard.
             <br>
-            Cliquez sur le bouton "Continuer" pour compléter votre signalement et le déposer sur Histologe.
+            Cliquez sur le bouton "Continuer" pour compléter votre signalement et le déposer sur {{ platform.name }}.
         </p>
 
         <p class="fr-hidden display-if-not-nde fr-mt-3w">
             D'après les informations renseignées, votre logement n'est pas concerné par la non décence énergétique.
-            Cliquez sur le bouton "Continuer" pour compléter votre signalement et le déposer sur Histologe.
+            Cliquez sur le bouton "Continuer" pour compléter votre signalement et le déposer sur {{ platform.name }}.
         </p>
 
         <p class="fr-hidden display-if-nde fr-mt-3w">
             D'après les informations renseignées, votre logement est en situation de non décence énergétique.
             Vous allez bénéficier d'un accompagnement spécifique sur les problèmes de consommation énergétique dans votre logement.
-            Cliquez sur le bouton "Continuer" pour compléter votre signalement et le déposer sur Histologe !
+            Cliquez sur le bouton "Continuer" pour compléter votre signalement et le déposer sur {{ platform.name }} !
         </p>
 
         <div class="fr-grid-row fr-hidden display-if-finished fr-mt-3w">

--- a/templates/_partials/_signalement_steps_tabs.html.twig
+++ b/templates/_partials/_signalement_steps_tabs.html.twig
@@ -844,7 +844,7 @@
                         soient partagées entre l’ensemble des partenaires
                         pour le traitement de ma demande conformément aux finalités indiquées dans les 
                         <a href="#" aria-controls="cguModal" data-fr-opened="false">Conditions Générales d'Utilisation</a>
-                        &nbsp;de la plateforme « Histologe ».
+                        &nbsp;de la plateforme « {{ platform.name }} ».
                     </label>
                     <p class="fr-error-text fr-hidden">
                         Vous devez accepter les Conditions Générales d'Utilisation pour transmettre votre signalement.

--- a/templates/back/cgu_bo.html.twig
+++ b/templates/back/cgu_bo.html.twig
@@ -1,8 +1,8 @@
 <div class="cgu-bo">
-    <strong class="title">Conditions d’utilisation de la plateforme Histologe</strong>
+    <strong class="title">Conditions d’utilisation de la plateforme {{ platform.name }}</strong>
     <br><br>
     <p>
-        Les présentes conditions générales d’utilisation (dites « CGU ») fixent le cadre juridique de la plateforme « Histologe »
+        Les présentes conditions générales d’utilisation (dites « CGU ») fixent le cadre juridique de la plateforme « {{ platform.name }} »
         et définissent les conditions d’accès et d’utilisation des services par les partenaires.
     </p>
     <br>
@@ -11,9 +11,9 @@
     <strong>1 – Champ d’application</strong>
     <br>
     <p>
-        L’utilisation de la plateforme Histologe et son Back-Office est gratuite pour tout partenaire inscrit sur la plateforme.
+        L’utilisation de la plateforme {{ platform.name }} et son Back-Office est gratuite pour tout partenaire inscrit sur la plateforme.
         La demande d’inscription aux services de la plateforme suppose la mise en œuvre d’un partenariat entre un territoire
-        et la start-up d’Etat Histologe et l’acceptation par tout partenaire des présentes conditions générales d’utilisation.
+        et la start-up d’Etat {{ platform.name }} et l’acceptation par tout partenaire des présentes conditions générales d’utilisation.
     </p>
     <br>
 
@@ -21,10 +21,10 @@
     <strong>2 – Objet</strong>
     <br>
     <p>
-        Histologe a pour objectif de permettre aux habitants de logements de repérer et de signaler les problèmes d’habitats,
+        {{ platform.name }} a pour objectif de permettre aux habitants de logements de repérer et de signaler les problèmes d’habitats,
         mais également d’accélérer l’apport de solutions à ces problèmes.
         <br>
-        Pour cela, Histologe met à disposition des partenaires une interface d’administration (ci-après « Back-Office »)
+        Pour cela, {{ platform.name }} met à disposition des partenaires une interface d’administration (ci-après « Back-Office »)
         dans laquelle ils pourront gérer les signalements saisis par les usagers.
         <br><br>
         Il vise notamment à mesurer la criticité d’un signalement concernant son logement. La mesure de cette criticité,
@@ -42,7 +42,7 @@
         </li>
         <li>
             « L’Administrateur» ou « L’agent » est la personne travaillant dans la structure (collectivité territoriale ou
-            services de l’Etat) ayant conventionné avec Histologe et habilitée à hiérarchiser les signalements et les
+            services de l’Etat) ayant conventionné avec {{ platform.name }} et habilitée à hiérarchiser les signalements et les
             transférer aux partenaires pour traitement des désordres.
         </li>
         <li>
@@ -50,7 +50,7 @@
             les entreprises auxquels sont transmis les signalements et qui pourront intervenir dans leurs champs de compétence.
         </li>
         <li>
-            « Les services » sont les moyens offerts par Histologe pour répondre à son objet et ses finalités.
+            « Les services » sont les moyens offerts par {{ platform.name }} pour répondre à son objet et ses finalités.
         </li>
         <li>
             « Le Back-Office » est l’interface d’administration mise à disposition des agents et partenaires.
@@ -62,7 +62,7 @@
             finalités et les moyens des traitements de données à caractère personnel.
         </li>
         <li>
-            « L’éditeur » est la startup d'État Histologe.
+            « L’éditeur » est la startup d'État {{ platform.name }}.
         </li>
     </ul>
     <br>
@@ -75,7 +75,7 @@
     <p>
         Le Back-Office et ses services sont accessibles :
         <ul>
-            <li>Aux partenaires des territoires sur lesquels la plateforme Histologe est déployée.</li>
+            <li>Aux partenaires des territoires sur lesquels la plateforme {{ platform.name }} est déployée.</li>
             <li>Aux agents des territoires</li>
         </ul>
     </p>
@@ -104,7 +104,7 @@
     <p>
         L’acceptation des présentes CGU par le partenaire est soumise au moment de l’activation du compte
         partenaire. Cette acceptation ne peut être que pleine et entière. Les partenaires qui n’acceptent
-        pas les présentes CGU ne peuvent pas utiliser la plateforme Histologe et n’ont pas accès au Back-Office.
+        pas les présentes CGU ne peuvent pas utiliser la plateforme {{ platform.name }} et n’ont pas accès au Back-Office.
     </p>
 
 
@@ -193,7 +193,7 @@
 
     <strong>6 – Responsabilités</strong>
     <br>
-    <em>6.1 – L’éditeur de la plateforme Histologe</em>
+    <em>6.1 – L’éditeur de la plateforme {{ platform.name }}</em>
     <br>
     <p>
         Les sources des informations diffusées sur la plateforme sont réputées fiables mais la plateforme ne garantit
@@ -331,7 +331,7 @@
                     <td>
                         5 ans à compter de la fin de la prise en charge du problème d’habitat par le partenaire.
                         <br>
-                        Histologe utilise ces données pour détecter des signalements sur une même adresse.
+                        {{ platform.name }} utilise ces données pour détecter des signalements sur une même adresse.
                     </td>
                 </tr>
                 <tr>
@@ -398,7 +398,7 @@
                 Ministère de la Transition écologique et solidaire<br>
                 Direction Générale de l'Aménagement, du Logement et de la Nature<br>
                 Direction de l’habitat, de l’urbanisme et des paysages<br>
-                Pôle Habitat - Service Histologe<br>
+                Pôle Habitat - Service {{ platform.name }}<br>
                 1 place Carpeaux, 92800 Puteaux
             </li>
         </ul>
@@ -440,7 +440,7 @@
         d’usage et de protection des données.
         <br>
         Seules les données nécessaires au traitement du signalement sont transmises et les sous-traitants sont les
-        partenaires d’Histologe.
+        partenaires de {{ platform.name }}.
         <br>
 
         <table aria-label="Liste des sous-traitants des données">

--- a/templates/back/config/index.html.twig
+++ b/templates/back/config/index.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <section class="fr-grid-row fr-grid-row--middle fr-p-5v ">
         <div class="fr-col-6">
-            <h1 class="fr-h2 fr-mb-0">Configuration Histologe</h1>
+            <h1 class="fr-h2 fr-mb-0">Configuration {{ platform.name }}</h1>
         </div>
         <div class="fr-col-6 fr-text--right">
             <img src="{{ asset('img/'~logotype) }}" alt="Logo territoire" height="75px">

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -6,7 +6,7 @@
         </button>
         <div class="fr-collapse" id="fr-sidemenu-wrapper">
             <div class="fr-pb-5v">
-                <img src="{{ asset('img/logo_145.png') }}" alt="{{ platform.name }}" width="145px">
+                <img src="{{ asset('img/' ~ platform.logo145) }}" alt="{{ platform.name }}" width="145px">
             </div>
             <div class="fr-sidemenu__title">
                 {% if is_granted('ROLE_ADMIN') %}

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -6,7 +6,7 @@
         </button>
         <div class="fr-collapse" id="fr-sidemenu-wrapper">
             <div class="fr-pb-5v">
-                <img src="{{ asset('img/logo_145.png') }}" alt="HISTOLOGE" width="145px">
+                <img src="{{ asset('img/logo_145.png') }}" alt="{{ platform.name }}" width="145px">
             </div>
             <div class="fr-sidemenu__title">
                 {% if is_granted('ROLE_ADMIN') %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -8,26 +8,26 @@
         <meta name="robots" content="index, follow">
     {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Histologe - {% block title %}{% endblock %}</title>
+    <title>{{ platform.name }} - {% block title %}{% endblock %}</title>
     <meta name="description" content="Signaler vos problèmes de logement.">
     <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://histologe.beta.gouv.fr/">
+    <meta property="og:url" content="{{ platform.url }}">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Histologe">
+    <meta property="og:title" content="{{ platform.name }}">
     <meta property="og:description" content="Signaler vos problèmes de logement.">
-    <meta property="og:image" content={{ asset('img/Logohistologe.png') }}>
-    <meta property="og:site_name" content="Histologe">
+    <meta property="og:image" content={{ asset('img/' ~ platform.logo) }}>
+    <meta property="og:site_name" content="{{ platform.name }}">
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="https://histologe.beta.gouv.fr/">
-    <meta property="twitter:url" content="https://histologe.beta.gouv.fr/">
-    <meta name="twitter:title" content="Histologe">
+    <meta property="twitter:domain" content="{{ platform.url }}">
+    <meta property="twitter:url" content="{{ platform.url }}">
+    <meta name="twitter:title" content="{{ platform.name }}">
     <meta name="twitter:description" content="Signalez vos problèmes de logement.">
-    <meta name="twitter:image" content={{ asset('img/Logohistologe.png') }}>
-    <meta name="twitter:title" content="Histologe">
+    <meta name="twitter:image" content={{ asset('img/' ~ platform.logo) }}>
+    <meta name="twitter:title" content="{{ platform.name }}">
     <meta name="twitter:description" content="Signalez vos problèmes de logement.">
-    <meta name="apple-mobile-web-app-title" content="Histologe">
+    <meta name="apple-mobile-web-app-title" content="{{ platform.name }}">
     <link rel="icon" href={{ asset('favicon.ico') }}>
     <link rel="stylesheet" href={{ asset('dsfr/dsfr.min.css') }}>
     <link rel="stylesheet" href={{ asset('build/app.css') }}>

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -8,7 +8,7 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">
                     <figure>
-                        <img src="{{ asset('img/Logohistologe.png') }}" alt="Logo HISTOLOGE" width="200">
+                        <img src="{{ asset('img/' ~ platform.logo) }}" alt="Logo {{ platform.name }}" width="200">
                     </figure>
                     <figure class="fr-my-5w fr-mx-0">
                         <figcaption>

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -8,7 +8,7 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">
                     <figure>
-                        <img src="{{ asset('img/Logohistologe.png') }}" alt="Logo HISTOLOGE" width="200">
+                        <img src="{{ asset('img/' ~ platform.logo) }}" alt="Logo {{ platform.name }}" width="200">
                     </figure>
                     <figure class="fr-my-5w fr-mx-0">
                         <figcaption>

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -8,7 +8,7 @@
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">
                     <figure>
-                        <img src="{{ asset('img/Logohistologe.png') }}" alt="Logo HISTOLOGE" width="200">
+                        <img src="{{ asset('img/' ~ platform.logo) }}" alt="Logo {{ platform.name }}" width="200">
                     </figure>
                     <figure class="fr-my-5w fr-mx-0">
                         <figcaption>

--- a/templates/emails/base_email.html.twig
+++ b/templates/emails/base_email.html.twig
@@ -410,7 +410,7 @@
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td class="content-block powered-by">
-                                    Message envoyé par <a href="//histologe.beta.gouv.fr">Histologe</a>.
+                                    Message envoyé par <a href="{{ platform.url }}">{{ platform.name }}</a>.
                                 </td>
                             </tr>
                         </table>

--- a/templates/emails/closed_to_usager_signalement_email.html.twig
+++ b/templates/emails/closed_to_usager_signalement_email.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>
-        Votre signalement sur la plateforme Histologe - {{territory.name}}  a été clôturé par nos équipes pour la raison suivante : {{ motif_cloture }}.
+        Votre signalement sur la plateforme {{ platform.name }} - {{territory.name}}  a été clôturé par nos équipes pour la raison suivante : {{ motif_cloture }}.
     </p>
     <p>
         Un commentaire est disponible sur votre page de suivi. Vous pouvez le consulter en cliquant sur le bouton ci-dessous :

--- a/templates/emails/delete_account_email.html.twig
+++ b/templates/emails/delete_account_email.html.twig
@@ -3,12 +3,12 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>
-        Votre compte a été supprimé de la plateforme {{territory.name}} - Histologe.
+        Votre compte a été supprimé de la plateforme {{territory.name}} - {{ platform.name }}.
         Vous ne pouvez désormais plus vous connecter à la plateforme, ni accéder à votre compte.
     </p>
     <p>
         Si vous voulez disposer d'un nouveau compte, rapprochez-vous de votre responsable de structure ou de votre référent territorial.
     </p>
 
-    <p>Merci d'avoir utilisé Histologe !</p>
+    <p>Merci d'avoir utilisé {{ platform.name }} !</p>
 {% endblock %}

--- a/templates/emails/login_link_email.html.twig
+++ b/templates/emails/login_link_email.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
     <p>Bonjour,</p>
-        <p>Votre compte Histologe vous attend !</p>
+        <p>Votre compte {{ platform.name }} vous attend !</p>
     {% if reminder is defined %}
         {% if nb_signalements != 0 %}
 
@@ -32,8 +32,8 @@
         </tbody>
     </table>
     <p>Si le bouton ne fonctionne pas <a href="{{ link|raw }}">cliquez ici</a></p>
-    <p>Première fois sur Histologe ? <br>
+    <p>Première fois sur {{ platform.name }} ? <br>
         Inscrivez-vous à nos sessions de formation <a
-                href="https://app.livestorm.co/incubateur-des-territoires/demonstration-histologe?type=detailed">en
+                href="{{ platform.demo }}">en
             cliquant sur ce lien.</a></p>
 {% endblock %}

--- a/templates/emails/lost_pass_email.html.twig
+++ b/templates/emails/lost_pass_email.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
     <p>Bonjour,</p>
-    <p>Vous avez demandé la récupération de votre mot de passe pour votre compte Histologe.</p>
+    <p>Vous avez demandé la récupération de votre mot de passe pour votre compte {{ platform.name }}.</p>
     <p>Cliquez sur le bouton ci-dessous pour vous en définir un nouveau.</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">

--- a/templates/emails/migration_pass_email.html.twig
+++ b/templates/emails/migration_pass_email.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
     <p>Bonjour,</p>
-    <p>Dans le cadre de l'amélioration du service Histologe, votre plateforme Histologe a été migrée vers une plateforme unique !</p>
+    <p>Dans le cadre de l'amélioration du service {{ platform.name }}, votre plateforme {{ platform.name }} a été migrée vers une plateforme unique !</p>
     <p>Afin d'assurer la sécurité de votre compte, nous vous invitons à définir un nouveau mot de passe. Pour cela, cliquez sur le bouton ci-dessous et renseignez votre adresse mail</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">

--- a/templates/emails/new_signalement_email.html.twig
+++ b/templates/emails/new_signalement_email.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>
-        Vous avez reçu un nouveau signalement sur votre plateforme Histologe - {{ territory.getName() }}.<br>
+        Vous avez reçu un nouveau signalement sur votre plateforme {{ platform.name }} - {{ territory.getName() }}.<br>
         Cliquez sur le bouton ci-dessous pour le consulter :
     </p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"

--- a/templates/emails/nouveau_suivi_signalement_back_email.html.twig
+++ b/templates/emails/nouveau_suivi_signalement_back_email.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <p>Bonjour, <br>un nouveau suivi est disponible pour le signalement
         <strong>#{{ entity.signalement.reference }}</strong> sur votre plateforme
-        Histologe par
+        {{ platform.name }} par
         <strong>{{
             entity.createdBy
             ? entity.createdBy.nomComplet

--- a/templates/emails/reactive_account_email.html.twig
+++ b/templates/emails/reactive_account_email.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
     <p>Bonjour,</p>
-    <p>Votre compte a bien été activé sur la plateforme Histologe - {{territoire_name}}.</p>
+    <p>Votre compte a bien été activé sur la plateforme {{ platform.name }} - {{territoire_name}}.</p>
     <p>Vous pouvez désormais traiter et assurer le suivi des signalements du partenaire {{partner_name}}.
 Cliquez ci-dessous pour vous connecter à votre compte.</p>
 
@@ -24,8 +24,8 @@ Cliquez ci-dessous pour vous connecter à votre compte.</p>
         </tbody>
     </table>
     <p>Si le bouton ne fonctionne pas <a href="{{ link|raw }}">cliquez ici</a></p>
-    <p>Première fois sur Histologe ? <br>
+    <p>Première fois sur {{ platform.name }} ? <br>
         Inscrivez-vous à nos sessions de formation <a
-                href="https://app.livestorm.co/incubateur-des-territoires/demonstration-histologe?type=detailed">en
+                href="{{ platform.demo }}">en
             cliquant sur ce lien.</a></p>
 {% endblock %}

--- a/templates/emails/refus_signalement_email.html.twig
+++ b/templates/emails/refus_signalement_email.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
     <p>
-        Votre signalement sur la plateforme <strong>Histologe - {{ territory.getName() }}</strong> ne peut pas être traité par nos
+        Votre signalement sur la plateforme <strong>{{ platform.name }} - {{ territory.getName() }}</strong> ne peut pas être traité par nos
         équipes pour la raison suivante :
         <br>
         <br>

--- a/templates/emails/transfer_account_email.html.twig
+++ b/templates/emails/transfer_account_email.html.twig
@@ -3,14 +3,14 @@
 {% block body %}
     <p>Bonjour,</p>
     {% if user_status == 1 %}
-        <p>Votre compte a été transféré vers le partenaire {{ partner_name }} sur votre plateforme Histologe
+        <p>Votre compte a été transféré vers le partenaire {{ partner_name }} sur votre plateforme {{ platform.name }}
             - {{ territory.name }}. </p>
         <p>Vous pouvez désormais traiter et assurer le suivi des signalements du partenaire {{ partner_name }}. <p>
         <p> Votre adresse de connexion et mot de passe ne changent pas. <br/>
             Cliquez ci-dessous pour vous connecter à votre compte.</p>
     {% endif %}
     {% if user_status == 0 %}
-        <p>Votre compte a été transféré vers le partenaire {{ partner_name }} sur votre plateforme Histologe
+        <p>Votre compte a été transféré vers le partenaire {{ partner_name }} sur votre plateforme {{ platform.name }}
             - {{ territory.name }}.</p>
         <p>Vous devez activer votre compte pour traiter les signalements du partenaire {{ partner_name }}. <br/>
             Cliquez ci-dessous pour activer votre compte et définir votre mot de passe.</p>
@@ -37,5 +37,5 @@
         Pour plus d'information, rapprochez vous de votre référent territorial.
     </p>
 
-    <p>Merci d'avoir utilisé Histologe !</p>
+    <p>Merci d'avoir utilisé {{ platform.name }} !</p>
 {% endblock %}

--- a/templates/emails/validation_signalement_email.html.twig
+++ b/templates/emails/validation_signalement_email.html.twig
@@ -5,7 +5,7 @@
     <p>
         Nous vous informons que votre signalement concernant le logement situé <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong> <br>
-        a bien été validé par le service Histologe - {{ territory.getName() }}.
+        a bien été validé par le service {{ platform.name }} - {{ territory.getName() }}.
     </p>
     
     <p>Vous pouvez désormais suivre l'avancée de son traitement en cliquant sur le bouton ci-dessous :</p>

--- a/templates/footer.html.twig
+++ b/templates/footer.html.twig
@@ -8,7 +8,7 @@
             </div>
             <div class="fr-footer__content">
                 <div class="fr-footer__content-desc fr-text--left">
-                    Histologe améliore la prise en charge du mal-logement.
+                    {{ platform.name }} améliore la prise en charge du mal-logement.
                 </div>
                 <ul class="fr-footer__content-list">
                     <li>
@@ -58,7 +58,7 @@
                 </li>
             </ul>
             <div class="fr-footer__bottom-copy">
-                © République Française & Histologe {{ ''|date('Y') }}
+                © République Française & {{ platform.name }} {{ ''|date('Y') }}
             </div>
         </div>
     </div>

--- a/templates/front/about.html.twig
+++ b/templates/front/about.html.twig
@@ -9,12 +9,12 @@
                 <div class="fr-col-12 fr-col-md-8">
                     <h1>Qui sommes-nous ?</h1>
                     <h2 class="fr-h6 fr-text--xx-light">
-                        Histologe est un service public permettant de faciliter la détection, le signalement,
+                        {{ platform.name }} est un service public permettant de faciliter la détection, le signalement,
                         l’évaluation, l’envoi d’alertes et le suivi des logements pour accélérer la prise en charge du
                         “mal logement”.
                         <br>
                         <br>
-                        Histologe est une start-up d’Etat portée par le 
+                        {{ platform.name }} est une start-up d’Etat portée par le 
                         <a href="https://www.ecologie.gouv.fr/" target="_blank" rel="noopener">
                         Ministère de la Transition Ecologique et de la Cohésion des territoires
                         </a>
@@ -27,7 +27,7 @@
                 </div>
                 <div class="fr-hidden fr-displayed-md fr-col-md-4 fr-text--center">
                     <figure>
-                        <img src="{{ asset('img/logo-histologe.svg') }}" alt="Logo Histologe" width="240">
+                        <img src="{{ asset('img/' ~ platform.logosvg) }}" alt="Logo {{ platform.name }}" width="240">
                     </figure>
                 </div>
             </div>
@@ -90,7 +90,7 @@
                         <p>
                             <strong>Prix de la grande enquête Initiatives Locales 2020</strong>
                             <br>
-                            Histologe a été primé dans la catégorie "Cadre de vie"
+                            {{ platform.name }} a été primé dans la catégorie "Cadre de vie"
                             parmi plus de 400 candidatures.
                         </p>
                     </div>

--- a/templates/front/cgu.html.twig
+++ b/templates/front/cgu.html.twig
@@ -3,11 +3,11 @@
     <main class="fr-container fr-py-5w fr-py-md-10w">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
-                <h1>Conditions d’utilisation du site Histologe</h1>
+                <h1>Conditions d’utilisation du site {{ platform.name }}</h1>
 
                 <p>
                     Les présentes conditions générales d’utilisation (dites « CGU ») fixent le cadre juridique
-                    du site “Histologe” et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
+                    du site “{{ platform.name }}” et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
                 </p>
 
 
@@ -24,7 +24,7 @@
                 <h2>2 – Objet</h2>
 
                 <p>
-                    Histologe a pour objectif de permettre aux habitants de logements de repérer et de signaler les problèmes
+                    {{ platform.name }} a pour objectif de permettre aux habitants de logements de repérer et de signaler les problèmes
                     d’habitats, mais également d’accélérer l’apport de solutions à ces problèmes.
                 </p>
 
@@ -44,7 +44,7 @@
                         </li>
                         <li>
                             «l’Administrateur« ou « L’agent » est la personne travaillant dans la structure (collectivité territoriale ou
-                            services de l’Etat) ayant conventionné avec Histologe et habilitée à hiérarchiser les signalements et les 
+                            services de l’Etat) ayant conventionné avec {{ platform.name }} et habilitée à hiérarchiser les signalements et les 
                             transférer aux partenaires pour traitement des désordres.
                         </li>
                         <li>
@@ -52,7 +52,7 @@
                             et les entreprises auxquels sont transmis les signalements et qui pourront intervenir dans leurs champs de compétence.
                         </li>
                         <li>
-                            « Les services » sont les moyens offerts par Histologe pour répondre à son objet et ses finalités.
+                            « Les services » sont les moyens offerts par {{ platform.name }} pour répondre à son objet et ses finalités.
                         </li>
                         <li>
                             « Le responsable de traitement » est la personne qui, au sens de l’article 4 du règlement UE) n°2016/679
@@ -61,7 +61,7 @@
                             détermine les finalités et les moyens des traitements de données à caractère personnel.
                         </li>
                         <li>
-                            « L’éditeur » est la startup d’Etat Histologe.
+                            « L’éditeur » est la startup d’Etat {{ platform.name }}.
                         </li>
                     </ul>
                 </p>
@@ -138,7 +138,7 @@
 
                 <h2>5 – Responsabilités</h2>
                 
-                <h3>5.1 – L’éditeur du site « Histologe »</h2>
+                <h3>5.1 – L’éditeur du site « {{ platform.name }} »</h2>
 
                 <p>
                     Les sources des informations diffusées sur le site sont réputées fiables mais le site ne garantit pas
@@ -301,7 +301,7 @@
                             <td>
                                 5 ans à compter de la fin de la prise en charge du problème d’habitat par le partenaire.
                                 <br>
-                                Histologe utilise ces données pour détecter des signalements sur une même adresse.
+                                {{ platform.name }} utilise ces données pour détecter des signalements sur une même adresse.
                             </td>
                         </tr>
                         <tr>
@@ -365,7 +365,7 @@
                             Ministère de la Transition écologique et solidaire<br>
                             Direction Générale de l'Aménagement, du Logement et de la Nature<br>
                             Direction de l’habitat, de l’urbanisme et des paysages<br>
-                            Pôle Habitat - Service Histologe<br>
+                            Pôle Habitat - Service {{ platform.name }}<br>
                             1 place Carpeaux, 92800 Puteaux
                         </li>
                     </ul>

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -5,7 +5,7 @@
 {% block body %}
     <main class="fr-container--fluid">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-py-5w fr-py-md-10w">
-            <h1 class="fr-col-11 fr-col-md-8 fr-text-title--blue-france fr-text--center">Contacter Histologe</h1>
+            <h1 class="fr-col-11 fr-col-md-8 fr-text-title--blue-france fr-text--center">Contacter {{ platform.name }}</h1>
 
             <p class="fr-col-11 fr-col-md-8 fr-text--center fr-text--lg">
                 Une question ? Une précision ? N'hésitez pas à nous envoyer un message !

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -12,7 +12,7 @@
             <div class="fr-container fr-grid-row">
                 <div class="fr-col-12 fr-col-md-8">
                     <p class="fr-mt-5w">
-                        <p class="fr-text--lead">Avec Histologe,</p>
+                        <p class="fr-text--lead">Avec {{ platform.name }},</p>
                         <h1>Sortez du mal-logement</h1>
                         {{ form_start(form_postalcode) }}
                         <div class="fr-grid-row fr-grid-row--gutters fr-mb-5v">
@@ -47,13 +47,13 @@
                     <img src="{{ asset('img/home/step-2.svg') }}" alt="Etape 2" class="img-mw-100">
                     <br>
                     <span>2. </span>
-                    Signalez votre problème en quelques clics sur le service Histologe.
+                    Signalez votre problème en quelques clics sur le service {{ platform.name }}.
                 </div>
                 <div class="fr-col-12 fr-col-md-3 fr-text--center">
                     <img src="{{ asset('img/home/step-3.svg') }}" alt="Etape 3" class="img-mw-100">
                     <br>
                     <span>3. </span>
-                    Histologe transmet votre signalement à la bonne administration.
+                    {{ platform.name }} transmet votre signalement à la bonne administration.
                 </div>
                 <div class="fr-col-12 fr-col-md-3 fr-text--center">
                     <img src="{{ asset('img/home/step-4.svg') }}" alt="Etape 4" class="img-mw-100">
@@ -77,7 +77,7 @@
                     </button>
                 </h3>
                 <div class="fr-collapse" id="accordion-quel-cas">
-                    Histologe permet de signaler les <strong>logements non décents</strong>.
+                    {{ platform.name }} permet de signaler les <strong>logements non décents</strong>.
                     <br>
                     Un logement est décent s’il remplit toutes les conditions suivantes :
                     <ul>
@@ -90,7 +90,7 @@
                     </ul>
                     <em>
                         Si votre logement ne respecte pas un ou plusieurs critères ou si vous avez un doute,
-                        déposez votre signalement sur Histologe !
+                        déposez votre signalement sur {{ platform.name }} !
                     </em>
                     <br>
                     <div class="fr-alert fr-alert--warning fr-mt-3v">
@@ -138,7 +138,7 @@
                     <div class="fr-alert fr-alert--success fr-mt-3v">
                         <p>
                             Pour vous aider, vous pouvez 
-                            <a href="https://faq.histologe.beta.gouv.fr/usager/probleme-logement/avertir-proprietaire" target="_blank" rel="noopener">
+                            <a href="{{ gitbook.faq }}/usager/probleme-logement/avertir-proprietaire" target="_blank" rel="noopener">
                                 consulter un modèle de lettre en cliquant ici
                             </a>.
                         </p>
@@ -154,7 +154,7 @@
                 <div class="fr-collapse" id="accordion-voir-signalement">
                     Les services publics en charge de votre dossier.
                     <br>
-                    En déposant un signalement sur Histologe, les acteurs publics compétents pouvant
+                    En déposant un signalement sur {{ platform.name }}, les acteurs publics compétents pouvant
                     vous aider à trouver une solution auront accès à votre signalement. Les services sont variés :
                     l’ADIL, la mairie de votre commune, la CAF, l’agence régionale de santé…
                     <br>
@@ -177,13 +177,13 @@
             <section class="fr-accordion">
                 <h3 class="fr-accordion__title">
                     <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-nouveau-logement">
-                        Est-ce que Histologe va me permettre d'avoir un nouveau logement ?
+                        Est-ce que {{ platform.name }} va me permettre d'avoir un nouveau logement ?
                     </button>
                 </h3>
                 <div class="fr-collapse" id="accordion-nouveau-logement">
                     Non.
                     <br>
-                    L’objectif du service Histologe et de (re)mettre votre logement aux normes.
+                    L’objectif du service {{ platform.name }} et de (re)mettre votre logement aux normes.
                     Ce n’est pas un service de relogement ou de demande de logement social.
                 </div>
             </section>
@@ -243,7 +243,7 @@
                                 <p>
                                     Logement plein de moisissures et mes vêtements ne sentent pas bon. J'ai honte
                                     d'inviter des amis et du coup j'ai tendance à m'isoler car je n'ai pas envie d'aller
-                                    crier mon problème sur les toits. Avec Histologe j'ai pu de chez moi sortir de
+                                    crier mon problème sur les toits. Avec {{ platform.name }} j'ai pu de chez moi sortir de
                                     l'ombre en quelques clics via mon téléphone portable. Je suis maintenant accompagné
                                     pour m'aider à résoudre ces problèmes.
                                 </p>
@@ -258,7 +258,7 @@
                                 <p>
                                     1 an et 11 mois que j'occupe un appartement sans chauffage malgré les promesses de
                                     mon propriétaire de résoudre ce problème. En déposant un signalement sur la
-                                    plateforme Histologe et accompagnée par les bons acteurs, le propriétaire a
+                                    plateforme {{ platform.name }} et accompagnée par les bons acteurs, le propriétaire a
                                     finalement missionné un artisan pour m'installer les équipements de chauffage. Avec
                                     mon mari nous n'avons plus froid ! Merci
                                 </p>

--- a/templates/front/signalement.html.twig
+++ b/templates/front/signalement.html.twig
@@ -328,7 +328,7 @@
             </p>
 
             <p class="fr-text--center fr-mt-5w">
-                <span class="fr-h3">Qu'avez-vous pensé du service Histologe ?</span>
+                <span class="fr-h3">Qu'avez-vous pensé du service {{ platform.name }} ?</span>
                 <br><br>
                 Cliquez sur le bouton ci-dessous et donnez votre avis !
                 <br><br>

--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -10,9 +10,9 @@
                             </div>
                         </div>
                         <div class="fr-header__operator">
-                            <a href="{{ path('home') }}" title="Accueil - HISTOLOGE">
-                                <img src={{ asset('img/logo_145.png') }} class="fr-responsive-img" width="100%"
-                                     alt="HISTOLOGE">
+                            <a href="{{ path('home') }}" title="Accueil - {{ platform.name }}">
+                                <img src={{ asset('img/' ~ platform.logo) }} class="fr-responsive-img" width="100%"
+                                     alt="{{ platform.name }}">
                             </a>
                         </div>
 


### PR DESCRIPTION
## Ticket

#1386    

## Description
Nom de la plateforme mis dans des variables de configuration

## Changements apportés
* Ajout de variables de configuration
* Modification des templates twig
* Modification des templates de mails
* Modification des objets de mails

## Tests
- [ ] Affichage de la plateforme sur différentes pages (accueil, cgu front et back, finalisation de signalement, ...)
- [ ] Envoi des différents mails avec vérification de l'objet et du contenu
