### PR TITLE
[New form] Profil non mis à jour après un retour en arrière (Bouton précédent) 

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -70,6 +70,7 @@ export default defineComponent({
   },
   data () {
     return {
+      slugCommonProfil: ['introduction', 'adresse_logement_intro', 'adresse_logement', 'signalement_concerne'],
       slugCoordonnees: ['vos_coordonnees_occupant', 'vos_coordonnees_tiers'],
       nextSlug: '',
       isErrorInit: false,
@@ -138,6 +139,17 @@ export default defineComponent({
         this.changeScreenBySlug(undefined)
       }
     },
+    removeNextScreensIfProfileUpdated () {
+      if (formStore.data.currentStep === 'signalement_concerne') {
+        const profil = formStore.data.profil
+        profileUpdater.update()
+        if (profil !== formStore.data.profil) {
+          formStore.screenData = formStore.screenData.filter(
+            (screen: any) => this.slugCommonProfil.includes(screen.slug)
+          )
+        }
+      }
+    },
     changeScreenBySlug (requestResponse: any) {
       formStore.lastButtonClicked = ''
       // si on reçoit un uuid on l'enregistre pour les mises à jour
@@ -145,6 +157,7 @@ export default defineComponent({
         formStore.data.uuidSignalementDraft = requestResponse.uuid
       }
       if (formStore.screenData) {
+        this.removeNextScreensIfProfileUpdated()
         const nextScreen = formStore.screenData.find((screen: any) => screen.slug === this.nextSlug)
         if (nextScreen !== undefined) {
           formStore.currentScreen = nextScreen
@@ -155,8 +168,6 @@ export default defineComponent({
           }
         } else {
           if (this.slugCoordonnees.includes(this.nextSlug)) { // TODO à mettre à jour suivant le slug des différents profils
-            // on détermine le profil
-            profileUpdater.update()
             // on fait un appel API pour charger la suite des questions avant de changer d'écran
             requests.initQuestionsProfil(this.handleInitQuestions)
           } else if (this.nextSlug.indexOf('desordres') !== -1) {

--- a/assets/vue/components/signalement-form/services/profileUpdater.ts
+++ b/assets/vue/components/signalement-form/services/profileUpdater.ts
@@ -3,8 +3,10 @@ import formStore from '../store'
 export const profileUpdater = {
   update () {
     if (formStore.data.signalement_concerne_profil === 'logement_occupez') {
+      delete formStore.data.signalement_concerne_profil_detail_tiers // eviter les effets de bord
       formStore.data.profil = formStore.data.signalement_concerne_profil_detail_occupant
     } else {
+      delete formStore.data.signalement_concerne_profil_detail_occupant // eviter les effets de bord
       formStore.data.profil = formStore.data.signalement_concerne_profil_detail_tiers
     }
   }


### PR DESCRIPTION
## Ticket

#1729    

## Description
Vérifier si le profil a été modifiée afin de mettre à jour le profil et supprimer les écrans précédemment chargés

## Changements apportés
* Ajout d'une méthode de suppressions des écrans précédemment chargés selon si le profil a changé

## Pré-requis
`make npm-build`

### Pour chaque retour arrière et changement, vérifier les différents appels
![image](https://github.com/MTES-MCT/histologe/assets/5757116/1b25d06d-2744-410d-910a-7935602c7b9c)

### Vérifier que screenData se reinitilise au changement de profil
![image](https://github.com/MTES-MCT/histologe/assets/5757116/e1ce17da-14d8-40b3-b9ed-6d333c01d3c2)

## Tests
- [ ] En tant que locataire, vérifier que l'API locataire est bien appelé ainsi que les écrans soit bien chargé 
- [ ] Revenir en artère et changer de profil en passant à propriétaire du logement (baillant_occupant)
- [ ] Revenir en artère et changer de profil en passant à particulier (tiers_particulier)
- [ ] Revenir en artère et changer de profil en passant à professionnel (tiers_pro)
- [ ] Revenir en artère et changer de profil en passant à bailleur du logement (bailleur)
- [ ] Revenir en artère et changer de profil en passant à service de secours (service_de_secours)
- [ ] Revenir au tout début du formulaire

