### PR TITLE
[BO - Signalement] Ajout d'une liste de motifs de refus d'affectation ou signalement

### DIFF
--- a/migrations/Version20231031132907.php
+++ b/migrations/Version20231031132907.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231031132907 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add field motif_refus to affectation and signalement tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE affectation ADD motif_refus VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE signalement ADD motif_refus VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE affectation DROP motif_refus');
+        $this->addSql('ALTER TABLE signalement DROP motif_refus');
+    }
+}

--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -117,7 +117,7 @@ class AffectationController extends AbstractController
             && $response = $request->get('signalement-affectation-response')
         ) {
             $status = isset($response['accept']) ? Affectation::STATUS_ACCEPTED : Affectation::STATUS_REFUSED;
-            $motifRefus = (Affectation::STATUS_REFUSED === $status) ? $response['motifRefus'] : '';
+            $motifRefus = (Affectation::STATUS_REFUSED === $status) ? $response['motifRefus'] : null;
             $affectation = $this->affectationManager->updateAffectation($affectation, $user, $status, $motifRefus);
 
             $suiviAffectationAccepted = $suiviRepository->findSuiviByDescription(

--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -117,7 +117,8 @@ class AffectationController extends AbstractController
             && $response = $request->get('signalement-affectation-response')
         ) {
             $status = isset($response['accept']) ? Affectation::STATUS_ACCEPTED : Affectation::STATUS_REFUSED;
-            $affectation = $this->affectationManager->updateAffectation($affectation, $user, $status);
+            $motifRefus = (Affectation::STATUS_REFUSED === $status) ? $response['motifRefus'] : '';
+            $affectation = $this->affectationManager->updateAffectation($affectation, $user, $status, $motifRefus);
 
             $suiviAffectationAccepted = $suiviRepository->findSuiviByDescription(
                 $signalement,

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -11,7 +11,6 @@ use App\Entity\User;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
-use App\Service\Signalement\QualificationStatusService;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -21,7 +20,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[Route('/bo/signalements')]
 class SignalementActionController extends AbstractController
@@ -31,9 +29,7 @@ class SignalementActionController extends AbstractController
         Signalement $signalement,
         Request $request,
         ManagerRegistry $doctrine,
-        UrlGeneratorInterface $urlGenerator,
         NotificationMailerRegistry $notificationMailerRegistry,
-        QualificationStatusService $qualificationStatusService
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
         if ($this->isCsrfTokenValid('signalement_validation_response_'.$signalement->getId(), $request->get('_token'))

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Back;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\MotifRefus;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\Tag;
@@ -58,6 +59,7 @@ class SignalementActionController extends AbstractController
                 }
             } else {
                 $statut = Signalement::STATUS_REFUSED;
+                $signalement->setMotifRefus(MotifRefus::tryFrom($response['motifRefus']));
                 $description = 'cloturé car non-valide avec le motif suivant :<br>'.$response['suivi'];
 
                 $toRecipients = $signalement->getMailUsagers();
@@ -72,11 +74,11 @@ class SignalementActionController extends AbstractController
                 );
             }
             $suivi = new Suivi();
-            $suivi->setSignalement($signalement);
-            $suivi->setDescription('Signalement '.$description);
-            $suivi->setCreatedBy($this->getUser());
-            $suivi->setIsPublic(true);
-            $suivi->setType(SUIVI::TYPE_AUTO);
+            $suivi->setSignalement($signalement)
+                ->setDescription('Signalement '.$description)
+                ->setCreatedBy($this->getUser())
+                ->setIsPublic(true)
+                ->setType(SUIVI::TYPE_AUTO);
             $signalement->setStatut($statut);
             $doctrine->getManager()->persist($signalement);
             $doctrine->getManager()->persist($suivi);

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -150,6 +150,7 @@ affectations:
     answered_by: "user-38-01@histologe.fr"
     affected_by: "user-38-01@histologe.fr"
     motif_cloture: ""
+    motif_refus: "DOUBLON"
     territory: "Isère"
   -
     signalement: 2023-23

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -1472,6 +1472,7 @@ signalements:
     cp_occupant: "13003"
     ville_occupant: "Marseille"
     statut: 8
+    motif_refus: "DOUBLON"
     code_suivi: '0123456784569'
     reference: "2023-21"
     geoloc: "{\"lng\":\"43.3117791\", \"lat\":\"5.3755551\"}"

--- a/src/DataFixtures/Loader/LoadAffectationData.php
+++ b/src/DataFixtures/Loader/LoadAffectationData.php
@@ -4,6 +4,7 @@ namespace App\DataFixtures\Loader;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\MotifRefus;
 use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Repository\TerritoryRepository;
@@ -49,6 +50,11 @@ class LoadAffectationData extends Fixture implements OrderedFixtureInterface
         if (Affectation::STATUS_CLOSED === $row['statut'] && '' !== $row['motif_cloture']) {
             $affectation
                 ->setMotifCloture(MotifCloture::tryFrom($row['motif_cloture']));
+        }
+
+        if (Affectation::STATUS_REFUSED === $row['statut'] && '' !== $row['motif_refus']) {
+            $affectation
+                ->setMotifRefus(MotifRefus::tryFrom($row['motif_refus']));
         }
 
         $manager->persist($affectation);

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -4,6 +4,7 @@ namespace App\DataFixtures\Loader;
 
 use App\Entity\Criticite;
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\MotifRefus;
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\QualificationStatus;
 use App\Entity\File;
@@ -134,6 +135,11 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 ->setMotifCloture(MotifCloture::tryFrom($row['motif_cloture']))
                 ->setClosedAt(new \DateTimeImmutable())
                 ->setClosedBy($this->userRepository->findOneBy(['statut' => User::STATUS_ACTIVE]));
+        }
+
+        if (Signalement::STATUS_REFUSED === $row['statut']) {
+            $signalement
+                ->setMotifRefus(MotifRefus::tryFrom($row['motif_refus']));
         }
 
         if (isset($row['tags'])) {

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\MotifRefus;
 use App\Repository\AffectationRepository;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -46,6 +47,9 @@ class Affectation
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     private ?User $affectedBy;
+
+    #[ORM\Column(type: 'string', enumType: MotifRefus::class, nullable: true)]
+    private ?MotifRefus $motifRefus;
 
     #[ORM\Column(type: 'string', enumType: MotifCloture::class, nullable: true)]
     private ?MotifCloture $motifCloture;
@@ -149,6 +153,18 @@ class Affectation
     public function setAffectedBy(?User $affectedBy): self
     {
         $this->affectedBy = $affectedBy;
+
+        return $this;
+    }
+
+    public function getMotifRefus(): ?MotifRefus
+    {
+        return $this->motifRefus;
+    }
+
+    public function setMotifRefus(?MotifRefus $motifRefus): self
+    {
+        $this->motifRefus = $motifRefus;
 
         return $this;
     }

--- a/src/Entity/Enum/MotifRefus.php
+++ b/src/Entity/Enum/MotifRefus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum MotifRefus: string
+{
+    case HORS_PDLHI = 'HORS_PDLHI';
+    case HORS_ZONE_GEOGRAPHIQUE = 'HORS_ZONE_GEOGRAPHIQUE';
+    case HORS_COMPETENCE = 'HORS_COMPETENCE';
+    case DOUBLON = 'DOUBLON';
+    case AUTRE = 'AUTRE';
+
+    public function label(): string
+    {
+        return self::getLabelList()[$this->name];
+    }
+
+    public static function getLabelList(): array
+    {
+        return [
+            'HORS_PDLHI' => 'Hors PDLHI',
+            'HORS_ZONE_GEOGRAPHIQUE' => 'Hors zone géographique',
+            'HORS_COMPETENCE' => 'Hors compétence',
+            'DOUBLON' => 'Doublon',
+            'AUTRE' => 'Autre',
+        ];
+    }
+}

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\MotifRefus;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Model\InformationComplementaire;
 use App\Entity\Model\InformationProcedure;
@@ -312,6 +313,9 @@ class Signalement
 
     #[ORM\Column(type: 'string', enumType: MotifCloture::class, nullable: true)]
     private ?MotifCloture $motifCloture;
+
+    #[ORM\Column(type: 'string', enumType: MotifRefus::class, nullable: true)]
+    private ?MotifRefus $motifRefus;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $closedAt;
@@ -1522,6 +1526,18 @@ class Signalement
     public function setMotifCloture(?MotifCloture $motifCloture): self
     {
         $this->motifCloture = $motifCloture;
+
+        return $this;
+    }
+
+    public function getMotifRefus(): ?MotifRefus
+    {
+        return $this->motifRefus;
+    }
+
+    public function setMotifRefus(?MotifRefus $motifRefus): self
+    {
+        $this->motifRefus = $motifRefus;
 
         return $this;
     }

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -22,7 +22,7 @@ class AffectationManager extends Manager
         parent::__construct($this->managerRegistry, $entityName);
     }
 
