### PR TITLE
[Back] Gérer les propriétés dynamiques (repeat) avec le DTO

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -116,6 +116,14 @@ services:
     App\Service\DashboardWidget\WidgetDataManagerCache:
         decorates: App\Service\DashboardWidget\WidgetDataManager
 
+    App\Serializer\SignalementDraftRequestNormalizer:
+        tags: [ 'serializer.normalizer' ]
+
+    App\Serializer\SignalementDraftRequestSerializer:
+        arguments:
+            $normalizers:
+                - '@App\Serializer\SignalementDraftRequestNormalizer'
+
 when@test:
     parameters:
         uploads_tmp_dir: '%kernel.project_dir%/tmp/'

--- a/src/Controller/FrontNewSignalementController.php
+++ b/src/Controller/FrontNewSignalementController.php
@@ -5,12 +5,12 @@ namespace App\Controller;
 use App\Dto\Request\Signalement\SignalementDraftRequest;
 use App\Entity\SignalementDraft;
 use App\Manager\SignalementDraftManager;
+use App\Serializer\SignalementDraftRequestSerializer;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[Route('/nouveau-formulaire')]
@@ -47,7 +47,7 @@ class FrontNewSignalementController extends AbstractController
     #[Route('/signalement-draft/envoi', name: 'envoi_nouveau_signalement_draft', methods: 'POST')]
     public function sendSignalementDraft(
         Request $request,
-        SerializerInterface $serializer,
+        SignalementDraftRequestSerializer $serializer,
         SignalementDraftManager $signalementDraftManager,
         ValidatorInterface $validator,
     ): Response {
@@ -73,7 +73,7 @@ class FrontNewSignalementController extends AbstractController
     #[Route('/signalement-draft/{uuid}/envoi', name: 'mise_a_jour_nouveau_signalement_draft', methods: 'PUT')]
     public function updateSignalementDraft(
         Request $request,
-        SerializerInterface $serializer,
+        SignalementDraftRequestSerializer $serializer,
         SignalementDraftManager $signalementDraftManager,
         ValidatorInterface $validator,
         SignalementDraft $signalementDraft,

--- a/src/Serializer/SignalementDraftRequestNormalizer.php
+++ b/src/Serializer/SignalementDraftRequestNormalizer.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Serializer;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\SignalementDraft;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+class SignalementDraftRequestNormalizer implements DenormalizerInterface, NormalizerInterface
+{
+    private const PIECES_SUPERFICIE_KEY_PATTERN = '/^type_logement_pieces_a_vivre_superficie_piece_(\d+)$/';
+    private const PIECES_HAUTEUR_KEY_PATTERN = '/^type_logement_pieces_a_vivre_hauteur_piece_(\d+)$/';
+    private const PIECES_SUPERFICIE_KEY = 'type_logement_pieces_a_vivre_superficie_piece';
+    private const PIECES_HAUTEUR_KEY = 'type_logement_pieces_a_vivre_hauteur_piece';
+
+    public function __construct(private ObjectNormalizer $objectNormalizer)
+    {
+    }
+
+    public function denormalize($data, $type, $format = null, array $context = [])
+    {
+        $transformedData = [];
+        foreach ($data as $key => $value) {
+            if (preg_match(self::PIECES_SUPERFICIE_KEY_PATTERN, $key, $matches)) {
+                $transformedData[self::PIECES_SUPERFICIE_KEY][] = $value;
+            } else if (preg_match(self::PIECES_HAUTEUR_KEY_PATTERN, $key, $matches)) {
+                $transformedData[self::PIECES_HAUTEUR_KEY][] = $value;
+            } else {
+                $transformedData[$key] = $value;
+            }
+        }
+
+        return $this->objectNormalizer->denormalize($transformedData, SignalementDraftRequest::class);
+    }
+
+    public function normalize(mixed $object, string $format = null, array $context = [])
+    {
+        $normalizedPayload = [];
+        /** @var SignalementDraft $signalementDraft */
+        $signalementDraft = $object;
+
+        if (empty($payload = $signalementDraft->getPayload())) {
+            return $object;
+        }
+
+        foreach ($payload as $key => $value) {
+            if (\in_array(
+                $key,
+                [self::PIECES_HAUTEUR_KEY, self::PIECES_SUPERFICIE_KEY]
+            )) {
+                foreach ($payload[$key] as $index => $valueItem) {
+                    $pieceNumber = $index + 1;
+                    $normalizedPayload[$key.'_'.$pieceNumber] = $valueItem;
+                }
+            } else {
+                $normalizedPayload[$key] = $value;
+            }
+        }
+        $signalementDraft->setPayload($normalizedPayload);
+
+        return $this->objectNormalizer->normalize($signalementDraft, $format, $context);
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return SignalementDraftRequest::class === $type;
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null)
+    {
+        return $data instanceof SignalementDraft;
+    }
+}

--- a/src/Serializer/SignalementDraftRequestNormalizer.php
+++ b/src/Serializer/SignalementDraftRequestNormalizer.php
@@ -25,7 +25,7 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
         foreach ($data as $key => $value) {
             if (preg_match(self::PIECES_SUPERFICIE_KEY_PATTERN, $key, $matches)) {
                 $transformedData[self::PIECES_SUPERFICIE_KEY][] = $value;
-            } else if (preg_match(self::PIECES_HAUTEUR_KEY_PATTERN, $key, $matches)) {
+            } elseif (preg_match(self::PIECES_HAUTEUR_KEY_PATTERN, $key, $matches)) {
                 $transformedData[self::PIECES_HAUTEUR_KEY][] = $value;
             } else {
                 $transformedData[$key] = $value;

--- a/src/Serializer/SignalementDraftRequestNormalizer.php
+++ b/src/Serializer/SignalementDraftRequestNormalizer.php
@@ -41,11 +41,7 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
         /** @var SignalementDraft $signalementDraft */
         $signalementDraft = $object;
 
-        if (empty($payload = $signalementDraft->getPayload())) {
-            return $object;
-        }
-
-        foreach ($payload as $key => $value) {
+        foreach ($payload = $signalementDraft->getPayload() as $key => $value) {
             if (\in_array(
                 $key,
                 [self::PIECES_HAUTEUR_KEY, self::PIECES_SUPERFICIE_KEY]

--- a/src/Serializer/SignalementDraftRequestSerializer.php
+++ b/src/Serializer/SignalementDraftRequestSerializer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Serializer;
+
+namespace App\Serializer;
+
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Serializer;
+
+class SignalementDraftRequestSerializer extends Serializer
+{
+    public function __construct($normalizers)
+    {
+        parent::__construct($normalizers, [new JsonEncoder()]);
+    }
+}

--- a/tests/Unit/Serializer/SignalementDraftRequestNormalizerTest.php
+++ b/tests/Unit/Serializer/SignalementDraftRequestNormalizerTest.php
@@ -23,11 +23,6 @@ class SignalementDraftRequestNormalizerTest extends TestCase
             'type_logement_pieces_a_vivre_hauteur_piece_2' => 'non',
         ];
 
-        $expectedPayload = [
-            'type_logement_pieces_a_vivre_superficie_piece' => [30, 15],
-            'type_logement_pieces_a_vivre_hauteur_piece' => ['oui', 'non'],
-        ];
-
         $signalementDraftRequest = (new SignalementDraftRequest())
             ->setProfil('locataire')
             ->setTypeLogementPiecesAVivreSuperficiePiece([30, 15])

--- a/tests/Unit/Serializer/SignalementDraftRequestNormalizerTest.php
+++ b/tests/Unit/Serializer/SignalementDraftRequestNormalizerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Tests\Unit\Serializer;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\SignalementDraft;
+use App\Serializer\SignalementDraftRequestNormalizer;
+use App\Serializer\SignalementDraftRequestSerializer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+class SignalementDraftRequestNormalizerTest extends TestCase
+{
+    public function testDenormalize(): void
+    {
+        $normalizer = new SignalementDraftRequestNormalizer(new ObjectNormalizer());
+
+        $data = [
+            'profil' => 'locataire',
+            'type_logement_pieces_a_vivre_superficie_piece_1' => 30,
+            'type_logement_pieces_a_vivre_superficie_piece_2' => 15,
+            'type_logement_pieces_a_vivre_hauteur_piece_1' => 'oui',
+            'type_logement_pieces_a_vivre_hauteur_piece_2' => 'non',
+        ];
+
+        $expectedPayload = [
+            'type_logement_pieces_a_vivre_superficie_piece' => [30, 15],
+            'type_logement_pieces_a_vivre_hauteur_piece' => ['oui', 'non'],
+        ];
+
+        $signalementDraftRequest = (new SignalementDraftRequest())
+            ->setProfil('locataire')
+            ->setTypeLogementPiecesAVivreSuperficiePiece([30, 15])
+            ->setTypeLogementPiecesAVivreHauteurPiece(['oui', 'non']);
+
+        $result = $normalizer->denormalize($data, SignalementDraftRequest::class);
+
+        $this->assertEquals($signalementDraftRequest, $result);
+    }
+
+    public function testNormalize(): void
+    {
+        $objectNormalizer = new ObjectNormalizer();
+        $normalizers = [
+            new SignalementDraftRequestNormalizer($objectNormalizer),
+            $objectNormalizer,
+        ];
+        $serializer = new SignalementDraftRequestSerializer($normalizers);
+
+        $payload = [
+            'profil' => 'locataire',
+            'type_logement_pieces_a_vivre_superficie_piece' => [30, 15],
+            'type_logement_pieces_a_vivre_hauteur_piece' => ['oui', 'non'],
+        ];
+
+        $signalementDraft = (new SignalementDraft())->setPayload($payload);
+        $result = $serializer->normalize($signalementDraft);
+
+        $this->assertArrayHasKey('type_logement_pieces_a_vivre_superficie_piece_1', $result['payload']);
+        $this->assertArrayHasKey('type_logement_pieces_a_vivre_superficie_piece_2', $result['payload']);
+        $this->assertArrayHasKey('type_logement_pieces_a_vivre_hauteur_piece_1', $result['payload']);
+        $this->assertArrayHasKey('type_logement_pieces_a_vivre_hauteur_piece_2', $result['payload']);
+    }
+}

--- a/tools/histologe/histologe.postman_collection.json
+++ b/tools/histologe/histologe.postman_collection.json
@@ -220,7 +220,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"adresse_logement_adresse\": \"17 quai de la joliette 13002 Marseille\",\n    \"adresse_logement_adresse_detail_numero\": \"17 quai de la joliette\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"adresse_logement_adresse_detail_insee\": \"13112\",\n    \"adresse_logement_adresse_detail_geoloc_lat\": 112,\n    \"adresse_logement_adresse_detail_geoloc_lng\": 115,\n    \"adresse_logement_complement_adresse_numero_appartement\": \"114\",\n    \"adresse_logement_complement_adresse_etage\": 2,\n    \"adresse_logement_complement_adresse_escalier\": 5,\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"signalement_concerne_profil_detail_tiers\": null,\n    \"signalement_concerne_profil_detail_bailleur_proprietaire\": null,\n    \"signalement_concerne_profil_detail_bailleur_bailleur\": null,\n    \"signalement_concerne_logement_social_service_secours\": null,\n    \"signalement_concerne_logement_social_autre_tiers\": null,\n    \"vos_coordonnees_occupant_civilite\": \"Mr\",\n    \"vos_coordonnees_occupant_nom\": \"Dupont\",\n    \"vos_coordonnees_occupant_prenom\": \"Jean\",\n    \"vos_coordonnees_occupant_email\": \"jean.dupont@example.com\",\n    \"vos_coordonnees_occupant_tel\": \"+33123456789\",\n    \"coordonnees_bailleur_nom\": \"Durand\",\n    \"coordonnees_bailleur_prenom\": \"Sophie\",\n    \"coordonnees_bailleur_email\": \"sophie.durand@example.com\",\n    \"coordonnees_bailleur_tel\": \"+33198765432\",\n    \"coordonnees_bailleur_adresse\": \"24 Avenue des Roses\",\n    \"coordonnees_bailleur_adresse_detail_numero\": \"Bâtiment B\",\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"75002\",\n    \"coordonnees_bailleur_adresse_commune\": \"Paris\",\n    \"zone_concernee_zone\": \"Zone A\",\n    \"type_logement_nature\": \"Appartement\",\n    \"composition_logement_piece_unique\": \"Non\",\n    \"composition_logement_superficie\": \"55m²\",\n    \"composition_logement_nb_pieces\": \"3\",\n    \"type_logement_pieces_a_vivre_superficie_piece\": [\n        30,\n        15,\n        10\n    ],\n    \"type_logement_pieces_a_vivre_hauteur_piece\": [\n        2.5,\n        2.6,\n        2.4\n    ],\n    \"type_logement_commodites_cuisine\": \"Oui\",\n    \"type_logement_commodites_cuisine_collective\": \"Non\",\n    \"type_logement_commodites_cuisine_hauteur_plafond\": \"2.3m\",\n    \"type_logement_commodites_salle_de_bain\": \"Oui\",\n    \"type_logement_commodites_salle_de_bain_collective\": \"Non\",\n    \"type_logement_commodites_salle_de_bain_hauteur_plafond\": \"2.2m\",\n    \"type_logement_commodites_wc\": \"Oui\",\n    \"type_logement_commodites_wc_collective\": \"Non\",\n    \"type_logement_commodites_wc_hauteur_plafond\": \"2.1m\",\n    \"type_logement_commodites_wc_cuisine\": \"Oui\",\n    \"bail_dpe_date_emmenagement\": \"2023-07-19\",\n    \"bail_dpe_bail\": \"Bail 1234\",\n    \"bail_dpe_bail_upload\": \"http://example.com/bail.pdf\",\n    \"bail_dpe_etat_des_lieux\": \"http://example.com/etat_des_lieux.pdf\",\n    \"bail_dpe_dpe\": \"C\",\n    \"logement_social_demande_relogement\": \"Oui\",\n    \"logement_social_allocation\": \"Oui\",\n    \"logement_social_allocation_caisse\": \"CAF Paris\",\n    \"logement_social_date_naissance\": \"1990-01-01\",\n    \"logement_social_montant_allocation\": \"500€\",\n    \"travailleur_social_quitte_logement\": \"Oui\",\n    \"travailleur_social_accompagnement\": \"Non\",\n    \"info_procedure_bailleur_prevenu\": \"Oui\",\n    \"info_procedure_assurance_contactee\": \"Non\",\n    \"info_procedure_autre_demarches\": \"Oui\",\n    \"info_procedure_quels_demarches\": \"Contact mairie pour subvention\",\n    \"date_demande\": \"2023-06-30\",\n    \"reponse_demande\": \"En cours d'examen\",\n    \"date_enregistrement\": \"2023-07-01\",\n    \"date_mise_en_relation\": \"2023-07-05\",\n    \"suivi_date_visite\": \"2023-07-10\",\n    \"suivi_interet_logement\": \"Oui\",\n    \"suivi_dossier_complet\": \"Oui\",\n    \"suivi_etude_dossier_delai\": \"2 semaines\",\n    \"suivi_commission_decision\": \"En attente\",\n    \"date_decision\": null,\n    \"decision_commission\": null\n}",
+							"raw": "{\n    \"profil\": \"locataire\",\n    \"adresse_logement_adresse\": \"99 quai de la joliette 13002 Marseille\",\n    \"adresse_logement_adresse_detail_numero\": \"17 quai de la joliette\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"adresse_logement_adresse_detail_insee\": \"13112\",\n    \"adresse_logement_adresse_detail_geoloc_lat\": 112,\n    \"adresse_logement_adresse_detail_geoloc_lng\": 115,\n    \"adresse_logement_complement_adresse_numero_appartement\": \"114\",\n    \"adresse_logement_complement_adresse_etage\": 2,\n    \"adresse_logement_complement_adresse_escalier\": 5,\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"signalement_concerne_profil_detail_tiers\": null,\n    \"signalement_concerne_profil_detail_bailleur_proprietaire\": null,\n    \"signalement_concerne_profil_detail_bailleur_bailleur\": null,\n    \"signalement_concerne_logement_social_service_secours\": null,\n    \"signalement_concerne_logement_social_autre_tiers\": null,\n    \"vos_coordonnees_occupant_civilite\": \"Mr\",\n    \"vos_coordonnees_occupant_nom\": \"Dupont\",\n    \"vos_coordonnees_occupant_prenom\": \"Jean\",\n    \"vos_coordonnees_occupant_email\": \"jean.dupont@example.com\",\n    \"vos_coordonnees_occupant_tel\": \"+33123456789\",\n    \"coordonnees_bailleur_nom\": \"Durand\",\n    \"coordonnees_bailleur_prenom\": \"Sophie\",\n    \"coordonnees_bailleur_email\": \"sophie.durand@example.com\",\n    \"coordonnees_bailleur_tel\": \"+33198765432\",\n    \"coordonnees_bailleur_adresse\": \"24 Avenue des Roses\",\n    \"coordonnees_bailleur_adresse_detail_numero\": \"Bâtiment B\",\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"75002\",\n    \"coordonnees_bailleur_adresse_commune\": \"Paris\",\n    \"zone_concernee_zone\": \"Zone A\",\n    \"type_logement_nature\": \"Appartement\",\n    \"composition_logement_piece_unique\": \"Non\",\n    \"composition_logement_superficie\": \"55m²\",\n    \"composition_logement_nb_pieces\": \"3\",\n    \"type_logement_pieces_a_vivre_superficie_piece_1\": 30,\n    \"type_logement_pieces_a_vivre_superficie_piece_2\": 15,\n    \"type_logement_pieces_a_vivre_superficie_piece_3\": 10,\n    \"type_logement_pieces_a_vivre_hauteur_piece_1\": \"oui\",\n    \"type_logement_pieces_a_vivre_hauteur_piece_2\": \"oui\",\n    \"type_logement_pieces_a_vivre_hauteur_piece_3\": \"non\",\n    \"type_logement_commodites_cuisine\": \"Oui\",\n    \"type_logement_commodites_cuisine_collective\": \"Non\",\n    \"type_logement_commodites_cuisine_hauteur_plafond\": \"2.3m\",\n    \"type_logement_commodites_salle_de_bain\": \"Oui\",\n    \"type_logement_commodites_salle_de_bain_collective\": \"Non\",\n    \"type_logement_commodites_salle_de_bain_hauteur_plafond\": \"2.2m\",\n    \"type_logement_commodites_wc\": \"Oui\",\n    \"type_logement_commodites_wc_collective\": \"Non\",\n    \"type_logement_commodites_wc_hauteur_plafond\": \"2.1m\",\n    \"type_logement_commodites_wc_cuisine\": \"Oui\",\n    \"bail_dpe_date_emmenagement\": \"2023-07-19\",\n    \"bail_dpe_bail\": \"Bail 1234\",\n    \"bail_dpe_bail_upload\": \"http://example.com/bail.pdf\",\n    \"bail_dpe_etat_des_lieux\": \"http://example.com/etat_des_lieux.pdf\",\n    \"bail_dpe_dpe\": \"C\",\n    \"logement_social_demande_relogement\": \"Oui\",\n    \"logement_social_allocation\": \"Oui\",\n    \"logement_social_allocation_caisse\": \"CAF Paris\",\n    \"logement_social_date_naissance\": \"1990-01-01\",\n    \"logement_social_montant_allocation\": \"500€\",\n    \"travailleur_social_quitte_logement\": \"Oui\",\n    \"travailleur_social_accompagnement\": \"Non\",\n    \"info_procedure_bailleur_prevenu\": \"Oui\",\n    \"info_procedure_assurance_contactee\": \"Non\",\n    \"info_procedure_autre_demarches\": \"Oui\",\n    \"info_procedure_quels_demarches\": \"Contact mairie pour subvention\",\n    \"date_demande\": \"2023-06-30\",\n    \"reponse_demande\": \"En cours d'examen\",\n    \"date_enregistrement\": \"2023-07-01\",\n    \"date_mise_en_relation\": \"2023-07-05\",\n    \"suivi_date_visite\": \"2023-07-10\",\n    \"suivi_interet_logement\": \"Oui\",\n    \"suivi_dossier_complet\": \"Oui\",\n    \"suivi_etude_dossier_delai\": \"2 semaines\",\n    \"suivi_commission_decision\": \"En attente\",\n    \"date_decision\": null,\n    \"decision_commission\": null\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -250,7 +250,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"adresse_logement_adresse\": \"17 quai de la joliette 13002 Marseille\",\n    \"adresse_logement_adresse_detail_numero\": \"17 quai de la joliette\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"adresse_logement_adresse_detail_insee\": \"13112\",\n    \"adresse_logement_adresse_detail_geoloc_lat\": 112,\n    \"adresse_logement_adresse_detail_geoloc_lng\": 115,\n    \"adresse_logement_complement_adresse_numero_appartement\": \"114\",\n    \"adresse_logement_complement_adresse_etage\": 21,\n    \"adresse_logement_complement_adresse_escalier\": 5,\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"signalement_concerne_profil_detail_tiers\": null,\n    \"signalement_concerne_profil_detail_bailleur_proprietaire\": null,\n    \"signalement_concerne_profil_detail_bailleur_bailleur\": null,\n    \"signalement_concerne_logement_social_service_secours\": null,\n    \"signalement_concerne_logement_social_autre_tiers\": null,\n    \"vos_coordonnees_occupant_civilite\": \"Mr\",\n    \"vos_coordonnees_occupant_nom\": \"Dupont\",\n    \"vos_coordonnees_occupant_prenom\": \"Jean\",\n    \"vos_coordonnees_occupant_email\": \"jean.dupont@example.com\",\n    \"vos_coordonnees_occupant_tel\": \"+33123456789\",\n    \"coordonnees_bailleur_nom\": \"Durand\",\n    \"coordonnees_bailleur_prenom\": \"Marc\",\n    \"coordonnees_bailleur_email\": \"sophie.durand@example.com\",\n    \"coordonnees_bailleur_tel\": \"+33198765432\",\n    \"coordonnees_bailleur_adresse\": \"24 Avenue des Roses\",\n    \"coordonnees_bailleur_adresse_detail_numero\": \"Bâtiment B\",\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"75002\",\n    \"coordonnees_bailleur_adresse_commune\": \"Paris\",\n    \"zone_concernee_zone\": \"Zone A\",\n    \"type_logement_nature\": \"Appartement\",\n    \"composition_logement_piece_unique\": \"Non\",\n    \"composition_logement_superficie\": \"55m²\",\n    \"composition_logement_nb_pieces\": \"3\",\n    \"type_logement_pieces_a_vivre_superficie_piece\": [\n        30,\n        15,\n        10\n    ],\n    \"type_logement_pieces_a_vivre_hauteur_piece\": [\n        2.5,\n        2.6,\n        2.4\n    ],\n    \"type_logement_commodites_cuisine\": \"Oui\",\n    \"type_logement_commodites_cuisine_collective\": \"Non\",\n    \"type_logement_commodites_cuisine_hauteur_plafond\": \"2.3m\",\n    \"type_logement_commodites_salle_de_bain\": \"Oui\",\n    \"type_logement_commodites_salle_de_bain_collective\": \"Non\",\n    \"type_logement_commodites_salle_de_bain_hauteur_plafond\": \"2.2m\",\n    \"type_logement_commodites_wc\": \"Oui\",\n    \"type_logement_commodites_wc_collective\": \"Non\",\n    \"type_logement_commodites_wc_hauteur_plafond\": \"2.1m\",\n    \"type_logement_commodites_wc_cuisine\": \"Oui\",\n    \"bail_dpe_date_emmenagement\": \"2023-07-19\",\n    \"bail_dpe_bail\": \"Bail 1234\",\n    \"bail_dpe_bail_upload\": \"http://example.com/bail.pdf\",\n    \"bail_dpe_etat_des_lieux\": \"http://example.com/etat_des_lieux.pdf\",\n    \"bail_dpe_dpe\": \"C\",\n    \"logement_social_demande_relogement\": \"Oui\",\n    \"logement_social_allocation\": \"Oui\",\n    \"logement_social_allocation_caisse\": \"CAF Paris\",\n    \"logement_social_date_naissance\": \"1990-01-01\",\n    \"logement_social_montant_allocation\": \"500€\",\n    \"travailleur_social_quitte_logement\": \"Oui\",\n    \"travailleur_social_accompagnement\": \"Non\",\n    \"info_procedure_bailleur_prevenu\": \"Oui\",\n    \"info_procedure_assurance_contactee\": \"Non\",\n    \"info_procedure_autre_demarches\": \"Oui\",\n    \"info_procedure_quels_demarches\": \"Contact mairie pour subvention\",\n    \"date_demande\": \"2023-06-30\",\n    \"reponse_demande\": \"En cours d'examen\",\n    \"date_enregistrement\": \"2023-07-01\",\n    \"date_mise_en_relation\": \"2023-07-05\",\n    \"suivi_date_visite\": \"2023-07-10\",\n    \"suivi_interet_logement\": \"Oui\",\n    \"suivi_dossier_complet\": \"Oui\",\n    \"suivi_etude_dossier_delai\": \"2 semaines\",\n    \"suivi_commission_decision\": \"En attente\",\n    \"date_decision\": null,\n    \"decision_commission\": null\n}",
+							"raw": "{\n    \"profil\": \"locataire\",\n    \"adresse_logement_adresse\": \"19 quai de la joliette 13002 Marseille\",\n    \"adresse_logement_adresse_detail_numero\": \"17 quai de la joliette\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"adresse_logement_adresse_detail_insee\": \"13112\",\n    \"adresse_logement_adresse_detail_geoloc_lat\": 112,\n    \"adresse_logement_adresse_detail_geoloc_lng\": 115,\n    \"adresse_logement_complement_adresse_numero_appartement\": \"114\",\n    \"adresse_logement_complement_adresse_etage\": 21,\n    \"adresse_logement_complement_adresse_escalier\": 5,\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"signalement_concerne_profil_detail_tiers\": null,\n    \"signalement_concerne_profil_detail_bailleur_proprietaire\": null,\n    \"signalement_concerne_profil_detail_bailleur_bailleur\": null,\n    \"signalement_concerne_logement_social_service_secours\": null,\n    \"signalement_concerne_logement_social_autre_tiers\": null,\n    \"vos_coordonnees_occupant_civilite\": \"Mr\",\n    \"vos_coordonnees_occupant_nom\": \"Dupont\",\n    \"vos_coordonnees_occupant_prenom\": \"Jean\",\n    \"vos_coordonnees_occupant_email\": \"jean.saidi@example.com\",\n    \"vos_coordonnees_occupant_tel\": \"+33123456789\",\n    \"coordonnees_bailleur_nom\": \"Durand\",\n    \"coordonnees_bailleur_prenom\": \"Marc\",\n    \"coordonnees_bailleur_email\": \"sophie.durand@example.com\",\n    \"coordonnees_bailleur_tel\": \"+33198765432\",\n    \"coordonnees_bailleur_adresse\": \"24 Avenue des Roses\",\n    \"coordonnees_bailleur_adresse_detail_numero\": \"Bâtiment B\",\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"75002\",\n    \"coordonnees_bailleur_adresse_commune\": \"Paris\",\n    \"zone_concernee_zone\": \"Zone A\",\n    \"type_logement_nature\": \"Appartement\",\n    \"composition_logement_piece_unique\": \"Non\",\n    \"composition_logement_superficie\": \"55m²\",\n    \"composition_logement_nb_pieces\": \"3\",\n    \"type_logement_pieces_a_vivre_superficie_piece_1\": 30,\n    \"type_logement_pieces_a_vivre_superficie_piece_2\": 15,\n    \"type_logement_pieces_a_vivre_superficie_piece_3\": 10,\n    \"type_logement_pieces_a_vivre_hauteur_piece_1\": \"oui\",\n    \"type_logement_pieces_a_vivre_hauteur_piece_2\": \"oui\",\n    \"type_logement_pieces_a_vivre_hauteur_piece_3\": \"non\",\n    \"type_logement_commodites_cuisine\": \"Oui\",\n    \"type_logement_commodites_cuisine_collective\": \"Non\",\n    \"type_logement_commodites_cuisine_hauteur_plafond\": \"2.3m\",\n    \"type_logement_commodites_salle_de_bain\": \"Oui\",\n    \"type_logement_commodites_salle_de_bain_collective\": \"Non\",\n    \"type_logement_commodites_salle_de_bain_hauteur_plafond\": \"2.2m\",\n    \"type_logement_commodites_wc\": \"Oui\",\n    \"type_logement_commodites_wc_collective\": \"Non\",\n    \"type_logement_commodites_wc_hauteur_plafond\": \"2.1m\",\n    \"type_logement_commodites_wc_cuisine\": \"Oui\",\n    \"bail_dpe_date_emmenagement\": \"2023-07-19\",\n    \"bail_dpe_bail\": \"Bail 1234\",\n    \"bail_dpe_bail_upload\": \"http://example.com/bail.pdf\",\n    \"bail_dpe_etat_des_lieux\": \"http://example.com/etat_des_lieux.pdf\",\n    \"bail_dpe_dpe\": \"C\",\n    \"logement_social_demande_relogement\": \"Oui\",\n    \"logement_social_allocation\": \"Oui\",\n    \"logement_social_allocation_caisse\": \"CAF Paris\",\n    \"logement_social_date_naissance\": \"1990-01-01\",\n    \"logement_social_montant_allocation\": \"500€\",\n    \"travailleur_social_quitte_logement\": \"Oui\",\n    \"travailleur_social_accompagnement\": \"Non\",\n    \"info_procedure_bailleur_prevenu\": \"Oui\",\n    \"info_procedure_assurance_contactee\": \"Non\",\n    \"info_procedure_autre_demarches\": \"Oui\",\n    \"info_procedure_quels_demarches\": \"Contact mairie pour subvention\",\n    \"date_demande\": \"2023-06-30\",\n    \"reponse_demande\": \"En cours d'examen\",\n    \"date_enregistrement\": \"2023-07-01\",\n    \"date_mise_en_relation\": \"2023-07-05\",\n    \"suivi_date_visite\": \"2023-07-10\",\n    \"suivi_interet_logement\": \"Oui\",\n    \"suivi_dossier_complet\": \"Oui\",\n    \"suivi_etude_dossier_delai\": \"2 semaines\",\n    \"suivi_commission_decision\": \"En attente\",\n    \"date_decision\": null,\n    \"decision_commission\": null\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -269,6 +269,28 @@
 								"signalement-draft",
 								"{{signalement_draft_uuid}}",
 								"envoi"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "signalement-draft/{uuid}/informations",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/nouveau-formulaire/signalement-draft/f31cb034-221c-4a48-8203-75d683b78dba/informations",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"nouveau-formulaire",
+								"signalement-draft",
+								"f31cb034-221c-4a48-8203-75d683b78dba",
+								"informations"
 							]
 						}
 					},
@@ -308,6 +330,86 @@
 					"path": [
 						"signalement",
 						"csrf-token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "questions?profil=tous",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"var data = JSON.parse(responseBody);",
+							"",
+							"if (null !== data.data) {",
+							"    postman.setEnvironmentVariable(\"csrf_token\", data.csrf_token.value);",
+							"}",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/api/questions?profil=tous",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"questions"
+					],
+					"query": [
+						{
+							"key": "profil",
+							"value": "tous"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "questions?profil=locataire",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/api/questions?profil=locataire",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"questions"
+					],
+					"query": [
+						{
+							"key": "profil",
+							"value": "locataire"
+						}
 					]
 				}
 			},


### PR DESCRIPTION
## Ticket

#1601   

## Description
Lors des différentes soumissions du formulaire les données répétables sont envoyés vers l'API sous ce format
```json
{
    "profil": "locataire",
    "type_logement_pieces_a_vivre_superficie_piece_1": 30,
    "type_logement_pieces_a_vivre_superficie_piece_2": 15,
    "type_logement_pieces_a_vivre_superficie_piece_3": 10,
    "type_logement_pieces_a_vivre_hauteur_piece_1": "oui",
    "type_logement_pieces_a_vivre_hauteur_piece_2": "oui",
    "type_logement_pieces_a_vivre_hauteur_piece_3": "non",
    "\\": "......."
}
```
Le DTO qui encapsule les données poussées par le formulaire ne peut pas prévoir le nombre de pièces que possède un usager. Il est donc normal de stocker ces données dans un tableau (format cible stocké en base de données), comme le montre la structure du DTO suivante :

```php
namespace App\Dto\Request\Signalement;

class SignalementDraftRequest
{
    private ?string $profil = null;
    .......
    private ?array $typeLogementPiecesAVivreSuperficiePiece = null;
    private ?array $typeLogementPiecesAVivreHauteurPiece = null;
    .....
}
```

Afin de gérer cette transformation entre le format JSON et le DTO, des ajustements ont été apportés au processus de dénormalisation et de normalisation de l'objet SignalementDraftRequest.

Le normaliseur est chargé d'appliquer les règles de transformation nécessaires pour les données répétables, en ajustant les clés et les valeurs dans le format approprié.

## Changements apportés

* Ajout nouveau normaliseur `SignalementDraftRequestNormalizer` pour gérer la transformation des données de tableau associatif en objet SignalementDraftRequest et vice versa.
* Injection du nouveau service `SignalementDraftRequestSerializer` qui utilise le `SignalementDraftRequestNormalizer` au lieu du SerializerInterface pour les opérations de serialization et deserialization (normalisation+encodage)
* Mise à jour collection POSTMAN avec la route `/nouveau-formulaire/signalement-draft/f{uuid}/informations`
* Mise à jour services.yaml


## Pré-requis
Petit rappel sur les étapes du composant serializer
![image](https://github.com/MTES-MCT/histologe/assets/5757116/6f0d294b-bb76-4e85-8515-a4e61effb717)
## Tests
- [ ] Déposer un nouveau formulaire avec un nombre de pièce supérieur supérieur à 1 et récupérer l'uuid
- [ ] Récupérer le formulaire déposé via la route `http://localhost:8080/nouveau-formulaire/signalement/{uuid}`
- [ ] Se rendre sur l'écran `type_logement_pieces_a_vivre` afin de vérifier que les champs soient bien remplis

## Demo
![image](https://github.com/MTES-MCT/histologe/assets/5757116/bf49f036-9a6a-4661-9999-114edc0551fe)
