### PR TITLE
[BO - Visites] Ajout contrôle sur la saisie de date de visite

### DIFF
--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -104,12 +104,8 @@ class SignalementVisitesController extends AbstractController
             document: $fileName,
         );
 
-        $errors = $validator->validate($visiteRequest);
-        if (\count($errors) > 0) {
-            $errorMessage = '';
-            foreach ($errors as $error) {
-                $errorMessage .= $error->getMessage().' ';
-            }
+        $errorMessage = $this->validateRequest($visiteRequest, $validator);
+        if ($errorMessage) {
             $this->addFlash('error', sprintf("Erreurs lors de l'enregistrement de la visite : %s", $errorMessage));
         } elseif ($intervention = $interventionManager->createVisiteFromRequest($signalement, $visiteRequest)) {
             $todayDate = new \DateTimeImmutable();
@@ -215,12 +211,8 @@ class SignalementVisitesController extends AbstractController
             document: $fileName,
         );
 
-        $errors = $validator->validate($visiteRequest);
-        if (\count($errors) > 0) {
-            $errorMessage = '';
-            foreach ($errors as $error) {
-                $errorMessage .= $error->getMessage().' ';
-            }
+        $errorMessage = $this->validateRequest($visiteRequest, $validator);
+        if ($errorMessage) {
             $this->addFlash('error', sprintf('Erreurs lors de la modification de la visite : %s', $errorMessage));
         } elseif ($intervention = $interventionManager->rescheduleVisiteFromRequest($signalement, $visiteRequest)) {
             if ($intervention->getScheduledAt() <= new \DateTimeImmutable()) {
@@ -336,5 +328,20 @@ class SignalementVisitesController extends AbstractController
         }
 
         return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+    }
+
+    private function validateRequest(VisiteRequest $visiteRequest, ValidatorInterface $validator): string
+    {
+        $errorMessage = '';
+
+        $errors = $validator->validate($visiteRequest);
+        if (\count($errors) > 0) {
+            $errorMessage = '';
+            foreach ($errors as $error) {
+                $errorMessage .= $error->getMessage().' ';
+            }
+        }
+
+        return $errorMessage;
     }
 }

--- a/src/Dto/Request/Signalement/VisiteRequest.php
+++ b/src/Dto/Request/Signalement/VisiteRequest.php
@@ -2,10 +2,13 @@
 
 namespace App\Dto\Request\Signalement;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
 class VisiteRequest
 {
     public function __construct(
         private readonly ?int $idIntervention = null,
+        #[Assert\DateTime('Y-m-d')]
         private readonly ?string $date = null,
         private readonly ?string $time = null,
         private readonly ?int $idPartner = null,

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -14,7 +14,6 @@ use App\Factory\FileFactory;
 use App\Repository\InterventionRepository;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\Persistence\ManagerRegistry;
-use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Workflow\WorkflowInterface;
 
@@ -28,7 +27,6 @@ class InterventionManager extends AbstractManager
         private readonly SignalementQualificationUpdater $signalementQualificationUpdater,
         private readonly FileFactory $fileFactory,
         private readonly Security $security,
-        private readonly LoggerInterface $logger,
         string $entityName = Intervention::class
     ) {
         parent::__construct($managerRegistry, $entityName);

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -52,18 +52,10 @@ class InterventionManager extends AbstractManager
             return null;
         }
 
-        try {
-            $scheduledAt = new \DateTimeImmutable($visiteRequest->getDateTime());
-        } catch (\Throwable $exception) {
-            $this->logger->error(sprintf('Visite date error %s', $exception->getMessage()));
-
-            return null;
-        }
-
         $intervention = new Intervention();
         $intervention->setSignalement($signalement)
             ->setPartner($partnerFound)
-            ->setScheduledAt($scheduledAt)
+            ->setScheduledAt(new \DateTimeImmutable($visiteRequest->getDateTime()))
             ->setType(InterventionType::VISITE)
             ->setStatus(Intervention::STATUS_PLANNED);
 
@@ -117,17 +109,9 @@ class InterventionManager extends AbstractManager
             return null;
         }
 
-        try {
-            $scheduledAt = new \DateTimeImmutable($visiteRequest->getDateTime());
-        } catch (\Throwable $exception) {
-            $this->logger->error(sprintf('Visite date error %s', $exception->getMessage()));
-
-            return null;
-        }
-
         $intervention
             ->setPartner($partnerFound)
-            ->setScheduledAt($scheduledAt);
+            ->setScheduledAt(new \DateTimeImmutable($visiteRequest->getDateTime()));
         $this->save($intervention);
 
         if ($intervention->getScheduledAt() <= new \DateTimeImmutable()) {

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -117,9 +117,17 @@ class InterventionManager extends AbstractManager
             return null;
         }
 
+        try {
+            $scheduledAt = new \DateTimeImmutable($visiteRequest->getDateTime());
+        } catch (\Throwable $exception) {
+            $this->logger->error(sprintf('Visite date error %s', $exception->getMessage()));
+
+            return null;
+        }
+
         $intervention
             ->setPartner($partnerFound)
-            ->setScheduledAt(new \DateTimeImmutable($visiteRequest->getDateTime()));
+            ->setScheduledAt($scheduledAt);
         $this->save($intervention);
 
         if ($intervention->getScheduledAt() <= new \DateTimeImmutable()) {

--- a/tests/Functional/Manager/InterventionManagerTest.php
+++ b/tests/Functional/Manager/InterventionManagerTest.php
@@ -14,6 +14,7 @@ use App\Repository\InterventionRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Workflow\WorkflowInterface;
@@ -28,6 +29,7 @@ class InterventionManagerTest extends KernelTestCase
     private SignalementQualificationUpdater $signalementQualificationUpdater;
     private FileFactory $fileFactory;
     private Security $security;
+    private LoggerInterface $loggerInterface;
 
     private ?InterventionManager $interventionManager = null;
 
@@ -45,6 +47,8 @@ class InterventionManagerTest extends KernelTestCase
         $this->security = static::getContainer()->get('security.helper');
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $this->fileFactory = static::getContainer()->get(FileFactory::class);
+        $this->loggerInterface = static::getContainer()->get(LoggerInterface::class);
 
         $this->interventionManager = new InterventionManager(
             $this->managerRegistry,
@@ -53,7 +57,8 @@ class InterventionManagerTest extends KernelTestCase
             $this->workflow,
             $this->signalementQualificationUpdater,
             $this->fileFactory,
-            $this->security
+            $this->security,
+            $this->loggerInterface
         );
     }
 

--- a/tests/Functional/Manager/InterventionManagerTest.php
+++ b/tests/Functional/Manager/InterventionManagerTest.php
@@ -14,7 +14,6 @@ use App\Repository\InterventionRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\Persistence\ManagerRegistry;
-use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Workflow\WorkflowInterface;
@@ -29,7 +28,6 @@ class InterventionManagerTest extends KernelTestCase
     private SignalementQualificationUpdater $signalementQualificationUpdater;
     private FileFactory $fileFactory;
     private Security $security;
-    private LoggerInterface $loggerInterface;
 
     private ?InterventionManager $interventionManager = null;
 
@@ -47,8 +45,6 @@ class InterventionManagerTest extends KernelTestCase
         $this->security = static::getContainer()->get('security.helper');
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
-        $this->fileFactory = static::getContainer()->get(FileFactory::class);
-        $this->loggerInterface = static::getContainer()->get(LoggerInterface::class);
 
         $this->interventionManager = new InterventionManager(
             $this->managerRegistry,
@@ -58,7 +54,6 @@ class InterventionManagerTest extends KernelTestCase
             $this->signalementQualificationUpdater,
             $this->fileFactory,
             $this->security,
-            $this->loggerInterface
         );
     }
 


### PR DESCRIPTION
## Ticket

#1449    

## Description
Ajout d'un contrôle sur la saisie de date de visite

## Tests
- [ ] Saisir une date fausse (par exemple 2022222) lors de la création de visite et vérifier qu'on reçoit bien une erreur logicielle (et pas une erreur 500)
- [ ] Saisir une date fausse (par exemple 2022222) lors de la reprogrammation de visite et vérifier qu'on reçoit bien une erreur logicielle (et pas une erreur 500)
