### PR TITLE
[Front] Affichage des subscreen et roomlist à la sélection d'une checkbox

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -1,38 +1,42 @@
 <template>
-  <div class="signalement-form-roomlist" :id="id">
-    <label :class="[ customCss, 'fr-label' ]" :for="id">{{ label }}</label>
-    <SignalementFormCheckbox
-      :key="idPieceAVivre"
-      :id="idPieceAVivre"
-      label="Une ou des pièces à vivre (salon, chambres)"
-      :validate="validate"
-      v-model="formStore.data[idPieceAVivre]"
-      :hasError="formStore.validationErrors[idPieceAVivre]  !== undefined"
-      :error="formStore.validationErrors[idPieceAVivre]"
-    />
-
-    <SignalementFormCheckbox
-      v-if="formStore.data.type_logement_commodites_cuisine === 'oui'"
-      :key="idCuisine"
-      :id="idCuisine"
-      label="La cuisine / le coin cuisine"
-      :validate="validate"
-      v-model="formStore.data[idCuisine]"
-      :hasError="formStore.validationErrors[idCuisine]  !== undefined"
-      :error="formStore.validationErrors[idCuisine]"
-    />
-    <!-- TODO : définir en dur que validate.require=false ? -->
-    <SignalementFormCheckbox
-      v-if="formStore.data.type_logement_commodites_salle_de_bain === 'oui' || formStore.data.type_logement_commodites_wc === 'oui'"
-      :key="idSalleDeBain"
-      :id="idSalleDeBain"
-      label="La salle de bain, salle d'eau et / ou les toilettes"
-      :validate="validate"
-      v-model="formStore.data[idSalleDeBain]"
-      :hasError="formStore.validationErrors[idSalleDeBain]  !== undefined"
-      :error="formStore.validationErrors[idSalleDeBain]"
-    />
-    <!-- TODO : définir en dur que validate.require=false ? -->
+  <div :class="[ customCss, 'signalement-form-roomlist' ]" :id="id">
+    <label class="fr-label" :for="id">{{ label }}</label>
+    <br>
+    <div class="signalement-form-roomlist-rooms">
+      <SignalementFormCheckbox
+        :key="idPieceAVivre"
+        :id="idPieceAVivre"
+        label="Une ou des pièces à vivre (salon, chambres)"
+        :validate="validate"
+        v-model="formStore.data[idPieceAVivre]"
+        :hasError="formStore.validationErrors[idPieceAVivre]  !== undefined"
+        :error="formStore.validationErrors[idPieceAVivre]"
+      />
+      <br>
+      <SignalementFormCheckbox
+        v-if="formStore.data.type_logement_commodites_cuisine === 'oui'"
+        :key="idCuisine"
+        :id="idCuisine"
+        label="La cuisine / le coin cuisine"
+        :validate="validate"
+        v-model="formStore.data[idCuisine]"
+        :hasError="formStore.validationErrors[idCuisine]  !== undefined"
+        :error="formStore.validationErrors[idCuisine]"
+      />
+      <br>
+      <!-- TODO : définir en dur que validate.require=false ? -->
+      <SignalementFormCheckbox
+        v-if="formStore.data.type_logement_commodites_salle_de_bain === 'oui' || formStore.data.type_logement_commodites_wc === 'oui'"
+        :key="idSalleDeBain"
+        :id="idSalleDeBain"
+        label="La salle de bain, salle d'eau et / ou les toilettes"
+        :validate="validate"
+        v-model="formStore.data[idSalleDeBain]"
+        :hasError="formStore.validationErrors[idSalleDeBain]  !== undefined"
+        :error="formStore.validationErrors[idSalleDeBain]"
+      />
+      <!-- TODO : définir en dur que validate.require=false ? -->
+    </div>
   </div>
 </template>
 
@@ -81,5 +85,15 @@ export default defineComponent({
 <style>
 .signalement-form-roomlist {
   width: 100%;
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+.signalement-form-roomlist-under-checkbox {
+  border-left: 3px solid var(--border-action-high-blue-france);
+  margin-left: 10px;
+  padding-left: 18px;
+}
+.signalement-form-roomlist-rooms {
+  margin-left: 20px;
 }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -99,4 +99,9 @@ export default defineComponent({
 </script>
 
 <style>
+.signalement-form-subscreen-under-checkbox {
+  border-left: 3px solid var(--border-action-high-blue-france);
+  margin-left: 10px;
+  padding-left: 18px;
+}
 </style>

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -439,6 +439,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_nuisibles_punaises_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_nuisibles_punaises === 1 && formStore.data.adresse_logement_adresse_detail_insee === '13000'" 
           },
@@ -527,6 +528,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_securite_sol_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_securite_sol === 1"
           },
@@ -584,6 +586,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_securite_escalier_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_securite_escalier === 1 "
           },
@@ -631,6 +634,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_securite_murs_fissures_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_securite_murs_fissures === 1"
           },
@@ -757,6 +761,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_accessibilite_friche_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_accessibilite_friche === 1"
           },
