### PR TITLE
[Email- Suivi] Lien email suivi ARS ESABORA

### DIFF
--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
@@ -32,9 +32,7 @@ class SuiviNewCommentBackMailer extends AbstractNotificationMailer
 
         return array_merge($notificationMail->getParams(), [
             'ref_signalement' => $signalement->getReference(),
-            'link' => $this->urlGenerator->generate('back_signalement_view', [
-                'uuid' => $uuid,
-            ], UrlGeneratorInterface::ABSOLUTE_URL),
+            'link' => $this->generateLink('back_signalement_view', ['uuid' => $uuid]),
         ]);
     }
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
@@ -28,11 +28,10 @@ class SuiviNewCommentBackMailer extends AbstractNotificationMailer
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
     {
         $signalement = $notificationMail->getSignalement();
-        $uuid = $signalement->getUuid();
 
         return array_merge($notificationMail->getParams(), [
             'ref_signalement' => $signalement->getReference(),
-            'link' => $this->generateLink('back_signalement_view', ['uuid' => $uuid]),
+            'link' => $this->generateLinkSignalementView($signalement->getUuid()),
         ]);
     }
 


### PR DESCRIPTION
## Ticket

#1481    

## Description
Email de suivi généré depuis les commandes esabora ne renvoie pas l'url absolue

## Changements apportés
* Utilisation de la méthode de la classe abstraite prévue à cet effet

## Pré-requis
```
make mock
```
## Tests
- [ ] Lancer la commande `make console app="sync-esabora-sish"` et `make console app="sync-esabora-schs"`
- [ ] Cliquer sur les liens des différents mail afin d'afficher le signalement

![image](https://github.com/MTES-MCT/histologe/assets/5757116/cbf12e5e-f476-46d6-86e2-c9c14deac477)

