### PR TITLE
[CGU] Modification

### DIFF
--- a/templates/back/cgu_bo.html.twig
+++ b/templates/back/cgu_bo.html.twig
@@ -42,8 +42,7 @@
         </li>
         <li>
             « L’Administrateur» ou « L’agent » est la personne travaillant dans la structure (collectivité territoriale ou
-            services de l’Etat) ayant conventionné avec {{ platform.name }} et habilitée à hiérarchiser les signalements et les
-            transférer aux partenaires pour traitement des désordres.
+            services de l’Etat) habilitée à hiérarchiser les signalements et les transférer aux partenaires pour traitement des désordres.
         </li>
         <li>
             « Les partenaires » sont les autres services de l’Etat, les collectivités territoriales, les opérateurs et

--- a/templates/front/cgu.html.twig
+++ b/templates/front/cgu.html.twig
@@ -44,8 +44,7 @@
                         </li>
                         <li>
                             «l’Administrateur« ou « L’agent » est la personne travaillant dans la structure (collectivité territoriale ou
-                            services de l’Etat) ayant conventionné avec {{ platform.name }} et habilitée à hiérarchiser les signalements et les 
-                            transférer aux partenaires pour traitement des désordres.
+                            services de l’Etat) habilitée à hiérarchiser les signalements et les transférer aux partenaires pour traitement des désordres.
                         </li>
                         <li>
                             « Les partenaires » sont les autres services de l’Etat, les collectivités territoriales, les opérateurs


### PR DESCRIPTION
## Ticket

#1839    

## Description

> Article 3 - Définition
remplacer :
`«l’Administrateur« ou « L’agent » est la personne travaillant dans la structure (collectivité territoriale ou services de l’Etat) ayant conventionné avec Histologe et habilitée à hiérarchiser les signalements et les transférer aux partenaires pour traitement des désordres.`
par
`«l’Administrateur« ou « L’agent » est la personne travaillant dans la structure (collectivité territoriale ou services de l’Etat) habilitée à hiérarchiser les signalements et les transférer aux partenaires pour traitement des désordres.`

## Changements apportés
* Modifications des 2 twigs de cgu

## Pré-requis

## Tests
- [ ] Vérifier les cgu front (lien "mentions légales" en bas)
- [ ] Vérifier les cgu back (en demandant et effectuant une activation de compte ou un cangement de mot de passe, dans la modale)
