### PR TITLE
[QA] Ne plus utiliser l'utilisateur partenaire dans les status esabora

### DIFF
--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -40,13 +40,11 @@ class EsaboraManager
         DossierResponseInterface $dossierResponse,
         Affectation $affectation
     ): void {
-        $user = $affectation->getPartner()->getUsers()->first();
+        $adminUser = $this->userManager->findOneBy(['email' => $this->parameterBag->get('user_system_email')]);
         $signalement = $affectation->getSignalement();
 
-        $description = $this->updateStatusFor($affectation, $user, $dossierResponse);
+        $description = $this->updateStatusFor($affectation, $adminUser, $dossierResponse);
         if (!empty($description)) {
-            $adminEmail = $this->parameterBag->get('user_system_email');
-            $adminUser = $this->userManager->findOneBy(['email' => $adminEmail]);
             $suivi = $this->suiviManager->createSuivi(
                 user: $adminUser,
                 signalement: $signalement,


### PR DESCRIPTION
## Ticket

#1819 

## Description
Des restes de récupération d'utilisateur de partenaire pour les suivi
[Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/69089/?project=61&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&referrer=issue-stream&sort=inbox&statsPeriod=14d)

## Changements apportés
* Suppression du code obsolète et appel de l'utilisateur de type admin

## Pré-requis
```bash
$ make mock
$ make worker-start
```
## Tests
- [ ] Executer `make sync-sish`
