### PR TITLE
[FO - Formulaire] Chargement des données d'un draft existant

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -6,28 +6,29 @@
       :data-ajaxurl-questions="sharedProps.ajaxurlQuestions"
       :data-ajaxurl-post-signalement-draft="sharedProps.ajaxurlPostSignalementDraft"
       :data-ajaxurl-put-signalement-draft="sharedProps.ajaxurlPutSignalementDraft"
-    >
+      :data-ajaxurl-get-signalement-draft="sharedProps.ajaxurlGetSignalementDraft"
+      >
       <div v-if="isLoadingInit" class="loading fr-m-10w">
-      Initialisation du formulaire...
+        Initialisation du formulaire...
 
-      <div v-if="isErrorInit" class="fr-my-5w">
-        Erreur lors de l'initialisation du formulaire.<br><br>
-        Veuillez recharger la page ou nous prévenir via le formulaire de contact.
+        <div v-if="isErrorInit" class="fr-my-5w">
+          Erreur lors de l'initialisation du formulaire.<br><br>
+          Veuillez recharger la page ou nous prévenir via le formulaire de contact.
+        </div>
       </div>
-    </div>
 
-    <div v-else-if="currentScreen">
-      <SignalementFormBreadCrumbs
-        :currentStep="currentScreen.label"
-      />
-      <SignalementFormScreen
-        class="fr-p-5w"
-        :label="currentScreen.label"
-        :description="currentScreen.description"
-        :components="currentScreen.components"
-        :changeEvent="saveAndChangeScreenBySlug"
-      />
-    </div>
+      <div v-else-if="currentScreen">
+        <SignalementFormBreadCrumbs
+          :currentStep="currentScreen.label"
+        />
+        <SignalementFormScreen
+          class="fr-p-5w"
+          :label="currentScreen.label"
+          :description="currentScreen.description"
+          :components="currentScreen.components"
+          :changeEvent="saveAndChangeScreenBySlug"
+        />
+      </div>
     </div>
 </template>
 
