### PR TITLE
[Formulaire - désordres] Bouton "rien à signaler" non visible sur mobile dans les listes de catégories de désordres

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -280,6 +280,10 @@ export default defineComponent({
       margin-bottom: 7.5rem !important;
     }
 
+    .form-screen-body-margin {
+      margin-bottom: 10rem !important;
+    }
+
     .form-screen-body .icon {
       text-align: center;
     }

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -59,6 +59,7 @@
     },
     "slug": "desordres_batiment",
     "screenCategory": "Désordres",
+    "customCss": "form-screen-body-margin",
     "components": {
       "body": [
         {
@@ -1040,6 +1041,7 @@
     },
     "slug": "desordres_logement",
     "screenCategory": "Désordres",
+    "customCss": "form-screen-body-margin",
     "components": {
       "body": [
         {

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -72,6 +72,7 @@
     },
     "slug": "desordres_batiment",
     "screenCategory": "Désordres",
+    "customCss": "form-screen-body-margin",
     "components": {
       "body": [
         {
@@ -1053,6 +1054,7 @@
     },
     "slug": "desordres_logement",
     "screenCategory": "Désordres",
+    "customCss": "form-screen-body-margin",
     "components": {
       "body": [
         {


### PR DESCRIPTION
## Ticket

#1867    

## Description
Ajout d'une margin-bottom plus importante quand le footer est plus important pour rendre visible le bouton "je n'ai rien à signaler"

## Changements apportés
* Ajout d'une classe css

## Pré-requis

## Tests
- [ ] Faire un signalement en mobile
- [ ] Choisir "les deux" pour la zone
- [ ] Vérifier la visibilité du bouton "je n'ai rien à signaler" dans les 2 listes de catégories de désordres
