### PR TITLE
[QA] Ne pas accepter de valeur null dans le nettoyage contenu html

### DIFF
--- a/src/Factory/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Esabora/DossierMessageSISHFactory.php
@@ -46,7 +46,11 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
 
         $address = AddressParser::parse($signalement->getAdresseOccupant());
         $firstSuivi = $this->suiviRepository->findFirstSuiviBy($signalement, Suivi::TYPE_PARTNER);
-        $cleanedSuiviDescription = HtmlCleaner::clean($firstSuivi?->getDescription());
+
+        $cleanedSuiviDescription = null !== $firstSuivi && null !== $firstSuivi->getDescription()
+            ? HtmlCleaner::clean($firstSuivi->getDescription())
+            : null;
+
         $formatDate = AbstractEsaboraService::FORMAT_DATE;
         $formatDateTime = AbstractEsaboraService::FORMAT_DATE_TIME;
         $routeSignalement = $this->urlGenerator->generate(

--- a/src/Service/HtmlCleaner.php
+++ b/src/Service/HtmlCleaner.php
@@ -4,7 +4,7 @@ namespace App\Service;
 
 class HtmlCleaner
 {
-    public static function clean($html): string
+    public static function clean(string $html): string
     {
         return strip_tags(html_entity_decode($html));
     }


### PR DESCRIPTION
## Ticket

#1650    

## Description
Ajouter un contrôle avant le nettoyage du commentaire à envoyer à Esabora afin de corriger l'ErrorException

## Changements apportés
* Ajout type et contrôle


## Pré-requis
`make mock`

## Tests
- [ ] Affecter un signalement avec commentaire et vérifier que le nettoyage continue de se faire 
- [ ] Affecter un signalement sans commentaire et vérifier que l'exception n'est plus loggé
