### PR TITLE
[Formulaire - Front] Ajustements de marges et bordures

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -37,6 +37,7 @@
               :description="formStore.currentScreen.description"
               :icon="formStore.currentScreen.icon"
               :components="formStore.currentScreen.components"
+              :customCss="formStore.currentScreen.customCss"
               :changeEvent="saveAndChangeScreenBySlug"
               />
           </div>

--- a/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
@@ -156,8 +156,10 @@ export default defineComponent({
     color: var(--text-disabled-grey);
   }
 
-  .force-height-max {
-    height: 100%;
-    min-height: 580px;
+  @media (min-width: 48em) {
+    .force-height-max {
+      height: 100%;
+      min-height: 580px;
+    }
   }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
@@ -35,7 +35,7 @@
     </div>
 
     <nav class="fr-sidemenu fr-hidden fr-unhidden-md" aria-labelledby="fr-sidemenu-title">
-      <div class="fr-sidemenu__inner">
+      <div class="fr-sidemenu__inner fr-pb-12w">
         <div class="fr-collapse" id="fr-sidemenu-wrapper">
           <div class="fr-sidemenu__title" id="fr-sidemenu-title">Mon signalement</div>
           <ul class="fr-sidemenu__list">

--- a/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="force-height-max">
     <div class="fr-hidden-md">
       <!-- Indicateur de progression -->
       <!-- TODO : vérifier les instructions de mathilde sur ce bloc-->
@@ -34,8 +34,8 @@
       <SignalementFormModalBackHome />
     </div>
 
-    <nav class="fr-sidemenu fr-hidden fr-unhidden-md" aria-labelledby="fr-sidemenu-title">
-      <div class="fr-sidemenu__inner fr-pb-12w">
+    <nav class="fr-sidemenu fr-hidden fr-unhidden-md force-height-max" aria-labelledby="fr-sidemenu-title">
+      <div class="fr-sidemenu__inner force-height-max fr-pb-12w">
         <div class="fr-collapse" id="fr-sidemenu-wrapper">
           <div class="fr-sidemenu__title" id="fr-sidemenu-title">Mon signalement</div>
           <ul class="fr-sidemenu__list">
@@ -154,5 +154,9 @@ export default defineComponent({
 
   .fr-sidemenu__item a.fr-sidemenu__link:not([href]) {
     color: var(--text-disabled-grey);
+  }
+
+  .force-height-max {
+    height: 100%;
   }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
@@ -35,7 +35,7 @@
     </div>
 
     <nav class="fr-sidemenu fr-hidden fr-unhidden-md force-height-max" aria-labelledby="fr-sidemenu-title">
-      <div class="fr-sidemenu__inner force-height-max fr-pb-12w">
+      <div class="fr-sidemenu__inner force-height-max">
         <div class="fr-collapse" id="fr-sidemenu-wrapper">
           <div class="fr-sidemenu__title" id="fr-sidemenu-title">Mon signalement</div>
           <ul class="fr-sidemenu__list">
@@ -158,5 +158,6 @@ export default defineComponent({
 
   .force-height-max {
     height: 100%;
+    min-height: 580px;
   }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-container form-screen-body">
+  <div :class="[ 'fr-container form-screen-body', customCss ]">
     <div
       v-if="icon"
       class="icon"
@@ -141,7 +141,8 @@ export default defineComponent({
     description: String,
     icon: Object,
     components: Object,
-    changeEvent: Function
+    changeEvent: Function,
+    customCss: String
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -46,6 +46,7 @@ interface FormStore {
     icon: PictureDescription
     desktopIllustration: PictureDescription
     components: ZoneComponents
+    customCss: string
   } | null
   lastButtonClicked: string
   validationErrors: FormData

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -8,7 +8,7 @@
       "src": "/img/illustration-undraw-home.svg",
       "alt": ""
     },
-    "customCss": "fr-my-10w",
+    "customCss": "fr-my-md-10w",
     "components": {
       "body": [
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -8,6 +8,7 @@
       "src": "/img/illustration-undraw-home.svg",
       "alt": ""
     },
+    "customCss": "fr-my-10w",
     "components": {
       "body": [
         {


### PR DESCRIPTION
## Ticket

#1747
#1748 
#1749

## Description
* Ajout marges verticales sur l'écran d'intro
* Ajout hauteur minimale sur le menu desktop
* Prolongement de la bordure du menu desktop jusqu'en bas de page

## Changements apportés
* Ajout d'une propriété customCss sur les screen

## Tests
- [ ] L'écran d'intro a des marges en haut et en bas pour espacer
- [ ] Les écrans d'après ont une hauteur minimum qui fait moins de variation d'écran
- [ ] La bordure du menu desktop va tout en bas, quel que soit l'écran