-    public function updateAffectation(Affectation $affectation, User $user, string $status, string $motifRefus = ''): Affectation
+    public function updateAffectation(Affectation $affectation, User $user, string $status, ?string $motifRefus = null): Affectation
     {
         $affectation
             ->setStatut($status)

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -4,6 +4,7 @@ namespace App\Manager;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\MotifRefus;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -21,12 +22,16 @@ class AffectationManager extends Manager
         parent::__construct($this->managerRegistry, $entityName);
     }
 
-    public function updateAffectation(Affectation $affectation, User $user, string $status): Affectation
+    public function updateAffectation(Affectation $affectation, User $user, string $status, string $motifRefus = ''): Affectation
     {
         $affectation
             ->setStatut($status)
             ->setAnsweredBy($user)
             ->setAnsweredAt(new \DateTimeImmutable());
+
+        if (!empty($motifRefus)) {
+            $affectation->setMotifRefus(MotifRefus::tryFrom($motifRefus));
+        }
 
         $this->save($affectation);
 

--- a/templates/_partials/_modal_refus_affectation.html.twig
+++ b/templates/_partials/_modal_refus_affectation.html.twig
@@ -10,15 +10,29 @@
                         </h1>
                         <a href="#" class="fr-link--close fr-link" aria-controls="refus-affectation-modal">Fermer</a>
                     </div>
-                    <div class="fr-modal__content">
+                    <div class="fr-modal__content fr-text--left">
+                        <div class="fr-select-group">
+                            <label class="fr-label required" for="signalement-affectation-response[motifRefus]">
+                                Veuillez sélectionner le motif de refus
+                            </label>
+                            <p class="fr-error-text fr-hidden">Vous devez sélectionner le motif de votre refus.</p>
+                            <select class="fr-select" id="signalement-affectation-response[motifRefus]" name="signalement-affectation-response[motifRefus]" required>
+                                <option value="" selected disabled hidden>Selectionnez une option</option>
+                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_ZONE_GEOGRAPHIQUE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_ZONE_GEOGRAPHIQUE.label }}</option>
+                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_COMPETENCE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_COMPETENCE.label }}</option>
+                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.label }}</option>
+                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.label }}</option>
+                            </select>
+                        </div>
                         <div class="fr-input-group fr-mt-2v fr-text--left">
