### PR TITLE
[Rebranding] Mise à jour taille logo homepage

### DIFF
--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -11,7 +11,7 @@
                         </div>
                         <div class="fr-header__operator">
                             <a href="{{ path('home') }}" title="Accueil - {{ platform.name }}">
-                                <img src={{ asset('img/' ~ platform.logo) }} class="fr-responsive-img" width="100%"
+                                <img src={{ asset('img/' ~ platform.logo145) }} class="fr-responsive-img" width="100%"
                                      alt="{{ platform.name }}">
                             </a>
                         </div>


### PR DESCRIPTION
## Ticket

#1386    

## Description
Mauvaise taille du logo dans la homepage
![image](https://github.com/MTES-MCT/histologe/assets/5757116/77a49675-a8c8-4ec8-8368-a08b22605770)

## Changements apportés
* Uiliser platform.logo145 au lieu platform.logo

## Tests
- [ ] Afficher la homepage
