### PR TITLE
[Esabora] Correction de la commande 'push-failed-esabora-dossier'

### DIFF
--- a/src/Command/PushFailedEsaboraDossierCommand.php
+++ b/src/Command/PushFailedEsaboraDossierCommand.php
@@ -66,7 +66,6 @@ class PushFailedEsaboraDossierCommand extends Command
         foreach ($failedDossiers as $failedDossier) {
             $signalementId = $failedDossier->getSignalementId();
             $partnerId = $failedDossier->getPartnerId();
-            $this->io->text('Renvoi du dossier pour le signalement '.$signalementId.' et le partenaire '.$partnerId);
 
             $signalement = $this->signalementRepository->find($signalementId);
 
@@ -74,7 +73,12 @@ class PushFailedEsaboraDossierCommand extends Command
                 return $affectation->getPartner()->getId() === $partnerId;
             })->first();
 
-            $this->esaboraBus->dispatch($affectation);
+            if ($affectation instanceof Affectation) {
+                $this->io->text('Renvoi du dossier pour le signalement '.$signalementId.' et le partenaire '.$partnerId);
+                $this->esaboraBus->dispatch($affectation);
+            } else {
+                $this->io->text('Pas d\'affectation trouvée pour le signalement '.$signalementId.' par le partenaire '.$partnerId);
+            }
         }
         sleep($delay);
         $failedDossiersAfter = $this->jobEventRepository->findFailedEsaboraDossierByPartnerTypeByAction(PartnerType::ARS, $action);


### PR DESCRIPTION
## Ticket

#1508    

## Description
Correction de la commande `push-failed-esabora-dossier` qui échouait si jamais l'affectation n'existe plus (ce qui peut arriver)

## Changements apportés
* On vérifie l'existence de l'affectation avant de renvoyer les dossiers

## Pré-requis

## Tests
- [ ] Idéalement cf ici : https://github.com/MTES-MCT/histologe/pull/1806 en enlevant l'affectation à mi-chemin (mais j'avoue que j'ai la flemme là)