-                            <label for="refus_affectation_suivi" class="fr-label required">Motif du refus</label>
-                            <p class="fr-hint-text">Veuillez préciser le motif de ce refus <em>(10 caractères
-                                    minimum)</em></p>
+                            <label for="refus_affectation_suivi" class="fr-label required">Message aux partenaires</label>
+                            <p class="fr-hint-text">Expliquez aux autres partenaires la raison du refus de ce signalement
+                                <em>(10 caractères minimum)</em>
+                            </p>
                             <textarea class="fr-input fr-input--no-resize editor"
                                       name="signalement-affectation-response[suivi]"
                                       id="refus_affectation_suivi"></textarea>
-                            <p class="fr-error-text fr-hidden">Vous devez indiquer le motif de votre refus.</p>
+                            <p class="fr-error-text fr-hidden">Vous devez saisir un message pour les partenaires.</p>
                         </div>
                     </div>
                     <div class="fr-modal__footer">
@@ -28,10 +42,7 @@
                                         form="signalement-affectation-response-form" type="submit"
                                         name="signalement-affectation-response[deny]" value="1" disabled
                                         onclick="return confirm('Êtes-vous certain de vouloir refuser ce signalement ?')">
-                                    Ce
-                                    n'est pas
-                                    pour
-                                    moi
+                                    Refuser l'affectation
                                 </button>
                             </li>
                         </ul>

