### PR TITLE
  [Relance auto] Correction sur la requête de première relance pour inclure les signalements n'ayant jamais eu ni suivi technique, ni suivi public

### DIFF
--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -1343,3 +1343,47 @@ signalements:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
       - "le sol ou la base des murs est très humide."
+  -
+    uuid: "00000000-0000-0000-2023-000000000020"
+    details: "Signalement ancien sans suivi"
+    is_proprio_averti: 1
+    is_logement_social: 0
+    nb_adultes: "2"
+    is_allocataire: ""
+    nature_logement: "Appartement"
+    type_logement: "T2"
+    superficie: 30
+    loyer: 300
+    phone_number: 0621127286
+    adresse_occupant: "7 Av. Rostand"
+    cp_occupant: "13003"
+    ville_occupant: "Marseille"
+    statut: 2
+    reference: "2023-20"
+    geoloc: "{\"lng\":\"43.3117791\",\"lat\":\"5.3755551\"}"
+    created_at: "2023-01-08 17:06:33"
+    score: 100
+    etage_occupant: "0"
+    escalier_occupant: ""
+    mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
+    insee_occupant: "13203"
+    is_rsa: 0
+    type_energie_logement: "Electrique"
+    origine_signalement: ""
+    nb_occupants_logement: 3
+    situation_occupant: "1"
+    territory: "Bouches-du-Rhône"
+    tags:
+      - "Urgent"
+    situations:
+      - "la vie commune et le voisinage"
+      - "la sécurité des occupants"
+      - "l'état et propreté du logement"
+    criteres:
+      - "Les déchets sont mal stockés."
+      - "La protection incendie n’est pas adaptée."
+      - "Les sols sont humides."
+    criticites:
+      - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
+      - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
+      - "le sol ou la base des murs est très humide."

--- a/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
+++ b/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
@@ -23,7 +23,7 @@ class AskFeedbackUsagerCommandTest extends KernelTestCase
         $commandTester->assertCommandIsSuccessful();
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('4 signalement(s) for which a request for feedback will be sent', $output);
+        $this->assertStringContainsString('5 signalement(s) for which a request for feedback will be sent', $output);
         $this->assertEmailCount(0);
     }
 
@@ -43,7 +43,7 @@ class AskFeedbackUsagerCommandTest extends KernelTestCase
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('1 signalement(s) for which the two last suivis are technicals ', $output);
         $this->assertStringContainsString('1 signalement(s) for which the last suivi is technical', $output);
-        $this->assertStringContainsString('2 signalement(s) without suivi public', $output);
-        $this->assertEmailCount(5); // with cron notification email (4+1)
+        $this->assertStringContainsString('3 signalement(s) without suivi public', $output);
+        $this->assertEmailCount(6); // with cron notification email (4+1)
     }
 }

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -48,20 +48,20 @@ class BackStatistiquesControllerTest extends WebTestCase
     public function provideRoutesStatistiquesDatas(): \Generator
     {
         yield 'Super Admin' => ['back_statistiques_filter', [], self::USER_SUPER_ADMIN, [
-            ['result' => 31, 'label' => 'count_signalement'],
-            ['result' => 70.6, 'label' => 'average_criticite'],
+            ['result' => 32, 'label' => 'count_signalement'],
+            ['result' => 71.5, 'label' => 'average_criticite'],
         ]];
         yield 'Responsable Territoire' => ['back_statistiques_filter', [], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 21, 'label' => 'count_signalement'],
-            ['result' => 98.1, 'label' => 'average_criticite'],
+            ['result' => 22, 'label' => 'count_signalement'],
+            ['result' => 98.2, 'label' => 'average_criticite'],
         ]];
         yield 'Partner' => ['back_statistiques_filter', [], self::USER_PARTNER, [
             ['result' => 3, 'label' => 'count_signalement'],
             ['result' => 100, 'label' => 'average_criticite'],
         ]];
         yield 'RT - filtered with commune Arles' => ['back_statistiques_filter', ['communes' => '["Arles"]'], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 21, 'label' => 'count_signalement'],
-            ['result' => 98.1, 'label' => 'average_criticite'],
+            ['result' => 22, 'label' => 'count_signalement'],
+            ['result' => 98.2, 'label' => 'average_criticite'],
             ['result' => 0, 'label' => 'count_signalement_filtered'],
             ['result' => 0, 'label' => 'average_criticite_filtered'],
         ]];

--- a/tests/Functional/Controller/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/SignalementListControllerTest.php
@@ -188,12 +188,12 @@ class SignalementListControllerTest extends WebTestCase
     public function provideFilterSearch(): \Generator
     {
         yield 'Search Terms with Reference' => ['bo-filters-searchterms', '2022-1', '1 signalement(s)'];
-        yield 'Search Terms with cp Occupant' => ['bo-filters-searchterms', '13003', '9 signalement(s)'];
+        yield 'Search Terms with cp Occupant' => ['bo-filters-searchterms', '13003', '10 signalement(s)'];
         yield 'Search Terms with cp Occupant 13005' => ['bo-filters-searchterms', '13005', '3 signalement(s)'];
         yield 'Search Terms with city Occupant' => ['bo-filters-searchterms', 'Gex', '5 signalement(s)'];
         yield 'Search by Territory' => ['bo-filters-territories', ['1'], '5 signalement(s)'];
         yield 'Search by Partner' => ['bo-filters-partners', ['5'], '2 signalement(s)'];
-        yield 'Search by Critere' => ['bo-filters-criteres', ['17'], '22 signalement(s)'];
+        yield 'Search by Critere' => ['bo-filters-criteres', ['17'], '23 signalement(s)'];
         yield 'Search by Tags' => ['bo-filters-tags', ['3'], '4 signalement(s)'];
         yield 'Search by Parc public/prive' => ['bo-filters-housetypes', ['1'], '4 signalement(s)'];
         yield 'Search by Relances usagers' => ['bo-filters-relances_usager', ['NO_SUIVI_AFTER_3_RELANCES'], '1 signalement(s)'];


### PR DESCRIPTION
## Tickets

#1499 

## Description
La troisième requête (qui correspond à la première relance sur les signalements) n'incluaient pas les signalements n'ayant ni suivi technique, ni suivi public. Ce qui fait que des vieux signalements n'étaient jamais relancés (291 aujourd'hui)
On a changé cette requête pour inclure ces signalements si leur date de création est antérieure de 45 jours à aujourd'hui

## Changements apportés
* Mise à jour de Suivi Repository pour créer des requêtes différentes
* Mise à jour des fixtures pour ajouter un signalement ancien sans suivi public ni suivi technique
* Mise à jour des  tests

## Tests
- [ ] make console app="ask-feedback-usager"
- [ ] Vérifier que le nouveau signalement (2023-20) sans suivi a bien eu une relance automatique
