### PR TITLE
[Front] Créer le composant SignalementFormRoomList

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]" >
+    <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]" :id="id">
       <input
           type="checkbox"
           :id="idCheckbox"

--- a/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -1,14 +1,16 @@
 <template>
-    <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]" :id="id">
+    <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]" >
       <input
           type="checkbox"
-          :name="id"
-          :value="internalValue"
+          :id="idCheckbox"
+          :name="idCheckbox"
+          :value="modelValue"
           :class="[ customCss ]"
           @input="updateValue($event)"
           aria-describedby="checkbox-error-messages"
+          :checked="Boolean(modelValue)"
           >
-      <label :class="[ customCss, 'fr-label' ]" :for="id">{{ labelVariablesReplaced }}</label>
+      <label :class="[ customCss, 'fr-label' ]" :for="idCheckbox">{{ labelVariablesReplaced }}</label>
       <div class="fr-messages-group" id="checkbox-error-messages" aria-live="assertive">
         <p
           id="checkbox-error-messages"
@@ -31,21 +33,18 @@ export default defineComponent({
     id: { type: String, default: null },
     label: { type: String, default: null },
     description: { type: String, default: null },
-    modelValue: { type: String, default: null },
+    modelValue: { type: Number, default: 0 },
     customCss: { type: String, default: '' },
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' }
   },
+  data () {
+    return {
+      idCheckbox: this.id + '_check'
+    }
+  },
   computed: {
-    internalValue: {
-      get () {
-        return this.modelValue
-      },
-      set (newValue: string) {
-        this.$emit('update:modelValue', newValue)
-      }
-    },
     labelVariablesReplaced (): string {
       if (this.label !== undefined) {
         return variablesReplacer.replace(this.label)
@@ -55,8 +54,8 @@ export default defineComponent({
   },
   methods: {
     updateValue (event: Event) {
-      const value = (event.target as HTMLInputElement).value
-      this.$emit('update:modelValue', value)
+      const value = (event.target as HTMLInputElement).checked
+      this.$emit('update:modelValue', Number(value))
     }
   },
   emits: ['update:modelValue']

--- a/assets/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="signalement-form-roomlist" :id="id">
+    <label :class="[ customCss, 'fr-label' ]" :for="id">{{ label }}</label>
+    <SignalementFormCheckbox
+      :key="idPieceAVivre"
+      :id="idPieceAVivre"
+      label="Une ou des pièces à vivre (salon, chambres)"
+      :validate="validate"
+      v-model="formStore.data[idPieceAVivre]"
+      :hasError="formStore.validationErrors[idPieceAVivre]  !== undefined"
+      :error="formStore.validationErrors[idPieceAVivre]"
+    />
+
+    <SignalementFormCheckbox
+      v-if="formStore.data.type_logement_commodites_cuisine === 'oui'"
+      :key="idCuisine"
+      :id="idCuisine"
+      label="La cuisine / le coin cuisine"
+      :validate="validate"
+      v-model="formStore.data[idCuisine]"
+      :hasError="formStore.validationErrors[idCuisine]  !== undefined"
+      :error="formStore.validationErrors[idCuisine]"
+    />
+    <!-- TODO : définir en dur que validate.require=false ? -->
+    <SignalementFormCheckbox
+      v-if="formStore.data.type_logement_commodites_salle_de_bain === 'oui' || formStore.data.type_logement_commodites_wc === 'oui'"
+      :key="idSalleDeBain"
+      :id="idSalleDeBain"
+      label="La salle de bain, salle d'eau et / ou les toilettes"
+      :validate="validate"
+      v-model="formStore.data[idSalleDeBain]"
+      :hasError="formStore.validationErrors[idSalleDeBain]  !== undefined"
+      :error="formStore.validationErrors[idSalleDeBain]"
+    />
+    <!-- TODO : définir en dur que validate.require=false ? -->
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import formStore from './../store'
+import SignalementFormCheckbox from './SignalementFormCheckbox.vue'
+
+export default defineComponent({
+  name: 'SignalementFormRoomList',
+  components: {
+    SignalementFormCheckbox
+  },
+  props: {
+    id: { type: String, default: null },
+    label: { type: String, default: null },
+    modelValue: { type: String, default: null },
+    customCss: { type: String, default: '' },
+    validate: { type: Object, default: null },
+    hasError: { type: Boolean, default: false },
+    error: { type: String, default: '' },
+    clickEvent: Function
+  },
+  data () {
+    return {
+      idPieceAVivre: this.id + '_piece_a_vivre',
+      idCuisine: this.id + '_cuisine',
+      idSalleDeBain: this.id + '_salle_de_bain',
+      formStore
+    }
+  },
+  methods: {
+    updateValue (value: any) {
+      this.$emit('update:modelValue', value)
+    },
+    handleClickButton (type:string, param:string, slugButton:string) {
+      if (this.clickEvent !== undefined) {
+        this.clickEvent(type, param, slugButton)
+      }
+    }
+  },
+  emits: ['update:modelValue']
+})
+</script>
+
+<style>
+.signalement-form-roomlist {
+  width: 100%;
+}
+</style>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -76,6 +76,7 @@ import SignalementFormLink from './SignalementFormLink.vue'
 import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
 import SignalementFormOverview from './SignalementFormOverview.vue'
 import SignalementFormPhonefield from './SignalementFormPhonefield.vue'
+import SignalementFormRoomList from './SignalementFormRoomList.vue'
 import SignalementFormSubscreen from './SignalementFormSubscreen.vue'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
 import SignalementFormTime from './SignalementFormTime.vue'
@@ -107,7 +108,8 @@ export default defineComponent({
     SignalementFormOverview,
     SignalementFormConfirmation,
     SignalementFormDisorderCategoryItem,
-    SignalementFormDisorderCategoryList
+    SignalementFormDisorderCategoryList,
+    SignalementFormRoomList
   },
   props: {
     label: String,

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[ customCss ]">
+  <div :class="[ customCss ]" :id="id">
     <h2 v-if="label">{{ label }}</h2>
     <p v-if="description" v-html="description"></p>
     <div
@@ -47,6 +47,7 @@ import SignalementFormPhonefield from './SignalementFormPhonefield.vue'
 import SignalementFormUpload from './SignalementFormUpload.vue'
 import SignalementFormOverview from './SignalementFormOverview.vue'
 import SignalementFormConfirmation from './SignalementFormConfirmation.vue'
+import SignalementFormRoomList from './SignalementFormRoomList.vue'
 import SignalementFormDisorderCategoryItem from './SignalementFormDisorderCategoryItem.vue'
 import SignalementFormDisorderCategoryList from './SignalementFormDisorderCategoryList.vue'
 
@@ -68,10 +69,12 @@ export default defineComponent({
     SignalementFormUpload,
     SignalementFormOverview,
     SignalementFormConfirmation,
+    SignalementFormRoomList,
     SignalementFormDisorderCategoryItem,
     SignalementFormDisorderCategoryList
   },
   props: {
+    id: String,
     label: String,
     description: String,
     components: Object,

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -23,7 +23,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "ecran_intermediaire_les_desordres_next",
-          "action": "goto:desordres_logement_aeration",
+          "action": "goto:desordres_batiment",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -23,7 +23,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "ecran_intermediaire_les_desordres_next",
-          "action": "goto:desordres_batiment",
+          "action": "goto:desordres_logement_aeration",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]


### PR DESCRIPTION
## Ticket

#1628   

## Description
Ajout du composant SignalementFormRoomList (pas stylé du tout, c'est brut de pomme)
Correction sur le composant SignalementFormCheckbox

## Changements apportés
* Ajout du composant SignalementFormRoomList
* Correction sur le composant SignalementFormCheckbox
* Changement temporaire d'un json pour pouvoir aller sur un écran possédant un SignalementFormRoomList

## Pré-requis

## Tests
- [ ] Créer un signalement en tant qu'occupant, et sélectionner plusieurs pièces
- [ ] Aller jusqu'aux désordres, et vérifier qu'on tombe sur le désordre Logement Aération, et qu'en cochant la première case à cocher les pièces s'affichent bien
- [ ] Vérifier qu'en choisissant une pièce, ke screenData se met bien à jour
