### PR TITLE
[Front - Formulaire] Début du composant de résumé des désordres

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -40,6 +40,9 @@
         </section>
       </div>
     </div>
+    <div v-if="formStore.data.categorieDisorders.batiment.length === 0 && formStore.data.categorieDisorders.logement.length === 0">
+      Aucun désordre sélectionné
+    </div>
   </div>
 </template>
 

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -1,0 +1,65 @@
+<template>
+  <div :id="id" class="signalement-form-disorder-overview fr-container--fluid fr-my-3v">
+    <div v-if="formStore.data.categorieDisorders.batiment.length > 0">
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-2"><img :src="icons ? icons[0].src : ''" :alt="icons ? icons[0].alt : ''"></div>
+        <div class="fr-col-10 fr-h2">Le bâtiment</div>
+      </div>
+      <div class="fr-accordions-group">
+        <section
+          v-for="(disorder, index) in formStore.data.categorieDisorders.batiment"
+          v-bind:key="disorder"
+          class="fr-accordion"
+          >
+          <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" :aria-controls="'accordion-disorder-batiment-' + index">{{ disorder }}</button>
+          </h3>
+          <div class="fr-collapse" :id="'accordion-disorder-batiment-' + index">
+            <h4 class="fr-h4">Contenu</h4>
+          </div>
+        </section>
+      </div>
+    </div>
+    <div v-if="formStore.data.categorieDisorders.logement.length > 0">
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-2"><img :src="icons ? icons[1].src : ''" :alt="icons ? icons[1].alt : ''"></div>
+        <div class="fr-col-10 fr-h2">Le logement</div>
+      </div>
+      <div class="fr-accordions-group">
+        <section
+          v-for="(disorder, index) in formStore.data.categorieDisorders.logement"
+          v-bind:key="disorder"
+          class="fr-accordion"
+          >
+          <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" :aria-controls="'accordion-disorder-logement-' + index">{{ disorder }}</button>
+          </h3>
+          <div class="fr-collapse" :id="'accordion-disorder-logement-' + index">
+            <h4 class="fr-h4">Contenu</h4>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import formStore from './../store'
+
+export default defineComponent({
+  name: 'SignalementFormDisorderOverview',
+  props: {
+    id: { type: String, default: null },
+    icons: { type: Object }
+  },
+  data () {
+    return {
+      formStore
+    }
+  }
+})
+</script>
+
+<style>
+</style>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -21,6 +21,7 @@
         :labelUpload="component.labelUpload"
         :description="component.description"
         :components="component.components"
+        :icons="component.icons"
         :action="component.action"
         :link="component.link"
         :linktarget="component.linktarget"
@@ -72,6 +73,7 @@ import SignalementFormCounter from './SignalementFormCounter.vue'
 import SignalementFormDate from './SignalementFormDate.vue'
 import SignalementFormDisorderCategoryItem from './SignalementFormDisorderCategoryItem.vue'
 import SignalementFormDisorderCategoryList from './SignalementFormDisorderCategoryList.vue'
+import SignalementFormDisorderOverview from './SignalementFormDisorderOverview.vue'
 import SignalementFormEmailfield from './SignalementFormEmailfield.vue'
 import SignalementFormInfo from './SignalementFormInfo.vue'
 import SignalementFormLink from './SignalementFormLink.vue'
