### PR TITLE
[BO - Signalement] Bouton PDF au premier plan pour signalements fermés

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -5,7 +5,7 @@ html, body {
 .signalement-invalid {
     position: relative;
 
-    #signalement-toggle-situations, .reopen, .reaffect, .fr-btn--success.fr-fi-file-pdf-fill, .admin-territory-validation, .signalement-file-item a {
+    #signalement-toggle-situations, .reopen, .reaffect, .fr-fi-file-pdf-fill, .admin-territory-validation, .signalement-file-item a {
         position: relative;
         z-index: 1002;
     }


### PR DESCRIPTION
## Ticket

#1441    

## Description
Bouton PDF au premier plan pour signalements fermés

## Changements apportés
* Ajustement règle css

## Tests
- [ ] Clotûrer un signalement et vérifier que le bouton d'accès au PDF est disponible