@@ -782,6 +787,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_accessibilite_acces_batiment_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_accessibilite_acces_batiment === 1"
           },
@@ -1083,6 +1089,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_aeration_aucune_aeration_details",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_aeration_aucune_aeration === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1096,6 +1103,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_aeration_aucune_aeration_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_aeration_ventilation_defectueuse === 1" 
           },
@@ -1128,6 +1136,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_aeration_ventilation_defectueuse_details_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_aeration_ventilation_defectueuse_details_nettoyage === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1193,6 +1202,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_chauffage_aucun_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_chauffage_type === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1216,6 +1226,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_chauffage_details_fenetres_permeables_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_fenetres_permeables === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1229,6 +1240,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_chauffage_details_difficultes_chauffage_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_difficultes_chauffage === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1242,6 +1254,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_chauffage_details_chauffage_KO_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_chauffage_KO === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1375,6 +1388,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_humidite_piece_a_vivre_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_humidite_piece_a_vivre === 1 || formStore.data.composition_logement_piece_unique === 'piece_unique'"
           },
@@ -1460,6 +1474,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_humidite_cuisine_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_humidite_cuisine === 1"
           },
@@ -1545,6 +1560,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_humidite_salle_de_bain_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_humidite_salle_de_bain === 1"
           },
@@ -1666,6 +1682,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_sol_glissant_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_sol_glissant === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1679,6 +1696,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_sol_dangereux_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_sol_dangereux === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1692,6 +1710,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_balcons_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_balcons === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1710,6 +1729,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_plomb_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_plomb === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1718,6 +1738,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_securite_plomb_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_plomb === 1" 
           },
@@ -1815,6 +1836,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_electricite_installation_dangereuse_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_electricite_installation_dangereuse === 1" 
           },
@@ -1840,6 +1862,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_electricite_manque_prises_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_electricite_manque_prises === 1" 
           },
@@ -1921,6 +1944,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_nuisibles_punaises_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_nuisibles_punaises === 1 && formStore.data.adresse_logement_adresse_detail_insee === '13000'" 
           },
@@ -1943,6 +1967,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_nuisibles_autres_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_nuisibles_autres === 1"
           },
@@ -2032,6 +2057,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_bruit_voisins_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_bruit_voisins === 1" 
           },
@@ -2085,6 +2111,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_lumiere_pas_lumiere_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_lumiere_pas_lumiere === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -2098,6 +2125,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_lumiere_pas_volets_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_lumiere_pas_volets === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -439,6 +439,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_nuisibles_punaises_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_nuisibles_punaises === 1 && formStore.data.adresse_logement_adresse_detail_insee === '13000'" 
           },
@@ -461,6 +462,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_nuisibles_autres_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_nuisibles_autres === 1"
           },
@@ -527,6 +529,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_securite_sol_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_securite_sol === 1"
           },
@@ -584,6 +587,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_securite_escalier_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_securite_escalier === 1 "
           },
@@ -631,6 +635,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_securite_murs_fissures_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_securite_murs_fissures === 1"
           },
@@ -757,6 +762,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_accessibilite_friche_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_accessibilite_friche === 1"
           },
@@ -782,6 +788,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_batiment_accessibilite_acces_batiment_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_batiment_accessibilite_acces_batiment === 1"
           },
@@ -1095,6 +1102,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_aeration_aucune_aeration_details",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_aeration_aucune_aeration === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1108,6 +1116,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_aeration_aucune_aeration_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_aeration_ventilation_defectueuse === 1" 
           },
@@ -1144,6 +1153,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_aeration_ventilation_defectueuse_details_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_aeration_ventilation_defectueuse_details_nettoyage === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1209,6 +1219,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_chauffage_aucun_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_chauffage_type === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1232,6 +1243,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_chauffage_details_fenetres_permeables_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_fenetres_permeables === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1245,6 +1257,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_chauffage_details_difficultes_chauffage_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_difficultes_chauffage === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1258,6 +1271,7 @@
                 "type": "SignalementFormRoomList",
                 "label": "Dans quelle(s) pièce(s) ?",
                 "slug": "desordres_logement_chauffage_details_chauffage_KO_pieces",
