### PR TITLE
[Front - Formulaire] Ajout option multiple sur les champs d'upload

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -30,6 +30,7 @@
         :customCss="component.customCss"
         :validate="component.validate"
         :disabled="component.disabled"
+        :multiple="component.multiple"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -21,6 +21,7 @@
         :customCss="component.customCss"
         :validate="component.validate"
         :disabled="component.disabled"
+        :multiple="component.multiple"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"

--- a/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -1,6 +1,10 @@
 <template>
 <div :class="['fr-upload-group', { 'fr-upload-group--disabled': disabled }]" :id="id">
   <div :class="[ customCss, 'fr-upload-wrap', 'fr-py-3v' ]">
+    <label :for="id" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
+      {{ label }}
+    </label>
+    <span class="fr-hint-text">{{ description }}</span>
     <input
       type="file"
       :name="id"
@@ -11,10 +15,6 @@
       @change="uploadFile($event)"
       >
       <!-- TODO : gérer type de fichier accept=".pdf,.doc,.docx" -->
-    <label :for="id" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
-      {{ label }}
-    </label>
-    <span class="fr-hint-text">{{ description }}</span>
   </div>
 
   <div v-if="formStore.data[id] !== undefined">
@@ -168,10 +168,11 @@ export default defineComponent({
 
 <style>
 .custom-file-input {
-  opacity: 0; /* Make the input transparent */
-  position: absolute; /* Position off-screen or adjust as needed */
+  opacity: 0;
+  position: relative;
+  line-height: 2.5rem;
+  top: -2.5rem;
   width: 100%;
-  height: 100%;
 }
 .fr-link--error {
   color: var(--text-default-error);

--- a/assets/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
@@ -9,13 +9,15 @@
     <SignalementFormUpload
       :id="id + '-upload'"
       :label="labelUpload"
-      :modelValue="modelValue"
+      v-model="formStore.data[id]"
+      :multiple="true"
       />
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import formStore from './../store'
 import SignalementFormInfo from './SignalementFormInfo.vue'
 import SignalementFormUpload from './SignalementFormUpload.vue'
 
@@ -29,9 +31,17 @@ export default defineComponent({
     id: { type: String, default: null },
     label: { type: String, default: null },
     description: { type: String, default: null },
-    modelValue: { type: String, default: null },
+    modelValue: {
+      type: Array as () => Array<Object>,
+      default: () => []
+    },
     labelInfo: { type: String, default: null },
     labelUpload: { type: String, default: null }
+  },
+  data () {
+    return {
+      formStore
+    }
   }
 })
 </script>

--- a/assets/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
@@ -9,7 +9,7 @@
     <SignalementFormUpload
       :id="id + '-upload'"
       :label="labelUpload"
-      v-model="formStore.data[id]"
+      v-model="formStore.data[id + '-upload']"
       :multiple="true"
       />
   </div>


### PR DESCRIPTION
## Ticket

#1623    

## Description
Ajout option `multiple` sur les champs d'upload

## Changements apportés
* Option `multiple` sur le composant `SignalementFormUpload`
* Défini à `true` par défaut sur le composant `SignalementFormUploadPhotos`

## Tests
- [ ] Vérifier que les champs d'upload de bail/dpe ne permettent d'envoyer qu'un seul fichier comme avant
- [ ] Vérifier que les champs d'upload de photos (dans les désordres) permettent d'envoyer plusieurs fichiers
