### PR TITLE
[BO - Signalement] Quelques améliorations UI

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -236,6 +236,10 @@ small {
     padding-inline-start: .25rem;
 }
 
+.fr-lh-2 {
+    line-height: 2rem;
+}
+
 /*COLOR*/
 .fr-background--white {
     background: white;

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -29,7 +29,7 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_address_'.$signalement->getId(), $request->get('_token'))) {
             /** @var AdresseOccupantRequest $adresseOccupantRequest */
             $adresseOccupantRequest = $serializer->deserialize(
@@ -61,7 +61,7 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_coordonnees_tiers_'.$signalement->getId(), $request->get('_token'))) {
             /** @var CoordonneesTiersRequest $coordonneesTiersRequest */
             $coordonneesTiersRequest = $serializer->deserialize(
@@ -93,7 +93,7 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_coordonnees_foyer_'.$signalement->getId(), $request->get('_token'))) {
             /** @var CoordonneesFoyerRequest $coordonneesFoyerRequest */
             $coordonneesFoyerRequest = $serializer->deserialize(
@@ -125,7 +125,7 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_coordonnees_bailleur_'.$signalement->getId(), $request->get('_token'))) {
             /** @var CoordonneesBailleurRequest $coordonneesBailleurRequest */
             $coordonneesBailleurRequest = $serializer->deserialize(
@@ -157,7 +157,7 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_informations_logement_'.$signalement->getId(), $request->get('_token'))) {
             /** @var InformationsLogementRequest $informationsLogementRequest */
             $informationsLogementRequest = $serializer->deserialize(
@@ -189,7 +189,7 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_situation_foyer_'.$signalement->getId(), $request->get('_token'))) {
             /** @var SituationFoyerRequest $situationFoyerRequest */
             $situationFoyerRequest = $serializer->deserialize(
@@ -221,7 +221,7 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_procedure_demarches_'.$signalement->getId(), $request->get('_token'))) {
             /** @var ProcedureDemarchesRequest $procedureDemarchesRequest */
             $procedureDemarchesRequest = $serializer->deserialize(

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -42,7 +42,7 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromAdresseOccupantRequest($signalement, $adresseOccupantRequest);
-                $this->addFlash('success', 'Adresse du logement mise à jour avec succès !');
+                $this->addFlash('success', 'L\'adresse du logement a bien été modifiée.');
             } else {
                 $this->addFlash('error', 'Erreur de saisie : '.$errorMessage);
             }
@@ -74,7 +74,7 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesTiersRequest($signalement, $coordonneesTiersRequest);
-                $this->addFlash('success', 'Coordonnées du tiers déclarant mises à jour avec succès !');
+                $this->addFlash('success', 'Les coordonnées du tiers déclarant ont bien été modifiées.');
             } else {
                 $this->addFlash('error', 'Erreur de saisie : '.$errorMessage);
             }
@@ -106,7 +106,7 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesFoyerRequest($signalement, $coordonneesFoyerRequest);
-                $this->addFlash('success', 'Coordonnées du foyer mises à jour avec succès !');
+                $this->addFlash('success', 'Les coordonnées du foyer ont bien été modifiées.');
             } else {
                 $this->addFlash('error', 'Erreur de saisie : '.$errorMessage);
             }
@@ -138,7 +138,7 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesBailleurRequest($signalement, $coordonneesBailleurRequest);
-                $this->addFlash('success', 'Coordonnées du bailleur mises à jour avec succès !');
+                $this->addFlash('success', 'Les coordonnées du bailleur ont bien été modifiées.');
             } else {
                 $this->addFlash('error', 'Erreur de saisie : '.$errorMessage);
             }
@@ -170,7 +170,7 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromInformationsLogementRequest($signalement, $informationsLogementRequest);
-                $this->addFlash('success', 'Informations du logement mises à jour avec succès !');
+                $this->addFlash('success', 'Les informations du logement ont bien été modifiées.');
             } else {
                 $this->addFlash('error', 'Erreur de saisie : '.$errorMessage);
             }
@@ -202,7 +202,7 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromSituationFoyerRequest($signalement, $situationFoyerRequest);
-                $this->addFlash('success', 'Situation du foyer mise à jour avec succès !');
+                $this->addFlash('success', 'La situation du foyer a bien été modifiée.');
             } else {
                 $this->addFlash('error', 'Erreur de saisie : '.$errorMessage);
             }
@@ -234,7 +234,7 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromProcedureDemarchesRequest($signalement, $procedureDemarchesRequest);
-                $this->addFlash('success', 'Procédure et démarches mises à jour avec succès !');
+                $this->addFlash('success', 'Les procédures et démarches ont bien été modifiées.');
             } else {
                 $this->addFlash('error', 'Erreur de saisie : '.$errorMessage);
             }

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -37,6 +37,7 @@ class SignalementListController extends AbstractController
             return $this->stream('back/table_result.html.twig', [
                 'filters' => $filters,
                 'signalements' => $signalements,
+                'isNewFormEnabled' => $parameterBag->get('feature_new_form'),
             ]);
         }
 

