### PR TITLE
 [Formulaire] Ajustements json

### DIFF
--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -1560,11 +1560,8 @@
       "body": [
         {
           "type": "SignalementFormCheckbox",
-          "slug": "desordres_logement_humidite_piece_a_vivre",
           "label": "{{dictionaryStore::desordres_logement_humidite_piece_a_vivre}}",
-          "conditional": {
-            "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
-          },
+          "slug": "desordres_logement_humidite_piece_a_vivre",
           "validate": {
             "required": false
           }
@@ -1575,7 +1572,7 @@
           "slug": "desordres_logement_humidite_piece_a_vivre_details",
           "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
-            "show": "formStore.data.desordres_logement_humidite_piece_a_vivre === 1 || formStore.data.composition_logement_piece_unique === 'piece_unique'"
+            "show": "formStore.data.desordres_logement_humidite_piece_a_vivre === 1"
           },
           "components": {
             "body": [
@@ -1593,6 +1590,14 @@
                     "value": "non"
                   }
                 ]
+              },
+              {
+                "type": "SignalementFormInfo",
+                "label": "Les dégâts des eaux sont généralement pris en charge par les assurances. Pour savoir comment faire un constat auprès de votre assurance, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/F1352' target='_blank'>le site du service public.</a>",
+                "slug": "desordres_logement_humidite_piece_a_vivre_details_fuite_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_humidite_piece_a_vivre_details_fuite ===  'oui'"
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",
@@ -1684,6 +1689,14 @@
                 ]
               },
               {
+                "type": "SignalementFormInfo",
+                "label": "Les dégâts des eaux sont généralement pris en charge par les assurances. Pour savoir comment faire un constat auprès de votre assurance, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/F1352' target='_blank'>le site du service public.</a>",
+                "slug": "desordres_logement_humidite_cuisine_details_fuite_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_humidite_cuisine_details_fuite ===  'oui'"
+                }
+              },
+              {
                 "type": "SignalementFormOnlyChoice",
                 "label": "{{dictionaryStore::desordres_logement_humidite_cuisine_details_machine}}",
                 "slug": "desordres_logement_humidite_cuisine_details_machine",
@@ -1771,6 +1784,14 @@
                     "value": "non"
                   }
                 ]
+              },
+              {
+                "type": "SignalementFormInfo",
+                "label": "Les dégâts des eaux sont généralement pris en charge par les assurances. Pour savoir comment faire un constat auprès de votre assurance, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/F1352' target='_blank'>le site du service public.</a>",
+                "slug": "desordres_logement_humidite_salle_de_bain_details_fuite_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_humidite_salle_de_bain_details_fuite ===  'oui'"
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -1589,11 +1589,8 @@
       "body": [
         {
           "type": "SignalementFormCheckbox",
-          "slug": "desordres_logement_humidite_piece_a_vivre",
           "label": "{{dictionaryStore::desordres_logement_humidite_piece_a_vivre}}",
-          "conditional": {
-            "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
-          },
+          "slug": "desordres_logement_humidite_piece_a_vivre",
           "validate": {
             "required": false
           }
@@ -1604,7 +1601,7 @@
           "slug": "desordres_logement_humidite_piece_a_vivre_details",
           "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
-            "show": "formStore.data.desordres_logement_humidite_piece_a_vivre === 1 || formStore.data.composition_logement_piece_unique === 'piece_unique'"
+            "show": "formStore.data.desordres_logement_humidite_piece_a_vivre === 1"
           },
           "components": {
             "body": [
@@ -1622,6 +1619,14 @@
                     "value": "non"
                   }
                 ]
+              },
+              {
+                "type": "SignalementFormInfo",
+                "label": "Les dégâts des eaux sont généralement pris en charge par les assurances. Pour savoir comment faire un constat auprès de votre assurance, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/F1352' target='_blank'>le site du service public.</a>",
+                "slug": "desordres_logement_humidite_piece_a_vivre_details_fuite_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_humidite_piece_a_vivre_details_fuite ===  'oui'"
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",
@@ -1690,6 +1695,14 @@
                 ]
               },
               {
+                "type": "SignalementFormInfo",
+                "label": "Les dégâts des eaux sont généralement pris en charge par les assurances. Pour savoir comment faire un constat auprès de votre assurance, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/F1352' target='_blank'>le site du service public.</a>",
+                "slug": "desordres_logement_humidite_cuisine_details_fuite_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_humidite_cuisine_details_fuite ===  'oui'"
+                }
+              },
+              {
                 "type": "SignalementFormOnlyChoice",
                 "label": "{{dictionaryStore::desordres_logement_humidite_cuisine_details_machine}}",
                 "slug": "desordres_logement_humidite_cuisine_details_machine",
@@ -1754,6 +1767,14 @@
                     "value": "non"
                   }
                 ]
