### PR TITLE
[BO - Traitement image] Commande de traitement de photos (Miniature, Resize)

### DIFF
--- a/migrations/Version20231121140808.php
+++ b/migrations/Version20231121140808.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231121140808 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add variants column to file table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file ADD variants TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file DROP variants');
+    }
+}

--- a/migrations/Version20231121140808.php
+++ b/migrations/Version20231121140808.php
@@ -11,16 +11,16 @@ final class Version20231121140808 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'add variants column to file table';
+        return 'add is_variants_generated column to file table';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE file ADD variants TINYINT(1) NOT NULL');
+        $this->addSql('ALTER TABLE file ADD is_variants_generated TINYINT(1) NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE file DROP variants');
+        $this->addSql('ALTER TABLE file DROP is_variants_generated');
     }
 }

--- a/src/Command/CreateSignalementPhotoVariantsCommand.php
+++ b/src/Command/CreateSignalementPhotoVariantsCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\File;
+use App\Entity\Territory;
+use App\Service\ImageManipulationHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:create-signalement-photo-variants',
+    description: 'Create thumbnails and resized photos of signalement for a departement'
+)]
+class CreateSignalementPhotoVariantsCommand extends Command
+{
+    private SymfonyStyle $io;
+    private int $i = 1;
+    private array $files = [];
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly FilesystemOperator $fileStorage,
+        private readonly ImageManipulationHandler $imageManipulationHandler,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('territory_zip', InputArgument::REQUIRED, 'Territory zip to target');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+        $this->imageManipulationHandler->setUseTmpDir(false);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $territoryZip = $input->getArgument('territory_zip');
+        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => $territoryZip]);
+        if (null === $territory) {
+            $this->io->error('Territory does not exists');
+
+            return Command::FAILURE;
+        }
+        $this->files = $this->entityManager->getRepository(File::class)->getPhotosWihoutVariantsForTerritory($territory);
+        foreach ($this->files as $file) {
+            $this->processFile($file);
+            ++$this->i;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function processFile(File $file): bool
+    {
+        try {
+            if (!$this->fileStorage->fileExists($file->getFilename())) {
+                $this->io->error('File '.$this->i.'/'.\count($this->files).' '.$file->getFilename().' ('.$file->getId().') : file does not exists');
+
+                return false;
+            }
+            $variantNames = ImageManipulationHandler::getVariantNames($file->getFilename());
+            $processed = false;
+            if (!$this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE])) {
+                $this->imageManipulationHandler->resize($file->getFilename());
+                $file->setSize($this->fileStorage->fileSize($variantNames[ImageManipulationHandler::SUFFIX_RESIZE]));
+                $processed = true;
+            }
+            if (!$file->getSize()) {
+                $file->setSize($this->fileStorage->fileSize($file->getFilename()));
+            }
+            if (!$this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
+                $this->imageManipulationHandler->thumbnail($file->getFilename());
+                $processed = true;
+            }
+            $file->setVariants(true);
+            $this->entityManager->flush();
+            if ($processed) {
+                $this->io->success('File '.$this->i.'/'.\count($this->files).' '.$file->getFilename().' ('.$file->getId().') : variants created');
+            } else {
+                $this->io->success('File '.$this->i.'/'.\count($this->files).' '.$file->getFilename().' ('.$file->getId().') : variants already exists');
+            }
+        } catch (\Exception $exception) {
+            $this->io->error('File '.$this->i.'/'.\count($this->files).' '.$file->getFilename().' ('.$file->getId().') : '.$exception->getMessage());
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Command/CreateSignalementPhotoVariantsCommand.php
+++ b/src/Command/CreateSignalementPhotoVariantsCommand.php
@@ -4,6 +4,7 @@ namespace App\Command;
 
 use App\Entity\File;
 use App\Entity\Territory;
+use App\Repository\FileRepository;
 use App\Service\ImageManipulationHandler;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemOperator;
@@ -52,7 +53,9 @@ class CreateSignalementPhotoVariantsCommand extends Command
 
             return Command::FAILURE;
         }
