### PR TITLE
[New form - info complémentaires] ajouter la partie "infos complémentaires" pour les tiers sauf secours

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -147,7 +147,7 @@
       </div>
 
       <!-- INFORMATIONS COMPLEMENTAIRES  -->
-      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire'">
+      <div v-if="formStore.data.profil !== 'service_secours'">
         <div v-if="hasInformationsComplementaires()">
           <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
             <div class="fr-col-8">
@@ -347,10 +347,18 @@ export default defineComponent({
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_beneficiaire_rsa', 'Bénéficiaire RSA : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_beneficiaire_fsl', 'Bénéficiaire FSL : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_revenu_fiscal', 'Revenu fiscal de référence : ', ' €')
-      result += this.addLineIfNeeded('informations_complementaires_logement_montant_loyer', 'Montant du loyer sans les charges : ', ' €')
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_date_naissance', 'Date de naissance : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_loyers_payes', 'Paiement des loyers à jour : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_preavis_depart', 'Préavis de départ : ')
+      result += this.addLineIfNeeded('informations_complementaires_logement_montant_loyer', 'Montant du loyer sans les charges : ', ' €')
       result += this.addLineIfNeeded('informations_complementaires_logement_nombre_etages', 'Nombre d\'étages du logement : ')
       result += this.addLineIfNeeded('informations_complementaires_logement_annee_construction', 'Année de construction du logement : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_demande_relogement', 'Demande de relogement ou de logement social : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_occupants_date_emmenagement', 'Date d\'emménagement : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_beneficiaire_rsa', 'Bénéficiaire RSA : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_beneficiaire_fsl', 'Bénéficiaire FSL : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_revenu_fiscal', 'Revenu fiscal de référence : ', ' €')
+      result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_date_naissance', 'Date de naissance : ')
       return result
     },
     hasInformationsComplementaires (): boolean {
@@ -358,10 +366,18 @@ export default defineComponent({
       if (this.isFormDataSet('informations_complementaires_situation_occupants_beneficiaire_rsa') ||
           this.isFormDataSet('informations_complementaires_situation_occupants_beneficiaire_fsl') ||
           this.isFormDataSet('informations_complementaires_situation_occupants_revenu_fiscal') ||
-          this.isFormDataSet('informations_complementaires_logement_montant_loyer') ||
           this.isFormDataSet('informations_complementaires_situation_occupants_date_naissance') ||
+          this.isFormDataSet('informations_complementaires_situation_occupants_loyers_payes') ||
+          this.isFormDataSet('informations_complementaires_situation_occupants_preavis_depart') ||
+          this.isFormDataSet('informations_complementaires_logement_montant_loyer') ||
           this.isFormDataSet('informations_complementaires_logement_nombre_etages') ||
-          this.isFormDataSet('informations_complementaires_logement_annee_construction')) {
+          this.isFormDataSet('informations_complementaires_logement_annee_construction') ||
+          this.isFormDataSet('informations_complementaires_situation_occupants_demande_relogement') ||
+          this.isFormDataSet('informations_complementaires_situation_occupants_date_emmenagement') ||
+          this.isFormDataSet('informations_complementaires_situation_bailleur_beneficiaire_rsa') ||
+          this.isFormDataSet('informations_complementaires_situation_bailleur_beneficiaire_fsl') ||
+          this.isFormDataSet('informations_complementaires_situation_bailleur_revenu_fiscal') ||
+          this.isFormDataSet('informations_complementaires_situation_bailleur_date_naissance')) {
         result = true
       }
       return result

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -1154,6 +1154,186 @@
   },
   {
     "type": "SignalementFormScreen",
+    "label": "Informations complémentaires",
+    "description": "Toutes les questions sont facultatives",
+    "slug": "informations_complementaires",
+    "screenCategory": "Procédure",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Situation des locataires",
+          "slug": "informations_complementaires_situation_occupants",
+          "customCss": "fr-mt-3v",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormDate",
+                "label": "Quelle est la date d'effet du bail ?",
+                "slug": "informations_complementaires_situation_occupants_date_emmenagement",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce que le paiement des loyers est à jour ?",
+                "slug": "informations_complementaires_situation_occupants_loyers_payes",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormCounter",
+                "label": "Quel est le montant du loyer, sans les charges ?",
+                "slug": "informations_complementaires_logement_montant_loyer",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce qu'un préavis de départ a été déposé pour le logement ? ",
+                "slug": "informations_complementaires_situation_occupants_preavis_depart",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Le logement",
+          "slug": "informations_complementaires_logement",
+          "customCss": "fr-mt-6v",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormCounter",
+                "label": "Le logement est sur combien d'étages ?",
+                "slug": "informations_complementaires_logement_nombre_etages",
+                "conditional": {
+                  "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+                },
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormDate",
+                "label": "En quelle année le logement a-t-il été construit ?",
+                "slug": "informations_complementaires_logement_annee_construction",
+                "validate": {
+                  "required": false
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Ma situation personnelle",
+          "slug": "informations_complementaires_situation_bailleur",
+          "customCss": "fr-mt-3v",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Êtes-vous bénéficiaire du RSA (revenu de solidarité active) ?",
+                "slug": "informations_complementaires_situation_bailleur_beneficiaire_rsa",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Êtes-vous bénéficiaire FSL (fonds de solidarité pour le logement) ?",
+                "slug": "informations_complementaires_situation_bailleur_beneficiaire_fsl",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormCounter",
+                "label": "Quel est votre revenu fiscal de référence ?",
+                "slug": "informations_complementaires_situation_bailleur_revenu_fiscal",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormDate",
+                "label": "Quelle est votre date de naissance ?",
+                "slug": "informations_complementaires_situation_bailleur_date_naissance",
+                "validate": {
+                  "required": false
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "informations_complementaires_previous",
+          "action": "goto:utilisation_service",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Enregistrer",
+          "slug": "informations_complementaires_next",
+          "action": "goto.save:validation_signalement",
+          "customCss": "fr-btn--icon-left fr-icon-check-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
     "label": "Validation du signalement",
     "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -1128,17 +1128,6 @@
                 "validate": {
                   "required": false
                 }
-              },
-              {
-                "type": "SignalementFormDate",
-                "label": "Quelle est votre date de naissance ?",
-                "slug": "informations_complementaires_situation_occupants_date_naissance",
-                "conditional": {
-                  "show": "formStore.data.logement_social_allocation === 'non'"
-                },
-                "validate": {
-                  "required": false
-                }
               }
             ]
           }
@@ -1154,6 +1143,9 @@
                 "type": "SignalementFormCounter",
                 "label": "Votre logement est sur combien d'étages ?",
                 "slug": "informations_complementaires_logement_nombre_etages",
+                "conditional": {
+                  "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+                },
                 "validate": {
                   "required": false
                 }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1291,6 +1291,9 @@
                 "type": "SignalementFormCounter",
                 "label": "Votre logement est sur combien d'étages ?",
                 "slug": "informations_complementaires_logement_nombre_etages",
+                "conditional": {
+                  "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+                },
                 "validate": {
                   "required": false
                 }

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -1027,6 +1027,142 @@
   },
   {
     "type": "SignalementFormScreen",
+    "label": "Informations complémentaires",
+    "description": "Toutes les questions sont facultatives",
+    "slug": "informations_complementaires",
+    "screenCategory": "Procédure",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "La situation du foyer",
+          "slug": "informations_complementaires_situation_occupants",
+          "customCss": "fr-mt-3v",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce que le foyer est bénéficiaire du RSA (revenu de solidarité active) ?",
+                "slug": "informations_complementaires_situation_occupants_beneficiaire_rsa",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce que le foyer est bénéficiaire FSL (Fonds de solidarité pour le logement) ?",
+                "slug": "informations_complementaires_situation_occupants_beneficiaire_fsl",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormCounter",
+                "label": "Quel est le montant du loyer, sans les charges ?",
+                "slug": "informations_complementaires_logement_montant_loyer",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce que le foyer a fait une demande de relogement ou de logement social ?",
+                "slug": "informations_complementaires_situation_occupants_demande_relogement",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormDate",
+                "label": "Quand le foyer a-t-il emménagé dans le logement ?",
+                "slug": "informations_complementaires_situation_occupants_date_emmenagement",
+                "validate": {
+                  "required": false
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Le logement",
+          "slug": "informations_complementaires_logement",
+          "customCss": "fr-mt-6v",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormCounter",
+                "label": "Le logement est sur combien d'étages ?",
+                "slug": "informations_complementaires_logement_nombre_etages",
+                "conditional": {
+                  "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+                },
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormDate",
+                "label": "En quelle année le logement a-t-il été construit ?",
+                "slug": "informations_complementaires_logement_annee_construction",
+                "validate": {
+                  "required": false
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "informations_complementaires_previous",
+          "action": "goto:utilisation_service",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Enregistrer",
+          "slug": "informations_complementaires_next",
+          "action": "goto.save:validation_signalement",
+          "customCss": "fr-btn--icon-left fr-icon-check-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
     "label": "Validation du signalement",
     "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -1021,6 +1021,142 @@
   },
   {
     "type": "SignalementFormScreen",
+    "label": "Informations complémentaires",
+    "description": "Toutes les questions sont facultatives",
+    "slug": "informations_complementaires",
+    "screenCategory": "Procédure",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "La situation du foyer",
+          "slug": "informations_complementaires_situation_occupants",
+          "customCss": "fr-mt-3v",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce que le foyer est bénéficiaire du RSA (revenu de solidarité active) ?",
+                "slug": "informations_complementaires_situation_occupants_beneficiaire_rsa",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce que le foyer est bénéficiaire FSL (Fonds de solidarité pour le logement) ?",
+                "slug": "informations_complementaires_situation_occupants_beneficiaire_fsl",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormCounter",
+                "label": "Quel est le montant du loyer, sans les charges ?",
+                "slug": "informations_complementaires_logement_montant_loyer",
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormOnlyChoice",
+                "label": "Est-ce que le foyer a fait une demande de relogement ou de logement social ?",
+                "slug": "informations_complementaires_situation_occupants_demande_relogement",
+                "validate": {
+                  "required": false
+                },
+                "values": [
+                  {
+                    "label": "Oui",
+                    "value": "oui"
+                  },
+                  {
+                    "label": "Non",
+                    "value": "non"
+                  }
+                ]
+              },
+              {
+                "type": "SignalementFormDate",
+                "label": "Quand le foyer a-t-il emménagé dans le logement ?",
+                "slug": "informations_complementaires_situation_occupants_date_emmenagement",
+                "validate": {
+                  "required": false
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "Le logement",
+          "slug": "informations_complementaires_logement",
+          "customCss": "fr-mt-6v",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormCounter",
+                "label": "Le logement est sur combien d'étages ?",
+                "slug": "informations_complementaires_logement_nombre_etages",
+                "conditional": {
+                  "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+                },
+                "validate": {
+                  "required": false
+                }
+              },
+              {
+                "type": "SignalementFormDate",
+                "label": "En quelle année le logement a-t-il été construit ?",
+                "slug": "informations_complementaires_logement_annee_construction",
+                "validate": {
+                  "required": false
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "informations_complementaires_previous",
+          "action": "goto:utilisation_service",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Enregistrer",
+          "slug": "informations_complementaires_next",
+          "action": "goto.save:validation_signalement",
+          "customCss": "fr-btn--icon-left fr-icon-check-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
     "label": "Validation du signalement",
     "description": "Vérifiez les informations et cliquez sur le bouton \"Valider\" pour envoyer votre signalement !",
     "slug": "validation_signalement",


### PR DESCRIPTION
## Ticket

#1714   

## Description
On avait mal déchiffré le fichier excel, la partie "Informations complémentaires" est également présente pour les tiers particuliers, tiers pro, et bailleur (avec plus d'infos pour celui-ci)

## Changements apportés
* Modification des json
* Modification de SignalementFormOverview pour prendre en compte ces nouveaux champs

## Pré-requis

## Tests
- [ ] Faire un signalement avec ces 3 profils, vérifier qu'on a accès à la partie InformationsComplémentaires depuis le récap
- [ ] Mettre des infos, vérifier qu'elles sont enregistrées et affichées dans le récap
