### PR TITLE
[BO - Statistiques] Correction de l'affichage des listes déroulantes (communes, étiquettes)

### DIFF
--- a/assets/vue/components/stats/TheHistoStatsFilters.vue
+++ b/assets/vue/components/stats/TheHistoStatsFilters.vue
@@ -158,10 +158,15 @@ export default defineComponent({
 </script>
 
 <style>
-  .align-right {
+  #histo-stats-filters .fr-container--fluid {
+    overflow: visible;
+  }
+
+  #histo-stats-filters .align-right {
     text-align: right;
   }
-  .fr-fi-refresh-line::before{
+
+  #histo-stats-filters .fr-fi-refresh-line::before{
     margin-right: 5px;
     font-size: 1rem;
     color: var(--blue-france-sun-113-625);


### PR DESCRIPTION
## Ticket

#1838    

## Description
A priori, suite à la mise à jour du DSFR (bizarre qu'on l'ait pas vu avant), les listes déroulantes des multiselect ne s'affichaient plus correctement.

## Tests
(a priori, pas d'effet de bord sur la correction effectuée)
- [ ] Affichage et sélection dans la page Statistiques du BO