@@ -69,12 +70,25 @@ export default defineComponent({
       this.sharedProps.ajaxurlQuestions = initElements.dataset.ajaxurlQuestions
       this.sharedProps.ajaxurlPostSignalementDraft = initElements.dataset.ajaxurlPostSignalementDraft
       this.sharedProps.ajaxurlPutSignalementDraft = initElements.dataset.ajaxurlPutSignalementDraft
-      requests.initQuestions(this.handleInitQuestions)
+      if (initElements.dataset.ajaxurlGetSignalementDraft !== undefined) {
+        this.sharedProps.ajaxurlGetSignalementDraft = initElements.dataset.ajaxurlGetSignalementDraft
+        requests.initWithExistingData(this.handleInitData)
+      } else {
+        requests.initQuestions(this.handleInitQuestions)
+      }
     } else {
       this.isErrorInit = true
     }
   },
   methods: {
+    handleInitData (requestResponse: any) {
+      if (requestResponse.signalement && requestResponse.signalement.payload) {
+        for (const prop in requestResponse.signalement.payload) {
+          formStore.data[prop] = requestResponse.signalement.payload[prop]
+        }
+      }
+      requests.initQuestions(this.handleInitQuestions)
+    },
     handleInitQuestions (requestResponse: any) {
       if (requestResponse === 'error') {
         this.isErrorInit = true

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
     <SignalementFormTextfield
-      :key="idAdress"
-      :id="idAdress"
+      :key="idAddress"
+      :id="idAddress"
       label="Commençons par l'adresse du logement"
       description="Tapez puis sélectionnez l'adresse dans la liste"
       :customCss="customCss"
       :validate="validate"
-      v-model="formStore.data[idAdress]"
-      :hasError="formStore.validationErrors[idAdress]  !== undefined"
-      :error="formStore.validationErrors[idAdress]"
+      v-model="formStore.data[idAddress]"
+      :hasError="formStore.validationErrors[idAddress] !== undefined"
+      :error="formStore.validationErrors[idAddress]"
     />
     <div id="sous_menu" class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
       <div
@@ -82,7 +82,7 @@ export default defineComponent({
     services.addSubscreenData(this.id, updatedSubscreenData)
     return {
       idFetchTimeout: 0 as unknown as ReturnType<typeof setTimeout>,
-      idAdress: this.id + '_suggestion',
+      idAddress: this.id + '_suggestion',
       idShow: this.id + '_afficher_les_champs',
       idSubscreen: this.id + '_detail',
       actionShow: 'show:' + this.id + '_detail',
@@ -93,7 +93,7 @@ export default defineComponent({
   },
   created () {
     watch(
-      () => this.formStore.data[this.idAdress],
+      () => this.formStore.data[this.idAddress],
       (newValue: any) => {
         clearTimeout(this.idFetchTimeout)
         this.idFetchTimeout = setTimeout(() => {

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -40,6 +40,11 @@ export const requests = {
       })
   },
 
+  initWithExistingData (functionReturn: Function) {
+    const url = formStore.props.ajaxurlGetSignalementDraft
+    requests.doRequestGet(url, functionReturn)
+  },
+
   initQuestions (functionReturn: Function) {
     const url = (formStore.props.ajaxurlQuestions as string) + 'tous'
     requests.doRequestGet(url, functionReturn)

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -44,7 +44,6 @@ interface Component {
 interface FormStore {
   data: FormData
   props: FormData
-  initData: any[]
   screenData: any[]
   currentScreenIndex: number
   validationErrors: FormData
@@ -66,7 +65,6 @@ const formStore: FormStore = reactive({
     ajaxurlGetSignalementDraft: '',
     urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q='
   },
-  initData: [],
   screenData: [],
   currentScreenIndex: 0,
   inputComponents: [

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -44,6 +44,7 @@ interface Component {
 interface FormStore {
   data: FormData
   props: FormData
+  initData: any[]
   screenData: any[]
   currentScreenIndex: number
   validationErrors: FormData
@@ -62,8 +63,10 @@ const formStore: FormStore = reactive({
     ajaxurlQuestions: '',
     ajaxurlPostSignalementDraft: '',
     ajaxurlPutSignalementDraft: '',
+    ajaxurlGetSignalementDraft: '',
     urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q='
   },
+  initData: [],
   screenData: [],
   currentScreenIndex: 0,
   inputComponents: [

--- a/src/Controller/FrontNewSignalementController.php
+++ b/src/Controller/FrontNewSignalementController.php
@@ -23,7 +23,25 @@ class FrontNewSignalementController extends AbstractController
             return $this->redirectToRoute('front_signalement');
         }
 
-        return $this->render('front/nouveau_formulaire.html.twig');
+        return $this->render('front/nouveau_formulaire.html.twig', [
+            'uuid_signalement' => null,
+        ]);
+    }
+
+    #[Route('/signalement/{uuid}', name: 'front_nouveau_formulaire_edit')]
+    public function edit(
+        SignalementDraft $signalementDraft,
+        ParameterBagInterface $parameterBag
+    ): Response {
+        // TODO : sécurité ?
+
+        if (!$parameterBag->get('feature_new_form')) {
+            return $this->redirectToRoute('front_signalement');
+        }
+
+        return $this->render('front/nouveau_formulaire.html.twig', [
+            'uuid_signalement' => $signalementDraft->getUuid(),
+        ]);
     }
 
     #[Route('/signalement-draft/envoi', name: 'envoi_nouveau_signalement_draft', methods: 'POST')]
@@ -79,5 +97,14 @@ class FrontNewSignalementController extends AbstractController
         }
 
         return $this->json('@todo error');
+    }
+
+    #[Route('/signalement-draft/{uuid}/informations', name: 'informations_signalement_draft', methods: 'GET')]
+    public function getSignalementDraft(
+        SignalementDraft $signalementDraft,
+    ): Response {
+        return $this->json([
+            'signalement' => $signalementDraft,
+        ]);
     }
 }

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -9,8 +9,12 @@
 
 {% block body %}
     <div id="app-signalement-form"
-         data-ajaxurl="{{ path('front_nouveau_formulaire') }}"
+         data-ajaxurl="{{ path('front_nouveau_formulaire') }}"            
          data-ajaxurl-questions="{{ path('api_question_profile') }}?profil="
          data-ajaxurl-post-signalement-draft="{{ path('envoi_nouveau_signalement_draft') }}"
-         data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft', {uuid: 'uuid'}) }}"></div>
+         data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft', {uuid: 'uuid'}) }}"
+         {% if uuid_signalement is not null %}
+           data-ajaxurl-get-signalement-draft="{{ path('informations_signalement_draft', {uuid: uuid_signalement}) }}"
+         {% endif %}
+        ></div>
 {% endblock %}

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -9,7 +9,7 @@
 
 {% block body %}
     <div id="app-signalement-form"
-         data-ajaxurl="{{ path('front_nouveau_formulaire') }}"            
+         data-ajaxurl="{{ path('front_nouveau_formulaire') }}"
          data-ajaxurl-questions="{{ path('api_question_profile') }}?profil="
          data-ajaxurl-post-signalement-draft="{{ path('envoi_nouveau_signalement_draft') }}"
          data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft', {uuid: 'uuid'}) }}"


### PR DESCRIPTION
## Ticket

#1528    

## Description
Chargement des données d'un draft existant dans le nouveau formulaire

## Changements apportés
* Ajout d'une nouvelle route GET
* Récupération des données éventuelles avant le chargement des questions et remplissage du tableau de données

## Tests
- [x] Accéder à `/nouveau-formulaire/signalement/XXX-UUID-XXX` existant et vérifier le chargement des données
- [x] Accéder à `/nouveau-formulaire/signalement/XXX-UUID-XXX` qui n'existe pas et vérifier que la page ne se charge pas
- [x] Accéder à `/nouveau-formulaire/signalement` et vérifier qu'on peut créer un nouveau draft
