### PR TITLE
[BO - Signalement ] Corrections sur l'affichage des partenaires affectés sur un signalement dans la partie Activité PDLHI

### DIFF
--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -3,7 +3,9 @@
 <h3 class="fr-h4 fr-text--center fr-text-title--blue-france">Activité PDLHI</h3>
 
 
-{% if is_granted('ROLE_ADMIN_TERRITORY') and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') and not needValidation %}
+{% if is_granted('ROLE_ADMIN_TERRITORY')
+        and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
+        and not needValidation %}
     <div class="fr-grid-row">
         <div class="fr-col-9 fr-col-md-6">
             <h3 class="fr-h5">Prise en charge partenaire</h3>
@@ -75,9 +77,8 @@
     </div>
 
 {% elseif
-        not is_granted('ROLE_ADMIN_PARTNER')
-        and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
-        and not needValidation %}
+        not isClosedForMe
+        and isAccepted %}
     <div class="fr-my-3w">
         <h3 class="fr-h5">Partenaires impliqués</h3>
         {% for affectation in signalement.affectations %}


### PR DESCRIPTION
## Ticket

#1445   

## Description
Corrections sur l'affichage de la partie "partenaires affectés" sur la fiche signalement


## Changements apportés
* Affiche les partenaires affectés pour le rôle ADMIN_PARTNER
* N'affiche pas les partenaires pour utilisateurs et admin_partner si l'affectation est fermée ou non acceptée

## Pré-requis

## Tests
- [ ] Se connecter avec les 4 rôles : Super Admin, Resp. territoire, Admin. Partenaire et utilisateur
- [ ] Vérifier l'affichage des partenaires impliqués sur un signalement fermé / en cours / à valider
- [ ] Pour les Super Admin et les Responsables territoires, les partenaires impliqués s'affichent avec des détails, seulement sur les signalements en cours
- [ ] Pour les Admin. partenaire et les utilisateurs, les partenaires impliqués s'affichent sans détails, seulement sur les signalements **dont leur affectation** est acceptée et non cloturée