@@ -114,6 +116,7 @@ export default defineComponent({
     SignalementFormConfirmation,
     SignalementFormDisorderCategoryItem,
     SignalementFormDisorderCategoryList,
+    SignalementFormDisorderOverview,
     SignalementFormRoomList
   },
   props: {

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -42,7 +42,7 @@ export function findNextScreen (
         if (formStore.data.zone_concernee_zone === 'batiment_logement') {
           nextScreenSlug = 'desordres_logement'
         } else if (formStore.data.zone_concernee_zone === 'batiment') {
-          nextScreenSlug = 'ecran_intermediaire_procedure'
+          nextScreenSlug = 'desordres_renseignes'
         }
       } else {
         nextScreenSlug = formStore.data.categorieDisorders.batiment[0]
@@ -50,7 +50,7 @@ export function findNextScreen (
       break
     case 'desordres_logement':
       if (slugButton === 'desordres_logement_ras') {
-        nextScreenSlug = 'ecran_intermediaire_procedure'
+        nextScreenSlug = 'desordres_renseignes'
       } else {
         nextScreenSlug = formStore.data.categorieDisorders.logement[0]
       }
@@ -73,10 +73,10 @@ export function findNextScreen (
       switch (formStore.data.zone_concernee_zone) {
         case 'batiment':
         case 'logement':
-          nextScreenSlug = 'ecran_intermediaire_procedure'
+          nextScreenSlug = 'desordres_renseignes'
           break
         case 'batiment_logement':
-          nextScreenSlug = slugButton.includes('batiment') ? 'desordres_logement' : 'ecran_intermediaire_procedure'
+          nextScreenSlug = slugButton.includes('batiment') ? 'desordres_logement' : 'desordres_renseignes'
           break
       }
       incrementIndex = 0

--- a/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -40,7 +40,7 @@ export function findNextScreen (
     case 'desordres_batiment':
       if (slugButton === 'desordres_batiment_ras') {
         if (formStore.data.zone_concernee_zone === 'batiment_logement') {
-          nextScreenSlug = 'desordres_logement'
+          nextScreenSlug = 'desordres_renseignes_batiment'
         } else if (formStore.data.zone_concernee_zone === 'batiment') {
           nextScreenSlug = 'desordres_renseignes'
         }
@@ -76,7 +76,7 @@ export function findNextScreen (
           nextScreenSlug = 'desordres_renseignes'
           break
         case 'batiment_logement':
-          nextScreenSlug = slugButton.includes('batiment') ? 'desordres_logement' : 'desordres_renseignes'
+          nextScreenSlug = slugButton.includes('batiment') ? 'desordres_renseignes_batiment' : 'desordres_renseignes'
           break
       }
       incrementIndex = 0

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -178,7 +178,7 @@
           "type": "SignalementFormButton",
           "label": "Valider ma sélection",
           "slug": "desordres_batiment_valider",
-          "action": "goto:desordres_renseignes",
+          "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -178,7 +178,7 @@
           "type": "SignalementFormButton",
           "label": "Valider ma sélection",
           "slug": "desordres_batiment_valider",
-          "action": "resolve:findNextScreen",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -2153,6 +2153,30 @@
           "slug": "desordres_logement_proprete_next",
           "action": "resolve:findNextScreen",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Les désordres renseignés",
+    "slug": "desordres_renseignes",
+    "screenCategory": "Désordres",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormDisorderOverview",
+          "slug": "desordres_resume",
+          "icons": [
+            {
+              "src": "/img/form/BATIMENT/Picto-batiment.svg",
+              "alt": ""
+            },
+            {
+              "src": "/img/form/LOGEMENT/Picto-logement.svg",
+              "alt": ""
+            }
+          ]
         }
       ]
     }

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -2178,6 +2178,22 @@
             }
           ]
         }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "desordres_renseignes_previous",
+          "action": "resolve:findPreviousScreen",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "desordres_renseignes_next",
+          "action": "goto:ecran_intermediaire_procedure",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+        }
       ]
     }
   }

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -857,7 +857,55 @@
         }
       ]
     }
-  }, 
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Les désordres renseignés",
+    "slug": "desordres_renseignes_batiment",
+    "screenCategory": "Désordres",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormDisorderOverview",
+          "slug": "desordres_renseignes_batiment_resume",
+          "icons": [
+            {
+              "src": "/img/form/BATIMENT/Picto-batiment.svg",
+              "alt": ""
+            },
+            {
+              "src": "/img/form/LOGEMENT/Picto-logement.svg",
+              "alt": ""
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Avez-vous terminé avec les désordres sur le bâtiment ?",
+          "slug": "desordres_renseignes_batiment_subscreen",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Oui, je passe à la suite",
+                "slug": "desordres_renseignes_batiment_next",
+                "action": "goto:desordres_logement",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Non, j'en ai encore à déclarer",
+                "slug": "desordres_renseignes_batiment_previous",
+                "action": "goto:desordres_batiment",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
   {
     "type": "SignalementFormScreen",
     "label": "Le logement",

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -2111,5 +2111,45 @@
         }
       ]
     }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Les désordres renseignés",
