### PR TITLE
[BO - Signalement] Affichage de la fenêtre de refus au-dessus des autres éléments

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -7,6 +7,10 @@ html, body {
 
     #signalement-toggle-situations, .reopen, .reaffect, .fr-btn--success.fr-fi-file-pdf-fill, .admin-territory-validation, .signalement-file-item a {
         position: relative;
+        z-index: 1002;
+    }
+
+    #signalement-toggle-situations {
         z-index: 1001;
     }
 }


### PR DESCRIPTION
## Ticket

#1422    

## Description
Affichage de la fenêtre de refus de signalement au-dessus des autres éléments

## Changements apportés
* Règle css spécifique appliquée

## Tests
- [ ] Ouvrir un signalement en attente de validation, ouvrir la modale de refus, vérifier que les désordes s'affichent en-dessous de la modale
