### PR TITLE
[New form - ecran logement social] Correction de la prise en compte de la conditionnalité d'affichage sur le composant SignalementFormCounter

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -1,5 +1,4 @@
 <template>
-    <!-- Champ type number -->
     <div class="fr-input-group" :id="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id" v-html="variablesReplacer.replace(label)"></label>
     <input


### PR DESCRIPTION
## Ticket

#1752    

## Description
Un commentaire html dans le composant était ciblé par l'affectation de la classe fr-hidden à l'évaluation de la conditionnalité d'affiche. Ce qui rendait le composant visible quand il ne devait pas l'être. On n'avait pas le souci si on faisait un `npm run watch`, mais seulement après le `npm run build`

## Changements apportés
* Suppression du premier commentaire dans la partie html du composant SignalementFormCounter

## Pré-requis
`npm run build`

**(surtout ne pas faire `npm run watch`)**

## Tests
- [ ] Faire un signalement en tant que locataire
- [ ] Parcourir le signalement et vérifier que les composant SignalementFormCounter devant l'être sont bien cachés avant le choix d'une option ("le nombre de pièces à vivre" ne doit s'afficher que si on sélectionne "plusieurs pièces" et "montant de l'allocation" ne s'affiche que si on répond "oui" pour allocation)
