### PR TITLE
[QA] Esabora - Erreur de type mode contact proprio

### DIFF
--- a/src/Factory/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Esabora/DossierMessageSISHFactory.php
@@ -52,6 +52,10 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ['uuid' => $signalement->getUuid()]
         );
 
+        if (is_array($signalement->getModeContactProprio())) {
+            $modeContactProprio = implode(',', $signalement->getModeContactProprio());
+        }
+
         return (new DossierMessageSISH())
             ->setUrl($partner->getEsaboraUrl())
             ->setToken($partner->getEsaboraToken())
@@ -105,7 +109,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ->setLogementNbNiveaux($signalement->getNbNiveauxLogement())
             ->setProprietaireAverti((int) $signalement->getIsProprioAverti())
             ->setProprietaireAvertiDate($signalement->getProprioAvertiAt()?->format($formatDate))
-            ->setProprietaireAvertiMoyen(implode(',', $signalement->getModeContactProprio()))
+            ->setProprietaireAvertiMoyen($modeContactProprio)
             ->setSignalementScore($signalement->getScore())
             ->setSignalementOrigine(AbstractEsaboraService::SIGNALEMENT_ORIGINE)
             ->setSignalementNumero($signalement->getReference())

--- a/src/Factory/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Esabora/DossierMessageSISHFactory.php
@@ -52,9 +52,9 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ['uuid' => $signalement->getUuid()]
         );
 
-        if (is_array($signalement->getModeContactProprio())) {
-            $modeContactProprio = implode(',', $signalement->getModeContactProprio());
-        }
+        $modeContactProprio = \is_array($signalement->getModeContactProprio())
+            ? implode(',', $signalement->getModeContactProprio())
+            : null;
 
         return (new DossierMessageSISH())
             ->setUrl($partner->getEsaboraUrl())


### PR DESCRIPTION
## Ticket

#1430    

## Description
Erreur déclenchée lorsque lors d'une affectation avec comme valeur mode contact proprio à NULL

| mode_contact_proprio |
|----------------------|
| NULL                 |
| NULL                 |
| NULL                 |


## Changements apportés
* Vérifier que le mode contact proprio est un tableau

## Pré-requis
```
$ make worker-start
$ make mock
```
## Tests
- [ ] Mettez le mode contact proprio d'un signalement à NULL
- [ ] Affecter le signalement à une ARS et vérifier qu'aucune erreur de type `TypeError` n'est relevé dans les logs
