### PR TITLE
[Back] Faire distinction entre nouveau signalement et ancien signalement

### DIFF
--- a/migrations/Version20230720102750.php
+++ b/migrations/Version20230720102750.php
@@ -16,7 +16,7 @@ final class Version20230720102750 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE signalement_draft (id INT AUTO_INCREMENT NOT NULL, uuid BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid)\', profile VARCHAR(255) DEFAULT NULL, email_declarant VARCHAR(255) NOT NULL, address VARCHAR(255) NOT NULL, payload LONGTEXT NOT NULL, current_step VARCHAR(128) NOT NULL, status VARCHAR(255) DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE signalement_draft (id INT AUTO_INCREMENT NOT NULL, uuid BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid)\', profile VARCHAR(255) DEFAULT NULL, email_declarant VARCHAR(255) NOT NULL, address VARCHAR(255) NOT NULL, payload JSON NOT NULL, current_step VARCHAR(128) NOT NULL, status VARCHAR(255) DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE signalement ADD created_from_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B551143EA4CB4D FOREIGN KEY (created_from_id) REFERENCES signalement_draft (id)');
         $this->addSql('CREATE INDEX IDX_F4B551143EA4CB4D ON signalement (created_from_id)');

--- a/migrations/Version20230720102750.php
+++ b/migrations/Version20230720102750.php
@@ -16,7 +16,7 @@ final class Version20230720102750 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE signalement_draft (id INT AUTO_INCREMENT NOT NULL, uuid BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid)\', profile VARCHAR(255) DEFAULT NULL, email_declarant VARCHAR(255) NOT NULL, address VARCHAR(255) NOT NULL, payload JSON NOT NULL, current_step VARCHAR(128) NOT NULL, status VARCHAR(255) DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE signalement_draft (id INT AUTO_INCREMENT NOT NULL, uuid BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid)\', profile_declarant VARCHAR(255) DEFAULT NULL, email_declarant VARCHAR(255) NOT NULL, address_complete VARCHAR(255) NOT NULL, payload JSON NOT NULL, current_step VARCHAR(128) NOT NULL, status VARCHAR(255) DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE signalement ADD created_from_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B551143EA4CB4D FOREIGN KEY (created_from_id) REFERENCES signalement_draft (id)');
         $this->addSql('CREATE INDEX IDX_F4B551143EA4CB4D ON signalement (created_from_id)');

--- a/migrations/Version20230720102750.php
+++ b/migrations/Version20230720102750.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230720102750 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add table signalement draft';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE signalement_draft (id INT AUTO_INCREMENT NOT NULL, uuid BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid)\', profile VARCHAR(255) DEFAULT NULL, email_declarant VARCHAR(255) NOT NULL, address VARCHAR(255) NOT NULL, payload LONGTEXT NOT NULL, current_step VARCHAR(128) NOT NULL, status VARCHAR(255) DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE signalement ADD created_from_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B551143EA4CB4D FOREIGN KEY (created_from_id) REFERENCES signalement_draft (id)');
+        $this->addSql('CREATE INDEX IDX_F4B551143EA4CB4D ON signalement (created_from_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B551143EA4CB4D');
+        $this->addSql('DROP INDEX IDX_F4B551143EA4CB4D ON signalement');
+        $this->addSql('ALTER TABLE signalement DROP created_from_id');
+        $this->addSql('DROP TABLE signalement_draft');
+    }
+}

--- a/src/Entity/Enum/Profile.php
+++ b/src/Entity/Enum/Profile.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum Profile: string
+{
+    case LOCATAIRE = 'LOCATAIRE';
+    case BAILLEUR_OCCUPANT = 'BAILLEUR_OCCUPANT';
+    case TIERS_PARTICULIER = 'TIERS_PARTICULIER';
+    case TIERS_PRO = 'TIERS_PRO';
+    case SERVICE_SECOURS = 'SERVICE_SECOURS';
+    case BAILLEUR = 'BAILLEUR';
+
+    public function label(): string
+    {
+        return self::getLabelList()[$this->name];
+    }
+
+    public static function getLabelList(): array
+    {
+        return [
+            'LOCATAIRE' => 'Locataire',
+            'BAILLEUR_OCCUPANT' => 'Bailleur occupant',
+            'TIERS_PARTICULIER' => 'Tiers particulier',
+            'TIERS_PRO' => 'Tiers pro',
+            'SERVICE_SECOURS' => 'Service de secours',
+            'BAILLEUR' => 'Bailleur',
+        ];
+    }
+}

