### PR TITLE
  [Front - formulaire] Ajouter un composant SignalementFormTextarea

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -84,6 +84,7 @@ import SignalementFormPhonefield from './SignalementFormPhonefield.vue'
 import SignalementFormRoomList from './SignalementFormRoomList.vue'
 import SignalementFormSubscreen from './SignalementFormSubscreen.vue'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
+import SignalementFormTextarea from './SignalementFormTextarea.vue'
 import SignalementFormTime from './SignalementFormTime.vue'
 import SignalementFormUpload from './SignalementFormUpload.vue'
 import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
@@ -96,6 +97,7 @@ export default defineComponent({
   name: 'SignalementFormScreen',
   components: {
     SignalementFormTextfield,
+    SignalementFormTextarea,
     SignalementFormButton,
     SignalementFormLink,
     SignalementFormOnlyChoice,

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -37,6 +37,7 @@ import { defineComponent } from 'vue'
 import formStore from './../store'
 import { variablesReplacer } from './../services/variableReplacer'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
+import SignalementFormTextarea from './SignalementFormTextarea.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormLink from './SignalementFormLink.vue'
 import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
@@ -60,6 +61,7 @@ export default defineComponent({
   name: 'SignalementFormSubscreen',
   components: {
     SignalementFormTextfield,
+    SignalementFormTextarea,
     SignalementFormButton,
     SignalementFormLink,
     SignalementFormOnlyChoice,

--- a/assets/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -1,0 +1,68 @@
+<template>
+<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id">
+  <label class='fr-label' :for="id">
+    {{ label }}
+    <span class="fr-hint-text">{{ description }}</span>
+  </label>
+    <div :class="[ customCss, 'fr-input-wrap' ]">
+      <textarea
+        type="text"
+        :name="id"
+        :value="internalValue"
+        :placeholder="placeholder"
+        :class="[ customCss, 'fr-input' ]"
+        @input="updateValue($event)"
+        aria-describedby="text-input-error-desc-error"
+        :disabled="disabled"
+      >
+      </textarea>
+    </div>
+    <div
+      id="text-input-error-desc-error"
+      class="fr-error-text"
+      v-if="hasError"
+      >
+      {{ error }}
+    </div>
+</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'SignalementFormTextarea',
+  props: {
+    id: { type: String, default: null },
+    label: { type: String, default: null },
+    description: { type: String, default: null },
+    placeholder: { type: String, default: null },
+    modelValue: { type: String, default: null },
+    customCss: { type: String, default: '' },
+    validate: { type: Object, default: null },
+    hasError: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+    error: { type: String, default: '' }
+  },
+  computed: {
+    internalValue: {
+      get () {
+        return this.modelValue
+      },
+      set (newValue: string) {
+        this.$emit('update:modelValue', newValue)
+      }
+    }
+  },
+  methods: {
+    updateValue (event: Event) {
+      const value = (event.target as HTMLInputElement).value
+      this.$emit('update:modelValue', value)
+    }
+  },
+  emits: ['update:modelValue']
+})
+</script>
+
+<style>
+</style>

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -76,6 +76,7 @@ const formStore: FormStore = reactive({
   lastButtonClicked: '',
   inputComponents: [
     'SignalementFormTextfield',
+    'SignalementFormTextarea',
     'SignalementFormOnlyChoice',
     'SignalementFormRoomList',
     'SignalementFormAddress',

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -1006,7 +1006,7 @@
           ]
         },
         {
-          "type": "SignalementFormTextfield",
+          "type": "SignalementFormTextarea",
           "label": "Quelle a été la réponse de votre assurance ?",
           "slug": "info_procedure_reponse_assurance",
           "conditional": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -907,7 +907,7 @@
           ]
         },
         {
-          "type": "SignalementFormTextfield",
+          "type": "SignalementFormTextarea",
           "label": "Quelle a été la réponse de votre assurance ?",
           "slug": "info_procedure_reponse_assurance",
           "conditional": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1041,7 +1041,7 @@
           }
         },
         {
-          "type": "SignalementFormTextfield",
+          "type": "SignalementFormTextarea",
           "label": "Quelle a été la réponse de votre assurance ?",
           "slug": "info_procedure_reponse_assurance",
           "conditional": {


### PR DESCRIPTION
## Ticket

#1712   

## Description
Création d'un composant SignalementFormTextarea et utilisation dans la partie "Procédure" pour la réponse de l'assurance

## Changements apportés
* Création d'un composant SignalementFormTextarea
* Ajout du composant dans la mécanique du formulaire
* Changement de textfield en textarea dans les json

## Pré-requis
```
make mock
npm run build
```

## Tests
- [ ] Créer ou rouvrir un signalement (en occupant ou en bailleur)
- [ ] Aller jusqu'à l'étape "Procédure"
- [ ] Répondre "oui" à "avez-vous contacté votre assurance ?"
- [ ] Vérifier que le champ qui s'affiche est un textarea
- [ ] Ne rien remplir, et cliquer sur suivant -> on a un message d'erreur
- [ ] Remplir quelque-chose et vérifier qu'on peut passer à la suite et que la réponse est bien sauvée en base (info_procedure_reponse_assurance)
