### PR TITLE
[ESABORA] Ajustement arrêté préfectoral et visite de contrôle

### DIFF
--- a/src/Entity/Enum/InterventionType.php
+++ b/src/Entity/Enum/InterventionType.php
@@ -10,7 +10,7 @@ enum InterventionType: string
 
     public const INTERVENTION_TYPE_LABEL = [
         'VISITE' => 'Visite',
-        'VISITE_CONTROLE' => 'Visite contrôle',
+        'VISITE_CONTROLE' => 'Visite de contrôle',
         'ARRETE_PREFECTORAL' => 'Arrêté préfectoral',
     ];
 

--- a/src/Entity/Enum/InterventionType.php
+++ b/src/Entity/Enum/InterventionType.php
@@ -8,6 +8,12 @@ enum InterventionType: string
     case VISITE_CONTROLE = 'VISITE_CONTROLE';
     case ARRETE_PREFECTORAL = 'ARRETE_PREFECTORAL';
 
+    public const INTERVENTION_TYPE_LABEL = [
+        'VISITE' => 'Visite',
+        'VISITE_CONTROLE' => 'Visite contrôle',
+        'ARRETE_PREFECTORAL' => 'Arrêté préfectoral',
+    ];
+
     public function label(): string
     {
         return self::getLabelList()[$this->name];
@@ -15,15 +21,12 @@ enum InterventionType: string
 
     public static function getLabelList(): array
     {
-        return [
-            'VISITE' => 'Visite',
-            'VISITE_CONTROLE' => 'Visite contrôle',
-            'ARRETE_PREFECTORAL' => 'Arrêté préfectoral',
-        ];
+        return self::INTERVENTION_TYPE_LABEL;
     }
 
     public static function tryFromLabel(string $label): ?self
     {
+        $label = str_contains($label, 'contrôle') ? self::INTERVENTION_TYPE_LABEL['VISITE_CONTROLE'] : $label;
         $key = array_search($label, self::getLabelList());
 
         return self::tryFrom($key);

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -134,8 +134,8 @@ class UserManager extends AbstractManager
             if (null === $user) {
                 $user = $this->userFactory->createInstanceFrom(
                     roleLabel: User::ROLES['Usager'],
-                    territory: null,
                     partner: null,
+                    territory: null,
                     firstname: $prenom,
                     lastname: $nom,
                     email: $mail
@@ -156,5 +156,10 @@ class UserManager extends AbstractManager
         }
 
         return null;
+    }
+
+    public function getSystemUser(): ?User
+    {
+        return $this->getRepository()->findOneBy(['email' => $this->parameterBag->get('user_system_email')]);
     }
 }

--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -17,6 +17,7 @@ use App\Service\Esabora\Enum\EsaboraStatus;
 use App\Service\Esabora\Response\DossierResponseInterface;
 use App\Service\Esabora\Response\Model\DossierArreteSISH;
 use App\Service\Esabora\Response\Model\DossierVisiteSISH;
+use App\Service\Intervention\InterventionDescriptionGenerator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -163,7 +164,7 @@ class EsaboraManager
                 status: Intervention::STATUS_DONE,
                 providerName: InterfacageType::ESABORA->value,
                 providerId: $dossierArreteSISH->getArreteId(),
-                details: $this->buildDetailArrete($dossierArreteSISH),
+                details: InterventionDescriptionGenerator::buildDescriptionArreteCreated($dossierArreteSISH),
                 additionalInformation: $additionalInformation
             );
 
