### PR TITLE
[Front - Formulaire] Suppression des données de désordre quand une catégorie est déselectionnée

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -61,6 +61,11 @@ export default defineComponent({
           formStore.data.categorieDisorders[category].push(idDisorder)
         } else if (!isSelected && indexInList !== -1) {
           formStore.data.categorieDisorders[category].splice(indexInList, 1)
+          for (const dataname in formStore.data) {
+            if (dataname.includes(idDisorder)) {
+              delete formStore.data[dataname]
+            }
+          }
         }
       }
       if (this.clickEvent !== undefined) {

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -61,11 +61,7 @@ export default defineComponent({
           formStore.data.categorieDisorders[category].push(idDisorder)
         } else if (!isSelected && indexInList !== -1) {
           formStore.data.categorieDisorders[category].splice(indexInList, 1)
-          for (const dataname in formStore.data) {
-            if (dataname.includes(idDisorder)) {
-              delete formStore.data[dataname]
-            }
-          }
+          this.deleteDisorder(idDisorder)
         }
       }
       if (this.clickEvent !== undefined) {
@@ -74,6 +70,13 @@ export default defineComponent({
     },
     hasSelectedDisorders () {
       return formStore.data.categorieDisorders.batiment.length > 0 || formStore.data.categorieDisorders.logement.length > 0
+    },
+    deleteDisorder (idDisorder: string) {
+      for (const dataname in formStore.data) {
+        if (dataname.includes(idDisorder)) {
+          delete formStore.data[dataname]
+        }
+      }
     }
   }
 })


### PR DESCRIPTION
## Ticket

#1656    

## Description
Suppression des données de désordre quand une catégorie est déselectionnée

## Tests
- [ ] Aller jusqu'aux catégories de désordres et sélectionner 2 catégories
- [ ] Remplir des informations pour ces 2 catégories
- [ ] Faire précédent pour revenir à la liste des catégories
- [ ] Désélectionner une des catégories
- [ ] Avancer, puis revenir à la liste
- [ ] Re-sélectionner la catégorie et avancer
- [ ] Vérifier que les données sont à nouveau vides
