### PR TITLE
[BO - signalement] Interdire l'accès à l'édition d'un signalement cloturé (ou archivé)

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -217,6 +217,17 @@ class SignalementController extends AbstractController
         CriticiteCalculator $criticiteCalculator,
         SignalementQualificationUpdater $signalementQualificationUpdater
     ): Response {
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
+        if (Signalement::STATUS_ARCHIVED === $signalement->getStatut()) {
+            $this->addFlash('error', "Ce signalement a été archivé et n'est pas éditable.");
+
+            return $this->redirectToRoute('back_index');
+        }
+        if (Signalement::STATUS_CLOSED === $signalement->getStatut()) {
+            $this->addFlash('error', "Ce signalement a été cloturé et n'est pas éditable.");
+
+            return $this->redirectToRoute('back_index');
+        }
         $title = 'Administration - Edition signalement #'.$signalement->getReference();
         $etats = ['Etat moyen', 'Mauvais état', 'Très mauvais état'];
         $etats_classes = ['moyen', 'grave', 'tres-grave'];

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -218,13 +218,8 @@ class SignalementController extends AbstractController
         SignalementQualificationUpdater $signalementQualificationUpdater
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
-        if (Signalement::STATUS_ARCHIVED === $signalement->getStatut()) {
-            $this->addFlash('error', "Ce signalement a été archivé et n'est pas éditable.");
-
-            return $this->redirectToRoute('back_index');
-        }
-        if (Signalement::STATUS_CLOSED === $signalement->getStatut()) {
-            $this->addFlash('error', "Ce signalement a été cloturé et n'est pas éditable.");
+        if (Signalement::STATUS_ACTIVE !== $signalement->getStatut()) {
+            $this->addFlash('error', "Ce signalement n'est pas éditable.");
 
             return $this->redirectToRoute('back_index');
         }

--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -68,8 +68,10 @@
         <td class="fr-text--right fr-ws-nowrap">
             <a href="{{ path('back_signalement_view',{uuid:signalement.uuid}) }}"
                class="fr-btn fr-btn--sm fr-fi-eye-fill"></a>
-            <a href="{{ path('back_signalement_edit',{uuid:signalement.uuid}) }}"
-               class="fr-btn fr-btn--secondary fr-btn--sm fr-fi-edit-fill"></a>
+            {% if signalement.statut is same as(2) %}
+                <a href="{{ path('back_signalement_edit',{uuid:signalement.uuid}) }}"
+                class="fr-btn fr-btn--secondary fr-btn--sm fr-fi-edit-fill"></a>
+            {% endif %}
             {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                 <button data-delete="{{ path('back_signalement_delete',{uuid:signalement.uuid}) }}"
                         data-token="{{ signalements.csrfTokens[signalement.uuid] }}"


### PR DESCRIPTION
## Ticket

#1825 
#1826 

## Description
Sécurisation de la route `back_signalement_edit` et suppression du bouton "éditer" dans la liste des signalements si le signalement n'est pas en cours

## Changements apportés
* Ajout d'une vérification d'accès et de statut du signalement dans la route `back_signalement_edit`
* Ajout d'une condition sur le statut du signalement dans l'affichage de la liste des signalements pour afficher le bouton d'édition

## Pré-requis

## Tests
- [ ] Dans la liste des signalements, vérifier que le bouton "éditer" n'apparait que sur les signalements "en cours"
- [ ] Ouvrir les signalements avec les autres statuts et essayer d'ajouter `/editer `dans la barre d'adresse pour voir s'il est possible de les éditer
