### PR TITLE
[Esabora] Gestion et affichage des messages d'erreur

### DIFF
--- a/assets/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -225,7 +225,8 @@ export default defineComponent({
           responseItem.last_event,
           responseItem.nom,
           responseItem.action,
-          responseItem.status
+          responseItem.status,
+          this.handleErrors(responseItem)
         ]
         this.sharedState.esaboraEvents.push(item)
       }
@@ -233,6 +234,17 @@ export default defineComponent({
     handleChangeTerritoire () {
       this.isLoadingRefresh = true
       requests.initKPI(this.handleInitKPI)
+    },
+    handleErrors (responseItem : any) {
+      let errorMessage = JSON.parse(responseItem.response)?.errorReason ?? null
+      if (errorMessage !== null) {
+        errorMessage = JSON.parse(errorMessage).message
+        if (typeof errorMessage === 'object') {
+          errorMessage = JSON.stringify(errorMessage)
+        }
+      }
+
+      return errorMessage
     }
   }
 })

--- a/assets/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -236,14 +236,11 @@ export default defineComponent({
       requests.initKPI(this.handleInitKPI)
     },
     handleErrors (responseItem : any) {
-      let errorMessage = JSON.parse(responseItem.response)?.errorReason ?? null
-      if (errorMessage !== null) {
-        errorMessage = JSON.parse(errorMessage).message
-        if (typeof errorMessage === 'object') {
-          errorMessage = JSON.stringify(errorMessage)
-        }
+      const jsonResponse = JSON.parse(responseItem.response)
+      let errorMessage = jsonResponse?.errorReason ?? jsonResponse?.message ?? null
+      if (errorMessage !== null && typeof errorMessage === 'object') {
+        errorMessage = JSON.stringify(errorMessage)
       }
-
       return errorMessage
     }
   }

--- a/assets/vue/components/dashboard/TheHistoDashboardTables.vue
+++ b/assets/vue/components/dashboard/TheHistoDashboardTables.vue
@@ -27,7 +27,7 @@
       </HistoDataTable>
     </div>
 
-    <div v-if="sharedState.user.isAdmin" class="fr-col-12 fr-col-lg-6">
+    <div v-if="sharedState.user.isAdmin" class="fr-col-12">
       <HistoDataTable
         :headers=connectionsEsaboraHeaders
         :items=sharedState.esaboraEvents
@@ -66,7 +66,8 @@ export default defineComponent({
         'Dernière synchro',
         'Partenaire',
         'Action',
-        'Statut'
+        'Statut',
+        'Message d\'erreur'
       ]
     }
   },

--- a/src/Messenger/MessageHandler/DossierMessageSCHSHandler.php
+++ b/src/Messenger/MessageHandler/DossierMessageSCHSHandler.php
@@ -41,7 +41,7 @@ final class DossierMessageSCHSHandler
             service: AbstractEsaboraService::TYPE_SERVICE,
             action: AbstractEsaboraService::ACTION_PUSH_DOSSIER,
             message: $this->serializer->serialize($schsDossierMessage, 'json'),
