### PR TITLE
[QA] Adresse invalide qui empêche l'envoi de dossier à esabora

### DIFF
--- a/src/Utils/AddressParser.php
+++ b/src/Utils/AddressParser.php
@@ -10,16 +10,32 @@ class AddressParser
     {
         $number = null;
         $suffix = null;
+        $address = str_replace(',', '', $address);
 
+        if (str_contains($address, '/')) {
+            return [
+                'number' => $number,
+                'suffix' => $suffix,
+                'street' => $address,
+            ];
+        }
+        // Match number and optional suffix at the beginning of the address
         preg_match('/^(\d+)\s*(\w+)?\s*/', $address, $matches);
         if (isset($matches[1])) {
             $number = $matches[1];
             if (isset($matches[2]) && \in_array(strtoupper($matches[2]), ExtensionAdresse::toArray())) {
                 $suffix = strtoupper($matches[2]);
+                // Remove the number and suffix from the street
                 $street = preg_replace('/^\d+\s*(?:\w+)?\s*/', '', $address);
             } else {
                 preg_match('/^(\d+)\s+(.*)$/', $address, $matches);
-                $street = $matches[2];
+                if (!empty($matches)) {
+                    $street = $matches[2];
+                } else {
+                    // The number and the street are not separated by a space
+                    // Remove number at the beginning of the address
+                    $street = preg_replace('/^\d+\s*/', '', $address);
+                }
             }
         } else {
             $street = $address;

--- a/tests/Unit/Utils/AddressParserTest.php
+++ b/tests/Unit/Utils/AddressParserTest.php
@@ -24,6 +24,41 @@ class AddressParserTest extends TestCase
 
     public function provideAdresse(): \Generator
     {
+        yield '123Rue de Canteraine' => [
+            '123Rue de Canteraine',
+            '123',
+            null,
+            'Rue de Canteraine',
+        ];
+
+        yield '61/63 Route de Calais' => [
+            '61/63 Route de Calais',
+            null,
+            null,
+            '61/63 Route de Calais',
+        ];
+
+        yield '33RUE THOMAS HERISSON' => [
+            '33RUE THOMAS HERISSON',
+            '33',
+            null,
+            'RUE THOMAS HERISSON',
+        ];
+
+        yield '53, rue de rû' => [
+            '53, rue de rû',
+            '53',
+            null,
+            'Rue de rû',
+        ];
+
+        yield '40 Allée Gustave Cantelon' => [
+            '40 Allée Gustave Cantelon',
+            '40',
+            null,
+            'Allée Gustave Cantelon',
+        ];
+
         yield '141bis Rue du Pdt J Fitzgerald Kennedy' => [
             '141bis Rue du Pdt J Fitzgerald Kennedy',
             '141',


### PR DESCRIPTION
## Ticket

#1580    

## Description
Certaines adresses de dossier ne sont pas parsable par AdressParser, en attendant d'avoir une stratégie et routine qui corrige les adresses, il faut permettre à AddressParser de parser les type d'adresse qui pose problème.

|  Adrresse                            | Problème rencontré                                    |  Commentaire       |
|-------------------------------------|---------------------------------------------------------|--------------------------|
| 123Rue de Canteraine       | Le numéro et le nom de la voie sont collés |
| 61/63 Route de Calais        | Présence de / | L'adresse sera envoyé telle quelle car le slash n'est pas toujours utilisé pour séparer les numéro va nécessiter un traitement en base de donnée, il existe 46 adresses avec présence de '\'
| 53, rue de rû                       | Présence virgule | Suppression de la virgule

## Changements apportés
* Modification de `AddressParser` avec gestions des cas ci dessus


## Pré-requis
Modifier les accès d'un partenaire ARS avec les environnements de test esabora

## Tests
- [ ] Modifier l'adresse d'un signalement avec un des type d'addresse founri
- [ ] Affecter le signalement à un partenaire ARS
- [ ] Vérifier que le dossier a bien été poussé 
