### PR TITLE
[BO - Signalement] Disponibilité du bouton pour afficher tous les suivis même si le signalement est fermé

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -483,3 +483,8 @@ hr.blue-border {
 #signalement_dateNaissanceOccupant_day, #signalement_dateNaissanceOccupant_month {
     border-right: 1px solid black;
 }
+
+#btn-display-all-suivis {
+    position: relative;
+    z-index: 1001;
+}


### PR DESCRIPTION
## Ticket

#1418    

## Description
Disponibilité du bouton pour afficher tous les suivis même si le signalement est fermé

## Changements apportés
* Modification css appliquée au bouton

## Tests
- [ ] Vérifier l'affichage et le fonctionnement du bouton sur un signalement ouvert
- [ ] Vérifier l'affichage et le fonctionnement du bouton sur un signalement fermé
