### PR TITLE
[BO - Suivi] Correction affichage fenêtre de partage de document

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -492,3 +492,7 @@ hr.blue-border {
     position: relative;
     z-index: 1001;
 }
+
+.tox-tinymce-aux {
+    z-index: 6000 !important;
+}


### PR DESCRIPTION
## Ticket

#1421    

## Description
Correction de l'affichage de la liste des documents à partager dans la modale d'ajout de suivi

## Changements apportés
* Modification css concernant le zindex du sous-menu

## Tests
- [ ] Ajouter un document à un signalement, aller dans la fenêtre d'ajout de suivi, vérifier que le document apparait dans "Partager un document", cliquer pour vérifier qu'il s'ajoute dans le texte
