### PR TITLE
[Front] Compléter SignalementFormOverview avec données dynamiques

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -2,8 +2,8 @@
   <div :id="id" class="signalement-form-disorder-overview fr-container--fluid fr-my-3v">
     <div v-if="formStore.data.categorieDisorders.batiment.length > 0">
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-2"><img :src="icons ? icons[0].src : ''" :alt="icons ? icons[0].alt : ''"></div>
-        <div class="fr-col-10 fr-h2">Le bâtiment</div>
+        <div class="fr-col-2 fr-col-md-1"><img :src="icons ? icons[0].src : ''" :alt="icons ? icons[0].alt : ''" class="fr-disorder-overview-image"></div>
+        <div class="fr-col-10 fr-col-md-11 fr-h2 fr-disorder-overview-title">Le bâtiment</div>
       </div>
       <div class="fr-accordions-group">
         <section
@@ -32,8 +32,8 @@
     </div>
     <div v-if="formStore.data.categorieDisorders.logement.length > 0">
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-2"><img :src="icons ? icons[1].src : ''" :alt="icons ? icons[1].alt : ''"></div>
-        <div class="fr-col-10 fr-h2">Le logement</div>
+        <div class="fr-col-2 fr-col-md-1"><img :src="icons ? icons[1].src : ''" :alt="icons ? icons[1].alt : ''" class="fr-disorder-overview-image"></div>
+        <div class="fr-col-10 fr-col-md-11 fr-h2 fr-disorder-overview-title">Le logement</div>
       </div>
       <div class="fr-accordions-group">
         <section
