### PR TITLE
[Back] Mock API - Récupération des questions avant profil

### DIFF
--- a/tools/histologe/histologe.postman_collection.json
+++ b/tools/histologe/histologe.postman_collection.json
@@ -7,6 +7,42 @@
 	},
 	"item": [
 		{
+			"name": "nouveau-formulaire",
+			"item": [
+				{
+					"name": "mock",
+					"item": [
+						{
+							"name": "questions?profil=tous",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8082/api/questions?profil=tous",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8082",
+									"path": [
+										"api",
+										"questions"
+									],
+									"query": [
+										{
+											"key": "profil",
+											"value": "tous"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
 			"name": "signalement/csrf-token",
 			"event": [
 				{

--- a/tools/wiremock/src/Mock/AppMock.php
+++ b/tools/wiremock/src/Mock/AppMock.php
@@ -6,6 +6,7 @@ include_once __DIR__.'/../../vendor/autoload.php';
 
 use Mock\Esabora\EsaboraSCHSMock;
 use Mock\Esabora\EsaboraSISHMock;
+use Mock\Signalement\QuestionMock;
 use WireMock\Client\WireMock;
 
 class AppMock
@@ -18,6 +19,7 @@ class AppMock
             $wireMock = WireMock::create(getenv('WIREMOCK_HOSTNAME'), getenv('WIREMOCK_PORT'));
             EsaboraSCHSMock::prepareMockForEsabora($wireMock);
             EsaboraSISHMock::prepareMockForEsabora($wireMock);
+            QuestionMock::prepareMockForQuestion($wireMock);
         } catch (\Throwable $exception) {
             printf('Error message: %s', $exception->getMessage());
         }

--- a/tools/wiremock/src/Mock/Signalement/QuestionMock.php
+++ b/tools/wiremock/src/Mock/Signalement/QuestionMock.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mock\Signalement;
+
+use Mock\AppMock;
+use WireMock\Client\WireMock;
+
+class QuestionMock
+{
+    protected const RESOURCES_DIR = '/Signalement';
+    protected const BASE_PATH = '/api';
+    protected const RESPONSE_CONTENT_TYPE = 'application/json';
+
+    public static function prepareMockForQuestion(WireMock $wireMock): void
+    {
+        $wireMock->stubFor(
+            WireMock::get(
+                WireMock::urlMatching(self::BASE_PATH.'/questions\\?profil=tous')
+            )
+            ->willReturn(
+                WireMock::aResponse()
+                ->withStatus(200)
+                ->withHeader('Content-Type', self::RESPONSE_CONTENT_TYPE)
+                ->withBody(AppMock::getMockContent(self::RESOURCES_DIR.'/questions_profile_tous.json'))
+            )
+        );
+    }
+}

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -31,7 +31,7 @@
         "slug": "adresse_logement",
         "description": "Tapez puis sélectionnez l'adresse dans la liste",
         "customCss": "question-xl",
-        "action": "show:complement-adresse"
+        "action": "show:complement_adresse"
       },
       {
         "type": "SignalementFormButton",
@@ -236,7 +236,7 @@
         "type": "SignalementFormButton",
         "label": "Suivant",
         "slug": "signalement_concerne_next",
-        "action": "goto:vos-coordonnees"
+        "action": "goto:vos_coordonnees"
       }
     ]
   }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -40,7 +40,6 @@
           "type": "SignalementFormSubscreen",
           "label": "Complément d'adresse (facultatif)",
           "slug": "adresse_logement_complement_adresse",
-          "conditionnal": "",
           "components": {
             "body": [
               {
@@ -85,7 +84,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "adresse_logement_previous",
-          "action": "goto:signalement_concerne"
+          "action": "goto:introduction"
         },
         {
           "type": "SignalementFormButton",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -68,7 +68,7 @@
               {
                 "type": "SignalementFormTextfield",
                 "label": "Numéro d'appartement",
-                "slug": "adresse_logement_complement_adresse_num_appartement",
+                "slug": "adresse_logement_complement_adresse_numero_appartement",
                 "validate": {
                   "required": false
                 }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -1,0 +1,243 @@
+[
+  {
+    "type": "SignalementFormScreen",
+    "label": "Introduction",
+    "slug": "introduction",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eu erat vel urna viverra pellentesque. Sed ac odio libero. Aliquam tristique neque vestibulum, ultrices sapien id, bibendum nisl.",
+    "components": [
+      {
+        "type": "SignalementFormButton",
+        "label": "C'est parti",
+        "slug": "introduction_go",
+        "action": "goto:adresse_logement"
+      },
+      {
+        "type": "SignalementFormButton",
+        "label": "Annuler",
+        "slug": "introduction_cancel",
+        "action": "cancel",
+        "customCss": "btn-link"
+      }
+    ]
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Adresse du logement",
+    "slug": "adresse_logement",
+    "components": [
+      {
+        "type": "SignalementFormAddress",
+        "label": "Commençons par l'adresse du logement",
+        "slug": "adresse_logement",
+        "description": "Tapez puis sélectionnez l'adresse dans la liste",
+        "customCss": "question-xl",
+        "action": "show:complement-adresse"
+      },
+      {
+        "type": "SignalementFormButton",
+        "label": "Afficher tous les champs",
+        "slug": "afficher_champs",
+        "customCss": "btn-link"
+      },
+      {
+        "type": "SignalementFormSubscreen",
+        "label": "Complément d'adresse",
+        "slug": "complement_adresse",
+        "conditionnal": "",
+        "components": [
+          {
+            "type": "SignalementFormTextfield",
+            "label": "Etage",
+            "slug": "etage",
+            "validate": {
+              "required": false
+            }
+          },
+          {
+            "type": "SignalementFormTextfield",
+            "label": "Escalier",
+            "slug": "escalier",
+            "validate": {
+              "required": false
+            }
+          },
+          {
+            "type": "SignalementFormTextfield",
+            "label": "Numéro d'appartement",
+            "slug": "num_appartement",
+            "validate": {
+              "required": false
+            }
+          },
+          {
+            "type": "SignalementFormTextfield",
+            "label": "Autre",
+            "placeholder": "résidence, lieu-dit...",
+            "slug": "autre",
+            "validate": {
+              "required": false
+            }
+          }
+        ]
+      },
+      {
+        "type": "SignalementFormButton",
+        "label": "Suivant",
+        "slug": "suivant_introduction",
+        "action": "goto:signalement_concerne"
+      }
+    ]
+  },
+  {
+    "type": "SignalementFormScreen",
+    "slug": "signalement_concerne",
+    "components": [
+      {
+        "type": "SignalementFormOnlyChoice",
+        "customCss": "question-xl",
+        "label": "Votre signalement concerne...",
+        "slug": "signalement_concerne",
+        "values": [
+          {
+            "value": "Le logement que vous occupez",
+            "slug": "logement_occupez"
+          },
+          {
+            "value": "Un autre logement",
+            "slug": "autre_logement"
+          }
+        ]
+      },
+      {
+        "type": "SignalementFormOnlyChoice",
+        "label": "Vous êtes...",
+        "customCss": "question-xl",
+        "slug": "signalement_concerne_profil_detail",
+        "values": [
+          {
+            "label": "Locataire du logement",
+            "value": "locataire"
+          },
+          {
+            "label": "Propriétaire du logement",
+            "value": "proprietaire"
+          }
+        ],
+        "conditional": {
+          "show": "data.signalement_concerne === 'logement_occupez'"
+        }
+      },
+      {
+        "type": "SignalementFormOnlyChoice",
+        "label": "Vous êtes...",
+        "customCss": "question-xl",
+        "slug": "signalement_concerne_profil_detail",
+        "values": [
+          {
+            "label": "Un particulier",
+            "value": "particulier"
+          },
+          {
+            "label": "Un ou une professionnelle",
+            "value": "professionnelle"
+          },
+          {
+            "label": "Le bailleur du logement",
+            "value": "bailleur"
+          },
+          {
+            "label": "Un service de secours",
+            "value": "service_secours"
+          }
+        ],
+        "conditional": {
+          "show": "data.signalement_concerne === 'autre_logement'"
+        }
+      },
+      {
+        "type": "SignalementFormOnlyChoice",
+        "label": "Plus précisément...",
+        "slug": "signalement_concerne_profil_detail_bailleur",
+        "values": [
+          {
+            "label": "Un particulier",
+            "value": "particulier"
+          },
+          {
+            "label": "Un organisme ou société",
+            "value": "organisme_societe"
+          }
+        ],
+        "conditional": {
+          "show": "data.signalement_concerne_profil_detail === 'proprietaire'"
+        }
+      },
+      {
+        "type": "SignalementFormOnlyChoice",
+        "label": "Plus précisément...",
+        "slug": "signalement_concerne_profil_detail_bailleur",
+        "values": [
+          {
+            "label": "Un particulier",
+            "value": "particulier"
+          },
+          {
+            "label": "Un organisme ou société",
+            "value": "organisme_societe"
+          }
+        ],
+        "conditional": {
+          "show": "data.signalement_concerne_profil_detail === 'bailleur'"
+        }
+      },
+      {
+        "type": "SignalementFormOnlyChoice",
+        "label": "S'agit-il d'un logement social ?",
+        "slug": "signalement_concerne_logement_social",
+        "customCss": "question-xl",
+        "values": [
+          {
+            "label": "Oui",
+            "value": "oui"
+          },
+          {
+            "label": "Non",
+            "value": "non"
+          },
+          {
+            "label": "Je ne sais pas",
+            "value": "ne-sais-pas"
+          }
+        ],
+        "conditional": {
+          "show": "data.signalement_concerne_profil_detail === 'service-secours'"
+        }
+      },
+      {
+        "type": "SignalementFormOnlyChoice",
+        "label": "S'agit-il d'un logement social ?",
+        "slug": "signalement_concerne_logement_social",
+        "customCss": "question-xl",
+        "values": [
+          {
+            "label": "Oui",
+            "value": "oui"
+          },
+          {
+            "label": "Non",
+            "value": "non"
+          }
+        ],
+        "conditional": {
+          "show": "data.signalement_concerne_profil_detail !== 'service-secours'"
+        }
+      },
+      {
+        "type": "SignalementFormButton",
+        "label": "Suivant",
+        "slug": "signalement_concerne_next",
+        "action": "goto:vos-coordonnees"
+      }
+    ]
+  }
+]

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -1,243 +1,267 @@
 [
   {
     "type": "SignalementFormScreen",
-    "label": "Introduction",
+    "label": "Votre signalement va démarrer",
     "slug": "introduction",
-    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eu erat vel urna viverra pellentesque. Sed ac odio libero. Aliquam tristique neque vestibulum, ultrices sapien id, bibendum nisl.",
-    "components": [
-      {
-        "type": "SignalementFormButton",
-        "label": "C'est parti",
-        "slug": "introduction_go",
-        "action": "goto:adresse_logement"
-      },
-      {
-        "type": "SignalementFormButton",
-        "label": "Annuler",
-        "slug": "introduction_cancel",
-        "action": "cancel",
-        "customCss": "btn-link"
-      }
-    ]
+    "description": "<p>Nous allons poser des questions sur le logement, les problèmes rencontrés et la situation du foyer.</p><p>Les informations demandées sont nécéssaires au bon traitement du signalement.</p><p>Attention: lisez bien les questions !</p>",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormButton",
+          "label": "C'est parti",
+          "slug": "introduction_go",
+          "action": "goto:adresse_logement"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Annuler",
+          "slug": "introduction_cancel",
+          "action": "cancel",
+          "customCss": "btn-link"
+        }
+      ]
+    }
   },
   {
     "type": "SignalementFormScreen",
     "label": "Adresse du logement",
     "slug": "adresse_logement",
-    "components": [
-      {
-        "type": "SignalementFormAddress",
-        "label": "Commençons par l'adresse du logement",
-        "slug": "adresse_logement",
-        "description": "Tapez puis sélectionnez l'adresse dans la liste",
-        "customCss": "question-xl",
-        "action": "show:complement_adresse"
-      },
-      {
-        "type": "SignalementFormButton",
-        "label": "Afficher tous les champs",
-        "slug": "afficher_champs",
-        "customCss": "btn-link"
-      },
-      {
-        "type": "SignalementFormSubscreen",
-        "label": "Complément d'adresse",
-        "slug": "complement_adresse",
-        "conditionnal": "",
-        "components": [
-          {
-            "type": "SignalementFormTextfield",
-            "label": "Etage",
-            "slug": "etage",
-            "validate": {
-              "required": false
-            }
-          },
-          {
-            "type": "SignalementFormTextfield",
-            "label": "Escalier",
-            "slug": "escalier",
-            "validate": {
-              "required": false
-            }
-          },
-          {
-            "type": "SignalementFormTextfield",
-            "label": "Numéro d'appartement",
-            "slug": "num_appartement",
-            "validate": {
-              "required": false
-            }
-          },
-          {
-            "type": "SignalementFormTextfield",
-            "label": "Autre",
-            "placeholder": "résidence, lieu-dit...",
-            "slug": "autre",
-            "validate": {
-              "required": false
-            }
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormAddress",
+          "label": "Commençons par l'adresse du logement",
+          "slug": "adresse_logement_adresse",
+          "description": "Tapez puis sélectionnez l'adresse dans la liste",
+          "customCss": "question-xl",
+          "action": "show:complement_adresse"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Afficher tous les champs",
+          "slug": "adresse_logement_afficher_champs",
+          "customCss": "btn-link"
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Complément d'adresse (facultatif)",
+          "slug": "adresse_logement_complement_adresse",
+          "conditionnal": "",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormTextfield",
+                "label": "Etage",
+                "slug": "adresse_logement_complement_adresse_etage",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormTextfield",
+                "label": "Escalier",
+                "slug": "adresse_logement_complement_adresse_escalier",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormTextfield",
+                "label": "Numéro d'appartement",
+                "slug": "adresse_logement_complement_adresse_num_appartement",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormTextfield",
+                "label": "Autre",
+                "placeholder": "résidence, lieu-dit...",
+                "slug": "adresse_logement_complement_adresse_autre",
+                "validate": {
+                  "required": false
+                }
+              }
+            ]
           }
-        ]
-      },
-      {
-        "type": "SignalementFormButton",
-        "label": "Suivant",
-        "slug": "suivant_introduction",
-        "action": "goto:signalement_concerne"
-      }
-    ]
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "adresse_logement_previous",
+          "action": "goto:signalement_concerne"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "adresse_logement_next",
+          "action": "goto:signalement_concerne"
+        }
+      ]
+    }
   },
   {
     "type": "SignalementFormScreen",
     "slug": "signalement_concerne",
-    "components": [
-      {
-        "type": "SignalementFormOnlyChoice",
-        "customCss": "question-xl",
-        "label": "Votre signalement concerne...",
-        "slug": "signalement_concerne",
-        "values": [
-          {
-            "value": "Le logement que vous occupez",
-            "slug": "logement_occupez"
-          },
-          {
-            "value": "Un autre logement",
-            "slug": "autre_logement"
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormOnlyChoice",
+          "customCss": "question-xl",
+          "label": "Votre signalement concerne...",
+          "slug": "signalement_concerne_profil",
+          "values": [
+            {
+              "value": "Le logement que vous occupez",
+              "slug": "logement_occupez"
+            },
+            {
+              "value": "Un autre logement",
+              "slug": "autre_logement"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Vous êtes...",
+          "customCss": "question-xl",
+          "slug": "signalement_concerne_profil_detail",
+          "values": [
+            {
+              "label": "Locataire du logement",
+              "value": "locataire"
+            },
+            {
+              "label": "Propriétaire du logement",
+              "value": "proprietaire"
+            }
+          ],
+          "conditional": {
+            "show": "data.signalement_concerne_profil === 'logement_occupez'"
           }
-        ]
-      },
-      {
-        "type": "SignalementFormOnlyChoice",
-        "label": "Vous êtes...",
-        "customCss": "question-xl",
-        "slug": "signalement_concerne_profil_detail",
-        "values": [
-          {
-            "label": "Locataire du logement",
-            "value": "locataire"
-          },
-          {
-            "label": "Propriétaire du logement",
-            "value": "proprietaire"
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Vous êtes...",
+          "customCss": "question-xl",
+          "slug": "signalement_concerne_profil_detail",
+          "values": [
+            {
+              "label": "Un particulier",
+              "value": "particulier"
+            },
+            {
+              "label": "Un ou une professionnelle",
+              "value": "professionnelle"
+            },
+            {
+              "label": "Le bailleur du logement",
+              "value": "bailleur"
+            },
+            {
+              "label": "Un service de secours",
+              "value": "service_secours"
+            }
+          ],
+          "conditional": {
+            "show": "data.signalement_concerne_profil === 'autre_logement'"
           }
-        ],
-        "conditional": {
-          "show": "data.signalement_concerne === 'logement_occupez'"
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Plus précisément...",
+          "slug": "signalement_concerne_profil_detail_bailleur",
+          "values": [
+            {
+              "label": "Un particulier",
+              "value": "particulier"
+            },
+            {
+              "label": "Un organisme ou société",
+              "value": "organisme_societe"
+            }
+          ],
+          "conditional": {
+            "show": "data.signalement_concerne_profil_detail === 'proprietaire'"
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Plus précisément...",
+          "slug": "signalement_concerne_profil_detail_bailleur",
+          "values": [
+            {
+              "label": "Un particulier",
+              "value": "particulier"
+            },
+            {
+              "label": "Un organisme ou société",
+              "value": "organisme_societe"
+            }
+          ],
+          "conditional": {
+            "show": "data.signalement_concerne_profil_detail === 'bailleur'"
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "S'agit-il d'un logement social ?",
+          "slug": "signalement_concerne_logement_social",
+          "customCss": "question-xl",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "ne-sais-pas"
+            }
+          ],
+          "conditional": {
+            "show": "data.signalement_concerne_profil_detail === 'service-secours'"
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "S'agit-il d'un logement social ?",
+          "slug": "signalement_concerne_logement_social",
+          "customCss": "question-xl",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            }
+          ],
+          "conditional": {
+            "show": "data.signalement_concerne_profil_detail !== 'service-secours'"
+          }
         }
-      },
-      {
-        "type": "SignalementFormOnlyChoice",
-        "label": "Vous êtes...",
-        "customCss": "question-xl",
-        "slug": "signalement_concerne_profil_detail",
-        "values": [
-          {
-            "label": "Un particulier",
-            "value": "particulier"
-          },
-          {
-            "label": "Un ou une professionnelle",
-            "value": "professionnelle"
-          },
-          {
-            "label": "Le bailleur du logement",
-            "value": "bailleur"
-          },
-          {
-            "label": "Un service de secours",
-            "value": "service_secours"
-          }
-        ],
-        "conditional": {
-          "show": "data.signalement_concerne === 'autre_logement'"
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "signalement_concerne_previous",
+          "action": "goto:adresse_logement"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "signalement_concerne_next",
+          "action": "goto:vos_coordonnees"
         }
-      },
-      {
-        "type": "SignalementFormOnlyChoice",
-        "label": "Plus précisément...",
-        "slug": "signalement_concerne_profil_detail_bailleur",
-        "values": [
-          {
-            "label": "Un particulier",
-            "value": "particulier"
-          },
-          {
-            "label": "Un organisme ou société",
-            "value": "organisme_societe"
-          }
-        ],
-        "conditional": {
-          "show": "data.signalement_concerne_profil_detail === 'proprietaire'"
-        }
-      },
-      {
-        "type": "SignalementFormOnlyChoice",
-        "label": "Plus précisément...",
-        "slug": "signalement_concerne_profil_detail_bailleur",
-        "values": [
-          {
-            "label": "Un particulier",
-            "value": "particulier"
-          },
-          {
-            "label": "Un organisme ou société",
-            "value": "organisme_societe"
-          }
-        ],
-        "conditional": {
-          "show": "data.signalement_concerne_profil_detail === 'bailleur'"
-        }
-      },
-      {
-        "type": "SignalementFormOnlyChoice",
-        "label": "S'agit-il d'un logement social ?",
-        "slug": "signalement_concerne_logement_social",
-        "customCss": "question-xl",
-        "values": [
-          {
-            "label": "Oui",
-            "value": "oui"
-          },
-          {
-            "label": "Non",
-            "value": "non"
-          },
-          {
-            "label": "Je ne sais pas",
-            "value": "ne-sais-pas"
-          }
-        ],
-        "conditional": {
-          "show": "data.signalement_concerne_profil_detail === 'service-secours'"
-        }
-      },
-      {
-        "type": "SignalementFormOnlyChoice",
-        "label": "S'agit-il d'un logement social ?",
-        "slug": "signalement_concerne_logement_social",
-        "customCss": "question-xl",
-        "values": [
-          {
-            "label": "Oui",
-            "value": "oui"
-          },
-          {
-            "label": "Non",
-            "value": "non"
-          }
-        ],
-        "conditional": {
-          "show": "data.signalement_concerne_profil_detail !== 'service-secours'"
-        }
-      },
-      {
-        "type": "SignalementFormButton",
-        "label": "Suivant",
-        "slug": "signalement_concerne_next",
-        "action": "goto:vos_coordonnees"
-      }
-    ]
+      ]
+    }
   }
 ]

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -37,12 +37,6 @@
           "action": "show:complement_adresse"
         },
         {
-          "type": "SignalementFormButton",
-          "label": "Afficher tous les champs",
-          "slug": "adresse_logement_afficher_champs",
-          "customCss": "btn-link"
-        },
-        {
           "type": "SignalementFormSubscreen",
           "label": "Complément d'adresse (facultatif)",
           "slug": "adresse_logement_complement_adresse",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -139,7 +139,7 @@
             }
           ],
           "conditional": {
-            "show": "data.signalement_concerne_profil === 'logement_occupez'"
+            "show": "formStore.data.signalement_concerne_profil === 'logement_occupez'"
           }
         },
         {
@@ -166,7 +166,7 @@
             }
           ],
           "conditional": {
-            "show": "data.signalement_concerne_profil === 'autre_logement'"
+            "show": "formStore.data.signalement_concerne_profil === 'autre_logement'"
           }
         },
         {
@@ -184,7 +184,7 @@
             }
           ],
           "conditional": {
-            "show": "data.signalement_concerne_profil_detail === 'proprietaire'"
+            "show": "formStore.data.signalement_concerne_profil_detail === 'proprietaire'"
           }
         },
         {
@@ -202,7 +202,7 @@
             }
           ],
           "conditional": {
-            "show": "data.signalement_concerne_profil_detail === 'bailleur'"
+            "show": "formStore.data.signalement_concerne_profil_detail === 'bailleur'"
           }
         },
         {
@@ -225,7 +225,7 @@
             }
           ],
           "conditional": {
-            "show": "data.signalement_concerne_profil_detail === 'service-secours'"
+            "show": "formStore.data.signalement_concerne_profil_detail === 'service-secours'"
           }
         },
         {
@@ -244,7 +244,7 @@
             }
           ],
           "conditional": {
-            "show": "data.signalement_concerne_profil_detail !== 'service-secours'"
+            "show": "formStore.data.signalement_concerne_profil_detail !== 'service-secours'"
           }
         }
       ],


### PR DESCRIPTION
## Ticket

#1423    

## Description
Web service retournant les questions à poser avant de déterminer le profile

## Changements apportés
Par rapport à l'excel
* Slug avec des "_" au lieu des "-"
* Propriété customCss au lieu de css
* Nom des composants retournés
* Prise en compte d'un body et un footer de component pour le coté ui
* Présence du nom du store dans les conditions

## Pré-requis
```
$ make mock
```

## Tests
- [ ] curl http://localhost:8082/api/questions?profil=tous