-        $this->files = $this->entityManager->getRepository(File::class)->getPhotosWihoutVariantsForTerritory($territory);
+        /** @var FileRepository $fileRepository */
+        $fileRepository = $this->entityManager->getRepository(File::class);
+        $this->files = $fileRepository->getPhotosWihoutVariantsForTerritory($territory);
         foreach ($this->files as $file) {
             $this->processFile($file);
             ++$this->i;

--- a/src/Command/CreateSignalementPhotoVariantsCommand.php
+++ b/src/Command/CreateSignalementPhotoVariantsCommand.php
@@ -83,7 +83,7 @@ class CreateSignalementPhotoVariantsCommand extends Command
                 $this->imageManipulationHandler->thumbnail($file->getFilename());
                 $processed = true;
             }
-            $file->setVariants(true);
+            $file->setIsVariantsGenerated(true);
             $this->entityManager->flush();
             if ($processed) {
                 $this->io->success('File '.$this->i.'/'.\count($this->files).' '.$file->getFilename().' ('.$file->getId().') : variants created');

--- a/src/Command/CreateSignalementPhotoVariantsCommand.php
+++ b/src/Command/CreateSignalementPhotoVariantsCommand.php
@@ -35,7 +35,7 @@ class CreateSignalementPhotoVariantsCommand extends Command
 
     protected function configure(): void
     {
-        $this->addArgument('territory_zip', InputArgument::REQUIRED, 'Territory zip to target');
+        $this->addArgument('territory_zip', InputArgument::OPTIONAL, 'Territory zip to target');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -47,15 +47,18 @@ class CreateSignalementPhotoVariantsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $territoryZip = $input->getArgument('territory_zip');
-        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => $territoryZip]);
-        if (null === $territory) {
-            $this->io->error('Territory does not exists');
+        $territory = null;
+        if ($territoryZip) {
+            $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => $territoryZip]);
+            if (null === $territory) {
+                $this->io->error('Territory does not exists');
 
-            return Command::FAILURE;
+                return Command::FAILURE;
+            }
         }
         /** @var FileRepository $fileRepository */
         $fileRepository = $this->entityManager->getRepository(File::class);
-        $this->files = $fileRepository->getPhotosWihoutVariantsForTerritory($territory);
+        $this->files = $fileRepository->getPhotosWihoutVariants($territory);
         foreach ($this->files as $file) {
             $this->processFile($file);
             ++$this->i;

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -154,6 +154,7 @@ class FrontSignalementController extends AbstractController
                         );
                         if (null !== $file) {
                             $file->setSize($uploadHandlerService->getFileSize($file->getFilename()));
+                            $file->setIsVariantsGenerated($uploadHandlerService->hasVariants($file->getFilename()));
                             $signalement->addFile($file);
                         }
                     }

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -59,17 +59,12 @@ class SecurityController extends AbstractController
         );
         try {
             $variant = $request->query->get('variant');
+            $variantNames = ImageManipulationHandler::getVariantNames($filename);
 
-            $pathInfo = pathinfo($filename);
-            $ext = \array_key_exists('extension', $pathInfo) ? '.'.$pathInfo['extension'] : '';
-
-            $resize = $pathInfo['filename'].ImageManipulationHandler::SUFFIX_RESIZE.$ext;
-            $thumb = $pathInfo['filename'].ImageManipulationHandler::SUFFIX_THUMB.$ext;
-
-            if ('thumb' == $variant && $fileStorage->fileExists($thumb)) {
-                $filename = $thumb;
-            } elseif ('resize' == $variant && $fileStorage->fileExists($resize)) {
-                $filename = $resize;
+            if ('thumb' == $variant && $fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
+                $filename = $variantNames[ImageManipulationHandler::SUFFIX_THUMB];
+            } elseif ('resize' == $variant && $fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE])) {
+                $filename = $variantNames[ImageManipulationHandler::SUFFIX_RESIZE];
             }
             $tmpFilepath = $this->getParameter('uploads_tmp_dir').$filename;
             $bucketFilepath = $this->getParameter('url_bucket').'/'.$filename;

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -53,12 +53,12 @@ class File
     private ?string $desordreSlug = null;
 
     #[ORM\Column]
