### PR TITLE
[BO - Signalement] Correction accès aux documents via suivis

### DIFF
--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -56,7 +56,12 @@
         </div>
 
         <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
-            {{ suivi.description|replace({'&t=___TOKEN___':'/'~signalement.uuid})|replace({'?t=___TOKEN___':'/'~signalement.uuid})|replace({'?folder=_up':'/'~signalement.uuid})|raw }}
+            {{ suivi.description
+                |replace({'&t=___TOKEN___':'/'~signalement.uuid})
+                |replace({'?t=___TOKEN___':'/'~signalement.uuid})
+                |replace({'?folder=_up':'/'~signalement.uuid})
+                |raw
+            }}
         </div>
         <div class="fr-col-2">
             {% if suivi.isPublic %}

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -56,7 +56,7 @@
         </div>
 
         <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
-            {{ suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|replace({'?folder=_up':'/'~signalement.uuid})|raw }}
+            {{ suivi.description|replace({'&t=___TOKEN___':'/'~signalement.uuid})|replace({'?t=___TOKEN___':'/'~signalement.uuid})|replace({'?folder=_up':'/'~signalement.uuid})|raw }}
         </div>
         <div class="fr-col-2">
             {% if suivi.isPublic %}

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -56,7 +56,7 @@
         </div>
 
         <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
-            {{ suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|raw }}
+            {{ suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|replace({'?folder=_up':'/'~signalement.uuid})|raw }}
         </div>
         <div class="fr-col-2">
             {% if suivi.isPublic %}


### PR DESCRIPTION
## Ticket

#1928    

## Description
Depuis la mise en place de la sécurité pour ne pas avoir accès au document via simple lien, le lien vers ces documents ajouté dans les suivis ne fonctionne plus.

## Changements apportés
* Ajout de l'uuid du signalement dans le lien pour pouvoir accéder au document

## Tests
- [ ] Vérifier l'accès aux photos et documents dans les suivis quand on ajoute un document dans le BO
- [ ] Vérifier l'accès aux documents dans les suivis quand on crée un suivi et qu'on partage un document
