### PR TITLE
[BO - Visites] Notifications pour agents uniquement si pas un agent qui remplit la visite

### DIFF
--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -60,10 +60,10 @@ class VisiteNotifier
         if ($intervention) {
             if ($notifyAdminTerritory) {
                 $listUsersTerritoryAdmin = $this->userRepository->findActiveTerritoryAdmins($intervention->getSignalement()->getTerritory());
-                $listUsersPartner = $intervention->getPartner() ? $intervention->getPartner()->getUsers()->toArray() : [];
+                $listUsersPartner = $intervention->getPartner() && $intervention->getPartner() != $currentUser->getPartner() ? $intervention->getPartner()->getUsers()->toArray() : [];
                 $listUsersToNotify = array_unique(array_merge($listUsersTerritoryAdmin, $listUsersPartner), \SORT_REGULAR);
             } else {
-                $listUsersToNotify = $intervention->getPartner() ? $intervention->getPartner()->getUsers() : [];
+                $listUsersToNotify = $intervention->getPartner() && $intervention->getPartner() != $currentUser->getPartner() ? $intervention->getPartner()->getUsers() : [];
             }
         } else {
             $listUsersToNotify = $affectation->getPartner()->getUsers();

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -58,12 +58,13 @@ class VisiteNotifier
         ?Affectation $affectation = null,
     ): void {
         if ($intervention) {
+            $listUsersPartner = $intervention->getPartner() && $intervention->getPartner() != $currentUser->getPartner() ?
+                $intervention->getPartner()->getUsers()->toArray() : [];
             if ($notifyAdminTerritory) {
                 $listUsersTerritoryAdmin = $this->userRepository->findActiveTerritoryAdmins($intervention->getSignalement()->getTerritory());
-                $listUsersPartner = $intervention->getPartner() && $intervention->getPartner() != $currentUser->getPartner() ? $intervention->getPartner()->getUsers()->toArray() : [];
                 $listUsersToNotify = array_unique(array_merge($listUsersTerritoryAdmin, $listUsersPartner), \SORT_REGULAR);
             } else {
-                $listUsersToNotify = $intervention->getPartner() && $intervention->getPartner() != $currentUser->getPartner() ? $intervention->getPartner()->getUsers() : [];
+                $listUsersToNotify = $listUsersPartner;
             }
         } else {
             $listUsersToNotify = $affectation->getPartner()->getUsers();


### PR DESCRIPTION
## Ticket

#1419    

## Description
Ne pas notifier un agent à propos des visites si c'est un agent du même partenaire qui a fait la visite

## Changements apportés
* Restriction des utilisateurs à notifier

## Tests
- [ ] Super admin conclut une visite dans le passé : admin territoire et agents du partenaire de la visite sont notifiés
- [ ] Admin territoire conclut une visite dans le passé : agents du partenaire de la visite sont notifiés
- [ ] Agent conclut une visite dans le passé : admin territoire est notifié
