### PR TITLE
[BO] Corrections couleurs liées à la mise à jour du DSFR

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -244,23 +244,23 @@ small {
 
 a[href].fr-btn--orange {
     background: #FF9940;
-}
-a[href].fr-btn--orange:hover {
-    background: rgba(255, 153, 64, 0.65);
+    &:hover {
+        background: rgba(255, 153, 64, 0.65);
+    }
 }
 
 button.fr-btn--danger,a[href].fr-btn--danger {
     background: var(--warning-425-625);
-}
-button.fr-btn--danger:hover,a[href].fr-btn--danger:hover {
-    background: var(--warning-425-625-hover);
+    &:hover {
+        background: var(--warning-425-625-hover);
+    }
 }
 
 button.fr-btn--success,a[href].fr-btn--success {
-    background-color: var(--green-emeraude-sun-425-moon-753);
-}
-button.fr-btn--success:hover,a[href].fr-btn--success:hover {
-    background-color: var(--green-emeraude-sun-425-moon-753-hover);
+    background-color: var(--success-425-625);
+    &:hover {
+        background-color: var(--success-425-625-hover);
+    }
 }
 
 .fr-background-contrast--blue-france {
@@ -273,6 +273,10 @@ button.fr-btn--success:hover,a[href].fr-btn--success:hover {
 
 .fr-background-alt--blue-france {
     background-color: var(--background-alt-blue-france);
+}
+
+.fr-background-contrast--orange-terre-battue, .fr-table--bordered tbody tr.fr-background-contrast--orange-terre-battue {
+    background-color: var(--background-contrast-orange-terre-battue);
 }
 
 .fr-text-label--red-marianne {

--- a/assets/vue/components/dashboard/TheHistoDashboardCards.vue
+++ b/assets/vue/components/dashboard/TheHistoDashboardCards.vue
@@ -302,6 +302,7 @@ export default defineComponent({
   }
   .histo-dashboard-cards .fr-card .fr-card__title a {
     box-shadow: none;
+    color: var(--text-title-grey);
   }
   .histo-dashboard-cards .fr-card ul {
     list-style: none;

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -11,8 +11,8 @@
                     <h1 class="fr-h1 fr-mb-0">Partenaires</h1>
                 </div>
                 <div class="fr-col-6 fr-text--right">
-                    <a class="fr-btn fr-btn--success fr-btn--icon-left fr-btn--md fr-fi-add-circle-line" href="{{ path('back_partner_new') }}">Ajouter
-                        un partenaire</a>
+                    <a class="fr-btn fr-btn--success fr-btn--icon-left fr-btn--md fr-fi-add-circle-line" href="{{ path('back_partner_new') }}"
+                        >Ajouter un partenaire</a>
                 </div>
             </div>
         </header>


### PR DESCRIPTION
## Ticket

#1632   
#1633   
#1636   

## Description
Plusieurs corrections de couleurs dans le back-office

## Tests
- [ ] Sur l'accueil du back-office, les titres des cartes sont noirs
- [ ] Dans la partie partenaire, le bouton d'ajout est de la bonne couleur verte
- [ ] Dans la liste des signalements, les lignes des nouveaux ont un fond orange
