### PR TITLE
[BO - Signalement] Signalement refusé par RT

### DIFF
--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -1472,7 +1472,7 @@ signalements:
     cp_occupant: "13003"
     ville_occupant: "Marseille"
     statut: 8
-    code_suivi: '0123456789'
+    code_suivi: '0123456784569'
     reference: "2023-21"
     geoloc: "{\"lng\":\"43.3117791\", \"lat\":\"5.3755551\"}"
     created_at: "2023-06-16 16:06:33"

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -1454,3 +1454,44 @@ signalements:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
       - "le sol ou la base des murs est très humide."
+  -
+    uuid: "00000000-0000-0000-2023-000000000021"
+    details: "Signalement au statut refusé."
+    is_proprio_averti: 1
+    is_logement_social: 0
+    nb_adultes: "2"
+    nb_enfants_m6: "1"
+    nb_enfants_p6: "2"
+    is_allocataire: ""
+    nature_logement: "Appartement"
+    type_logement: "T2"
+    superficie: 30
+    loyer: 300
+    phone_number: 0621127286
+    adresse_occupant: "142 Rue Loubon"
+    cp_occupant: "13003"
+    ville_occupant: "Marseille"
+    statut: 8
+    code_suivi: '0123456789'
+    reference: "2023-21"
+    geoloc: "{\"lng\":\"43.3117791\", \"lat\":\"5.3755551\"}"
+    created_at: "2023-06-16 16:06:33"
+    score: 4
+    etage_occupant: "0"
+    escalier_occupant: ""
+    mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
+    insee_occupant: "13203"
+    is_rsa: 0
+    type_energie_logement: "Electrique"
+    origine_signalement: ""
+    nb_occupants_logement: 3
+    situation_occupant: "1"
+    territory: "Bouches-du-Rhône"
+    tags:
+      - "Urgent"
+    situations:
+      - "la vie commune et le voisinage"
+    criteres:
+      - "Les déchets sont mal stockés."
+    criticites:
+      - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -181,3 +181,9 @@ suivis:
   is_public: 0
   signalement: "2023-15"
   type: 4
+-
+  created_by: admin-territoire-13-01@histologe.fr
+  description: "Signalement Refusé"
+  is_public: 1
+  signalement: "2023-21"
+  type: 1

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -70,6 +70,7 @@ class SuiviRepository extends ServiceEntityRepository
             'type_suivi_auto' => Suivi::TYPE_AUTO,
             'status_archived' => Signalement::STATUS_ARCHIVED,
             'status_closed' => Signalement::STATUS_CLOSED,
+            'status_refused' => Signalement::STATUS_REFUSED,
         ];
 
         if (null !== $territory) {
@@ -106,6 +107,7 @@ class SuiviRepository extends ServiceEntityRepository
             'type_suivi_auto' => Suivi::TYPE_AUTO,
             'status_archived' => Signalement::STATUS_ARCHIVED,
             'status_closed' => Signalement::STATUS_CLOSED,
+            'status_refused' => Signalement::STATUS_REFUSED,
         ];
 
         if (null !== $territory) {
@@ -187,7 +189,7 @@ class SuiviRepository extends ServiceEntityRepository
                 INNER JOIN signalement s on s.id = su.signalement_id
                 '.$innerPartnerJoin.'
                 WHERE type in (:type_suivi_usager,:type_suivi_partner, :type_suivi_auto)
-                AND s.statut NOT IN (:status_closed, :status_archived)
+                AND s.statut NOT IN (:status_closed, :status_archived, :status_refused)
                 '.$whereTerritory.'
                 '.$wherePartner.'
                 GROUP BY su.signalement_id

--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -61,6 +61,8 @@
                 <strong class="fr-text-label--red-marianne">En attente</strong>
             {% elseif signalement.statut is same as(6) %}
                 Fermé
+            {% elseif signalement.statut is same as(8) %}
+                Refusé
             {% endif %}
         </td>
         <td class="fr-text--right fr-ws-nowrap">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -75,7 +75,8 @@
 {% set statuses = {
     1:'Nouveau',
     2:'En cours',
-    6:'Fermés'
+    6:'Fermés',
+    8:'Refusés'
 } %}
 {% set allocations = {
     'CAF':'CAF',

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -48,20 +48,20 @@ class BackStatistiquesControllerTest extends WebTestCase
     public function provideRoutesStatistiquesDatas(): \Generator
     {
         yield 'Super Admin' => ['back_statistiques_filter', [], self::USER_SUPER_ADMIN, [
-            ['result' => 32, 'label' => 'count_signalement'],
-            ['result' => 71.5, 'label' => 'average_criticite'],
+            ['result' => 33, 'label' => 'count_signalement'],
+            ['result' => 69.5, 'label' => 'average_criticite'],
         ]];
         yield 'Responsable Territoire' => ['back_statistiques_filter', [], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 22, 'label' => 'count_signalement'],
-            ['result' => 98.2, 'label' => 'average_criticite'],
+            ['result' => 23, 'label' => 'count_signalement'],
+            ['result' => 94.1, 'label' => 'average_criticite'],
         ]];
         yield 'Partner' => ['back_statistiques_filter', [], self::USER_PARTNER, [
             ['result' => 3, 'label' => 'count_signalement'],
             ['result' => 100, 'label' => 'average_criticite'],
         ]];
         yield 'RT - filtered with commune Arles' => ['back_statistiques_filter', ['communes' => '["Arles"]'], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 22, 'label' => 'count_signalement'],
-            ['result' => 98.2, 'label' => 'average_criticite'],
+            ['result' => 23, 'label' => 'count_signalement'],
+            ['result' => 94.1, 'label' => 'average_criticite'],
             ['result' => 0, 'label' => 'count_signalement_filtered'],
             ['result' => 0, 'label' => 'average_criticite_filtered'],
         ]];

