### PR TITLE
[BO - Signalement ] Mention "Aucun document ou photo disponible" alors qu'il y a des photos

### DIFF
--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -38,7 +38,7 @@
     </p>
 </div>
 
-{% if signalement.photos|length == 0 and signalement.documents|length == 0 %}
+{% if signalement.files|length == 0 %}
     <p class="fr-text--sm">
         Aucun document ou photo disponible
     </p>

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -115,7 +115,10 @@
                     </div>
                     <div class="fr-col-2 fr-text--right">
                         <a href="{{ asset('_up/'~photo.filename) }}?t={{ csrf_token('suivi_signalement_ext_file_view') }}"
-                           class="fr-btn fr-fi-eye-fill fr-btn--icon-left" title="Afficher la photos">Afficher</a>
+                           class="fr-btn fr-fi-eye-fill fr-btn--icon-left"
+                           title="Afficher la photos"
+                           target="_blank"
+                           rel="noopener">Afficher</a>
                     </div>
                 </div>
             {% else %}

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -108,7 +108,7 @@
             <h2 class="fr-mb-0">Photo(s) liée(s) à votre signalement</h2>
             <p class="fr-hint-text">Ci-dessous, les photos ajoutées lors du dépôt de votre signalement ainsi que celles
                 ajoutées par le(s) partenaire(s) en charge de votre dossier.</p>
-            {% for photo in signalement.files %}
+            {% for photo in signalement.files|filter(photo => photo.fileType == 'photo') %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v">
                     <div class="fr-col-10">
                         Photos N°{{ loop.index }}

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -108,13 +108,13 @@
             <h2 class="fr-mb-0">Photo(s) liée(s) à votre signalement</h2>
             <p class="fr-hint-text">Ci-dessous, les photos ajoutées lors du dépôt de votre signalement ainsi que celles
                 ajoutées par le(s) partenaire(s) en charge de votre dossier.</p>
-            {% for photo in signalement.photos %}
+            {% for photo in signalement.files %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v">
                     <div class="fr-col-10">
                         Photos N°{{ loop.index }}
                     </div>
                     <div class="fr-col-2 fr-text--right">
-                        <a href="{{ asset('_up/'~photo.file) }}?t={{ csrf_token('suivi_signalement_ext_file_view') }}"
+                        <a href="{{ asset('_up/'~photo.filename) }}?t={{ csrf_token('suivi_signalement_ext_file_view') }}"
                            class="fr-btn fr-fi-eye-fill fr-btn--icon-left" title="Afficher la photos">Afficher</a>
                     </div>
                 </div>

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -116,7 +116,7 @@
                     <div class="fr-col-2 fr-text--right">
                         <a href="{{ asset('_up/'~photo.filename) }}?t={{ csrf_token('suivi_signalement_ext_file_view') }}"
                            class="fr-btn fr-fi-eye-fill fr-btn--icon-left"
-                           title="Afficher la photos"
+                           title="Afficher la photo"
                            target="_blank"
                            rel="noopener">Afficher</a>
                     </div>


### PR DESCRIPTION
## Ticket

#1509    

## Description
![image](https://github.com/MTES-MCT/histologe/assets/5757116/99924cde-19eb-42ca-893e-eaa22b0bca0f)

## Changements apportés
* Filtre sur la collections files
* Affichage des photos fiche suivi usager sur collection files

## Pré-requis

## Tests
- [ ] Aller sur un signalement, ajouter ou supprimer des photos avant de voir si la mention s'affiche ou pas selon les cas
- [ ] Créer un suivi public. Sur la fiche de suivi usager les photos doivent afficher les photos depuis la table file
