### PR TITLE
[Visites] Correction de la migration des dates de visites déjà renseignées

### DIFF
--- a/migrations/Version20230530084228.php
+++ b/migrations/Version20230530084228.php
@@ -34,7 +34,7 @@ final class Version20230530084228 extends AbstractMigration
                     'intervention',
                     [
                         'signalement_id' => $idSignalement,
-                        'date' => $dateVisite,
+                        'scheduled_at' => $dateVisite,
                         'occupant_present' => $isOccupantPresentVisite,
                         'type' => InterventionType::VISITE->name,
                         'status' => Intervention::STATUS_PLANNED,

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -34,8 +34,11 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
         $intervention = $event->getSubject();
         $currentUser = $this->security->getUser();
         if (InterventionType::VISITE === $intervention->getType()) {
-            $description = 'Après visite du logement par '.$intervention->getPartner()->getNom().',';
-            $description .= ' la situation observée du logement est :<br>';
+            $description = 'Après visite du logement';
+            if ($intervention->getPartner()) {
+                $description .= ' par '.$intervention->getPartner()->getNom();
+            }
+            $description .= ', la situation observée du logement est :<br>';
             foreach ($intervention->getConcludeProcedure() as $concludeProcedure) {
                 $description .= '- '.$concludeProcedure->label().'<br>';
             }

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -60,10 +60,10 @@ class VisiteNotifier
         if ($intervention) {
             if ($notifyAdminTerritory) {
                 $listUsersTerritoryAdmin = $this->userRepository->findActiveTerritoryAdmins($intervention->getSignalement()->getTerritory());
-                $listUsersPartner = $intervention->getPartner()->getUsers();
-                $listUsersToNotify = array_unique(array_merge($listUsersTerritoryAdmin, $listUsersPartner->toArray()), \SORT_REGULAR);
+                $listUsersPartner = $intervention->getPartner() ? $intervention->getPartner()->getUsers()->toArray() : [];
+                $listUsersToNotify = array_unique(array_merge($listUsersTerritoryAdmin, $listUsersPartner), \SORT_REGULAR);
             } else {
-                $listUsersToNotify = $intervention->getPartner()->getUsers();
+                $listUsersToNotify = $intervention->getPartner() ? $intervention->getPartner()->getUsers() : [];
             }
         } else {
             $listUsersToNotify = $affectation->getPartner()->getUsers();

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -37,7 +37,7 @@
     {% if is_granted('SIGN_ADD_VISITE', signalement) %}
         {% set displayAddVisiteButton = true %}
         {% for pendingVisite in pendingVisites %}
-            {% if pendingVisite.partner.id is same as app.user.partner.id %}
+            {% if pendingVisite.partner and pendingVisite.partner.id is same as app.user.partner.id %}
                 {% set displayAddVisiteButton = false %}
             {% endif %}
         {% endfor %}

--- a/templates/emails/nouveau_suivi_visite_confirmed_to_partner_email.html.twig
+++ b/templates/emails/nouveau_suivi_visite_confirmed_to_partner_email.html.twig
@@ -7,7 +7,10 @@
         <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>
         <br>
-        effectuée par {{ intervention.partner.nom }} est disponible.
+        {% if intervention.partner %}
+        effectuée par {{ intervention.partner.nom }}
+        {% endif %}
+        est disponible.
         <br><br>
         Cliquez sur le bouton ci-dessous pour y accéder.
     </p>

--- a/templates/emails/nouveau_suivi_visite_confirmed_to_user_email.html.twig
+++ b/templates/emails/nouveau_suivi_visite_confirmed_to_user_email.html.twig
@@ -7,7 +7,10 @@
         <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>
         <br>
-        effectuée par {{ intervention.partner.nom }} est disponible.
+        {% if intervention.partner %}
+        effectuée par {{ intervention.partner.nom }}
+        {% endif %}
+        est disponible.
         <br><br>
         Cliquez sur le bouton ci-dessous pour y accéder.
     </p>


### PR DESCRIPTION
## Description
Correction de la migration des dates de visites déjà renseignées
Correction de l'affichage des visites si aucun partenaire n'est lié

## Pré-requis

## Tests
- [ ] Se mettre sur la branche `main` et faire `make create-db`
- [ ] Mettre une date de visite sur 2 signalements
- [ ] Se placer sur cette branche, faire `make composer` puis `make load-migrations`
- [ ] Vérifier les deux signalements et la prise en compte des date de visite
