### PR TITLE
[Front] Dans écran de validation de signalement, changer texte première case

### DIFF
--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -1121,11 +1121,6 @@
       "body": [
         {
           "type": "SignalementFormCheckbox",
-          "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement."
-        },
-        {
-          "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_visite",
           "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement."
         },

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -1047,11 +1047,6 @@
       "body": [
         {
           "type": "SignalementFormCheckbox",
-          "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement."
-        },
-        {
-          "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_visite",
           "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement."
         },

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -753,7 +753,7 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement."
+          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement."
         },
         {
           "type": "SignalementFormCheckbox",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -990,7 +990,7 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement."
+          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement."
         },
         {
           "type": "SignalementFormCheckbox",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -984,7 +984,7 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement."
+          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement."
         },
         {
           "type": "SignalementFormCheckbox",


### PR DESCRIPTION
## Ticket

#1746    

## Description
Supprimer une des checkbox pour bailleur et bailleur_occupant
Corriger le texte pour les autres tiers

## Changements apportés
* Changement des json

## Pré-requis

## Tests
- [ ] Profil Bailleur ou Bailleur_occupant, vérifier qu'il n'y a plus la checkbox `Je comprends que Histologe va prévenir le bailleur (propriétaire) de mon logement.`
- [ ] Profil locataire, vérifier que le texte est `Je comprends que Histologe va prévenir le bailleur (propriétaire) de mon logement.`
- [ ] Autre profil, vérifier que le texte est `Je comprends que Histologe va prévenir le bailleur (propriétaire) du logement.`
