### PR TITLE
[BO - Partenaires] Suppression des vérifications caduques de mails utilisateurs

### DIFF
--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -32,7 +32,6 @@ class Partner
     private $nom;
 
     #[ORM\OneToMany(mappedBy: 'partner', targetEntity: User::class, cascade: ['persist'])]
-    #[Assert\Valid]
     private $users;
 
     #[ORM\Column(type: 'boolean')]


### PR DESCRIPTION
## Ticket

#1974    

## Description
Suppression des vérifications caduques de mails utilisateurs quand on édite un partenaire

## Tests
- [ ] Faire en sorte via BDD que 2 ou plus utilisateurs aient la même adresse e-mail
- [ ] Modifier les informations du partenaire d'un de ces utilisateurs
- [ ] Les informations s'éditent correctement, sans retour d'erreur
