### PR TITLE
[BO- Relance automatique] Problème de correspondance mail entre le nom/prénom du déclarant et l'occupant

### DIFF
--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -614,7 +614,7 @@ signalements:
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
       - "le sol ou la base des murs est très humide."
   -
-    uuid: "00000000-0000-0000-2023-00000000001"
+    uuid: "00000000-0000-0000-2023-000000000001"
     details: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
     is_proprio_averti: 1
     is_logement_social: 0
@@ -650,7 +650,7 @@ signalements:
     criteres: []
     criticites: []
   -
-    uuid: "00000000-0000-0000-2023-0000000002"
+    uuid: "00000000-0000-0000-2023-000000000002"
     details: "[COR] Signalement dans la commune Affoux (code insee: 69001, code postal: 69170)"
     is_proprio_averti: 0
     is_logement_social: 0
@@ -684,7 +684,7 @@ signalements:
     criteres: []
     criticites: []
   -
-    uuid: "00000000-0000-0000-2023-0000000003"
+    uuid: "00000000-0000-0000-2023-000000000003"
     details: "[MDL] Signalement dans la commune Lyon (code insee: 69381, code postal: 69001)"
     is_proprio_averti: 1
     is_logement_social: 0
@@ -718,7 +718,7 @@ signalements:
     criteres: []
     criticites: []
   -
-    uuid: "00000000-0000-0000-2023-0000000004"
+    uuid: "00000000-0000-0000-2023-000000000004"
     details: "[MDL] Signalement pour la commune St Genis les Ollieres	(code insee: 69205, code postal: 69290)"
     is_proprio_averti: 1
     is_logement_social: 0
@@ -752,7 +752,7 @@ signalements:
     criteres: []
     criticites: []
   -
-    uuid: "00000000-0000-0000-2023-0000000005"
+    uuid: "00000000-0000-0000-2023-000000000005"
     details: "[COR] Signalement pour la commune Chenelette (code insee: 69054, code postal: 69430)"
     is_proprio_averti: 1
     is_logement_social: 0
@@ -829,7 +829,7 @@ signalements:
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
       - "le sol ou la base des murs est très humide."
   -
-    uuid: "00000000-0000-0000-2023-0000000007"
+    uuid: "00000000-0000-0000-2023-000000000007"
     details: "Signalement Non-Décence dans l'Yonne"
     is_proprio_averti: 1
     is_logement_social: 0
@@ -872,7 +872,7 @@ signalements:
       - "NON_DECENCE_ENERGETIQUE"
     date_entree: "2022-06-08 17:06:33"
   -
-    uuid: "00000000-0000-0000-2023-0000000008"
+    uuid: "00000000-0000-0000-2023-000000000008"
     details: "Signalement Non-Décence dans le Puy de dôme"
     is_proprio_averti: 1
     is_logement_social: 0
@@ -1348,6 +1348,7 @@ signalements:
     details: "Signalement ancien sans suivi"
     is_proprio_averti: 1
     is_logement_social: 0
+    is_not_occupant: true
     nb_adultes: "2"
     is_allocataire: ""
     nature_logement: "Appartement"

--- a/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerMailer.php
@@ -33,6 +33,7 @@ class SignalementFeedbackUsagerMailer extends AbstractNotificationMailer
 
         return [
             'signalement' => $signalement,
+            'from' => $toRecipient,
             'lien_suivi' => $this->generateLink(
                 'front_suivi_signalement',
                 ['code' => $signalement->getCodeSuivi(), 'from' => $toRecipient]

--- a/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerThirdMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerThirdMailer.php
@@ -33,6 +33,7 @@ class SignalementFeedbackUsagerThirdMailer extends AbstractNotificationMailer
 
         return [
             'signalement' => $signalement,
+            'from' => $toRecipient,
             'lien_suivi_poursuivre' => $this->generateLink(
                 'front_suivi_procedure',
                 ['code' => $signalement->getCodeSuivi(), 'from' => $toRecipient, 'suiviAuto' => Suivi::POURSUIVRE_PROCEDURE]

--- a/templates/emails/demande_feedback_usager_email.html.twig
+++ b/templates/emails/demande_feedback_usager_email.html.twig
@@ -1,7 +1,13 @@
 {% extends 'emails/base_email.html.twig' %}
 
 {% block body %}
-    <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    {% if from == signalement.mailOccupant %}
+        <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    {% elseif from == signalement.mailDeclarant %}
+        <p>Bonjour {{ signalement.nomDeclarant|upper ~' '~signalement.prenomDeclarant|capitalize }}</p>
+    {% else %}
+        <p>Bonjour</p>
+    {% endif %}
     <p>
         Vous avez signalé un problème dans le logement au <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>. <br>
         Les services compétents ont bien pris en charge votre dossier et vous contacteront bientôt si ce n'a pas encore été fait.<br>

--- a/templates/emails/demande_feedback_usager_third_email.html.twig
+++ b/templates/emails/demande_feedback_usager_third_email.html.twig
@@ -3,8 +3,10 @@
 {% block body %}
     {% if from == signalement.mailOccupant %}
         <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    {% elseif from == signalement.mailDeclarant %}
+        <p>Bonjour {{ signalement.nomDeclarant|upper ~' '~signalement.prenomDeclarant|capitalize }}</p>
     {% else %}
-        <p>Bonjour {{ signalement.nomDeclant|upper ~' '~signalement.prenomDeclarant|capitalize }}</p>
+        <p>Bonjour</p>
     {% endif %}
     <p>
         Vous avez signalé un problème dans le logement au <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>. <br>

--- a/templates/emails/demande_feedback_usager_third_email.html.twig
+++ b/templates/emails/demande_feedback_usager_third_email.html.twig
@@ -1,7 +1,11 @@
 {% extends 'emails/base_email.html.twig' %}
 
 {% block body %}
-    <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    {% if from == signalement.mailOccupant %}
+        <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    {% else %}
+        <p>Bonjour {{ signalement.nomDeclant|upper ~' '~signalement.prenomDeclarant|capitalize }}</p>
+    {% endif %}
     <p>
         Vous avez signalé un problème dans le logement au <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>. <br>
         Les services sont pleinement investis sur votre dossier. <br>

--- a/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
+++ b/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
@@ -44,6 +44,6 @@ class AskFeedbackUsagerCommandTest extends KernelTestCase
         $this->assertStringContainsString('1 signalement(s) for which the two last suivis are technicals ', $output);
         $this->assertStringContainsString('1 signalement(s) for which the last suivi is technical', $output);
         $this->assertStringContainsString('4 signalement(s) without suivi public', $output);
-        $this->assertEmailCount(7); // with cron notification email (6+1)
+        $this->assertEmailCount(8); // with cron notification email (7+1)
     }
 }


### PR DESCRIPTION
## Ticket

#1567    

## Description
Les mails de relance automatique sont toujours envoyé à l'occupant

## Changements apportés
* Ajout d'une condition sur les template de mail de relance automatique

## Pré-requis

## Tests
- [ ] Lancer la commande `make console app="ask-feedback-usager"` et vérifier que les emails envoyé au déclarant et occupant correspondent à leur nom et prénom pour le signalement 2023-20 (qui a un occupant et déclarat)
