### PR TITLE
[Front] Correction de la duplication de draft au rechargement sur la page coordonnées

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -108,6 +108,7 @@ export default defineComponent({
         for (const prop in requestResponse.signalement.payload) {
           formStore.data[prop] = requestResponse.signalement.payload[prop]
         }
+        formStore.data.uuidSignalementDraft = requestResponse.signalement.uuid
       }
       if (formStore.data.currentStep !== undefined) {
         this.nextSlug = formStore.data.currentStep


### PR DESCRIPTION
## Ticket

#1768    

## Description
Quand on rechargeait un draft sur la page "vos coordonnées", une requête POST était envoyée au lieu d'une requête PUT, car l'uuid du draft n'était pas encore enregistré dans le formStore. On avait donc une duplication de draft en base

## Changements apportés
* Enregistrement du uuid dès handleInit

## Pré-requis

## Tests
- [ ] Faire un signalement en tant que locataire
- [ ] Aller jusqu'à "Vos coordonnées", remplir les infos, puis récupérer l'uuid et recharger la page
- [ ] Passer quelques écrans, vérifier en base qu'il n'y a pas de deuxième draft de créé
