### PR TITLE
[Docker] Modification conf Mysql pour pouvoir importer des gros fichiers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3.8"
 services:
   histologe_mysql:
     image: 'mysql:5.7.38'
+    command: --max_allowed_packet=32505856
     container_name: histologe_mysql
     restart: always
     environment:


### PR DESCRIPTION
## Ticket

#1968   

## Description
Modification conf Docker Mysql pour pouvoir importer des gros fichiers

## Tests
- [ ] `make build`
- [ ] Déposer un fichier de dump dans `/data/dump.sql`
- [ ] `make load-data`
