### PR TITLE
[Esabora] Modification de la donnée d'observation des pièces jointes

### DIFF
--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -94,7 +94,10 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
     {
         $piecesJointesObservation = '';
         foreach ($signalement->getFiles() as $file) {
-            $piecesJointesObservation .= $file->getTitle().', ';
+            if ($piecesJointesObservation != '') {
+                $piecesJointesObservation .= ', ';
+            }
+            $piecesJointesObservation .= $file->getFilename();
         }
 
         return $piecesJointesObservation;

--- a/src/Factory/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Esabora/DossierMessageSCHSFactory.php
@@ -94,7 +94,7 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
     {
         $piecesJointesObservation = '';
         foreach ($signalement->getFiles() as $file) {
-            if ($piecesJointesObservation != '') {
+            if (!empty($piecesJointesObservation)) {
                 $piecesJointesObservation .= ', ';
             }
             $piecesJointesObservation .= $file->getFilename();

--- a/tests/Unit/Factory/Esabora/DossierMessageSCHSFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSCHSFactoryTest.php
@@ -29,7 +29,7 @@ class DossierMessageSCHSFactoryTest extends TestCase
         );
 
         $this->assertCount(2, $dossierMessage->getPiecesJointes());
-        $this->assertStringContainsString('Doc', $dossierMessage->getPiecesJointesObservation());
+        $this->assertStringContainsString('document.pdf', $dossierMessage->getPiecesJointesObservation());
         $this->assertStringContainsString('Points signalés', $dossierMessage->getDossierCommentaire());
         $this->assertStringContainsString('Etat grave', $dossierMessage->getDossierCommentaire());
         $this->assertStringContainsString('25', $dossierMessage->getNumeroAdresseSignalement());


### PR DESCRIPTION
## Ticket

#1912   

## Description
Sur certaines bases de données, l'encodage des données d'observation des pièces jointes bloque l'enregistrement sur Esabora.
On prend à présent les noms de fichiers slugifiés (donnée filename).

## Pré-requis

`make mock-start`

## Tests
- [ ] Prendre un signalement sur le 13, ajouter un fichier avec caractères spéciaux, affecter à parternaire SCHS, vérifier données en BDD dans la table `job_event`
