### PR TITLE
[Front] Gérer la propriété repeat sur un composant

### DIFF
--- a/assets/vue/components/signalement-form/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/SignalementFormScreen.vue
@@ -114,9 +114,7 @@ export default defineComponent({
     },
     showScreenBySlug (slug: string, slugButton:string) {
       formStore.validationErrors = {}
-      console.log(slugButton)
       const isScreenAfterCurrent = services.isScreenAfterCurrent(slug)
-      console.log(isScreenAfterCurrent)
 
       const traverseComponents = (components: any) => {
         for (const field of components) {
@@ -127,7 +125,7 @@ export default defineComponent({
             }
           }
           // Effectuer d'autres validations nécessaires pour les autres règles (minLength, maxLength, pattern, etc.)
-          // Vérifier si le composant est de type Subscreen et a des composants enfants
+          // Vérifier si le composant est de type Subscreen ou Address et a des composants enfants
           if ((field.type === 'SignalementFormSubscreen' || field.type === 'SignalementFormAddress') && field.components) {
             traverseComponents(field.components.body)
           }
@@ -141,7 +139,7 @@ export default defineComponent({
           return
         }
       }
-      // Si pas d'erreur de validation, ou screen précédent, on change d'écran
+      // Si pas d'erreur de validation, ou screen précédent (donc pas de validation), on change d'écran
       if (this.changeEvent !== undefined) {
         this.changeEvent(slug)
       }

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -38,6 +38,11 @@ import { services } from './services'
 import SignalementFormScreen from './SignalementFormScreen.vue'
 import SignalementFormBreadCrumbs from './SignalementFormBreadCrumbs.vue'
 const initElements:any = document.querySelector('#app-signalement-form')
+// TODO : centraliser les interfaces et les utiliser partout
+interface Components {
+  body?: any[];
+  footer?: any[];
+}
 
 export default defineComponent({
   name: 'TheSignalementAppForm',
@@ -51,8 +56,9 @@ export default defineComponent({
       nextSlug: '',
       isErrorInit: false,
       isLoadingInit: true,
+      formStore,
       sharedProps: formStore.props,
-      currentScreen: null as { slug: string; label: string; description: string ; components: object } | null
+      currentScreen: null as { slug: string; label: string; description: string ; components: Components } | null
     }
   },
   created () {
@@ -84,6 +90,10 @@ export default defineComponent({
         if (screenIndex !== -1) {
           formStore.currentScreenIndex = screenIndex
           this.currentScreen = formStore.screenData[screenIndex]
+          if (this.currentScreen?.components && this.currentScreen.components.body) {
+            // Prétraitement des composants avec repeat
+            this.currentScreen.components.body = formStore.preprocessScreen(this.currentScreen.components.body)
+          }
         } else {
           if (slug === this.slugVosCoordonnees) { // TODO à mettre à jour suivant le slug des différents profils
             // on détermine le profil

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -4,6 +4,7 @@ interface FormData {
   [key: string]: any
 }
 
+// TODO : compléter, centraliser et utiliser les interfaces
 // interface FormField {
 //   type: string
 //   slug: string
@@ -30,6 +31,16 @@ interface FormData {
 //   }
 // }
 
+interface Component {
+  type: string
+  label: string
+  slug: string
+  repeat?: {
+    count: string
+  }
+  // TODO ajouter toutes les propriétés possibles
+}
+
 interface FormStore {
   data: FormData
   props: FormData
@@ -39,6 +50,7 @@ interface FormStore {
   inputComponents: string[]
   updateData: (key: string, value: any) => void
   shouldShowField: (conditional: string) => boolean
+  preprocessScreen: (screenBodyComponents: any) => Component[]
 }
 
 const formStore: FormStore = reactive({
@@ -64,6 +76,43 @@ const formStore: FormStore = reactive({
   },
   shouldShowField (conditional: string) {
     return computed(() => eval(conditional)).value
+  },
+  preprocessScreen (screenBodyComponents: any): Component[] {
+    const repeatedComponents: Component[] = []
+    screenBodyComponents.forEach((component: Component) => {
+      if (component.repeat !== null && component.repeat !== undefined) {
+        for (let i = 1; i <= eval(component.repeat.count); i++) {
+          repeatedComponents.push(this.cloneComponentWithNumber(component, i))
+        }
+      } else {
+        repeatedComponents.push(component)
+      }
+    })
+    return repeatedComponents
+  },
+  replaceNumberInString (value: string, number: number): string {
+    return value.replace('{{number}}', String(number))
+  },
+  cloneComponentWithNumber (component: any, number: number): any {
+    const clonedComponent: any = {}
+
+    for (const prop in component) {
+      if (Object.prototype.hasOwnProperty.call(component, prop)) {
+        if (prop !== 'repeat') {
+          if (typeof component[prop] === 'string') {
+            clonedComponent[prop] = this.replaceNumberInString(component[prop], number)
+          } else if (Array.isArray(component[prop])) {
+            clonedComponent[prop] = component[prop].map((item: any) => this.cloneComponentWithNumber(item, number))
+          } else if (typeof component[prop] === 'object') {
+            clonedComponent[prop] = this.cloneComponentWithNumber(component[prop], number)
+          } else {
+            clonedComponent[prop] = component[prop]
+          }
+        }
+      }
+    }
+
+    return clonedComponent
   }
 })
 

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -385,8 +385,9 @@
         {
           "type": "SignalementFormSubscreen",
           "repeat": {
-            "count": "{{formStore.data.nombre_pieces}}"
+            "count": "formStore.data.composition_logement_nb_pieces"
           },
+          "slug": "type_logement_pieces_a_vivre_piece_{{number}}",
           "components": {
             "body": [
               {
@@ -401,6 +402,16 @@
                 "type": "SignalementFormOnlyChoice",
                 "label": "La hauteur jusqu'au plafond est de 2,20m (220cm) ou plus ?",
                 "slug": "type_logement_pieces_a_vivre_hauteur_piece_{{number}}",
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ],
                 "validate": {
                   "required": false
                 }
@@ -596,7 +607,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "type_logement_commodites_previous",
-          "action": "goto:type_logement_suite_1"
+          "action": "goto:type_logement_pieces_a_vivre"
         },
         {
           "type": "SignalementFormButton",


### PR DESCRIPTION
## Ticket

#1517    

## Description
Il est possible de répéter sur le même un composant SignalementFormSubscreen grâce à la propriété repeat voir json
{{count}} est un entier avec une boucle qui commence à 1 .
{{number}} est l'index courant pour chaque itération

{{count}} pouvant être défini l'écran précédent, ce n'est pas au chargement des données du screen (après l'appel api) qu'on gère cette répétition, mais à son affichage

## Changements apportés
* Ajustements sur le mock
* Création de fonctions de clonage et renommage des données de composants dans le store pour pouvoir évalier le {{formStore.data.xxx}} qui sert à définir le nombre d'itérations
* Appel de ces fonctions dans changeScreenBySlug() 

## Pré-requis

## Tests
- [ ] Aller jusqu'à l'étape 8 pour définir le nombre de pièces dans la maison 
- [ ] A l'étape 9 vérifier que le composant est bien dupliqué selon le nombre de pièces
- [ ] Remplir les données pour passer à la suite
- [ ] Revenir sur l'écran et vérifier qu'il n'y a pas un nombre au carré de composant, et que les données précédemment enregistrées sont bien restituées
