### PR TITLE
 [Front][Back] Stocker l'état de saisie en cours

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -118,7 +118,6 @@ export default defineComponent({
         if (screenIndex !== -1) {
           formStore.currentScreenIndex = screenIndex
           this.currentScreen = formStore.screenData[screenIndex]
-          // TODO : sauvegarder dans le store index:slug_ecran
           formStore.data.currentStep = formStore.currentScreenIndex + ':' + this.currentScreen?.slug
           if (this.currentScreen?.components && this.currentScreen.components.body) {
             // Prétraitement des composants avec repeat

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -86,6 +86,9 @@ export default defineComponent({
           formStore.data[prop] = requestResponse.signalement.payload[prop]
         }
       }
+      if (formStore.data.currentStep.split(':')[1] !== undefined) {
+        this.nextSlug = formStore.data.currentStep.split(':')[1]
+      }
       requests.initQuestions(this.handleInitQuestions)
     },
     handleInitQuestions (requestResponse: any) {
@@ -115,6 +118,8 @@ export default defineComponent({
         if (screenIndex !== -1) {
           formStore.currentScreenIndex = screenIndex
           this.currentScreen = formStore.screenData[screenIndex]
+          // TODO : sauvegarder dans le store index:slug_ecran
+          formStore.data.currentStep = formStore.currentScreenIndex + ':' + this.currentScreen?.slug
           if (this.currentScreen?.components && this.currentScreen.components.body) {
             // Prétraitement des composants avec repeat
             this.currentScreen.components.body = formStore.preprocessScreen(this.currentScreen.components.body)
@@ -123,6 +128,9 @@ export default defineComponent({
           if (this.slugCoordonnees.includes(this.nextSlug)) { // TODO à mettre à jour suivant le slug des différents profils
             // on détermine le profil
             services.updateProfil()
+            // on fait un appel API pour charger la suite des questions avant de changer d'écran
+            requests.initQuestionsProfil(this.handleInitQuestions)
+          } else {
             // on fait un appel API pour charger la suite des questions avant de changer d'écran
             requests.initQuestionsProfil(this.handleInitQuestions)
           }

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -5,6 +5,7 @@ namespace App\Dto\Request\Signalement;
 class SignalementDraftRequest
 {
     private ?string $profil = null;
+    private ?string $currentStep = null;
     private ?string $adresseLogementAdresse = null;
     private ?string $adresseLogementAdresseDetailNumero = null;
     private ?string $adresseLogementAdresseDetailCodePostal = null;
@@ -96,6 +97,18 @@ class SignalementDraftRequest
     public function setProfil(?string $profil): self
     {
         $this->profil = $profil;
+
+        return $this;
+    }
+
+    public function getCurrentStep(): ?string
+    {
+        return $this->currentStep;
+    }
+
+    public function setCurrentStep(?string $currentStep): self
+    {
+        $this->currentStep = $currentStep;
 
         return $this;
     }

--- a/src/Manager/SignalementDraftManager.php
+++ b/src/Manager/SignalementDraftManager.php
@@ -35,7 +35,7 @@ class SignalementDraftManager extends AbstractManager
     ): ?string {
         $signalementDraft
             ->setPayload($payload)
-            ->setCurrentStep('4:type_logement_commodites') /* @todo: https://github.com/MTES-MCT/histologe/issues/1597 */
+            ->setCurrentStep($signalementDraftRequest->getCurrentStep())
             ->setAddressComplete($signalementDraftRequest->getAdresseLogementAdresse())
             ->setEmailDeclarant($this->signalementDraftFactory->getEmailDeclarent($signalementDraftRequest))
             ->setProfileDeclarant(ProfileDeclarant::from(strtoupper($signalementDraftRequest->getProfil())))


### PR DESCRIPTION
## Ticket

#1597    

## Description
Enregiste l'étape courante sous la forme 3:vos_coordonnees_occupant pour réouvrir le parcours au bon endroit

## Changements apportés
* ajout d'un currentStep au bon format dans formStore.data
* ajout de currentStep dans le DTO
* lors de l'ouverture d'un signalement draft existant, on récupère ce currentStep pour déterminer le nextSlug, et si besoin charger la suite des questions 

## Pré-requis

## Tests
- [ ] Créer un signalement, s'arrêter en cours de route
- [ ] Rouvrir le signalement avec son uuid
- [ ] Vérifier qu'on ouvre bien à la bonne étape (qui est la dernière enregistrée, donc l'avant-dernière vue)
