### PR TITLE
[BO - Visites] Envoi des notifications de rappel de visite J+2 uniquement pour agents concernés

### DIFF
--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -2,11 +2,13 @@
 
 namespace App\Command\Cron;
 
+use App\Entity\Intervention;
 use App\Entity\Suivi;
 use App\Manager\InterventionManager;
 use App\Manager\SuiviManager;
 use App\Repository\AffectationRepository;
 use App\Repository\InterventionRepository;
+use App\Repository\SuiviRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
@@ -29,6 +31,7 @@ class NotifyVisitsCommand extends AbstractCronCommand
         private InterventionManager $interventionManager,
         private AffectationRepository $affectationRepository,
         private SuiviManager $suiviManager,
+        private SuiviRepository $suiviRepository,
         private VisiteNotifier $visiteNotifier,
         private NotificationMailerRegistry $notificationMailerRegistry,
         private ParameterBagInterface $parameterBag,
@@ -82,7 +85,8 @@ class NotifyVisitsCommand extends AbstractCronCommand
 
         $listPastVisits = $this->interventionRepository->getPastVisits();
         foreach ($listPastVisits as $intervention) {
-            foreach ($intervention->getPartner()->getUsers() as $user) {
+            $pastVisiteReminderUsers = $this->getPastVisiteReminderUsers($intervention);
+            foreach ($pastVisiteReminderUsers as $user) {
                 $this->notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER,
@@ -147,5 +151,38 @@ class NotifyVisitsCommand extends AbstractCronCommand
         );
 
         return Command::SUCCESS;
+    }
+
+    private function getPastVisiteReminderUsers(Intervention $intervention): array
+    {
+        $usersToNotify = [];
+
+        $partnerUsers = $intervention->getPartner()->getUsers();
+        foreach ($partnerUsers as $user) {
+            if (\in_array('ROLE_ADMIN_PARTNER', $user->getRoles())) {
+                $usersToNotify[] = $user;
+            }
+        }
+
+        $agentToNotify = null;
+        $suivisLinkedToSignalement = $this->suiviRepository->findSuivisByContext($intervention->getSignalement(), Suivi::CONTEXT_INTERVENTION);
+        foreach ($suivisLinkedToSignalement as $suivi) {
+            if ($suivi->getCreatedBy() && $suivi->getCreatedBy()->getPartner() == $intervention->getPartner()) {
+                $agentToNotify = $suivi->getCreatedBy();
+                $usersToNotify[] = $agentToNotify;
+                break;
+            }
+        }
+
+        if (!$agentToNotify) {
+            foreach ($suivisLinkedToSignalement as $suivi) {
+                if ($suivi->getCreatedBy() && \in_array('ROLE_ADMIN_TERRITORY', $suivi->getCreatedBy()->getRoles())) {
+                    $usersToNotify[] = $suivi->getCreatedBy();
+                    break;
+                }
+            }
+        }
+
+        return $usersToNotify;
     }
 }

--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -167,7 +167,7 @@ class NotifyVisitsCommand extends AbstractCronCommand
         $agentToNotify = null;
         $suivisLinkedToSignalement = $this->suiviRepository->findSuivisByContext($intervention->getSignalement(), Suivi::CONTEXT_INTERVENTION);
         foreach ($suivisLinkedToSignalement as $suivi) {
-            if ($suivi->getCreatedBy() && $suivi->getCreatedBy()->getPartner() == $intervention->getPartner()) {
+            if ($suivi->getCreatedBy()?->getPartner() == $intervention->getPartner()) {
                 $agentToNotify = $suivi->getCreatedBy();
                 $usersToNotify[] = $agentToNotify;
                 break;

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -398,6 +398,21 @@ class SuiviRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return Suivi[]
+     */
+    public function findSuivisByContext(Signalement $signalement, string $context): array
+    {
+        $qb = $this->createQueryBuilder('s');
+        $qb->where('s.signalement = :signalement')
+            ->andWhere('s.context = :context')
+            ->orderBy('s.createdAt', 'DESC')
+            ->setParameter('signalement', $signalement)
+            ->setParameter('context', $context);
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
      * @throws NonUniqueResultException
      */
     public function findFirstSuiviBy(Signalement $signalement, string $typeSuivi): ?Suivi

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToOnePartnerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToOnePartnerMailer.php
@@ -15,7 +15,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SignalementClosedToOnePartnerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_PARTNER;
-    protected ?string $mailerSubject = '%s a terminé son intervention sur #%s';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'closed_to_partner_signalement_email';
 
@@ -47,7 +46,7 @@ class SignalementClosedToOnePartnerMailer extends AbstractNotificationMailer
         /** @var User $user */
         $user = $this->security->getUser();
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
+            '%s a terminé son intervention sur #%s',
             $user?->getPartner()->getNom(),
             $notificationMail?->getSignalement()->getReference()
         );

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
@@ -13,7 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisiteAbortedToPartnerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_ABORTED_TO_PARTNER;
-    protected ?string $mailerSubject = '#%s Visite non effectuée';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_aborted_email';
 
@@ -40,6 +39,6 @@ class SuiviVisiteAbortedToPartnerMailer extends AbstractNotificationMailer
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getSignalement()->getReference());
+        $this->mailerSubject = sprintf('#%s Visite non effectuée', $notificationMail->getSignalement()->getReference());
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToPartnerMailer.php
@@ -13,7 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisiteConfirmedToPartnerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CONFIRMED_TO_PARTNER;
-    protected ?string $mailerSubject = '#%s Conclusion de visite disponible';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_confirmed_to_partner_email';
 
@@ -40,6 +39,6 @@ class SuiviVisiteConfirmedToPartnerMailer extends AbstractNotificationMailer
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getSignalement()->getReference());
+        $this->mailerSubject = sprintf('#%s Conclusion de visite disponible', $notificationMail->getSignalement()->getReference());
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToPartnerMailer.php
@@ -13,7 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisiteCreatedToPartnerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CREATED_TO_PARTNER;
-    protected ?string $mailerSubject = '#%s Visite du logement prévue';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_created_to_partner_email';
 
@@ -40,6 +39,6 @@ class SuiviVisiteCreatedToPartnerMailer extends AbstractNotificationMailer
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getSignalement()->getReference());
+        $this->mailerSubject = sprintf('#%s Visite du logement prévue', $notificationMail->getSignalement()->getReference());
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
@@ -13,7 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisiteFutureReminderToPartnerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_FUTURE_REMINDER_TO_PARTNER;
-    protected ?string $mailerSubject = '#%s Rappel : visite du logement prévue';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_future_reminder_to_partner_email';
 
