### PR TITLE
[QA] Ne pas passer null lors de la manipulation de l'étage

### DIFF
--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -28,6 +28,7 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
         $signalement = $affectation->getSignalement();
         $partner = $affectation->getPartner();
         $address = AddressParser::parse($signalement->getAdresseOccupant());
+        $etage = $signalement->getEtageOccupant() ? EtageParser::parse($signalement->getEtageOccupant()) : null;
 
         return (new DossierMessageSCHS())
             ->setUrl($partner->getEsaboraUrl())
@@ -42,7 +43,7 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
             ->setAdresseSignalement($address['street'])
             ->setCodepostaleSignalement($signalement->getCpOccupant())
             ->setVilleSignalement($signalement->getVilleOccupant())
-            ->setEtageSignalement(EtageParser::parse($signalement->getEtageOccupant()))
+            ->setEtageSignalement($etage)
             ->setNumeroAppartementSignalement($signalement->getNumAppartOccupant())
             ->setNumeroAdresseSignalement($address['number'])
             ->setLatitudeSignalement($signalement->getGeoloc()['lat'] ?? 0)

--- a/src/Factory/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Esabora/DossierMessageSISHFactory.php
@@ -63,6 +63,8 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ? implode(',', $signalement->getModeContactProprio())
             : null;
 
+        $etage = $signalement->getEtageOccupant() ? EtageParser::parse($signalement->getEtageOccupant()) : null;
+
         return (new DossierMessageSISH())
             ->setUrl($partner->getEsaboraUrl())
             ->setToken($partner->getEsaboraToken())
@@ -86,7 +88,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
                     ?->setTimezone(new \DateTimeZone(self::DEFAULT_TIMEZONE))
                     ->format($formatDateTime)
             )
-            ->setLocalisationEtage(EtageParser::parse($signalement->getEtageOccupant()))
+            ->setLocalisationEtage($etage)
             ->setLocalisationEscalier($signalement->getEscalierOccupant())
             ->setLocalisationNumPorte($signalement->getNumAppartOccupant())
             ->setSitOccupantNbAdultes($signalement->getNbAdultes())

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -595,7 +595,7 @@ class SignalementType extends AbstractType
                 function ($currentEtage): ?int {
                     return $currentEtage ? EtageParser::parse($currentEtage) : null;
                 },
-                function ($updtatedEtage): string {
+                function ($updtatedEtage): ?string {
                     return $updtatedEtage;
                 }
             ));

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -593,7 +593,7 @@ class SignalementType extends AbstractType
         $builder->get('etageOccupant')
             ->addModelTransformer(new CallbackTransformer(
                 function ($currentEtage): ?int {
-                    return EtageParser::parse($currentEtage);
+                    return $currentEtage ? EtageParser::parse($currentEtage) : null;
                 },
                 function ($updtatedEtage): string {
                     return $updtatedEtage;

--- a/src/Utils/EtageParser.php
+++ b/src/Utils/EtageParser.php
@@ -4,7 +4,7 @@ namespace App\Utils;
 
 class EtageParser
 {
-    public static function parse(?string $etage): ?int
+    public static function parse(string $etage): ?int
     {
         if (preg_match('/(rez|rdc|rdj|rh|chauss)/i', $etage, $matches)) {
             return 0;

--- a/tests/Unit/Utils/EtageParserTest.php
+++ b/tests/Unit/Utils/EtageParserTest.php
@@ -48,6 +48,5 @@ class EtageParserTest extends TestCase
 
         yield 'Dernière maison à gauche' => ['Dernière maison à gauche', null];
 
-        yield 'null' => [null, null];
     }
 }

--- a/tests/Unit/Utils/EtageParserTest.php
+++ b/tests/Unit/Utils/EtageParserTest.php
@@ -47,6 +47,5 @@ class EtageParserTest extends TestCase
         yield '4ème étage - entrée 1' => ['4ème étage - entrée 1', 4];
 
         yield 'Dernière maison à gauche' => ['Dernière maison à gauche', null];
-
     }
 }


### PR DESCRIPTION
## Ticket

#1743    

## Description
Suite à de nombreux événements sentry

## Changements apportés
* Appeler EtageParser uniquement pour les valeurs non null

## Pré-requis
```
$ make worker-start
$ make mock
```

## Tests
- [ ] Editer un signalement qui n'a pas d'étage renseigné  
- [ ] Editer un signalement qui a un étage renseigné
- [ ] Affecter le signalement 2023-12 au partenaire SCHS et SISH et vérfier que l'étage parsé est bien envoyé en vérifiant la colonne message de la table job_event
