### PR TITLE
[BO - Signalement] Laisser accessible pour l'admin territoire si son affectation est clôturée mais que le signalement est ouvert

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -17,7 +17,7 @@
     {% endif %}
     <section id="signalement-{{ signalement.id }}-content"
         class="fr-p-5v fr-background--white
-            {{ isClosedForMe
+            {{ (isClosedForMe and not is_granted('ROLE_ADMIN_TERRITORY'))
                 or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION')
                 or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
                 or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED')

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -57,7 +57,7 @@
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left reopen"
                                 name="signalement-action[reopenAll]" value="1"
                                 onclick="return confirm('Êtes-vous certain de vouloir rouvrir ce signalement pour TOUS les partenaires ?')">
-                            Rouvrir pous tous
+                            Rouvrir pour tous
                         </button>
                     {% endif %}
                     {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') %}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -53,7 +53,7 @@
 
             {% elseif isClosedForMe or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') %}
                 <form action="{{ path('back_signalement_reopen',{uuid:signalement.uuid}) }}" class="fr-mb-3v">
-                    {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+                    {% if isClosed and is_granted('ROLE_ADMIN_TERRITORY') %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left reopen"
                                 name="signalement-action[reopenAll]" value="1"
                                 onclick="return confirm('Êtes-vous certain de vouloir rouvrir ce signalement pour TOUS les partenaires ?')">


### PR DESCRIPTION
## Ticket

#1398    

## Description
Lorque le statut d'un signalement est ouvert mais que l'affectation d'un admin territoire est clôturée, on laisse tout de même le signalement accessible pour l'admin territoire

## Changements apportés
* Modification de condition dans twig pour la classe css `signalement-invalid`

## Tests
- [ ] Se connecter en Admin territoire
- [ ] Affecter un signalement à 2 partenaires, dont 1 Admin territoire
- [ ] Accepter puis clôturer l'affectation depuis le compte de l'Admin territoire
- [ ] Vérifier que l'accès est toujours ok sur le signalement pour cet Admin territoire
