### PR TITLE
[Front] Soumission formulaire sans désordres

### DIFF
--- a/assets/vue/components/signalement-form/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/SignalementFormAddress.vue
@@ -119,6 +119,7 @@ export default defineComponent({
     },
     handleClickSuggestion (index: number) {
       if (this.suggestions) {
+        this.formStore.data[this.id] = this.suggestions[index].properties.label
         this.formStore.data[this.id + '_detail_numero'] = this.suggestions[index].properties.name
         this.formStore.data[this.id + '_detail_code_postal'] = this.suggestions[index].properties.postcode
         this.formStore.data[this.id + '_detail_commune'] = this.suggestions[index].properties.city

--- a/assets/vue/components/signalement-form/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/SignalementFormScreen.vue
@@ -116,9 +116,7 @@ export default defineComponent({
     },
     showScreenBySlug (slug: string, slugButton:string) {
       formStore.validationErrors = {}
-      console.log(slugButton)
       const isScreenAfterCurrent = services.isScreenAfterCurrent(slug)
-      console.log(isScreenAfterCurrent)
 
       const traverseComponents = (components: any) => {
         for (const field of components) {

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -3,9 +3,33 @@ import formStore from './store'
 
 export const requests = {
   // TODO : voir avec Emilien pour ne plus gérer via des callbacks mais faire de l'async pour rendre le code plus lisible
-  doRequest (ajaxUrl: string, functionReturn: Function) {
+  doRequestGet (ajaxUrl: string, functionReturn: Function) {
     axios
       .get(ajaxUrl, { timeout: 15000 })
+      .then(response => {
+        const responseData = response.data
+        functionReturn(responseData)
+      })
+      .catch(error => {
+        console.log(error)
+        functionReturn('error')
+      })
+  },
+  doRequestPost (ajaxUrl: string, data: any, functionReturn: Function) {
+    axios
+      .post(ajaxUrl, data, { timeout: 15000 })
+      .then(response => {
+        const responseData = response.data
+        functionReturn(responseData)
+      })
+      .catch(error => {
+        console.log(error)
+        functionReturn('error')
+      })
+  },
+  doRequestPut (ajaxUrl: string, data: any, functionReturn: Function) {
+    axios
+      .put(ajaxUrl, data, { timeout: 15000 })
       .then(response => {
         const responseData = response.data
         functionReturn(responseData)
@@ -18,16 +42,31 @@ export const requests = {
 
   initQuestions (functionReturn: Function) {
     const url = (formStore.props.ajaxurlQuestions as string) + 'tous'
-    requests.doRequest(url, functionReturn)
+    requests.doRequestGet(url, functionReturn)
   },
 
   initQuestionsProfil (functionReturn: Function) {
     const url = (formStore.props.ajaxurlQuestions as string) + (formStore.data.profil as string)
-    requests.doRequest(url, functionReturn)
+    requests.doRequestGet(url, functionReturn)
+  },
+
+  saveSignalementDraft (functionReturn: Function) {
+    if (formStore.data.uuidSignalementDraft !== '') {
+      // TODO : il y a sûrement plus élégant à faire pour construire l'url (cf controlleur et twig)
+      const url = formStore.props.ajaxurlPutSignalementDraft.replace('uuid', formStore.data.uuidSignalementDraft)
+      requests.doRequestPut(url, formStore.data, functionReturn)
+    } else if (formStore.data.vos_coordonnees_occupant_email !== undefined && formStore.data.adresse_logement_adresse !== undefined) {
+      // TODO : vérifier la condition (notamment en fonction des profils)
+      const url = formStore.props.ajaxurlPostSignalementDraft
+      requests.doRequestPost(url, formStore.data, functionReturn)
+    } else {
+      // TODO : que renvoyer ?
+      functionReturn('no need to save')
+    }
   },
 
   validateAddress (valueAdress: string, functionReturn: Function) {
     const url = (formStore.props.urlApiAdress as string) + valueAdress
-    requests.doRequest(url, functionReturn)
+    requests.doRequestGet(url, functionReturn)
   }
 }

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -43,10 +43,13 @@ interface FormStore {
 
 const formStore: FormStore = reactive({
   data: {
+    uuidSignalementDraft: ''
   },
   props: {
     ajaxurl: '',
     ajaxurlQuestions: '',
+    ajaxurlPostSignalementDraft: '',
+    ajaxurlPutSignalementDraft: '',
     urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q='
   },
   screenData: [],

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -12,5 +12,6 @@
         data-ajaxurl="{{ path('front_nouveau_formulaire') }}"            
         data-ajaxurl-questions="http://localhost:8082/api/questions?profil="
         data-ajaxurl-post-signalement-draft="{{ path('envoi_nouveau_signalement_draft') }}"
-        data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft') }}"></div>
+        data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft',{uuid:'uuid'}) }}"
+    ></div>
 {% endblock %}


### PR DESCRIPTION
## Ticket

#1459    

## Description
A chaque changement de screen, à partir du moment où on a adresse + email, on enregistre en base le signalement draft et on le met à jour

## Changements apportés
* Création de nouvelles fonctions dans requests pour faire des POST et des PUT
* Création d'une fonction saveSignalementDraft() appelée à chaque changement de screen, et qui fait soit un POST (création du signalement draft), soit un PUT (mise à jour du signalementDraft), soit rien si on n'a pas le tuple mail+adresse

## Pré-requis
```
make create-db
make mock
```
## Tests
- [ ] Parcourir le formulaire et vérifier à chaque écran, selon le cas, qu'on ne fait rien, qu'on créé un signalement Draft ou qu'on le met à jour