+              },
+              {
+                "type": "SignalementFormInfo",
+                "label": "Les dégâts des eaux sont généralement pris en charge par les assurances. Pour savoir comment faire un constat auprès de votre assurance, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/F1352' target='_blank'>le site du service public.</a>",
+                "slug": "desordres_logement_humidite_salle_de_bain_details_fuite_info",
+                "conditional": {
+                  "show": "formStore.data.desordres_logement_humidite_salle_de_bain_details_fuite ===  'oui'"
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -867,7 +867,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Est-ce que les locataires bénéficient d'une aide ou allocation logement ?",
+          "label": "Est-ce que le foyer bénéficie d'une aide ou allocation logement ?",
           "slug": "logement_social_allocation",
           "values": [
             {
@@ -963,7 +963,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "travailleur_social_quitte_logement",
-          "label": "Savez-vous si les locataires souhaitent ou ont prévu de quitter votre logement ?",
+          "label": "Savez-vous si le foyer souhaite ou a prévu de quitter le logement ?",
           "values": [
             {
               "label": "Oui",
@@ -982,7 +982,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "travailleur_social_accompagnement",
-          "label": "Est-ce que les locataires bénéficient d'un accompagnement par un ou une travailleuse sociale ?",
+          "label": "Est-ce que le foyer bénéficie d'un accompagnement par un ou une travailleuse sociale ?",
           "values": [
             {
               "label": "Oui",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -805,7 +805,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Est-ce que les locataires bénéficient d'une aide ou allocation logement ?",
+          "label": "Est-ce que le foyer bénéficie d'une aide ou allocation logement ?",
           "slug": "logement_social_allocation",
           "values": [
             {
@@ -901,7 +901,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "travailleur_social_quitte_logement",
-          "label": "Savez-vous si les locataires souhaitent ou ont prévu de quitter votre logement ?",
+          "label": "Savez-vous si le foyer souhaite ou a prévu de quitter le logement ?",
           "values": [
             {
               "label": "Oui",
@@ -920,7 +920,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "travailleur_social_accompagnement",
-          "label": "Est-ce que les locataires bénéficient d'un accompagnement par un ou une travailleuse sociale ?",
+          "label": "Est-ce que le foyer bénéficie d'un accompagnement par un ou une travailleuse sociale ?",
           "values": [
             {
               "label": "Oui",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -788,7 +788,7 @@
       "body": [
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Est-ce que les locataires bénéficient d'une aide ou allocation logement ?",
+          "label": "Est-ce que le foyer bénéficie d'une aide ou allocation logement ?",
           "slug": "logement_social_allocation",
           "values": [
             {
@@ -884,7 +884,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "travailleur_social_quitte_logement",
-          "label": "Savez-vous si les locataires souhaitent ou ont prévu de quitter votre logement ?",
+          "label": "Savez-vous si le foyer souhaite ou a prévu de quitter le logement ?",
           "values": [
             {
               "label": "Oui",
@@ -903,7 +903,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "travailleur_social_accompagnement",
-          "label": "Est-ce que les locataires bénéficient d'un accompagnement par un ou une travailleuse sociale ?",
+          "label": "Est-ce que le foyer bénéficie d'un accompagnement par un ou une travailleuse sociale ?",
           "values": [
             {
               "label": "Oui",


### PR DESCRIPTION
## Ticket

#1845 
#1840 

## Description
Ajout d'un SignalementFormInfo sur le désordre logement "hulmidité moisissure" (et suppression d'une incohérence de condition d'affichage entre la première checkbox et son subscreen)
Changement de textes pour les tiers

## Changements apportés
* Changement des 2 json de désordres
* Changement de 3 json de questions pour les tiers

## Pré-requis

## Tests
- [ ] Faire un signalement en tiers sauf secours
- [ ] Choisir la zone "logement"
- [ ] Dans la situation du foyer, vérifier que les termes "les locataires" ont été remplacés par "le foyer"
- [ ] Choisir la catégorie de désordre "Humidité et moisissures", vérifier dans l'affichage du désordre, que si on choisit "oui" à "est-ce qu'il y a une fuite?" un texte d'info ss'affiche sur la prise en charge par les assurances. Vérifier le lien vers le site du service public.
