### PR TITLE
[Front - Formulaire] Correction de place de picto et d'intro des désordres

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -310,4 +310,13 @@ export default defineComponent({
     display: inline-flex;
     margin-left: 0.25rem;
   }
+
+  .fr-span-highlight-batiment {
+    /* équivalent de --orange-terre-battue-main-645 en rgb */
+    background-color: rgb(228, 121, 74, 0.25);
+  }
+  .fr-span-highlight-logement {
+    /* équivalent de --blue-france-main-525 en rgb */
+    background-color: rgb(106, 106, 244, 0.25);
+  }
 </style>

--- a/tools/wiremock/src/Resources/Signalement/dictionary.json
+++ b/tools/wiremock/src/Resources/Signalement/dictionary.json
@@ -17,7 +17,7 @@
   "desordres_logement_nuisibles": { "label": "Présence de nuisibles" },
   "desordres_logement_bruit": { "label": "Bruit, pollution sonore" },
   "desordres_logement_lumiere": { "label": "Eclairement, lumière naturelle" },
-  "batiment": { "label": "le bâtiment" },
-  "logement": { "label": "le logement" },
-  "batiment_logement": { "label": "le bâtiment et le logement" }
+  "batiment": { "label": "le <span class=\"fr-span-highlight-batiment\">bâtiment</span>" },
+  "logement": { "label": "le <span class=\"fr-span-highlight-logement\">logement</span>" },
+  "batiment_logement": { "label": "le <span class=\"fr-span-highlight-batiment\">bâtiment</span> et le <span class=\"fr-span-highlight-logement\">logement</span>" }
 }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -116,6 +116,10 @@
     "description": "<p>Nous allons vous poser des questions sur la composition du logement.<p><p>Les documents utiles sont:</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p>Toutes les questions sont obligatoires, sauf mention contraire.<p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
+    "icon": {
+      "src": "/img/form/screens/type_composition_logement-colors.svg",
+      "alt": ""
+    },
     "components": {
       "body": [
       ],
@@ -579,10 +583,6 @@
     "label": "",
     "slug": "bail_dpe",
     "screenCategory": "Type et composition",
-    "icon": {
-      "src": "/img/form/screens/type_composition_logement-colors.svg",
-      "alt": ""
-    },
     "components": {
       "body": [
         {


### PR DESCRIPTION
## Ticket

#1702   
#1706

## Description
- Correction de la place du picto Composition du logement
- Surligne "batiment" et "logement" sur la page d'intro des désordres

## Tests
- [ ] Picto visible sur la page d'intro de Type et composition du logement
- [ ] "batiment" et "logement" surligné dans la page d'intro des désordres
- [ ] "batiment" surligné si on choisit juste batiment
- [ ] "logement" surligné si on choisit juste logement