--- a/templates/_partials/_modal_refus_affectation.html.twig
+++ b/templates/_partials/_modal_refus_affectation.html.twig
@@ -3,50 +3,56 @@
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
-                    <div class="fr-modal__header">
-                        <h1 id="refus-affectation-modal-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
-                            Refus signalement #{{ signalement.reference }}
-                        </h1>
-                        <a href="#" class="fr-link--close fr-link" aria-controls="refus-affectation-modal">Fermer</a>
-                    </div>
-                    <div class="fr-modal__content fr-text--left">
-                        <div class="fr-select-group">
-                            <label class="fr-label required" for="signalement-affectation-response[motifRefus]">
-                                Veuillez sélectionner le motif de refus
-                            </label>
-                            <p class="fr-error-text fr-hidden">Vous devez sélectionner le motif de votre refus.</p>
-                            <select class="fr-select" id="signalement-affectation-response[motifRefus]" name="signalement-affectation-response[motifRefus]" required>
-                                <option value="" selected disabled hidden>Selectionnez une option</option>
-                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_ZONE_GEOGRAPHIQUE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_ZONE_GEOGRAPHIQUE.label }}</option>
-                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_COMPETENCE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_COMPETENCE.label }}</option>
-                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.label }}</option>
-                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.label }}</option>
-                            </select>
+                    <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isAffected.id}) }}"
+                            class="tinyCheck fr-mb-3v" id="signalement-affectation-response-deny-form"
+                            name="signalement-affectation-response-form" method="POST">
+                        <div class="fr-modal__header">
+                            <h1 id="refus-affectation-modal-title" class="fr-modal__title">
+                                <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
+                                Refus signalement #{{ signalement.reference }}
+                            </h1>
+                            <a href="#" class="fr-link--close fr-link" aria-controls="refus-affectation-modal">Fermer</a>
                         </div>
-                        <div class="fr-input-group fr-mt-2v fr-text--left">
-                            <label for="refus_affectation_suivi" class="fr-label required">Message aux partenaires</label>
-                            <p class="fr-hint-text">Expliquez aux autres partenaires la raison du refus de ce signalement
-                                <em>(10 caractères minimum)</em>
-                            </p>
-                            <textarea class="fr-input fr-input--no-resize editor"
-                                      name="signalement-affectation-response[suivi]"
-                                      id="refus_affectation_suivi"></textarea>
-                            <p class="fr-error-text fr-hidden">Vous devez saisir un message pour les partenaires.</p>
+                        <div class="fr-modal__content fr-text--left">
+                            <div class="fr-select-group">
+                                <label class="fr-label required" for="signalement-affectation-response[motifRefus]">
+                                    Veuillez sélectionner le motif de refus
+                                </label>
+                                <p class="fr-error-text fr-hidden">Vous devez sélectionner le motif de votre refus.</p>
+                                <select class="fr-select" id="signalement-affectation-response[motifRefus]" name="signalement-affectation-response[motifRefus]" required>
+                                    <option value="" selected disabled hidden>Selectionnez une option</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_ZONE_GEOGRAPHIQUE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_ZONE_GEOGRAPHIQUE.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_COMPETENCE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_COMPETENCE.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.label }}</option>
+                                </select>
+                            </div>
+                            <div class="fr-input-group fr-mt-2v fr-text--left">
+                                <label for="refus_affectation_suivi" class="fr-label required">Message aux partenaires</label>
+                                <p class="fr-hint-text">Expliquez aux autres partenaires la raison du refus de ce signalement
+                                    <em>(10 caractères minimum)</em>
+                                </p>
+                                <textarea class="fr-input fr-input--no-resize editor"
+                                        name="signalement-affectation-response[suivi]"
+                                        id="refus_affectation_suivi"></textarea>
+                                <p class="fr-error-text fr-hidden">Vous devez saisir un message pour les partenaires.</p>
+                            </div>
                         </div>
