### PR TITLE
[QA - Sentry] undefined array key publicSuivi

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -92,7 +92,11 @@ class SignalementController extends AbstractController
         if ($clotureForm->isSubmitted() && $clotureForm->isValid()) {
             $params['motif_cloture'] = $clotureForm->get('motif')->getData();
             $params['motif_suivi'] = $clotureForm->getExtraData()['suivi'];
-            $params['suivi_public'] = $clotureForm->getExtraData()['publicSuivi'];
+            if ($this->isGranted('ROLE_ADMIN_TERRITORY') && isset($clotureForm->getExtraData()['publicSuivi'])) {
+                $params['suivi_public'] = $clotureForm->getExtraData()['publicSuivi'];
+            } else {
+                $params['suivi_public'] = false;
+            }
             $params['subject'] = $user?->getPartner()?->getNom();
             $params['closed_for'] = $clotureForm->get('type')->getData();
 

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -92,10 +92,9 @@ class SignalementController extends AbstractController
         if ($clotureForm->isSubmitted() && $clotureForm->isValid()) {
             $params['motif_cloture'] = $clotureForm->get('motif')->getData();
             $params['motif_suivi'] = $clotureForm->getExtraData()['suivi'];
+            $params['suivi_public'] = false;
             if ($this->isGranted('ROLE_ADMIN_TERRITORY') && isset($clotureForm->getExtraData()['publicSuivi'])) {
                 $params['suivi_public'] = $clotureForm->getExtraData()['publicSuivi'];
-            } else {
-                $params['suivi_public'] = false;
             }
             $params['subject'] = $user?->getPartner()?->getNom();
             $params['closed_for'] = $clotureForm->get('type')->getData();

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -160,3 +160,10 @@ affectations:
     affected_by: "user-38-01@histologe.fr"
     motif_cloture: ""
     territory: "Isère"
+  - 
+    signalement: 2023-26
+    partner: "partenaire-13-01@histologe.fr"
+    statut: 1
+    answered_by: "admin-03@histologe.fr"
+    affected_by: "admin-03@histologe.fr"
+    territory: "Bouches-du-Rhône"

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -1562,3 +1562,35 @@ signalements:
     situation_occupant: "1"
     territory: "Isère"
     is_imported: true
+  -
+    uuid: "00000000-0000-0000-2023-000000000026"
+    details: "Absence d’isolation toiture<br><br>Courrier adressé non pas à la mairie mais au bailleur social"
+    is_proprio_averti: 1
+    is_logement_social: 1
+    nb_adultes: "2"
+    nb_enfants_m6: "1"
+    nb_enfants_p6: "2"
+    is_allocataire: "CAF"
+    nature_logement: "Appartement"
+    type_logement: "T2"
+    superficie: 40
+    loyer: 500
+    phone_number: 0621127284
+    adresse_occupant: "3 rue Mars"
+    cp_occupant: "13015"
+    ville_occupant: "Marseille"
+    statut: 2
+    reference: "2023-26"
+    geoloc: "{\"lat\":\"43.3426152\",\"lng\":\"5.3711848\"}"
+    score: 100
+    etage_occupant: "A"
+    escalier_occupant: "1"
+    insee_occupant: "13213"
+    territory: "Bouches-du-Rhône"
+    nb_occupants_logement: 5
+    situation_occupant: "1"
+    origine_signalement: "Guichet Unique"
+    type_energie_logement: "Electrique"
+    mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
+    is_imported: true
+

--- a/tests/Functional/Controller/BackSignalementControllerTest.php
+++ b/tests/Functional/Controller/BackSignalementControllerTest.php
@@ -125,7 +125,7 @@ class BackSignalementControllerTest extends WebTestCase
         );
     }
 
-    public function testSubmitClotureSignalementWihEmailSentToPartnersAndUsager()
+    public function testAdminSubmitClotureSignalementWithEmailSentToPartners()
     {
         $client = static::createClient();
 
@@ -150,6 +150,7 @@ class BackSignalementControllerTest extends WebTestCase
             [
                 'cloture[motif]' => 'INSALUBRITE',
                 'cloture[suivi]' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'cloture[publicSuivi]' => '0',
                 'cloture[type]' => 'all',
             ]
         );
