### PR TITLE
1786 : css on category item

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['signalement-form-disorder-category-item fr-container--fluid fr-p-3v', isSelected || isAlreadySelected ? 'is-selected' : '']"
+    :class="['signalement-form-disorder-category-item fr-container--fluid fr-p-3v', isSelected || isAlreadySelected ? categoryZoneCss : '']"
     @click="handleClick"
     >
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
@@ -47,6 +47,12 @@ export default defineComponent({
         return formStore.data.categorieDisorders.batiment.includes(this.id) || formStore.data.categorieDisorders.logement.includes(this.id)
       }
       return false
+    },
+    categoryZoneCss () {
+      if (this.id.includes('batiment')) {
+        return 'is-selected-batiment'
+      }
+      return 'is-selected-logement'
     }
   },
   methods: {
@@ -72,8 +78,11 @@ export default defineComponent({
 .signalement-form-disorder-category-item {
   border: 1px solid var(--border-default-grey);
 }
-.signalement-form-disorder-category-item.is-selected {
+.signalement-form-disorder-category-item.is-selected-batiment {
   border: 1px solid var(--border-default-orange-terre-battue);
+}
+.signalement-form-disorder-category-item.is-selected-logement {
+  border: 1px solid var(--border-default-blue-france);
 }
 .signalement-form-disorder-category-item input[type=checkbox] {
   position: absolute;


### PR DESCRIPTION
## Ticket

#1786    

## Description
Changement de la couleur de bordure des catégories de désordres sélectionnées pour le logement

## Changements apportés
* SignalementFormDisorderCategoryItem : classe css computed

## Pré-requis

## Tests
- [ ] Faire un signalement avec les deux types de désordres. Vérifier que dans le batiment les bordures des items sélectionnés sont restées oranges et qu'elles sont bleues pour le logement
