### PR TITLE
[Front - Formulaire] Corrections d'affichage sur la zone d'action smartphone

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -41,7 +41,7 @@
     </div>
   </div>
   <div
-    v-if="components != undefined"
+    v-if="components !== undefined && components.footer !== undefined && components.footer.length > 0"
     class="fr-container form-screen-footer"
     >
     <div>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -283,7 +283,7 @@ export default defineComponent({
     .form-screen-footer {
       position: fixed;
       left: 0px;
-      bottom: 2.5rem;
+      bottom: 0px;
 
       background-position: 0 0;
       background-repeat: no-repeat;


### PR DESCRIPTION
## Ticket

#1685
#1686

## Description
Corrections d'affichage sur la zone d'action smartphone

## Tests
(sur smartphone)
- [ ] La zone est bien fixée en bas (en debug, recouverte par la barre Symfony)
- [ ] La zone est absente de la première et de la deuxième étapes
