### PR TITLE
[Commandes] Déplacement de la commande de notification de visites en tant que commande CRON

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -13,6 +13,9 @@
       "command": "0 6 * * * php bin/console app:ask-feedback-usager"
     },
     {
+      "command": "0 5 * * * php bin/console app:notify-visits"
+    },
+    {
       "command": "0 0 * * * bash scripts/sync-esabora-sish.sh"
     }
   ]

--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Command;
+namespace App\Command\Cron;
 
 use App\Entity\Suivi;
 use App\Manager\InterventionManager;
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
     name: 'app:notify-visits',
     description: 'Sends notifications concerning visits'
 )]
-class NotifyVisitsCommand extends Command
+class NotifyVisitsCommand extends AbstractCronCommand
 {
     public function __construct(
         private InterventionRepository $interventionRepository,
@@ -33,7 +33,7 @@ class NotifyVisitsCommand extends Command
         private NotificationMailerRegistry $notificationMailerRegistry,
         private ParameterBagInterface $parameterBag,
     ) {
-        parent::__construct();
+        parent::__construct($this->parameterBag);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
## Ticket

#1419    

## Description
Déplacement de la commande de notification de visites en tant que commande CRON

## Changements apportés
* Déplacement de fichier et namespace

## Tests
- [ ] Vérifier que la commande fonctionne toujours `make console app="notify-visits"`