-                    </div>
-                    <div class="fr-modal__footer">
-                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
-                            <li>
-                                <button class="fr-btn fr-btn--danger fr-w-100"
-                                        form="signalement-affectation-response-form" type="submit"
-                                        name="signalement-affectation-response[deny]" value="1" disabled
-                                        onclick="return confirm('Êtes-vous certain de vouloir refuser ce signalement ?')">
-                                    Refuser l'affectation
-                                </button>
-                            </li>
-                        </ul>
-                    </div>
+                        <div class="fr-modal__footer">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-btn--danger fr-w-100"
+                                            form="signalement-affectation-response-deny-form" type="submit"
+                                            name="signalement-affectation-response[deny]" value="1" disabled
+                                            onclick="return confirm('Êtes-vous certain de vouloir refuser ce signalement ?')">
+                                        Refuser l'affectation
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
+                        <input type="hidden" name="_token"
+                                value="{{ csrf_token('signalement_affectation_response_'~signalement.id) }}">
+                    </form>
                 </div>
             </div>
         </div>

--- a/templates/_partials/_modal_refus_signalement.html.twig
+++ b/templates/_partials/_modal_refus_signalement.html.twig
@@ -3,50 +3,55 @@
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
-                    <div class="fr-modal__header">
-                        <h1 id="refus-signalement-modal-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
-                            Refus signalement #{{ signalement.reference }}
-                        </h1>
-                        <a href="#" class="fr-link--close fr-link" aria-controls="refus-signalement-modal">Fermer</a>
-                    </div>
-                    <div class="fr-modal__content fr-text--left">
-                        <div class="fr-select-group">
-                            <label class="fr-label required" for="signalement-validation-response[motifRefus]">
-                                Veuillez sélectionner le motif de refus
-                            </label>
-                            <select class="fr-select" id="signalement-validation-response[motifRefus]" name="signalement-validation-response[motifRefus]" required>
-                                <option value="" selected disabled hidden>Selectionnez une option</option>
-                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_PDLHI.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_PDLHI.label }}</option>
-                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.label }}</option>
-                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.label }}</option>
-                            </select>
+                    <form id="signalement-validation-response-deny-form" class="tinyCheck"
+                            action="{{ path('back_signalement_validation_response',{uuid:signalement.uuid}) }}">
+                        <div class="fr-modal__header">
+                            <h1 id="refus-signalement-modal-title" class="fr-modal__title">
+                                <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
+                                Refus signalement #{{ signalement.reference }}
+                            </h1>
+                            <a href="#" class="fr-link--close fr-link" aria-controls="refus-signalement-modal">Fermer</a>
                         </div>
