### PR TITLE
[Form] Ajout d'un composant SignalementFormModal

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormLink.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormLink.vue
@@ -6,6 +6,8 @@
       :href="variablesReplacer.replace(link)"
       :target="linktarget"
       @click="handleClick"
+      :aria-controls="ariaControls"
+      data-fr-opened="false"
       >
         {{ label}}
     </a>
@@ -24,6 +26,7 @@ export default defineComponent({
     link: { type: String, default: '' },
     linktarget: { type: String, default: '' },
     customCss: { type: String, default: '' },
+    ariaControls: { type: String, default: '' },
     clickEvent: Function
   },
   methods: {

--- a/assets/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -1,0 +1,35 @@
+<template>
+  <dialog aria-labelledby="fr-modal-title-modal-back-home" role="dialog" :id="id" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+      <div class="fr-grid-row fr-grid-row--center">
+        <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+          <div class="fr-modal__body">
+            <div class="fr-modal__header">
+              <button class="fr-btn--close fr-btn fr-btn--icon-right fr-icon-close-line" title="Fermer la fenêtre modale" :aria-controls="id">Fermer</button>
+            </div>
+            <div class="fr-modal__content">
+              <h1>{{ label }}</h1>
+              <p v-html="description"></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'SignalementFormModal',
+  props: {
+    id: String,
+    label: String,
+    description: String
+  }
+})
+</script>
+
+<style>
+</style>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -31,6 +31,7 @@
         :validate="component.validate"
         :disabled="component.disabled"
         :multiple="component.multiple"
+        :ariaControls="component.ariaControls"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"
@@ -104,6 +105,7 @@ import SignalementFormUpload from './SignalementFormUpload.vue'
 import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
 import SignalementFormWarning from './SignalementFormWarning.vue'
 import SignalementFormYear from './SignalementFormYear.vue'
+import SignalementFormModal from './SignalementFormModal.vue'
 import { variablesReplacer } from './../services/variableReplacer'
 import { componentValidator } from './../services/componentValidator'
 import { findPreviousScreen, findNextScreen } from '../services/disorderScreenNavigator'
@@ -135,7 +137,8 @@ export default defineComponent({
     SignalementFormDisorderCategoryItem,
     SignalementFormDisorderCategoryList,
     SignalementFormDisorderOverview,
-    SignalementFormRoomList
+    SignalementFormRoomList,
+    SignalementFormModal
   },
   props: {
     label: String,

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="[ customCss ]" :id="id">
     <h2 v-if="label">{{ variablesReplacer.replace(label) }}</h2>
-    <p v-if="description" v-html="description"></p>
+    <p v-if="description" v-html="variablesReplacer.replace(description)"></p>
     <div
       v-if="components != undefined"
       >

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -4,13 +4,33 @@
     "label": "Les désordres",
     "slug": "ecran_intermediaire_les_desordres",
     "screenCategory": "Désordres",
-    "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p> <p>Vous pourrez aussi ajouter des photos des problèmes.<p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "icon": {
       "src": "/img/form/screens/desordres.svg",
       "alt": ""
     },
     "components": {
-      "body": [],
+      "body": [
+        {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_les_desordres_text",
+          "customCss": "fr-mt-5v",
+          "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p> <p>Vous pourrez aussi ajouter des photos des problèmes.<p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>"
+        }
+      ],
       "footer": [
         {
           "type": "SignalementFormButton",

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -4,13 +4,33 @@
     "label": "Les désordres",
     "slug": "ecran_intermediaire_les_desordres",
     "screenCategory": "Désordres",
-    "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p> <p>Vous pourrez aussi ajouter des photos des problèmes.<p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "icon": {
       "src": "/img/form/screens/desordres.svg",
       "alt": ""
     },
     "components": {
-      "body": [],
+      "body": [
+        {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_les_desordres_text",
+          "customCss": "fr-mt-5v",
+          "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p> <p>Vous pourrez aussi ajouter des photos des problèmes.<p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>"
+        }
+      ],
       "footer": [
         {
           "type": "SignalementFormButton",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -119,6 +119,20 @@
     "components": {
       "body": [
         {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "label": "",
           "slug": "zone_concernee_zone",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -79,6 +79,20 @@
     "components": {
       "body": [
         {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "label": "",
           "slug": "zone_concernee_zone",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -136,6 +136,20 @@
     "components": {
       "body": [
         {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "label": "",
           "slug": "zone_concernee_zone",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -185,6 +185,20 @@
     "components": {
       "body": [
         {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "label": "",
           "slug": "zone_concernee_zone",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -196,6 +196,20 @@
     "components": {
       "body": [
         {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "label": "",
           "slug": "zone_concernee_zone",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -179,6 +179,20 @@
     "components": {
       "body": [
         {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Les désordres sur le bâtiment concernent :<ul><li>La structure du bâtiment (toit, murs porteurs, les façades, sol)</li><li>Les caves et sous-sol</li><li>Autour du bâtiment</li><li>Pour les immeubles : les parties communes</li></ul><br>Les désordres sur le logement concernent tous les problèmes à l'intérieur du logement (aération, chauffage, moisissure, équipements, etc.).",
+          "slug": "zone_concernee_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "zone_concernee_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "zone_concernee_modal"
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "label": "",
           "slug": "zone_concernee_zone",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -157,13 +157,27 @@
   {
     "type": "SignalementFormScreen",
     "slug": "signalement_concerne",
+    "label": "Vous déposez un signalement...",
     "screenCategory": "Adresse et coordonnées",
     "components": {
       "body": [
         {
+          "type": "SignalementFormModal",
+          "label": "En savoir plus",
+          "description": "Vous déposez un signalement pour vous-même lorsque vous avez un problème dans le logement dans lequel vous vivez.<br>Vous déposez un signalement pour quelqu'un d'autre quand vous déposez un signalement pour une autre personne qui rencontre des problèmes dans son logement et qui ne vit pas avec vous.",
+          "slug": "signalement_concerne_modal"
+        },
+        {
+          "type": "SignalementFormLink",
+          "label": "En savoir plus",
+          "slug": "signalement_concerne_savoir_plus",
+          "customCss": "fr-badge fr-badge--info",
+          "link": "#",
+          "ariaControls": "signalement_concerne_modal"
+        },
+        {
           "type": "SignalementFormOnlyChoice",
-          "label": "Vous déposez un signalement...",
-          "customCss": "question-h1",
+          "label": "",
           "slug": "signalement_concerne_profil",
           "values": [
             {


### PR DESCRIPTION
## Ticket

#1871 
#1869    

## Description
Ajout d'un composant SignalementFormModal, pour préciser la différence entre déclarant occupant/ déclarant tiers, et la différence entre batiment/logement

## Changements apportés
* Création d'un nouveau composant VueJS
* Modification des json pour utiliser ce composant

## Pré-requis

## Tests
- [ ] Faire un nouveau signalement
- [ ] Sur l'écran "Votre signalement concerne" vérifier l'affichage du bouton "En savoir plus" et de la modale dans plusieurs formats
- [ ] Idem sur les écrans "zone concernée" et sur l'écran intermédiraire des désordres
