### PR TITLE
[BO - Fiche signalement] Afficher mail agent qui a redigé le suivi au survol

### DIFF
--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -31,6 +31,9 @@
                 Suivi automatique
 
             {% elseif suivi.createdBy is not null %}
+                <div class="part-infos-hover"
+                     data-user="{{ suivi.createdBy.nomComplet }}"
+                     data-mail="{{ suivi.createdBy.email }}">
                 {{
                     'ROLE_USAGER' in suivi.createdBy.roles
                         ? (suivi.createdBy.email is same as signalement.mailDeclarant
@@ -44,7 +47,7 @@
                             )
                             : 'Aucun')|nl2br
                 }}
-
+                </div>
             {% else %}
                 <strong>{{ signalement.isNotOccupant ? signalement.nomDeclarant|upper~' '~signalement.prenomDeclarant|capitalize : signalement.nomOccupant|upper~' '~signalement.prenomOccupant|capitalize }}</strong>
                 <br>


### PR DESCRIPTION
## Ticket

#1413    

## Description
Régression de comportement suite à la refonte de la fiche signalement
Une tooltip avec les informations personnelles de l'agent doit apparaître au survol de la souris

## Changements apportés
* Englober les informations dans une div avec les classes et attributs associés.

## Tests
- [ ] Afficher une fiche signalement
