### PR TITLE
[CRON - Synchro Esabora] Correction pour l'envoi de mail à des destinataires non prévus

### DIFF
--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -71,6 +71,7 @@ class ActivityListener implements EventSubscriberInterface
                 $notifyAdminsAndPartners = $entity->getDescription() != $this->parameterBag->get('suivi_message')['first_accepted_affectation'];
 
                 if ($notifyAdminsAndPartners) {
+                    $this->tos->clear();
                     $this->notifyAdmins($entity, Notification::TYPE_SUIVI, $entity->getSignalement()->getTerritory());
                     $entity->getSignalement()->getAffectations()->filter(function (Affectation $affectation) use ($entity) {
                         $partner = $affectation->getPartner();


### PR DESCRIPTION
## Description
Lorsqu'on fait la synchronisation Esabora, si on reçoit des mises à jour, on crée des suivis.
Lorsqu'on sauvegarde les suivis (`onFlush`), un mail est envoyé aux agents concernés.
La liste des destinataires est ensuite vidée après envoi.

Il arrive cependant qu'on crée un début de liste de destinataires et que l'envoi ne se fasse pas (par exemple, si le signalement est fermé).
Dans ce cas, la liste des destinataires n'était pas vidée et pouvait être gardée pour le `onFlush` suivant.

## Changements apportés
* On vide la liste des destinataires avant tout envoi de mail

## Tests
J'avoue que je n'ai pas trouvé de moyen de tester...
