### PR TITLE
[BO - Signalement] Export PDF pour tous les agents affectés même si le signalement est clôturé

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -132,10 +132,7 @@ class SignalementController extends AbstractController
         if (Signalement::STATUS_ACTIVE === $signalement->getStatut() || Signalement::STATUS_NEED_PARTNER_RESPONSE === $signalement->getStatut()) {
             $canEditSignalement = $this->isGranted('ROLE_ADMIN') || $this->isGranted('ROLE_ADMIN_TERRITORY') || $isAccepted;
         }
-        $canExportSignalement = $canEditSignalement;
-        if (!$canExportSignalement && Signalement::STATUS_CLOSED === $signalement->getStatut()) {
-            $canExportSignalement = $this->isGranted('ROLE_ADMIN') || $this->isGranted('ROLE_ADMIN_TERRITORY') || $isAccepted;
-        }
+        $canExportSignalement = $this->isGranted('ROLE_ADMIN') || $this->isGranted('ROLE_ADMIN_TERRITORY') || $isAffected;
 
         $experimentationTerritories = $parameterBag->get('experimentation_territory');
         $isExperimentationTerritory = \array_key_exists($signalement->getTerritory()->getZip(), $experimentationTerritories);


### PR DESCRIPTION
## Ticket

#1946   

## Description
Export PDF accessible pour tous les agents affectés même si le signalement est clôturé

## Tests
- [ ] Bouton export PDF accessible pour Admin dans tous les statuts de signalement
- [ ] Bouton export PDF accessible pour Admin Territoire dans tous les statuts de signalement
- [ ] Bouton export PDF accessible pour Agent affecté à signalement, dans tous les statuts de signalement + tous les statuts d'affectation
