### PR TITLE
[Mails] Envoi de 2 mails séparés pour occupant et déclarant

### DIFF
--- a/src/Service/Mailer/Mail/Signalement/SignalementAskBailDpeMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementAskBailDpeMailer.php
@@ -29,7 +29,7 @@ class SignalementAskBailDpeMailer extends AbstractNotificationMailer
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
     {
         $signalement = $notificationMail->getSignalement();
-        $toRecipient = $signalement->getMailUsagers();
+        $toRecipient = $notificationMail->getTo();
 
         return [
             'signalement' => $signalement,

--- a/src/Service/Mailer/Mail/Signalement/SignalementValidationMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementValidationMailer.php
@@ -29,7 +29,7 @@ class SignalementValidationMailer extends AbstractNotificationMailer
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
     {
         $signalement = $notificationMail->getSignalement();
-        $toRecipient = $signalement->getMailUsagers();
+        $toRecipient = $notificationMail->getTo();
 
         return [
             'signalement' => $signalement,

--- a/templates/emails/accuse_reception_email.html.twig
+++ b/templates/emails/accuse_reception_email.html.twig
@@ -1,7 +1,7 @@
 {% extends 'emails/base_email.html.twig' %}
 
 {% block body %}
-    <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    <p>Bonjour,</p>
     <p>Nous avons bien reçu votre signalement concernant le logement situé <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>
         <br>Vous recevrez par email les mises à jour concernant votre signalement.</p>

--- a/templates/emails/ask_bail_dpe_signalement_email.html.twig
+++ b/templates/emails/ask_bail_dpe_signalement_email.html.twig
@@ -1,7 +1,7 @@
 {% extends 'emails/base_email.html.twig' %}
 
 {% block body %}
-    <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    <p>Bonjour</p>
     <p>
         Vous avez signalé un problème dans le logement au <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong> <br>

--- a/templates/emails/ask_bail_dpe_signalement_email.html.twig
+++ b/templates/emails/ask_bail_dpe_signalement_email.html.twig
@@ -1,7 +1,7 @@
 {% extends 'emails/base_email.html.twig' %}
 
 {% block body %}
-    <p>Bonjour</p>
+    <p>Bonjour,</p>
     <p>
         Vous avez signalé un problème dans le logement au <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong> <br>

--- a/templates/emails/validation_signalement_email.html.twig
+++ b/templates/emails/validation_signalement_email.html.twig
@@ -1,7 +1,7 @@
 {% extends 'emails/base_email.html.twig' %}
 
 {% block body %}
-    <p>Bonjour {{ signalement.nomOccupant|upper ~' '~signalement.prenomOccupant|capitalize }}</p>
+    <p>Bonjour</p>
     <p>
         Nous vous informons que votre signalement concernant le logement situé <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong> <br>

--- a/templates/emails/validation_signalement_email.html.twig
+++ b/templates/emails/validation_signalement_email.html.twig
@@ -1,7 +1,7 @@
 {% extends 'emails/base_email.html.twig' %}
 
 {% block body %}
-    <p>Bonjour</p>
+    <p>Bonjour,</p>
     <p>
         Nous vous informons que votre signalement concernant le logement situé <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong> <br>


### PR DESCRIPTION
## Ticket

#1972   

## Description
Afin de déterminer correctement si c'est l'occupant ou le déclarant qui crée un suivi usager, on sépare l'envoi en deux mails différents.

## Tests
- [ ] Faire un signalement avec un tiers déclarant, valider le signalement avec un admin, vérifier que deux mails sont envoyés
- [ ] Faire un signalement avec un tiers déclarant en non-décence énergétique, valider le signalement avec un admin, vérifier que deux mails de demandes de docs sont envoyés
