### PR TITLE
[BO - Signalement - 69] Mails reçus par la mauvaise communauté de communes

### DIFF
--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -136,3 +136,10 @@ affectations:
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
     is_synchronized: true
+  -
+    signalement: 2023-3
+    partner: "partenaire-05-69@histologe.fr"
+    statut: 1
+    answered_by: "admin-03@histologe.fr"
+    affected_by: "admin-03@histologe.fr"
+    territory: "Rhône"

--- a/src/DataFixtures/Files/Intervention.yml
+++ b/src/DataFixtures/Files/Intervention.yml
@@ -28,3 +28,8 @@ interventions:
     conclude_procedure: [ 'INSALUBRITE', 'MISE_EN_SECURITE_PERIL' ]
     occupant_present: 1
     proprietaire_present: 1
+  -
+    signalement: "2023-3"
+    user: "user-69-05@histologe.fr"
+    partner: "partenaire-05-69@histologe.fr"
+    status: 'PLANNED'

--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -148,6 +148,7 @@ partners:
     insee: "[\"\"]"
     territory: "Rhône"
     type: "DISPOSITIF_RENOVATION_HABITAT"
+    competence: "VISITES"
   -
     nom: "Partenaire 69-06"
     email: "partenaire-06-69@histologe.fr"

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -61,7 +61,7 @@ class VisiteNotifier
             $listUsersPartner = $intervention->getPartner() && $intervention->getPartner() != $currentUser?->getPartner() ?
                 $intervention->getPartner()->getUsers()->toArray() : [];
             if ($notifyAdminTerritory) {
-                $listUsersTerritoryAdmin = $this->userRepository->findActiveTerritoryAdmins($intervention->getSignalement()->getTerritory());
+                $listUsersTerritoryAdmin = $this->userRepository->findActiveTerritoryAdmins($intervention->getSignalement()->getTerritory(), $intervention->getSignalement()->getInseeOccupant());
                 $listUsersToNotify = array_unique(array_merge($listUsersTerritoryAdmin, $listUsersPartner), \SORT_REGULAR);
             } else {
                 $listUsersToNotify = $listUsersPartner;
@@ -105,7 +105,7 @@ class VisiteNotifier
     public function notifyVisiteToConclude(Intervention $intervention): int
     {
         $signalement = $intervention->getSignalement();
-        $listUsersToNotify = $this->userRepository->findActiveTerritoryAdmins($signalement->getTerritory());
+        $listUsersToNotify = $this->userRepository->findActiveTerritoryAdmins($signalement->getTerritory(), $signalement->getInseeOccupant());
         $affectations = $signalement->getAffectations();
         foreach ($affectations as $affectation) {
             if ($affectation->getPartner()->hasCompetence(Qualification::VISITES)) {

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -89,7 +89,7 @@ class PartnerRepositoryTest extends KernelTestCase
         $signalement = $signalementRepository->findOneBy(['reference' => '2023-3']);
 
         $partners = $this->partnerRepository->findByLocalization($signalement, false);
-        $this->assertCount(3, $partners);
+        $this->assertCount(2, $partners);
 
         $partnerMDL = array_filter($partners, function ($partner) {
             return 'EMHA - Métropole de Lyon' === $partner['name'];

--- a/tests/Functional/Repository/UserRepositoryTest.php
+++ b/tests/Functional/Repository/UserRepositoryTest.php
@@ -18,7 +18,6 @@ class UserRepositoryTest extends KernelTestCase
         $kernel = self::bootKernel();
 
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
-        // $this->signalementRepository = $this->entityManager->getRepository(Signalement::class);
         $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
     }
 

--- a/tests/Functional/Repository/UserRepositoryTest.php
+++ b/tests/Functional/Repository/UserRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Repository;
 
 use App\Entity\User;
+use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -10,12 +11,15 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 class UserRepositoryTest extends KernelTestCase
 {
     private EntityManagerInterface $entityManager;
+    private SignalementRepository $signalementRepository;
 
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
 
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        // $this->signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
     }
 
     public function testFindInactiveUserWithNbAffectations(): void
@@ -33,5 +37,31 @@ class UserRepositoryTest extends KernelTestCase
                 $this->assertEquals($user['nb_signalements'], \count(explode(',', $user['signalements'])));
             }
         }
+    }
+
+    public function testFindActiveTerritoryAdmins69(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000003']);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+
+        $users = $userRepository->findActiveTerritoryAdmins($signalement->getTerritory(), $signalement->getInseeOccupant());
+
+        $this->assertIsArray($users);
+        $this->assertCount(1, $users);
+    }
+
+    public function testFindActiveTerritoryAdmins13(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000006']);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+
+        $users = $userRepository->findActiveTerritoryAdmins($signalement->getTerritory(), $signalement->getInseeOccupant());
+
+        $this->assertIsArray($users);
+        $this->assertCount(2, $users);
     }
 }

--- a/tests/Functional/Service/Signalement/VisiteNotifierTest.php
+++ b/tests/Functional/Service/Signalement/VisiteNotifierTest.php
@@ -49,4 +49,14 @@ class VisiteNotifierTest extends KernelTestCase
         $nbNotified = $this->visiteNotifier->notifyVisiteToConclude($intervention);
         $this->assertEquals($nbNotified, 3);
     }
+
+    public function testNotifyVisiteToConclude69()
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000003']);
+        /** @var Intervention $intervention * */
+        $intervention = $signalement->getInterventions()[0];
+
+        $nbNotified = $this->visiteNotifier->notifyVisiteToConclude($intervention);
+        $this->assertEquals($nbNotified, 2);
+    }
 }


### PR DESCRIPTION
## Ticket

#1804    

## Description
Pour le territoire 69, qui a un comportement spécial, nous avons constaté que certains mails concernant les visites ("mail de conclusion de visite" par exemple) étaient envoyés à tous les responsables territoires du 69 et pas seulement à la métropole concernée (COR ou MDL)

## Changements apportés
* Modification de la fonction findActiveTerritoryAdmins() dans le userRepository, pour lui envoyer le code insee du signalement, et filtrer les responsables de territoires liés à ce code insee
* Créations de fixtures pour faire les tests adéquats

## Pré-requis
`make load-fixtures`

## Tests
- [ ] CD/CI Ok
- [ ] ouvrir le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000003
- [ ] Modifier la date de visite pour la mettre dans le passé, et pouvoir ajouter une conclusion de visite
- [ ] Vérifier que le mail TYPE_VISITE_CONFIRMED_TO_PARTNER a été envoyé au partenaire, et seulement au resp territoire de la bonne métropole (MDL, et non pas COR) et à l'usager le cas échéant