@@ -183,5 +183,11 @@ export default defineComponent({
 }
 .italic-text {
     font-style: italic;
+}
+.fr-disorder-overview-title {
+  margin: 0;
+}
+.fr-disorder-overview-image {
+  width: 60px;
 }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -4,125 +4,179 @@
       <br>
       <h2 class="fr-h4">Récapitulatif</h2>
 
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6">Adresse du logement</h3>
+      <!-- ADRESSE DU LOGEMENT -->
+      <div>
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">Adresse du logement</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('adresse_logement')">Editer</a>
+          </div>
         </div>
-        <div class="fr-col-4 fr-text--right">
-          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('adresse_logement')">Editer</a>
-        </div>
-      </div>
-      <p v-html="getFormDataAdresse()"></p>
-
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6">Vos coordonnées</h3>
-        </div>
-        <div class="fr-col-4 fr-text--right">
-          <a v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" href="#" @click="handleEdit('vos_coordonnees_occupant')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
-          <a v-else href="#" @click="handleEdit('vos_coordonnees_tiers')"  class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
-        </div>
-      </div>
-      <p v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" v-html="getFormDataCoordonneesOccupant()"></p>
-      <p v-else v-html="getFormDataCoordonneesDeclarant()"></p>
-
-      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'bailleur'" class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6">Les coordonnées du bailleur</h3>
-        </div>
-        <div class="fr-col-4 fr-text--right">
-          <a href="#" @click="handleEdit('coordonnees_bailleur')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
-        </div>
-      </div>
-      <p v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'bailleur'" v-html="getFormDataCoordonneesBailleur()"></p>
-
-      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire' && formStore.data.profil !== 'service_secours'" class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6">Les coordonnées du foyer</h3>
-        </div>
-        <div class="fr-col-4 fr-text--right">
-          <a href="#" @click="handleEdit('coordonnees_occupant')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
-        </div>
-      </div>
-      <p v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire' && formStore.data.profil !== 'service_secours'" v-html="getFormDataCoordonneesOccupant()"></p>
-
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6">Type et composition du logement</h3>
-        </div>
-        <div class="fr-col-4 fr-text--right">
-          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_type_composition')">Editer</a>
-        </div>
-      </div>
-      <section class="fr-accordion fr-mb-3w">
-        <h3 class="fr-accordion__title">
-          <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-type-composition">Afficher les informations</button>
-        </h3>
-        <div class="fr-collapse" id="accordion-type-composition">
-          <p v-html="getFormDataTypeComposition()"></p>
-        </div>
-      </section>
-
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6" v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">Votre situation</h3>
-          <h3 class="fr-h6" v-else>La situation du foyer</h3>
-        </div>
-        <div class="fr-col-4 fr-text--right">
-          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_situation_occupant')">Editer</a>
-        </div>
-      </div>
-      <section class="fr-accordion fr-mb-3w">
-        <h3 class="fr-accordion__title">
-          <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-situation-occupant">Afficher les informations</button>
-        </h3>
-        <div class="fr-collapse" id="accordion-situation-occupant">
-          <p v-html="getFormDataSituationOccupant()"></p>
-        </div>
-      </section>
-
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6">Les désordres</h3>
-        </div>
-        <div class="fr-col-4 fr-text--right">
-          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_les_desordres')">Editer</a>
-        </div>
-      </div>
-      <SignalementFormDisorderOverview
-        :id="idDisorderOverview"
-        :icons="disorderIcons"
-        />
-
-      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.data.profil === 'bailleur'" class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
-        <div class="fr-col-8">
-          <h3 class="fr-h6">La procédure</h3>
-        </div>
-        <div class="fr-col-4 fr-text--right">
-          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('info_procedure')">Editer</a>
-        </div>
-      </div>
-      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.data.profil === 'bailleur'" class="fr-collapse" id="accordion-procedure">
-        <p v-html="getFormDataProcedure()"></p>
+        <p v-html="getFormDataAdresse()"></p>
       </div>
 
+      <!-- VOS COORDONNES SI OCCUPANT -->
       <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">
-        <h2 class="fr-h4">Informations complémentaires</h2>
-
-        <p>
-          Plus nous avons d'informations sur la situation,
-          mieux nous pouvons vous accompagner.
-          Cliquez sur le bouton pour ajouter des informations.
-        </p>
-        <button
-          type="button"
-          class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line"
-          @click="handleEdit('informations_complementaires')"
-          >
-          Ajouter des informations
-        </button>
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">Vos coordonnées</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" @click="handleEdit('vos_coordonnees_occupant')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+          </div>
+        </div>
+        <p v-html="getFormDataCoordonneesOccupant()"></p>
       </div>
 
+      <!-- VOS COORDONNEES SI TIERS -->
+      <div v-else>
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">Vos coordonnées</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" @click="handleEdit('vos_coordonnees_tiers')"  class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+          </div>
+        </div>
+        <p v-html="getFormDataCoordonneesDeclarant()"></p>
+      </div>
+
+      <!-- LES COORDONNEES DU BAILLEUR -->
+      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'bailleur'">
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">Les coordonnées du bailleur</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" @click="handleEdit('coordonnees_bailleur')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+          </div>
+        </div>
+        <p v-html="getFormDataCoordonneesBailleur()"></p>
+      </div>
+
+      <!-- LES COORDONNEES DU FOYER -->
+      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire' && formStore.data.profil !== 'service_secours'">
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">Les coordonnées du foyer</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" @click="handleEdit('coordonnees_occupant')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+          </div>
+        </div>
+        <p v-html="getFormDataCoordonneesOccupantSiTiers()"></p>
+      </div>
+
+      <!-- TYPE ET COMPOSITION DU LOGEMENT -->
+      <div>
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">Type et composition du logement</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_type_composition')">Editer</a>
+          </div>
+        </div>
+        <section class="fr-accordion fr-mb-3w">
+          <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-type-composition">Afficher les informations</button>
+          </h3>
+          <div class="fr-collapse" id="accordion-type-composition">
+            <p v-html="getFormDataTypeComposition()"></p>
+          </div>
+        </section>
+      </div>
+
+      <!-- SITUATION OCCUPANT -->
+      <div>
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6" v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">Votre situation</h3>
+            <h3 class="fr-h6" v-else>La situation du foyer</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_situation_occupant')">Editer</a>
+          </div>
+        </div>
+        <section class="fr-accordion fr-mb-3w">
+          <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-situation-occupant">Afficher les informations</button>
+          </h3>
+          <div class="fr-collapse" id="accordion-situation-occupant">
+            <p v-html="getFormDataSituationOccupant()"></p>
+          </div>
+        </section>
+      </div>
+
+      <!-- LES DESORDRES -->
+      <div>
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">Les désordres</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_les_desordres')">Editer</a>
+          </div>
+        </div>
+        <SignalementFormDisorderOverview
+          :id="idDisorderOverview"
+          :icons="disorderIcons"
+          />
+      </div>
+
+      <!-- LA PROCEDURE  -->
+      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.data.profil === 'bailleur'">
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+          <div class="fr-col-8">
+            <h3 class="fr-h6">La procédure</h3>
+          </div>
+          <div class="fr-col-4 fr-text--right">
+            <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('info_procedure')">Editer</a>
+          </div>
+        </div>
+        <section class="fr-accordion fr-mb-3w">
+          <h3 class="fr-accordion__title">
+            <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-procedure">Afficher les informations</button>
+          </h3>
+          <div class="fr-collapse" id="accordion-procedure">
+            <p v-html="getFormDataProcedure()"></p>
+          </div>
+        </section>
+      </div>
+
+      <!-- INFORMATIONS COMPLEMENTAIRES  -->
+      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">
+        <div v-if="hasInformationsComplementaires()">
+          <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+            <div class="fr-col-8">
+              <h2 class="fr-h4">Informations complémentaires</h2>
+            </div>
+            <div class="fr-col-4 fr-text--right">
+              <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('informations_complementaires')">Editer</a>
+            </div>
+          </div>
+          <p v-html="getFormDataInformationsComplementaires()"></p>
+        </div>
+        <div v-else>
+          <h2 class="fr-h4">Informations complémentaires</h2>
+          <p>
+            Plus nous avons d'informations sur la situation,
+            mieux nous pouvons vous accompagner.
+            Cliquez sur le bouton pour ajouter des informations.
+          </p>
+          <button
+            type="button"
+            class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line"
+            @click="handleEdit('informations_complementaires')"
+            >
+            Ajouter des informations
+          </button>
+        </div>
+      </div>
+
+      <!-- MESSAGE A L'ADMINISTRATION -->
       <br>
       <h2 class="fr-h4">Message à l'administration (facultatif)</h2>
       <p>Ce message sera joint à votre signalement.</p>
@@ -138,8 +192,10 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import formStore from './../store'
+import dictionaryStore from './../dictionary-store'
 import SignalementFormDisorderOverview from './SignalementFormDisorderOverview.vue'
 import SignalementFormTextarea from './SignalementFormTextarea.vue'
+import { dictionaryManager } from './../services/dictionaryManager'
 
 export default defineComponent({
   name: 'SignalementFormOverview',
@@ -154,6 +210,7 @@ export default defineComponent({
   data () {
     return {
       formStore,
+      dictionaryStore,
       idDisorderOverview: this.id + '_disorder_overview',
       idMessageAdministration: this.id + '_message_administration',
       disorderIcons: [{ src: '/img/form/BATIMENT/Picto-batiment.svg', alt: '' }, { src: '/img/form/LOGEMENT/Picto-logement.svg', alt: '' }]
@@ -163,18 +220,10 @@ export default defineComponent({
     getFormDataAdresse (): string {
       let result = ''
       result += this.formStore.data.adresse_logement_adresse + '<br>'
-      if (this.isFormDataSet('adresse_logement_complement_adresse_etage')) {
-        result += 'Etage : ' + this.formStore.data.adresse_logement_complement_adresse_etage + '<br>'
-      }
-      if (this.isFormDataSet('adresse_logement_complement_adresse_escalier')) {
-        result += 'Escalier : ' + this.formStore.data.adresse_logement_complement_adresse_escalier + '<br>'
-      }
-      if (this.isFormDataSet('adresse_logement_complement_adresse_numero_appartement')) {
-        result += 'Numéro d\'appartement : ' + this.formStore.data.adresse_logement_complement_adresse_numero_appartement + '<br>'
-      }
-      if (this.isFormDataSet('adresse_logement_complement_adresse_autre')) {
-        result += 'Autre : ' + this.formStore.data.adresse_logement_complement_adresse_autre
-      }
+      result += this.addLineIfNeeded('adresse_logement_complement_adresse_etage', 'Etage : ')
+      result += this.addLineIfNeeded('adresse_logement_complement_adresse_escalier', 'Escalier : ')
+      result += this.addLineIfNeeded('adresse_logement_complement_adresse_numero_appartement', 'Numéro d\'appartement : ')
+      result += this.addLineIfNeeded('adresse_logement_complement_adresse_autre', 'Autre : ')
       return result
     },
     getFormDataCoordonneesOccupant (): string {
@@ -182,17 +231,31 @@ export default defineComponent({
       result += this.formStore.data.vos_coordonnees_occupant_civilite + ' '
       result += this.formStore.data.vos_coordonnees_occupant_prenom + ' '
       result += this.formStore.data.vos_coordonnees_occupant_nom + '<br>'
-      result += this.formStore.data.vos_coordonnees_occupant_email + '<br>'
-      result += this.formStore.data.vos_coordonnees_occupant_tel
+      result += this.addLineIfNeeded('vos_coordonnees_occupant_email', 'Adresse email : ')
+      result += this.addLineIfNeeded('vos_coordonnees_occupant_tel', 'Numéro de téléphone : ')
+      return result
+    },
+    getFormDataCoordonneesOccupantSiTiers (): string {
+      let result = ''
+      if (this.isFormDataSet('coordonnees_occupant_prenom')) {
+        result += this.formStore.data.coordonnees_occupant_prenom + ' '
+      }
+      if (this.isFormDataSet('coordonnees_occupant_nom')) {
+        result += this.formStore.data.coordonnees_occupant_nom + '<br>'
+      }
+      result += this.addLineIfNeeded('coordonnees_occupant_email', 'Adresse email : ')
+      result += this.addLineIfNeeded('coordonnees_occupant_tel', 'Numéro de téléphone : ')
       return result
     },
     getFormDataCoordonneesDeclarant (): string {
       let result = ''
-      result += this.formStore.data.coordonnees_occupant_civilite + ' '
-      result += this.formStore.data.coordonnees_occupant_prenom + ' '
-      result += this.formStore.data.coordonnees_occupant_nom + '<br>'
-      result += this.formStore.data.coordonnees_occupant_email + '<br>'
-      result += this.formStore.data.coordonnees_occupant_tel
+      result += this.addLineIfNeeded('vos_coordonnees_tiers_nom_organisme')
+      result += this.formStore.data.vos_coordonnees_tiers_prenom + ' '
+      result += this.formStore.data.vos_coordonnees_tiers_nom + '<br>'
+      result += this.addLineIfNeeded('vos_coordonnees_tiers_lien', 'Lien avec l\'occupant : ')
+      result += this.addLineIfNeeded('vos_coordonnees_tiers_email', 'Adresse email : ')
+      result += this.addLineIfNeeded('vos_coordonnees_tiers_tel', 'Numéro de téléphone : ')
+      result += this.addLineIfNeeded('vos_coordonnees_tiers_tel_secondaire', 'Numéro de téléphone secondaire : ')
       return result
     },
     getFormDataCoordonneesBailleur (): string {
@@ -201,60 +264,101 @@ export default defineComponent({
         result += this.formStore.data.coordonnees_bailleur_prenom + ' '
       }
       result += this.formStore.data.coordonnees_bailleur_nom
+      result += this.addLineIfNeeded('coordonnees_bailleur_email', 'Adresse email : ')
+      result += this.addLineIfNeeded('coordonnees_bailleur_tel', 'Numéro de téléphone : ')
+      result += this.addLineIfNeeded('coordonnees_bailleur_tel_secondaire', 'Numéro de téléphone secondaire : ')
+      result += this.addLineIfNeeded('coordonnees_bailleur_adresse', 'Adresse: ')
       return result
     },
     getFormDataTypeComposition (): string {
       let result = ''
-      result += 'Nature du logement : ' + this.formStore.data.type_logement_nature + '<br>'
+      result += this.addLineIfNeeded('type_logement_nature', 'Nature du logement  : ')
       if (this.formStore.data.type_logement_nature === 'appartement') {
-        result += 'Au RDC ? ' + this.formStore.data.type_logement_rdc + '<br>'
+        result += this.addLineIfNeeded('type_logement_rdc', 'Au RDC ? ')
         if (this.formStore.data.type_logement_rdc === 'non') {
-          result += 'Au dernier étage ? ' + this.formStore.data.type_logement_dernier_etage + '<br>'
+          result += this.addLineIfNeeded('type_logement_dernier_etage', 'Au dernier étage ? ')
           if (this.formStore.data.type_logement_dernier_etage === 'oui') {
-            result += 'Sous les combles et sans fenêtre ? ' + this.formStore.data.type_logement_sous_comble_sans_fenetre + '<br>'
+            result += this.addLineIfNeeded('type_logement_sous_comble_sans_fenetre', 'Sous les combles et sans fenêtre ? ')
           }
           if (this.formStore.data.type_logement_dernier_etage === 'non') {
-            result += 'En sous-sol et sans fenêtre ? ' + this.formStore.data.type_logement_sous_sol_sans_fenetre + '<br>'
+            result += this.addLineIfNeeded('type_logement_sous_sol_sans_fenetre', 'En sous-sol et sans fenêtre ? ')
           }
         }
       }
-      result += 'Une seule ou plusieurs pièces ? ' + this.formStore.data.composition_logement_piece_unique + '<br>'
+      result += this.addLineIfNeeded('composition_logement_piece_unique', 'Une seule ou plusieurs pièces ? ')
       if (this.formStore.data.composition_logement_piece_unique === 'plusieurs_pieces') {
-        result += 'Nombre de pièces à vivre : ' + this.formStore.data.composition_logement_nb_pieces + '<br>'
+        result += this.addLineIfNeeded('composition_logement_nb_pieces', 'Nombre de pièces à vivre : ')
       }
-      result += 'Superficie en m² : ' + this.formStore.data.composition_logement_superficie + '<br>'
-      result += 'Nombre de personnes : ' + this.formStore.data.composition_logement_nombre_personnes + '<br>'
-      result += 'Enfants de moins de 6 ans ? ' + this.formStore.data.composition_logement_enfants + '<br>'
+      result += this.addLineIfNeeded('composition_logement_superficie', 'Superficie en m² : ')
+      result += this.addLineIfNeeded('composition_logement_nombre_personnes', 'Nombre de personnes : ')
+      result += this.addLineIfNeeded('composition_logement_enfants', 'Enfants de moins de 6 ans ? ')
       return result
     },
     getFormDataSituationOccupant (): string {
       let result = ''
-      result += 'Demande de relogement ? ' + this.formStore.data.logement_social_demande_relogement + '<br>'
-      result += 'Aide ou allocation ? ' + this.formStore.data.logement_social_allocation + '<br>'
+      result += this.addLineIfNeeded('logement_social_demande_relogement', 'Demande de relogement ? ')
+      result += this.addLineIfNeeded('logement_social_allocation', 'Aide ou allocation ? ', 'overview')// utilisation d'un contexte de traduction
       if (this.formStore.data.logement_social_allocation === 'oui') {
-        result += 'Caisse : ' + this.formStore.data.logement_social_allocation_caisse + '<br>'
-        result += 'Date de naissance : ' + this.formStore.data.logement_social_date_naissance + '<br>'
-        result += 'Numéro allocataire : ' + this.formStore.data.logement_social_numero_allocataire + '<br>'
-        result += 'Montant allocation : ' + this.formStore.data.logement_social_allocation + '€<br>'
+        result += this.addLineIfNeeded('logement_social_allocation_caisse', 'Caisse : ')
+        result += this.addLineIfNeeded('logement_social_date_naissance', 'Date de naissance : ')
+        result += this.addLineIfNeeded('logement_social_numero_allocataire', 'Numéro allocataire : ')
+        result += this.addLineIfNeeded('logement_social_montant_allocation', 'Montant allocation : ', undefined, ' €') // TOTO monrant en €
+        // result += 'Montant allocation : ' + this.formStore.data.logement_social_montant_allocation + '€<br>'
       }
       return result
     },
     getFormDataProcedure (): string {
       let result = ''
-      if (this.isFormDataSet('info_procedure_bailleur_prevenu')) {
-        result += 'Bailleur (propriétaire) prévenu ? ' + this.formStore.data.info_procedure_bailleur_prevenu + '<br>'
-      }
-      result += 'Assurance contactée ? ' + this.formStore.data.info_procedure_assurance_contactee + '<br>'
+      result += this.addLineIfNeeded('info_procedure_bailleur_prevenu', 'Bailleur (propriétaire) prévenu ? ')
+      result += this.addLineIfNeeded('info_procedure_assurance_contactee', 'Assurance contactée ? ')
       if (this.formStore.data.info_procedure_assurance_contactee === 'oui') {
-        result += 'Réponse de l\'assurance ' + this.formStore.data.info_procedure_reponse_assurance + '<br>'
+        result += this.addLineIfNeeded('info_procedure_reponse_assurance', 'Réponse de l\'assurance : ')
       }
-      if (this.isFormDataSet('info_procedure_depart_apres_travaux')) {
-        result += 'Si des travaux sont faits, voulez-vous rester dans le logement  ' + this.formStore.data.info_procedure_depart_apres_travaux + '<br>'
+      result += this.addLineIfNeeded('info_procedure_depart_apres_travaux', 'Si des travaux sont faits, voulez-vous rester dans le logement ? ')
+      return result
+    },
+    getFormDataInformationsComplementaires (): string {
+      let result = ''
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_beneficiaire_rsa', 'Bénéficiaire RSA : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_beneficiaire_fsl', 'Bénéficiaire FSL : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_revenu_fiscal', 'Revenu fiscal de référence : ', undefined, ' €')
+      result += this.addLineIfNeeded('informations_complementaires_logement_montant_loyer', 'Montant du loyer sans les charges : ', undefined, ' €')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_date_naissance', 'Date de naissance : ')
+      result += this.addLineIfNeeded('informations_complementaires_logement_nombre_etages', 'Nombre d\'étages du logement : ')
+      result += this.addLineIfNeeded('informations_complementaires_logement_annee_construction', 'Année de construction du logement : ')
+      return result
+    },
+    hasInformationsComplementaires (): boolean {
+      let result = false
+      if (this.isFormDataSet('informations_complementaires_situation_occupants_beneficiaire_rsa') ||
+          this.isFormDataSet('informations_complementaires_situation_occupants_beneficiaire_fsl') ||
+          this.isFormDataSet('informations_complementaires_situation_occupants_revenu_fiscal') ||
+          this.isFormDataSet('informations_complementaires_logement_montant_loyer') ||
+          this.isFormDataSet('informations_complementaires_situation_occupants_date_naissance') ||
+          this.isFormDataSet('informations_complementaires_logement_nombre_etages') ||
+          this.isFormDataSet('informations_complementaires_logement_annee_construction')) {
+        result = true
       }
       return result
     },
     isFormDataSet (formSlug: string) {
-      return (this.formStore.data[formSlug] !== '' && this.formStore.data[formSlug] !== undefined)
+      return (this.formStore.data[formSlug] !== '' && this.formStore.data[formSlug] !== undefined && this.formStore.data[formSlug] !== null)
+    },
+    addLineIfNeeded (formSlug: string, questionTitle?: string, dictionaryContext ?: string, suffixe?: string): string {
+      let result = ''
+      if (this.isFormDataSet(formSlug)) {
+        if (dictionaryContext !== null && dictionaryContext !== undefined) {
+          result += dictionaryManager.translate(formSlug, dictionaryContext)
+        } else if (questionTitle !== null && questionTitle !== undefined) {
+          result += questionTitle
+        }
+        result += dictionaryManager.translate(this.formStore.data[formSlug], 'default')
+        if (suffixe !== null && suffixe !== undefined) {
+          result += suffixe
+        }
+        result += '<br>'
+      }
+      return result
     },
     handleEdit (screenSlug: string) {
       if (this.clickEvent !== undefined) {

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -285,11 +285,36 @@ export default defineComponent({
           }
         }
       }
+      result += this.addLineIfNeeded('composition_logement_superficie', 'Superficie en m² : ')
       result += this.addLineIfNeeded('composition_logement_piece_unique', 'Une seule ou plusieurs pièces ? ')
       if (this.formStore.data.composition_logement_piece_unique === 'plusieurs_pieces') {
         result += this.addLineIfNeeded('composition_logement_nb_pieces', 'Nombre de pièces à vivre : ')
       }
-      result += this.addLineIfNeeded('composition_logement_superficie', 'Superficie en m² : ')
+      for (let i = 1; i <= this.formStore.data.composition_logement_nb_pieces; i++) {
+        result += this.addLineIfNeeded('type_logement_pieces_a_vivre_superficie_piece_' + i, 'Superficie de la pièce ' + i + ' : ')
+        result += this.addLineIfNeeded('type_logement_pieces_a_vivre_hauteur_piece_' + i, 'Hauteur de la pièce ' + i + ' : ')
+      }
+      result += this.addLineIfNeeded('type_logement_commodites_cuisine', 'Cuisine ou coin cuisine ? ')
+      if (this.formStore.data.type_logement_commodites_cuisine === 'non') {
+        result += this.addLineIfNeeded('type_logement_commodites_cuisine_collective', 'Accès à une cuisine collective ? ')
+      } else {
+        result += this.addLineIfNeeded('type_logement_commodites_cuisine_hauteur_plafond', 'La hauteur jusqu\'au plafond est de 2m (200cm) ou plus ? ')
+      }
+      result += this.addLineIfNeeded('type_logement_commodites_salle_de_bain', 'Salle de bain, salle d\'eau avec douche ou baignoire ? ')
+      if (this.formStore.data.type_logement_commodites_salle_de_bain === 'non') {
+        result += this.addLineIfNeeded('type_logement_commodites_salle_de_bain_collective', 'Accès à une salle de bain ou des douches collectives ? ')
+      } else {
+        result += this.addLineIfNeeded('type_logement_commodites_salle_de_bain_hauteur_plafond', 'La hauteur jusqu\'au plafond est de 2m (200cm) ou plus ? ')
+      }
+      result += this.addLineIfNeeded('type_logement_commodites_wc', 'Toilettes (WC) ? ')
+      if (this.formStore.data.type_logement_commodites_wc === 'non') {
+        result += this.addLineIfNeeded('type_logement_commodites_wc_collective', 'Accès à des toilettes (WC) collectives ? ')
+      } else {
+        result += this.addLineIfNeeded('type_logement_commodites_wc_hauteur_plafond', 'La hauteur jusqu\'au plafond est de 2m (200cm) ou plus ? ')
+      }
+      if (this.formStore.data.type_logement_commodites_cuisine === 'oui' && this.formStore.data.type_logement_commodites_wc === 'oui') {
+        result += this.addLineIfNeeded('type_logement_commodites_wc_cuisine', 'Toilettes (WC) et cuisine dans la même pièce ? ')
+      }
       result += this.addLineIfNeeded('composition_logement_nombre_personnes', 'Nombre de personnes : ')
       result += this.addLineIfNeeded('composition_logement_enfants', 'Enfants de moins de 6 ans ? ')
       return result

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -183,8 +183,9 @@
       <SignalementFormTextarea
         :id="idMessageAdministration"
         description="Votre message ici"
+        @input="updateValue($event)"
+        :modelValue="formStore.data[idMessageAdministration]"
         />
-
     </div>
   </div>
 </template>
@@ -322,13 +323,12 @@ export default defineComponent({
     getFormDataSituationOccupant (): string {
       let result = ''
       result += this.addLineIfNeeded('logement_social_demande_relogement', 'Demande de relogement ? ')
-      result += this.addLineIfNeeded('logement_social_allocation', 'Aide ou allocation ? ', 'overview')// utilisation d'un contexte de traduction
+      result += this.addLineIfNeeded('logement_social_allocation', 'Aide ou allocation logement ? ')
       if (this.formStore.data.logement_social_allocation === 'oui') {
         result += this.addLineIfNeeded('logement_social_allocation_caisse', 'Caisse : ')
         result += this.addLineIfNeeded('logement_social_date_naissance', 'Date de naissance : ')
         result += this.addLineIfNeeded('logement_social_numero_allocataire', 'Numéro allocataire : ')
-        result += this.addLineIfNeeded('logement_social_montant_allocation', 'Montant allocation : ', undefined, ' €') // TOTO monrant en €
-        // result += 'Montant allocation : ' + this.formStore.data.logement_social_montant_allocation + '€<br>'
+        result += this.addLineIfNeeded('logement_social_montant_allocation', 'Montant allocation : ', ' €')
       }
       return result
     },
@@ -346,8 +346,8 @@ export default defineComponent({
       let result = ''
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_beneficiaire_rsa', 'Bénéficiaire RSA : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_beneficiaire_fsl', 'Bénéficiaire FSL : ')
-      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_revenu_fiscal', 'Revenu fiscal de référence : ', undefined, ' €')
-      result += this.addLineIfNeeded('informations_complementaires_logement_montant_loyer', 'Montant du loyer sans les charges : ', undefined, ' €')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_revenu_fiscal', 'Revenu fiscal de référence : ', ' €')
+      result += this.addLineIfNeeded('informations_complementaires_logement_montant_loyer', 'Montant du loyer sans les charges : ', ' €')
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_date_naissance', 'Date de naissance : ')
       result += this.addLineIfNeeded('informations_complementaires_logement_nombre_etages', 'Nombre d\'étages du logement : ')
       result += this.addLineIfNeeded('informations_complementaires_logement_annee_construction', 'Année de construction du logement : ')
@@ -369,12 +369,10 @@ export default defineComponent({
     isFormDataSet (formSlug: string) {
       return (this.formStore.data[formSlug] !== '' && this.formStore.data[formSlug] !== undefined && this.formStore.data[formSlug] !== null)
     },
-    addLineIfNeeded (formSlug: string, questionTitle?: string, dictionaryContext ?: string, suffixe?: string): string {
+    addLineIfNeeded (formSlug: string, questionTitle?: string, suffixe?: string): string {
       let result = ''
       if (this.isFormDataSet(formSlug)) {
-        if (dictionaryContext !== null && dictionaryContext !== undefined) {
-          result += dictionaryManager.translate(formSlug, dictionaryContext)
-        } else if (questionTitle !== null && questionTitle !== undefined) {
+        if (questionTitle !== null && questionTitle !== undefined) {
           result += questionTitle
         }
         result += dictionaryManager.translate(this.formStore.data[formSlug], 'default')
@@ -389,6 +387,10 @@ export default defineComponent({
       if (this.clickEvent !== undefined) {
         this.clickEvent('goto', screenSlug, '')
       }
+    },
+    updateValue (event: Event) {
+      const value = (event.target as HTMLInputElement).value
+      this.formStore.data[this.idMessageAdministration] = value
     }
   }
 })

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -292,7 +292,7 @@ export default defineComponent({
       }
       for (let i = 1; i <= this.formStore.data.composition_logement_nb_pieces; i++) {
         result += this.addLineIfNeeded('type_logement_pieces_a_vivre_superficie_piece_' + i, 'Superficie de la pièce ' + i + ' : ')
-        result += this.addLineIfNeeded('type_logement_pieces_a_vivre_hauteur_piece_' + i, 'Hauteur de la pièce ' + i + ' : ')
+        result += this.addLineIfNeeded('type_logement_pieces_a_vivre_hauteur_piece_' + i, 'La hauteur jusqu\'au plafond de la pièce ' + i + ' est de 2,20m (220cm) ou plus ? ')
       }
       result += this.addLineIfNeeded('type_logement_commodites_cuisine', 'Cuisine ou coin cuisine ? ')
       if (this.formStore.data.type_logement_commodites_cuisine === 'non') {

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -1,47 +1,56 @@
 <template>
   <div :id="id">
     <div>
-      <h2>Récapitulatif</h2>
+      <br>
+      <h2 class="fr-h4">Récapitulatif</h2>
 
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-md-8">
-          <h3>Adresse du logement</h3>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6">Adresse du logement</h3>
         </div>
-        <div class="fr-col-12 fr-col-md-4">
+        <div class="fr-col-4 fr-text--right">
           <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('adresse_logement')">Editer</a>
         </div>
       </div>
       <p v-html="getFormDataAdresse()"></p>
 
-      <!-- TODO : changer intitulés ? -->
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-md-8">
-          <h3>Vos coordonnées</h3>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6">Vos coordonnées</h3>
         </div>
-        <div class="fr-col-12 fr-col-md-4">
+        <div class="fr-col-4 fr-text--right">
           <a v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" href="#" @click="handleEdit('vos_coordonnees_occupant')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
           <a v-else href="#" @click="handleEdit('vos_coordonnees_tiers')"  class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
         </div>
       </div>
-      <p v-html="getFormDataCoordonneesOccupant()"></p>
+      <p v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" v-html="getFormDataCoordonneesOccupant()"></p>
+      <p v-else v-html="getFormDataCoordonneesDeclarant()"></p>
 
-      <!-- TODO : si profil est bailleur ou bailleur_occupant que met-on ? -->
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-md-8">
-          <h3>Les coordonnées du bailleur</h3>
+      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'bailleur'" class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6">Les coordonnées du bailleur</h3>
         </div>
-        <div class="fr-col-12 fr-col-md-4">
-          <a v-if="formStore.data.profil !== 'bailleur_occupant'" href="#" @click="handleEdit('coordonnees_bailleur')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
-          <a v-else href="#" @click="handleEdit('vos_coordonnees_tiers')"  class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+        <div class="fr-col-4 fr-text--right">
+          <a href="#" @click="handleEdit('coordonnees_bailleur')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
         </div>
       </div>
-      <p v-html="getFormDataCoordonneesBailleur()"></p>
+      <p v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'bailleur'" v-html="getFormDataCoordonneesBailleur()"></p>
 
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-md-8">
-          <h3>Type et composition du logement</h3>
+      <div v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire' && formStore.data.profil !== 'service_secours'" class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6">Les coordonnées du foyer</h3>
         </div>
-        <div class="fr-col-12 fr-col-md-4">
+        <div class="fr-col-4 fr-text--right">
+          <a href="#" @click="handleEdit('coordonnees_occupant')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+        </div>
+      </div>
+      <p v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire' && formStore.data.profil !== 'service_secours'" v-html="getFormDataCoordonneesOccupant()"></p>
+
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6">Type et composition du logement</h3>
+        </div>
+        <div class="fr-col-4 fr-text--right">
           <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_type_composition')">Editer</a>
         </div>
       </div>
@@ -54,12 +63,12 @@
         </div>
       </section>
 
-      <!-- TODO quels profils, quel intitulé -->
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-md-8">
-          <h3>Votre situation</h3>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6" v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">Votre situation</h3>
+          <h3 class="fr-h6" v-else>La situation du foyer</h3>
         </div>
-        <div class="fr-col-12 fr-col-md-4">
+        <div class="fr-col-4 fr-text--right">
           <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_situation_occupant')">Editer</a>
         </div>
       </div>
@@ -72,11 +81,11 @@
         </div>
       </section>
 
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-md-8">
-          <h3>Les désordres</h3>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6">Les désordres</h3>
         </div>
-        <div class="fr-col-12 fr-col-md-4">
+        <div class="fr-col-4 fr-text--right">
           <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_les_desordres')">Editer</a>
         </div>
       </div>
@@ -85,20 +94,20 @@
         :icons="disorderIcons"
         />
 
-      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-md-8">
-          <h3>TODO : La procédure</h3>
+      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.data.profil === 'bailleur'" class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+        <div class="fr-col-8">
+          <h3 class="fr-h6">La procédure</h3>
         </div>
-        <div class="fr-col-12 fr-col-md-4">
+        <div class="fr-col-4 fr-text--right">
           <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('info_procedure')">Editer</a>
         </div>
       </div>
-        <div class="fr-collapse" id="accordion-procedure">
-          <p v-html="getFormDataProcedure()"></p>
-        </div>
+      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.data.profil === 'bailleur'" class="fr-collapse" id="accordion-procedure">
+        <p v-html="getFormDataProcedure()"></p>
+      </div>
 
       <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">
-        <h2>Informations complémentaires</h2>
+        <h2 class="fr-h4">Informations complémentaires</h2>
 
         <p>
           Plus nous avons d'informations sur la situation,
@@ -114,11 +123,13 @@
         </button>
       </div>
 
-      <h2>Message à l'administration (facultatif)</h2>
+      <br>
+      <h2 class="fr-h4">Message à l'administration (facultatif)</h2>
       <p>Ce message sera joint à votre signalement.</p>
-      <textarea placeholder="Votre message ici"></textarea>
-      <!-- <SignalementFormTextarea></SignalementFormTextarea> -->
-      <!-- TODO utiliser composant SignalementFormTextarea -->
+      <SignalementFormTextarea
+        :id="idMessageAdministration"
+        description="Votre message ici"
+        />
 
     </div>
   </div>
@@ -128,11 +139,13 @@
 import { defineComponent } from 'vue'
 import formStore from './../store'
 import SignalementFormDisorderOverview from './SignalementFormDisorderOverview.vue'
+import SignalementFormTextarea from './SignalementFormTextarea.vue'
 
 export default defineComponent({
   name: 'SignalementFormOverview',
   components: {
-    SignalementFormDisorderOverview
+    SignalementFormDisorderOverview,
+    SignalementFormTextarea
   },
   props: {
     id: { type: String, default: null },
@@ -142,6 +155,7 @@ export default defineComponent({
     return {
       formStore,
       idDisorderOverview: this.id + '_disorder_overview',
+      idMessageAdministration: this.id + '_message_administration',
       disorderIcons: [{ src: '/img/form/BATIMENT/Picto-batiment.svg', alt: '' }, { src: '/img/form/LOGEMENT/Picto-logement.svg', alt: '' }]
     }
   },
@@ -170,6 +184,15 @@ export default defineComponent({
       result += this.formStore.data.vos_coordonnees_occupant_nom + '<br>'
       result += this.formStore.data.vos_coordonnees_occupant_email + '<br>'
       result += this.formStore.data.vos_coordonnees_occupant_tel
+      return result
+    },
+    getFormDataCoordonneesDeclarant (): string {
+      let result = ''
+      result += this.formStore.data.coordonnees_occupant_civilite + ' '
+      result += this.formStore.data.coordonnees_occupant_prenom + ' '
+      result += this.formStore.data.coordonnees_occupant_nom + '<br>'
+      result += this.formStore.data.coordonnees_occupant_email + '<br>'
+      result += this.formStore.data.coordonnees_occupant_tel
       return result
     },
     getFormDataCoordonneesBailleur (): string {
@@ -218,12 +241,16 @@ export default defineComponent({
     },
     getFormDataProcedure (): string {
       let result = ''
-      // TODO : conditionner en fonction des réponses et profils
-      result += 'Bailleur (propriétaire) prévenu ? ' + this.formStore.data.info_procedure_bailleur_prevenu + '<br>'
+      if (this.isFormDataSet('info_procedure_bailleur_prevenu')) {
+        result += 'Bailleur (propriétaire) prévenu ? ' + this.formStore.data.info_procedure_bailleur_prevenu + '<br>'
+      }
       result += 'Assurance contactée ? ' + this.formStore.data.info_procedure_assurance_contactee + '<br>'
-      result += 'Réponse de l\'assurance ' + this.formStore.data.info_procedure_reponse_assurance + '<br>'
-      result += 'Si des travaux sont faits, voulez-vous rester dans le logement  ' + this.formStore.data.info_procedure_depart_apres_travaux + '<br>'
-
+      if (this.formStore.data.info_procedure_assurance_contactee === 'oui') {
+        result += 'Réponse de l\'assurance ' + this.formStore.data.info_procedure_reponse_assurance + '<br>'
+      }
+      if (this.isFormDataSet('info_procedure_depart_apres_travaux')) {
+        result += 'Si des travaux sont faits, voulez-vous rester dans le logement  ' + this.formStore.data.info_procedure_depart_apres_travaux + '<br>'
+      }
       return result
     },
     isFormDataSet (formSlug: string) {

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -1,25 +1,50 @@
 <template>
   <div :id="id">
-    <div class="fr-container">
+    <div>
       <h2>Récapitulatif</h2>
 
-      <h3>Adresse du logement</h3>
-      <a href="#" @click="handleEdit('adresse_logement')">Editer</a>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-12 fr-col-md-8">
+          <h3>Adresse du logement</h3>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('adresse_logement')">Editer</a>
+        </div>
+      </div>
       <p v-html="getFormDataAdresse()"></p>
 
       <!-- TODO : changer intitulés ? -->
-      <h3>Vos coordonnées</h3>
-      <a v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" href="#" @click="handleEdit('vos_coordonnees_occupant')">Editer</a>
-      <a v-else href="#" @click="handleEdit('vos_coordonnees_tiers')">Editer</a>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-12 fr-col-md-8">
+          <h3>Vos coordonnées</h3>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <a v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'" href="#" @click="handleEdit('vos_coordonnees_occupant')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+          <a v-else href="#" @click="handleEdit('vos_coordonnees_tiers')"  class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+        </div>
+      </div>
       <p v-html="getFormDataCoordonneesOccupant()"></p>
 
       <!-- TODO : si profil est bailleur ou bailleur_occupant que met-on ? -->
-      <h3>Les coordonnées du bailleur</h3>
-      <a href="#" @click="handleEdit('coordonnees_bailleur')">Editer</a>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-12 fr-col-md-8">
+          <h3>Les coordonnées du bailleur</h3>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <a v-if="formStore.data.profil !== 'bailleur_occupant'" href="#" @click="handleEdit('coordonnees_bailleur')" class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+          <a v-else href="#" @click="handleEdit('vos_coordonnees_tiers')"  class="btn-link fr-btn--icon-left fr-icon-edit-line" >Editer</a>
+        </div>
+      </div>
       <p v-html="getFormDataCoordonneesBailleur()"></p>
 
-      <h3>Type et composition du logement</h3>
-      <a href="#" @click="handleEdit('ecran_intermediaire_type_composition')">Editer</a>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-12 fr-col-md-8">
+          <h3>Type et composition du logement</h3>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_type_composition')">Editer</a>
+        </div>
+      </div>
       <section class="fr-accordion">
         <h3 class="fr-accordion__title">
           <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-type-composition">Afficher les informations</button>
@@ -29,8 +54,15 @@
         </div>
       </section>
 
-      <h3>Votre situation</h3>
-      <a href="#" @click="handleEdit('ecran_intermediaire_situation_occupant')">Editer</a>
+      <!-- TODO quels profils, quel intitulé -->
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-12 fr-col-md-8">
+          <h3>Votre situation</h3>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_situation_occupant')">Editer</a>
+        </div>
+      </div>
       <section class="fr-accordion">
         <h3 class="fr-accordion__title">
           <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-situation-occupant">Afficher les informations</button>
@@ -40,39 +72,53 @@
         </div>
       </section>
 
-      <h3>TODO : Les désordres</h3>
-      <a href="#" @click="handleEdit('ecran_intermediaire_les_desordres')">Editer</a>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-12 fr-col-md-8">
+          <h3>Les désordres</h3>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_les_desordres')">Editer</a>
+        </div>
+      </div>
+      <SignalementFormDisorderOverview
+        :id="idDisorderOverview"
+        :icons="disorderIcons"
+        />
 
-      <h3>TODO : La procédure</h3>
-      <a href="#" @click="handleEdit('info_procedure')">Editer</a>
+      <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+        <div class="fr-col-12 fr-col-md-8">
+          <h3>TODO : La procédure</h3>
+        </div>
+        <div class="fr-col-12 fr-col-md-4">
+          <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('info_procedure')">Editer</a>
+        </div>
+      </div>
+        <div class="fr-collapse" id="accordion-procedure">
+          <p v-html="getFormDataProcedure()"></p>
+        </div>
 
       <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">
-        <h2>TODO : Informations complémentaires</h2>
+        <h2>Informations complémentaires</h2>
 
         <p>
           Plus nous avons d'informations sur la situation,
           mieux nous pouvons vous accompagner.
           Cliquez sur le bouton pour ajouter des informations.
-        <a href="#" @click="handleEdit('informations_complementaires')">Editer</a>
         </p>
-      </div>
-
-      Ma situation personnelle
-      <br>
-      Mon logement
-      <br>
-      <button
-        type="button"
-        class="fr-btn fr-secondary"
-        @click="handleEdit('')"
-        >
+        <button
+          type="button"
+          class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line"
+          @click="handleEdit('informations_complementaires')"
+          >
           Ajouter des informations
-      </button>
-      <br><br>
+        </button>
+      </div>
 
       <h2>Message à l'administration (facultatif)</h2>
       <p>Ce message sera joint à votre signalement.</p>
       <textarea placeholder="Votre message ici"></textarea>
+      <!-- <SignalementFormTextarea></SignalementFormTextarea> -->
+      <!-- TODO utiliser composant SignalementFormTextarea -->
 
     </div>
   </div>
@@ -81,16 +127,22 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import formStore from './../store'
+import SignalementFormDisorderOverview from './SignalementFormDisorderOverview.vue'
 
 export default defineComponent({
   name: 'SignalementFormOverview',
+  components: {
+    SignalementFormDisorderOverview
+  },
   props: {
     id: { type: String, default: null },
     clickEvent: Function
   },
   data () {
     return {
-      formStore
+      formStore,
+      idDisorderOverview: this.id + '_disorder_overview',
+      disorderIcons: [{ src: '/img/form/BATIMENT/Picto-batiment.svg', alt: '' }, { src: '/img/form/LOGEMENT/Picto-logement.svg', alt: '' }]
     }
   },
   methods: {
@@ -162,6 +214,16 @@ export default defineComponent({
         result += 'Numéro allocataire : ' + this.formStore.data.logement_social_numero_allocataire + '<br>'
         result += 'Montant allocation : ' + this.formStore.data.logement_social_allocation + '€<br>'
       }
+      return result
+    },
+    getFormDataProcedure (): string {
+      let result = ''
+      // TODO : conditionner en fonction des réponses et profils
+      result += 'Bailleur (propriétaire) prévenu ? ' + this.formStore.data.info_procedure_bailleur_prevenu + '<br>'
+      result += 'Assurance contactée ? ' + this.formStore.data.info_procedure_assurance_contactee + '<br>'
+      result += 'Réponse de l\'assurance ' + this.formStore.data.info_procedure_reponse_assurance + '<br>'
+      result += 'Si des travaux sont faits, voulez-vous rester dans le logement  ' + this.formStore.data.info_procedure_depart_apres_travaux + '<br>'
+
       return result
     },
     isFormDataSet (formSlug: string) {

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -54,7 +54,7 @@
           <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_type_composition')">Editer</a>
         </div>
       </div>
-      <section class="fr-accordion">
+      <section class="fr-accordion fr-mb-3w">
         <h3 class="fr-accordion__title">
           <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-type-composition">Afficher les informations</button>
         </h3>
@@ -72,7 +72,7 @@
           <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_situation_occupant')">Editer</a>
         </div>
       </div>
-      <section class="fr-accordion">
+      <section class="fr-accordion fr-mb-3w">
         <h3 class="fr-accordion__title">
           <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-situation-occupant">Afficher les informations</button>
         </h3>
@@ -266,4 +266,12 @@ export default defineComponent({
 </script>
 
 <style>
+#validation_signalement_overview_disorder_overview .fr-disorder-overview-title {
+  font-size: 20px !important;
+  line-height: 28px !important;
+  margin: 0;
+}
+#validation_signalement_overview_disorder_overview .fr-disorder-overview-image {
+  width: 40px;
+}
 </style>

--- a/tools/wiremock/src/Resources/Signalement/dictionary.json
+++ b/tools/wiremock/src/Resources/Signalement/dictionary.json
@@ -276,13 +276,5 @@
   "desordres_logement_bruit_exterieur": { "default": "On entend le bruit extérieur, même en fermant les portes et les fenêtres" },
   "desordres_logement_bruit_voisins": { "default": "On entend les voisins parler et marcher depuis le logement, comme s'ils étaient dans la pièce" },
   "desordres_logement_lumiere_pas_lumiere": { "default": "Le logement n'est pas éclairé par la lumière du jour. Il est difficile de voir sans allumer la lumière, même en pleine journée." },
-  "desordres_logement_lumiere_pas_volets": { "default": "Il n'y a pas de volets, ni de stores aux fenêtres" },
-  "logement_social_allocation": {
-    "default": "Recevez-vous une aide ou allocation logement ?",
-    "occupant": "Recevez-vous une aide ou allocation logement ?",
-    "tiers": "Est-ce que les locataires bénéficient d'une aide ou allocation logement ?",
-    "overview": {
-      "default": "Aide ou allocation logement : "
-    }
-  }
+  "desordres_logement_lumiere_pas_volets": { "default": "Il n'y a pas de volets, ni de stores aux fenêtres" }
 }

--- a/tools/wiremock/src/Resources/Signalement/dictionary.json
+++ b/tools/wiremock/src/Resources/Signalement/dictionary.json
@@ -8,6 +8,10 @@
   "oui": { "default": "OUI" },
   "non": { "default": "NON" },
   "nsp": { "default": "Ne sait pas" },
+  "piece_unique": { "default": "Une pièce unique" },
+  "plusieurs_pieces": { "default": "Plusieurs pièces" },
+  "caf": { "default": "CAF" },
+  "msa": { "default": "MSA" },
   "post2023": { "default": "En 2023" },
   "before2023": { "default": "Avant 2023" },
   "before_movein": { "default": "Avant emménagement" },
@@ -272,5 +276,13 @@
   "desordres_logement_bruit_exterieur": { "default": "On entend le bruit extérieur, même en fermant les portes et les fenêtres" },
   "desordres_logement_bruit_voisins": { "default": "On entend les voisins parler et marcher depuis le logement, comme s'ils étaient dans la pièce" },
   "desordres_logement_lumiere_pas_lumiere": { "default": "Le logement n'est pas éclairé par la lumière du jour. Il est difficile de voir sans allumer la lumière, même en pleine journée." },
-  "desordres_logement_lumiere_pas_volets": { "default": "Il n'y a pas de volets, ni de stores aux fenêtres" }
+  "desordres_logement_lumiere_pas_volets": { "default": "Il n'y a pas de volets, ni de stores aux fenêtres" },
+  "logement_social_allocation": {
+    "default": "Recevez-vous une aide ou allocation logement ?",
+    "occupant": "Recevez-vous une aide ou allocation logement ?",
+    "tiers": "Est-ce que les locataires bénéficient d'une aide ou allocation logement ?",
+    "overview": {
+      "default": "Aide ou allocation logement : "
+    }
+  }
 }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -1178,7 +1178,7 @@
           "type": "SignalementFormButton",
           "label": "Valider mon signalement",
           "slug": "validation_signalement_next",
-          "action": "goto:confirmation_signalement",
+          "action": "goto.save:confirmation_signalement",
           "customCss": "fr-btn--icon-left fr-icon-check-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -1156,6 +1156,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Validation du signalement",
+    "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -1222,7 +1222,7 @@
           "type": "SignalementFormButton",
           "label": "Valider mon signalement",
           "slug": "validation_signalement_next",
-          "action": "goto:confirmation_signalement",
+          "action": "goto.save:confirmation_signalement",
           "customCss": "fr-btn--icon-left fr-icon-check-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -1200,6 +1200,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Validation du signalement",
+    "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1354,7 +1354,7 @@
           "type": "SignalementFormButton",
           "label": "Valider mon signalement",
           "slug": "validation_signalement_next",
-          "action": "goto:confirmation_signalement",
+          "action": "goto.save:confirmation_signalement",
           "customCss": "fr-btn--icon-left fr-icon-check-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1332,6 +1332,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Validation du signalement",
+    "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -809,7 +809,7 @@
           "type": "SignalementFormButton",
           "label": "Valider mon signalement",
           "slug": "validation_signalement_next",
-          "action": "goto:confirmation_signalement",
+          "action": "goto.save:confirmation_signalement",
           "customCss": "fr-btn--icon-left fr-icon-check-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -787,6 +787,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Validation du signalement",
+    "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -1046,7 +1046,7 @@
           "type": "SignalementFormButton",
           "label": "Valider mon signalement",
           "slug": "validation_signalement_next",
-          "action": "goto:confirmation_signalement",
+          "action": "goto.save:confirmation_signalement",
           "customCss": "fr-btn--icon-left fr-icon-check-line"
         }
       ]

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -1024,6 +1024,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Validation du signalement",
+    "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -1018,6 +1018,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Validation du signalement",
+    "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -1040,7 +1040,7 @@
           "type": "SignalementFormButton",
           "label": "Valider mon signalement",
           "slug": "validation_signalement_next",
-          "action": "goto:confirmation_signalement",
+          "action": "goto.save:confirmation_signalement",
           "customCss": "fr-btn--icon-left fr-icon-check-line"
         }
       ]


### PR DESCRIPTION
## Ticket

#1589   

## Description
Finition du composant SignalementFormOverview

## Changements apportés
* Ajout de la description de la page dans tous les json
* Intégration du SignalementFormDisorderOverview pour les désordres avec ajustements css
* Affichage des parties Coordonnées  / Type et composition / situation en fonction du profil de l'usager
* Intégration de la partie Procédure
* Css sur les informations Complémentaires
* Utilisation de SignalementFormTextarea pour le message à l'administration

## Pré-requis

## Tests
- [ ] Faire un signalement avec chacun des 6 profils
- [ ] Vérifier que la mise en page des résumés intermédiaires des désordres n'est pas cassée
- [ ] Vérifier que les informations affichées dans le récapitulatif sont cohérentes avec le profil
- [ ] Vérifier que les boutons d'édition mènent bien vers les bonnes pages
- [ ] Vérifier que le message à l'administration et les informations complémentaires sont bien enregistrées
