### PR TITLE
 [Back] Renforcer la validation de l'email, il faut un email occupant ou déclarant

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -717,7 +717,14 @@ forms.forEach((form) => {
                                         event.target.querySelector('[type="submit"]').disabled = false;
                                         event.target.querySelector('[type="submit"]').innerHTML = "Confirmer";
                                         ['fr-icon-checkbox-circle-fill', 'fr-icon-refresh-fill'].map(v => event.target.querySelector('[type="submit"]').classList.toggle(v));
-                                        alert('Oups... Il semblerait que vous ayez passé trop de temps sur cette étape ! Retournez à l\'étape précédente puis continuez le formulaire pour régler le problème. Si cela ne fonctionne pas, veuillez réessayer plus tard.')
+                                        let messageAlert = 'Oups... Il semblerait que vous ayez passé trop de temps sur cette étape ! Retournez à l\'étape précédente puis continuez le formulaire pour régler le problème. Si cela ne fonctionne pas, veuillez réessayer plus tard.';
+                                        if(res.response === "formErrors"){
+                                            messageAlert = "Le formulaire contient des erreurs : \n";
+                                            for (const [key, error] of Object.entries(res.errsMsgList)) {
+                                                messageAlert += "- " + error + "\n";
+                                            }           
+                                        }
+                                        alert(messageAlert);
                                     }
                                 })
                             } else {

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -27,6 +27,7 @@ use App\Repository\SignalementQualificationRepository;
 use App\Repository\SituationRepository;
 use App\Repository\TagRepository;
 use App\Security\Voter\UserVoter;
+use App\Service\FormHelper;
 use App\Service\Signalement\CriticiteCalculator;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use DateTimeImmutable;
@@ -275,7 +276,12 @@ class SignalementController extends AbstractController
                 return $this->json(['response' => 'success_edited']);
             }
 
-            return $this->json(['response' => $form->getErrors()]);
+            return $this->json(
+                [
+                    'response' => 'formErrors',
+                    'errsMsgList' => FormHelper::getErrorsFromForm($form),
+                ],
+            );
         }
 
         return $this->render('back/signalement/edit.html.twig', [

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -228,9 +228,16 @@ class FrontSignalementController extends AbstractController
             $errors = $validator->validate($signalement);
 
             if (\count($errors) > 0) {
+                $errsMsgList = [];
+                foreach ($errors as $error) {
+                    $errsMsgList[$error->getPropertyPath().'_'.uniqid()] = $error->getMessage();
+                }
+
                 return $this->json(
-                    ['response' => sprintf('Le formulaire comporte des erreurs: %s', $errors)],
-                    Response::HTTP_BAD_REQUEST
+                    [
+                        'response' => 'formErrors',
+                        'errsMsgList' => $errsMsgList,
+                    ],
                 );
             }
 

--- a/src/Service/FormHelper.php
+++ b/src/Service/FormHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\Form\FormInterface;
+
+class FormHelper
+{
+    public static function getErrorsFromForm(FormInterface $form)
+    {
+        $errors = [];
+        foreach ($form->getErrors() as $error) {
+            $errors[] = $error->getMessage();
+        }
+        foreach ($form->all() as $childForm) {
+            if ($childForm instanceof FormInterface) {
+                if ($childErrors = self::getErrorsFromForm($childForm)) {
+                    foreach ($childErrors as $childError) {
+                        $errors[$childForm->getName().'_'.uniqid()] = $childError;
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/tests/Functional/Controller/FrontSignalementControllerTest.php
+++ b/tests/Functional/Controller/FrontSignalementControllerTest.php
@@ -86,10 +86,10 @@ class FrontSignalementControllerTest extends WebTestCase
         $urlPostSignalement = $router->generate('envoi_signalement');
         $client->request('POST', $urlPostSignalement, $payloadSignalement);
 
-        $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         $bodyContent = $client->getResponse()->getContent();
         $this->assertStringContainsString(
-            'Le formulaire comporte des erreurs',
+            'formErrors',
             json_decode($bodyContent, true)['response']
         );
     }


### PR DESCRIPTION
## Ticket

#1799

## Description
Ajout de contraintes sur le valeur des emails occupant ou déclarant (doivent être des email valide, au moins un des deux renseigné et de valeurs différentes)

## Changements apportés
* Ajout des contraintes sur l'entité Signalement
* Modification de app.js pour afficher les erreurs du formulaire
* Modification du FrontSignalementController et Back/SignalementController pour qu'il retourne les erreurs du formulaire

## Pré-requis

## Tests
- [ ] Tester en back et front la soumission de signalement avec des donnée incorrecte sur les email (faisable faciement en revenant sur l'onglet contenant ces informations puis en retournant sur le dernier onglet sans passer par le bouton continuer.)
