### PR TITLE
[Front] Créer le composant SignalementFormInfo

### DIFF
--- a/assets/vue/components/signalement-form/SignalementFormInfo.vue
+++ b/assets/vue/components/signalement-form/SignalementFormInfo.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="fr-notice fr-notice--info">
+      <div class="fr-container">
+          <div class="fr-notice__body">
+              <p class="fr-notice__title" v-html="label">
+              </p>
+          </div>
+      </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'SignalementFormInfo',
+  props: {
+    id: { type: String, default: null },
+    label: { type: String, default: null }
+  }
+})
+</script>
+
+<style>
+/* TODO : virer les styles quand bonne version dsfr */
+  .fr-notice {
+    --title-spacing: 0;
+    --text-spacing: 0;
+    background-color: #eee;
+    color: #161616;
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+    position: relative;
+  }
+  .fr-notice--info {
+    --idle: transparent;
+    --hover: var(--background-contrast-info-hover);
+    --active: var(--background-contrast-info-active);
+    background-color: #e8edff;
+    color: #0063cb;
+  }
+  .fr-notice__body::before {
+    --icon-size: 1.5rem;
+    background-color: currentColor;
+    display: inline-block;
+    flex: 0 0 auto;
+    height: 1.5rem;
+    left: 0;
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    position: absolute;
+    vertical-align: calc(.375em - .75rem);
+    width: 1.5rem;
+    mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCI+PHBhdGggZD0iTTE5LjUgMi41aC0xNWMtMS4xIDAtMiAuOS0yIDJ2MTVjMCAxLjEuOSAyIDIgMmgxNWMxLjEgMCAyLS45IDItMnYtMTVjMC0xLjEtLjktMi0yLTJ6TTEzIDE3aC0ydi02aDJ2NnptMC04aC0yVjdoMnYyeiIvPjwvc3ZnPg==);
+  }
+  .fr-notice__body {
+    padding: 0 2.5rem;
+    position: relative;
+  }
+  .fr-notice__title {
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.5rem;
+    position: relative;
+  }
+</style>

--- a/assets/vue/components/signalement-form/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/SignalementFormScreen.vue
@@ -53,6 +53,7 @@ import SignalementFormTextfield from './SignalementFormTextfield.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
 import SignalementFormSubscreen from './SignalementFormSubscreen.vue'
+import SignalementFormInfo from './SignalementFormInfo.vue'
 
 export default defineComponent({
   name: 'SignalementFormScreen',
@@ -60,7 +61,8 @@ export default defineComponent({
     SignalementFormTextfield,
     SignalementFormButton,
     SignalementFormOnlyChoice,
-    SignalementFormSubscreen
+    SignalementFormSubscreen,
+    SignalementFormInfo
   },
   props: {
     label: String,

--- a/assets/vue/components/signalement-form/exemple_socle.json
+++ b/assets/vue/components/signalement-form/exemple_socle.json
@@ -51,6 +51,11 @@
         "type": "SignalementFormTextfield",
         "label": "Etage",
         "slug": "adresse_logement_etage"
+      },        
+      {
+        "type": "SignalementFormInfo",
+        "slug": "bail_dpe_bail_info",
+        "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur le site du service public."
       },
       {
         "type": "SignalementFormTextfield",


### PR DESCRIPTION
## Ticket

#1493    

## Description
Ajout du composant SignalementFormInfo

## Changements apportés
* création du composant SignalementFormInfo

## Pré-requis

## Tests
- [ ] Aller sur l'écran 2 du formulaire et vérifier la présence du composant SignalementFormInfo (css temporairement dans le composant en attendant la maj du dsfr)
