### PR TITLE
[BO -Signalement] Partager document en suivi

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -138,13 +138,13 @@
             editor.ui.registry.addMenuButton('mybutton', {
                 text: 'Partager un document',
                 fetch: function (callback) {
-                    var items = [
-                        {% for doc in signalement.documents %}
+                    let items = [
+                        {% for doc in signalement.files|filter(doc => doc.fileType == 'document') %}
                         {
                             type: 'menuitem',
-                            text: '{{ doc.titre }}',
+                            text: '{{ doc.title }}',
                             onAction: function () {
-                                editor.insertContent('&nbsp;<a href="{{ asset('_up/'~doc.file) }}?t=___TOKEN___" class="fr-btn fr-fi-eye-fill fr-btn--icon-left" title="Afficher le document" target="_blank">Consulter "{{ doc.titre }}"</a>');
+                                editor.insertContent('&nbsp;<a href="{{ asset('_up/'~doc.filename) }}?t=___TOKEN___" class="fr-btn fr-fi-eye-fill fr-btn--icon-left" title="Afficher le document" target="_blank">Consulter "{{ doc.title }}"</a>');
                             }
                         },
                         {% endfor %}


### PR DESCRIPTION
## Ticket

#1485    

## Description
Ajouter un document et vérifier que les douments apparaissent sous "Partager un document"

![image](https://github.com/MTES-MCT/histologe/assets/5757116/da3d05d9-0ab0-42a1-bf7d-326639470c2f)

## Changements apportés
* Charrger le documents depuis la nouvelle table file

## Pré-requis
 make console app="migrate-document-data 0"

## Tests
- [ ] J'ajoute un document
- [ ] Je crée un suivi avec le document ajouté
