### PR TITLE
[BO - Signalement] Rapport de visite non consultable

### DIFF
--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -65,7 +65,7 @@
             {% if signalement.interventions is empty or intervention.files is empty %}
                 <span class="fr-badge fr-badge--no-icon" title="Non disponible">Non disponible</span>
             {% else %}
-                <a href="{{ asset('_up/'~intervention.files[0].filename) }}"
+                <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
                     class="fr-btn fr-btn--sm fr-fi-file-line fr-btn--icon-left"
                    title="Afficher le document"
                    rel="noopener"

--- a/templates/emails/nouveau_suivi_visite_confirmed_to_user_email.html.twig
+++ b/templates/emails/nouveau_suivi_visite_confirmed_to_user_email.html.twig
@@ -33,5 +33,5 @@
     </table>
     <p>Si le bouton ne fonctionne pas <a href="{{ lien_suivi|raw }}">cliquez ici</a></p>
     
-    <p>A noter : Le rapport de visite vous sera également envoyé en version papier par les services compétents.</p>
+    <p>A noter : Le rapport de visite vous sera envoyé en version papier par les services compétents.</p>
 {% endblock %}


### PR DESCRIPTION
## Ticket

#1980   

## Description
Suite à un correctif sur la gestion de permission des fichiers 
https://github.com/MTES-MCT/histologe/pull/1902/files#r1385008863

Le lien de rapport de visite n'a pas été mise à jour

## Changements apportés
* Mise à jour du lien de rapport de visite
* Mise à jour du template d'email d'envoi du rapport à l'usager (car il n'est actuellement pas envoyé => https://github.com/MTES-MCT/histologe/issues/1983) 

## Pré-requis

## Tests
- [ ] Depuis la fiche signalement du BO, ajouter une visite dans le passé en ajoutant un rapport de visite (document)
- [ ] Ensuite cliquer sur le bouton voir `le rapport de visite`
![image](https://github.com/MTES-MCT/histologe/assets/5757116/e6c61a03-b64c-4026-ba2b-148694f95698)