@@ -188,32 +189,10 @@ class EsaboraManager
     {
         $intervention
             ->setScheduledAt(DateParser::parse($dossierArreteSISH->getArreteDate()))
-            ->setDetails($this->buildDetailArrete($dossierArreteSISH))
-            ->setStatus(Intervention::STATUS_DONE)
-            ->setDetails($this->buildDetailArrete($dossierArreteSISH));
+            ->setDetails(InterventionDescriptionGenerator::buildDescriptionArreteCreated($dossierArreteSISH))
+            ->setStatus(Intervention::STATUS_DONE);
 
         $this->interventionRepository->save($intervention, true);
-    }
-
-    private function buildDetailArrete(DossierArreteSISH $dossierArreteSISH): string
-    {
-        $description = sprintf(
-            'Il existe 1 arrêté de type %s de n°%s daté du %s dans le dossier de n°%s.'.\PHP_EOL,
-            $dossierArreteSISH->getArreteType(),
-            $dossierArreteSISH->getArreteNumero(),
-            $dossierArreteSISH->getArreteDate(),
-            $dossierArreteSISH->getDossNum()
-        );
-
-        if ($dossierArreteSISH->getArreteMLNumero()) {
-            $description .= sprintf(
-                'Pour cet arrêté, il a également été pris un arrêté de mainlevée n°%s en date du %s.',
-                $dossierArreteSISH->getArreteMLNumero(),
-                $dossierArreteSISH->getArreteMLDate()
-            );
-        }
-
-        return $description;
     }
 
     private function shouldBeAcceptedViaEsabora(string $esaboraDossierStatus, int $currentStatus): bool

--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -7,15 +7,18 @@ use App\Entity\Enum\InterfacageType;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Intervention;
 use App\Entity\User;
+use App\Event\InterventionCreatedEvent;
 use App\Factory\InterventionFactory;
 use App\Manager\AffectationManager;
 use App\Manager\SuiviManager;
+use App\Manager\UserManager;
 use App\Repository\InterventionRepository;
 use App\Service\Esabora\Enum\EsaboraStatus;
 use App\Service\Esabora\Response\DossierResponseInterface;
 use App\Service\Esabora\Response\Model\DossierArreteSISH;
 use App\Service\Esabora\Response\Model\DossierVisiteSISH;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EsaboraManager
 {
@@ -24,6 +27,8 @@ class EsaboraManager
         private readonly SuiviManager $suiviManager,
         private readonly InterventionRepository $interventionRepository,
         private readonly InterventionFactory $interventionFactory,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly UserManager $userManager,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -128,6 +133,10 @@ class EsaboraManager
                     doneBy: $dossierVisiteSISH->getVisitePar(),
                 );
                 $this->interventionRepository->save($newIntervention, true);
+                $this->eventDispatcher->dispatch(
+                    new InterventionCreatedEvent($newIntervention, $this->userManager->getSystemUser()),
+                    InterventionCreatedEvent::NAME
+                );
             }
         }
     }
@@ -159,6 +168,10 @@ class EsaboraManager
             );
 
             $this->interventionRepository->save($intervention, true);
+            $this->eventDispatcher->dispatch(
+                new InterventionCreatedEvent($intervention, $this->userManager->getSystemUser()),
+                InterventionCreatedEvent::NAME
+            );
         }
     }
 

--- a/src/Service/Intervention/InterventionDescriptionGenerator.php
+++ b/src/Service/Intervention/InterventionDescriptionGenerator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Service\Intervention;
+
+use App\Entity\Enum\InterventionType;
+use App\Entity\Intervention;
+use App\Event\InterventionCreatedEvent;
+use App\Service\Esabora\Response\Model\DossierArreteSISH;
+
+class InterventionDescriptionGenerator
+{
+    public static function generate(Intervention $intervention, string $eventName): ?string
+    {
+        if (InterventionCreatedEvent::NAME === $eventName) {
+            if (InterventionType::ARRETE_PREFECTORAL === $intervention->getType()) {
+                return $intervention->getDetails();
+            }
+
+            return self::buildDescriptionVisiteCreated($intervention);
+        }
+
+        return null;
+    }
+
+    public static function buildDescriptionVisiteCreated(Intervention $intervention): string
+    {
+        $labelVisite = strtolower($intervention->getType()->label());
+        $partnerName = $intervention->getPartner() ? $intervention->getPartner()->getNom() : 'Non renseigné';
+
+        return sprintf(
+            '%s programmée : une %s du logement situé %s est prévue le %s.<br>La %s sera effectuée par %s.',
+            ucfirst($labelVisite),
+            $labelVisite,
+            $intervention->getSignalement()->getAdresseOccupant(),
+            $intervention->getScheduledAt()->format('d/m/Y'),
+            $labelVisite,
+            $partnerName
+        );
+    }
+
+    public static function buildDescriptionArreteCreated(DossierArreteSISH $dossierArreteSISH): string
+    {
+        $description = sprintf(
+            'Il existe 1 arrêté de type %s de n°%s daté du %s dans le dossier de n°%s.'.\PHP_EOL,
+            $dossierArreteSISH->getArreteType(),
+            $dossierArreteSISH->getArreteNumero(),
+            $dossierArreteSISH->getArreteDate(),
+            $dossierArreteSISH->getDossNum()
+        );
+
+        if ($dossierArreteSISH->getArreteMLNumero()) {
+            $description .= sprintf(
+                'Pour cet arrêté, il a également été pris un arrêté de mainlevée n°%s en date du %s.',
+                $dossierArreteSISH->getArreteMLNumero(),
+                $dossierArreteSISH->getArreteMLDate()
+            );
+        }
+
+        return $description;
+    }
+}

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -1,5 +1,11 @@
 <div class="fr-grid-row fr-mt-3v fr-mb-3w">
     <div class="fr-col-12 fr-col-md-6">
