### PR TITLE
[Import] Ajout de la gestion des fichiers lors de l'import de signalements via csv

### DIFF
--- a/scripts/upload-s3.sh
+++ b/scripts/upload-s3.sh
@@ -44,6 +44,11 @@ else
       aws s3 cp data/signalement/signalement_${zip}.csv s3://${BUCKET_URL}/csv/ ${debug}
       aws s3 ls s3://${BUCKET_URL}/csv/signalement_${zip}.csv
       ;;
+    "slugify-signalement")
+      echo "Upload signalement_$2.csv to cloud..."
+      aws s3 cp data/images/signalement_${zip}.csv s3://${BUCKET_URL}/csv/ ${debug}
+      aws s3 ls s3://${BUCKET_URL}/csv/signalement_${zip}.csv
+      ;;
     "image")
       echo "Upload image_$zip to cloud"
       aws s3 cp --recursive data/images/import_${zip} s3://${BUCKET_URL}/ ${debug}

--- a/src/Command/UpdateSignalementDocumentFieldsCommand.php
+++ b/src/Command/UpdateSignalementDocumentFieldsCommand.php
@@ -67,7 +67,7 @@ class UpdateSignalementDocumentFieldsCommand extends Command
             return Command::FAILURE;
         }
 
-        $fromFile = 'csv/'.SlugifyDocumentSignalementCommand::PREFIX_FILENAME_STORAGE.$zip.'.csv';
+        $fromFile = 'csv/'.SlugifyDocumentSignalementCommand::PREFIX_FILENAME_STORAGE_MAPPING_SLUGGED.$zip.'.csv';
         $toFile = $this->parameterBag->get('uploads_tmp_dir').'mapping_doc_signalement_'.$zip.'.csv';
         if (!$this->fileStorage->fileExists($fromFile)) {
             $io->error('CSV Mapping file '.$fromFile.' does not exist, please execute app:slugify-doc-signalement');

--- a/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
+++ b/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional\Service\Import\Signalement;
 use App\Entity\Territory;
 use App\EventListener\SuiviCreatedListener;
 use App\Manager\AffectationManager;
+use App\Manager\FileManager;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
 use App\Manager\TagManager;
@@ -32,6 +33,7 @@ class SignalementImportLoaderTest extends KernelTestCase
     private LoggerInterface $logger;
     private CriticiteCalculator $criticiteCalculator;
     private SignalementQualificationUpdater $signalementQualificationUpdater;
+    private FileManager $fileManager;
 
     protected function setUp(): void
     {
@@ -45,6 +47,7 @@ class SignalementImportLoaderTest extends KernelTestCase
         $this->logger = self::getContainer()->get(LoggerInterface::class);
         $this->criticiteCalculator = self::getContainer()->get(CriticiteCalculator::class);
         $this->signalementQualificationUpdater = self::getContainer()->get(SignalementQualificationUpdater::class);
+        $this->fileManager = self::getContainer()->get(FileManager::class);
 
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
     }
@@ -66,6 +69,7 @@ class SignalementImportLoaderTest extends KernelTestCase
             $this->logger,
             $this->criticiteCalculator,
             $this->signalementQualificationUpdater,
+            $this->fileManager,
         );
 
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '01']);

--- a/tests/Unit/Command/UpdateSignalementDocumentFieldsCommandTest.php
+++ b/tests/Unit/Command/UpdateSignalementDocumentFieldsCommandTest.php
@@ -76,7 +76,7 @@ class UpdateSignalementDocumentFieldsCommandTest extends TestCase
             ->method('getRepository')
             ->willReturn($signalementRepositoryMock);
 
-        $fromFile = 'csv/'.SlugifyDocumentSignalementCommand::PREFIX_FILENAME_STORAGE.'01.csv';
+        $fromFile = 'csv/'.SlugifyDocumentSignalementCommand::PREFIX_FILENAME_STORAGE_MAPPING_SLUGGED.'01.csv';
         $toFile = $this->parameterBag->get('uploads_tmp_dir').'mapping_doc_signalement_01.csv';
 
         $this->fileStorage->expects($this->once())
@@ -174,7 +174,7 @@ class UpdateSignalementDocumentFieldsCommandTest extends TestCase
             ->with(['zip' => '99'])
             ->willReturn($this->territory);
 
-        $fromFile = 'csv/'.SlugifyDocumentSignalementCommand::PREFIX_FILENAME_STORAGE.'99.csv';
+        $fromFile = 'csv/'.SlugifyDocumentSignalementCommand::PREFIX_FILENAME_STORAGE_MAPPING_SLUGGED.'99.csv';
 
         $this->fileStorage->expects($this->once())
             ->method('fileExists')


### PR DESCRIPTION
## Ticket

#1904    

## Description
Gestion des fichiers lors de l'import de signalements via csv

## Changements apportés
* Modification de la commande de slugification des fichiers à importer pour gérer les fichiers d'imports de signalement
* Modification de la commande d'import de signalements pour prendre en compte les fichiers renseignés

## Pré-requis
* `export BUCKET_URL=[dev_bucket]`
* Utiliser les fichiers présents sur le drive dans le ticket joint
* Utiliser le fichier csv joint à cette PR (correspond au fichier du drive, mais modifié pour éviter les erreurs) : [signalement_67.csv](https://github.com/MTES-MCT/histologe/files/13267144/signalement_67.csv)

## Tests de gestion des fichiers lors de l'import
Dans le dossier `/data/images` :
- [ ] Placer le fichier csv
- [ ] Créer un dossier import_67 avec tous les fichiers du drive dedans
- [ ] Exécuter la commande `./scripts/upload-s3.sh slugify-signalement 67`
- [ ] Exécuter la commande `make console app="slugify-doc-signalement 67 0"`

Dans le dossier `/tmp` :
- [ ] Récupérer le fichier `signalement_slugged_67.csv`
- [ ] Le copier dans `/data/signalement`
- [ ] Le renommer `signalement_67.csv`

Importer :
- [ ] Exécuter la commande `./scripts/upload-s3.sh image 67`
- [ ] Exécuter la commande `./scripts/upload-s3.sh signalement 67`
- [ ] Exécuter la commande `make console app="import-signalement 67"`
- [ ] Activer le Bas-Rhin en BDD
- [ ] Vérifier que les signalements sont bien importés avec les fichiers

## Tests de non-régression pour le fichier de mapping
- [ ] Exécuter la commande `./scripts/upload-s3.sh mapping-doc 01`
- [ ] Exécuter la commande `make console app="slugify-doc-signalement 01 1"`

