### PR TITLE
[Back] Créer un service pour la transformation des valeurs d'entrée du formulaire 

### DIFF
--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -32,7 +32,8 @@ class SignalementBuilder
         private TypeCompositionLogementFactory $typeCompositionLogementFactory,
         private SituationFoyerFactory $situationFoyerFactory,
         private InformationProcedureFactory $informationProcedureFactory,
-        private InformationComplementaireFactory $informationComplementaireFactory
+        private InformationComplementaireFactory $informationComplementaireFactory,
+        private SignalementInputValueMapper $signalementInputValueMapper,
     ) {
     }
 
@@ -271,7 +272,7 @@ class SignalementBuilder
             return null;
         }
 
-        return 'oui' === $value;
+        return $this->signalementInputValueMapper->map($value);
     }
 
     private function isConstructionAvant1949(?string $dateConstruction): ?bool
@@ -311,7 +312,9 @@ class SignalementBuilder
     private function resolveIsAllocataire(): ?string
     {
         if ($this->evalBoolean($this->signalementDraftRequest->getLogementSocialAllocation())) {
-            return strtoupper($this->signalementDraftRequest->getLogementSocialAllocationCaisse());
+            return $this->signalementInputValueMapper->map(
+                $this->signalementDraftRequest->getLogementSocialAllocationCaisse()
+            );
         }
 
         return '0';

--- a/src/Service/Signalement/SignalementInputValueMapper.php
+++ b/src/Service/Signalement/SignalementInputValueMapper.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Service\Signalement;
+
+class SignalementInputValueMapper
+{
+    public const MAPPING_VALUES = [
+        'oui' => true,
+        'non' => false,
+        'nsp' => null,
+        'caf' => 'CAF',
+        'msa' => 'MSA',
+    ];
+
+    public function map(string $value)
+    {
+        return self::MAPPING_VALUES[$value] ?? null;
+    }
+}

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -13,6 +13,7 @@ use App\Repository\TerritoryRepository;
 use App\Serializer\SignalementDraftRequestSerializer;
 use App\Service\Signalement\ReferenceGenerator;
 use App\Service\Signalement\SignalementBuilder;
+use App\Service\Signalement\SignalementInputValueMapper;
 use App\Service\Signalement\ZipcodeProvider;
 use App\Service\Token\TokenGeneratorInterface;
 use App\Tests\FixturesHelper;
@@ -39,6 +40,7 @@ class SignalementBuilderTest extends KernelTestCase
         $situationFoyerFactory = static::getContainer()->get(SituationFoyerFactory::class);
         $informationProcedureFactory = static::getContainer()->get(InformationProcedureFactory::class);
         $informationComplementaireFactory = static::getContainer()->get(InformationComplementaireFactory::class);
+        $signalementInputValueMapper = static::getContainer()->get(SignalementInputValueMapper::class);
 
         $this->signalementBuilder = new SignalementBuilder(
             $territoryRepository,
@@ -49,7 +51,8 @@ class SignalementBuilderTest extends KernelTestCase
             $typeCompositionLogementFactory,
             $situationFoyerFactory,
             $informationProcedureFactory,
-            $informationComplementaireFactory
+            $informationComplementaireFactory,
+            $signalementInputValueMapper
         );
     }
 

--- a/tests/Unit/Service/Signalement/SignalementInputValueMapperTest.php
+++ b/tests/Unit/Service/Signalement/SignalementInputValueMapperTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests\Unit\Service\Signalement;
+
+use App\Service\Signalement\SignalementInputValueMapper;
+use PHPUnit\Framework\TestCase;
+
+class SignalementInputValueMapperTest extends TestCase
+{
+    /**
+     * @dataProvider provideInputValue
+     */
+    public function testMap(string $inputValue, bool|string|null $mappedInputValue): void
+    {
+        $signalementInputValueMapper = new SignalementInputValueMapper();
+        $this->assertEquals($mappedInputValue, $signalementInputValueMapper->map($inputValue));
+    }
+
+    public function provideInputValue(): \Generator
+    {
+        yield 'Input with Oui value' => ['oui', true];
+        yield 'Input with Non value' => ['non', false];
+        yield 'Input with Nsp value' => ['nsp', null];
+        yield 'Input with caf value' => ['caf', 'CAF'];
+        yield 'Input with msa value' => ['msa', 'MSA'];
+    }
+}


### PR DESCRIPTION
## Ticket

#1835    

## Description
Centraliser les valeurs à transformer qui sont propre au nouveau formulaire

## Changements apportés
* Ajout d'un service mapper
* Utilisation de ce service dans signalementBuilder

## Pré-requis
https://github.com/MTES-MCT/histologe/pull/1788#discussion_r1363882760

## Tests
- [ ] Non regression dans la soumission de signalement OK
- [ ] Non regression dans l'affichage
![image](https://github.com/MTES-MCT/histologe/assets/5757116/9a062202-0e6c-43ba-bb4c-076e702bd3e3)