+    "slug": "desordres_renseignes",
+    "screenCategory": "Désordres",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormDisorderOverview",
+          "slug": "desordres_resume",
+          "icons": [
+            {
+              "src": "/img/form/BATIMENT/Picto-batiment.svg",
+              "alt": ""
+            },
+            {
+              "src": "/img/form/LOGEMENT/Picto-logement.svg",
+              "alt": ""
+            }
+          ]
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "desordres_renseignes_previous",
+          "action": "resolve:findPreviousScreen",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "desordres_renseignes_next",
+          "action": "goto:ecran_intermediaire_procedure",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+        }
+      ]
+    }
   }
 ]

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -857,7 +857,55 @@
         }
       ]
     }
-  }, 
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Les désordres renseignés",
+    "slug": "desordres_renseignes_batiment",
+    "screenCategory": "Désordres",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormDisorderOverview",
+          "slug": "desordres_renseignes_batiment_resume",
+          "icons": [
+            {
+              "src": "/img/form/BATIMENT/Picto-batiment.svg",
+              "alt": ""
+            },
+            {
+              "src": "/img/form/LOGEMENT/Picto-logement.svg",
+              "alt": ""
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Avez-vous terminé avec les désordres sur le bâtiment ?",
+          "slug": "desordres_renseignes_batiment_subscreen",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Oui, je passe à la suite",
+                "slug": "desordres_renseignes_batiment_next",
+                "action": "goto:desordres_logement",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Non, j'en ai encore à déclarer",
+                "slug": "desordres_renseignes_batiment_previous",
+                "action": "goto:desordres_batiment",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
   {
     "type": "SignalementFormScreen",
     "label": "Le logement",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -989,7 +989,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -1090,7 +1090,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -664,7 +664,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "",
+    "label": "Votre situation",
     "description": "<p>Nous allons vous poser des questions sur votre situation.<br>Si vous êtes allocataire CAF ou MSA, préparez votre numéro allocataire !</p><p>Toutes les questions sont obligatoires, sauf mention contraire.</p>",
     "slug": "ecran_intermediaire_situation_occupant",
     "screenCategory": "Situation du foyer",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -890,7 +890,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1001,7 +1001,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -779,7 +779,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "",
+    "label": "Votre situation",
     "description": "<p>Nous allons vous poser des questions sur votre situation.<br>Si vous êtes allocataire CAF ou MSA, préparez votre numéro allocataire !</p><p>Toutes les questions sont obligatoires, sauf mention contraire.</p>",
     "slug": "ecran_intermediaire_situation_occupant",
     "screenCategory": "Situation du foyer",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -720,7 +720,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -924,7 +924,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -965,7 +965,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -719,7 +719,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "",
+    "label": "Situation du foyer",
     "description": "<p>Nous allons vous poser des questions sur la situation du foyer.<br>Si possible, préparez les informations concernant l'allocation logement.</p><p>Toutes les questions sont obligatoires, sauf mention contraire.</p>",
     "slug": "ecran_intermediaire_situation_occupant",
     "screenCategory": "Situation du foyer",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -918,7 +918,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -959,7 +959,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_les_desordres",
+          "action": "goto:desordres_renseignes",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -702,7 +702,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "",
+    "label": "Situation du foyer",
     "description": "<p>Nous allons vous poser des questions sur la situation du foyer.<br>Si possible, préparez les informations concernant l'allocation logement.</p><p>Toutes les questions sont obligatoires, sauf mention contraire.</p>",
     "slug": "ecran_intermediaire_situation_occupant",
     "screenCategory": "Situation du foyer",


### PR DESCRIPTION
## Ticket

#1540   

## Description
Création du composant de résumé des désordres et navigation avec les écrans autour.
Pour l'instant, des slugs s'affichent pour les titres de catégorie.
Le contenu des parties déroulantes n'existe pas encore.

## Tests
- [ ] Faire un signalement avec juste batiment sélectionné et vérifier le résumé final
- [ ] Faire un signalement avec juste logement sélectionné et vérifier le résumé final
- [ ] Faire un signalement avec batiment et logement sélectionnés et vérifier le résumé intermédiaire (bâtiment) et final (tous les désordres)
