### PR TITLE
[Front] Appel API avant de changer de screen

### DIFF
--- a/assets/vue/components/signalement-form/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/SignalementFormAddress.vue
@@ -84,8 +84,8 @@ export default defineComponent({
       idFetchTimeout: 0 as unknown as ReturnType<typeof setTimeout>,
       idAdress: this.id + '_suggestion',
       idShow: this.id + '_afficher_les_champs',
-      idSubscreen: this.id + '_tous_les_champs',
-      actionShow: 'show:' + this.id + '_tous_les_champs',
+      idSubscreen: this.id + '_detail',
+      actionShow: 'show:' + this.id + '_detail',
       screens: { body: updatedSubscreenData },
       suggestions: [] as any[],
       formStore
@@ -119,12 +119,12 @@ export default defineComponent({
     },
     handleClickSuggestion (index: number) {
       if (this.suggestions) {
-        this.formStore.data[this.id + '_tous_les_champs_numero'] = this.suggestions[index].properties.name
-        this.formStore.data[this.id + '_tous_les_champs_code_postal'] = this.suggestions[index].properties.postcode
-        this.formStore.data[this.id + '_tous_les_champs_commune'] = this.suggestions[index].properties.city
-        this.formStore.data[this.id + '_tous_les_champs_insee'] = this.suggestions[index].properties.citycode
-        this.formStore.data[this.id + '_tous_les_champs_geoloc_lat'] = this.suggestions[index].geometry.coordinates[0]
-        this.formStore.data[this.id + '_tous_les_champs_geoloc_lng'] = this.suggestions[index].geometry.coordinates[1]
+        this.formStore.data[this.id + '_detail_numero'] = this.suggestions[index].properties.name
+        this.formStore.data[this.id + '_detail_code_postal'] = this.suggestions[index].properties.postcode
+        this.formStore.data[this.id + '_detail_commune'] = this.suggestions[index].properties.city
+        this.formStore.data[this.id + '_detail_insee'] = this.suggestions[index].properties.citycode
+        this.formStore.data[this.id + '_detail_geoloc_lat'] = this.suggestions[index].geometry.coordinates[0]
+        this.formStore.data[this.id + '_detail_geoloc_lng'] = this.suggestions[index].geometry.coordinates[1]
         this.suggestions.length = 0
       }
       const subscreen = document.querySelector('#' + this.idSubscreen)

--- a/assets/vue/components/signalement-form/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/SignalementFormAddress.vue
@@ -53,6 +53,7 @@
 import { defineComponent, watch } from 'vue'
 import formStore from './store'
 import { requests } from './requests'
+import { services } from './services'
 import subscreenData from './address_subscreen.json'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
@@ -76,8 +77,9 @@ export default defineComponent({
     clickEvent: Function
   },
   data () {
-    const updatedSubscreenData = this.generateSubscreenData(this.id, subscreenData.body)
-
+    const updatedSubscreenData = services.generateSubscreenData(this.id, subscreenData.body)
+    // on met à jour formStore en ajoutant les sous-composants du composant Address
+    services.addSubscreenData(this.id, updatedSubscreenData)
     return {
       idFetchTimeout: 0 as unknown as ReturnType<typeof setTimeout>,
       idAdress: this.id + '_suggestion',
@@ -114,14 +116,6 @@ export default defineComponent({
     handleSubscreenModelUpdate (newValue: string) {
       // Mettre à jour la valeur dans formStore.data lorsque la valeur du sous-écran change
       this.formStore.data[this.idSubscreen] = newValue
-    },
-    generateSubscreenData (id: string, data: any[]) {
-      return data.map((component) => {
-        return {
-          ...component,
-          slug: id + '_' + component.slug
-        }
-      })
     },
     handleClickSuggestion (index: number) {
       if (this.suggestions) {

--- a/assets/vue/components/signalement-form/SignalementFormOnlyChoice.vue
+++ b/assets/vue/components/signalement-form/SignalementFormOnlyChoice.vue
@@ -13,6 +13,7 @@
               :value="radioValue.value"
               :class="[ 'fr-input' ]"
               @input="updateValue($event)"
+              :checked="radioValue.value === modelValue"
               aria-describedby="radio-error-messages"
               >
               <label class="fr-label" :for="id + '_' + radioValue.value">
@@ -34,7 +35,7 @@ export default defineComponent({
   props: {
     id: { type: String, default: null },
     label: { type: String, default: null },
-    modelValue: { type: String, default: null },
+    modelValue: { type: String as () => null | string, default: null },
     values: { type: Array as () => Array<{ label: string; value: string }>, default: null },
     customCss: { type: String, default: '' },
     validate: { type: Object, default: null },

--- a/assets/vue/components/signalement-form/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/SignalementFormScreen.vue
@@ -50,7 +50,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import formStore from './store'
-import subscreenData from './address_subscreen.json'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
@@ -89,8 +88,10 @@ export default defineComponent({
   },
   methods: {
     isRequired (field: any): boolean {
-      if ((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
-          (field.validate && field.validate.required)) { // ou il y a des règles de validation explicites
+      const subscreen = document.querySelector('#' + field.slug)
+      if (((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
+          (field.validate && field.validate.required)) && // ou il y a des règles de validation explicites
+          subscreen?.classList.contains('fr-hidden') === false) { // et que le composant n'est pas caché par conditionnalité
         return true
       } else {
         return false
@@ -119,19 +120,12 @@ export default defineComponent({
             const value = formStore.data[field.slug]
             if (!value) {
               formStore.validationErrors[field.slug] = 'Ce champ est requis' // field.errorText ?
-              // TODO : si le champ requis est caché ou dans un subscreen caché, comment gère t-on ?
             }
           }
           // Effectuer d'autres validations nécessaires pour les autres règles (minLength, maxLength, pattern, etc.)
           // Vérifier si le composant est de type Subscreen et a des composants enfants
-          if (field.type === 'SignalementFormSubscreen' && field.components) {
+          if ((field.type === 'SignalementFormSubscreen' || field.type === 'SignalementFormAddress') && field.components) {
             traverseComponents(field.components.body)
-          }
-          // Traitement spécifique pour SignalementFormAddress on génère les composants enfants
-          // TODO : il y a surement mieux à faire car là on duplique le chargement du json et generateSubscreenData entre SignalementFormAddress et ici
-          if (field.type === 'SignalementFormAddress') {
-            const updatedSubscreenData = this.generateSubscreenData(field.slug, subscreenData.body)
-            traverseComponents(updatedSubscreenData)
           }
         }
       }
@@ -157,14 +151,6 @@ export default defineComponent({
       if (buttonToHide) {
         buttonToHide.classList.add('fr-hidden')
       }
-    },
-    generateSubscreenData (id: string, data: any[]) {
-      return data.map((component) => {
-        return {
-          ...component,
-          slug: id + '_' + component.slug
-        }
-      })
     }
   }
 })

--- a/assets/vue/components/signalement-form/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/SignalementFormScreen.vue
@@ -60,6 +60,7 @@ import SignalementFormCounter from './SignalementFormCounter.vue'
 import SignalementFormWarning from './SignalementFormWarning.vue'
 import SignalementFormInfo from './SignalementFormInfo.vue'
 import SignalementFormCheckbox from './SignalementFormCheckbox.vue'
+import { services } from './services'
 
 export default defineComponent({
   name: 'SignalementFormScreen',
@@ -106,13 +107,16 @@ export default defineComponent({
       } else if (type === 'cancel') {
         alert('on fait quoi quand on annule ?')
       } else if (type === 'goto') {
-        this.showScreenBySlug(param)
+        this.showScreenBySlug(param, slugButton)
       } else if (type === 'show') {
         this.showComponentBySlug(param, slugButton)
       }
     },
-    showScreenBySlug (slug: string) {
+    showScreenBySlug (slug: string, slugButton:string) {
       formStore.validationErrors = {}
+      console.log(slugButton)
+      const isScreenAfterCurrent = services.isScreenAfterCurrent(slug)
+      console.log(isScreenAfterCurrent)
 
       const traverseComponents = (components: any) => {
         for (const field of components) {
@@ -130,14 +134,14 @@ export default defineComponent({
         }
       }
 
-      if (this.components) {
+      if (this.components && isScreenAfterCurrent) {
         traverseComponents(this.components.body)
         if (Object.keys(formStore.validationErrors).length > 0) {
           window.scrollTo(0, 0)
           return
         }
       }
-      // Si pas d'erreur de validation, on change d'écran
+      // Si pas d'erreur de validation, ou screen précédent, on change d'écran
       if (this.changeEvent !== undefined) {
         this.changeEvent(slug)
       }

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -47,6 +47,7 @@ export default defineComponent({
   },
   data () {
     return {
+      slugVosCoordonnees: 'vos_coordonnees',
       isErrorInit: false,
       isLoadingInit: true,
       sharedProps: formStore.props,
@@ -79,7 +80,7 @@ export default defineComponent({
           formStore.currentScreenIndex = screenIndex
           this.currentScreen = formStore.screenData[screenIndex]
         } else {
-          if (slug === 'vos_coordonnees') {
+          if (slug === this.slugVosCoordonnees) {
             // on détermine le profil
             services.updateProfil()
             // on fait un appel API pour charger la suite des questions avant de changer d'écran

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -34,6 +34,7 @@
 import { defineComponent } from 'vue'
 import formStore from './store'
 import { requests } from './requests'
+import { services } from './services'
 import SignalementFormScreen from './SignalementFormScreen.vue'
 import SignalementFormBreadCrumbs from './SignalementFormBreadCrumbs.vue'
 const initElements:any = document.querySelector('#app-signalement-form')
@@ -45,18 +46,14 @@ export default defineComponent({
     SignalementFormBreadCrumbs
   },
   data () {
-    // const currentScreen = screenData[formStore.currentScreenIndex]
     return {
       isErrorInit: false,
       isLoadingInit: true,
       sharedProps: formStore.props,
-      // sharedState: formStore.data,
-      // screens: [] as Array<{ slug: string; label: string; description: string; components: object }>,
       currentScreen: null as { slug: string; label: string; description: string ; components: object } | null
     }
   },
   created () {
-    // formStore.screenData = screenData
     if (initElements !== null) {
       this.sharedProps.ajaxurl = initElements.dataset.ajaxurl
       this.sharedProps.ajaxurlQuestions = initElements.dataset.ajaxurlQuestions
@@ -81,6 +78,13 @@ export default defineComponent({
         if (screenIndex !== -1) {
           formStore.currentScreenIndex = screenIndex
           this.currentScreen = formStore.screenData[screenIndex]
+        } else {
+          if (slug === 'vos_coordonnees') {
+            // on détermine le profil
+            services.updateProfil()
+            // on fait un appel API pour charger la suite des questions avant de changer d'écran
+            requests.initQuestionsProfil(this.handleInitQuestions)
+          }
         }
       }
     }

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -47,7 +47,8 @@ export default defineComponent({
   },
   data () {
     return {
-      slugVosCoordonnees: 'vos_coordonnees',
+      slugVosCoordonnees: 'vos_coordonnees_occupant',
+      nextSlug: '',
       isErrorInit: false,
       isLoadingInit: true,
       sharedProps: formStore.props,
@@ -69,20 +70,25 @@ export default defineComponent({
         this.isErrorInit = true
       } else {
         this.isLoadingInit = false
-        formStore.screenData = requestResponse
-        this.currentScreen = requestResponse[0]
+        formStore.screenData = formStore.screenData.concat(requestResponse)
+        if (this.nextSlug !== '') {
+          this.changeScreenBySlug(this.nextSlug)
+        } else {
+          this.currentScreen = requestResponse[0]
+        }
       }
     },
     changeScreenBySlug (slug:string) {
       if (formStore.screenData) {
-        const screenIndex = formStore.screenData.findIndex((screen) => screen.slug === slug)
+        const screenIndex = formStore.screenData.findIndex((screen: any) => screen.slug === slug)
         if (screenIndex !== -1) {
           formStore.currentScreenIndex = screenIndex
           this.currentScreen = formStore.screenData[screenIndex]
         } else {
-          if (slug === this.slugVosCoordonnees) {
+          if (slug === this.slugVosCoordonnees) { // TODO à mettre à jour suivant le slug des différents profils
             // on détermine le profil
             services.updateProfil()
+            this.nextSlug = slug
             // on fait un appel API pour charger la suite des questions avant de changer d'écran
             requests.initQuestionsProfil(this.handleInitQuestions)
           }

--- a/assets/vue/components/signalement-form/address_subscreen.json
+++ b/assets/vue/components/signalement-form/address_subscreen.json
@@ -3,19 +3,19 @@
         {
         "type": "SignalementFormTextfield",
         "label": "Numéro et voie",
-        "slug": "tous_les_champs_numero",
+        "slug": "detail_numero",
         "disabled": true
         },
         {
         "type": "SignalementFormTextfield",
         "label": "Code postal",
-        "slug": "tous_les_champs_code_postal",
+        "slug": "detail_code_postal",
         "disabled": true
         },
         {
         "type": "SignalementFormTextfield",
         "label": "Commune",
-        "slug": "tous_les_champs_commune",
+        "slug": "detail_commune",
         "disabled": true
         }
     ]

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -17,7 +17,12 @@ export const requests = {
   },
 
   initQuestions (functionReturn: Function) {
-    const url = formStore.props.ajaxurlQuestions
+    const url = (formStore.props.ajaxurlQuestions as string) + 'tous'
+    requests.doRequest(url, functionReturn)
+  },
+
+  initQuestionsProfil (functionReturn: Function) {
+    const url = (formStore.props.ajaxurlQuestions as string) + (formStore.data.profil as string)
     requests.doRequest(url, functionReturn)
   },
 

--- a/assets/vue/components/signalement-form/services.ts
+++ b/assets/vue/components/signalement-form/services.ts
@@ -22,5 +22,12 @@ export const services = {
     } else {
       formStore.data.profil = formStore.data.signalement_concerne_profil_detail_tiers
     }
+  },
+  isScreenAfterCurrent (slug: string): boolean {
+    const nextScreenIndex = formStore.screenData.findIndex((screen: any) => screen.slug === slug)
+    if (nextScreenIndex <= formStore.currentScreenIndex) {
+      return false
+    }
+    return true
   }
 }

--- a/assets/vue/components/signalement-form/services.ts
+++ b/assets/vue/components/signalement-form/services.ts
@@ -1,0 +1,26 @@
+import formStore from './store'
+
+export const services = {
+  generateSubscreenData (id: string, data: any[]) {
+    return data.map((component) => {
+      return {
+        ...component,
+        slug: id + '_' + (component.slug as string)
+      }
+    })
+  },
+  addSubscreenData (id: string, data: any[]) {
+    const componentIndex = formStore.screenData[formStore.currentScreenIndex].components.body.findIndex((component: any) => component.slug === id)
+    console.log(componentIndex)
+    formStore.screenData[formStore.currentScreenIndex].components.body[componentIndex].components = {}
+    formStore.screenData[formStore.currentScreenIndex].components.body[componentIndex].components.body = data
+    console.log(formStore.screenData[formStore.currentScreenIndex].components.body[componentIndex])
+  },
+  updateProfil () {
+    if (formStore.data.signalement_concerne_profil === 'logement_occupez') {
+      formStore.data.profil = formStore.data.signalement_concerne_profil_detail_occupant
+    } else {
+      formStore.data.profil = formStore.data.signalement_concerne_profil_detail_tiers
+    }
+  }
+}

--- a/assets/vue/components/signalement-form/services.ts
+++ b/assets/vue/components/signalement-form/services.ts
@@ -9,12 +9,12 @@ export const services = {
       }
     })
   },
-  addSubscreenData (id: string, data: any[]) {
-    const componentIndex = formStore.screenData[formStore.currentScreenIndex].components.body.findIndex((component: any) => component.slug === id)
-    console.log(componentIndex)
+  addSubscreenData (slug: string, data: any[]) {
+    // on récupère l'index du composant dans son screen
+    const componentIndex = formStore.screenData[formStore.currentScreenIndex].components.body.findIndex((component: any) => component.slug === slug)
+    // pour ce composant on ajoute un objet "components" qu'on alimente avec les data reçues
     formStore.screenData[formStore.currentScreenIndex].components.body[componentIndex].components = {}
     formStore.screenData[formStore.currentScreenIndex].components.body[componentIndex].components.body = data
-    console.log(formStore.screenData[formStore.currentScreenIndex].components.body[componentIndex])
   },
   updateProfil () {
     if (formStore.data.signalement_concerne_profil === 'logement_occupez') {

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -10,5 +10,5 @@
 {% block body %}
     <div id="app-signalement-form" 
         data-ajaxurl="{{ path('front_nouveau_formulaire') }}"            
-        data-ajaxurl-questions="http://localhost:8082/api/questions?profil=tous"></div>
+        data-ajaxurl-questions="http://localhost:8082/api/questions?profil="></div>
 {% endblock %}

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "SignalementFormScreen",
-    "label": "Vos coordonées",
+    "label": "Vos coordonnées",
     "slug": "vos_coordonnees_occupant",
     "components": {
       "body": [

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -252,7 +252,19 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "signalement_concerne_next",
-          "action": "goto:vos_coordonnees"
+          "action": "goto:vos_coordonnees_occupant",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil === 'logement_occupez'"
+          }
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "signalement_concerne_next",
+          "action": "goto:vos_coordonnees",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil === 'autre_logement'"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Ticket

#1492     

## Description
Au clic sur le bouton suite après détermination du profil, on rappelle l'API avec le profil pour avoir la suite des questions

## Changements apportés

- Modification de ajaxurl-questions pour enlever le profil "tous"
- Création d'une nouvelle fonction dans requests.ts pour appeler ajaxurl-questions avec le profil du déclarant
- Création d'un fichier services.ts avec des fonctions réutilisables 
- dans services.ts création d'une fonction updateProfil() pour enregistrer le profil dans le store en fonction des réponses aux questions
- dans l'application principale, mise à jour de changeScreenBySlug(), si on ne trouve pas le screenIndex du screen appelé, c'est qu'on n'a pas les informations dans le store. alors en fonction du slug du screen appelé, on peut rappeler l'api. Dans le cas présent, on met d'abord à jour le profil pour rappeler l'api avec le bon profil
- factorisation du chargement des composants d'Address, avec les fonctions generateSubscreenData et addSubscreenData dans le fichier services. On créé maintenant les sous-composants du composant SignalementFormAddress dans le store, pour faciliter la validation des données au changement d'écran

## Pré-requis
`make mock`

## Tests
- [ ] Lancer le formulaire
- [ ] Vérifier le comportement du composant SignalementFormAdress
- [ ] Sur le 3è screen, faire en sorte d'avoir le profil locataire
- [ ] Passer au screen suivant, et vérifier qu'il s'affiche correctement
