### PR TITLE
[New form - ecran logement social] Retirer option "je ne sais pas" pour la question logement_social_allocation pour les occupants

### DIFF
--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -784,10 +784,6 @@
             {
               "label": "Non",
               "value": "non"
-            },
-            {
-              "label": "Je ne sais pas",
-              "value": "nsp"
             }
           ]
         },

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -906,10 +906,6 @@
             {
               "label": "Non",
               "value": "non"
-            },
-            {
-              "label": "Je ne sais pas",
-              "value": "nsp"
             }
           ]
         },


### PR DESCRIPTION
## Ticket

#1756    

## Description
A la question `Recevez-vous une aide ou allocation logement ?`, on me propose l'option `Je ne sais pas`
-> Pour tous les occupants, on devrait juste avoir `oui` ou `non`

## Changements apportés
* Changement des json de locataire et bailleur_occupant

## Pré-requis

## Tests
- [ ] Faire un signalement en tant que locataire, vérifier qu'à la question `Recevez-vous une aide ou allocation logement ?` on peut juste répondre oui ou non
- [ ] Idem en tant que bailleur occupant
- [ ] Faire le test avec un pro, on peut choisir "je ne sais pas'