--- a/src/Entity/Enum/ProfileDeclarant.php
+++ b/src/Entity/Enum/ProfileDeclarant.php
@@ -2,7 +2,7 @@
 
 namespace App\Entity\Enum;
 
-enum Profile: string
+enum ProfileDeclarant: string
 {
     case LOCATAIRE = 'LOCATAIRE';
     case BAILLEUR_OCCUPANT = 'BAILLEUR_OCCUPANT';
@@ -22,7 +22,7 @@ enum Profile: string
             'LOCATAIRE' => 'Locataire',
             'BAILLEUR_OCCUPANT' => 'Bailleur occupant',
             'TIERS_PARTICULIER' => 'Tiers particulier',
-            'TIERS_PRO' => 'Tiers pro',
+            'TIERS_PRO' => 'Tiers professionnel',
             'SERVICE_SECOURS' => 'Service de secours',
             'BAILLEUR' => 'Bailleur',
         ];

--- a/src/Entity/Enum/SignalementDraftStatus.php
+++ b/src/Entity/Enum/SignalementDraftStatus.php
@@ -4,7 +4,7 @@ namespace App\Entity\Enum;
 
 enum SignalementDraftStatus: string
 {
-    case EN_COURS = 'EN COURS';
+    case EN_COURS = 'EN_COURS';
     case EN_CUL_DE_SAC = 'EN_CUL_DE_SAC';
     case EN_SIGNALEMENT = 'EN_SIGNALEMENT';
 
@@ -17,7 +17,7 @@ enum SignalementDraftStatus: string
     {
         return [
             'EN_COURS' => 'En cours',
-            'EN_CUL_DE_SAC' => 'EN cul de sac',
+            'EN_CUL_DE_SAC' => 'En cul de sac',
             'EN_SIGNALEMENT' => 'En signalement',
         ];
     }

--- a/src/Entity/Enum/SignalementDraftStatus.php
+++ b/src/Entity/Enum/SignalementDraftStatus.php
@@ -5,7 +5,7 @@ namespace App\Entity\Enum;
 enum SignalementDraftStatus: string
 {
     case EN_COURS = 'EN_COURS';
-    case EN_CUL_DE_SAC = 'EN_CUL_DE_SAC';
+    case HORS_PDLHI = 'HORS_PDLHI';
     case EN_SIGNALEMENT = 'EN_SIGNALEMENT';
 
     public function label(): string
@@ -17,7 +17,7 @@ enum SignalementDraftStatus: string
     {
         return [
             'EN_COURS' => 'En cours',
-            'EN_CUL_DE_SAC' => 'En cul de sac',
+            'HORS_PDLHI' => 'Hors PDLHI',
             'EN_SIGNALEMENT' => 'En signalement',
         ];
     }

--- a/src/Entity/Enum/SignalementDraftStatus.php
+++ b/src/Entity/Enum/SignalementDraftStatus.php
@@ -5,7 +5,7 @@ namespace App\Entity\Enum;
 enum SignalementDraftStatus: string
 {
     case EN_COURS = 'EN COURS';
-    case CUL_DE_SAC = 'EN_CUL_DE_SAC';
+    case EN_CUL_DE_SAC = 'EN_CUL_DE_SAC';
     case EN_SIGNALEMENT = 'EN_SIGNALEMENT';
 
     public function label(): string

--- a/src/Entity/Enum/SignalementDraftStatus.php
+++ b/src/Entity/Enum/SignalementDraftStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum SignalementDraftStatus: string
+{
+    case EN_COURS = 'EN COURS';
+    case CUL_DE_SAC = 'EN_CUL_DE_SAC';
+    case EN_SIGNALEMENT = 'EN_SIGNALEMENT';
+
+    public function label(): string
+    {
+        return self::getLabelList()[$this->name];
+    }
+
+    public static function getLabelList(): array
+    {
+        return [
+            'EN_COURS' => 'En cours',
+            'EN_CUL_DE_SAC' => 'EN cul de sac',
+            'EN_SIGNALEMENT' => 'En signalement',
+        ];
+    }
+}

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -329,6 +329,9 @@ class Signalement
     #[ORM\OneToMany(mappedBy: 'signalement', targetEntity: File::class, cascade: ['persist'])]
     private Collection $files;
 
+    #[ORM\ManyToOne(inversedBy: 'signalements')]
+    private ?SignalementDraft $createdFrom = null;
+
     public function __construct()
     {
         $this->situations = new ArrayCollection();
@@ -1710,6 +1713,18 @@ class Signalement
                 $file->setSignalement(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getCreatedFrom(): ?SignalementDraft
+    {
+        return $this->createdFrom;
+    }
+
+    public function setCreatedFrom(?SignalementDraft $createdFrom): self
+    {
+        $this->createdFrom = $createdFrom;
 
         return $this;
     }

--- a/src/Entity/SignalementDraft.php
+++ b/src/Entity/SignalementDraft.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Behaviour\TimestampableTrait;
+use App\Entity\Enum\Profile;
+use App\Entity\Enum\SignalementDraftStatus;
+use App\Repository\SignalementDraftRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity(repositoryClass: SignalementDraftRepository::class)]
+class SignalementDraft
+{
+    use TimestampableTrait;
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'uuid')]
+    private ?Uuid $uuid = null;
+
+    #[ORM\Column(type: 'string', nullable: true, enumType: Profile::class)]
+    private ?Profile $profile = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $emailDeclarant = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $address = null;
+
+    #[ORM\Column(type: Types::TEXT)]
+    private ?string $payload = null;
+
+    #[ORM\Column(length: 128)]
+    private ?string $currentStep = null;
+
+    #[ORM\Column(type: 'string', nullable: true, enumType: SignalementDraftStatus::class)]
+    private ?SignalementDraftStatus $status = null;
+
+    #[ORM\OneToMany(mappedBy: 'createdFrom', targetEntity: Signalement::class)]
+    private Collection $signalements;
+
+    public function __construct()
+    {
+        $this->uuid = Uuid::v4();
+        $this->signalements = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUuid(): ?Uuid
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(Uuid $uuid): self
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    public function getProfile(): ?Profile
+    {
+        return $this->profile;
+    }
+
+    public function setProfile(Profile $profile): self
+    {
+        $this->profile = $profile;
+
+        return $this;
+    }
+
+    public function getEmailDeclarant(): ?string
+    {
+        return $this->emailDeclarant;
+    }
+
+    public function setEmailDeclarant(string $emailDeclarant): self
+    {
+        $this->emailDeclarant = $emailDeclarant;
+
+        return $this;
+    }
+
+    public function getAddress(): ?string
+    {
+        return $this->address;
+    }
+
+    public function setAddress(?string $address): self
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    public function getPayload(): ?string
+    {
+        return $this->payload;
+    }
+
+    public function setPayload(string $payload): self
+    {
+        $this->payload = $payload;
+
+        return $this;
+    }
+
+    public function getCurrentStep(): ?string
+    {
+        return $this->currentStep;
+    }
+
+    public function setCurrentStep(string $currentStep): self
+    {
+        $this->currentStep = $currentStep;
+
+        return $this;
+    }
+
+    public function getStatus(): ?SignalementDraftStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(SignalementDraftStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Signalement>
+     */
+    public function getSignalements(): Collection
+    {
+        return $this->signalements;
+    }
+
+    public function addSignalement(Signalement $signalement): self
+    {
+        if (!$this->signalements->contains($signalement)) {
+            $this->signalements->add($signalement);
+            $signalement->setCreatedFrom($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSignalement(Signalement $signalement): self
+    {
+        if ($this->signalements->removeElement($signalement)) {
+            // set the owning side to null (unless already changed)
+            if ($signalement->getCreatedFrom() === $this) {
+                $signalement->setCreatedFrom(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Entity/SignalementDraft.php
+++ b/src/Entity/SignalementDraft.php
@@ -3,7 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Behaviour\TimestampableTrait;
-use App\Entity\Enum\Profile;
+use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\SignalementDraftStatus;
 use App\Repository\SignalementDraftRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -24,14 +24,14 @@ class SignalementDraft
     #[ORM\Column(type: 'uuid')]
     private ?Uuid $uuid = null;
 
-    #[ORM\Column(type: 'string', nullable: true, enumType: Profile::class)]
-    private ?Profile $profile = null;
+    #[ORM\Column(type: 'string', nullable: true, enumType: ProfileDeclarant::class)]
+    private ?ProfileDeclarant $profileDeclarant = null;
 
     #[ORM\Column(length: 255)]
     private ?string $emailDeclarant = null;
 
     #[ORM\Column(length: 255)]
-    private ?string $address = null;
+    private ?string $addressComplete = null;
 
     #[ORM\Column(type: 'json')]
     private ?array $payload = [];
@@ -68,14 +68,14 @@ class SignalementDraft
         return $this;
     }
 
-    public function getProfile(): ?Profile
+    public function getProfileDeclarant(): ?ProfileDeclarant
     {
-        return $this->profile;
+        return $this->profileDeclarant;
     }
 
-    public function setProfile(Profile $profile): self
+    public function setProfileDeclarant(ProfileDeclarant $profileDeclarant): self
     {
-        $this->profile = $profile;
+        $this->profileDeclarant = $profileDeclarant;
 
         return $this;
     }
@@ -92,14 +92,14 @@ class SignalementDraft
         return $this;
     }
 
-    public function getAddress(): ?string
+    public function getAddressComplete(): ?string
     {
-        return $this->address;
+        return $this->addressComplete;
     }
 
-    public function setAddress(?string $address): self
+    public function setAddressComplete(?string $addressComplete): self
     {
-        $this->address = $address;
+        $this->addressComplete = $addressComplete;
 
         return $this;
     }

--- a/src/Entity/SignalementDraft.php
+++ b/src/Entity/SignalementDraft.php
@@ -8,7 +8,6 @@ use App\Entity\Enum\SignalementDraftStatus;
 use App\Repository\SignalementDraftRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
@@ -34,8 +33,8 @@ class SignalementDraft
     #[ORM\Column(length: 255)]
     private ?string $address = null;
 
-    #[ORM\Column(type: Types::TEXT)]
-    private ?string $payload = null;
+    #[ORM\Column(type: 'json')]
+    private ?array $payload = [];
 
     #[ORM\Column(length: 128)]
     private ?string $currentStep = null;
@@ -105,12 +104,12 @@ class SignalementDraft
         return $this;
     }
 
-    public function getPayload(): ?string
+    public function getPayload(): ?array
     {
         return $this->payload;
     }
 
-    public function setPayload(string $payload): self
+    public function setPayload(array $payload): self
     {
         $this->payload = $payload;
 

--- a/src/Repository/SignalementDraftRepository.php
+++ b/src/Repository/SignalementDraftRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\SignalementDraft;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<SignalementDraft>
+ *
+ * @method SignalementDraft|null find($id, $lockMode = null, $lockVersion = null)
+ * @method SignalementDraft|null findOneBy(array $criteria, array $orderBy = null)
+ * @method SignalementDraft[]    findAll()
+ * @method SignalementDraft[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class SignalementDraftRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SignalementDraft::class);
+    }
+
+    public function save(SignalementDraft $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(SignalementDraft $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+}

--- a/tests/Unit/Entity/SignalementDraftTest.php
+++ b/tests/Unit/Entity/SignalementDraftTest.php
@@ -13,7 +13,7 @@ class SignalementDraftTest extends TestCase
     {
         $signalementDraft = (new SignalementDraft())
             ->setAddress('17 quai de la joliette 13002 Marseille')
-            ->setPayload(json_encode(['adresse_logement_etage' => 2]))
+            ->setPayload(['adresse_logement_etage' => 2])
             ->setProfile(Profile::LOCATAIRE)
             ->setEmailDeclarant('john.doe@yopmail.com')
             ->setCurrentStep('3:zone_concernee');

--- a/tests/Unit/Entity/SignalementDraftTest.php
+++ b/tests/Unit/Entity/SignalementDraftTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests\Unit\Entity;
 
-use App\Entity\Enum\Profile;
+use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\SignalementDraft;
 use App\Utils\AddressParser;
 use PHPUnit\Framework\TestCase;
@@ -12,17 +12,17 @@ class SignalementDraftTest extends TestCase
     public function testCreateSignalementDraft(): void
     {
         $signalementDraft = (new SignalementDraft())
-            ->setAddress('17 quai de la joliette 13002 Marseille')
+            ->setAddressComplete('17 quai de la joliette 13002 Marseille')
             ->setPayload(['adresse_logement_etage' => 2])
-            ->setProfile(Profile::LOCATAIRE)
+            ->setProfileDeclarant(ProfileDeclarant::LOCATAIRE)
             ->setEmailDeclarant('john.doe@yopmail.com')
             ->setCurrentStep('3:zone_concernee');
 
         $this->assertNotNull($signalementDraft->getUuid());
         $this->assertNotEmpty($signalementDraft->getPayload());
-        $this->assertNotEmpty($signalementDraft->getProfile());
+        $this->assertNotEmpty($signalementDraft->getProfileDeclarant());
 
-        $addressParsed = AddressParser::parse($signalementDraft->getAddress());
+        $addressParsed = AddressParser::parse($signalementDraft->getAddressComplete());
         $this->assertEquals('17', $addressParsed['number']);
         $this->assertNull($addressParsed['suffix']);
         $this->assertEquals('Quai de la joliette 13002 Marseille', $addressParsed['street']);

--- a/tests/Unit/Entity/SignalementDraftTest.php
+++ b/tests/Unit/Entity/SignalementDraftTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Enum\Profile;
+use App\Entity\SignalementDraft;
+use App\Utils\AddressParser;
+use PHPUnit\Framework\TestCase;
+
+class SignalementDraftTest extends TestCase
+{
+    public function testCreateSignalementDraft(): void
+    {
+        $signalementDraft = (new SignalementDraft())
+            ->setAddress('17 quai de la joliette 13002 Marseille')
+            ->setPayload(json_encode(['adresse_logement_etage' => 2]))
+            ->setProfile(Profile::LOCATAIRE)
+            ->setEmailDeclarant('john.doe@yopmail.com')
+            ->setCurrentStep('3:zone_concernee');
+
+        $this->assertNotNull($signalementDraft->getUuid());
+        $this->assertNotEmpty($signalementDraft->getPayload());
+        $this->assertNotEmpty($signalementDraft->getProfile());
+
+        $addressParsed = AddressParser::parse($signalementDraft->getAddress());
+        $this->assertEquals('17', $addressParsed['number']);
+        $this->assertNull($addressParsed['suffix']);
+        $this->assertEquals('Quai de la joliette 13002 Marseille', $addressParsed['street']);
+
+        $this->assertEquals('john.doe@yopmail.com', $signalementDraft->getEmailDeclarant());
+        $this->assertEquals('3:zone_concernee', $signalementDraft->getCurrentStep());
+    }
+}


### PR DESCRIPTION
## Ticket

#1428    

## Description
Utilisé pour restituer le signalement en cours de saisie. 
| Nom de colonne | Description
|----------------|------------------|
| id             | L'identifiant unique de chaque signalement.
| uuid           | Un identifiant universel unique (UUID) pour chaque signalement.
| profile| Profil usager
| email    | Email de l'usager
| address    | Adresse de l'habitant
| payload        | La payload de la requête (le contenu du store)
| current_step   | Ecran en cours
| status         | en cours", "cul-de-sac" (par exemple assurantiel), "transformé en signalement"
| created_at    | Date de création
| updated_at     | Date de mise à jour


## Changements apportés
* Ajout de la table signalement_draft

## Pré-requis
```
make create-db
```

## Tests
- [ ] Migration OK
 - [ ] CI OK
