### PR TITLE
 [QA - Sentry] Deprecated str_replace

### DIFF
--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -81,8 +81,9 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
         ) {
             $suffix = '+';
         }
-        $nbEnfantsM6 = ($signalement->getNbEnfantsM6()) ? (int) str_replace('+', '', $signalement->getNbEnfantsM6()) : 0;
-        $nbEnfantsP6 = ($signalement->getNbEnfantsP6()) ? (int) str_replace('+', '', $signalement->getNbEnfantsP6()) : 0;
+
+        $nbEnfantsM6 = (int) str_replace('+', '', $signalement->getNbEnfantsM6() ?? 0);
+        $nbEnfantsP6 = (int) str_replace('+', '', $signalement->getNbEnfantsP6() ?? 0);
         $nbEnfants = $nbEnfantsM6 + $nbEnfantsP6;
         $nbEnfants .= $suffix;
 

--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -81,8 +81,8 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
         ) {
             $suffix = '+';
         }
-        $nbEnfantsM6 = (int) str_replace('+', '', $signalement->getNbEnfantsM6());
-        $nbEnfantsP6 = (int) str_replace('+', '', $signalement->getNbEnfantsP6());
+        $nbEnfantsM6 = ($signalement->getNbEnfantsM6()) ? (int) str_replace('+', '', $signalement->getNbEnfantsM6()) : 0;
+        $nbEnfantsP6 = ($signalement->getNbEnfantsP6()) ? (int) str_replace('+', '', $signalement->getNbEnfantsP6()) : 0;
         $nbEnfants = $nbEnfantsM6 + $nbEnfantsP6;
         $nbEnfants .= $suffix;
 


### PR DESCRIPTION
## Ticket

#1961 

## Description
Contrôle de la valeur du 3ème paramètre passé a str_replace

## Changements apportés
* Méthode "buildNbEnfants" de "src/Factory/Esabora/DossierMessageSCHSFactory.php"

## Pré-requis

## Tests
- [ ] Vérifier que l'appel DossierMessageSCHSFactory->createInstance() sur un signalement ayant un des champs nbEnfantP6 ou NbEnfantM6 a null ne génère plus de dépréciation dans le profiler
