### PR TITLE
[Front - Formulaire] Corrections de marge et affichage de composants

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormConfirmation.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormConfirmation.vue
@@ -1,15 +1,13 @@
 <template>
   <div :id="id">
-    <div class="fr-container">
-      <p>
-        Votre signalement est bien enregistré.
-        Vous allez recevoir un email de confirmation avec un lien vers votre page de suivi : <strong>gardez-le précieusement</strong> !
-      </p>
-      <p>
-        Bon à savoir : en fonction du type de problèmes rencontrés, la procédure peut prendre du temps.
-        Nos services font le maximum pour traiter votre demande au plus vite.
-      </p>
-    </div>
+    <p>
+      Votre signalement est bien enregistré.
+      Vous allez recevoir un email de confirmation avec un lien vers votre page de suivi : <strong>gardez-le précieusement</strong> !
+    </p>
+    <p>
+      Bon à savoir : en fonction du type de problèmes rencontrés, la procédure peut prendre du temps.
+      Nos services font le maximum pour traiter votre demande au plus vite.
+    </p>
   </div>
 </template>
 

--- a/assets/vue/components/signalement-form/components/SignalementFormInfo.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-notice fr-notice--info">
+  <div class="fr-notice fr-notice--info fr-mb-5v">
       <div class="fr-container">
           <div class="fr-notice__body">
               <p class="fr-notice__title" v-html="labelVariablesReplaced">

--- a/assets/vue/components/signalement-form/components/SignalementFormInfo.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormInfo.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="fr-notice fr-notice--info fr-mb-5v">
-      <div class="fr-container">
-          <div class="fr-notice__body">
-              <p class="fr-notice__title" v-html="labelVariablesReplaced">
-              </p>
-          </div>
+    <div class="fr-container">
+      <div class="fr-notice__body">
+        <p class="fr-notice__title" v-html="labelVariablesReplaced">
+        </p>
       </div>
+    </div>
   </div>
 </template>
 

--- a/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
@@ -1,7 +1,12 @@
 <template>
-    <div class="fr-alert fr-alert--warning fr-mb-5v">
-        <p class="fr-alert__title" v-html="labelVariablesReplaced"></p>
+  <div class="fr-notice fr-notice--info fr-notice--info-warning fr-mb-5v">
+    <div class="fr-container">
+      <div class="fr-notice__body">
+        <p class="fr-notice__title" v-html="labelVariablesReplaced">
+        </p>
+      </div>
     </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -26,4 +31,15 @@ export default defineComponent({
 </script>
 
 <style>
+.fr-notice.fr-notice--info.fr-notice--info-warning {
+  --idle: transparent;
+  --hover: var(--background-contrast-warning-hover);
+  --active: var(--background-contrast-warning-active);
+  background-color: var(--background-contrast-warning);
+  color: var(--text-default-warning);
+}
+.fr-notice.fr-notice--info.fr-notice--info-warning .fr-notice__body::before {
+  -webkit-mask-image: url("../../../../../public/build/dsfr/icons/system/fr--warning-fill.svg");
+  mask-image: url("../../../../../public/build/dsfr/icons/system/fr--warning-fill.svg");
+}
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
@@ -39,7 +39,7 @@ export default defineComponent({
   color: var(--text-default-warning);
 }
 .fr-notice.fr-notice--info.fr-notice--info-warning .fr-notice__body::before {
-  -webkit-mask-image: url("../../../../../public/build/dsfr/icons/system/fr--warning-fill.svg");
-  mask-image: url("../../../../../public/build/dsfr/icons/system/fr--warning-fill.svg");
+  -webkit-mask-image: url("../../../img/fr--warning-fill.svg");
+  mask-image: url("../../../img/fr--warning-fill.svg");
 }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="fr-alert fr-alert--warning fr-my-5w">
+    <div class="fr-alert fr-alert--warning fr-mb-5v">
         <p class="fr-alert__title" v-html="labelVariablesReplaced"></p>
     </div>
 </template>

--- a/assets/vue/img/fr--warning-fill.svg
+++ b/assets/vue/img/fr--warning-fill.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="m12.866 3 9.526 16.5a1 1 0 0 1-.866 1.5H2.474a1 1 0 0 1-.866-1.5L11.134 3a1 1 0 0 1 1.732 0ZM11 16v2h2v-2h-2Zm0-7v5h2V9h-2Z"/></svg>


### PR DESCRIPTION
## Ticket

#1715   
#1700    
#1699    

## Description
- Corrections de marge sur la conclusion
- Corrections de marge et affichage de composants info et warning

## Tests
- [ ] Vérifier l'affichage des composants info et warning sur la page avec le DPE (cocher Non pour le bail et Non pour l'état des lieux)
- [ ] Vérifier l'affichage de l'écran de conclusion
