### PR TITLE
[QA] Transformer 4+ en 4 (pb addition d'enfants si "4+")

### DIFF
--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -64,20 +64,25 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
 
         $commentaire .= '\nPropriétaire averti: '.$signalement->getIsProprioAverti() ? 'OUI' : 'NON';
         $commentaire .= '\nAdultes: '.$signalement->getNbAdultes().' Adultes';
-
-        $suffix = '';
-        if (str_ends_with($signalement->getNbEnfantsM6(), '+') || str_ends_with($signalement->getNbEnfantsP6(), '+')) {
-            $suffix = '+';
-        }
-        $nbEnfants = str_replace('+', '', $signalement->getNbEnfantsM6()) + str_replace('+', '', $signalement->getNbEnfantsP6());
-        $nbEnfants .= $suffix;
-        $commentaire .= '\n'.$nbEnfants.' Enfants';
+        $commentaire .= $this->buildNbEnfants($signalement);
 
         foreach ($signalement->getAffectations() as $affectation) {
             $commentaire .= '\n'.$affectation->getPartner()->getNom().' => '.$affectation->getAffectationLabel();
         }
 
         return $commentaire;
+    }
+
+    private function buildNbEnfants(Signalement $signalement)
+    {
+        $suffix = '';
+        if (str_ends_with($signalement->getNbEnfantsM6(), '+') || str_ends_with($signalement->getNbEnfantsP6(), '+')) {
+            $suffix = '+';
+        }
+        $nbEnfants = str_replace('+', '', $signalement->getNbEnfantsM6()) + str_replace('+', '', $signalement->getNbEnfantsP6());
+        $nbEnfants .= $suffix;
+
+        return '\n'.$nbEnfants.' Enfants';
     }
 
     private function buildPiecesJointesObservation(Signalement $signalement): string

--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -64,7 +64,14 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
 
         $commentaire .= '\nPropriétaire averti: '.$signalement->getIsProprioAverti() ? 'OUI' : 'NON';
         $commentaire .= '\nAdultes: '.$signalement->getNbAdultes().' Adultes';
-        $commentaire .= '\n'.$signalement->getNbEnfantsM6() + $signalement->getNbEnfantsP6().' Enfants';
+
+        $suffix = '';
+        if (str_ends_with($signalement->getNbEnfantsM6(), '+') || str_ends_with($signalement->getNbEnfantsP6(), '+')) {
+            $suffix = '+';
+        }
+        $nbEnfants = str_replace('+', '', $signalement->getNbEnfantsM6()) + str_replace('+', '', $signalement->getNbEnfantsP6());
+        $nbEnfants .= $suffix;
+        $commentaire .= '\n'.$nbEnfants.' Enfants';
 
         foreach ($signalement->getAffectations() as $affectation) {
             $commentaire .= '\n'.$affectation->getPartner()->getNom().' => '.$affectation->getAffectationLabel();


### PR DESCRIPTION
## Ticket

#1029
#1830

## Description
Correction de l’addition du nombre d'enfant sur le commentaire du dossier ESABORA lorsque que le nombre contient un "+" (4+)

## Changements apportés
* Modification dans le fichier "DossierMessageSCHSFactory.php" méthode "buildCommentaire"

## Pré-requis

## Tests
- [ ] Mettre la valeur "4+" sur une des champs nombre d'enfants et instancier le DossierMessageSCHSFactory pour l'affectation correspondante
