### PR TITLE
[BO - Visites] Ne pas notifier par mail les utilisateurs ayant désactivé

### DIFF
--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -83,15 +83,17 @@ class VisiteNotifier
         ?Affectation $affectation = null,
     ) {
         if ($notificationMailerType) {
-            $this->notificationMailerRegistry->send(
-                new NotificationMail(
-                    type: $notificationMailerType,
-                    to: $user->getEmail(),
-                    territory: $intervention ? $intervention->getSignalement()->getTerritory() : $affectation->getSignalement()->getTerritory(),
-                    signalement: $intervention ? $intervention->getSignalement() : $affectation->getSignalement(),
-                    intervention: $intervention,
-                )
-            );
+            if ($user->getIsMailingActive()) {
+                $this->notificationMailerRegistry->send(
+                    new NotificationMail(
+                        type: $notificationMailerType,
+                        to: $user->getEmail(),
+                        territory: $intervention ? $intervention->getSignalement()->getTerritory() : $affectation->getSignalement()->getTerritory(),
+                        signalement: $intervention ? $intervention->getSignalement() : $affectation->getSignalement(),
+                        intervention: $intervention,
+                    )
+                );
+            }
         }
 
         $notification = $this->notificationFactory->createInstanceFrom($user, $suivi);
@@ -112,15 +114,17 @@ class VisiteNotifier
         }
 
         foreach ($listUsersToNotify as $user) {
-            $this->notificationMailerRegistry->send(
-                new NotificationMail(
-                    type: NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER,
-                    to: $user->getEmail(),
-                    territory: $signalement->getTerritory(),
-                    signalement: $signalement,
-                    intervention: $intervention,
-                )
-            );
+            if ($user->getIsMailingActive()) {
+                $this->notificationMailerRegistry->send(
+                    new NotificationMail(
+                        type: NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER,
+                        to: $user->getEmail(),
+                        territory: $signalement->getTerritory(),
+                        signalement: $signalement,
+                        intervention: $intervention,
+                    )
+                );
+            }
         }
 
         return \count($listUsersToNotify);


### PR DESCRIPTION
## Ticket

#1429    

## Description
Ne pas envoyer les mails de visites aux utilisateurs ayant désactivé les mails

## Changements apportés
* Condition ajoutée pour l'envoi de mails de visites

## Tests
- [ ] Se logger en admin territoire ou super admin
- [ ] Assigner un partenaire pouvant faire des visites à un signalement
- [ ] Il faut 2 agents dans ce partenaire : un qui accepte les notifs, un autre qui refuse
- [ ] Assigner une visite à ce partenaire, en la créant dans le passé avec une conclusion
- [ ] Vérifier que les agents ont bien reçu ou non les visites, selon le statut choisi