+        {% if intervention.type == enum('App\\Entity\\Enum\\InterventionType').VISITE_CONTROLE %}
+            <div class="fr-mb-3v">
+                <strong>Type de visite :</strong>
+                {{ intervention.type.label() }}
+            </div>
+        {% endif %}
         <div class="fr-mb-3v">
             {% include 'back/signalement/view/visites/visite-status.html.twig' %}
         </div>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -1,6 +1,6 @@
 <div class="fr-grid-row fr-mt-3v fr-mb-3w">
     <div class="fr-col-12 fr-col-md-6">
-        {% if intervention.type == enum('App\\Entity\\Enum\\InterventionType').VISITE_CONTROLE %}
+        {% if intervention is defined and intervention.type == enum('App\\Entity\\Enum\\InterventionType').VISITE_CONTROLE %}
             <div class="fr-mb-3v">
                 <strong>Type de visite :</strong>
                 {{ intervention.type.label() }}

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -16,7 +16,7 @@
     {% endif %}
     {% include 'back/signalement/view/visites/visite-item.html.twig' %}
 {% else %}
-    {% for intervention in signalement.interventions %}
+    {% for intervention in signalement.interventions | filter(intervention => intervention.type != enum('App\\Entity\\Enum\\InterventionType').ARRETE_PREFECTORAL) %}
         <div class="fr-grid-row">
             <div class="fr-col-12 fr-col-md-6 fr-h6 fr-mb-3v">
                 Visite #{{loop.index}}
@@ -29,7 +29,7 @@
             </div>
         </div>
         {% include 'back/signalement/view/visites/visite-item.html.twig' %}
-        {% if not loop.last %}
+        {% if loop.last is defined and not loop.last %}
             <hr class="fr-hr--sm">
         {% endif %}
     {% endfor %}

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -5,8 +5,10 @@ namespace App\Tests;
 use App\Entity\Affectation;
 use App\Entity\Critere;
 use App\Entity\Criticite;
+use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\PartnerType;
 use App\Entity\File;
+use App\Entity\Intervention;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Situation;
@@ -319,7 +321,7 @@ trait FixturesHelper
 
         return (new Partner())
             ->setId(1)
-            ->setNom($faker->company())
+            ->setNom('ARS')
             ->setType(PartnerType::ARS)
             ->setEmail($faker->email())
             ->setTerritory($this->getTerritory());
@@ -349,5 +351,18 @@ trait FixturesHelper
             ->setTitle('Photo')
             ->setFileType(File::FILE_TYPE_PHOTO)
             ->setCreatedAt(new \DateTimeImmutable('2022-12-02'));
+    }
+
+    public function getIntervention(
+        InterventionType $interventionType,
+        \DateTimeImmutable $scheduledAt,
+        string $status
+    ): Intervention {
+        return (new Intervention())
+            ->setSignalement($this->getSignalement())
+            ->setPartner($this->getPartner())
+            ->setType($interventionType)
+            ->setScheduledAt($scheduledAt)
+            ->setStatus($status);
     }
 }

--- a/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
@@ -2,14 +2,64 @@
 
 namespace App\Tests\Functional\EventSubscriber;
 
+use App\Entity\Enum\InterventionType;
+use App\Entity\Intervention;
+use App\Entity\User;
 use App\Event\InterventionCreatedEvent;
 use App\EventSubscriber\InterventionCreatedSubscriber;
