### PR TITLE
[Back] Adaptation mock profil locataire

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ on:
       - develop
   schedule:
     - cron: '0 7 * * *'
+
+env:
+  HISTOLOGE_URL: http://localhost:8080
+
 jobs:
   code-quality:
     name: Histologe (PHP ${{ matrix.php-versions }})
@@ -74,8 +78,6 @@ jobs:
         run: | 
           composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
           composer install --working-dir=tools/php-cs-fixer --no-progress --no-suggest --prefer-dist --optimize-autoloader
-        env:
-          HISTOLOGE_URL: http://localhost:8080
 
       # https://github.com/symfonycorp/security-checker-action
       - name: Security check installed dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,8 @@ jobs:
         run: | 
           composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
           composer install --working-dir=tools/php-cs-fixer --no-progress --no-suggest --prefer-dist --optimize-autoloader
+        env:
+          HISTOLOGE_URL: http://localhost:8080
 
       # https://github.com/symfonycorp/security-checker-action
       - name: Security check installed dependencies

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -6,9 +6,7 @@
       :data-ajaxurl-questions="sharedProps.ajaxurlQuestions"
       :data-ajaxurl-post-signalement-draft="sharedProps.ajaxurlPostSignalementDraft"
       :data-ajaxurl-put-signalement-draft="sharedProps.ajaxurlPutSignalementDraft"
-      :data-platform-name="sharedProps.platformName"
-      :data-platform-url="sharedProps.platformUrl"
-      >
+    >
       <div v-if="isLoadingInit" class="loading fr-m-10w">
       Initialisation du formulaire...
 
