### PR TITLE
[New form] Bouton Précédent - Affichage écran des pièces a vivre non mise à jour

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -155,24 +155,26 @@ export default defineComponent({
   },
   methods: {
     isRequired (field: any): boolean {
-      const component = document.querySelector('#' + field.slug)
-      if (((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
-          (field.validate && field.validate.required !== false)) && // ou il y a des règles de validation explicites
-          component?.classList.contains('fr-hidden') === false) { // et que le composant n'est pas caché par conditionnalité
-        return true
-      } else {
-        return false
+      if (!field.slug.includes('{{number}}')) {
+        const component = document.querySelector('#' + field.slug)
+        if (((field.validate === undefined && formStore.inputComponents.includes(field.type)) || // si c'est un composant de saisie sans objet de validation c'est qu'il est obligatoire
+            (field.validate && field.validate.required !== false)) && // ou il y a des règles de validation explicites
+            component?.classList.contains('fr-hidden') === false) { // et que le composant n'est pas caché par conditionnalité
+          return true
+        }
       }
+      return false
     },
     needToValidateSubComponents (field: any): boolean {
-      const component = document.querySelector('#' + field.slug)
-      if ((field.type === 'SignalementFormSubscreen' || field.type === 'SignalementFormAddress') && // si le composant est de type Subscreen ou Address
-            field.components && // et il a des composants enfants
-            (component?.classList.contains('fr-hidden') === false || field.type === 'SignalementFormAddress')) { // et que le composant n'est pas caché par conditionnalité si ce n'est pas un SignalementFormAddress
-        return true
-      } else {
-        return false
+      if (!field.slug.includes('{{number}}')) {
+        const component = document.querySelector('#' + field.slug)
+        if ((field.type === 'SignalementFormSubscreen' || field.type === 'SignalementFormAddress') && // si le composant est de type Subscreen ou Address
+              field.components && // et il a des composants enfants
+              (component?.classList.contains('fr-hidden') === false || field.type === 'SignalementFormAddress')) { // et que le composant n'est pas caché par conditionnalité si ce n'est pas un SignalementFormAddress
+          return true
+        }
       }
+      return false
     },
     validateComponents (components: any) {
       for (const component of components) {

--- a/assets/vue/components/signalement-form/interfaces/interfaceComponent.ts
+++ b/assets/vue/components/signalement-form/interfaces/interfaceComponent.ts
@@ -7,8 +7,20 @@ export interface Component {
   repeat?: {
     count: string
   }
-  components: ZoneComponents
-  customCss: string
-  isCloned: boolean
-  // TODO ajouter toutes les propriétés possibles ?
+  components?: ZoneComponents
+  customCss?: string
+  isCloned?: boolean
+  labelInfo?: string
+  labelUpload?: string
+  description?: string
+  icons?: string
+  action?: string
+  link?: string
+  linktarget?: string
+  values?: any
+  defaultValue?: string
+  validate?: string
+  disabled?: string
+  multiple?: string
+  conditional?: any
 }

--- a/assets/vue/components/signalement-form/interfaces/interfaceComponent.ts
+++ b/assets/vue/components/signalement-form/interfaces/interfaceComponent.ts
@@ -8,5 +8,7 @@ export interface Component {
     count: string
   }
   components: ZoneComponents
+  customCss: string
+  isCloned: boolean
   // TODO ajouter toutes les propriétés possibles ?
 }

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -105,7 +105,10 @@ const formStore: FormStore = reactive({
       // on ne remet pas les composants clonés dans le tableau puisqu'on refait le clonage pour avoir le bon nombre
       if (component.isCloned !== true) {
         if (component.repeat !== null && component.repeat !== undefined) {
-          for (let i = 1; i <= eval(component.repeat.count); i++) {
+          // TODO : virer les éventuelles données existantes ?
+          const nbRepetitions = eval(component.repeat.count)
+          this.deleteSavedClonedData(component.slug, nbRepetitions)
+          for (let i = 1; i <= nbRepetitions; i++) {
             const clonedComponent = this.cloneComponentWithNumber(component, i)
             clonedComponent.isCloned = true
             // on supprime fr-hidden du customCss s'il existe (en cas de retour sur l'écran)
@@ -147,6 +150,18 @@ const formStore: FormStore = reactive({
     }
 
     return clonedComponent
+  },
+  deleteSavedClonedData (slug: string, nbRepetitions: number) {
+    const slugShort = slug.replace('{{number}}', '')
+    for (const dataname in formStore.data) {
+      if (dataname.includes(slugShort)) {
+        const numOccurrence = parseInt(dataname.replace(slugShort, ''))
+        if (numOccurrence > nbRepetitions) {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete formStore.data[dataname]
+        }
+      }
+    }
   }
 })
 

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -103,7 +103,7 @@ const formStore: FormStore = reactive({
     const repeatedComponents: Component[] = []
     screenBodyComponents.forEach((component: Component) => {
       // on ne remet pas les composants clonés dans le tableau puisqu'on refait le clonage pour avoir le bon nombre
-      if (!component.isCloned) {
+      if (component.isCloned !== true) {
         if (component.repeat !== null && component.repeat !== undefined) {
           for (let i = 1; i <= eval(component.repeat.count); i++) {
             const clonedComponent = this.cloneComponentWithNumber(component, i)

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -102,12 +102,24 @@ const formStore: FormStore = reactive({
   preprocessScreen (screenBodyComponents: any): Component[] {
     const repeatedComponents: Component[] = []
     screenBodyComponents.forEach((component: Component) => {
-      if (component.repeat !== null && component.repeat !== undefined) {
-        for (let i = 1; i <= eval(component.repeat.count); i++) {
-          repeatedComponents.push(this.cloneComponentWithNumber(component, i))
+      // on ne remet pas les composants clonés dans le tableau puisqu'on refait le clonage pour avoir le bon nombre
+      if (!component.isCloned) {
+        if (component.repeat !== null && component.repeat !== undefined) {
+          for (let i = 1; i <= eval(component.repeat.count); i++) {
+            const clonedComponent = this.cloneComponentWithNumber(component, i)
+            clonedComponent.isCloned = true
+            // on supprime fr-hidden du customCss s'il existe (en cas de retour sur l'écran)
+            if (clonedComponent.customCss !== undefined) {
+              clonedComponent.customCss = clonedComponent.customCss.replace(/\bfr-hidden\b/g, '')
+            }
+            repeatedComponents.push(clonedComponent)
+          }
+          // on garde le composant original et on le cache avec un customCss
+          component.customCss = 'fr-hidden'
+          repeatedComponents.push(component)
+        } else {
+          repeatedComponents.push(component)
         }
-      } else {
-        repeatedComponents.push(component)
       }
     })
     return repeatedComponents

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -403,7 +403,7 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la superficie de la <strong>pièce {{number}}</strong> (taille en m²) ? (facultatif)",
-                "slug": "type_logement_pieces_a_vivre_superficie_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_superficie",
                 "customCss": "fr-mt-5v",
                 "validate": {
                   "required": false
@@ -412,7 +412,7 @@
               {
                 "type": "SignalementFormOnlyChoice",
                 "label": "La hauteur jusqu'au plafond est de 2,20m (220cm) ou plus ?",
-                "slug": "type_logement_pieces_a_vivre_hauteur_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_hauteur",
                 "values": [
                   {
                     "label": "Oui",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -361,7 +361,7 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la superficie de la <strong>pièce {{number}}</strong> (taille en m²) ? (facultatif)",
-                "slug": "type_logement_pieces_a_vivre_superficie_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_superficie",
                 "customCss": "fr-mt-5v",
                 "validate": {
                   "required": false
@@ -370,7 +370,7 @@
               {
                 "type": "SignalementFormOnlyChoice",
                 "label": "La hauteur jusqu'au plafond est de 2,20m (220cm) ou plus ?",
-                "slug": "type_logement_pieces_a_vivre_hauteur_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_hauteur",
                 "values": [
                   {
                     "label": "Oui",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -418,7 +418,7 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la superficie de la <strong>pièce {{number}}</strong> (taille en m²) ? (facultatif)",
-                "slug": "type_logement_pieces_a_vivre_superficie_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_superficie",
                 "customCss": "fr-mt-5v",
                 "validate": {
                   "required": false
@@ -427,7 +427,7 @@
               {
                 "type": "SignalementFormOnlyChoice",
                 "label": "La hauteur jusqu'au plafond est de 2,20m (220cm) ou plus ?",
-                "slug": "type_logement_pieces_a_vivre_hauteur_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_hauteur",
                 "values": [
                   {
                     "label": "Oui",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -452,7 +452,7 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la superficie de la <strong>pièce {{number}}</strong> (taille en m²) ?",
-                "slug": "type_logement_pieces_a_vivre_superficie_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_superficie",
                 "customCss": "fr-mt-5v",
                 "validate": {
                   "required": false
@@ -461,7 +461,7 @@
               {
                 "type": "SignalementFormOnlyChoice",
                 "label": "La hauteur jusqu'au plafond est de 2,20m (220cm) ou plus ?",
-                "slug": "type_logement_pieces_a_vivre_hauteur_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_hauteur",
                 "values": [
                   {
                     "label": "Oui",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -481,7 +481,7 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la superficie de la <strong>pièce {{number}}</strong> (taille en m²) ? (facultatif)",
-                "slug": "type_logement_pieces_a_vivre_superficie_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_superficie",
                 "customCss": "fr-mt-5v",
                 "validate": {
                   "required": false
@@ -490,7 +490,7 @@
               {
                 "type": "SignalementFormOnlyChoice",
                 "label": "La hauteur jusqu'au plafond est de 2,20m (220cm) ou plus ?",
-                "slug": "type_logement_pieces_a_vivre_hauteur_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_hauteur",
                 "values": [
                   {
                     "label": "Oui",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -464,7 +464,7 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la superficie de la <strong>pièce {{number}}</strong> (taille en m²) ? (facultatif)",
-                "slug": "type_logement_pieces_a_vivre_superficie_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_superficie",
                 "customCss": "fr-mt-5v",
                 "validate": {
                   "required": false
@@ -473,7 +473,7 @@
               {
                 "type": "SignalementFormOnlyChoice",
                 "label": "La hauteur jusqu'au plafond est de 2,20m (220cm) ou plus ?",
-                "slug": "type_logement_pieces_a_vivre_hauteur_piece_{{number}}",
+                "slug": "type_logement_pieces_a_vivre_piece_{{number}}_hauteur",
                 "values": [
                   {
                     "label": "Oui",


### PR DESCRIPTION
## Ticket

#1773   

## Description
Amélioration de la gestion des composants clonés (paramètre repeat...count) pour mettre à jour le nombre de composant clonés lorsqu'on modifie la valeur du count sur un autre écran

## Changements apportés
* Modification de la fonction preprocessScreen

## Pré-requis

## Tests
- [ ] Faire un signalement, peu importe le profil
- [ ] Dans l'écran "Votre logement est composé d'une pièce unique ou de plusieurs pièces ?", choisir plusieurs pièces, et indiquer un nombre de pièces dans le SignalementFormCounter qui apparait plus bas
- [ ] Aller sur l'écran suivant, et vérifier qu'il y a bien le bon nombre de subscreen (pièce 1, pièce 2 etc.)
- [ ] Revenir en arrière et changer pour un nombre plus petit
- [ ] Retourner sur l'écran suivant, et vérifier qu'il y a le bon nombre de subscreen
- [ ] Mettre quelques valeurs
- [ ] Revenir en arrière et changer pour un nombre plus grand
- [ ] Retourner sur l'écran suivant, et vérifier qu'il y a le bon nombre de subscreen et que les valeurs sont conservées