+use App\Manager\SuiviManager;
+use App\Repository\InterventionRepository;
+use App\Repository\UserRepository;
+use App\Service\Signalement\VisiteNotifier;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class InterventionCreatedSubscriberTest extends KernelTestCase
 {
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+    }
+
     public function testEventSubscription(): void
     {
-        $this->assertArrayHasKey(InterventionCreatedEvent::NAME, InterventionCreatedSubscriber::getSubscribedEvents());
+        $this->assertArrayHasKey(
+            InterventionCreatedEvent::NAME,
+            InterventionCreatedSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function testBuildVisiteDescription(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+        $visiteNotifier = static::getContainer()->get(VisiteNotifier::class);
+        $suiviManager = static::getContainer()->get(SuiviManager::class);
+
+        /** @var InterventionRepository $interventionRepository */
+        $interventionRepository = $this->entityManager->getRepository(Intervention::class);
+        $interventions = $interventionRepository->findBy([
+            'status' => Intervention::STATUS_PLANNED,
+            'type' => InterventionType::VISITE,
+        ]);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
+        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager);
+        $eventDispatcher->addSubscriber($interventionCreatedSubscriber);
+
+        $intervention = $interventions[0];
+
+        $eventDispatcher->dispatch(
+            new InterventionCreatedEvent($intervention, $user),
+            InterventionCreatedEvent::NAME
+        );
+
+        $this->assertEmailCount(2);
+        $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
     }
 }

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -8,6 +8,7 @@ use App\Entity\Suivi;
 use App\Factory\InterventionFactory;
 use App\Manager\AffectationManager;
 use App\Manager\SuiviManager;
+use App\Manager\UserManager;
 use App\Repository\InterventionRepository;
 use App\Service\Esabora\Enum\EsaboraStatus;
 use App\Service\Esabora\EsaboraManager;
@@ -15,6 +16,7 @@ use App\Service\Esabora\Response\DossierStateSCHSResponse;
 use App\Service\Esabora\Response\DossierStateSISHResponse;
 use App\Tests\FixturesHelper;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -26,6 +28,8 @@ class EsaboraManagerTest extends KernelTestCase
     private AffectationManager $affectationManager;
     private SuiviManager $suiviManager;
     private InterventionRepository $interventionRepository;
+    private EventDispatcherInterface $eventDispatcher;
+    private UserManager $userManager;
     private LoggerInterface $logger;
 
     protected function setUp(): void
@@ -35,6 +39,8 @@ class EsaboraManagerTest extends KernelTestCase
         $this->affectationManager = self::getContainer()->get(AffectationManager::class);
         $this->suiviManager = self::getContainer()->get(SuiviManager::class);
         $this->interventionRepository = self::getContainer()->get(InterventionRepository::class);
+        $this->eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $this->userManager = self::getContainer()->get(UserManager::class);
         $this->logger = self::getContainer()->get(LoggerInterface::class);
     }
 
@@ -67,6 +73,8 @@ class EsaboraManagerTest extends KernelTestCase
             $this->suiviManager,
             $this->interventionRepository,
             new InterventionFactory(),
+            $this->eventDispatcher,
+            $this->userManager,
             $this->logger,
         );
 

--- a/tests/Unit/Entity/Enum/InterventionTypeTest.php
+++ b/tests/Unit/Entity/Enum/InterventionTypeTest.php
@@ -19,13 +19,14 @@ class InterventionTypeTest extends TestCase
 
     public function testFromInvalidLabel()
     {
-        $intervention = InterventionType::tryFromLabel('Visite de contrôle');
+        $intervention = InterventionType::tryFromLabel('Type de visite invalide');
         $this->assertNull($intervention);
     }
 
     public function provideInterventionType(): \Generator
     {
         yield 'Visite contrôle' => ['Visite contrôle', InterventionType::VISITE_CONTROLE];
+        yield 'Visite de contrôle' => ['Visite de contrôle', InterventionType::VISITE_CONTROLE];
         yield 'Visite' => ['Visite', InterventionType::VISITE];
         yield 'Arrêté préfectoral' => ['Arrêté préfectoral', InterventionType::ARRETE_PREFECTORAL];
     }

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -7,11 +7,13 @@ use App\Entity\Intervention;
 use App\Factory\InterventionFactory;
 use App\Manager\AffectationManager;
 use App\Manager\SuiviManager;
