### PR TITLE
[BO - Signalement] Ajout du motif de refus sélectionné dans le suivi

### DIFF
--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -55,8 +55,9 @@ class SignalementActionController extends AbstractController
                 }
             } else {
                 $statut = Signalement::STATUS_REFUSED;
-                $signalement->setMotifRefus(MotifRefus::tryFrom($response['motifRefus']));
-                $description = 'cloturé car non-valide avec le motif suivant :<br>'.$response['suivi'];
+                $motifRefus = MotifRefus::tryFrom($response['motifRefus']);
+                $signalement->setMotifRefus($motifRefus);
+                $description = 'cloturé car non-valide avec le motif suivant : '.$motifRefus->label().'<br>Plus précisément :<br>'.$response['suivi'];
 
                 $toRecipients = $signalement->getMailUsagers();
                 $notificationMailerRegistry->send(

--- a/src/Factory/SuiviFactory.php
+++ b/src/Factory/SuiviFactory.php
@@ -2,6 +2,7 @@
 
 namespace App\Factory;
 
+use App\Entity\Enum\MotifRefus;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
@@ -88,8 +89,9 @@ class SuiviFactory
         if (isset($params['accept'])) {
             $description = 'Le signalement a été accepté';
         } elseif (isset($params['suivi'])) {
-            $motifRejected = Sanitizer::sanitize($params['suivi']);
-            $description = 'Le signalement a été refusé avec le motif suivant:<br> '.$motifRejected;
+            $motifRejected = !empty($params['motifRefus']) ? MotifRefus::tryFrom($params['motifRefus'])->label() : 'Non précisé';
+            $commentaire = Sanitizer::sanitize($params['suivi']);
+            $description = 'Le signalement a été refusé avec le motif suivant : '.$motifRejected.'.<br>Plus précisément :<br>'.$commentaire;
         }
 
         return $description;


### PR DESCRIPTION
## Ticket

#1882   

## Description
Ajout du motif de refus sélectionné dans le suivi

## Tests
- [ ] Refuser un signalement en tant que RT et vérifier le suivi généré
- [ ] Refuser une affectation en tant que partenaire et vérifier le suivi généré
