### PR TITLE
[New form - logement -nuisibles] Demander depuis quand pour chaque type de nuisible

### DIFF
--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -2142,11 +2142,83 @@
           }
         },
         {
+          "type": "SignalementFormSubscreen",
+          "label": "",
+          "slug": "desordres_logement_nuisibles_cafards_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
+          "conditional": {
+            "show": "formStore.data.desordres_logement_nuisibles_cafards === 1"
+          },
+          "components": {
+            "body": [
+                {
+                  "type": "SignalementFormOnlyChoice",
+                  "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                  "slug": "desordres_logement_nuisibles_cafards_details_date",
+                  "values": [
+                    {
+                      "label": "Avant que j'emménage",
+                      "value": "before"
+                    },
+                    {
+                      "label": "Après mon emménagement",
+                      "value": "after"
+                    }
+                  ]
+                },
+                {
+                  "type": "SignalementFormInfo",
+                  "slug": "desordres_logement_nuisibles_cafards_details_info",
+                  "conditional": {
+                    "show": "formStore.data.desordres_logement_nuisibles_cafards_details_date === 'after'"
+                  },
+                  "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
+                }
+            ]
+          }
+        },
+        {
           "type": "SignalementFormCheckbox",
           "slug": "desordres_logement_nuisibles_rongeurs",
           "label": "Il y a des rongeurs (rats, souris...)",
           "validate": {
             "required": false
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "",
+          "slug": "desordres_logement_nuisibles_rongeurs_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
+          "conditional": {
+            "show": "formStore.data.desordres_logement_nuisibles_rongeurs === 1"
+          },
+          "components": {
+            "body": [
+                {
+                  "type": "SignalementFormOnlyChoice",
+                  "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                  "slug": "desordres_logement_nuisibles_rongeurs_details_date",
+                  "values": [
+                    {
+                      "label": "Avant que j'emménage",
+                      "value": "before"
+                    },
+                    {
+                      "label": "Après mon emménagement",
+                      "value": "after"
+                    }
+                  ]
+                },
+                {
+                  "type": "SignalementFormInfo",
+                  "slug": "desordres_logement_nuisibles_rongeurs_details_info",
+                  "conditional": {
+                    "show": "formStore.data.desordres_logement_nuisibles_rongeurs_details_date === 'after'"
+                  },
+                  "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
+                }
+            ]
           }
         },
         {
@@ -2167,6 +2239,29 @@
           },
           "components": {
             "body": [
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                "slug": "desordres_logement_nuisibles_punaises_details_date",
+                "values": [
+                  {
+                    "label": "Avant que j'emménage",
+                    "value": "before"
+                  },
+                  {
+                    "label": "Après mon emménagement",
+                    "value": "after"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormInfo",
+                "slug": "desordres_logement_nuisibles_punaises_details_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_nuisibles_punaises_details_date === 'after'"
+                },
+                "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
+              },
               {
                 "type": "SignalementFormInfo",
                 "label": "Le saviez-vous ? Sur votre département, le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
@@ -2197,35 +2292,32 @@
                   "type": "SignalementFormTextfield",
                   "label": "Précisez le type de nuisibles",
                   "slug": "desordres_logement_nuisibles_autres_details_type_nuisibles"
+                },
+                {
+                  "type": "SignalementFormOnlyChoice",
+                  "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                  "slug": "desordres_logement_nuisibles_autres_details_date",
+                  "values": [
+                    {
+                      "label": "Avant que j'emménage",
+                      "value": "before"
+                    },
+                    {
+                      "label": "Après mon emménagement",
+                      "value": "after"
+                    }
+                  ]
+                },
+                {
+                  "type": "SignalementFormInfo",
+                  "slug": "desordres_logement_nuisibles_autres_details_info",
+                  "conditional": {
+                    "show": "formStore.data.desordres_logement_nuisibles_autres_details_date === 'after'"
+                  },
+                  "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
                 }
             ]
           }
-        },
-        {
-          "type": "SignalementFormOnlyChoice",
-          "label": "Depuis quand les nuisibles sont présents dans le logement ?",
-          "slug": "desordres_logement_nuisibles_date",
-          "conditional": {
-            "show": "formStore.data.desordres_logement_nuisibles_cafards === 1 || formStore.data.desordres_logement_nuisibles_rongeurs === 1 || formStore.data.desordres_logement_nuisibles_punaises === 1 || formStore.data.desordres_logement_nuisibles_autres === 1"
-          },
-          "values": [
-            {
-              "label": "Avant que j'emménage",
-              "value": "before"
-            },
-            {
-              "label": "Après mon emménagement",
-              "value": "after"
-            }
-          ]
-        },
-        {
-          "type": "SignalementFormInfo",
-          "slug": "desordres_logement_nuisibles_info",
-          "conditional": {
-            "show": "formStore.data.desordres_logement_nuisibles_date === 'after' || formStore.data.desordres_logement_nuisibles_date === 'nsp'"
-          },
-          "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
         },
         {
           "type": "SignalementFormUploadPhotos",

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -2153,7 +2153,7 @@
             "body": [
                 {
                   "type": "SignalementFormOnlyChoice",
-                  "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                  "label": "{{dictionaryStore::desordres_logement_nuisibles_cafards_details_date}}",
                   "slug": "desordres_logement_nuisibles_cafards_details_date",
                   "values": [
                     {
@@ -2197,7 +2197,7 @@
             "body": [
                 {
                   "type": "SignalementFormOnlyChoice",
-                  "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                  "label": "{{dictionaryStore::desordres_logement_nuisibles_rongeurs_details_date}}",
                   "slug": "desordres_logement_nuisibles_rongeurs_details_date",
                   "values": [
                     {
@@ -2241,7 +2241,7 @@
             "body": [
               {
                 "type": "SignalementFormOnlyChoice",
-                "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                "label": "{{dictionaryStore::desordres_logement_nuisibles_punaises_details_date}}",
                 "slug": "desordres_logement_nuisibles_punaises_details_date",
                 "values": [
                   {
@@ -2295,7 +2295,7 @@
                 },
                 {
                   "type": "SignalementFormOnlyChoice",
-                  "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                  "label": "{{dictionaryStore::desordres_logement_nuisibles_autres_details_date}}",
                   "slug": "desordres_logement_nuisibles_autres_details_date",
                   "values": [
                     {

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -2117,7 +2117,7 @@
             "body": [
                 {
                   "type": "SignalementFormOnlyChoice",
-                  "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                  "label": "{{dictionaryStore::desordres_logement_nuisibles_cafards_details_date}}",
                   "slug": "desordres_logement_nuisibles_cafards_details_date",
                   "values": [
                     {
@@ -2165,7 +2165,7 @@
             "body": [
                 {
                   "type": "SignalementFormOnlyChoice",
-                  "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                  "label": "{{dictionaryStore::desordres_logement_nuisibles_rongeurs_details_date}}",
                   "slug": "desordres_logement_nuisibles_rongeurs_details_date",
                   "values": [
                     {
@@ -2213,7 +2213,7 @@
             "body": [
               {
                 "type": "SignalementFormOnlyChoice",
-                "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                "label": "{{dictionaryStore::desordres_logement_nuisibles_punaises_details_date}}",
                 "slug": "desordres_logement_nuisibles_punaises_details_date",
                 "values": [
                   {
@@ -2271,7 +2271,7 @@
                 },
                 {
                   "type": "SignalementFormOnlyChoice",
-                  "label": "{{dictionaryStore::desordres_logement_nuisibles_date}}",
+                  "label": "{{dictionaryStore::desordres_logement_nuisibles_autres_details_date}}",
                   "slug": "desordres_logement_nuisibles_autres_details_date",
                   "values": [
                     {

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -2106,11 +2106,91 @@
           }
         },
         {
+          "type": "SignalementFormSubscreen",
+          "label": "",
+          "slug": "desordres_logement_nuisibles_cafards_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
+          "conditional": {
+            "show": "formStore.data.desordres_logement_nuisibles_cafards === 1"
+          },
+          "components": {
+            "body": [
+                {
+                  "type": "SignalementFormOnlyChoice",
+                  "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                  "slug": "desordres_logement_nuisibles_cafards_details_date",
+                  "values": [
+                    {
+                      "label": "Avant l'emménagement du foyer",
+                      "value": "before"
+                    },
+                    {
+                      "label": "Après l'emménagement du foyer",
+                      "value": "after"
+                    },
+                    {
+                      "label": "Je ne sais pas",
+                      "value": "nsp"
+                    }
+                  ]
+                },
+                {
+                  "type": "SignalementFormInfo",
+                  "slug": "desordres_logement_nuisibles_cafards_details_info",
+                  "conditional": {
+                    "show": "formStore.data.desordres_logement_nuisibles_cafards_details_date === 'after' || formStore.data.desordres_logement_nuisibles_cafards_details_date === 'nsp'"
+                  },
+                  "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
+                }
+            ]
+          }
+        },
+        {
           "type": "SignalementFormCheckbox",
           "slug": "desordres_logement_nuisibles_rongeurs",
           "label": "Il y a des rongeurs (rats, souris...)",
           "validate": {
             "required": false
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "",
+          "slug": "desordres_logement_nuisibles_rongeurs_details",
+          "customCss": "signalement-form-subscreen-under-checkbox",
+          "conditional": {
+            "show": "formStore.data.desordres_logement_nuisibles_rongeurs === 1"
+          },
+          "components": {
+            "body": [
+                {
+                  "type": "SignalementFormOnlyChoice",
+                  "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                  "slug": "desordres_logement_nuisibles_rongeurs_details_date",
+                  "values": [
+                    {
+                      "label": "Avant l'emménagement du foyer",
+                      "value": "before"
+                    },
+                    {
+                      "label": "Après l'emménagement du foyer",
+                      "value": "after"
+                    },
+                    {
+                      "label": "Je ne sais pas",
+                      "value": "nsp"
+                    }
+                  ]
+                },
+                {
+                  "type": "SignalementFormInfo",
+                  "slug": "desordres_logement_nuisibles_rongeurs_details_info",
+                  "conditional": {
+                    "show": "formStore.data.desordres_logement_nuisibles_rongeurs_details_date === 'after' || formStore.data.desordres_logement_nuisibles_rongeurs_details_date === 'nsp'"
+                  },
+                  "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
+                }
+            ]
           }
         },
         {
@@ -2131,6 +2211,33 @@
           },
           "components": {
             "body": [
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                "slug": "desordres_logement_nuisibles_punaises_details_date",
+                "values": [
+                  {
+                    "label": "Avant l'emménagement du foyer",
+                    "value": "before"
+                  },
+                  {
+                    "label": "Après l'emménagement du foyer",
+                    "value": "after"
+                  },
+                  {
+                    "label": "Je ne sais pas",
+                    "value": "nsp"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormInfo",
+                "slug": "desordres_logement_nuisibles_punaises_details_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_nuisibles_punaises_details_date === 'after' || formStore.data.desordres_logement_nuisibles_punaises_details_date === 'nsp'"
+                },
+                "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
+              },
               {
                 "type": "SignalementFormInfo",
                 "label": "Le saviez-vous ? Sur votre département, le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
@@ -2161,39 +2268,36 @@
                   "type": "SignalementFormTextfield",
                   "label": "Précisez le type de nuisibles",
                   "slug": "desordres_logement_nuisibles_autres_details_type_nuisibles"
+                },
+                {
+                  "type": "SignalementFormOnlyChoice",
+                  "label": "Depuis quand les nuisibles sont présents dans le logement ?",
+                  "slug": "desordres_logement_nuisibles_autres_details_date",
+                  "values": [
+                    {
+                      "label": "Avant l'emménagement du foyer",
+                      "value": "before"
+                    },
+                    {
+                      "label": "Après l'emménagement du foyer",
+                      "value": "after"
+                    },
+                    {
+                      "label": "Je ne sais pas",
+                      "value": "nsp"
+                    }
+                  ]
+                },
+                {
+                  "type": "SignalementFormInfo",
+                  "slug": "desordres_logement_nuisibles_autres_details_info",
+                  "conditional": {
+                    "show": "formStore.data.desordres_logement_nuisibles_autres_details_date === 'after' || formStore.data.desordres_logement_nuisibles_autres_details_date === 'nsp'"
+                  },
+                  "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
                 }
             ]
           }
-        },
-        {
-          "type": "SignalementFormOnlyChoice",
-          "label": "Depuis quand les nuisibles sont présents dans le logement ?",
-          "slug": "desordres_logement_nuisibles_date",
-          "conditional": {
-            "show": "formStore.data.desordres_logement_nuisibles_cafards === 1 || formStore.data.desordres_logement_nuisibles_rongeurs === 1 || formStore.data.desordres_logement_nuisibles_punaises === 1 || formStore.data.desordres_logement_nuisibles_autres === 1"
-          },
-          "values": [
-            {
-              "label": "Avant l'emménagement du foyer",
-              "value": "before"
-            },
-            {
-              "label": "Après l'emménagement du foyer",
-              "value": "after"
-            },
-            {
-              "label": "Je ne sais pas",
-              "value": "nsp"
-            }
-          ]
-        },      
-        {
-          "type": "SignalementFormInfo",
-          "slug": "desordres_logement_nuisibles_info",
-          "conditional": {
-            "show": "formStore.data.desordres_logement_nuisibles_date === 'after' || formStore.data.desordres_logement_nuisibles_date === 'nsp'"
-          },
-          "label": "Bon à savoir : si la présence de nuisibles est dûe à un manque d'entretien ou de nettoyage du logement, c'est aux locataires de payer la prise en charge. Si les nuisibles sont présents dans tout le bâtiment, ou étaient présents dès l'emménagement dans le logement : c'est à la charge du bailleur (propriétaire)."
         },
         {
           "type": "SignalementFormUploadPhotos",

--- a/tools/wiremock/src/Resources/Signalement/dictionary.json
+++ b/tools/wiremock/src/Resources/Signalement/dictionary.json
@@ -245,10 +245,28 @@
       "default": "Autre type de nuisible : {{formStore.data.desordres_logement_nuisibles_autres_details_type_nuisibles}}"
     }
   },
-  "desordres_logement_nuisibles_date": {
-    "default": "Depuis quand les nuisibles sont présents dans le logement ?",
+  "desordres_logement_nuisibles_cafards_details_date": {
+    "default": "Depuis quand les cafards ou blattes sont présents dans le logement ?",
     "disorderOverview": {
-      "default": "Nuisibles présents depuis : {{dictionaryStore::formStore.data.desordres_logement_nuisibles_date}}"
+      "default": "Cafards ou blattes présents depuis : {{dictionaryStore::formStore.data.desordres_logement_nuisibles_cafards_details_date}}"
+    }
+  },
+  "desordres_logement_nuisibles_rongeurs_details_date": {
+    "default": "Depuis quand les rongeurs sont présents dans le logement ?",
+    "disorderOverview": {
+      "default": "Rongeurs présents depuis : {{dictionaryStore::formStore.data.desordres_logement_nuisibles_rongeurs_details_date}}"
+    }
+  },
+  "desordres_logement_nuisibles_punaises_details_date": {
+    "default": "Depuis quand les punaises de lit sont présentes dans le logement ?",
+    "disorderOverview": {
+      "default": "Punaises de lit présentes depuis : {{dictionaryStore::formStore.data.desordres_logement_nuisibles_punaises_details_date}}"
+    }
+  },
+  "desordres_logement_nuisibles_autres_details_date": {
+    "default": "Depuis quand ces nuisibles sont présents dans le logement ?",
+    "disorderOverview": {
+      "default": "Nuisibles présents depuis : {{dictionaryStore::formStore.data.desordres_logement_nuisibles_autres_details_date}}"
     }
   },
   "desordres_logement_bruit_exterieur": { "default": "On entend le bruit extérieur, même en fermant les portes et les fenêtres" },


### PR DESCRIPTION
## Ticket

#1713   

## Description
On déplace la question "Depuis quand les nuisibles sont présents?" et le composant Info lié dans un subscreen pour chaque type de nuisible, dans la zone logement.
Correction de l'affichage du composant Info
On en profite du coup pour adapter la question en fonction du type de nuisibles (ce qui n'avait pas été possible quand la question était générale)

## Changements apportés
* modification de json de désordres
* modification du dictionary.json

## Pré-requis

## Tests
- [ ] Faire un signalement en occupant avec batiment et logement
- [ ] Choisir "nuisibles" dans les deux zones, vérifier que rien n'a changé pour le batiment
- [ ] Pour le logement, vérifier qu'on demande depuis quand les nuisibles sont présents pour chaque type de nuisibles, et que le composant Info s'affiche également pour chaque type de nuisible si on choisit Après l'emménagement
- [ ] Vérifier l'affichage dans le résumé
- [ ] Faire un signalement en tiers, et faire les mêmes vérifications + il doit y avoir une option "je ne sais pas" dans "depuis quand" qui active également l'affichage du composant Info
