### PR TITLE
 [New form - info complémentaires] Sortir "Infos complémentaires" du parcours

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -9,9 +9,11 @@
 
       <!-- TODO : changer intitulés ? -->
       <h3>Vos coordonnées</h3>
-      <a href="#" @click="handleEdit('vos_coordonnees_occupant')">Editer</a>
+      <a v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" href="#" @click="handleEdit('vos_coordonnees_occupant')">Editer</a>
+      <a v-else href="#" @click="handleEdit('vos_coordonnees_tiers')">Editer</a>
       <p v-html="getFormDataCoordonneesOccupant()"></p>
 
+      <!-- TODO : si profil est bailleur ou bailleur_occupant que met-on ? -->
       <h3>Les coordonnées du bailleur</h3>
       <a href="#" @click="handleEdit('coordonnees_bailleur')">Editer</a>
       <p v-html="getFormDataCoordonneesBailleur()"></p>
@@ -44,13 +46,16 @@
       <h3>TODO : La procédure</h3>
       <a href="#" @click="handleEdit('info_procedure')">Editer</a>
 
-      <h2>TODO : Informations complémentaires</h2>
+      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">
+        <h2>TODO : Informations complémentaires</h2>
 
-      <p>
-        Plus nous avons d'informations sur la situation,
-        mieux nous pouvons vous accompagner.
-        Cliquez sur le bouton pour ajouter des informations.
-      </p>
+        <p>
+          Plus nous avons d'informations sur la situation,
+          mieux nous pouvons vous accompagner.
+          Cliquez sur le bouton pour ajouter des informations.
+        <a href="#" @click="handleEdit('informations_complementaires')">Editer</a>
+        </p>
+      </div>
 
       Ma situation personnelle
       <br>

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -1073,7 +1073,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "utilisation_service_next",
-          "action": "goto.save:informations_complementaires",
+          "action": "goto.save:validation_signalement",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1081,7 +1081,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "Information complémentaires",
+    "label": "Informations complémentaires",
     "description": "Toutes les questions sont facultatives",
     "slug": "informations_complementaires",
     "screenCategory": "Procédure",
@@ -1214,7 +1214,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "validation_signalement_previous",
-          "action": "goto:informations_complementaires",
+          "action": "goto:utilisation_service",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1205,7 +1205,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "utilisation_service_next",
-          "action": "goto.save:informations_complementaires",
+          "action": "goto.save:validation_signalement",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
@@ -1213,7 +1213,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "Information complémentaires",
+    "label": "Informations complémentaires",
     "description": "Toutes les questions sont facultatives",
     "slug": "informations_complementaires",
     "screenCategory": "Procédure",
@@ -1346,7 +1346,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "validation_signalement_previous",
-          "action": "goto:informations_complementaires",
+          "action": "goto:utilisation_service",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {


### PR DESCRIPTION
## Ticket

#1714   

## Description
Retirer l'écran " info complémentaires" du parcours du signalement, il ne doit être accessible que depuis le récapitulatif

## Changements apportés
* Changement des actions suivant/et précédent de 2 écrans dans les json concernés
* Modification du composant SignalementFormOverview pour lier cette partie de récap au bon écran, mais seulement pour les profils occupants

## Pré-requis

## Tests
- [ ] Faire un signalement en tant qu'occupant, et vérifier qu'on ne passe plus sur la partie "Infos complémentaires", mais qu'on peut y accéder par un bouton "éditer" dans le récapitulatif
- [ ] Faire un signalement en tant que tiers, vérifier qu'on ne passe pas par cette partie "Infos complémentaires" et qu'on n'y a pas accès dans le récaptiulatif
