### PR TITLE
[Sécurité] Ajout commande de réinitialisation des mots de passe pour les admins

### DIFF
--- a/src/Command/ReinitAdminPasswordsCommand.php
+++ b/src/Command/ReinitAdminPasswordsCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use App\Manager\UserManager;
+use App\Repository\UserRepository;
+use App\Service\Mailer\NotificationMail;
+use App\Service\Mailer\NotificationMailerRegistry;
+use App\Service\Mailer\NotificationMailerType;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsCommand(
+    name: 'app:reinit-admin-passwords',
+    description: 'Reinitialize admin passwords'
+)]
+class ReinitAdminPasswordsCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public const ROLE_ADMIN = 'ROLE_ADMIN';
+
+    public function __construct(
+        private UserManager $userManager,
+        private ValidatorInterface $validator,
+        private UserPasswordHasherInterface $hasher,
+        private UserRepository $userRepository,
+        private NotificationMailerRegistry $notificationMailerRegistry
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $users = $this->userRepository->findActiveAdmins();
+
+        foreach ($users as $user) {
+            $password = $this->hasher->hashPassword($user, md5(rand(1000000, 10000000)));
+
+            $user->setPassword($password)->setStatut(User::STATUS_INACTIVE);
+            $this->userManager->loadUserToken($user->getEmail());
+
+            /** @var ConstraintViolationList $errors */
+            $errors = $this->validator->validate($user);
+
+            if (\count($errors) > 0) {
+                $this->io->error((string) $errors);
+
+                return Command::FAILURE;
+            }
+
+            $this->userManager->save($user);
+
+            $this->notificationMailerRegistry->send(
+                new NotificationMail(
+                    type: NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_REMINDER,
+                    to: $user->getEmail(),
+                    user: $user,
+                    params: [
+                        'nb_signalements' => 0,
+                    ],
+                )
+            );
+        }
+
+        $this->io->success(sprintf(
+            '%s admin users were successfully reinitialized',
+            \count($users)
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -41,6 +41,19 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $this->_em->flush();
     }
 
+    public function findActiveAdmins(): ?array
+    {
+        $queryBuilder = $this->createQueryBuilder('u');
+
+        return $queryBuilder
+            ->andWhere('u.roles LIKE :role')
+            ->setParameter('role', '%"ROLE_ADMIN"%')
+            ->andWhere('u.statut LIKE :active')
+            ->setParameter('active', User::STATUS_ACTIVE)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findActiveTerritoryAdmins(?Territory $territory): ?array
     {
         if (empty($territory)) {


### PR DESCRIPTION
## Ticket

#724   

## Description
Ajout d'une commande qui 
- prend la liste des admins actifs
- les désactive
- modifie le mot de passe
- envoie un mail d'activation de compte

## Tests
- [ ] Vérifier qu'il y a des admins actifs
- [ ] Exécuter la commande `make console app="reinit-admin-passwords"`
- [ ] Vérifier dans mailcatcher que les mails d'activation de compte sont bien partis
- [ ] Vérifier en BDD que les comptes sont bien désactivés
