### PR TITLE
[FO - Signalement] Finistère - limiter le dépot des signalements aux communes de quimper et brest 

### DIFF
--- a/migrations/Version20230726081531.php
+++ b/migrations/Version20230726081531.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230726081531 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add codes insee to Finistere';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $codesInsee = [
+            29232, 29019,
+        ];
+
+        $this->addSql(
+            'UPDATE territory SET authorized_codes_insee = \''.json_encode($codesInsee).'\' WHERE zip = \'29\''
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1046,7 +1046,7 @@ const refetchAddress = (form) => {
             let feature = r.features[0];
             form.querySelector('#signalement-insee-occupant').value = feature.properties.citycode;
             let zipOccupant = feature.properties.citycode.substr(0, 2)
-            if (zipOccupant == '69') {
+            if (zipOccupant == '69' || zipOccupant == '29') {
                 const METROPOLE_RHONES_AUTHORIZED_INSEE_CODES = [
                     69091, 69096, 69123, 69149, 69199, 69205, 69290, 69259, 69266,
                     69381, 69382, 69383, 69384, 69385, 69386, 69387, 69388, 69389,
@@ -1055,17 +1055,23 @@ const refetchAddress = (form) => {
                     69087, 69088, 69089, 69100, 69279, 69142, 69250, 69116, 69117,
                     69127, 69282, 69283, 69284, 69143, 69152, 69153, 69163, 69286,
                     69168, 69191, 69194, 69204, 69207, 69202, 69292, 69293, 69296,
-                    69244, 69256, 69260, 69233, 69278 ];
+                    69244, 69256, 69260, 69233, 69278
+                ];
                 const COR_RHONES_AUTHORIZED_INSEE_CODES = [
                     69001, 69006, 69008, 69037, 69054, 69060, 69066, 69070, 69075,
                     69093, 69102, 69107, 69174, 69130, 69160, 69164, 69169, 69181,
                     69183, 69188, 69200, 69214, 69217, 69225, 69229, 69234, 69240,
                     69243, 69248, 69254, 69157
                 ];
-                const RHONES_AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
-                    COR_RHONES_AUTHORIZED_INSEE_CODES
+
+                const FINISTERE_AUTHORIZED_INSEE_CODES = [29232, 29019];
+
+                const AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
+                    COR_RHONES_AUTHORIZED_INSEE_CODES, 
+                    FINISTERE_AUTHORIZED_INSEE_CODES
                 );
-                if (RHONES_AUTHORIZED_INSEE_CODES.indexOf(Number(feature.properties.citycode)) == -1) {
+
+                if (AUTHORIZED_INSEE_CODES.indexOf(Number(feature.properties.citycode)) == -1) {
                     form.querySelector('#fr-error-text-insee')?.classList?.remove('fr-hidden');
                 } else {
                     form.querySelector('#fr-error-text-insee')?.classList?.add('fr-hidden');

--- a/public/js/const.js
+++ b/public/js/const.js
@@ -282,7 +282,7 @@ const searchAddress = (form, autocomplete) => {
                             form.querySelector('#signalement_villeOccupant').value = feature.properties.city;
                             form.querySelector('#signalement-insee-occupant').value = feature.properties.citycode;
                             let zipOccupant = feature.properties.citycode.substr(0, 2)
-                            if (zipOccupant == '69') {
+                            if (zipOccupant == '69' || zipOccupant == '29') {
                                 const METROPOLE_RHONES_AUTHORIZED_INSEE_CODES = [
                                     69091, 69096, 69123, 69149, 69199, 69205, 69290, 69259, 69266,
                                     69381, 69382, 69383, 69384, 69385, 69386, 69387, 69388, 69389,
@@ -291,25 +291,27 @@ const searchAddress = (form, autocomplete) => {
                                     69087, 69088, 69089, 69100, 69279, 69142, 69250, 69116, 69117,
                                     69127, 69282, 69283, 69284, 69143, 69152, 69153, 69163, 69286,
                                     69168, 69191, 69194, 69204, 69207, 69202, 69292, 69293, 69296,
-                                    69244, 69256, 69260, 69233, 69278 ];
+                                    69244, 69256, 69260, 69233, 69278
+                                ];
                                 const COR_RHONES_AUTHORIZED_INSEE_CODES = [
                                     69001, 69006, 69008, 69037, 69054, 69060, 69066, 69070, 69075,
                                     69093, 69102, 69107, 69174, 69130, 69160, 69164, 69169, 69181,
                                     69183, 69188, 69200, 69214, 69217, 69225, 69229, 69234, 69240,
                                     69243, 69248, 69254, 69157
                                 ];
-                                const RHONES_AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
-                                    COR_RHONES_AUTHORIZED_INSEE_CODES
+    
+                                const FINISTERE_AUTHORIZED_INSEE_CODES = [29232, 29019];
+    
+                                const AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
+                                    COR_RHONES_AUTHORIZED_INSEE_CODES, 
+                                    FINISTERE_AUTHORIZED_INSEE_CODES
                                 );
-
-                                if (RHONES_AUTHORIZED_INSEE_CODES.indexOf(Number(feature.properties.citycode)) == -1) {
-                                    form.querySelector('#fr-error-text-insee')?.classList?.remove('fr-hidden');
+    
+                                if (AUTHORIZED_INSEE_CODES.indexOf(Number(a.properties.citycode)) == -1) {
+                                    e.querySelector('#fr-error-text-insee')?.classList?.remove('fr-hidden');
                                 } else {
-                                    form.querySelector('#fr-error-text-insee')?.classList?.add('fr-hidden');
+                                    e.querySelector('#fr-error-text-insee')?.classList?.add('fr-hidden');
                                 }
-                                form.querySelector('#signalement-geoloc-lat-occupant').value = feature.geometry.coordinates[0];
-                                form.querySelector('#signalement-geoloc-lng-occupant').value = feature.geometry.coordinates[1];
-                                container.innerHTML = '';
                             }
 
                             // Zip codes available for Non Conformité Energétique

--- a/public/js/const.min.js
+++ b/public/js/const.min.js
@@ -13,7 +13,7 @@ searchAddress=(e,t)=>{
 
                         let zipOccupant = a.properties.citycode.substr(0, 2)
                         // dirty change because we dont know how to minify this file ; will disappear when refacto
-                        if (zipOccupant == '69') {
+                        if (zipOccupant == '69' || zipOccupant == '29') {
                             const METROPOLE_RHONES_AUTHORIZED_INSEE_CODES = [
                                 69091, 69096, 69123, 69149, 69199, 69205, 69290, 69259, 69266,
                                 69381, 69382, 69383, 69384, 69385, 69386, 69387, 69388, 69389,
@@ -31,11 +31,14 @@ searchAddress=(e,t)=>{
                                 69243, 69248, 69254, 69157
                             ];
 
-                            const RHONES_AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
-                                COR_RHONES_AUTHORIZED_INSEE_CODES
+                            const FINISTERE_AUTHORIZED_INSEE_CODES = [29232, 29019];
+
+                            const AUTHORIZED_INSEE_CODES = METROPOLE_RHONES_AUTHORIZED_INSEE_CODES.concat(
+                                COR_RHONES_AUTHORIZED_INSEE_CODES, 
+                                FINISTERE_AUTHORIZED_INSEE_CODES
                             );
 
-                            if (RHONES_AUTHORIZED_INSEE_CODES.indexOf(Number(a.properties.citycode)) == -1) {
+                            if (AUTHORIZED_INSEE_CODES.indexOf(Number(a.properties.citycode)) == -1) {
                                 e.querySelector('#fr-error-text-insee')?.classList?.remove('fr-hidden');
                             } else {
                                 e.querySelector('#fr-error-text-insee')?.classList?.add('fr-hidden');

--- a/src/DataFixtures/Files/Territory.yml
+++ b/src/DataFixtures/Files/Territory.yml
@@ -149,6 +149,9 @@ territories:
     name: "Finistère"
     is_active: 1
     bbox: "{\"n\":\"48.7535\",\"e\":\"-3.386619\",\"s\":\"47.701242\",\"w\":\"-5.141292\"}"
+    authorized_codes_insee: # Quimper + Brest
+      - "29232"
+      - "29019"
   -
     zip: "30"
     name: "Gard"


### PR DESCRIPTION
## Ticket

#1489    

## Description
Limiter le dépot des signalements aux communes de quimper (insee : 29232) et brest (insee: 29019)

## Changements apportés
* Migration pour mettre à jour la liste des codes insee autorisés sur le territoire 29
* Idem dans les fixtures
* Mise à jour JS pour afficher un message d'erreur si code postal hors communes autorisés

## Pré-requis

## Tests
- [x] Je créé un signalement sur Quimper, il se créé bien
- [x] Je créé un signalement sur Brest, il se créé bien
- [x] Je créé un signalement dans une autre commune du FInistère, j'ai un message d'erreur (Plogoff, Le Guilvinec, Guissény, Treffiagat...)
