### PR TITLE
[BO - Signalement] Ajout d'une option pour notifier les usagers lors de la clôture pour tous

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -92,6 +92,7 @@ class SignalementController extends AbstractController
         if ($clotureForm->isSubmitted() && $clotureForm->isValid()) {
             $params['motif_cloture'] = $clotureForm->get('motif')->getData();
             $params['motif_suivi'] = $clotureForm->getExtraData()['suivi'];
+            $params['suivi_public'] = $clotureForm->getExtraData()['publicSuivi'];
             $params['subject'] = $user?->getPartner()?->getNom();
             $params['closed_for'] = $clotureForm->get('type')->getData();
 

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -48,16 +48,18 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
                 $user,
                 $signalement,
                 params: $params,
-                isPublic: true
+                isPublic: '1' == $params['suivi_public']
             );
             $this->suiviManager->save($suivi);
 
             $signalement
-                ->setCodeSuivi($this->tokenGenerator->generateToken())
                 ->setClosedBy($user)
                 ->addSuivi($suivi);
 
-            $this->sendMailToUsager($signalement);
+            if ('1' == $params['suivi_public']) {
+                $signalement->setCodeSuivi($this->tokenGenerator->generateToken());
+                $this->sendMailToUsager($signalement);
+            }
             $this->sendMailToPartners($signalement);
         }
 

--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -25,6 +25,31 @@
                                       id="cloture_suivi"></textarea>
                             <p class="fr-error-text fr-hidden">Vous devez préciser votre motif de cloture.</p>
                         </div>
+
+                        {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+                        <fieldset class="fr-fieldset" id="radio-hint" aria-labelledby="radio-hint-legend radio-hint-messages">
+                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-hint-legend">
+                                Notifier l'usager par e-mail de la clôture du signalement.
+                            </legend>
+                            <div class="fr-fieldset__element">
+                                <div class="fr-radio-group">
+                                    <input type="radio" id="publicSuivi-1" name="cloture[publicSuivi]" value="1" checked>
+                                    <label class="fr-label" for="publicSuivi-1">
+                                        Oui
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="fr-fieldset__element">
+                                <div class="fr-radio-group">
+                                    <input type="radio" id="publicSuivi-2" name="cloture[publicSuivi]" value="0">
+                                    <label class="fr-label" for="publicSuivi-2">
+                                        Non
+                                    </label>
+                                </div>
+                            </div>
+                        </fieldset>
+                        {% endif %}
+
                         {{ form_end(clotureForm) }}
                         
                         {% if is_granted('ROLE_ADMIN_TERRITORY') %}

--- a/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
@@ -95,6 +95,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
             [
                 'motif_suivi' => 'Lorem ipsum suivi sit amet, consectetur adipiscing elit.',
                 'motif_cloture' => MotifCloture::tryFrom('NON_DECENCE'),
+                'suivi_public' => '1',
                 'subject' => 'tous les partenaires',
                 'closed_for' => 'all',
             ]


### PR DESCRIPTION
## Ticket

#1884   

## Description
Ajout d'une option pour notifier les usagers lors de la clôture pour tous

## Tests
- [ ] En tant que RT, clôturer un signalement pour tous, activer la notification pour les usagers, vérifier (suivi et mail)
- [ ] En tant que RT, clôturer un signalement pour tous, désactiver la notification pour les usagers, vérifier (suivi et mail)
