### PR TITLE
[Sécurité] Rendre le site invisible dans une iframe

### DIFF
--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -4,6 +4,8 @@ server {
 
     client_max_body_size 200M;
 
+    include /etc/nginx/conf.d/server.location;
+
     location / {
         try_files $uri /index.php$is_args$args;
     }

--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,0 +1,9 @@
+add_header X-Frame-Options "deny";
+
+location ~* \.(css|js|jpg|jpeg|png|svg|webp|mp4|ico|woff2|woff|eot|ttf) {
+    # Cache for 1 year.
+    # Caching JS and CSS is safe too, as Symfony includes hashes in build filenames.
+    # So, new versions will be consistently downloaded by clients.
+    # See: https://symfony.com/doc/current/frontend/encore/versioning.html
+    add_header Cache-Control "public, max-age=31536000";
+}

--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,5 +1,9 @@
 add_header X-Frame-Options "deny";
 
+location ~* ^/_up/.*\.(jpg|jpeg|png)/.*$ {
+    try_files $uri /index.php$is_args$args;
+}
+
 location ~* \.(css|js|jpg|jpeg|png|svg|webp|mp4|ico|woff2|woff|eot|ttf) {
     # Cache for 1 year.
     # Caching JS and CSS is safe too, as Symfony includes hashes in build filenames.

--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,9 @@
                 "opcache.preload_user=appsdeck",
                 "realpath_cache_size=4096K",
                 "realpath_cache_ttl=600"
+            ],
+            "nginx-includes": [
+                ".scalingo/nginx/server.location"
             ]
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     working_dir: /app
     volumes:
       - .:/app/
+      - ./.scalingo/nginx/server.location:/etc/nginx/conf.d/server.location
     ports:
       - 8080:80
 


### PR DESCRIPTION
## Ticket
Merci de lire la PR qui traite du même sujet coté punaises
https://github.com/MTES-MCT/stop-punaises/pull/478

#1951 

## Description
Dans le rapport fourni par https://dashlord.mte.incubateur.net/dashlord/url/histologe-beta-gouv-fr/securite/#http, il n'y'a pas d'en tête `X-Frame-Options`.

> L'en-tête de réponse [HTTP](https://developer.mozilla.org/fr/docs/Web/HTTP) X-Frame-Options peut être utilisé afin d'indiquer si un navigateur devrait être autorisé à afficher une page au sein d'un élément [<frame>](https://developer.mozilla.org/fr/docs/Web/HTML/Element/frame), [<iframe>]. 
Les sites peuvent utiliser cet en-tête afin d'éviter les attaques de [clickjacking](https://fr.wikipedia.org/wiki/Clickjacking) (ou « détournement de clic ») pour s'assurer que leur contenu ne soit pas embarqué dans d'autres sites.

*Source: https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/X-Frame-Options*

## Changements apportés
* Ajout de l'en-tête dans la configuration nginx
* Mise en cache des fichiers statiques comme sur punaises

## Pré-requis
```sh
make build 
```
ou
```
 docker compose build histologe_nginx
 docker compose restart histologe_nginx
```

## Tests 
*(à faire également sur la RA => https://histologe-staging-pr1998.osc-fr1.scalingo.io/)*
- [ ] Vérifier que les images d'un signalement ou sur un nouvel onglet s'affiche bien
- [ ] Vérifier que l'en-tête HTTP est bien présente sur le site
![image](https://github.com/MTES-MCT/histologe/assets/5757116/8e07c978-09bb-4b43-ae5b-6d1b1ff6420b)
- [ ] Créer une page html et vérifier que le site ne s'affiche pas dans une iframe
![image](https://github.com/MTES-MCT/histologe/assets/5757116/d5dffa5f-a6b4-4f92-a327-c67668178bd9)


Pour les en-têtes de cache (Vérifier la présence du `Cache-Control`)

```bash
curl  -I http://localhost:8080/build/dsfr/dsfr.min.css 
```
```
HTTP/1.1 200 OK
Server: nginx/1.20.2
Date: Tue, 17 Oct 2023 13:33:11 GMT
Content-Type: text/css
Content-Length: 504718
Last-Modified: Tue, 17 Oct 2023 12:40:09 GMT
Connection: keep-alive
ETag: "652e80a9-7b38e"
Cache-Control: public, max-age=31536000
Accept-Ranges: bytes
```