-    private ?bool $variants = null;
+    private ?bool $isVariantsGenerated = null;
 
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
-        $this->variants = false;
+        $this->isVariantsGenerated = false;
     }
 
     public function getId(): ?int
@@ -186,14 +186,14 @@ class File
         return $this;
     }
 
-    public function isVariants(): ?bool
+    public function isIsVariantsGenerated(): ?bool
     {
-        return $this->variants;
+        return $this->isVariantsGenerated;
     }
 
-    public function setVariants(bool $variants): static
+    public function setIsVariantsGenerated(bool $isVariantsGenerated): self
     {
-        $this->variants = $variants;
+        $this->isVariantsGenerated = $isVariantsGenerated;
 
         return $this;
     }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -52,9 +52,13 @@ class File
     #[ORM\Column(nullable: true)]
     private ?string $desordreSlug = null;
 
+    #[ORM\Column]
+    private ?bool $variants = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
+        $this->variants = false;
     }
 
     public function getId(): ?int
@@ -178,6 +182,18 @@ class File
     public function setDesordreSlug(?string $desordreSlug): self
     {
         $this->desordreSlug = $desordreSlug;
+
+        return $this;
+    }
+
+    public function isVariants(): ?bool
+    {
+        return $this->variants;
+    }
+
+    public function setVariants(bool $variants): static
+    {
+        $this->variants = $variants;
 
         return $this;
     }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -40,17 +40,18 @@ class FileRepository extends ServiceEntityRepository
         }
     }
 
-    public function getPhotosWihoutVariantsForTerritory(Territory $territory)
+    public function getPhotosWihoutVariants(?Territory $territory = null)
     {
-        return $this->createQueryBuilder('f')
+        $qb = $this->createQueryBuilder('f')
             ->select('f')
             ->innerJoin('f.signalement', 's')
-            ->where('s.territory = :territory')
-            ->andWhere('f.fileType = :type')
+            ->where('f.fileType = :type')
             ->andWhere('f.isVariantsGenerated = false')
-            ->setParameter('territory', $territory)
-            ->setParameter('type', File::FILE_TYPE_PHOTO)
-            ->getQuery()
-            ->getResult();
+            ->setParameter('type', File::FILE_TYPE_PHOTO);
+        if ($territory) {
+            $qb->andWhere('s.territory = :territory')->setParameter('territory', $territory);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -47,7 +47,7 @@ class FileRepository extends ServiceEntityRepository
             ->innerJoin('f.signalement', 's')
             ->where('s.territory = :territory')
             ->andWhere('f.fileType = :type')
-            ->andWhere('f.variants = false')
+            ->andWhere('f.isVariantsGenerated = false')
             ->setParameter('territory', $territory)
             ->setParameter('type', File::FILE_TYPE_PHOTO)
             ->getQuery()

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\File;
+use App\Entity\Territory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -37,5 +38,19 @@ class FileRepository extends ServiceEntityRepository
         if ($flush) {
             $this->getEntityManager()->flush();
         }
+    }
+
+    public function getPhotosWihoutVariantsForTerritory(Territory $territory)
+    {
+        return $this->createQueryBuilder('f')
+            ->select('f')
+            ->innerJoin('f.signalement', 's')
+            ->where('s.territory = :territory')
+            ->andWhere('f.fileType = :type')
+            ->andWhere('f.variants = false')
+            ->setParameter('territory', $territory)
+            ->setParameter('type', File::FILE_TYPE_PHOTO)
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/src/Service/ImageManipulationHandler.php
+++ b/src/Service/ImageManipulationHandler.php
@@ -89,4 +89,14 @@ class ImageManipulationHandler
 
         return $newPath;
     }
+
+    public static function getVariantNames(string $filename): array
+    {
+        $pathInfo = pathinfo($filename);
+        $ext = \array_key_exists('extension', $pathInfo) ? '.'.$pathInfo['extension'] : '';
+        $resize = $pathInfo['filename'].self::SUFFIX_RESIZE.$ext;
+        $thumb = $pathInfo['filename'].self::SUFFIX_THUMB.$ext;
+
+        return [self::SUFFIX_RESIZE => $resize, self::SUFFIX_THUMB => $thumb];
+    }
 }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -157,8 +157,11 @@ class SignalementBuilder
             foreach ($files as $key => $fileList) {
                 foreach ($fileList as $fileItem) {
                     $fileItem['slug'] = $key;
-                    $this->signalement->addFile($file = $this->fileFactory->createFromFileArray(file: $fileItem));
+                    $file = $this->fileFactory->createFromFileArray(file: $fileItem);
                     $this->uploadHandlerService->moveFromBucketTempFolder($file->getFilename());
+                    $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
+                    $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
+                    $this->signalement->addFile($file);
                 }
             }
         }

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -90,6 +90,7 @@ class SignalementFileProcessor
                 intervention: $intervention,
             );
             $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
