### PR TITLE
[BO - Notification Email] SISH/SCHS

### DIFF
--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -56,18 +56,18 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
 
     private function buildCommentaire(Signalement $signalement): string
     {
-        $commentaire = 'Points signalés:\n';
+        $commentaire = 'Points signalés:'.\PHP_EOL;
 
         foreach ($signalement->getCriticites() as $criticite) {
-            $commentaire .= '\n'.$criticite->getCritere()->getLabel().' => Etat '.$criticite->getScoreLabel();
+            $commentaire .= \PHP_EOL.$criticite->getCritere()->getLabel().' => Etat '.$criticite->getScoreLabel();
         }
 
-        $commentaire .= '\nPropriétaire averti: '.$signalement->getIsProprioAverti() ? 'OUI' : 'NON';
-        $commentaire .= '\nAdultes: '.$signalement->getNbAdultes().' Adultes';
+        $commentaire .= \PHP_EOL.'Propriétaire averti: '.$signalement->getIsProprioAverti() ? 'OUI' : 'NON';
+        $commentaire .= \PHP_EOL.'Adultes: '.$signalement->getNbAdultes().' Adulte(s)';
         $commentaire .= $this->buildNbEnfants($signalement);
 
         foreach ($signalement->getAffectations() as $affectation) {
-            $commentaire .= '\n'.$affectation->getPartner()->getNom().' => '.$affectation->getAffectationLabel();
+            $commentaire .= \PHP_EOL.$affectation->getPartner()->getNom().' => '.$affectation->getAffectationLabel();
         }
 
         return $commentaire;
@@ -76,13 +76,17 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
     private function buildNbEnfants(Signalement $signalement)
     {
         $suffix = '';
-        if (str_ends_with($signalement->getNbEnfantsM6(), '+') || str_ends_with($signalement->getNbEnfantsP6(), '+')) {
+        if (null !== $signalement->getNbEnfantsM6() && str_ends_with($signalement->getNbEnfantsM6(), '+') ||
+            null !== $signalement->getNbEnfantsP6() && str_ends_with($signalement->getNbEnfantsP6(), '+')
+        ) {
             $suffix = '+';
         }
-        $nbEnfants = str_replace('+', '', $signalement->getNbEnfantsM6()) + str_replace('+', '', $signalement->getNbEnfantsP6());
+        $nbEnfantsM6 = (int) str_replace('+', '', $signalement->getNbEnfantsM6());
+        $nbEnfantsP6 = (int) str_replace('+', '', $signalement->getNbEnfantsP6());
+        $nbEnfants = $nbEnfantsM6 + $nbEnfantsP6;
         $nbEnfants .= $suffix;
 
-        return '\n'.$nbEnfants.' Enfants';
+        return \PHP_EOL.$nbEnfants.' Enfant(s)';
     }
 
     private function buildPiecesJointesObservation(Signalement $signalement): string

--- a/src/Service/Esabora/Response/DossierStateSCHSResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSCHSResponse.php
@@ -20,14 +20,14 @@ class DossierStateSCHSResponse implements DossierResponseInterface
         if (!empty($response)) {
             $data = $response['rowList'][0]['columnDataList'] ?? null;
             if (null !== $data) {
-                $this->sasReference = $data[0];
-                $this->sasEtat = $data[1];
-                $this->id = $data[2];
-                $this->numero = $data[3];
-                $this->statutAbrege = $data[4];
-                $this->statut = $data[5];
-                $this->etat = $data[6];
-                $this->dateCloture = $data[7];
+                $this->sasReference = $data[0] ?? null;
+                $this->sasEtat = $data[1] ?? null;
+                $this->id = $data[2] ?? null;
+                $this->numero = $data[3] ?? null;
+                $this->statutAbrege = $data[4] ?? null;
+                $this->statut = $data[5] ?? null;
+                $this->etat = $data[6] ?? null;
+                $this->dateCloture = $data[7] ?? null;
             } else {
                 $this->errorReason = json_encode($response);
             }

--- a/src/Service/Esabora/Response/DossierStateSISHResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSISHResponse.php
@@ -25,19 +25,19 @@ class DossierStateSISHResponse implements DossierResponseInterface
         if (!empty($response)) {
             $data = $response['rowList'][0]['columnDataList'] ?? null;
             if (null !== $data) {
-                $this->referenceDossier = $data[0];
-                $this->sasEtat = $data[1];
-                $this->sasDateDecision = $data[2];
-                $this->sasCauseRefus = $data[3];
-                $this->dossId = $data[4];
-                $this->dossNum = $data[5];
-                $this->dossObjet = $data[6];
-                $this->dossDateCloture = $data[7];
-                $this->dossStatutAbr = $data[8];
-                $this->dossStatut = $data[9];
-                $this->dossEtat = $data[10];
-                $this->dossTypeCode = $data[11];
-                $this->dossTypeLib = $data[12];
+                $this->referenceDossier = $data[0] ?? null;
+                $this->sasEtat = $data[1] ?? null;
+                $this->sasDateDecision = $data[2] ?? null;
+                $this->sasCauseRefus = $data[3] ?? null;
+                $this->dossId = $data[4] ?? null;
+                $this->dossNum = $data[5] ?? null;
+                $this->dossObjet = $data[6] ?? null;
+                $this->dossDateCloture = $data[7] ?? null;
+                $this->dossStatutAbr = $data[8] ?? null;
+                $this->dossStatut = $data[9] ?? null;
+                $this->dossEtat = $data[10] ?? null;
+                $this->dossTypeCode = $data[11] ?? null;
+                $this->dossTypeLib = $data[12] ?? null;
             } else {
                 $this->errorReason = json_encode($response);
             }

--- a/tests/Unit/Factory/Esabora/DossierMessageSCHSFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSCHSFactoryTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Unit\Factory\Esabora;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Signalement;
 use App\Factory\Esabora\DossierMessageSCHSFactory;
 use App\Service\UploadHandlerService;
 use App\Tests\FixturesHelper;
@@ -33,5 +34,38 @@ class DossierMessageSCHSFactoryTest extends TestCase
         $this->assertStringContainsString('Etat grave', $dossierMessage->getDossierCommentaire());
         $this->assertStringContainsString('25', $dossierMessage->getNumeroAdresseSignalement());
         $this->assertStringContainsString('Rue du test', $dossierMessage->getAdresseSignalement());
+    }
+
+    /**
+     * @dataProvider provideNbChildren
+     */
+    public function testBuildNbEnfants(string $expectedResult, ?string $nbEnfantsM6 = null, ?string $nbEnfantsP6 = null): void
+    {
+        $uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
+        $uploadHandlerServiceMock
+            ->expects($this->exactly(0))
+            ->method('getTmpFilepath')
+            ->willReturn(self::FILE);
+
+        $dossierMessageFactory = new DossierMessageSCHSFactory($uploadHandlerServiceMock);
+        $signalement = (new Signalement())->setNbEnfantsM6($nbEnfantsM6)->setNbEnfantsP6($nbEnfantsP6);
+
+        $buildNbEnfantsMethod = new \ReflectionMethod(DossierMessageSCHSFactory::class, 'buildNbEnfants');
+        $buildNbEnfantsMethod->setAccessible(true);
+
+        $actualResult = $buildNbEnfantsMethod->invoke($dossierMessageFactory, $signalement);
+
+        $this->assertStringContainsString($expectedResult, $actualResult);
+    }
+
+    public function provideNbChildren(): \Generator
+    {
+        yield 'No child' => ['0 Enfant(s)', null, null];
+        yield '1 children M6, 0 children P6' => ['1 Enfant(s)', '1', null];
+        yield '3 children M6, 2 children P6' => ['5 Enfant(s)', '3', '2'];
+        yield '4+ children M6, 4+ children P6' => ['8+ Enfant(s)', '4+', '4+'];
+        yield '4+ children M6, 1 children P6' => ['5+ Enfant(s)', '4+', '1'];
+        yield '4+ children M6, 0 children P6' => ['4+ Enfant(s)', '4+', null];
+        yield '0 children M6, 4+ children P6' => ['4+ Enfant(s)', null, '4+'];
     }
 }


### PR DESCRIPTION
## Ticket

#1942   

![image](https://github.com/MTES-MCT/histologe/assets/5757116/6e344b40-56c3-43f2-9272-37d23d916577)

## Description
Ne pas envoyer de mail pour les suivi généré par Esabora `remis en attente via`
 
## Changements apportés
* Passer de suivi automatique à suivi technique

## Pré-requis
- Mettre les identifiants esabora-test à un partenaire ARS
- Ouvrir et purger Mailcatcher

## Tests
- [ ] Affecter un dossier à un partenaire ARS 
- [ ] Accepter l'affectation 
- [ ] Lancer la commande `make console app="sync-esabora-sish"` et vérifier l'output de la console afin de trouver un dossier en attente 

![image](https://github.com/MTES-MCT/histologe/assets/5757116/7cb89b71-dc72-463a-abff-e35cbab8098b)

- [ ] Vérifier qu'aucun email n'a été reçu suite à l'ajout du suvi `Signalement remis en attente via SI-SH par Partenaire 13-06 ESABORA ARS`