-            response: $response->getContent(),
+            response: $response->getContent(throw: false),
             status: 200 === $response->getStatusCode() ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED,
             codeStatus: $response->getStatusCode(),
             signalementId: $schsDossierMessage->getSignalementId(),

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -32,7 +32,7 @@ class JobEventRepository extends ServiceEntityRepository
         ?Territory $territory,
     ): array {
         $qb = $this->createQueryBuilder('j')
-            ->select('MAX(j.createdAt) AS last_event, p.id, p.nom, s.reference, j.status, j.action, j.codeStatus')
+            ->select('MAX(j.createdAt) AS last_event, p.id, p.nom, s.reference, j.status, j.action, j.codeStatus, j.response')
             ->innerJoin(Signalement::class, 's', 'WITH', 's.id = j.signalementId')
             ->innerJoin(Partner::class, 'p', 'WITH', 'p.id = j.partnerId')
             ->where('j.service LIKE :service')
@@ -44,7 +44,7 @@ class JobEventRepository extends ServiceEntityRepository
 
         $qb->setParameter('service', '%'.$type.'%')
             ->setParameter('day_period', $dayPeriod)
-            ->groupBy('p.id, p.nom, s.reference, j.action, j.status, j.codeStatus')
+            ->groupBy('p.id, p.nom, s.reference, j.action, j.status, j.codeStatus, j.response')
             ->orderBy('last_event', 'DESC');
 
         return $qb->getQuery()->getArrayResult();

--- a/src/Service/Esabora/EsaboraSCHSService.php
+++ b/src/Service/Esabora/EsaboraSCHSService.php
@@ -56,7 +56,7 @@ class EsaboraSCHSService extends AbstractEsaboraService
 
             return new DossierStateSCHSResponse(
                 Response::HTTP_INTERNAL_SERVER_ERROR !== $statusCode
-                    ? $response->toArray()
+                    ? $response->toArray(throw: false)
                     : [],
                 $statusCode
             );

--- a/src/Service/Esabora/EsaboraSISHService.php
+++ b/src/Service/Esabora/EsaboraSISHService.php
@@ -87,7 +87,7 @@ class EsaboraSISHService extends AbstractEsaboraService
 
             return new DossierStateSISHResponse(
                 Response::HTTP_INTERNAL_SERVER_ERROR !== $statusCode
-                    ? $response->toArray()
+                    ? $response->toArray(throw: false)
                     : [],
                 $statusCode
             );
@@ -117,7 +117,7 @@ class EsaboraSISHService extends AbstractEsaboraService
 
             return new DossierVisiteSISHCollectionResponse(
                 Response::HTTP_INTERNAL_SERVER_ERROR !== $statusCode
-                    ? $response->toArray()
+                    ? $response->toArray(throw: false)
                     : [],
                 $statusCode
             );
@@ -147,7 +147,7 @@ class EsaboraSISHService extends AbstractEsaboraService
 
             return new DossierArreteSISHCollectionResponse(
                 Response::HTTP_INTERNAL_SERVER_ERROR !== $statusCode
-                    ? $response->toArray()
+                    ? $response->toArray(throw: false)
                     : [],
                 $statusCode
             );
@@ -170,7 +170,7 @@ class EsaboraSISHService extends AbstractEsaboraService
 
             return new DossierPushSISHResponse(
                 Response::HTTP_INTERNAL_SERVER_ERROR >= $statusCode
-                    ? $response->toArray()
+                    ? $response->toArray(throw: false)
                     : [],
                 $statusCode
             );


### PR DESCRIPTION
## Ticket

#1941    
#1462 

![image](https://github.com/MTES-MCT/histologe/assets/5757116/66e8dda4-fa59-4a67-bd54-f77501435b44)

## Description
Le client HTTP de Symfony lève une exception lorsque le code http est supérieur à 300. C'est pour cette raison que le message d'erreur d'origine n'était jamais récupéré.

https://symfony.com/doc/current/http_client.html#handling-exceptions
> When the HTTP status code of the response is in the 300-599 range (i.e. 3xx, 4xx or 5xx), the getHeaders(), getContent() and toArray() methods throw an appropriate exception, all of which implement the [HttpExceptionInterface](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Contracts/HttpClient/Exception/HttpExceptionInterface.php).

> To opt-out from this exception and deal with 300-599 status codes on your own, pass false as the optional argument to every call of those methods, e.g. $response->getHeaders(false);.

> If you do not call any of these 3 methods at all, the exception will still be thrown when the $response object is destructed.


## Changements apportés
* Désactiver le déclenchement de l'exception lors de l'appel à `toArrray` et `toContent` 
* Pour des raisons de confort en terme de support et d'autonomie d'équipe, afficher les messages d'erreur sur le dashboard

## Pré-requis
Mettre les accès de l'environnement de test SI-SH

## Tests
- [ ] Déclencher des erreurs lors de l'affectation de signalement et vérifier sur le tableau de bord que les erreurs s'affichent bien
- [ ] Couper le serveur de mock et faite des affectations SCHS et vérifier sur le tableau de bord que les erreurs s'affichent bien