+                "customCss": "signalement-form-roomlist-under-checkbox",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_chauffage_KO === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                 }
@@ -1391,6 +1405,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_humidite_piece_a_vivre_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_humidite_piece_a_vivre === 1 || formStore.data.composition_logement_piece_unique === 'piece_unique'"
           },
@@ -1453,6 +1468,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_humidite_cuisine_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_humidite_cuisine === 1"
           },
@@ -1515,6 +1531,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_humidite_salle_de_bain_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_humidite_salle_de_bain === 1"
           },
@@ -1613,6 +1630,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_sol_glissant_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_sol_glissant === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1626,6 +1644,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_sol_dangereux_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_sol_dangereux === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1639,6 +1658,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_balcons_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_balcons === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1657,6 +1677,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_securite_plomb_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_plomb === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -1665,6 +1686,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_securite_plomb_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_securite_plomb === 1" 
           },
@@ -1762,6 +1784,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_electricite_installation_dangereuse_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_electricite_installation_dangereuse === 1" 
           },
@@ -1787,6 +1810,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_electricite_manque_prises_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_electricite_manque_prises === 1" 
           },
@@ -1872,6 +1896,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_nuisibles_punaises_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_nuisibles_punaises === 1 && formStore.data.adresse_logement_adresse_detail_insee === '13000'" 
           },
@@ -1894,6 +1919,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_nuisibles_autres_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_nuisibles_autres === 1"
           },
@@ -1987,6 +2013,7 @@
           "type": "SignalementFormSubscreen",
           "label": "",
           "slug": "desordres_logement_bruit_voisins_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_bruit_voisins === 1" 
           },
@@ -2040,6 +2067,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_lumiere_pas_lumiere_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_lumiere_pas_lumiere === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }
@@ -2053,6 +2081,7 @@
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
           "slug": "desordres_logement_lumiere_pas_volets_pieces",
+          "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_lumiere_pas_volets === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
           }


### PR DESCRIPTION
## Ticket

#1624    

## Description
Création de classes css pour modifier l'affichage des composants Subscreen et RoomList quand ils s'affichent à la sélection d'une checkbox

## Changements apportés
* Création de classes css
* Utilisation des classes css dans les json

## Pré-requis

en attendant la création des actions findNextScreen et findPreviousScreen permettant de naviguer dans les désordres, copier les composants de json concernés dans questions_profile_locataire.json par exemple

```
       {
          "type": "SignalementFormCheckbox",
          "slug": "desordres_logement_lumiere_pas_lumiere",
          "label": "Le logement n'est pas éclairé par la lumière du jour. Je dois allumer la lumière en plein jour"
        },   
        {
          "type": "SignalementFormRoomList",
          "label": "Dans quelle(s) pièce(s) ?",
          "slug": "desordres_logement_lumiere_pas_lumiere_pieces",
          "customCss": "signalement-form-roomlist-under-checkbox",
          "conditional": {
            "show": "formStore.data.desordres_logement_lumiere_pas_lumiere === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
          }
        },
        {
          "type": "SignalementFormCheckbox",
          "slug": "desordres_logement_electricite_manque_prises",
          "label": "Il n'y a pas de prises, ou il en manque"
        },
        {
          "type": "SignalementFormSubscreen",
          "label": "",
          "slug": "desordres_logement_electricite_manque_prises_details",
          "customCss": "signalement-form-subscreen-under-checkbox",
          "conditional": {
            "show": "formStore.data.desordres_logement_electricite_manque_prises === 1" 
          },
          "components": {
            "body": [
              {
                "type": "SignalementFormOnlyChoice",
                "label": "Devez-vous brancher des multi-prises les unes sur les autres ?",
                "slug": "desordres_logement_electricite_manque_prises_details_multiprises",
                "values": [
                  {
                    "label": "Oui",
                    "value": "oui"
                  },
                  {
                    "label": "Non",
                    "value": "non"
                  }
                ]
              },
              {
                "type": "SignalementFormRoomList",
                "label": "Dans quelle(s) pièce(s) ?",
                "slug": "desordres_logement_electricite_manque_prises_details_pieces",
                "conditional": {
                  "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 
                }
              }
            ]
          }
        }
```

## Tests
- [ ] Aller sur l'écran concerné, et vérifier que les subscreen et roomlist s'affichent bien avec une légère marge et une bordure bleue à gauche