### PR TITLE
 [BO - Signalement] Mettre en place des groupes de validation pour les différents formulaires d'édition

### DIFF
--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -102,7 +102,11 @@ class SignalementEditController extends AbstractController
                 'json'
             );
 
-            $errorMessage = $this->getErrorMessage($validator, $coordonneesFoyerRequest);
+            $validationGroups = ['Default'];
+            if ($signalement->getProfileDeclarant()) {
+                $validationGroups[] = $signalement->getProfileDeclarant()->value;
+            }
+            $errorMessage = $this->getErrorMessage($validator, $coordonneesFoyerRequest, $validationGroups);
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesFoyerRequest($signalement, $coordonneesFoyerRequest);
@@ -134,7 +138,11 @@ class SignalementEditController extends AbstractController
                 'json'
             );
 
-            $errorMessage = $this->getErrorMessage($validator, $coordonneesBailleurRequest);
+            $validationGroups = ['Default'];
+            if ($signalement->getProfileDeclarant()) {
+                $validationGroups[] = $signalement->getProfileDeclarant()->value;
+            }
+            $errorMessage = $this->getErrorMessage($validator, $coordonneesBailleurRequest, $validationGroups);
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesBailleurRequest($signalement, $coordonneesBailleurRequest);
@@ -166,7 +174,11 @@ class SignalementEditController extends AbstractController
                 'json'
             );
 
-            $errorMessage = $this->getErrorMessage($validator, $informationsLogementRequest);
+            $validationGroups = ['Default'];
+            if ($signalement->getProfileDeclarant()) {
+                $validationGroups[] = $signalement->getProfileDeclarant()->value;
+            }
+            $errorMessage = $this->getErrorMessage($validator, $informationsLogementRequest, $validationGroups);
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromInformationsLogementRequest($signalement, $informationsLogementRequest);
@@ -198,7 +210,11 @@ class SignalementEditController extends AbstractController
                 'json'
             );
 
-            $errorMessage = $this->getErrorMessage($validator, $situationFoyerRequest);
+            $validationGroups = ['Default'];
+            if ($signalement->getProfileDeclarant()) {
+                $validationGroups[] = $signalement->getProfileDeclarant()->value;
+            }
+            $errorMessage = $this->getErrorMessage($validator, $situationFoyerRequest, $validationGroups);
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromSituationFoyerRequest($signalement, $situationFoyerRequest);
@@ -230,7 +246,11 @@ class SignalementEditController extends AbstractController
                 'json'
             );
 
-            $errorMessage = $this->getErrorMessage($validator, $procedureDemarchesRequest);
+            $validationGroups = ['Default'];
+            if ($signalement->getProfileDeclarant()) {
+                $validationGroups[] = $signalement->getProfileDeclarant()->value;
+            }
+            $errorMessage = $this->getErrorMessage($validator, $procedureDemarchesRequest, $validationGroups);
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromProcedureDemarchesRequest($signalement, $procedureDemarchesRequest);
@@ -245,10 +265,10 @@ class SignalementEditController extends AbstractController
         return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
     }
 
