### PR TITLE
[Front] Créer les actions findNextScreen et findPreviousScreen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ cs-check: ## Check source code with PHP-CS-Fixer
 cs-fix: ## Fix source code with PHP-CS-Fixer
 	@$(DOCKER_COMP) exec -it histologe_phpfpm composer cs-fix
 
+es-vue-fix: ## Fix vue source code with es-lint --fix
+	@$(DOCKER_COMP) exec -it histologe_phpfpm npm run es-vue-fix
+
 mock: ## Start Mock server
 	@${DOCKER_COMP} start histologe_wiremock && sleep 5
 	@${DOCKER_COMP} exec -it histologe_phpfpm sh -c "cd tools/wiremock/src/Mock && php AppMock.php"

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -144,6 +144,7 @@ export default defineComponent({
           formStore.currentScreenIndex = screenIndex
           this.currentScreen = formStore.screenData[screenIndex]
           formStore.data.currentStep = formStore.currentScreenIndex + ':' + this.currentScreen?.slug
+          formStore.data.currentSlug = this.currentScreen?.slug
           if (this.currentScreen?.components && this.currentScreen.components.body) {
             // Prétraitement des composants avec repeat
             this.currentScreen.components.body = formStore.preprocessScreen(this.currentScreen.components.body)

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['signalement-form-disorder-category-item fr-container--fluid fr-p-3v', isSelected ? 'is-selected' : '']"
+    :class="['signalement-form-disorder-category-item fr-container--fluid fr-p-3v', isSelected || isAlreadySelected ? 'is-selected' : '']"
     @click="handleClick"
     >
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
@@ -24,6 +24,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import formStore from "../store";
 
 export default defineComponent({
   name: 'SignalementFormDisorderCategoryItem',
@@ -36,7 +37,16 @@ export default defineComponent({
   },
   data () {
     return {
-      isSelected: this.modelValue
+      isSelected: this.modelValue,
+      formStore
+    }
+  },
+  computed: {
+    isAlreadySelected() {
+      if (formStore && formStore.data.categorieDisorders !== undefined || formStore.data.categorieDisorders !== undefined) {
+        return formStore.data.categorieDisorders.batiment.includes(this.id) || formStore.data.categorieDisorders.logement.includes(this.id)
+      }
+      return false
     }
   },
   methods: {

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -24,7 +24,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import formStore from "../store";
+import formStore from '../store'
 
 export default defineComponent({
   name: 'SignalementFormDisorderCategoryItem',
@@ -42,8 +42,8 @@ export default defineComponent({
     }
   },
   computed: {
-    isAlreadySelected() {
-      if (formStore && formStore.data.categorieDisorders !== undefined || formStore.data.categorieDisorders !== undefined) {
+    isAlreadySelected () {
+      if (formStore?.data?.categorieDisorders !== undefined) {
         return formStore.data.categorieDisorders.batiment.includes(this.id) || formStore.data.categorieDisorders.logement.includes(this.id)
       }
       return false

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -38,8 +38,7 @@ export default defineComponent({
     return {
       formStore,
       actionType: (this.action.includes(':')) ? this.action.split(':')[0] : '',
-      actionParam: (this.action.includes(':')) ? this.action.split(':')[1] : '',
-      listSelectedDisorders
+      actionParam: (this.action.includes(':')) ? this.action.split(':')[1] : ''
     }
   },
   created () {
@@ -49,20 +48,28 @@ export default defineComponent({
   },
   methods: {
     handleUpdateSelected (idDisorder: string, isSelected: boolean) {
+      if (!formStore.data.categorieDisorders) {
+        formStore.data.categorieDisorders = {
+          batiment: [],
+          logement: [],
+        };
+      }
       if (idDisorder !== '') {
-        if (isSelected) {
-          this.listSelectedDisorders.push(idDisorder)
-        } else {
-          const index = this.listSelectedDisorders.indexOf(idDisorder)
-          if (index > -1) {
-            this.listSelectedDisorders.splice(index, 1)
-          }
+        const category = idDisorder.includes('batiment') ? 'batiment' : 'logement';
+        const indexInList = formStore.data.categorieDisorders[category].indexOf(idDisorder);
+
+        if (isSelected && indexInList === -1) {
+          formStore.data.categorieDisorders[category].push(idDisorder);
+        } else if (!isSelected && indexInList !== -1) {
+          formStore.data.categorieDisorders[category].splice(indexInList, 1);
         }
-        this.formStore.data.categorieDesordres = this.listSelectedDisorders
       }
       if (this.clickEvent !== undefined) {
-        this.clickEvent(this.actionType, this.actionParam, this.listSelectedDisorders.length > 0 ? '1' : '0')
+        this.clickEvent(this.actionType, this.actionParam, this.hasSelectedDisorders() ? '1' : '0')
       }
+    },
+    hasSelectedDisorders() {
+      return formStore.data.categorieDisorders.batiment.length > 0 || formStore.data.categorieDisorders.logement.length > 0
     }
   }
 })

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -58,6 +58,7 @@ export default defineComponent({
             this.listSelectedDisorders.splice(index, 1)
           }
         }
+        this.formStore.data.categorieDesordres = this.listSelectedDisorders
       }
       if (this.clickEvent !== undefined) {
         this.clickEvent(this.actionType, this.actionParam, this.listSelectedDisorders.length > 0 ? '1' : '0')

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -34,7 +34,6 @@ export default defineComponent({
     clickEvent: Function
   },
   data () {
-    const listSelectedDisorders = new Array<string>()
     return {
       formStore,
       actionType: (this.action.includes(':')) ? this.action.split(':')[0] : '',
@@ -51,24 +50,24 @@ export default defineComponent({
       if (!formStore.data.categorieDisorders) {
         formStore.data.categorieDisorders = {
           batiment: [],
-          logement: [],
-        };
+          logement: []
+        }
       }
       if (idDisorder !== '') {
-        const category = idDisorder.includes('batiment') ? 'batiment' : 'logement';
-        const indexInList = formStore.data.categorieDisorders[category].indexOf(idDisorder);
+        const category = idDisorder.includes('batiment') ? 'batiment' : 'logement'
+        const indexInList = formStore.data.categorieDisorders[category].indexOf(idDisorder)
 
         if (isSelected && indexInList === -1) {
-          formStore.data.categorieDisorders[category].push(idDisorder);
+          formStore.data.categorieDisorders[category].push(idDisorder)
         } else if (!isSelected && indexInList !== -1) {
-          formStore.data.categorieDisorders[category].splice(indexInList, 1);
+          formStore.data.categorieDisorders[category].splice(indexInList, 1)
         }
       }
       if (this.clickEvent !== undefined) {
         this.clickEvent(this.actionType, this.actionParam, this.hasSelectedDisorders() ? '1' : '0')
       }
     },
-    hasSelectedDisorders() {
+    hasSelectedDisorders () {
       return formStore.data.categorieDisorders.batiment.length > 0 || formStore.data.categorieDisorders.logement.length > 0
     }
   }

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -88,7 +88,7 @@ import SignalementFormWarning from './SignalementFormWarning.vue'
 import SignalementFormYear from './SignalementFormYear.vue'
 import { variablesReplacer } from './../services/variableReplacer'
 import { navManager } from './../services/navManager'
-import { findPreviousScreen, findNextScreen } from "../services/disorderScreenNavigator";
+import { findPreviousScreen, findNextScreen } from '../services/disorderScreenNavigator'
 
 export default defineComponent({
   name: 'SignalementFormScreen',
@@ -167,18 +167,18 @@ export default defineComponent({
         await this.toggleComponentBySlug(param, param2)
       } else if (type === 'resolve') {
         if (param === 'findNextScreen') {
-          let index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
+          const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
           const { currentCategory, incrementIndex, nextScreenSlug } = findNextScreen(formStore, index, param2)
-          await this.showScreenBySlug(nextScreenSlug,param2)
+          await this.showScreenBySlug(nextScreenSlug, param2)
           if (Object.keys(formStore.validationErrors).length > 0) {
-            this.currentDisorderIndex[currentCategory] -=  1
+            this.currentDisorderIndex[currentCategory] -= 1
           } else {
-              this.currentDisorderIndex[currentCategory] = incrementIndex
+            this.currentDisorderIndex[currentCategory] = incrementIndex
           }
         }
 
         if (param === 'findPreviousScreen') {
-          let index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
+          const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
           const { currrentCategory, decrementIndex, previousScreenSlug } = findPreviousScreen(formStore, index)
           await this.showScreenBySlug(previousScreenSlug, param2)
 

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -160,6 +160,31 @@ export default defineComponent({
         this.showComponentBySlug(param, param2)
       } else if (type === 'toggle') {
         this.toggleComponentBySlug(param, param2)
+      } else if (type === 'resolve') {
+        if (param === 'findNextScreen') {
+          // TODO: en faire un service
+          const screenMapping: any  = {
+            ecran_intermediaire_les_desordres_next: () => {
+              if (['batiment', 'batiment_logement'].includes(formStore.data.zone_concernee_zone)) {
+                return 'desordres_batiment'
+              }
+              return 'desordres_logement'
+            },
+            desordres_batiment_ras: () => {
+              if (formStore.data.zone_concernee_zone === 'batiment_logement') {
+                return 'desordres_logement'
+              } else if (formStore.data.zone_concernee_zone === 'batiment') {
+                return 'ecran_intermediaire_procedure'
+              }
+            },
+            desordres_logement_ras: () => {
+              if (['logement', 'batiment_logement'].includes(formStore.data.zone_concernee_zone)) {
+                return 'ecran_intermediaire_procedure'
+              }
+            }
+          }
+          this.showScreenBySlug(screenMapping[param2](), param2)
+        }
       }
     },
     showScreenBySlug (slug: string, slugButton:string) {

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -162,16 +162,18 @@ export default defineComponent({
       } else if (type === 'goto') {
         await this.showScreenBySlug(param, param2)
       } else if (type === 'show') {
-        await this.showComponentBySlug(param, param2)
+        this.showComponentBySlug(param, param2)
       } else if (type === 'toggle') {
-        await this.toggleComponentBySlug(param, param2)
+        this.toggleComponentBySlug(param, param2)
       } else if (type === 'resolve') {
         if (param === 'findNextScreen') {
           const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
           const { currentCategory, incrementIndex, nextScreenSlug } = findNextScreen(formStore, index, param2)
           await this.showScreenBySlug(nextScreenSlug, param2)
           if (Object.keys(formStore.validationErrors).length > 0) {
-            this.currentDisorderIndex[currentCategory] -= 1
+            if (incrementIndex !== 0) {
+              this.currentDisorderIndex[currentCategory] -= 1
+            }
           } else {
             this.currentDisorderIndex[currentCategory] = incrementIndex
           }

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -166,22 +166,7 @@ export default defineComponent({
       } else if (type === 'toggle') {
         this.toggleComponentBySlug(param, param2)
       } else if (type === 'resolve') {
-        if (param === 'findNextScreen') {
-          const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
-          const { currentCategory, incrementIndex, nextScreenSlug } = findNextScreen(formStore, index, param2)
-          await this.showScreenBySlug(nextScreenSlug, param2)
-          if (Object.keys(formStore.validationErrors).length === 0) {
-            this.currentDisorderIndex[currentCategory] = incrementIndex
-          }
-        }
-
-        if (param === 'findPreviousScreen') {
-          const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
-          const { currrentCategory, decrementIndex, previousScreenSlug } = findPreviousScreen(formStore, index)
-          await this.showScreenBySlug(previousScreenSlug, param2)
-
-          this.currentDisorderIndex[currrentCategory] = decrementIndex < 0 ? 0 : decrementIndex
-        }
+        this.navigateToDisorderScreen(param, param2)
       }
     },
     async showScreenBySlug (slug: string, slugButton:string) {
@@ -235,6 +220,24 @@ export default defineComponent({
         } else {
           componentToToggle.classList.add('fr-hidden')
         }
+      }
+    },
+    async navigateToDisorderScreen (action: string, slugButton:string) {
+      if (action === 'findNextScreen') {
+        const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
+        const { currentCategory, incrementIndex, nextScreenSlug } = findNextScreen(formStore, index, slugButton)
+        await this.showScreenBySlug(nextScreenSlug, slugButton)
+        if (Object.keys(formStore.validationErrors).length === 0) {
+          this.currentDisorderIndex[currentCategory] = incrementIndex
+        }
+      }
+
+      if (action === 'findPreviousScreen') {
+        const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
+        const { currentCategory, decrementIndex, previousScreenSlug } = findPreviousScreen(formStore, index)
+        await this.showScreenBySlug(previousScreenSlug, slugButton)
+
+        this.currentDisorderIndex[currentCategory] = decrementIndex < 0 ? 0 : decrementIndex
       }
     }
   }

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -170,11 +170,7 @@ export default defineComponent({
           const index = formStore.data.currentSlug.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
           const { currentCategory, incrementIndex, nextScreenSlug } = findNextScreen(formStore, index, param2)
           await this.showScreenBySlug(nextScreenSlug, param2)
-          if (Object.keys(formStore.validationErrors).length > 0) {
-            if (incrementIndex !== 0) {
-              this.currentDisorderIndex[currentCategory] -= 1
-            }
-          } else {
+          if (Object.keys(formStore.validationErrors).length === 0) {
             this.currentDisorderIndex[currentCategory] = incrementIndex
           }
         }

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -1,0 +1,85 @@
+export function findPreviousScreen (
+  formStore: any,
+  index: number
+): { currrentCategory: string, decrementIndex: number, previousScreenSlug: string } {
+  const currentSlug = formStore.data.currentSlug
+  let currrentCategory: string | null = null
+  if (currentSlug.includes('batiment')) {
+    currrentCategory = 'batiment'
+  } else {
+    currrentCategory = 'logement'
+  }
+
+  const disorderList = formStore.data.categorieDisorders[currrentCategory]
+  const decrementIndex = index < 0 ? 0 : index - 1
+  const previousScreenSlug = decrementIndex < 0 ? `desordres_${currrentCategory}` : disorderList[decrementIndex]
+
+  return { currrentCategory, decrementIndex, previousScreenSlug }
+}
+
+export function findNextScreen (
+  formStore: any,
+  index: number,
+  slugButton: string = ''
+): { currentCategory: string, incrementIndex: number, nextScreenSlug: string } {
+  const currentSlug = formStore.data.currentSlug
+  let nextScreenSlug: string = ''
+  let incrementIndex: number = index
+  let isDynamicScreen: boolean = false
+  let currentCategory: string = ''
+  console.log(currentSlug)
+  switch (currentSlug) {
+    case 'ecran_intermediaire_les_desordres':
+      nextScreenSlug = ['batiment', 'batiment_logement'].includes(formStore.data.zone_concernee_zone) ? 'desordres_batiment' : 'desordres_logement'
+      break
+    case 'desordres_batiment':
+      if (slugButton === 'desordres_batiment_ras') {
+        if (formStore.data.zone_concernee_zone === 'batiment_logement') {
+          nextScreenSlug = 'desordres_logement'
+        } else if (formStore.data.zone_concernee_zone === 'batiment') {
+          nextScreenSlug = 'ecran_intermediaire_procedure'
+        }
+      } else {
+        nextScreenSlug = formStore.data.categorieDisorders.batiment[0]
+      }
+      currentCategory = 'batiment'
+      break
+    case 'desordres_logement':
+      if (slugButton === 'desordres_logement_ras') {
+        nextScreenSlug = 'ecran_intermediaire_procedure'
+      } else {
+        nextScreenSlug = formStore.data.categorieDisorders.logement[0]
+      }
+      currentCategory = 'logement'
+      break
+    default:
+      isDynamicScreen = true
+      incrementIndex = index + 1
+  }
+
+  if (isDynamicScreen) {
+    if (currentSlug.includes('batiment')) {
+      currentCategory = 'batiment'
+    } else {
+      currentCategory = 'logement'
+    }
+    const disorderList = formStore.data.categorieDisorders[currentCategory]
+
+    if (incrementIndex >= disorderList.length) {
+      switch (formStore.data.zone_concernee_zone) {
+        case 'batiment':
+        case 'logement':
+          nextScreenSlug = 'ecran_intermediaire_procedure'
+          break
+        case 'batiment_logement':
+          nextScreenSlug = slugButton.includes('batiment') ? 'desordres_logement' : 'ecran_intermediaire_procedure'
+          break
+      }
+      incrementIndex = 0
+    } else {
+      nextScreenSlug = disorderList[incrementIndex]
+    }
+  }
+
+  return { currentCategory, incrementIndex, nextScreenSlug }
+}

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -47,7 +47,6 @@ export function findNextScreen (
       } else {
         nextScreenSlug = formStore.data.categorieDisorders.batiment[0]
       }
-      currentCategory = 'batiment'
       break
     case 'desordres_logement':
       if (slugButton === 'desordres_logement_ras') {

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -7,6 +7,7 @@ export function findPreviousScreen (
 
   const disorderList = formStore.data.categorieDisorders[currentCategory]
   const decrementIndex = index < 0 ? 0 : index - 1
+  let previousScreenSlug: string
 
   if (decrementIndex >= 0) {
     previousScreenSlug = disorderList[decrementIndex]

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -26,11 +26,16 @@ export function findNextScreen (
   let nextScreenSlug: string = ''
   let incrementIndex: number = index
   let isDynamicScreen: boolean = false
-  let currentCategory: string = ''
+  let currentCategory: string = 'batiment'
 
   switch (currentSlug) {
     case 'ecran_intermediaire_les_desordres':
-      nextScreenSlug = ['batiment', 'batiment_logement'].includes(formStore.data.zone_concernee_zone) ? 'desordres_batiment' : 'desordres_logement'
+      if (['batiment', 'batiment_logement'].includes(formStore.data.zone_concernee_zone)) {
+        nextScreenSlug = 'desordres_batiment'
+      } else {
+        nextScreenSlug = 'desordres_logement'
+        currentCategory = 'logement'
+      }
       break
     case 'desordres_batiment':
       if (slugButton === 'desordres_batiment_ras') {

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -7,7 +7,6 @@ export function findPreviousScreen (
 
   const disorderList = formStore.data.categorieDisorders[currentCategory]
   const decrementIndex = index < 0 ? 0 : index - 1
-  let previousScreenSlug: string = 'ecran_intermediaire_les_desordres'
 
   if (decrementIndex >= 0) {
     previousScreenSlug = disorderList[decrementIndex]

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -2,7 +2,7 @@ export function findPreviousScreen (
   formStore: any,
   index: number
 ): { currrentCategory: string, decrementIndex: number, previousScreenSlug: string } {
-  const currentSlug = formStore.data.currentSlug
+  const currentSlug: string = formStore.data.currentSlug
   let currrentCategory: string | null = null
   if (currentSlug.includes('batiment')) {
     currrentCategory = 'batiment'
@@ -22,12 +22,12 @@ export function findNextScreen (
   index: number,
   slugButton: string = ''
 ): { currentCategory: string, incrementIndex: number, nextScreenSlug: string } {
-  const currentSlug = formStore.data.currentSlug
+  const currentSlug: string = formStore.data.currentSlug
   let nextScreenSlug: string = ''
   let incrementIndex: number = index
   let isDynamicScreen: boolean = false
   let currentCategory: string = ''
-  console.log(currentSlug)
+
   switch (currentSlug) {
     case 'ecran_intermediaire_les_desordres':
       nextScreenSlug = ['batiment', 'batiment_logement'].includes(formStore.data.zone_concernee_zone) ? 'desordres_batiment' : 'desordres_logement'

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -1,20 +1,33 @@
 export function findPreviousScreen (
   formStore: any,
   index: number
-): { currrentCategory: string, decrementIndex: number, previousScreenSlug: string } {
+): { currentCategory: string, decrementIndex: number, previousScreenSlug: string } {
   const currentSlug: string = formStore.data.currentSlug
-  let currrentCategory: string | null = null
-  if (currentSlug.includes('batiment')) {
-    currrentCategory = 'batiment'
+  const currentCategory: string = currentSlug.includes('batiment') ? 'batiment' : 'logement'
+
+  const disorderList = formStore.data.categorieDisorders[currentCategory]
+  const decrementIndex = index < 0 ? 0 : index - 1
+  let previousScreenSlug: string = 'ecran_intermediaire_les_desordres'
+
+  if (decrementIndex >= 0) {
+    previousScreenSlug = disorderList[decrementIndex]
   } else {
-    currrentCategory = 'logement'
+    switch (currentSlug) {
+      case 'desordres_logement':
+        previousScreenSlug = (formStore.data.zone_concernee_zone === 'batiment_logement') ? 'desordres_batiment' : 'ecran_intermediaire_les_desordres'
+        break
+      case 'desordres_batiment':
+        previousScreenSlug = (formStore.data.zone_concernee_zone === 'batiment_logement') ? 'ecran_intermediaire_les_desordres' : 'desordres_logement'
+        break
+      default:
+        previousScreenSlug = (['logement', 'batiment_logement'].includes(formStore.data.zone_concernee_zone) && currentSlug.includes('logement'))
+          ? 'desordres_logement'
+          : 'desordres_batiment'
+        break
+    }
   }
 
-  const disorderList = formStore.data.categorieDisorders[currrentCategory]
-  const decrementIndex = index < 0 ? 0 : index - 1
-  const previousScreenSlug = decrementIndex < 0 ? `desordres_${currrentCategory}` : disorderList[decrementIndex]
-
-  return { currrentCategory, decrementIndex, previousScreenSlug }
+  return { currentCategory, decrementIndex, previousScreenSlug }
 }
 
 export function findNextScreen (

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "dev-server": "encore dev-server",
     "dev": "encore dev",
     "watch": "encore dev --watch",
-    "build": "encore production --progress"
+    "build": "encore production --progress",
+    "es-vue-fix": "node_modules/.bin/eslint --config=.eslintrc.js assets/vue --fix"
+
   },
   "engines": {
     "node": "18.14.2"

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -62,7 +62,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Eau et évacuation",
-                "slug": "desordres_batiment_liste_choix_eau",
+                "slug": "desordres_batiment_eau",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-eau_evacuation.svg",
                   "alt": "illustration eau et évacuation"
@@ -74,7 +74,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Isolation du bâtiment",
-                "slug": "desordres_batiment_liste_choix_isolation",
+                "slug": "desordres_batiment_isolation",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-isolation_batiment.svg",
                   "alt": "illustration isolation"
@@ -86,7 +86,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Maintenance et équipements",
-                "slug": "desordres_batiment_liste_choix_maintenance",
+                "slug": "desordres_batiment_maintenance",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-maintenance_equipement.svg",
                   "alt": "illustration Maintenance et équipements"
@@ -98,7 +98,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Présence de nuisibles",
-                "slug": "desordres_batiment_liste_choix_nuisibles",
+                "slug": "desordres_batiment_nuisibles",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-presence_nuisibles.svg",
                   "alt": "illustration Présence de nuisibles"
@@ -110,7 +110,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Sécurité, risque de chute",
-                "slug": "desordres_batiment_liste_choix_securite",
+                "slug": "desordres_batiment_securite",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-securite_risque_chute.svg",
                   "alt": "illustration Sécurité, risque de chute"
@@ -122,7 +122,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Risque d'incendie",
-                "slug": "desordres_batiment_liste_choix_incendie",
+                "slug": "desordres_batiment_incendie",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-protection_incendie.svg",
                   "alt": "illustration Risque d'incendie"
@@ -134,7 +134,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Accessibilité et alentours",
-                "slug": "desordres_batiment_liste_choix_accessibilite",
+                "slug": "desordres_batiment_accessibilite",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-accessibilite_et_alentours.svg",
                   "alt": "illustration Accessibilité et alentours"
@@ -146,7 +146,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Bruit, pollution sonore",
-                "slug": "desordres_batiment_liste_choix_bruit",
+                "slug": "desordres_batiment_bruit",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-bruit_pollution_sonore.svg",
                   "alt": "illustration Bruit, pollution sonore"
@@ -230,14 +230,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_proprete_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_proprete_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -281,14 +281,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_eau_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_eau_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -343,14 +343,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_isolation_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_isolation_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -395,14 +395,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_maintenance_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_maintenance_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -493,14 +493,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_nuisibles_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_nuisibles_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -677,14 +677,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_securite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_securite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -718,14 +718,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_incendie_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_incendie_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -804,14 +804,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_accessibilite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_accessibilite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -845,14 +845,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_bruit_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_bruit_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -879,7 +879,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Eau et évacuation",
-                "slug": "desordres_logement_liste_choix_eau",
+                "slug": "desordres_logement_eau",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-eau_evacuation.svg",
                   "alt": "illustration eau et évacuation"
@@ -891,7 +891,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Aération et ventilation",
-                "slug": "desordres_logement_liste_choix_aeration",
+                "slug": "desordres_logement_aeration",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-aeration_ventilation.svg",
                   "alt": "illustration Aération et ventilation"
@@ -903,7 +903,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Chauffage et isolation",
-                "slug": "desordres_logement_liste_choix_chauffage",
+                "slug": "desordres_logement_chauffage",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-chauffage_isolation.svg",
                   "alt": "illustration Chauffage et isolation"
@@ -915,7 +915,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Humidité et moisissure",
-                "slug": "desordres_logement_liste_choix_humidite",
+                "slug": "desordres_logement_humidite",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-humidite_moisissure.svg",
                   "alt": "illustration Humidité et moisissure"
@@ -927,7 +927,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Sécurité",
-                "slug": "desordres_logement_liste_choix_securite",
+                "slug": "desordres_logement_securite",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-securite.svg",
                   "alt": "illustration Sécurité"
@@ -939,7 +939,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Electricité",
-                "slug": "desordres_logement_liste_choix_electricite",
+                "slug": "desordres_logement_electricite",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-electricite.svg",
                   "alt": "illustration Electricité"
@@ -951,7 +951,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Présence de nuisibles",
-                "slug": "desordres_logement_liste_choix_nuisibles",
+                "slug": "desordres_logement_nuisibles",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-presence_nuisibles.svg",
                   "alt": "illustration Présence de nuisibles"
@@ -963,7 +963,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Bruit, pollution sonore",
-                "slug": "desordres_logement_liste_choix_bruit",
+                "slug": "desordres_logement_bruit",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-bruit_pollution_sonore.svg",
                   "alt": "illustration Bruit, pollution sonore"
@@ -975,7 +975,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Eclairement, lumière naturelle",
-                "slug": "desordres_logement_liste_choix_lumiere",
+                "slug": "desordres_logement_lumiere",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-lumiere_naturelle.svg",
                   "alt": "illustration Eclairement, lumière naturelle"
@@ -1049,14 +1049,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_eau_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_eau_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1141,14 +1141,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_aeration_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_aeration_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1338,14 +1338,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_chauffage_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_chauffage_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1632,14 +1632,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_humidite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_humidite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1771,14 +1771,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_securite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_securite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1877,14 +1877,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_electricite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_electricite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1993,14 +1993,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_nuisibles_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_nuisibles_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -2051,14 +2051,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_bruit_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_bruit_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -2108,14 +2108,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_lumiere_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_lumiere_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -2144,14 +2144,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_proprete_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_proprete_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -23,7 +23,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "ecran_intermediaire_les_desordres_next",
-          "action": "goto:desordres_batiment",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -50,7 +50,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Propreté et entretien",
-                "slug": "desordres_batiment_liste_choix_proprete",
+                "slug": "desordres_batiment_proprete",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-proprete_entretien.svg",
                   "alt": "illustration propreté"
@@ -162,7 +162,7 @@
           "type": "SignalementFormButton",
           "label": "Je n'ai rien à signaler",
           "slug": "desordres_batiment_ras",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line"
         }
       ],
@@ -178,7 +178,7 @@
           "type": "SignalementFormButton",
           "label": "Valider ma sélection",
           "slug": "desordres_batiment_valider",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -994,7 +994,7 @@
           "type": "SignalementFormButton",
           "label": "Je n'ai rien à signaler",
           "slug": "desordres_logement_ras",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line"
         }
       ],
@@ -1010,7 +1010,7 @@
           "type": "SignalementFormButton",
           "label": "Valider ma sélection",
           "slug": "desordres_logement_valider",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -1003,7 +1003,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -50,7 +50,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Propreté et entretien",
-                "slug": "desordres_batiment_liste_choix_proprete",
+                "slug": "desordres_batiment_proprete",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-proprete_entretien.svg",
                   "alt": "illustration propreté"
@@ -62,7 +62,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Eau et évacuation",
-                "slug": "desordres_batiment_liste_choix_eau",
+                "slug": "desordres_batiment_eau",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-eau_evacuation.svg",
                   "alt": "illustration eau et évacuation"
@@ -74,7 +74,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Isolation du bâtiment",
-                "slug": "desordres_batiment_liste_choix_isolation",
+                "slug": "desordres_batiment_isolation",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-isolation_batiment.svg",
                   "alt": "illustration isolation"
@@ -86,7 +86,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Maintenance et équipements",
-                "slug": "desordres_batiment_liste_choix_maintenance",
+                "slug": "desordres_batiment_maintenance",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-maintenance_equipement.svg",
                   "alt": "illustration Maintenance et équipements"
@@ -98,7 +98,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Présence de nuisibles",
-                "slug": "desordres_batiment_liste_choix_nuisibles",
+                "slug": "desordres_batiment_nuisibles",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-presence_nuisibles.svg",
                   "alt": "illustration Présence de nuisibles"
@@ -110,7 +110,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Sécurité, risque de chute",
-                "slug": "desordres_batiment_liste_choix_securite",
+                "slug": "desordres_batiment_securite",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-securite_risque_chute.svg",
                   "alt": "illustration Sécurité, risque de chute"
@@ -122,7 +122,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Risque d'incendie",
-                "slug": "desordres_batiment_liste_choix_incendie",
+                "slug": "desordres_batiment_incendie",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-protection_incendie.svg",
                   "alt": "illustration Risque d'incendie"
@@ -134,7 +134,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Accessibilité et alentours",
-                "slug": "desordres_batiment_liste_choix_accessibilite",
+                "slug": "desordres_batiment_accessibilite",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-accessibilite_et_alentours.svg",
                   "alt": "illustration Accessibilité et alentours"
@@ -146,7 +146,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Bruit, pollution sonore",
-                "slug": "desordres_batiment_liste_choix_bruit",
+                "slug": "desordres_batiment_bruit",
                 "icon": {
                   "src": "/img/form/BATIMENT/Picto-bruit_pollution_sonore.svg",
                   "alt": "illustration Bruit, pollution sonore"
@@ -178,7 +178,7 @@
           "type": "SignalementFormButton",
           "label": "Valider ma sélection",
           "slug": "desordres_batiment_valider",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -230,14 +230,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_proprete_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_proprete_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -281,14 +281,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_eau_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_eau_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -343,14 +343,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_isolation_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_isolation_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -395,14 +395,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_maintenance_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_maintenance_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -493,14 +493,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_nuisibles_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_nuisibles_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -677,14 +677,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_securite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_securite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -718,14 +718,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_incendie_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_incendie_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -804,14 +804,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_accessibilite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_accessibilite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -845,14 +845,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_batiment_bruit_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_batiment_bruit_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -879,7 +879,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Eau et évacuation",
-                "slug": "desordres_logement_liste_choix_eau",
+                "slug": "desordres_logement_eau",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-eau_evacuation.svg",
                   "alt": "illustration eau et évacuation"
@@ -891,7 +891,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Aération et ventilation",
-                "slug": "desordres_logement_liste_choix_aeration",
+                "slug": "desordres_logement_aeration",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-aeration_ventilation.svg",
                   "alt": "illustration Aération et ventilation"
@@ -903,7 +903,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Chauffage et isolation",
-                "slug": "desordres_logement_liste_choix_chauffage",
+                "slug": "desordres_logement_chauffage",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-chauffage_isolation.svg",
                   "alt": "illustration Chauffage et isolation"
@@ -915,7 +915,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Humidité et moisissure",
-                "slug": "desordres_logement_liste_choix_humidite",
+                "slug": "desordres_logement_humidite",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-humidite_moisissure.svg",
                   "alt": "illustration Humidité et moisissure"
@@ -927,7 +927,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Sécurité",
-                "slug": "desordres_logement_liste_choix_securite",
+                "slug": "desordres_logement_securite",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-securite.svg",
                   "alt": "illustration Sécurité"
@@ -939,7 +939,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Electricité",
-                "slug": "desordres_logement_liste_choix_electricite",
+                "slug": "desordres_logement_electricite",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-electricite.svg",
                   "alt": "illustration Electricité"
@@ -951,7 +951,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Présence de nuisibles",
-                "slug": "desordres_logement_liste_choix_nuisibles",
+                "slug": "desordres_logement_nuisibles",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-presence_nuisibles.svg",
                   "alt": "illustration Présence de nuisibles"
@@ -963,7 +963,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Bruit, pollution sonore",
-                "slug": "desordres_logement_liste_choix_bruit",
+                "slug": "desordres_logement_bruit",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-bruit_pollution_sonore.svg",
                   "alt": "illustration Bruit, pollution sonore"
@@ -975,7 +975,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Eclairement, lumière naturelle",
-                "slug": "desordres_logement_liste_choix_lumiere",
+                "slug": "desordres_logement_lumiere",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-lumiere_naturelle.svg",
                   "alt": "illustration Eclairement, lumière naturelle"
@@ -990,7 +990,7 @@
               {
                 "type": "SignalementFormDisorderCategoryItem",
                 "label": "Propreté et entretien",
-                "slug": "desordres_logement_liste_choix_proprete",
+                "slug": "desordres_logement_proprete",
                 "icon": {
                   "src": "/img/form/LOGEMENT/Picto-proprete.svg",
                   "alt": "illustration propreté"
@@ -1022,7 +1022,7 @@
           "type": "SignalementFormButton",
           "label": "Valider ma sélection",
           "slug": "desordres_logement_valider",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1061,14 +1061,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_eau_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_eau_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1157,14 +1157,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_aeration_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_aeration_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1354,14 +1354,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_chauffage_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_chauffage_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1579,14 +1579,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_humidite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_humidite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1718,14 +1718,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_securite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_securite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1828,14 +1828,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_electricite_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_electricite_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1948,14 +1948,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_nuisibles_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_nuisibles_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -2006,14 +2006,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_bruit_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_bruit_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -2063,14 +2063,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_lumiere_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_lumiere_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -2099,14 +2099,14 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_proprete_previous",
-          "action": "findPreviousScreen",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "desordres_logement_proprete_next",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -162,7 +162,7 @@
           "type": "SignalementFormButton",
           "label": "Je n'ai rien à signaler",
           "slug": "desordres_batiment_ras",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line"
         }
       ],
@@ -1006,7 +1006,7 @@
           "type": "SignalementFormButton",
           "label": "Je n'ai rien à signaler",
           "slug": "desordres_logement_ras",
-          "action": "findNextScreen",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-close-line"
         }
       ],

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -23,7 +23,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "ecran_intermediaire_les_desordres_next",
-          "action": "goto:desordres_batiment",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1015,7 +1015,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "desordres_logement_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "resolve:findPreviousScreen",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {


### PR DESCRIPTION
## Ticket

#1622    

## Description
Mise en place du service permettant de naviguer entre les désordres logements, batiments ou les deux

![image](https://github.com/MTES-MCT/histologe/assets/5757116/e65fbb48-2558-450f-a70c-0be9eadec2f5)


## Changements apportés
* Gestion des catégories de désordres bâtiment ou logement depuis le store
* Ajout d'un nouveau service gérant la navigation des désordres
* Rendre la fonction handleClickComponent asynchrone afin de récupérer les erreurs de validation stocké dans le store
* Ajout nouvelle commande npm et make pour eslint
* Mise à jour des fichiers json des désordres `resolve:findNextScreen` et `resolve:findPreviousScreen`

## Pré-requis

## Tests
- [ ] Créer un signalement en sélectionnant 'bâtiment' afin de sélectionner uniquement les désordre de bâtiments
- [ ] Créer un signalement en sélectionnant 'logement' afin de sélectionner uniquement les désordre de logement
- [ ] Créer un signalement en sélectionnant 'les deux' afin de sélectionner les désordres de bâtiment et logement
