### PR TITLE
[FO - Formulaire] Souci de validation quand un champ n'est pas visible

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -9,8 +9,8 @@
       :customCss="customCss"
       :validate="validate"
       v-model="formStore.data[idAddress]"
-      :hasError="formStore.validationErrors[idAddress] !== undefined"
-      :error="formStore.validationErrors[idAddress]"
+      :hasError="hasErrorOnSubscreen"
+      :error="errorOnSubscreen"
     />
     <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
       <div
@@ -92,6 +92,26 @@ export default defineComponent({
       screens: { body: updatedSubscreenData },
       suggestions: [] as any[],
       formStore
+    }
+  },
+  computed: {
+    hasErrorOnSubscreen (): boolean {
+      if (formStore.validationErrors[this.id + '_detail_numero'] !== undefined ||
+      formStore.validationErrors[this.id + '_detail_code_postal'] !== undefined ||
+      formStore.validationErrors[this.id + '_detail_commune'] !== undefined) {
+        return true
+      } else {
+        return false
+      }
+      // TODO, n'afficher l'erreur que si le subscreen est caché ?
+    },
+    errorOnSubscreen (): string {
+      const values = [
+        formStore.validationErrors[this.id + '_detail_numero'],
+        formStore.validationErrors[this.id + '_detail_code_postal'],
+        formStore.validationErrors[this.id + '_detail_commune']
+      ]
+      return values.find(value => value !== undefined)
     }
   },
   created () {

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -80,7 +80,7 @@ export default defineComponent({
     clickEvent: Function
   },
   data () {
-    const updatedSubscreenData = services.generateSubscreenData(this.id, subscreenData.body)
+    const updatedSubscreenData = services.generateSubscreenData(this.id, subscreenData.body, this.validate)
     // on met à jour formStore en ajoutant les sous-composants du composant Address
     services.addSubscreenData(this.id, updatedSubscreenData)
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="signalement-form-address">
+  <div class="signalement-form-address" :id="id">
     <SignalementFormTextfield
       :key="idAddress"
       :id="idAddress"

--- a/assets/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -1,8 +1,7 @@
 <template>
-    <div class="fr-mt-3v signalement-form-button">
+    <div class="fr-mt-3v signalement-form-button" :id="id">
         <button
         :type="type"
-        :id="id"
         :class="[ 'fr-btn', customCss ]"
         @click="handleClick"
         >

--- a/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -1,8 +1,7 @@
 <template>
-    <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]">
+    <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]" :id="id">
       <input
           type="checkbox"
-          :id="id"
           :name="id"
           :value="internalValue"
           :class="[ customCss ]"

--- a/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -1,12 +1,11 @@
 <template>
     <!-- Champ type number -->
-    <div class="fr-input-group">
+    <div class="fr-input-group" :id="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id">{{ label }}</label>
     <input
         type="number"
         pattern="[0-9]*"
         inputmode="numeric"
-        :id="id"
         :name="id"
         :value="internalValue"
         :class="[ customCss, 'fr-input' ]"

--- a/assets/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -1,9 +1,8 @@
 <template>
-    <div class="fr-input-group">
+    <div class="fr-input-group" :id="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id">{{ label }}</label>
     <input
         type="date"
-        :id="id"
         :name="id"
         :value="internalValue"
         :class="[ customCss, 'fr-input' ]"

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -111,10 +111,15 @@ export default defineComponent({
   },
   methods: {
     isRequired (field: any): boolean {
-      const subscreen = document.querySelector('#' + field.slug)
+      const component = document.querySelector('#' + field.slug)
+      console.log(component)
+      console.log(component?.classList)
+      console.log(field.slug)
+      console.log(field.validate)
+      console.log(field.type)
       if (((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
           (field.validate && field.validate.required)) && // ou il y a des règles de validation explicites
-          subscreen?.classList.contains('fr-hidden') === false) { // et que le composant n'est pas caché par conditionnalité
+          component?.classList.contains('fr-hidden') === false) { // et que le composant n'est pas caché par conditionnalité
         return true
       } else {
         return false

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -112,11 +112,6 @@ export default defineComponent({
   methods: {
     isRequired (field: any): boolean {
       const component = document.querySelector('#' + field.slug)
-      console.log(component)
-      console.log(component?.classList)
-      console.log(field.slug)
-      console.log(field.validate)
-      console.log(field.type)
       if (((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
           (field.validate && field.validate.required)) && // ou il y a des règles de validation explicites
           component?.classList.contains('fr-hidden') === false) { // et que le composant n'est pas caché par conditionnalité

--- a/assets/vue/components/signalement-form/components/SignalementFormTime.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTime.vue
@@ -1,9 +1,8 @@
 <template>
-  <div class="fr-input-group">
+  <div class="fr-input-group" :id="id">
   <label :class="[ customCss, 'fr-label' ]" :for="id">{{ label }}</label>
   <input
       type="time"
-      :id="id"
       :name="id"
       :value="internalValue"
       :class="[ customCss, 'fr-input' ]"

--- a/assets/vue/components/signalement-form/components/SignalementFormYear.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormYear.vue
@@ -1,8 +1,7 @@
 <template>
-  <div class="fr-input-group">
+  <div class="fr-input-group" :id="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id">{{ label }}</label>
     <input
-      :id="id"
       :name="id"
       :placeholder="placeholder"
       type="number"

--- a/assets/vue/components/signalement-form/services.ts
+++ b/assets/vue/components/signalement-form/services.ts
@@ -1,11 +1,12 @@
 import formStore from './store'
 
 export const services = {
-  generateSubscreenData (id: string, data: any[]) {
+  generateSubscreenData (id: string, data: any[], validateParent: any) {
     return data.map((component) => {
       return {
         ...component,
-        slug: id + '_' + (component.slug as string)
+        slug: id + '_' + (component.slug as string),
+        validate: validateParent
       }
     })
   },


### PR DESCRIPTION
## Ticket

#1592    

## Description
Correction sur la validation des pages

## Changements apportés
* Déplacement de l'id au niveau de la plus haute balise pour les composants (car c'est sur ce premier niveau qu'est ajouté la classe fr-hidden, donc c'est pour vérifier si le composant est visible ou non afin de prendre en compte l'attribut validate.required)
* On répercute l'objet validate sur les composants du composant Address pour vérifier la validation de l'adresse 
* Si l'adresse n'est pas indiquée sur un composant obligatoire, on affiche un message d'erreur au plus haut niveau

## Pré-requis

## Tests
- [ ] Créer un signalement en tant que Service de secours, et vérifier qu'on n'est pas obligés de renseigner l'adresse postale du propriétaire
- [ ] Créer un signalement avec un autre profil, vérifier qu'on a un message d'erreur visible quand on ne rentre pas d'adresse postale
- [ ] Aller jusqu'à la page "Avez-vous fait une demande de logement social ou de relogement ?", indiquer "Non" et "Non" et vérifier qu'on peut passer à la page suivante (pas d'erreur sur la date de naissance qui est cachée)
- [ ] Créer un signalement en entier et vérifier qu'il n'y a pas d'erreur de validation ni de régression
