### PR TITLE
[BO - Signalement] Correction de la sélection des boutons radio dans les modales de réouverture et cloture

### DIFF
--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -33,16 +33,16 @@
                             </legend>
                             <div class="fr-fieldset__element">
                                 <div class="fr-radio-group">
-                                    <input type="radio" id="publicSuivi-1" name="cloture[publicSuivi]" value="1" checked>
-                                    <label class="fr-label" for="publicSuivi-1">
+                                    <input type="radio" id="publicSuiviCloture-1" name="cloture[publicSuivi]" value="1" checked>
+                                    <label class="fr-label" for="publicSuiviCloture-1">
                                         Oui
                                     </label>
                                 </div>
                             </div>
                             <div class="fr-fieldset__element">
                                 <div class="fr-radio-group">
-                                    <input type="radio" id="publicSuivi-2" name="cloture[publicSuivi]" value="0">
-                                    <label class="fr-label" for="publicSuivi-2">
+                                    <input type="radio" id="publicSuiviCloture-2" name="cloture[publicSuivi]" value="0">
+                                    <label class="fr-label" for="publicSuiviCloture-2">
                                         Non
                                     </label>
                                 </div>

--- a/templates/_partials/_modal_reopen_signalement.html.twig
+++ b/templates/_partials/_modal_reopen_signalement.html.twig
@@ -16,24 +16,24 @@
                         </div>
 
                         <div class="fr-modal__content fr-text--left">
-                            <fieldset class="fr-fieldset" id="radio-hint" aria-labelledby="radio-hint-legend radio-hint-messages">
-                                <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-hint-legend">
+                            <fieldset class="fr-fieldset" id="radio-hint{% if all == '1' %}-all{% endif %}" aria-labelledby="radio-hint-legend{% if all == '1' %}-all{% endif %} radio-hint-messages">
+                                <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-hint-legend{% if all == '1' %}-all{% endif %}">
                                     Un suivi de ré-ouverture va être créé.
                                     <br>
                                     Souhaitez-vous qu'il soit partagé à l'usager ?
                                 </legend>
                                 <div class="fr-fieldset__element">
                                     <div class="fr-radio-group">
-                                        <input type="radio" id="publicSuivi-1" name="publicSuivi" value="1" checked>
-                                        <label class="fr-label" for="publicSuivi-1">
+                                        <input type="radio" id="publicSuiviReopen-1{% if all == '1' %}-all{% endif %}" name="publicSuivi" value="1" checked>
+                                        <label class="fr-label" for="publicSuiviReopen-1{% if all == '1' %}-all{% endif %}">
                                             Oui
                                         </label>
                                     </div>
                                 </div>
                                 <div class="fr-fieldset__element">
                                     <div class="fr-radio-group">
-                                        <input type="radio" id="publicSuivi-2" name="publicSuivi" value="0">
-                                        <label class="fr-label" for="publicSuivi-2">
+                                        <input type="radio" id="publicSuiviReopen-2{% if all == '1' %}-all{% endif %}" name="publicSuivi" value="0">
+                                        <label class="fr-label" for="publicSuiviReopen-2{% if all == '1' %}-all{% endif %}">
                                             Non
                                         </label>
                                     </div>


### PR DESCRIPTION
## Ticket

#1884   

## Description
Correction de la sélection des boutons radio dans les modales de réouverture et cloture

## Changements apportés
* Identifiants uniques pour les radio buttons ; les doublons empêchaient les choix

## Tests
- [ ] Réouvrir un signalement pour l'agent en cours, vérifier que l'option est prise en compte
- [ ] Réouvrir un signalement pour tous, vérifier que l'option est prise en compte
- [ ] Cloturer un signalement, vérifier que l'option est prise en compte