@@ -71,8 +69,6 @@ export default defineComponent({
       this.sharedProps.ajaxurlQuestions = initElements.dataset.ajaxurlQuestions
       this.sharedProps.ajaxurlPostSignalementDraft = initElements.dataset.ajaxurlPostSignalementDraft
       this.sharedProps.ajaxurlPutSignalementDraft = initElements.dataset.ajaxurlPutSignalementDraft
-      this.sharedProps.platformName = initElements.dataset.platformName
-      this.sharedProps.platformUrl = initElements.dataset.platformUrl
       requests.initQuestions(this.handleInitQuestions)
     } else {
       this.isErrorInit = true

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -6,6 +6,8 @@
       :data-ajaxurl-questions="sharedProps.ajaxurlQuestions"
       :data-ajaxurl-post-signalement-draft="sharedProps.ajaxurlPostSignalementDraft"
       :data-ajaxurl-put-signalement-draft="sharedProps.ajaxurlPutSignalementDraft"
+      :data-platform-name="sharedProps.platformName"
+      :data-platform-url="sharedProps.platformUrl"
       >
       <div v-if="isLoadingInit" class="loading fr-m-10w">
       Initialisation du formulaire...
@@ -69,6 +71,8 @@ export default defineComponent({
       this.sharedProps.ajaxurlQuestions = initElements.dataset.ajaxurlQuestions
       this.sharedProps.ajaxurlPostSignalementDraft = initElements.dataset.ajaxurlPostSignalementDraft
       this.sharedProps.ajaxurlPutSignalementDraft = initElements.dataset.ajaxurlPutSignalementDraft
+      this.sharedProps.platformName = initElements.dataset.platformName
+      this.sharedProps.platformUrl = initElements.dataset.platformUrl
       requests.initQuestions(this.handleInitQuestions)
     } else {
       this.isErrorInit = true

--- a/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -36,12 +36,13 @@ export default defineComponent({
     customCss: { type: String, default: '' },
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
-    error: { type: String, default: '' }
+    error: { type: String, default: '' },
+    defaultValue: { type: Number, default: null }
   },
   computed: {
     internalValue: {
       get () {
-        return this.modelValue
+        return this.modelValue || this.defaultValue
       },
       set (newValue: string) {
         this.$emit('update:modelValue', newValue)
@@ -54,6 +55,11 @@ export default defineComponent({
       this.$emit('update:modelValue', value)
     }
   },
-  emits: ['update:modelValue']
+  emits: ['update:modelValue'],
+  mounted () {
+    if (this.modelValue === null) {
+      this.$emit('update:modelValue', this.internalValue)
+    }
+  }
 })
 </script>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -15,6 +15,7 @@
         :components="component.components"
         :action="component.action"
         :values="component.values"
+        :defaultValue="component.defaultValue"
         :customCss="component.customCss"
         :validate="component.validate"
         :disabled="component.disabled"

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -62,7 +62,9 @@ const formStore: FormStore = reactive({
     ajaxurlQuestions: '',
     ajaxurlPostSignalementDraft: '',
     ajaxurlPutSignalementDraft: '',
-    urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q='
+    urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q=',
+    platformName: '',
+    platformUrl: ''
   },
   screenData: [],
   currentScreenIndex: 0,

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -62,9 +62,7 @@ const formStore: FormStore = reactive({
     ajaxurlQuestions: '',
     ajaxurlPostSignalementDraft: '',
     ajaxurlPutSignalementDraft: '',
-    urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q=',
-    platformName: '',
-    platformUrl: ''
+    urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q='
   },
   screenData: [],
   currentScreenIndex: 0,

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -6,7 +6,7 @@ twig:
             logo: 'Logohistologe.png'
             logo145: 'logo_145.png'
             logosvg: 'logo-histologe.svg'
-            url: 'https://histologe.beta.gouv.fr'
+            url: '%host_url%'
             demo: 'https://app.livestorm.co/incubateur-des-territoires/demonstration-histologe?type=detailed'
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -8,9 +8,11 @@
 {% endblock %}
 
 {% block body %}
-    <div id="app-signalement-form" 
-        data-ajaxurl="{{ path('front_nouveau_formulaire') }}"            
-        data-ajaxurl-questions="{{ path('api_question_profile') }}?profil="
-        data-ajaxurl-post-signalement-draft="{{ path('envoi_nouveau_signalement_draft') }}"
-        data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft', {uuid: 'uuid'}) }}"></div>
+    <div id="app-signalement-form"
+         data-platform-name="{{ platform.name }}"
+         data-platform-url="{{ platform.url }}"
+         data-ajaxurl="{{ path('front_nouveau_formulaire') }}"
+         data-ajaxurl-questions="{{ path('api_question_profile') }}?profil="
+         data-ajaxurl-post-signalement-draft="{{ path('envoi_nouveau_signalement_draft') }}"
+         data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft', {uuid: 'uuid'}) }}"></div>
 {% endblock %}

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -9,8 +9,6 @@
 
 {% block body %}
     <div id="app-signalement-form"
-         data-platform-name="{{ platform.name }}"
-         data-platform-url="{{ platform.url }}"
          data-ajaxurl="{{ path('front_nouveau_formulaire') }}"
          data-ajaxurl-questions="{{ path('api_question_profile') }}?profil="
          data-ajaxurl-post-signalement-draft="{{ path('envoi_nouveau_signalement_draft') }}"

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -335,7 +335,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "customCss": "question-xl",
-          "label": "Il y a-t-il des enfants de moins de 6 ans ?",
+          "label": "Des enfants de moins de 6 ans vivent dans le logement ?",
           "slug": "composition_logement_enfants",
           "values": [
             {
@@ -375,7 +375,8 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "",
+    "label": "Les pièces à vivre",
+    "description": "Vous avez indiqué qu'il y a {{number}} pièces à vivre (salon, chambre) dans votre logement",
     "slug": "type_logement_pieces_a_vivre",
     "conditional": {
       "show": "formStore.data.composition_logement_nombre_pieces === 'plusieurs_pieces'"
@@ -771,7 +772,7 @@
           "type": "SignalementFormOnlyChoice",
           "label": "Avez-vous fait une demande de logement social ou de relogement ?",
           "customCss": "question-xl",
-          "warning": "{{platform.name}} ne permet pas de faire une demande de logement social ou de relogement.",
+          "warning": "{{platformName}} ne permet pas de faire une demande de logement social ou de relogement.",
           "slug": "logement_social_demande_relogement",
           "values": [
             {
@@ -926,6 +927,53 @@
   },
   {
     "type": "SignalementFormScreen",
+    "label": "Les désordres",
+    "slug": "ecran_intermediaire_les_desordres",
+    "description": "<p>Vous avez indiqué que votre signalement concerne {{formStore.data.zone_concernee_zone}}. </p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p> <p>Vous pourrez aussi ajouter des photos des problèmes.<p><p>Toutes les questions sont obligatoires, sauf mention contraire.</p>",
+    "components": {
+      "body": [],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "ecran_intermediaire_les_desordres_previous",
+          "action": "goto:travailleur_social"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "ecran_intermediaire_les_desordres_next",
+          "action": "goto:info_procedure"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "La prodécure",
+    "description": "<p>Vous avez presque terminé ! <br>Répondez aux dernières questions puis envoyez votre signalement.</p><p>Toutes les questions sont obligatoires, sauf mention contraire.</p>",
+    "slug": "ecran_intermediaire_procedure",
+    "components": {
+      "body": [
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "ecran_intermediaire_procedure_previous",
+          "action": "goto:ecran_intermediaire_les_desordres"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "ecran_intermediaire_procedure_next",
+          "action": "goto:info_procedure"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
     "label": "",
     "slug": "info_procedure",
     "components": {
@@ -968,6 +1016,14 @@
           ]
         },
         {
+          "type": "SignalementFormTextfield",
+          "label": "Quelle a été la réponse de votre assurance ?",
+          "slug": "info_procedure_reponse_assurance",
+          "conditional": {
+            "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
+          }
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "label": "Si des travaux sont faits, voulez-vous rester dans le logement ?",
           "customCss": "question-xl",
@@ -986,22 +1042,133 @@
               "value": "nsp"
             }
           ]
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "info_procedure_utilisation_service_previous",
+          "action": "goto:travailleur_social"
         },
         {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "info_procedure_utilisation_service_next",
+          "action": "goto:utilisation_service"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Utilisation du service",
+    "description": "Lisez attentivement les conditions ci-dessous.",
+    "slug": "utilisation_service",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormCheckbox",
+          "value": "utilisation_service_ok_prevenir_bailleur",
+          "label": "Je comprends que {{platformName}} va prévenir le bailleur (propriétaire) de mon logement."
+        },
+        {
+          "type": "SignalementFormCheckbox",
+          "value": "utilisation_service_ok_visite",
+          "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement."
+        },
+        {
+          "type": "SignalementFormCheckbox",
+          "value": "utilisation_service_ok_demande_logement",
+          "label": "Je comprends que {{platformName}} ne permet pas de faire une demande de logement social et relogement."
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "utilisation_service_previous",
+          "action": "goto:info_procedure"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "utilisation_service_next",
+          "action": "goto:informations_complementaires"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Information complémentaires",
+    "description": "Toutes les questions sont facultatives",
+    "slug": "informations_complementaires",
+    "components": {
+      "body": [
+        {
           "type": "SignalementFormSubscreen",
-          "label": "Utilisation du service",
-          "slug": "info_procedure_utilisation_service",
+          "label": "Ma situation personnelle",
+          "slug": "informations_complementaires_situation_occupants",
           "components": {
             "body": [
               {
-                "type": "SignalementFormCheckbox",
-                "value": "info_procedure_ok_prevenir_bailleur",
-                "label": "Je comprends que {{platform.name}} va prévenir le bailleur (propriétaire) de mon logement."
+                "type": "SignalementFormOnlyChoice",
+                "label": "Êtes-vous bénéficiaire du RSA (revenu de solidarité active) ?",
+                "slug": "informations_complementaires_situation_occupants_beneficiaire_rsa",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
               },
               {
-                "type": "SignalementFormCheckbox",
-                "value": "info_procedure_ok_visite",
-                "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement."
+                "type": "SignalementFormOnlyChoice",
+                "label": "Êtes-vous bénéficiaire FSL (fonds de solidarité pour le logement) ?",
+                "slug": "informations_complementaires_situation_occupants_beneficiaire_fsl",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Mon logement",
+          "slug": "informations_complementaires_logement",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormCounter",
+                "label": "Votre logement est sur combien d'étages ?",
+                "slug": "informations_complementaires_logement_nombre_etages",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormDate",
+                "label": "En quelle année votre logement a-t-il été construit ?",
+                "slug": "informations_complementaires_logement_annee_construction"
               }
             ]
           }
@@ -1011,14 +1178,36 @@
         {
           "type": "SignalementFormButton",
           "label": "Précédent",
-          "slug": "info_procedure_previous",
-          "action": "goto:travailleur_social"
+          "slug": "informations_complementaires_previous",
+          "action": "goto:utilisation_service"
         },
         {
           "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "info_procedure_next",
-          "action": "goto:validation-signalement"
+          "label": "Enregistrer",
+          "slug": "informations_complementaires_next",
+          "action": "goto:validation_signalement"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Validation du signalement",
+    "slug": "validation_signalement",
+    "components": {
+      "body": [],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "validation_signalement_previous",
+          "action": "goto:informations_complementaires"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Valider mon signalement",
+          "slug": "validation_signalement_next",
+          "action": "goto:confirmation_signalement"
         }
       ]
     }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -318,19 +318,13 @@
           "type": "SignalementFormCounter",
           "customCss": "question-xl",
           "label": "Quelle est la superficie de votre logement (taille en m²)",
-          "slug": "composition_logement_superficie",
-          "validate": {
-            "required": false
-          }
+          "slug": "composition_logement_superficie"
         },
         {
           "type": "SignalementFormCounter",
           "customCss": "question-xl",
           "label": "Combien de personnes vivent dans votre logement ?",
-          "slug": "composition_logement_nombre_personnes",
-          "validate": {
-            "required": false
-          }
+          "slug": "composition_logement_nombre_personnes"
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -352,6 +346,7 @@
           "type": "SignalementFormCounter",
           "label": "Quel est le nombre de pièces à vivre (salon, chambre) dans votre logement ?",
           "slug": "composition_logement_nb_pieces",
+          "defaultValue": 1,
           "conditional": {
             "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
           }
@@ -426,7 +421,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "type_logement_pieces_a_vivre_previous",
-          "action": "goto:type_logement"
+          "action": "goto:composition_logement"
         },
         {
           "type": "SignalementFormButton",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -943,7 +943,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "ecran_intermediaire_les_desordres_next",
-          "action": "goto:info_procedure"
+          "action": "goto:ecran_intermediaire_procedure"
         }
       ]
     }
@@ -1208,6 +1208,29 @@
           "label": "Valider mon signalement",
           "slug": "validation_signalement_next",
           "action": "goto:confirmation_signalement"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Merci pour votre signalement",
+    "slug": "confirmation_signalement",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormConfirmation",
+          "label": "",
+          "slug": "confirmation_signalement_message"
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormLink",
+          "label": "Retour à l'acceuil",
+          "slug": "validation_signalement_homepage",
+          "customCss": "fr-btn",
+          "link": "{{platformUrl}}"
         }
       ]
     }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1168,7 +1168,10 @@
               {
                 "type": "SignalementFormDate",
                 "label": "En quelle année votre logement a-t-il été construit ?",
-                "slug": "informations_complementaires_logement_annee_construction"
+                "slug": "informations_complementaires_logement_annee_construction",
+                "validate": {
+                  "required": false
+                }
               }
             ]
           }


### PR DESCRIPTION
## Ticket

#1584    

## Description
Description de la modification apportée

## Changements apportés
* [config] Paramètre url dynamique pour twig
* [mock] Ajout écran désordres vides *ecran_intermediaire_les_desordres*
* [mock] Ajout écran *ecran_intermediaire_procedure*
* [mock] Ajout écran *utilisation_service*
* [mock] Ajout écran *informations_complementaires*
* [mock] Ajout écran *validation_signalement*
* [mock] Ajout écran *validation_signalement*
* [mock] Ajout écran "confirmation_signalement"

## Tests
- [ ] Déposer un nouveau signalement en tant que locataire et vérifier qu'on va à l'écran de confirmation
