### PR TITLE
[FO] Ajout d'une contrainte numérique sur l'étage

### DIFF
--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -204,7 +204,7 @@ signalements:
     reference: "2022-5"
     geoloc: "{\"lng\":\"43.2909138\",\"lat\":\"5.3719882\"}"
     score: 100
-    etage_occupant: "Annexe du bâtiment"
+    etage_occupant: "0"
     escalier_occupant: ""
     mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
     insee_occupant: "13203"
@@ -1063,7 +1063,7 @@ signalements:
     reference: "2023-12"
     geoloc: "{\"lng\":\"43.3062255\", \"lat\":\"5.3898396\"}"
     score: 80
-    etage_occupant: "0"
+    etage_occupant: "Annexe du bâtiment"
     escalier_occupant: ""
     mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
     insee_occupant: "13204"

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -113,7 +113,7 @@ signalements:
     reference: "2022-3"
     geoloc: "{\"lng\":\"43.2928291\",\"lat\":\"5.3695447\"}"
     score: 100
-    etage_occupant: "0"
+    etage_occupant: "rdc"
     escalier_occupant: ""
     mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
     insee_occupant: "13203"
@@ -159,7 +159,7 @@ signalements:
     reference: "2022-4"
     geoloc: "{\"lng\":\"43.2928291\",\"lat\":\"5.3695447\"}"
     score: 100
-    etage_occupant: "0"
+    etage_occupant: "Etage 1"
     escalier_occupant: ""
     mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
     insee_occupant: "13203"
@@ -204,7 +204,7 @@ signalements:
     reference: "2022-5"
     geoloc: "{\"lng\":\"43.2909138\",\"lat\":\"5.3719882\"}"
     score: 100
-    etage_occupant: "0"
+    etage_occupant: "Annexe du bâtiment"
     escalier_occupant: ""
     mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
     insee_occupant: "13203"

--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -8,6 +8,7 @@ use App\Entity\Signalement;
 use App\Messenger\Message\DossierMessageSCHS;
 use App\Service\UploadHandlerService;
 use App\Utils\AddressParser;
+use App\Utils\EtageParser;
 
 class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
 {
@@ -41,7 +42,7 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
             ->setAdresseSignalement($address['street'])
             ->setCodepostaleSignalement($signalement->getCpOccupant())
             ->setVilleSignalement($signalement->getVilleOccupant())
-            ->setEtageSignalement($signalement->getEtageOccupant())
+            ->setEtageSignalement(EtageParser::parse($signalement->getEtageOccupant()))
             ->setNumeroAppartementSignalement($signalement->getNumAppartOccupant())
             ->setNumeroAdresseSignalement($address['number'])
             ->setLatitudeSignalement($signalement->getGeoloc()['lat'] ?? 0)

--- a/src/Factory/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Esabora/DossierMessageSISHFactory.php
@@ -14,6 +14,7 @@ use App\Service\Esabora\Model\DossierMessageSISHPersonne;
 use App\Service\HtmlCleaner;
 use App\Service\UploadHandlerService;
 use App\Utils\AddressParser;
+use App\Utils\EtageParser;
 use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -85,7 +86,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
                     ?->setTimezone(new \DateTimeZone(self::DEFAULT_TIMEZONE))
                     ->format($formatDateTime)
             )
-            ->setLocalisationEtage($signalement->getEtageOccupant())
+            ->setLocalisationEtage(EtageParser::parse($signalement->getEtageOccupant()))
             ->setLocalisationEscalier($signalement->getEscalierOccupant())
             ->setLocalisationNumPorte($signalement->getNumAppartOccupant())
             ->setSitOccupantNbAdultes($signalement->getNbAdultes())

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -386,6 +386,9 @@ class SignalementType extends AbstractType
                 ],
                 'label' => 'Etage',
                 'help' => 'Saisissez 0 pour le rez-de-chaussée (RDC), 1 pour le premier étage, etc.',
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
                 'required' => false,
             ])
             ->add('escalierOccupant', TextType::class, [

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -3,10 +3,13 @@
 namespace App\Form;
 
 use App\Entity\Signalement;
+use App\Utils\EtageParser;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -371,18 +374,18 @@ class SignalementType extends AbstractType
                 ],
                 'label' => 'Ville du logement',
             ])
