### PR TITLE
[FO - Signalement]  Ajoute la possibilité de mettre des étages négatifs

### DIFF
--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -377,7 +377,7 @@ class SignalementType extends AbstractType
             ->add('etageOccupant', NumberType::class, [
                 'attr' => [
                     'class' => 'fr-input',
-                    'pattern' => '^\d{1,3}$',
+                    'pattern' => '^(-\d{1,3}|\d{1,3})$',
                     'maxlength' => '3',
                 ],
                 'label_attr' => [

--- a/templates/_partials/_signalement_steps_tabs.html.twig
+++ b/templates/_partials/_signalement_steps_tabs.html.twig
@@ -298,9 +298,9 @@
                         <div class="fr-input-group">
                             {{ form_label(form.etageOccupant) }}
                             {{ form_widget(form.etageOccupant) }}
-                            <p class="fr-hint-text">Saisissez 0 pour le rez-de-chaussée (RDC), 1 pour le premier étage, etc.</p>
+                            <p class="fr-hint-text">Saisissez 0 pour le rez-de-chaussée (RDC), 1 pour le premier étage, -1 pour le sous-sol, etc.</p>
                             <p class="fr-error-text fr-hidden">
-                                Veuillez saisir 0 pour le rez-de-chaussée (RDC), 1 pour le premier étage, etc.
+                                Veuillez saisir 0 pour le rez-de-chaussée (RDC), 1 pour le premier étage, -1 pour le sous-sol, etc.
                             </p>
                         </div>
                         {{ form_row(form.escalierOccupant) }}


### PR DESCRIPTION
## Ticket

#1834    

## Description
Dansle formulaire actuel, ajoute la possibilité de mettre un étage négatif pour le sous-sol

## Changements apportés
* Modification du pattern dans le formType
* Modification de la description et de l'erreur du champ texte

## Pré-requis

## Tests
- [ ] Faire un signalement et vérifier qu'il est possible de mettre -1 pour un étage