@@ -40,6 +39,6 @@ class SuiviVisiteFutureReminderToPartnerMailer extends AbstractNotificationMaile
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getSignalement()->getReference());
+        $this->mailerSubject = sprintf('#%s Rappel : visite du logement prévue', $notificationMail->getSignalement()->getReference());
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
@@ -13,7 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisiteFutureReminderToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_FUTURE_REMINDER_TO_USAGER;
-    protected ?string $mailerSubject = 'Rappel pour votre visite du %s';
     protected ?string $mailerButtonText = 'Accéder à mon signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_future_reminder_to_usager_email';
 
@@ -43,6 +42,6 @@ class SuiviVisiteFutureReminderToUsagerMailer extends AbstractNotificationMailer
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getIntervention()->getScheduledAt()->format('d/m/Y'));
+        $this->mailerSubject = sprintf('Rappel pour votre visite du %s', $notificationMail->getIntervention()->getScheduledAt()->format('d/m/Y'));
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteNeededMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteNeededMailer.php
@@ -13,7 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisiteNeededMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_NEEDED;
-    protected ?string $mailerSubject = '#%s Veuillez renseigner une date de visite';
     protected ?string $mailerButtonText = 'Accéder à mon signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_needed_email';
 
@@ -41,6 +40,6 @@ class SuiviVisiteNeededMailer extends AbstractNotificationMailer
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getSignalement()->getReference());
+        $this->mailerSubject = sprintf('#%s Veuillez renseigner une date de visite', $notificationMail->getSignalement()->getReference());
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
@@ -13,7 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisitePastReminderToPartnerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER;
-    protected ?string $mailerSubject = '#%s Veuillez renseigner la conclusion de visite';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_past_reminder_to_partner_email';
 
@@ -40,6 +39,6 @@ class SuiviVisitePastReminderToPartnerMailer extends AbstractNotificationMailer
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getSignalement()->getReference());
+        $this->mailerSubject = sprintf('#%s Veuillez renseigner la conclusion de visite', $notificationMail->getSignalement()->getReference());
     }
 }


### PR DESCRIPTION
## Ticket

#1470   

## Description
Jusqu'à présent, l'ensemble des agents d'un partenaire étaient prévenus à J+2 après une visite prévue pour remplir une conclusion.
On modifie pour que ceux qui sont notifiés soient :
- l'administrateur du partenaire affecté à la visite
- le dernier agent du partenaire affecté qui a fait un suivi sur ce signalement
- si il n'y en a pas, on prend le dernier agent du responsable territoire qui a fait un suivi sur ce signalement

## Changements apportés
* Modification de la commande de notification automatique
* Correction collatérale : Modification de l'appel de fonction pour la mise à jour du sujet de mails, car si on appelle plusieurs fois le même type de mail (comme dans la commande), le sujet ne bougeait plus une fois mis à jour.

## Tests
- [ ] Signalement 1 : Se connecter en agent, prévoir une visite dans le futur (elle est auto-affectée)
- [ ] Signalement 2 : Se connecter en admin territoire, prévoir une visite dans le futur, sans que le partenaire concerné n'intervienne sur ce signalement
- [ ] Changer la date des visites en BDD pour qu'elle soit 2 jours dans le passé
- [ ] `make console app="notify-visits"`
- [ ] Signalement 1 : L'agent du partenaire affecté est notifié ; si il y a un admin partenaire dans le partenaire affecté, il est notifié
- [ ] Signalement 2 : L'agent de l'admin territoire est notifié ; si il y a un admin partenaire dans le partenaire affecté, il est notifié