+use App\Manager\UserManager;
 use App\Repository\InterventionRepository;
 use App\Service\Esabora\EsaboraManager;
 use App\Tests\FixturesHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 
 class EsaboraManagerTest extends TestCase
@@ -22,6 +24,8 @@ class EsaboraManagerTest extends TestCase
     protected MockObject|SuiviManager $suiviManager;
     protected MockObject|InterventionRepository $interventionRepository;
     protected MockObject|InterventionFactory $interventionFactory;
+    protected MockObject|EventDispatcherInterface $eventDispatcher;
+    protected MockObject|UserManager $userManager;
     private MockObject|LoggerInterface $logger;
 
     protected function setUp(): void
@@ -30,6 +34,8 @@ class EsaboraManagerTest extends TestCase
         $this->suiviManager = $this->createMock(SuiviManager::class);
         $this->interventionRepository = $this->createMock(InterventionRepository::class);
         $this->interventionFactory = $this->createMock(InterventionFactory::class);
+        $this->userManager = $this->createMock(UserManager::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
     }
 
@@ -56,6 +62,8 @@ class EsaboraManagerTest extends TestCase
             $this->suiviManager,
             $this->interventionRepository,
             $this->interventionFactory,
+            $this->eventDispatcher,
+            $this->userManager,
             $this->logger,
         );
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
@@ -87,6 +95,8 @@ class EsaboraManagerTest extends TestCase
             $this->suiviManager,
             $this->interventionRepository,
             $this->interventionFactory,
+            $this->eventDispatcher,
+            $this->userManager,
             $this->logger,
         );
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
@@ -111,6 +121,8 @@ class EsaboraManagerTest extends TestCase
             $this->suiviManager,
             $this->interventionRepository,
             $this->interventionFactory,
+            $this->eventDispatcher,
+            $this->userManager,
             $this->logger,
         );
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
@@ -139,6 +151,8 @@ class EsaboraManagerTest extends TestCase
             $this->suiviManager,
             $this->interventionRepository,
             $this->interventionFactory,
+            $this->eventDispatcher,
+            $this->userManager,
             $this->logger
         );
         $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);
@@ -163,6 +177,8 @@ class EsaboraManagerTest extends TestCase
             $this->suiviManager,
             $this->interventionRepository,
             $this->interventionFactory,
+            $this->eventDispatcher,
+            $this->userManager,
             $this->logger
         );
         $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Service\Esabora;
 
 use App\Entity\Enum\PartnerType;
 use App\Entity\Intervention;
+use App\Entity\User;
 use App\Factory\InterventionFactory;
 use App\Manager\AffectationManager;
 use App\Manager\SuiviManager;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class EsaboraManagerTest extends TestCase
 {
@@ -35,7 +37,7 @@ class EsaboraManagerTest extends TestCase
         $this->interventionRepository = $this->createMock(InterventionRepository::class);
         $this->interventionFactory = $this->createMock(InterventionFactory::class);
         $this->userManager = $this->createMock(UserManager::class);
-        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->eventDispatcher = new EventDispatcher();
         $this->logger = $this->createMock(LoggerInterface::class);
     }
 
@@ -56,6 +58,11 @@ class EsaboraManagerTest extends TestCase
         $this->interventionRepository
             ->expects($this->once())
             ->method('save');