-                        <div class="fr-input-group fr-mt-2v fr-text--left">
-                            <label for="signalement_validation_refus_motif" class="fr-label required">Message à l'usager</label>
-                            <p class="fr-hint-text">Expliquez à l'usager la raison du refus de son signalement
-                                <em>(10 caractères minimum)</em>
-                            </p>
-                            <textarea class="fr-input fr-input--no-resize editor"
-                                      name="signalement-validation-response[suivi]"
-                                      id="signalement_validation_refus_motif"></textarea>
-                            <p class="fr-error-text fr-hidden">Vous devez indiquer le motif de ce refus. (10 caractères
-                                minimum)</p>
+                        <div class="fr-modal__content fr-text--left">
+                            <div class="fr-select-group">
+                                <label class="fr-label required" for="signalement-validation-response[motifRefus]">
+                                    Veuillez sélectionner le motif de refus
+                                </label>
+                                <select class="fr-select" id="signalement-validation-response[motifRefus]" name="signalement-validation-response[motifRefus]" required>
+                                    <option value="" selected disabled hidden>Selectionnez une option</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_PDLHI.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_PDLHI.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.label }}</option>
+                                </select>
+                            </div>
+                            <div class="fr-input-group fr-mt-2v fr-text--left">
+                                <label for="signalement_validation_refus_motif" class="fr-label required">Message à l'usager</label>
+                                <p class="fr-hint-text">Expliquez à l'usager la raison du refus de son signalement
+                                    <em>(10 caractères minimum)</em>
+                                </p>
+                                <textarea class="fr-input fr-input--no-resize editor"
+                                        name="signalement-validation-response[suivi]"
+                                        id="signalement_validation_refus_motif"></textarea>
+                                <p class="fr-error-text fr-hidden">Vous devez indiquer le motif de ce refus. (10 caractères
+                                    minimum)</p>
+                            </div>
                         </div>
-                    </div>
 
-                    <div class="fr-modal__footer">
-                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
-                            <li>
-                                <button class="fr-btn fr-btn--danger fr-w-100"
-                                        form="signalement-validation-response-form" type="submit"
-                                        name="signalement-validation-response[deny]" value="1" disabled
-                                        onclick="return confirm('Êtes-vous certain de vouloir refuser ce signalement ?')">
-                                    Refuser le signalement
-                                </button>
-                            </li>
-                        </ul>
-                    </div>
+                        <div class="fr-modal__footer">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-btn--danger fr-w-100"
+                                            form="signalement-validation-response-deny-form" type="submit"
+                                            name="signalement-validation-response[deny]" value="1" disabled
+                                            onclick="return confirm('Êtes-vous certain de vouloir refuser ce signalement ?')">
+                                        Refuser le signalement
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
+                        <input type="hidden" name="_token"
+                                value="{{ csrf_token('signalement_validation_response_'~signalement.id) }}">
+                    </form>
                 </div>
             </div>
         </div>

--- a/templates/_partials/_modal_refus_signalement.html.twig
+++ b/templates/_partials/_modal_refus_signalement.html.twig
@@ -10,12 +10,23 @@
                         </h1>
                         <a href="#" class="fr-link--close fr-link" aria-controls="refus-signalement-modal">Fermer</a>
                     </div>
-                    <div class="fr-modal__content">
+                    <div class="fr-modal__content fr-text--left">
+                        <div class="fr-select-group">
+                            <label class="fr-label required" for="signalement-validation-response[motifRefus]">
+                                Veuillez sélectionner le motif de refus
+                            </label>
+                            <select class="fr-select" id="signalement-validation-response[motifRefus]" name="signalement-validation-response[motifRefus]" required>
+                                <option value="" selected disabled hidden>Selectionnez une option</option>
+                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_PDLHI.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').HORS_PDLHI.label }}</option>
+                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').DOUBLON.label }}</option>
+                                <option value="{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.name }}">{{ enum('App\\Entity\\Enum\\MotifRefus').AUTRE.label }}</option>
+                            </select>
+                        </div>
                         <div class="fr-input-group fr-mt-2v fr-text--left">