--- a/src/Validator/TelephoneFormatValidator.php
+++ b/src/Validator/TelephoneFormatValidator.php
@@ -20,7 +20,7 @@ class TelephoneFormatValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\TelephoneFormat');
         }
 
-        /** @var App\Validator\TelephoneFormat $constraint */
+        /* @var App\Validator\TelephoneFormat $constraint */
 
         if (null === $value || '' === $value) {
             return;

--- a/templates/_partials/_modal_affectation.html.twig
+++ b/templates/_partials/_modal_affectation.html.twig
@@ -8,7 +8,7 @@
                             <span class="fr-fi-arrow-right-line"></span>
                             Affectation de partenaires
                         </h1>
-                        <button class="fr-link--close fr-link" aria-controls="fr-modal-affectation">Fermer</button>
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-affectation">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-h-100 fr-hidden fr-mt-5w"
@@ -75,14 +75,14 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn" type="submit"
+                                <button class="fr-btn fr-icon-checkbox-line" type="submit"
                                         form="signalement-affectation-form" id="signalement-affectation-form-submit"
                                         formaction="{{ path('back_signalement_toggle_affectation',{uuid:signalement.uuid}) }}">
                                     Affecter partenaire(s)
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
                                         aria-controls="fr-modal-affectation">
                                     Annuler
                                 </button>

--- a/templates/_partials/_modal_dpe.html.twig
+++ b/templates/_partials/_modal_dpe.html.twig
@@ -8,7 +8,7 @@
                             <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
                             Consulter le(s) DPE
                         </h1>
-                        <button class="fr-link--close fr-link" aria-controls="modal-dpe">Fermer</button>
+                        <button class="fr-btn--close fr-btn" aria-controls="modal-dpe">Fermer</button>
                     </div>
                     <div class="fr-modal__content" id="modal-dpe-content">
                         <h4>Aucun DPE connu pour ce logement</h4>

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -7,7 +7,7 @@
                             <h1 id="fr-modal-edit-nde-title" class="fr-modal__title">
                                 Non décence énergétique
                             </h1>
-                            <button class="fr-link--close fr-link" aria-controls="fr-modal-edit-nde">Fermer</button>
+                            <button class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-nde">Fermer</button>
                      </div>
                     <div class="fr-modal__content">
                         <p>
@@ -156,13 +156,13 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn" type="submit"
+                                <button class="fr-btn fr-icon-checkbox-line" type="submit"
                                         id="signalement-edit-nde-form-submit">
                                     Valider
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
                                         aria-controls="fr-modal-edit-nde">
                                     Annuler
                                 </button>

--- a/templates/_partials/signalement/add_suivi.html.twig
+++ b/templates/_partials/signalement/add_suivi.html.twig
@@ -7,7 +7,7 @@
                         <h1 id="fr-modal-add-suivi-title" class="fr-modal__title">
                             Ajouter un suivi
                         </h1>
-                        <button class="fr-link--close fr-link" aria-controls="fr-modal-add-suivi">Fermer</button>
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-add-suivi">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <form method="POST" name="signalement-add-suivi" id="signalement-add-suivi-form" class="tinyCheck"
@@ -41,13 +41,13 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button type="submit" class="fr-btn fr-btn--icon-left"
+                                <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-checkbox-line"
                                         form="signalement-add-suivi-form" disabled>
                                     Enregistrer
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-add-suivi">
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-add-suivi">
                                     Annuler
                                 </button>
                             </li>

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -5,7 +5,7 @@
                 <form method="POST" id="form-edit-address" enctype="application/json" action="{{ path('back_signalement_edit_address',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-edit-address">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-address">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-address" class="fr-modal__title">
@@ -86,13 +86,13 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary"
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-address">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" type="submit">
+                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
                                         Valider
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -5,13 +5,12 @@
                 <form method="POST" id="form-edit-coordonnees-bailleur" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_bailleur',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-edit-coordonnees-bailleur">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-bailleur">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-coordonnees-bailleur" class="fr-modal__title">
                                 Modifier les coordonnées du bailleur
                             </h1>
-
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nom">Nom</label>
                                 <input class="fr-input" type="text" name="nom" value="{{ signalement.nomProprio }}">
@@ -70,13 +69,13 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary"
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-coordonnees-bailleur">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" type="submit">
+                                    <button class="fr-btn fr-icon-checkbox-line" type="submit">
                                         Valider
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
@@ -5,7 +5,7 @@
                 <form method="POST" id="form-edit-coordonnees-foyer" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_foyer',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-edit-coordonnees-foyer">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-foyer">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-coordonnees-foyer" class="fr-modal__title">
@@ -41,13 +41,13 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary"
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-coordonnees-foyer">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" type="submit">
+                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
                                         Valider
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -5,7 +5,7 @@
                 <form method="POST" id="form-edit-coordonnees-tiers" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_tiers',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-edit-coordonnees-tiers">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-tiers">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-coordonnees-tiers" class="fr-modal__title">
@@ -54,13 +54,13 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary"
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-coordonnees-tiers">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" type="submit">
+                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
                                         Valider
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -5,7 +5,7 @@
                 <form method="POST" id="form-edit-informations-logement" enctype="application/json" action="{{ path('back_signalement_edit_informations_logement',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-edit-informations-logement">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-informations-logement">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-informations-logement" class="fr-modal__title">
@@ -132,13 +132,13 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary"
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-informations-logement">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" type="submit">
+                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
                                         Valider
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -50,7 +50,7 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="infoProcedureReponseAssurance">Réponse assurance</label>
-                                <textarea class="fr-input fr-input--no-resize" name="infoProcedureReponseAssurance">{{ signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance ? signalement.informationProcedure.infoProcedureReponseAssurance|raw : '' }}</textarea>
+                                <textarea class="fr-input fr-input--no-resize" name="infoProcedureReponseAssurance">{{ signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance ? signalement.informationProcedure.infoProcedureReponseAssurance : '' }}</textarea>
                             </div>
 
                             <div class="fr-input-group">

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -5,7 +5,7 @@
                 <form method="POST" id="form-edit-procedure-demarches" enctype="application/json" action="{{ path('back_signalement_edit_procedure_demarches',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-edit-procedure-demarches">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-procedure-demarches">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-procedure-demarches" class="fr-modal__title">
@@ -75,13 +75,13 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary"
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-procedure-demarches">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" type="submit">
+                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
                                         Valider
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -50,7 +50,7 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="infoProcedureReponseAssurance">Réponse assurance</label>
-                                <input class="fr-input" type="text" name="infoProcedureReponseAssurance" value="{{ signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance ? signalement.informationProcedure.infoProcedureReponseAssurance|raw : '' }}">
+                                <textarea class="fr-input fr-input--no-resize" name="infoProcedureReponseAssurance">{{ signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance ? signalement.informationProcedure.infoProcedureReponseAssurance|raw : '' }}</textarea>
                             </div>
 
                             <div class="fr-input-group">

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -5,7 +5,7 @@
                 <form method="POST" id="form-edit-situation-foyer" enctype="application/json" action="{{ path('back_signalement_edit_situation_foyer',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-edit-situation-foyer">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-situation-foyer">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-situation-foyer" class="fr-modal__title">
@@ -126,13 +126,13 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary"
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-situation-foyer">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" type="submit">
+                                    <button class="fr-btn fr-icon-checkbox-line" type="submit">
                                         Valider
                                     </button>
                                 </li>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -92,14 +92,22 @@
     <div class="fr-grid-row">
         <div class="fr-col-12">
             Déposé le : {{ signalement.createdAt|format_datetime(locale='fr') }} 
-            {% if signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').LOCATAIRE or 
-            signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT or
-            signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
-                par le
+            {% if signalement.profileDeclarant %}
+                {% if signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').LOCATAIRE or 
+                signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT or
+                signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
+                    par le
+                {% else %}
+                    par un
+                {% endif %}
+                {{ signalement.profileDeclarant.label }}
             {% else %}
-                par un
+                {% if signalement.isNotOccupant %}
+                    par un tiers déclarant
+                {% else %}
+                    par l'occupant
+                {% endif %}
             {% endif %}
-            {{ signalement.profileDeclarant.label }}
 
             <br>
 

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -91,12 +91,16 @@
 
     <div class="fr-grid-row">
         <div class="fr-col-12">
-            Déposé le : {{ signalement.createdAt|format_datetime(locale='fr') }}
-            {% if signalement.isNotOccupant %}
-                par un tiers déclarant
+            Déposé le : {{ signalement.createdAt|format_datetime(locale='fr') }} 
+            {% if signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').LOCATAIRE or 
+            signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT or
+            signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
+                par le
             {% else %}
-                par l'occupant
+                par un
             {% endif %}
+            {{ signalement.profileDeclarant.label }}
+
             <br>
 
             {% if isAffected and not isAccepted and not isRefused and not needValidation and not isClosed and not isClosedForMe %}

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -565,7 +565,7 @@
                         <strong>Réponse assurance :</strong>
                         {% if signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance %}
                             <br>
-                            {{ signalement.informationProcedure.infoProcedureReponseAssurance|raw }}
+                            {{ signalement.informationProcedure.infoProcedureReponseAssurance | nl2br  }}
                         {% else %}
                             N/C
                         {% endif %}

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -202,7 +202,7 @@
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
                         {% if isNewFormEnabled %}
-                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-tiers">Modifier</a>
+                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-tiers" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
@@ -243,7 +243,7 @@
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
                         {% if isNewFormEnabled %}
-                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-foyer">Modifier</a>
+                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-foyer" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
@@ -277,7 +277,7 @@
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
                         {% if isNewFormEnabled %}
-                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-bailleur">Modifier</a>
+                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-bailleur" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
@@ -326,7 +326,7 @@
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
                         {% if isNewFormEnabled %}
-                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-informations-logement">Modifier</a>
+                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-informations-logement" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
@@ -429,7 +429,7 @@
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
                         {% if isNewFormEnabled %}
-                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-situation-foyer">Modifier</a>
+                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-situation-foyer" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
@@ -525,7 +525,7 @@
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
                         {% if isNewFormEnabled %}
-                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-procedure-demarches">Modifier</a>
+                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-procedure-demarches" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -194,7 +194,7 @@
     <div class="fr-grid-row fr-grid-row--gutters">
         {% if signalement.isNotOccupant %}
         {% include 'back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig' %}
-        <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
+        <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
             <div class="fr-p-3v fr-background-alt--grey">
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-9">
@@ -234,7 +234,7 @@
         </div>
         {% endif %}
 
-        <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
+        <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
             {% include 'back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig' %}
             <div class="fr-p-3v fr-background-alt--grey">
                 <div class="fr-grid-row">
@@ -276,7 +276,7 @@
         </div>
 
         {% if signalement.profileDeclarant and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT %}
-           <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
+           <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
                 {% include 'back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig' %}
                 <div class="fr-p-3v fr-background-alt--grey">
                     <div class="fr-grid-row">
@@ -326,7 +326,7 @@
             </div>
         {% endif %}
 
-        <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
+        <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
             {% include 'back/signalement/view/edit-modals/edit-informations-logement.html.twig' %}
             <div class="fr-p-3v fr-background-alt--grey">
                 <div class="fr-grid-row">
@@ -429,7 +429,7 @@
             </div>
         </div>
 
-        <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
+        <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
             {% include 'back/signalement/view/edit-modals/edit-situation-foyer.html.twig' %}
             <div class="fr-p-3v fr-background-alt--grey">
                 <div class="fr-grid-row">
@@ -525,7 +525,7 @@
             </div>
         </div>
 
-        <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
+        <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
             {% include 'back/signalement/view/edit-modals/edit-procedure-demarches.html.twig' %}
             <div class="fr-p-3v fr-background-alt--grey">
                 <div class="fr-grid-row">

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -246,6 +246,13 @@
                         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-foyer" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
+                    
+                    {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT  %}
+                        <div class="fr-col-12">
+                            <strong>Type de déclarant :</strong> {{ signalement.profileDeclarant.label }}
+                        </div>
+                    {% endif %}
+
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Nom :</strong> {{ signalement.nomOccupant }}
                     </div>
@@ -268,54 +275,56 @@
             </div>
         </div>
 
-        <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
-            {% include 'back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig' %}
-            <div class="fr-p-3v fr-background-alt--grey">
-                <div class="fr-grid-row">
-                    <div class="fr-col-12 fr-col-md-9">
-                        <h4 class="fr-h6">Coordonnées du bailleur</h4>
-                    </div>
-                    <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                        {% if isNewFormEnabled %}
-                        <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-bailleur" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
-                        {% endif %}
-                    </div>
-                    <div class="fr-col-12 fr-col-md-6">
-                        <strong>Nom :</strong> {{ signalement.nomProprio ?? 'N/R' }}
-                    </div>
-                    <div class="fr-col-12 fr-col-md-6">
-                        <strong>Prénom :</strong> {{ signalement.prenomProprio ?? 'N/R' }}
-                    </div>
-                    <div class="fr-col-12">
-                        <strong>Courriel :</strong>
-                        {% if signalement.mailProprio %}
-                            <a href="mailto:{{ signalement.mailProprio }}">{{ signalement.mailProprio }}</a>
-                        {% else %}
-                            N/R
-                        {% endif %}
-                    </div>
-                    <div class="fr-col-12 fr-col-md-6">
-                        <strong>Tél. :</strong>
-                        {% if signalement.telProprio %}
-                            <a href="mailto:{{ signalement.telProprioDecoded }}">{{ signalement.telProprioDecoded }}</a>
-                        {% else %}
-                            N/R
-                        {% endif %}
-                    </div>
-                    <div class="fr-col-12 fr-col-md-6">
-                        <strong>Tél. sec. :</strong>
-                        {% if signalement.telProprioSecondaire %}
-                            <a href="mailto:{{ signalement.telProprioSecondaireDecoded }}">{{ signalement.telProprioSecondaireDecoded }}</a>
-                        {% else %}
-                            N/R
-                        {% endif %}
-                    </div>
-                    <div class="fr-col-12">
-                        <strong>Adresse :</strong> {{ signalement.adresseProprio ? signalement.adresseProprio ~ ', ' ~ signalement.codePostalProprio ~ ' ' ~ signalement.villeProprio : 'N/R' }}
+        {% if signalement.profileDeclarant and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT %}
+           <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
+                {% include 'back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig' %}
+                <div class="fr-p-3v fr-background-alt--grey">
+                    <div class="fr-grid-row">
+                        <div class="fr-col-12 fr-col-md-9">
+                            <h4 class="fr-h6">Coordonnées du bailleur</h4>
+                        </div>
+                        <div class="fr-col-12 fr-col-md-3 fr-text--right">
+                            {% if isNewFormEnabled %}
+                            <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-bailleur" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Nom :</strong> {{ signalement.nomProprio ?? 'N/R' }}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Prénom :</strong> {{ signalement.prenomProprio ?? 'N/R' }}
+                        </div>
+                        <div class="fr-col-12">
+                            <strong>Courriel :</strong>
+                            {% if signalement.mailProprio %}
+                                <a href="mailto:{{ signalement.mailProprio }}">{{ signalement.mailProprio }}</a>
+                            {% else %}
+                                N/R
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Tél. :</strong>
+                            {% if signalement.telProprio %}
+                                <a href="mailto:{{ signalement.telProprioDecoded }}">{{ signalement.telProprioDecoded }}</a>
+                            {% else %}
+                                N/R
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Tél. sec. :</strong>
+                            {% if signalement.telProprioSecondaire %}
+                                <a href="mailto:{{ signalement.telProprioSecondaireDecoded }}">{{ signalement.telProprioSecondaireDecoded }}</a>
+                            {% else %}
+                                N/R
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12">
+                            <strong>Adresse :</strong> {{ signalement.adresseProprio ? signalement.adresseProprio ~ ', ' ~ signalement.codePostalProprio ~ ' ' ~ signalement.villeProprio : 'N/R' }}
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {% endif %}
 
         <div class="fr-col-12 fr-col-md-6 fr-mb-1v">
             {% include 'back/signalement/view/edit-modals/edit-informations-logement.html.twig' %}

--- a/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
@@ -6,7 +6,7 @@
 
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="add-visite-modal">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="add-visite-modal">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-add-visite-modal" class="fr-modal__title">Définir une date de visite</h1>
@@ -85,12 +85,12 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary" aria-controls="add-visite-modal">
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="add-visite-modal">
                                         Annuler
                                     </button>
                                 </li>
                                 <li>
-                                    <button type="submit" class="fr-btn" id="form-signalement-add-visite-submit">
+                                    <button type="submit" class="fr-btn fr-icon-checkbox-line" id="form-signalement-add-visite-submit">
                                         Valider
                                     </button>
                                 </li>


### PR DESCRIPTION
## Ticket

#1896 
#1900 
#1898 
#1899 
#1901 
#1909 
#1910 
#1907 

## Description
#1896 : ajouter icone au lien modifier
#1898 : en cas de bailleur occupant, cacher le bloc "coordonnées du bailleur" et ajouter une info dans le bloc "coordonnées du foyer"
#1899 : dans l'édition des procédures et démarches, mettre un textarea pour la réponse de l'assurance
#1900 : dans les modales d'édition, ajouter un picto pour les boutons fermer annuler et valider
#1901 : augementer l'espace entre les lignes pour les différents blocs d'infos
#1909 : changer les messages de succès lors de l'édition des blocs d'info
#1910 : préciser le type de déclarant dans l'en-tête de la fiche signalement
#1907 : fix de l'édition de signalement en cas de non-admin


## Changements apportés
* Ajout d'une classe css
* Modification du SignalementEditController
* Modifications de twig

## Pré-requis

## Tests
- [ ] Faire quelques signalements à partir du nouveau formulaire (locataire, bailleur occupant et un tiers... utiliser les fixtures)
- [ ] Aller dans le BO et vérifier l'affichage des pages signalements pour les signalements avec l'ancien formulaire et avec le nouveau (cf liste ci-dessus)
- [ ] Vérifier aussi les modales
- [ ] Se connecter avec des comptes qui ne sont pas super admin, et vérifier qu'on peut éditer les informations d'un signalement