+
+        $this->userManager
+            ->expects($this->once())
+            ->method('getSystemUser')
+            ->willReturn($this->getUser([User::ROLE_ADMIN]));
 
         $esaboraManager = new EsaboraManager(
             $this->affectationManager,
@@ -145,6 +152,11 @@ class EsaboraManagerTest extends TestCase
         $this->interventionRepository
             ->expects($this->once())
             ->method('save');
+
+        $this->userManager
+            ->expects($this->once())
+            ->method('getSystemUser')
+            ->willReturn($this->getUser([User::ROLE_ADMIN]));
 
         $esaboraManager = new EsaboraManager(
             $this->affectationManager,

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -113,20 +113,22 @@ class EsaboraManagerTest extends TestCase
         $this->interventionRepository
             ->expects($this->once())
             ->method('findOneBy')
-            ->willReturn(self::CREATE_ACTION ? null : new Intervention());
-
-        $this->interventionFactory
-            ->expects($this->once())
-            ->method('createInstanceFrom');
+            ->willReturn(self::CREATE_ACTION === $action ? null : new Intervention());
 
         $this->interventionRepository
             ->expects($this->once())
             ->method('save');
 
-        $this->userManager
-            ->expects($this->once())
-            ->method('getSystemUser')
-            ->willReturn($this->getUser([User::ROLE_ADMIN]));
+        if (self::CREATE_ACTION === $action) {
+            $this->interventionFactory
+                ->expects($this->once())
+                ->method('createInstanceFrom');
+
+            $this->userManager
+                ->expects($this->once())
+                ->method('getSystemUser')
+                ->willReturn($this->getUser([User::ROLE_ADMIN]));
+        }
 
         return new EsaboraManager(
             $this->affectationManager,

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 class EsaboraManagerTest extends TestCase
 {
     use FixturesHelper;
+    protected const CREATE_ACTION = 'create';
+    protected const UPDATE_ACTION = 'update';
 
     protected MockObject|AffectationManager $affectationManager;
     protected MockObject|SuiviManager $suiviManager;
@@ -45,34 +47,7 @@ class EsaboraManagerTest extends TestCase
     {
         $dossierVisiteCollection = $this->getDossierVisiteSISHCollectionResponse()->getCollection();
         $dossierVisite = $dossierVisiteCollection[0];
-
-        $this->interventionRepository
-            ->expects($this->once())
-            ->method('findOneBy')
-            ->willReturn(null);
-
-        $this->interventionFactory
-            ->expects($this->once())
-            ->method('createInstanceFrom');
-
-        $this->interventionRepository
-            ->expects($this->once())
-            ->method('save');
-
-        $this->userManager
-            ->expects($this->once())
-            ->method('getSystemUser')
-            ->willReturn($this->getUser([User::ROLE_ADMIN]));
-
-        $esaboraManager = new EsaboraManager(
-            $this->affectationManager,
-            $this->suiviManager,
-            $this->interventionRepository,
-            $this->interventionFactory,
-            $this->eventDispatcher,
-            $this->userManager,
-            $this->logger,
-        );
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::CREATE_ACTION);
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
 
@@ -113,25 +88,7 @@ class EsaboraManagerTest extends TestCase
     {
         $dossierVisiteCollection = $this->getDossierVisiteSISHCollectionResponse()->getCollection();
         $dossierVisite = $dossierVisiteCollection[0];
-
-        $this->interventionRepository
-            ->expects($this->once())
-            ->method('findOneBy')
-            ->willReturn(new Intervention());
-
-        $this->interventionFactory
-            ->expects($this->any())
-            ->method('createInstanceFrom');
-
-        $esaboraManager = new EsaboraManager(
-            $this->affectationManager,
-            $this->suiviManager,
-            $this->interventionRepository,
-            $this->interventionFactory,
-            $this->eventDispatcher,
-            $this->userManager,
-            $this->logger,
-        );
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::UPDATE_ACTION);
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
 
@@ -139,11 +96,24 @@ class EsaboraManagerTest extends TestCase
     {
         $dossierArreteCollection = $this->getDossierArreteSISHCollectionResponse()->getCollection();
         $dossierArrete = $dossierArreteCollection[0];
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::CREATE_ACTION);
+        $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);
+    }
 
+    public function testUpdateArrete(): void
+    {
+        $dossierArreteCollection = $this->getDossierArreteSISHCollectionResponse()->getCollection();
+        $dossierArrete = $dossierArreteCollection[0];
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::UPDATE_ACTION);
+        $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);
+    }
+
+    private function provideEsaboraManagerForIntervention(string $action): EsaboraManager
+    {
         $this->interventionRepository
             ->expects($this->once())
             ->method('findOneBy')
-            ->willReturn(null);
+            ->willReturn(self::CREATE_ACTION ? null : new Intervention());
 
         $this->interventionFactory
             ->expects($this->once())
@@ -158,41 +128,14 @@ class EsaboraManagerTest extends TestCase
             ->method('getSystemUser')
             ->willReturn($this->getUser([User::ROLE_ADMIN]));
 
-        $esaboraManager = new EsaboraManager(
+        return new EsaboraManager(
             $this->affectationManager,
             $this->suiviManager,
             $this->interventionRepository,
             $this->interventionFactory,
             $this->eventDispatcher,
             $this->userManager,
-            $this->logger
+            $this->logger,
         );
-        $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);
-    }
-
-    public function testUpdateArrete(): void
-    {
-        $dossierArreteCollection = $this->getDossierArreteSISHCollectionResponse()->getCollection();
-        $dossierArrete = $dossierArreteCollection[0];
-
-        $this->interventionRepository
-            ->expects($this->once())
-            ->method('findOneBy')
-            ->willReturn(new Intervention());
-
-        $this->interventionFactory
-            ->expects($this->any())
-            ->method('createInstanceFrom');
-
-        $esaboraManager = new EsaboraManager(
-            $this->affectationManager,
-            $this->suiviManager,
-            $this->interventionRepository,
-            $this->interventionFactory,
-            $this->eventDispatcher,
-            $this->userManager,
-            $this->logger
-        );
-        $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);
     }
 }