--- a/tests/Functional/Controller/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/SignalementListControllerTest.php
@@ -188,12 +188,12 @@ class SignalementListControllerTest extends WebTestCase
     public function provideFilterSearch(): \Generator
     {
         yield 'Search Terms with Reference' => ['bo-filters-searchterms', '2022-1', '1 signalement(s)'];
-        yield 'Search Terms with cp Occupant' => ['bo-filters-searchterms', '13003', '10 signalement(s)'];
+        yield 'Search Terms with cp Occupant' => ['bo-filters-searchterms', '13003', '11 signalement(s)'];
         yield 'Search Terms with cp Occupant 13005' => ['bo-filters-searchterms', '13005', '3 signalement(s)'];
         yield 'Search Terms with city Occupant' => ['bo-filters-searchterms', 'Gex', '5 signalement(s)'];
         yield 'Search by Territory' => ['bo-filters-territories', ['1'], '5 signalement(s)'];
         yield 'Search by Partner' => ['bo-filters-partners', ['5'], '2 signalement(s)'];
-        yield 'Search by Critere' => ['bo-filters-criteres', ['17'], '23 signalement(s)'];
+        yield 'Search by Critere' => ['bo-filters-criteres', ['17'], '24 signalement(s)'];
         yield 'Search by Tags' => ['bo-filters-tags', ['3'], '4 signalement(s)'];
         yield 'Search by Parc public/prive' => ['bo-filters-housetypes', ['1'], '4 signalement(s)'];
         yield 'Search by Relances usagers' => ['bo-filters-relances_usager', ['NO_SUIVI_AFTER_3_RELANCES'], '1 signalement(s)'];

--- a/tests/Functional/Service/Notification/NotificationCounterTest.php
+++ b/tests/Functional/Service/Notification/NotificationCounterTest.php
@@ -25,6 +25,6 @@ class NotificationCounterTest extends KernelTestCase
 
         $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
         $notificationCount = (new NotificationCounter($notificationRepository))->countUnseenNotification($user);
-        $this->assertEquals(7, $notificationCount);
+        $this->assertEquals(8, $notificationCount);
     }
 }


### PR DESCRIPTION
## Ticket

#1684   

## Description
Prise en compte du statut "Refusé" à divers endroits : 
- affichage de ce statut dans la liste des signalements (il n'y avait rien)
- ajout du statut "Refusé" dans le filtre par statut
- exclusion des signalements au statut "Refusés" dans le compte des signalements sans suivi depuis 30 jours

## Changements apportés
* Modification du SuiviRepository pour la prise en compte du statut dans les signalements sans suivi depuis 30 jours
* Modification du twig table_result pour afficher le statut
* Modification du twig de base pour ajouter le statut Refusé dans les filtres

## Pré-requis

## Tests
- [ ] En superAdmin, aller sur le tableau de bord et vérifier le nombre de signalements sans suivi depuis 30 jours
- [ ] Retenir ce nombre et cliquer sur cette carte pour afficher la liste
- [ ] Modifier le statut d'un de ces signalements en bdd et lui affecter le statut 8
- [ ] Mettre à jour la liste -> le signalement ne doit plus apparaitre
- [ ] Sur le tableau de bord, le widget doit avoir 1 de moins sur la carte
- [ ] Afficher maintenant les nouveaux signalements.
- [ ] En ouvrir 1 et le refuser
- [ ] Revenir sur la liste, et filtrer les signalements par statut "refusé"
- [ ] Il doit y avoir les deux signalements précédents (ou plus s'il y en avait déj)
- [ ] la colonne statut ne doit pas être vide, il doit être écrit "Refusé"