@@ -160,6 +161,80 @@ class BackSignalementControllerTest extends WebTestCase
         $this->assertEquals(Signalement::STATUS_CLOSED, $signalement->getStatut());
 
         $client->enableProfiler();
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(1);
+    }
+
+    public function testAdminTerritorySubmitClotureSignalementWithEmailSentToPartnersAndUsagers()
+    {
+        $client = static::createClient();
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2022-1']);
+        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+
+        $crawler = $client->request('GET', $route);
+        $client->submitForm(
+            'Cloturer pour tous les partenaires',
+            [
+                'cloture[motif]' => 'INSALUBRITE',
+                'cloture[suivi]' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'cloture[publicSuivi]' => '1',
+                'cloture[type]' => 'all',
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/signalements/');
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2022-1']);
+        $this->assertEquals(Signalement::STATUS_CLOSED, $signalement->getStatut());
+
+        $client->enableProfiler();
+        $this->assertEmailCount(3);
+    }
+
+    public function testAdminPartnerSubmitClotureSignalementWithEmailSentToPartners()
+    {
+        $client = static::createClient();
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-26']);
+        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-partenaire-13-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+
+        $crawler = $client->request('GET', $route);
+        $client->submitForm(
+            'Cloturer pour Partenaire 13-01',
+            [
+                'cloture[motif]' => 'INSALUBRITE',
+                'cloture[suivi]' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+                'cloture[type]' => 'partner',
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/signalements/');
+
+        $client->enableProfiler();
+        $this->assertEmailCount(1);
     }
 }

--- a/tests/Functional/Controller/BackSignalementControllerTest.php
+++ b/tests/Functional/Controller/BackSignalementControllerTest.php
@@ -132,8 +132,7 @@ class BackSignalementControllerTest extends WebTestCase
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = self::getContainer()->get(SignalementRepository::class);
         /** @var Signalement $signalement */
-        $signalement = $signalementRepository->findOneBy(['reference' => '2022-8']);
-        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+        $signalement = $signalementRepository->findOneBy(['reference' => '2022-8', 'statut' => Signalement::STATUS_ACTIVE]);
 
         /** @var UserRepository $userRepository */
         $userRepository = self::getContainer()->get(UserRepository::class);
@@ -171,8 +170,7 @@ class BackSignalementControllerTest extends WebTestCase
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = self::getContainer()->get(SignalementRepository::class);
         /** @var Signalement $signalement */
-        $signalement = $signalementRepository->findOneBy(['reference' => '2022-1']);
-        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+        $signalement = $signalementRepository->findOneBy(['reference' => '2022-1', 'statut' => Signalement::STATUS_ACTIVE]);
 
         /** @var UserRepository $userRepository */
         $userRepository = self::getContainer()->get(UserRepository::class);
@@ -210,8 +208,7 @@ class BackSignalementControllerTest extends WebTestCase
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = self::getContainer()->get(SignalementRepository::class);
         /** @var Signalement $signalement */
-        $signalement = $signalementRepository->findOneBy(['reference' => '2023-26']);
-        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-26', 'statut' => Signalement::STATUS_ACTIVE]);
 
         /** @var UserRepository $userRepository */
         $userRepository = self::getContainer()->get(UserRepository::class);

--- a/tests/Functional/Controller/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/SignalementListControllerTest.php
@@ -195,7 +195,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Partner' => ['bo-filters-partners', ['5'], '2 signalement(s)'];
         yield 'Search by Critere' => ['bo-filters-criteres', ['17'], '24 signalement(s)'];
         yield 'Search by Tags' => ['bo-filters-tags', ['3'], '4 signalement(s)'];
-        yield 'Search by Parc public/prive' => ['bo-filters-housetypes', ['1'], '4 signalement(s)'];
+        yield 'Search by Parc public/prive' => ['bo-filters-housetypes', ['1'], '5 signalement(s)'];
         yield 'Search by Relances usagers' => ['bo-filters-relances_usager', ['NO_SUIVI_AFTER_3_RELANCES'], '1 signalement(s)'];
     }
 }


### PR DESCRIPTION
## Ticket

#1906

## Description
Correction du warning "Warning: Undefined array key "publicSuivi" se produisant lorsqu'un utilisateur n'ayant pas le role "ROLE_ADMIN_TERRITORY" cloture un signalement.

## Changements apportés
* Correction de l'erreur dans src/Controller/Back/SignalementController.php (viewSignalement)
* Ajout de fixture permettant d'avoir le signalement "2023-26" cloturable pour l'utilisateur "admin-partenaire-13-01@histologe.fr"
* Modification et ajout de tests permettant de verifier le bon fonctionnement du formulaire de cloture pour différents roles en fonction du champ "publicSuivi" 
    * Cloture par ROLE_ADMIN avec le champs public à "Non" 
    * Cloture par ROLE_ADMIN_TERRITORY avec le champs public a "Oui" 
    * Cloture par ROLE_ADMIN_PARTNER sans le champ public

## Pré-requis

## Tests
- [ ] Clôturer un signalement en tant que ROLE_ADMIN_PARTNER 