--- a/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
+++ b/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
@@ -24,7 +24,10 @@ class InterventionDescriptionGeneratorTest extends TestCase
         string $scheduledAt,
         string $partnerName
     ): void {
-        $description = InterventionDescriptionGenerator::generate($intervention, InterventionCreatedEvent::NAME);
+        $description = InterventionDescriptionGenerator::generate(
+            $intervention,
+            InterventionCreatedEvent::NAME
+        );
 
         $this->assertStringStartsWith($label, $description);
         $this->assertStringContainsString($address, $description);
@@ -70,12 +73,24 @@ class InterventionDescriptionGeneratorTest extends TestCase
             $this->getIntervention(
                 InterventionType::VISITE_CONTROLE,
                 new \DateTimeImmutable('2023-09-01'),
-                Intervention::STATUS_PLANNED), 'Visite de contrôle programmée :', '25 rue du test', '01/09/2023', 'ARS', ];
+                Intervention::STATUS_PLANNED
+            ),
+            'Visite de contrôle programmée :',
+            '25 rue du test',
+            '01/09/2023',
+            'ARS',
+        ];
 
         yield 'Visite' => [
             $this->getIntervention(
                 InterventionType::VISITE,
                 new \DateTimeImmutable('2023-10-01'),
-                Intervention::STATUS_PLANNED), 'Visite programmée', '25 rue du test', '01/10/2023', 'ARS', ];
+                Intervention::STATUS_PLANNED
+            ),
+            'Visite programmée',
+            '25 rue du test',
+            '01/10/2023',
+            'ARS',
+        ];
     }
 }