-                            <label for="signalement_validation_refus_motif" class="fr-label required">Motif de ce
-                                refus</label>
-                            <p class="fr-hint-text">Veuillez préciser le motif de ce refus <em>(10 caractères
-                                    minimum)</em></p>
+                            <label for="signalement_validation_refus_motif" class="fr-label required">Message à l'usager</label>
+                            <p class="fr-hint-text">Expliquez à l'usager la raison du refus de son signalement
+                                <em>(10 caractères minimum)</em>
+                            </p>
                             <textarea class="fr-input fr-input--no-resize editor"
                                       name="signalement-validation-response[suivi]"
                                       id="signalement_validation_refus_motif"></textarea>
@@ -23,15 +34,15 @@
                                 minimum)</p>
                         </div>
                     </div>
-                    <div class="fr-modal__footer">
 
+                    <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
                             <li>
                                 <button class="fr-btn fr-btn--danger fr-w-100"
                                         form="signalement-validation-response-form" type="submit"
                                         name="signalement-validation-response[deny]" value="1" disabled
                                         onclick="return confirm('Êtes-vous certain de vouloir refuser ce signalement ?')">
-                                    Refuser et envoyer à l'usager
+                                    Refuser le signalement
                                 </button>
                             </li>
                         </ul>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -15,10 +15,10 @@
                     <a href="#" class="fr-btn fr-btn--sm fr-btn--icon-left fr-fi-close-circle-fill fr-btn--danger"
                         data-fr-opened="false" aria-controls="refus-affectation-modal">Refuser
                     </a>
-                    {% include '_partials/_modal_refus_affectation.html.twig' %}
                     <input type="hidden" name="_token"
                             value="{{ csrf_token('signalement_affectation_response_'~signalement.id) }}">
                 </form>
+                {% include '_partials/_modal_refus_affectation.html.twig' %}
 
             {% elseif isRefused %}
                 <form method="POST" action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isRefused.id}) }}">

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -41,10 +41,10 @@
                                 onclick="return confirm('Êtes-vous certain de vouloir valider ce signalement ?')">
                             Valider ce signalement
                         </button>
-                        {% include '_partials/_modal_refus_signalement.html.twig' %}
                         <input type="hidden" name="_token"
                                 value="{{ csrf_token('signalement_validation_response_'~signalement.id) }}">
                     </form>
+                    {% include '_partials/_modal_refus_signalement.html.twig' %}
                     <a href="#" class="fr-btn fr-btn--sm fr-btn--icon-left fr-fi-close-line fr-btn--danger"
                         aria-controls="refus-signalement-modal" data-fr-opened="false">
                         Refuser ce signalement

--- a/tests/Functional/Controller/AffectationControllerTest.php
+++ b/tests/Functional/Controller/AffectationControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller;
 
+use App\Entity\Enum\MotifRefus;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Repository\SignalementRepository;
@@ -57,6 +58,7 @@ class AffectationControllerTest extends WebTestCase
             $routeAffectationResponse,
             [
                 'signalement-affectation-response' => [
+                    'motifRefus' => MotifRefus::AUTRE->name,
                     'suivi' => 'Cela ne me concerne pas, voir avec un autre organisme',
                 ],
                 '_token' => $this->generateCsrfToken($this->client, $tokenId),


### PR DESCRIPTION
## Ticket

#946

## Description
Ajout de liste de motifs de refus pour 
- la modale de refus d'affectation
- la modale de refus de signalement

Pour l'instant, c'est un enregistrement, on n'affiche la sélection nulle part

## Changements apportés
* Ajout d'un champ motifRefus dans la table affectation et la table signalement

## Pré-requis
`make load-migrations`

## Tests
### Refuser une affectation
- [ ] Refuser une affectation avec un partenaire
- [ ] Vérifier la liste de motifs
- [ ] Vérifier qu'on ne peut pas valider le formulaire sans sélectionner
- [ ] Vérifier l'enregistrement en BDD

### Refuser un signalement
- [ ] Refuser un signalement avec un RT
- [ ] Vérifier la liste des motifs
- [ ] Vérifier qu'on ne peut pas valider le formulaire sans sélectionner
- [ ] Vérifier l'enregistrement en BDD
