### PR TITLE
[FO - dpot signalement] corrige le dépôt de signalement quand pas allocataire CAF

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -181,8 +181,10 @@ class FrontSignalementController extends AbstractController
                         break;
 
                     case 'dateNaissanceOccupant':
-                        $value = new DateTimeImmutable($value['year'].'-'.$value['month'].'-'.$value['day']);
-                        $signalement->$method($value);
+                        if ('' !== $value['year'] && '' !== $value['month'] && '' !== $value['day']) {
+                            $value = new DateTimeImmutable($value['year'].'-'.$value['month'].'-'.$value['day']);
+                            $signalement->$method($value);
+                        }
                         break;
 
                     case 'geoloc':


### PR DESCRIPTION
## Ticket

#NumIssue   

## Description
On ne peut plus déposer de signalement si on n'est pas allocataire CAF (ou "ne sait pas") on reçoit une erreur 
`
Plateforme: localhost

Code erreur: 0

Message erreur: Failed to parse time string (--) at position 0 (-): Unexpected character

Documents: 0

Photos: 0
`

## Changements apportés
* Vérification des champs dans le FrontSignalementController

## Pré-requis

## Tests
- [ ] Tester le dépôt de signalement dans plusieurs cas (allocataire, pas allocataire etc.)
