### PR TITLE
[Front - formulaire] Fix problèmes de navigation

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -164,6 +164,7 @@ export default defineComponent({
             requests.initDesordresProfil(this.handleInitQuestions)
           } else {
             // on fait un appel API pour charger la suite des questions avant de changer d'écran
+            // TODO : il faudrait trouver un moyen de repérer si les questions profils ont déjà été chargées, et si c'est juste un slug qui n'existe pas avec ce profil
             requests.initQuestionsProfil(this.handleInitQuestions)
           }
         }

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -15,9 +15,22 @@
         {
           "type": "SignalementFormButton",
           "label": "Précédent",
-          "slug": "ecran_intermediaire_les_desordres_previous",
+          "slug": "ecran_intermediaire_les_desordres_previous_autre",
           "action": "goto:travailleur_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+          }
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "ecran_intermediaire_les_desordres_previous_secours",
+          "action": "goto:type_logement_commodites",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
+          }
         },
         {
           "type": "SignalementFormButton",
@@ -2408,9 +2421,22 @@
         {
           "type": "SignalementFormButton",
           "label": "Suivant",
-          "slug": "desordres_renseignes_next",
+          "slug": "desordres_renseignes_next_autre",
           "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+          }
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "desordres_renseignes_next_secours",
+          "action": "goto:utilisation_service",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
+          }
         }
       ]
     }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -97,8 +97,8 @@
         {
           "type": "SignalementFormButton",
           "label": "Précédent",
-          "slug": "coordonnees_occupant_tel",
-          "action": "goto:coordonnees_tiers",
+          "slug": "coordonnees_occupant_previous",
+          "action": "goto:vos_coordonnees_tiers",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -143,7 +143,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "zone_concernee_zone_previous",
-          "action": "goto:coordonnees_bailleur",
+          "action": "goto:coordonnees_occupant",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -428,7 +428,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "type_logement_pieces_a_vivre_previous",
-          "action": "goto:type_logement",
+          "action": "goto:composition_logement",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -97,7 +97,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "zone_concernee_zone_previous",
-          "action": "goto:coordonnees_bailleur",
+          "action": "goto:vos_coordonnees_occupant",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -97,8 +97,8 @@
         {
           "type": "SignalementFormButton",
           "label": "Précédent",
-          "slug": "coordonnees_occupant_tel",
-          "action": "goto:coordonnees_tiers",
+          "slug": "coordonnees_occupant_previous",
+          "action": "goto:vos_coordonnees_tiers",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -477,7 +477,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "type_logement_pieces_a_vivre_previous",
-          "action": "goto:type_logement",
+          "action": "goto:composition_logement",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -111,8 +111,8 @@
         {
           "type": "SignalementFormButton",
           "label": "Précédent",
-          "slug": "coordonnees_occupant_tel",
-          "action": "goto:coordonnees_tiers",
+          "slug": "coordonnees_occupant_previous",
+          "action": "goto:vos_coordonnees_tiers",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -175,7 +175,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "coordonnees_bailleur_previous",
-          "action": "goto:vos_coordonnees_occupant",
+          "action": "goto:coordonnees_occupant",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -506,7 +506,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "type_logement_pieces_a_vivre_previous",
-          "action": "goto:type_logement",
+          "action": "goto:composition_logement",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -94,8 +94,8 @@
         {
           "type": "SignalementFormButton",
           "label": "Précédent",
-          "slug": "coordonnees_occupant_tel",
-          "action": "goto:coordonnees_tiers",
+          "slug": "coordonnees_occupant_previous",
+          "action": "goto:vos_coordonnees_tiers",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -158,7 +158,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "coordonnees_bailleur_previous",
-          "action": "goto:vos_coordonnees_occupant",
+          "action": "goto:coordonnees_occupant",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
@@ -489,7 +489,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "type_logement_pieces_a_vivre_previous",
-          "action": "goto:type_logement",
+          "action": "goto:composition_logement",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {


### PR DESCRIPTION
## Ticket

#1688   

## Description
Changement de slugs dans certains json pour éviter une bloucle infinie lors de la navigation, quand un slug n'existe pas dans un profil

## Changements apportés
* Changements de slugs dans les json

## Pré-requis

## Tests
- [ ] Idéalement, parcourir l'intégralité du formulaire du début à la fin et de la fin au début avec chacun des profils, si il y a un changement d'écran qui ne se fait pas, avec un GET en boucle dans la console, c'est qu'il y a un faux slug
