### PR TITLE
[New form - ecrans zone désordre et travailleur social]  quelques corrections

### DIFF
--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -120,7 +120,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Vous souhaitez signaler des problèmes sur",
+          "label": "",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -128,7 +128,7 @@
               "value": "batiment"
             },
             {
-              "label": "Votre logement",
+              "label": "Le logement",
               "value": "logement"
             },
             {
@@ -989,6 +989,10 @@
             {
               "label": "Non",
               "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
             }
           ]
         }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -80,7 +80,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Vous souhaitez signaler des problèmes sur",
+          "label": "",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -137,7 +137,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Vous souhaitez signaler des problèmes sur",
+          "label": "",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -191,7 +191,7 @@
               "value": "batiment"
             },
             {
-              "label": "Votre logement",
+              "label": "Le logement",
               "value": "logement"
             },
             {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -183,7 +183,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Vous souhaitez signaler des problèmes sur",
+          "label": "",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -197,7 +197,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Vous souhaitez signaler des problèmes sur",
+          "label": "",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -205,7 +205,7 @@
               "value": "batiment"
             },
             {
-              "label": "Votre logement",
+              "label": "Le logement",
               "value": "logement"
             },
             {
@@ -927,6 +927,10 @@
             {
               "label": "Non",
               "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
             }
           ]
         }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -180,7 +180,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Vous souhaitez signaler des problèmes sur",
+          "label": "",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -188,7 +188,7 @@
               "value": "batiment"
             },
             {
-              "label": "Votre logement",
+              "label": "Le logement",
               "value": "logement"
             },
             {
@@ -910,15 +910,19 @@
             {
               "label": "Non",
               "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
             }
           ]
         },
         {
           "type": "SignalementFormCheckbox",
           "slug": "travailleur_social_accompagnement_declarant",
-          "label": "Cochez cette case si vous êtes le ou la travailleuse sociale accompagnant le foyer.",
+          "label": "Cochez cette case si vous êtes la personne accompagnant le foyer.",
           "validate": {
-            "reuired": false
+            "required": false
           },
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui'"


### PR DESCRIPTION
## Ticket

#1753 
#1754 
#1755    
#1758 

## Description
Pour tous, sur la page où on sélectionne les zones de désordres on supprime le label qui doublonne le titre
Sur la page où on sélectionne les zones de désordres, il a écrit Votre logement il faudrait écrire Le logement pour les tiers
Ajout de  l'option "Je ne sais pas" pour les tiers sur l'écran "travailleur social" pour l'accompagnement
Pour les tiers pro, la case à cocher pour signaler qu'on est le travailleur social est rendu facultative (faute de frappe corrigée) et le texte est simplifié


## Changements apportés
* Modification des 4 json des déclarants tiers
* Et petite modification sur les 2 json occupant

## Pré-requis

## Tests
- [ ] Faire un signalement en tant que **tiers pro**
- [ ] Sur l'écran "zone concernée" vérifier que la zone est bien "Le logement" et non plus "Votre logement"
- [ ] Vérifier qu'il n'y a pas 2 fois "Vous souhaitez déclarer des problèmes"
- [ ] Sur l'écran "travailleur social", vérifier qu'on a l'option "je ne sais pas" pour la question "accompagnement par un ou une travailleuse sociale"
- [ ] Choisir Oui à cette question, et vérifier que la case à cocher qui apparait est bien facultative et que son intitulé est `Cochez cette case si vous êtes la personne accompagnant le foyer`
