### PR TITLE
  [New form] Rendre éléments du menu inactifs après dépôt

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
@@ -42,7 +42,7 @@
             <li
               v-for="menuItem in desktopMenuItems"
               v-bind:key="menuItem.label"
-              :class="[ 'fr-sidemenu__item', menuItem.active ? 'fr-sidemenu__item--active' : '' ]"
+              :class="[ 'fr-sidemenu__item', (menuItem.active) ? 'fr-sidemenu__item--active' : '' ]"
               >
               <a
                 v-if="menuItem.current"
@@ -103,7 +103,7 @@ export default defineComponent({
       const menuItems:Array<MenuItem> = []
       const currentCategoryIndex:number = this.currentCategoryIndex
       for (let i:number = 0; i < this.desktopMenuLabels.length; i++) {
-        menuItems.push({ label: this.desktopMenuLabels[i].label, slug: this.desktopMenuLabels[i].slug, active: (i <= currentCategoryIndex), current: (this.desktopMenuLabels[i].label === formStore.currentScreen?.screenCategory) })
+        menuItems.push({ label: this.desktopMenuLabels[i].label, slug: this.desktopMenuLabels[i].slug, active: (i <= currentCategoryIndex && formStore.currentScreen?.slug !== 'confirmation_signalement'), current: (this.desktopMenuLabels[i].label === formStore.currentScreen?.screenCategory) })
       }
       return menuItems
     },


### PR DESCRIPTION
## Ticket

#1787    

## Description
Rendre les éléments de menu inactif une fois le signalement déposé

## Changements apportés
* Changement dans SignalementFormBreadCrumbs, prise en compte du currentScreen pour définir si le menu est actif ou non

## Pré-requis

## Tests
- [ ] Faire un signalement jusqu'au bout, vérifier que le menu n'est plus cliquable sur le dernier screen