-            ->add('etageOccupant', TextType::class, [
+            ->add('etageOccupant', NumberType::class, [
                 'row_attr' => [
                     'class' => 'fr-input-group',
                 ],
                 'attr' => [
                     'class' => 'fr-input',
-                    'maxlength' => '200',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
                 ],
                 'label' => 'Etage',
+                'help' => 'Saisissez 0 pour le rez-de-chaussée (RDC), 1 pour le premier étage, etc.',
                 'required' => false,
             ])
             ->add('escalierOccupant', TextType::class, [
@@ -588,6 +591,16 @@ class SignalementType extends AbstractType
                 'label' => 'Structure déclarant',
                 'required' => false,
             ]);
+
+        $builder->get('etageOccupant')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($currentEtage): ?int {
+                    return EtageParser::parse($currentEtage);
+                },
+                function ($updtatedEtage): string {
+                    return $updtatedEtage;
+                }
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Utils/EtageParser.php
+++ b/src/Utils/EtageParser.php
@@ -4,7 +4,7 @@ namespace App\Utils;
 
 class EtageParser
 {
-    public static function parse(string $etage): ?int
+    public static function parse(?string $etage): ?int
     {
         if (preg_match('/(rez|rdc|rdj|rh|chauss)/i', $etage, $matches)) {
             return 0;

--- a/src/Utils/EtageParser.php
+++ b/src/Utils/EtageParser.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Utils;
+
+class EtageParser
+{
+    public static function parse(string $etage): ?int
+    {
+        if (preg_match('/(rez|rdc|rdj|rh|chauss)/i', $etage, $matches)) {
+            return 0;
+        } elseif (preg_match('/\d+/', $etage, $matches)) {
+            return (int) $matches[0];
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Utils/EtageParserTest.php
+++ b/tests/Unit/Utils/EtageParserTest.php
@@ -32,7 +32,7 @@ class EtageParserTest extends TestCase
             0,
         ];
 
-        yield 'Bâtiment principal' => ['Bâtiment principal', 0];
+        yield 'Bâtiment principal' => ['Bâtiment principal', null];
 
         yield '4e etage gauche' => ['4e etage gauche', 4];
 

--- a/tests/Unit/Utils/EtageParserTest.php
+++ b/tests/Unit/Utils/EtageParserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\Unit\Utils;
+
+use App\Utils\EtageParser;
+use PHPUnit\Framework\TestCase;
+
+class EtageParserTest extends TestCase
+{
+    /**
+     * @dataProvider provideEtage
+     */
+    public function testEtageParser(string $currentEtageValue, $etageParsed): void
+    {
+        $this->assertEquals($etageParsed, EtageParser::parse($currentEtageValue));
+    }
+
+    public function provideEtage(): \Generator
+    {
+        yield '3 ème étage porte à droite' => ['3 ème étage porte à droite', 3];
+
+        yield '3 EME ETAGE APPARTEMENT B329' => ['3 EME ETAGE APPARTEMENT B329', 3];
+
+        yield 'Bâtiment C1' => ['Bâtiment C', null];
+
+        yield 'ETAGE 5' => ['ETAGE 5', 5];
+
+        yield '1er - 2ème - 3ème - 4ème' => ['1er - 2ème - 3ème - 4ème', 1];
+
+        yield 'Annexe du bâtiment n° 51 rue Jean - Augustin Asselin, rdc' => [
+            'Annexe du bâtiment n° 51 rue Jean - Augustin Asselin, rdc',
+            0,
+        ];
+
+        yield 'Bâtiment principal' => ['Bâtiment principal', 0];
+
+        yield '4e etage gauche' => ['4e etage gauche', 4];
+
+        yield '2emes' => ['2emes', 2];
+
+        yield 'Petite cours' => ['Petite cours', null];
+
+        yield 'RDC  entrée 10' => ['RDC  entrée 10', 0];
+
+        yield '1 / 2 rdc' => ['1 / 2 rdc', 0];
+
+        yield '4ème étage - entrée 1' => ['4ème étage - entrée 1', 4];
+
+        yield 'Dernière maison à gauche' => ['Dernière maison à gauche', null];
+    }
+}

--- a/tests/Unit/Utils/EtageParserTest.php
+++ b/tests/Unit/Utils/EtageParserTest.php
@@ -10,7 +10,7 @@ class EtageParserTest extends TestCase
     /**
      * @dataProvider provideEtage
      */
-    public function testEtageParser(string $currentEtageValue, $etageParsed): void
+    public function testEtageParser(?string $currentEtageValue, ?int $etageParsed): void
     {
         $this->assertEquals($etageParsed, EtageParser::parse($currentEtageValue));
     }
@@ -47,5 +47,7 @@ class EtageParserTest extends TestCase
         yield '4ème étage - entrée 1' => ['4ème étage - entrée 1', 4];
 
         yield 'Dernière maison à gauche' => ['Dernière maison à gauche', null];
+
+        yield 'null' => [null, null];
     }
 }


### PR DESCRIPTION
## Ticket

#1732    

## Description
Nettoiement des données saisi par les utilisateurs à l'édition, Cette PR permet aussi d'éviter les erreurs 400 esabora sur la contrainte de l'étage.


## Changements apportés
* Mise à jour du type de champs dans le formulaire
* Ajout d'un transformer  afin de déterminer l'étage sur le nouveau format (type=number)
* Ajout d'un parser afin d'envoyer une valeur parsé selon les contrainte ESABORA

## Pré-requis
```
make worker-start
```

## Tests
- [ ] Créer un signalement afin de vérifier que le nouveau format est prise en charge
- [ ] Editer un signalement avec un étage de type ""string" et vérifier que la conversion se fait bien (Transformer) (2023-12 ou 2022-3 ou 2022-4)
- [ ] Affecter le signalement 2023-12 au partenaire SCHS et SISH et vérfier que l'étage parsé est bien envoyé
- [ ] Vérifier les données envoyés en base dans la table job_event