+            $file->setVariants($this->uploadHandlerService->hasVariants($file->getFilename()));
             $signalement->addFile($file);
         }
     }

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -90,7 +90,7 @@ class SignalementFileProcessor
                 intervention: $intervention,
             );
             $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
-            $file->setVariants($this->uploadHandlerService->hasVariants($file->getFilename()));
+            $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
             $signalement->addFile($file);
         }
     }

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -232,11 +232,14 @@ class UploadHandlerService
 
     public function getFileSize(string $filename): ?int
     {
-        $pathInfo = pathinfo($filename);
-        $ext = \array_key_exists('extension', $pathInfo) ? '.'.$pathInfo['extension'] : '';
-        $fileResize = $pathInfo['filename'].ImageManipulationHandler::SUFFIX_RESIZE.$ext;
-        if ($this->fileStorage->fileExists($fileResize)) {
-            return $this->fileStorage->fileSize($fileResize);
+        try {
+            $variantNames = ImageManipulationHandler::getVariantNames($filename);
+            $fileResize = $variantNames[ImageManipulationHandler::SUFFIX_RESIZE];
+            if ($this->fileStorage->fileExists($fileResize)) {
+                return $this->fileStorage->fileSize($fileResize);
+            }
+        } catch (\Exception $exception) {
+            $this->logger->error($exception->getMessage());
         }
 
         return null;
@@ -244,9 +247,13 @@ class UploadHandlerService
 
     public function hasVariants(string $filename): bool
     {
-        $variantNames = ImageManipulationHandler::getVariantNames($filename);
-        if ($this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE]) && $this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
-            return true;
+        try {
+            $variantNames = ImageManipulationHandler::getVariantNames($filename);
+            if ($this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE]) && $this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
+                return true;
+            }
+        } catch (\Exception $exception) {
+            $this->logger->error($exception->getMessage());
         }
 
         return false;


### PR DESCRIPTION
## Ticket

#1929 

## Description
Création de la commande "app:create-signalement-photo-variants [numero_departement]" permettant de générer les miniature et redimensionnements de toutes les photos existantes sur les signalement du département (optionnel) passé en paramètre.

## Changements apportés
* Ajout d'un champ "variants" (booléen) sur File afin de savoir si les variantes de l'image ont été générés
* Création de la commande qui parcours les images des signalements (du département) afin de générer les variantes et d'enregistrer la taille des images redimensionnées
* Petit refactoring sur le traitement des images

## Pré-requis
Lancer les migrations

## Tests
- [ ] Lancer la commande "app:create-signalement-photo-variants [numero_departement]" sur un département (test déjà fait sur le 13 pour ma part) et vérifier que les image traité ont bien eu leurs variante de générés.
- [ ] Relancer la commande et vérifier que le traitement se relance uniquement sur les image en erreur (inexistante)