-    private function getErrorMessage(ValidatorInterface $validator, $dtoRequest): string
+    private function getErrorMessage(ValidatorInterface $validator, $dtoRequest, ?array $validationGroups = []): string
     {
         $errorMessage = '';
-        $errors = $validator->validate($dtoRequest);
+        $errors = $validator->validate($dtoRequest, null, $validationGroups);
         if (\count($errors) > 0) {
             $errorMessage = '';
             foreach ($errors as $error) {

--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -13,13 +13,13 @@ class AdresseOccupantRequest
         private readonly ?string $codePostal = null,
         #[Assert\NotBlank(message: 'Merci de saisir une ville.')]
         private readonly ?string $ville = null,
-        #[Assert\Length(max: 5)]
+        #[Assert\Length(max: 5, maxMessage: 'L\'étage ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $etage = null,
-        #[Assert\Length(max: 3)]
+        #[Assert\Length(max: 3, maxMessage: 'L\'escalier ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $escalier = null,
-        #[Assert\Length(max: 30)]
+        #[Assert\Length(max: 30, maxMessage: 'Le numéro d\'appartement ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $numAppart = null,
-        #[Assert\Length(max: 255)]
+        #[Assert\Length(max: 255, maxMessage: 'Le champ Autre ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $autre = null,
         private readonly ?string $geolocLng = null,
         private readonly ?string $geolocLat = null,

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -9,16 +9,23 @@ use Symfony\Component\Validator\Constraints\Email;
 class CoordonneesBailleurRequest
 {
     public function __construct(
+        #[Assert\NotBlank(message: 'Merci de saisir le nom du bailleur.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO'])]
         private readonly ?string $nom = null,
+        #[Assert\NotBlank(message: 'Merci de saisir le prénom du bailleur.', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         private readonly ?string $prenom = null,
+        #[Assert\NotBlank(message: 'Merci de saisir l\'email du bailleur', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
         private readonly ?string $mail = null,
+        #[Assert\NotBlank(message: 'Merci de saisir le numéro de téléphone du bailleur', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephone = null,
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephoneBis = null,
+        #[Assert\NotBlank(message: 'Merci de saisisr l\'adresse du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $adresse = null,
+        #[Assert\NotBlank(message: 'Merci de saisir le code postal du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $codePostal = null,
+        #[Assert\NotBlank(message: 'Merci de saisir la ville du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $ville = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -21,7 +21,7 @@ class CoordonneesBailleurRequest
         private readonly ?string $telephone = null,
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephoneBis = null,
-        #[Assert\NotBlank(message: 'Merci de saisisr l\'adresse du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci de saisir l\'adresse du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $adresse = null,
         #[Assert\NotBlank(message: 'Merci de saisir le code postal du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $codePostal = null,

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -9,10 +9,14 @@ use Symfony\Component\Validator\Constraints\Email;
 class CoordonneesFoyerRequest
 {
     public function __construct(
+        #[Assert\NotBlank(message: 'Merci de saisir un nom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         private readonly ?string $nom = null,
+        #[Assert\NotBlank(message: 'Merci de saisir un prénom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         private readonly ?string $prenom = null,
+        #[Assert\NotBlank(message: 'Merci de saisir un email', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
         private readonly ?string $mail = null,
+        #[Assert\NotBlank(message: 'Merci de saisir un numéro de téléphone', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephone = null,
         #[AppAssert\TelephoneFormat]

--- a/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
@@ -16,6 +16,7 @@ class CoordonneesTiersRequest
         #[Assert\NotBlank(message: 'Merci de saisir un courriel.')]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
         private readonly ?string $mail = null,
+        #[Assert\NotBlank(message: 'Merci de saisir un numéro de téléphone.')]
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephone = null,
         private readonly ?string $lien = null,

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -9,12 +9,18 @@ class InformationsLogementRequest
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de définir le type de logement.')]
         private readonly ?string $type = null,
+        #[Assert\NotBlank(message: 'Merci de définir le nombre de personnes.')]
         private readonly ?string $nombrePersonnes = null,
+        #[Assert\NotBlank(message: 'Merci de définir le nombre d\'enfants.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
         private readonly ?string $compositionLogementEnfants = null,
+        #[Assert\NotBlank(message: 'Merci de définit la date d\'arrivée', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $bailDpeDateEmmenagement = null,
+        #[Assert\NotBlank(message: 'Merci de définir le bail.', groups: ['LOCATAIRE', 'BAILLEUR'])]
         private readonly ?string $bailDpeBail = null,
+        #[Assert\NotBlank(message: 'Merci de définir l\'état des lieux.', groups: ['LOCATAIRE', 'BAILLEUR'])]
         private readonly ?string $bailDpeEtatDesLieux = null,
+        #[Assert\NotBlank(message: 'Merci de définir le DPE.', groups: ['LOCATAIRE', 'BAILLEUR', 'BAILLEUR_OCCUPANT'])]
         private readonly ?string $bailDpeDpe = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -13,7 +13,7 @@ class InformationsLogementRequest
         private readonly ?string $nombrePersonnes = null,
         #[Assert\NotBlank(message: 'Merci de définir le nombre d\'enfants.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
         private readonly ?string $compositionLogementEnfants = null,
-        #[Assert\NotBlank(message: 'Merci de définit la date d\'arrivée', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci de définir la date d\'arrivée', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $bailDpeDateEmmenagement = null,
         #[Assert\NotBlank(message: 'Merci de définir le bail.', groups: ['LOCATAIRE', 'BAILLEUR'])]

--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -7,12 +7,12 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ProcedureDemarchesRequest
 {
     public function __construct(
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ bailleur averti', 'groups' => ['LOCATAIRE']])]
+        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si le bailleur a été averti', 'groups' => ['LOCATAIRE']])]
         private readonly ?string $isProprioAverti = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ contact assurance', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']])]
+        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'assurance a été contacté', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']])]
         private readonly ?string $infoProcedureAssuranceContactee = null,
         private readonly ?string $infoProcedureReponseAssurance = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ garder logement aprés travaux', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
+        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux ', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
         private readonly ?string $infoProcedureDepartApresTravaux = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -9,7 +9,7 @@ class ProcedureDemarchesRequest
     public function __construct(
         #[Assert\NotBlank(['message' => 'Merci d\'indiquer si le bailleur a été averti', 'groups' => ['LOCATAIRE']])]
         private readonly ?string $isProprioAverti = null,
-        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'assurance a été contacté', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']])]
+        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'assurance a été contactée', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']])]
         private readonly ?string $infoProcedureAssuranceContactee = null,
         private readonly ?string $infoProcedureReponseAssurance = null,
         #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux ', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]

--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -2,12 +2,17 @@
 
 namespace App\Dto\Request\Signalement;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
 class ProcedureDemarchesRequest
 {
     public function __construct(
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ bailleur averti', 'groups' => ['LOCATAIRE']])]
         private readonly ?string $isProprioAverti = null,
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ contact assurance', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']])]
         private readonly ?string $infoProcedureAssuranceContactee = null,
         private readonly ?string $infoProcedureReponseAssurance = null,
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ garder logement aprés travaux', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
         private readonly ?string $infoProcedureDepartApresTravaux = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -7,14 +7,19 @@ use Symfony\Component\Validator\Constraints as Assert;
 class SituationFoyerRequest
 {
     public function __construct(
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ logement social'])]
         private readonly ?string $isLogementSocial = null,
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ demande relogement', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
         private readonly ?string $isRelogement = null,
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ allocataire', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
         private readonly ?string $isAllocataire = null,
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $dateNaissanceOccupant = null,
         private readonly ?string $numAllocataire = null,
         private readonly ?string $logementSocialMontantAllocation = null,
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ souhaite quitter le logement', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
         private readonly ?string $travailleurSocialQuitteLogement = null,
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ accompagnement par un travailleur social', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
         private readonly ?string $travailleurSocialAccompagnementDeclarant = null,
     ) {
     }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -700,7 +700,7 @@ class Signalement
     {
         $telDecoded = json_decode($this->getTelProprio());
 
-        return $telDecoded ? $telDecoded->phone_number : $this->telProprio;
+        return isset($telDecoded->phone_number) ? $telDecoded->phone_number : $this->telProprio;
     }
 
     public function setTelProprio(?string $telProprio): self
@@ -835,7 +835,7 @@ class Signalement
     {
         $telDecoded = json_decode($this->getTelDeclarant());
 
-        return $telDecoded ? $telDecoded->phone_number : $this->telDeclarant;
+        return isset($telDecoded->phone_number) ? $telDecoded->phone_number : $this->telDeclarant;
     }
 
     public function setTelDeclarant(?string $telDeclarant): self

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -236,7 +236,7 @@ class SignalementBuilder
                 ->setVilleProprio($this->signalementDraftRequest->getAdresseLogementAdresseDetailCommune())
                 ->setCodePostalProprio($this->signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal())
                 ->setMailProprio($this->signalementDraftRequest->getVosCoordonneesOccupantEmail())
-                ->setNomProprio($this->resolveNomProprioBailleurOccupant())
+                ->setNomProprio($this->signalementDraftRequest->getVosCoordonneesOccupantNom())
                 ->setPrenomProprio($this->signalementDraftRequest->getVosCoordonneesOccupantPrenom())
                 ->setTelProprio(Json::encode($this->signalementDraftRequest->getVosCoordonneesOccupantTel()))
                 ->setTelProprioSecondaire(Json::encode($this->signalementDraftRequest->getVosCoordonneesOccupantTelSecondaire()));
@@ -369,11 +369,5 @@ class SignalementBuilder
         }
 
         return new \DateTimeImmutable($this->signalementDraftRequest->getLogementSocialDateNaissance());
-    }
-
-    private function resolveNomProprioBailleurOccupant(): ?string
-    {
-        return $this->signalementDraftRequest->getVosCoordonneesTiersNomOrganisme()
-        ?? $this->signalementDraftRequest->getVosCoordonneesTiersNom();
     }
 }


### PR DESCRIPTION
## Ticket

#1905 

## Description
Copie des contraintes existantes sur le nouveaux formulaire (dépôt) sur les modale d'édition coté (bo, contraintes coté serveur)

## Changements apportés
* Ajout de contraintes et groupes de validation et utilisation de ces groupes et contraintes à l'édition du signalement ("src/Controller/Back/SignalementEditController.php", "src/Dto/Request/Signalement/AdresseOccupantRequest.php"...)
* Fix function "getTelProprioDecoded" / "getTelProprioDecoded" qui tombe sinon en erreur suite à une édition coté back ("src/Entity/Signalement.php")
* Fix function setProprietaireData pour qu'elle copie bien le nom du bailleur occupant ("src/Service/Signalement/SignalementBuilder.php")

## Pré-requis

## Tests
- [ ] Tester les modale d'édition d'un signalement et vérifier que les contraintes diffère en fonction du profil occupant
