### PR TITLE
  [Front] Créer les composants OnlyChoice et Subscreen

### DIFF
--- a/assets/vue/components/signalement-form/SignalementFormButton.vue
+++ b/assets/vue/components/signalement-form/SignalementFormButton.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 
 export default defineComponent({
   name: 'SignalementFormButton',
@@ -23,7 +23,7 @@ export default defineComponent({
       type: String,
       default: '',
       validator: (value: string) => {
-        if (value && value.includes(':')) {
+        if ((value && value.includes(':')) || value === 'cancel') {
           // const [actionType, actionParam] = value.split(':')
           // Utilisez actionType et actionParam pour des vérifications supplémentaires si nécessaire
           return true
@@ -31,7 +31,7 @@ export default defineComponent({
         return false
       }
     },
-    type: { type: String, default: 'button' },
+    type: { type: String as PropType<'button' | 'submit' | 'reset' | undefined>, default: 'button' },
     customCss: { type: String, default: '' },
     clickEvent: Function
   },

--- a/assets/vue/components/signalement-form/SignalementFormOnlyChoice.vue
+++ b/assets/vue/components/signalement-form/SignalementFormOnlyChoice.vue
@@ -1,0 +1,65 @@
+<template>
+  <fieldset class="fr-fieldset" id="radio-hint" aria-labelledby="radio-hint-legend radio-hint-messages">
+      <legend :class="[ customCss, 'fr-fieldset__legend--regular', 'fr-fieldset__legend']" :for="id" id="radio-hint-legend">
+        {{ label }}
+      </legend>
+      <div v-for="radioValue in values" class="fr-fieldset__element" :key="radioValue.slug">
+          <div class="fr-radio-group">
+            <input
+              type="radio"
+              :id="radioValue.slug"
+              v-bind:key="radioValue.slug"
+              :name="id"
+              :value="radioValue.slug"
+              :class="[ customCss, 'fr-input' ]"
+              @input="updateValue($event)"
+              aria-describedby="radio-error-messages"
+              >
+              <label class="fr-label" :for="radioValue.slug">
+                  {{ radioValue.value }}
+              </label>
+          </div>
+      </div>
+      <div class="fr-messages-group" id="radio-error-messages" aria-live="assertive">
+          <p class="fr-message fr-message--error fr-error-text" id="radio-error-message-error" v-if="hasError">{{ error }}</p>
+      </div>
+  </fieldset>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'SignalementFormOnlyChoice',
+  props: {
+    id: { type: String, default: null },
+    label: { type: String, default: null },
+    modelValue: { type: String, default: null },
+    values: { type: Array as () => Array<{ slug: string; value: string }>, default: null },
+    customCss: { type: String, default: '' },
+    validate: { type: Object, default: null },
+    hasError: { type: Boolean, default: false },
+    error: { type: String, default: '' }
+  },
+  computed: {
+    internalValue: {
+      get () {
+        return this.modelValue
+      },
+      set (newValue: string) {
+        this.$emit('update:modelValue', newValue)
+      }
+    }
+  },
+  methods: {
+    updateValue (event: Event) {
+      const value = (event.target as HTMLInputElement).getAttribute('value')
+      this.$emit('update:modelValue', value)
+    }
+  },
+  emits: ['update:modelValue']
+})
+</script>
+
+<style>
+</style>

--- a/assets/vue/components/signalement-form/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/SignalementFormScreen.vue
@@ -95,11 +95,11 @@ export default defineComponent({
         this.showComponentBySlug(param)
       }
     },
-    showScreenBySlug (slug:string) {
+    showScreenBySlug (slug: string) {
       formStore.validationErrors = {}
 
-      if (this.components) {
-        for (const field of this.components.body) {
+      const traverseComponents = (components: any) => {
+        for (const field of components) {
           if (this.isRequired(field)) {
             const value = formStore.data[field.slug]
             if (!value) {
@@ -107,13 +107,21 @@ export default defineComponent({
             }
           }
           // Effectuer d'autres validations nécessaires pour les autres règles (minLength, maxLength, pattern, etc.)
+          // Vérifier si le composant est de type Subscreen et a des composants enfants
+          if (field.type === 'SignalementFormSubscreen' && field.components) {
+            traverseComponents(field.components.body)
+          }
         }
+      }
+
+      if (this.components) {
+        traverseComponents(this.components.body)
         if (Object.keys(formStore.validationErrors).length > 0) {
           window.scrollTo(0, 0)
           return
         }
       }
-      // si pas d'erreur de validation, on change d'écran
+      // Si pas d'erreur de validation, on change d'écran
       if (this.changeEvent !== undefined) {
         this.changeEvent(slug)
       }

--- a/assets/vue/components/signalement-form/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/SignalementFormSubscreen.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="fr-container">
-    <h1>{{ label }}</h1>
-    <div v-html="description"></div>
+  <div>
+    <h2>{{ label }}</h2>
+    <p v-html="description"></p>
     <div
       v-if="components != undefined"
       >
@@ -11,8 +11,6 @@
         v-bind:key="component.slug"
         :id="component.slug"
         :label="component.label"
-        :description="component.description"
-        :components="component.components"
         :action="component.action"
         :values="component.values"
         :customCss="component.customCss"
@@ -25,24 +23,6 @@
       />
     </div>
   </div>
-  <div class="fr-mt-5w"
-    v-if="components != undefined"
-    >
-    <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
-      <component
-        v-for="component in components.footer"
-        :is="component.type"
-        v-bind:key="component.slug"
-        :id="component.slug"
-        :label="component.label"
-        :action="component.action"
-        :customCss="component.customCss"
-        v-model="formStore.data[component.slug]"
-        :class="[ 'fr-col-4', { 'fr-hidden': component.conditional && !formStore.shouldShowField(component.conditional.show) } ]"
-        :clickEvent="handleClickComponent"
-      />
-    </div>
-  </div>
 </template>
 
 <script lang="ts">
@@ -51,15 +31,13 @@ import formStore from './store'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
-import SignalementFormSubscreen from './SignalementFormSubscreen.vue'
 
 export default defineComponent({
-  name: 'SignalementFormScreen',
+  name: 'SignalementFormSubscreen',
   components: {
     SignalementFormTextfield,
     SignalementFormButton,
-    SignalementFormOnlyChoice,
-    SignalementFormSubscreen
+    SignalementFormOnlyChoice
   },
   props: {
     label: String,
@@ -73,14 +51,6 @@ export default defineComponent({
     }
   },
   methods: {
-    isRequired (field: any): boolean {
-      if ((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
-          (field.validate && field.validate.required)) { // ou il y a des règles de validation explicites
-        return true
-      } else {
-        return false
-      }
-    },
     updateFormData (slug: string, value: any) {
       this.formStore.data[slug] = value
     },
@@ -100,10 +70,11 @@ export default defineComponent({
 
       if (this.components) {
         for (const field of this.components.body) {
-          if (this.isRequired(field)) {
+          if ((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
+          (field.validate && field.validate.required)) { // ou il y a des règles de validation explicites
             const value = formStore.data[field.slug]
             if (!value) {
-              formStore.validationErrors[field.slug] = 'Ce champ est requis' // field.errorText ?
+              formStore.validationErrors[field.slug] = 'Ce champ est requis'
             }
           }
           // Effectuer d'autres validations nécessaires pour les autres règles (minLength, maxLength, pattern, etc.)

--- a/assets/vue/components/signalement-form/SignalementFormTextfield.vue
+++ b/assets/vue/components/signalement-form/SignalementFormTextfield.vue
@@ -7,7 +7,7 @@
         :name="id"
         :value="internalValue"
         :class="[ customCss, 'fr-input' ]"
-        @input="updateValue($event.target.value)"
+        @input="updateValue($event)"
         aria-describedby="text-input-error-desc-error"
         >
     <div
@@ -45,7 +45,8 @@ export default defineComponent({
     }
   },
   methods: {
-    updateValue (value: any) {
+    updateValue (event: Event) {
+      const value = (event.target as HTMLInputElement).value
       this.$emit('update:modelValue', value)
     }
   },

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -1,7 +1,7 @@
 <template>
     <div
       id="app-signalement-form"
-      class="signalement-form fr-pt-5w"
+      class="signalement-form fr-p-5w"
       :data-ajaxurl="sharedProps.ajaxurl"
       >
       <SignalementFormScreen

--- a/assets/vue/components/signalement-form/exemple_socle.json
+++ b/assets/vue/components/signalement-form/exemple_socle.json
@@ -12,6 +12,20 @@
           "slug": "introduction_test"
         },
         {
+          "type": "SignalementFormSubscreen",
+          "label": "test subscreen",
+          "slug": "introduction_subscreen",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormTextfield",
+                "label": "composant de test dans le subscreen",
+                "slug": "introduction_subscreen_test"
+              }
+            ]
+          }
+        },
+        {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "introduction_go",
@@ -49,6 +63,22 @@
         "validate": {
           "required": false
         }
+      },
+      {
+        "type": "SignalementFormOnlyChoice",
+        "customCss": "question-xl",        
+        "label": "Votre signalement concerne...",
+        "slug": "signalement_concerne",
+        "values": [          
+          {
+            "value": "Le logement que vous occupez",
+            "slug": "logement_occupez"
+          },
+          {
+            "value": "Un autre logement",
+            "slug": "autre_logement"
+          }
+        ]
       }
       ],
       "footer": [

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -30,14 +30,17 @@ interface FormStore {
 const formStore: FormStore = reactive({
   data: {
     introduction_test: '',
+    introduction_subscreen_test: '',
     adresse_logement_etage: '',
-    adresse_logement_escalier: ''
+    adresse_logement_escalier: '',
+    signalement_concerne: ''
   },
   props: {
     ajaxurl: ''
   },
   inputComponents: [
-    'SignalementFormTextfield'
+    'SignalementFormTextfield',
+    'SignalementFormOnlyChoice'
   ],
   validationErrors: {}, // Les erreurs de validation
   updateData (key: string, value: any) {


### PR DESCRIPTION
## Ticket

#1472 
#1474    

## Description
Création de 2 nouveaux composants : SignalementFormOnlyChoice et SignalementFormSubscreen


## Changements apportés
* Modification du json pour ajouter ces composants
* Création des 2 composants
* Corrections de typage sur plusieurs fichiers (code smells typescript)

**Pas fait** : la gestion du précédent (se comporte comme le suivant en validant les champs)

## Pré-requis

## Tests
- [ ] Aller sur la route https://histologe.beta.gouv.fr/nouveau-formulaire/signalement
- [ ] Sur le premier écran on a un textfield, et un sous-écran avec un textfield. Les deux sont obligatoires
- [ ] Le clique sur le bouton Suivant change de screen si les deux champs sont remplis
- [ ] Les données entrées en Input sont bien stockées dans le formData
- [ ] Sur le deuxième écran, l'input Escalier ne s'affiche que si on a saisit le nombre d'étage
- [ ] Sur le deuxième écran, on a maintenant un OnlyChoice qui est obligatoire
