### PR TITLE
[Esabora] Mise à jour des libellés de suivi pour les arrêtés

### DIFF
--- a/src/Service/Intervention/InterventionDescriptionGenerator.php
+++ b/src/Service/Intervention/InterventionDescriptionGenerator.php
@@ -41,16 +41,17 @@ class InterventionDescriptionGenerator
     public static function buildDescriptionArreteCreated(DossierArreteSISH $dossierArreteSISH): string
     {
         $description = sprintf(
-            'Il existe 1 arrêté de type %s de n°%s daté du %s dans le dossier de n°%s.'.\PHP_EOL,
-            $dossierArreteSISH->getArreteType(),
+            'L\'arrêté %s du %s dans le dossier de n°%s.<br>',
             $dossierArreteSISH->getArreteNumero(),
             $dossierArreteSISH->getArreteDate(),
-            $dossierArreteSISH->getDossNum()
+            $dossierArreteSISH->getDossNum(),
         );
 
-        if ($dossierArreteSISH->getArreteMLNumero()) {
+        $description .= sprintf('Type arrêté: %s<br>', $dossierArreteSISH->getArreteType());
+
+        if ($dossierArreteSISH->getArreteMLDate()) {
             $description .= sprintf(
-                'Pour cet arrêté, il a également été pris un arrêté de mainlevée n°%s en date du %s.',
+                'Pour cet arrêté, il a également été pris un arrêté de mainlevée %s du %s.',
                 $dossierArreteSISH->getArreteMLNumero(),
                 $dossierArreteSISH->getArreteMLDate()
             );

--- a/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
+++ b/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
@@ -41,10 +41,10 @@ class InterventionDescriptionGeneratorTest extends TestCase
         $description = InterventionDescriptionGenerator::buildDescriptionArreteCreated($dossierArreteSISH);
 
         $this->assertStringContainsString('Arrêté L.511-11', $description, 'Type arrêté incorrecte');
-        $this->assertStringContainsString('n°2023/DD13/00664', $description, 'N° arrêté incorrecte');
+        $this->assertStringContainsString('2023/DD13/00664', $description, 'N° arrêté incorrecte');
         $this->assertStringContainsString('14/06/2023', $description, 'Date arrêté incorrecte');
         $this->assertStringContainsString('n°2023/DD13/0010', $description, 'N° dossier incorrecte');
-        $this->assertStringContainsString('n°2023-DD13-00172', $description, 'N° main levée incorrecte');
+        $this->assertStringContainsString('2023-DD13-00172', $description, 'N° main levée incorrecte');
         $this->assertStringContainsString('01/07/2023', $description, 'Date de main levée incorrecte');
 
         $intervention = (new Intervention())

--- a/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
+++ b/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
@@ -40,11 +40,11 @@ class InterventionDescriptionGeneratorTest extends TestCase
         $dossierArreteSISH = $this->getDossierArreteSISHCollectionResponse()->getCollection()[0];
         $description = InterventionDescriptionGenerator::buildDescriptionArreteCreated($dossierArreteSISH);
 
-        $this->assertStringContainsString('Arrêté L.511-11', $description, 'Type arrêté incorrecte');
-        $this->assertStringContainsString('2023/DD13/00664', $description, 'N° arrêté incorrecte');
+        $this->assertStringContainsString('Arrêté L.511-11', $description, 'Type arrêté incorrect');
+        $this->assertStringContainsString('2023/DD13/00664', $description, 'N° arrêté incorrect');
         $this->assertStringContainsString('14/06/2023', $description, 'Date arrêté incorrecte');
-        $this->assertStringContainsString('n°2023/DD13/0010', $description, 'N° dossier incorrecte');
-        $this->assertStringContainsString('2023-DD13-00172', $description, 'N° main levée incorrecte');
+        $this->assertStringContainsString('n°2023/DD13/0010', $description, 'N° dossier incorrect');
+        $this->assertStringContainsString('2023-DD13-00172', $description, 'N° main levée incorrect');
         $this->assertStringContainsString('01/07/2023', $description, 'Date de main levée incorrecte');
 
         $intervention = (new Intervention())

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
@@ -1,6 +1,6 @@
 {
   "searchId": "00000000-0000-0000-2023-000000000012",
-  "nbResults": 1,
+  "nbResults": 2,
   "columnList": [
     "Sas_LogicielProvenance",
     "Reference_Dossier",
@@ -30,6 +30,22 @@
       "keyDataList": [
         30,
         601
+      ]
+    },
+    {
+      "columnDataList": [
+        "Histologe",
+        "00000000-0000-0000-2023-000000000012",
+        "2023/DD13/0011",
+        "05/06/2023",
+        null,
+        "Arrêté L.511-11 - Suroccupation",
+        "01/08/2023",
+        null
+      ],
+      "keyDataList": [
+        31,
+        602
       ]
     }
   ]


### PR DESCRIPTION
## Ticket

#1522    

## Description
Mise à jour des libelles de suivi pour les arrêtes préfectoraux
```txt
L’arrêté [numéro arrêté] du [date] 
```
## Changements apportés
* Mise à jour des libellés
* Mise à jour de la condition pour les mainlevées
* Mise à jour du mock avec un arrêté sans numéro d'arrêté

## Pré-requis
```
$ make mock
```

## Tests
- [ ] Lancer la commande `make console app="sync-esabora-sish-intervention"`et ouvrir le signalement [2023-12](http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012) afin de vérifier que les libellés soient correctes

![image](https://github.com/MTES-MCT/histologe/assets/5757116/ffc49de3-e1f6-4aa3-a86e-30b351be38f7)

