### PR TITLE
[Back] Correction pour faire un suivi public dans tous les cas si c'est une clôture pour tous

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -95,21 +95,23 @@ class SignalementController extends AbstractController
             $params['subject'] = $user?->getPartner()?->getNom();
             $params['closed_for'] = $clotureForm->get('type')->getData();
 
+            $entity = null;
             if ('all' === $params['closed_for']) {
                 $params['subject'] = 'tous les partenaires';
                 $entity = $signalement = $signalementManager->closeSignalementForAllPartners(
                     $signalement,
                     $params['motif_cloture']
                 );
-            }
 
-            /** @var Affectation $isAffected */
-            if ($isAffected) {
+                /* @var Affectation $isAffected */
+            } elseif ($isAffected) {
                 $entity = $affectationManager->closeAffectation($isAffected, $user, $params['motif_cloture'], true);
             }
 
-            $eventDispatcher->dispatch(new SignalementClosedEvent($entity, $params), SignalementClosedEvent::NAME);
-            $this->addFlash('success', 'Signalement cloturé avec succès !');
+            if (!empty($entity)) {
+                $eventDispatcher->dispatch(new SignalementClosedEvent($entity, $params), SignalementClosedEvent::NAME);
+                $this->addFlash('success', 'Signalement cloturé avec succès !');
+            }
 
             return $this->redirectToRoute('back_index');
         }


### PR DESCRIPTION
## Ticket

#1857   

## Description
Correction pour faire un suivi public dans tous les cas si c'est une clôture pour tous

## Tests
- [ ] Affecter un signalement à un ou plusieurs partenaires, dont un comprenant un admin territoire
- [ ] Se logger en admin territoire, clôturer le signalement pour tous
- [ ] Vérifier que le suivi est public, et non interne
