### PR TITLE
[Esabora - SISH] Nettoyage des tags HTML avant envoi à SISH pour le champ commentaire

### DIFF
--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -51,7 +51,7 @@ class NotifyVisitsCommand extends AbstractCronCommand
         foreach ($listFutureVisits as $intervention) {
             $partnerName = $intervention->getPartner() ? $intervention->getPartner()->getNom() : 'Non renseigné';
             $signalement = $intervention->getSignalement();
-            $description = '<strong>Rappel de visite :</strong> la visite du logement situé';
+            $description = '<strong>Rappel de visite :</strong> la visite du logement situé ';
             $description .= $signalement->getAdresseOccupant().' '.$signalement->getCpOccupant().' '.$signalement->getVilleOccupant();
             $description .= ' aura lieu le '.$intervention->getScheduledAt()->format('d/m/Y');
             $description .= '<br>La visite sera effectuée par '.$partnerName.'.';

--- a/src/Factory/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Esabora/DossierMessageSISHFactory.php
@@ -11,6 +11,7 @@ use App\Repository\SuiviRepository;
 use App\Service\Esabora\AbstractEsaboraService;
 use App\Service\Esabora\Enum\PersonneType;
 use App\Service\Esabora\Model\DossierMessageSISHPersonne;
+use App\Service\HtmlCleaner;
 use App\Service\UploadHandlerService;
 use App\Utils\AddressParser;
 use Doctrine\ORM\NonUniqueResultException;
@@ -45,6 +46,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
 
         $address = AddressParser::parse($signalement->getAdresseOccupant());
         $firstSuivi = $this->suiviRepository->findFirstSuiviBy($signalement, Suivi::TYPE_PARTNER);
+        $cleanedSuiviDescription = HtmlCleaner::clean($firstSuivi?->getDescription());
         $formatDate = AbstractEsaboraService::FORMAT_DATE;
         $formatDateTime = AbstractEsaboraService::FORMAT_DATE_TIME;
         $routeSignalement = $this->urlGenerator->generate(
@@ -113,7 +115,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ->setSignalementScore($signalement->getScore())
             ->setSignalementOrigine(AbstractEsaboraService::SIGNALEMENT_ORIGINE)
             ->setSignalementNumero($signalement->getReference())
-            ->setSignalementCommentaire($firstSuivi?->getDescription())
+            ->setSignalementCommentaire($cleanedSuiviDescription)
             ->setSignalementDate($signalement->getCreatedAt()?->format($formatDate))
             ->setSignalementDetails($signalement->getDetails())
             ->setSignalementProblemes($this->buildProblemes($signalement))

--- a/src/Service/HtmlCleaner.php
+++ b/src/Service/HtmlCleaner.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Service;
+
+class HtmlCleaner
+{
+    public static function clean($html): string
+    {
+        return strip_tags(html_entity_decode($html));
+    }
+}

--- a/tests/Unit/Service/HtmlCleanerTest.php
+++ b/tests/Unit/Service/HtmlCleanerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\HtmlCleaner;
+use PHPUnit\Framework\TestCase;
+
+class HtmlCleanerTest extends TestCase
+{
+    /**
+     * @dataProvider providePartnerType
+     */
+    public function testTextWithHtml(string $textToClean, string $textCleaned): void
+    {
+        $this->assertEquals(HtmlCleaner::clean($textToClean), $textCleaned);
+    }
+
+    public function providePartnerType(): \Generator
+    {
+        yield 'Bold' => ['<strong>Fat</strong> Joe', 'Fat Joe'];
+        yield 'Accents' => ['&eacute;&egrave;&agrave;&ugrave;', 'éèàù'];
+        yield 'Bullets' => ['<ul><li>one</li><li>two</li></ul>', 'onetwo'];
+        yield 'Line break' => ['First line<br>Second line', 'First lineSecond line'];
+        yield 'Paragrap' => ['<p>First paragraph</p><p>Second paragraph</p>', 'First paragraphSecond paragraph'];
+    }
+}


### PR DESCRIPTION
## Ticket

#1573   

## Description
Le champ commentaire envoyé à SISH correspond au premier suivi envoyé. Il a de grandes chances de contenir du HTML qu'Esabora n'est pas en mesure d'afficher.

## Changements apportés
* Ajout d'une nouvelle classe de nettoyage appelée à cette occasion.

## Tests
- [ ] Lier un partenaire local à Esabora
- [ ] Prendre un signalement où ce partenaire n'est pas affecté et vérifier qu'aucun suivi non-automatique n'existe
- [ ] Ajouter un suivi avec de la mise en forme html
- [ ] Affecter le paramètre et vérifier l'affichage du texte au sein d'Esabora