--- a/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
+++ b/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Tests\Unit\Service\Intervention;
+
+use App\Entity\Enum\InterventionType;
+use App\Entity\Intervention;
+use App\Event\InterventionCreatedEvent;
+use App\Event\InterventionRescheduledEvent;
+use App\Service\Intervention\InterventionDescriptionGenerator;
+use App\Tests\FixturesHelper;
+use PHPUnit\Framework\TestCase;
+
+class InterventionDescriptionGeneratorTest extends TestCase
+{
+    use FixturesHelper;
+
+    /**
+     * @dataProvider provideVisiteIntervention
+     */
+    public function testVisiteDescriptionOnInterventionCreated(
+        Intervention $intervention,
+        string $label,
+        string $address,
+        string $scheduledAt,
+        string $partnerName
+    ): void {
+        $description = InterventionDescriptionGenerator::generate($intervention, InterventionCreatedEvent::NAME);
+
+        $this->assertStringStartsWith($label, $description);
+        $this->assertStringContainsString($address, $description);
+        $this->assertStringContainsString($scheduledAt, $description);
+        $this->assertStringContainsString($partnerName, $description);
+    }
+
+    public function testArreteDescriptionOnInterventionCreated(): void
+    {
+        $dossierArreteSISH = $this->getDossierArreteSISHCollectionResponse()->getCollection()[0];
+        $description = InterventionDescriptionGenerator::buildDescriptionArreteCreated($dossierArreteSISH);
+
+        $this->assertStringContainsString('Arrêté L.511-11', $description, 'Type arrêté incorrecte');
+        $this->assertStringContainsString('n°2023/DD13/00664', $description, 'N° arrêté incorrecte');
+        $this->assertStringContainsString('14/06/2023', $description, 'Date arrêté incorrecte');
+        $this->assertStringContainsString('n°2023/DD13/0010', $description, 'N° dossier incorrecte');
+        $this->assertStringContainsString('n°2023-DD13-00172', $description, 'N° main levée incorrecte');
+        $this->assertStringContainsString('01/07/2023', $description, 'Date de main levée incorrecte');
+
+        $intervention = (new Intervention())
+            ->setDetails('Test description')
+            ->setType(InterventionType::ARRETE_PREFECTORAL);
+
+        $this->assertEquals('Test description',
+            InterventionDescriptionGenerator::generate(
+                $intervention,
+                InterventionCreatedEvent::NAME
+            )
+        );
+    }
+
+    public function testVisiteDescriptionOnUnknownEvent()
+    {
+        $this->assertNull(InterventionDescriptionGenerator::generate(
+            (new Intervention())->setType(InterventionType::VISITE),
+            InterventionRescheduledEvent::NAME
+        ));
+    }
+
+    public function provideVisiteIntervention(): \Generator
+    {
+        yield 'Visite de contrôle' => [
+            $this->getIntervention(
+                InterventionType::VISITE_CONTROLE,
+                new \DateTimeImmutable('2023-09-01'),
+                Intervention::STATUS_PLANNED), 'Visite de contrôle programmée :', '25 rue du test', '01/09/2023', 'ARS', ];
+
+        yield 'Visite' => [
+            $this->getIntervention(
+                InterventionType::VISITE,
+                new \DateTimeImmutable('2023-10-01'),
+                Intervention::STATUS_PLANNED), 'Visite programmée', '25 rue du test', '01/10/2023', 'ARS', ];
+    }
+}

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas_en_cours.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas_en_cours.json
@@ -22,7 +22,7 @@
         "2023/DD13/0010",
         "03/05/2023 10:16",
         "2023/DD13/00664-03/05/2023 10:16",
-        "Visite de contrôle",
+        "Type de visite invalide",
         "SH"
       ],
       "keyDataList": [


### PR DESCRIPTION
## Ticket

#1476 
#1478    
#1477

## Description

**Etre plus permissif sur le type Visite de contrôle**
Test plus souple sur le libellé provenant d'ésabora en vérifiant si le champ "libellé de la visite" contient le mot "contrôle", en ignorant la casse.

**Ajout du type de visite s'il s'agit d'une visite de contrôle**
![image](https://github.com/MTES-MCT/histologe/assets/5757116/0a9648c4-532c-48d7-b63e-d8a8812e7a7f)


**Modification de l'affichage des arrêtés préfectoraux**
Actuellement, les arrêtés préfectoraux s'affichent dans le bloc de visite. Pour une meilleure organisation, il a été décidé de ne plus les afficher de cette manière, mais plutôt de créer un nouveau suivi dans le fil d'actualité des suivis. Toutefois, il faudra toujours les enregistrer en base de données en tant qu'intervention.

Pour être cohérent avec le fonctionnement de la plateforme dans la création de visite, la création d'une visite venant d'ésabora créera également un suivi 

![image](https://github.com/MTES-MCT/histologe/assets/5757116/5dc98af5-ecb4-4048-9768-bf3a7475766f)

## Changements apportés
* Déclenchement de l’événement `InterventionCreatedEvent` sur la création de visite et arrête depuis EsaboraManager permettant la création de suivi
* Création d'une classe statique pour la génération des descriptions d'intervention (doit servir à toutes les description généré dans le workflow des interventions)
* Filtrer l'affichage des intervention sur la fiche de signalement
* Ajout du type de visite dans la fiche de signalement pour les visites de contrôle
* Ajout d'une méthode permettant de récupérer l'utilisateur systeme depuis UserManager

## Pré-requis
```
$ make mock
```
## Tests
### Tests de régression
- [ ] Création d'une visite futur et passé depuis la fiche signalement afin de vérifier que la description généré soit correcte.

### Tests esabora
Exécuter ` make console app="sync-esabora-sish-intervention`
- [ ] Vérifier que l'arrêté préfectorale ne se trouve plus dans la liste des visites
- [ ] Vérifier que le type est présent pour la visite de contrôle
- [ ] Vérifier que les suivis sont générés pour l’arrête préfectorale
- [ ] Vérifier que les suivis sont générés pour la visite

