### PR TITLE
  [Esabora] Affecter les suivis de synchronisation à l'utilisateur système et remplacer Esabora par SI-SH

### DIFF
--- a/migrations/Version20230929142816.php
+++ b/migrations/Version20230929142816.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230929142816 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Replace Esabora by SI-SH in suivis from SI-SH';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $connection = $this->connection;
+        $sql = "UPDATE suivi SET description = REPLACE(description, 'Esabora', 'SI-SH')
+                WHERE description LIKE '%Esabora%'
+                  AND is_public = 0
+                  AND type = 1
+                  AND EXISTS (
+                      SELECT 1
+                      FROM user u
+                      INNER JOIN partner p ON u.partner_id = p.id
+                      WHERE u.id = suivi.created_by_id
+                      AND p.type = 'ARS'
+                  )";
+
+        $connection->executeQuery($sql);
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Service/Esabora/Response/DossierPushSISHResponse.php
+++ b/src/Service/Esabora/Response/DossierPushSISHResponse.php
@@ -50,4 +50,9 @@ class DossierPushSISHResponse implements DossierResponseInterface
     {
         return null;
     }
+
+    public function getNameSI(): ?string
+    {
+        return 'SI-SH';
+    }
 }

--- a/src/Service/Esabora/Response/DossierResponseInterface.php
+++ b/src/Service/Esabora/Response/DossierResponseInterface.php
@@ -13,4 +13,6 @@ interface DossierResponseInterface
     public function getSasCauseRefus(): ?string;
 
     public function getEtat(): ?string;
+
+    public function getNameSI(): ?string;
 }

--- a/src/Service/Esabora/Response/DossierStateSCHSResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSCHSResponse.php
@@ -89,4 +89,9 @@ class DossierStateSCHSResponse implements DossierResponseInterface
     {
         return null;
     }
+
+    public function getNameSI(): ?string
+    {
+        return 'Esabora';
+    }
 }

--- a/src/Service/Esabora/Response/DossierStateSISHResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSISHResponse.php
@@ -124,4 +124,9 @@ class DossierStateSISHResponse implements DossierResponseInterface
     {
         return $this->getDossEtat();
     }
+
+    public function getNameSI(): ?string
+    {
+        return 'SI-SH';
+    }
 }

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class EsaboraManagerTest extends KernelTestCase
 {
@@ -31,6 +32,7 @@ class EsaboraManagerTest extends KernelTestCase
     private EventDispatcherInterface $eventDispatcher;
     private UserManager $userManager;
     private LoggerInterface $logger;
+    private ParameterBagInterface $parameterBag;
 
     protected function setUp(): void
     {
@@ -42,6 +44,7 @@ class EsaboraManagerTest extends KernelTestCase
         $this->eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $this->userManager = self::getContainer()->get(UserManager::class);
         $this->logger = self::getContainer()->get(LoggerInterface::class);
+        $this->parameterBag = self::getContainer()->get(ParameterBagInterface::class);
     }
 
     /**
@@ -76,6 +79,7 @@ class EsaboraManagerTest extends KernelTestCase
             $this->eventDispatcher,
             $this->userManager,
             $this->logger,
+            $this->parameterBag,
         );
 
         $esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);
@@ -129,7 +133,7 @@ class EsaboraManagerTest extends KernelTestCase
         yield EsaboraStatus::ESABORA_REJECTED->value => [
             '2022-2',
             '../../sish/ws_etat_dossier_sas/etat_rejete.json',
-            'refusé via Esabora pour motif suivant:',
+            'refusé via SI-SH pour motif suivant:',
             Affectation::STATUS_REFUSED,
         ];
     }

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class EsaboraManagerTest extends TestCase
@@ -31,6 +32,7 @@ class EsaboraManagerTest extends TestCase
     protected MockObject|EventDispatcherInterface $eventDispatcher;
     protected MockObject|UserManager $userManager;
     private MockObject|LoggerInterface $logger;
+    private MockObject|ParameterBagInterface $parameterBag;
 
     protected function setUp(): void
     {
@@ -41,6 +43,7 @@ class EsaboraManagerTest extends TestCase
         $this->userManager = $this->createMock(UserManager::class);
         $this->eventDispatcher = new EventDispatcher();
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
     }
 
     public function testCreateVisite(): void
@@ -80,6 +83,7 @@ class EsaboraManagerTest extends TestCase
             $this->eventDispatcher,
             $this->userManager,
             $this->logger,
+            $this->parameterBag,
         );
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
@@ -138,6 +142,7 @@ class EsaboraManagerTest extends TestCase
             $this->eventDispatcher,
             $this->userManager,
             $this->logger,
+            $this->parameterBag,
         );
     }
 }


### PR DESCRIPTION
## Ticket

#1778 
#1776   

## Description
Remplacer « ESABORA » par « SI-SH » dans les messages liés à l’interconnexion entre « Histologe ß à SI-SH »  (mais pas pour SCHS)
Affecter les suivis de synchronisation à l'utilisateur système


## Changements apportés
* Création d'une migration pour changer `Esabora` par `SI-SH` dans les suivis créés par Esabora
* Ajout d'une fonction `getNameSI()` dans DossierResponseInterface et ses implémentations
* Dans `EsaboraManager.synchronizeAffectationFrom()` on récupère l'administrateur système pour l'affecter aux suivis
* Dans `EsaboraManager.updateStatusFor()` on utilise `getNameSI()` à la place d'`Esabora`

## Pré-requis
Se mettre sur develop
```
make worker-start
make mock
make console app="sync-esabora-schs"
make console app="sync-esabora-sish"
make console app="ask-feedback-usager"
```

Puis en base dans la table de suivi, ajouter `Esabora` dans des suivis usagers, dans des suivis internes, dans des suivis partenaires publics, dans des suivis techniques... 

## Tests
- [ ] Se mettre sur la branche présente, et jouer les migrations sans recréer la base de donnée
- [ ] Vérifier qu'Esabora a été remplacé par SI-SH seulement dans le suivi créé par la commande "sync-esabora-sish"
- [ ] make create-db
- [ ] Relancer les commandes des pré-requis et vérifier que maintenant le suivi créé par la commande "sync-esabora-sish" comporte bien SI-SH à la place d'Esabora, mais que le suivi créé pour le partenaire SCHS comporte toujours Esabora
- [ ] Vérifier que l'utilisateur de ces suivis est bien l'utilisateur système (vérifier aussi dans la page de signalement)
