### PR TITLE
[Signalement] Affectation automatiques pour territoires et partenaires définis

### DIFF
--- a/migrations/Version20231201140751.php
+++ b/migrations/Version20231201140751.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231201140751 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add is_auto_affectation_enabled property to territory';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE territory ADD is_auto_affectation_enabled TINYINT(1) NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE territory DROP is_auto_affectation_enabled');
+    }
+}

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -26,6 +26,7 @@ use App\Service\ImageManipulationHandler;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
+use App\Service\Signalement\AutoAssigner;
 use App\Service\Signalement\CriticiteCalculator;
 use App\Service\Signalement\PostalCodeHomeChecker;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
@@ -134,7 +135,8 @@ class FrontSignalementController extends AbstractController
         CriticiteCalculator $criticiteCalculator,
         FileFactory $fileFactory,
         LoggerInterface $logger,
-        DocumentProvider $documentProvider
+        DocumentProvider $documentProvider,
+        AutoAssigner $autoAssigner,
     ): Response {
         if ($this->isCsrfTokenValid('new_signalement', $request->request->get('_token'))
             && $data = $request->get('signalement')) {
@@ -310,6 +312,7 @@ class FrontSignalementController extends AbstractController
 
             $entityManager->persist($signalement);
             $entityManager->flush();
+            $autoAssigner->assign($signalement);
 
             $toRecipients = $signalement->getMailUsagers();
             foreach ($toRecipients as $toRecipient) {

--- a/src/DataFixtures/Files/Territory.yml
+++ b/src/DataFixtures/Files/Territory.yml
@@ -4,6 +4,7 @@ territories:
     name: "Ain"
     is_active: 1
     bbox: "{\"n\":\"46.519953\",\"e\":\"6.170198\",\"s\":\"45.611093\",\"w\":\"4.728067\"}"
+    is_auto_affectation_enabled: 1
   -
     zip: "02"
     name: "Aisne"

--- a/src/DataFixtures/Loader/LoadTerritoryData.php
+++ b/src/DataFixtures/Loader/LoadTerritoryData.php
@@ -29,7 +29,12 @@ class LoadTerritoryData extends Fixture implements OrderedFixtureInterface
             ->setZip($row['zip'])
             ->setName($row['name'])
             ->setIsActive($row['is_active'])
+            ->setIsAutoAffectationEnabled(false)
             ->setBbox(json_decode($row['bbox'], true));
+
+        if (isset($row['is_auto_affectation_enabled']) && $row['is_auto_affectation_enabled']) {
+            $territory->setIsAutoAffectationEnabled(true);
+        }
 
         if (isset($row['authorized_codes_insee'])) {
             $territory->setAuthorizedCodesInsee($row['authorized_codes_insee']);

--- a/src/Entity/Territory.php
+++ b/src/Entity/Territory.php
@@ -59,7 +59,7 @@ class Territory
     private $authorizedCodesInsee = [];
 
     #[ORM\Column]
-    private ?bool $isAutoAffectationEnabled = null;
+    private ?bool $isAutoAffectationEnabled = false;
 
     public function __construct()
     {
@@ -303,7 +303,7 @@ class Territory
         return $this->isAutoAffectationEnabled;
     }
 
-    public function setIsAutoAffectationEnabled(bool $isAutoAffectationEnabled): static
+    public function setIsAutoAffectationEnabled(bool $isAutoAffectationEnabled): self
     {
         $this->isAutoAffectationEnabled = $isAutoAffectationEnabled;
 

--- a/src/Entity/Territory.php
+++ b/src/Entity/Territory.php
@@ -58,6 +58,9 @@ class Territory
     #[Ignore]
     private $authorizedCodesInsee = [];
 
+    #[ORM\Column]
+    private ?bool $isAutoAffectationEnabled = null;
+
     public function __construct()
     {
         $this->users = new ArrayCollection();
@@ -291,6 +294,18 @@ class Territory
     public function setAuthorizedCodesInsee(?array $authorizedCodesInsee): self
     {
         $this->authorizedCodesInsee = $authorizedCodesInsee;
+
+        return $this;
+    }
+
+    public function isAutoAffectationEnabled(): ?bool
+    {
+        return $this->isAutoAffectationEnabled;
+    }
+
+    public function setIsAutoAffectationEnabled(bool $isAutoAffectationEnabled): static
+    {
+        $this->isAutoAffectationEnabled = $isAutoAffectationEnabled;
 
         return $this;
     }

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -9,6 +9,7 @@ use App\Service\Files\DocumentProvider;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
+use App\Service\Signalement\AutoAssigner;
 use App\Service\Signalement\SignalementBuilder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -19,6 +20,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
         private SignalementManager $signalementManager,
         private NotificationMailerRegistry $notificationMailerRegistry,
         private DocumentProvider $documentProvider,
+        private AutoAssigner $autoAssigner,
     ) {
     }
 
@@ -64,5 +66,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                 )
             );
         }
+
+        $this->autoAssigner->assign($signalement);
     }
 }

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -99,11 +99,21 @@ class PartnerRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function findWithCodeInseeNotNull()
+    public function findAutoAssignable(string $codeInsee): ?array
     {
+        if (empty($codeInsee)) {
+            return null;
+        }
+
         return $this
             ->createQueryBuilder('p')
-            ->where("p.insee NOT LIKE '[\"\"]'")
+            ->leftJoin('p.users', 'u')
+            ->where('p.insee LIKE :codeInsee')
+            ->setParameter('codeInsee', '%'.$codeInsee.'%')
+            ->andWhere('p.type = :partnerType')
+            ->setParameter('partnerType', PartnerType::COMMUNE_SCHS)
+            ->groupBy('p.id')
+            ->having('count(u.id) > 0')
             ->getQuery()
             ->getResult();
     }

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -99,7 +99,7 @@ class PartnerRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function findAutoAssignable(string $codeInsee): ?array
+    public function findAutoAssignable(string $codeInsee, PartnerType $partnerType): ?array
     {
         if (empty($codeInsee)) {
             return null;
@@ -107,13 +107,11 @@ class PartnerRepository extends ServiceEntityRepository
 
         return $this
             ->createQueryBuilder('p')
-            ->leftJoin('p.users', 'u')
+            ->innerJoin('p.users', 'u')
             ->where('p.insee LIKE :codeInsee')
             ->setParameter('codeInsee', '%'.$codeInsee.'%')
             ->andWhere('p.type = :partnerType')
-            ->setParameter('partnerType', PartnerType::COMMUNE_SCHS)
-            ->groupBy('p.id')
-            ->having('count(u.id) > 0')
+            ->setParameter('partnerType', $partnerType)
             ->getQuery()
             ->getResult();
     }

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -3,24 +3,28 @@
 namespace App\Service\Signalement;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\PartnerType;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
+use App\Factory\SuiviFactory;
 use App\Manager\AffectationManager;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
 use App\Manager\UserManager;
 use App\Messenger\EsaboraBus;
 use App\Repository\PartnerRepository;
-use DateTimeImmutable;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class AutoAssigner
 {
+    private int $countAffectations;
+
     public function __construct(
         private SignalementManager $signalementManager,
         private AffectationManager $affectationManager,
         private SuiviManager $suiviManager,
+        private SuiviFactory $suiviFactory,
         private PartnerRepository $partnerRepository,
         private UserManager $userManager,
         private ParameterBagInterface $parameterBag,
@@ -28,48 +32,56 @@ class AutoAssigner
     ) {
     }
 
-    public function assign(Signalement $signalement): array
+    public function assign(Signalement $signalement): void
     {
-        $affectations = [];
+        $this->countAffectations = 0;
         if ($signalement->getTerritory()->isAutoAffectationEnabled()) {
             $inseeOccupant = $signalement->getInseeOccupant();
             if (!empty($inseeOccupant)) {
                 $adminEmail = $this->parameterBag->get('user_system_email');
                 $adminUser = $this->userManager->findOneBy(['email' => $adminEmail]);
 
-                $partners = $this->partnerRepository->findAutoAssignable($inseeOccupant);
+                $partners = $this->partnerRepository->findAutoAssignable($inseeOccupant, PartnerType::COMMUNE_SCHS);
                 if (!empty($partners)) {
                     $signalement->setStatut(Signalement::STATUS_ACTIVE);
-                    $signalement->setValidatedAt(new DateTimeImmutable());
+                    $signalement->setValidatedAt(new \DateTimeImmutable());
                     $this->signalementManager->save($signalement);
 
-                    $suivi = new Suivi();
-                    $suivi->setSignalement($signalement)
-                        ->setDescription('Signalement validé')
-                        ->setCreatedBy($adminUser)
-                        ->setIsPublic(true)
-                        ->setType(SUIVI::TYPE_AUTO);
+                    $params = [
+                        'type' => SUIVI::TYPE_AUTO,
+                        'description' => 'Signalement validé',
+                    ];
+                    $suivi = $this->suiviFactory->createInstanceFrom(
+                        user: $adminUser,
+                        signalement: $signalement,
+                        params: $params,
+                        isPublic: true,
+                    );
                     $this->suiviManager->save($suivi);
 
                     /** @var Partner $partner */
                     foreach ($partners as $partner) {
                         $affectation = $this->affectationManager->createAffectationFrom($signalement, $partner, $adminUser);
-                        $affectations[] = $affectation;
+                        ++$this->countAffectations;
                         if ($affectation instanceof Affectation) {
                             $this->affectationManager->persist($affectation);
                             if ($partner->getEsaboraToken() && $partner->getEsaboraUrl() && $partner->isEsaboraActive()) {
                                 $affectation->setIsSynchronized(true);
-                                $this->affectationManager->save($affectation);
+                                $this->affectationManager->save($affectation, false);
                                 $this->esaboraBus->dispatch($affectation);
                             } else {
-                                $this->affectationManager->save($affectation);
+                                $this->affectationManager->save($affectation, false);
                             }
                         }
                     }
+                    $this->affectationManager->flush();
                 }
             }
         }
+    }
 
-        return $affectations;
+    public function getCountAffectations(): int
+    {
+        return $this->countAffectations;
     }
 }

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Service\Signalement;
+
+use App\Entity\Affectation;
+use App\Entity\Partner;
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Manager\AffectationManager;
+use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
+use App\Manager\UserManager;
+use App\Messenger\EsaboraBus;
+use App\Repository\PartnerRepository;
+use DateTimeImmutable;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class AutoAssigner
+{
+    public function __construct(
+        private SignalementManager $signalementManager,
+        private AffectationManager $affectationManager,
+        private SuiviManager $suiviManager,
+        private PartnerRepository $partnerRepository,
+        private UserManager $userManager,
+        private ParameterBagInterface $parameterBag,
+        private EsaboraBus $esaboraBus,
+    ) {
+    }
+
+    public function assign(Signalement $signalement): array
+    {
+        $affectations = [];
+        if ($signalement->getTerritory()->isAutoAffectationEnabled()) {
+            $inseeOccupant = $signalement->getInseeOccupant();
+            if (!empty($inseeOccupant)) {
+                $adminEmail = $this->parameterBag->get('user_system_email');
+                $adminUser = $this->userManager->findOneBy(['email' => $adminEmail]);
+
+                $partners = $this->partnerRepository->findAutoAssignable($inseeOccupant);
+                if (!empty($partners)) {
+                    $signalement->setStatut(Signalement::STATUS_ACTIVE);
+                    $signalement->setValidatedAt(new DateTimeImmutable());
+                    $this->signalementManager->save($signalement);
+
+                    $suivi = new Suivi();
+                    $suivi->setSignalement($signalement)
+                        ->setDescription('Signalement validé')
+                        ->setCreatedBy($adminUser)
+                        ->setIsPublic(true)
+                        ->setType(SUIVI::TYPE_AUTO);
+                    $this->suiviManager->save($suivi);
+
+                    /** @var Partner $partner */
+                    foreach ($partners as $partner) {
+                        $affectation = $this->affectationManager->createAffectationFrom($signalement, $partner, $adminUser);
+                        $affectations[] = $affectation;
+                        if ($affectation instanceof Affectation) {
+                            $this->affectationManager->persist($affectation);
+                            if ($partner->getEsaboraToken() && $partner->getEsaboraUrl() && $partner->isEsaboraActive()) {
+                                $affectation->setIsSynchronized(true);
+                                $this->affectationManager->save($affectation);
+                                $this->esaboraBus->dispatch($affectation);
+                            } else {
+                                $this->affectationManager->save($affectation);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $affectations;
+    }
+}

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -97,6 +97,18 @@ class PartnerRepositoryTest extends KernelTestCase
         $this->assertCount(1, $partnerMDL);
     }
 
+    public function testFindAutoAssignable(): void
+    {
+        $partners = $this->partnerRepository->findAutoAssignable('01173');
+        $this->assertCount(1, $partners);
+        $partners = $this->partnerRepository->findAutoAssignable('2A247');
+        $this->assertCount(1, $partners);
+        $partners = $this->partnerRepository->findAutoAssignable('13000');
+        $this->assertCount(0, $partners);
+        $partners = $this->partnerRepository->findAutoAssignable('');
+        $this->assertNull($partners);
+    }
+
     public function testGetPartnerPaginator(): void
     {
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '69']);

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Repository;
 
+use App\Entity\Enum\PartnerType;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
@@ -99,13 +100,13 @@ class PartnerRepositoryTest extends KernelTestCase
 
     public function testFindAutoAssignable(): void
     {
-        $partners = $this->partnerRepository->findAutoAssignable('01173');
+        $partners = $this->partnerRepository->findAutoAssignable('01173', PartnerType::COMMUNE_SCHS);
         $this->assertCount(1, $partners);
-        $partners = $this->partnerRepository->findAutoAssignable('2A247');
+        $partners = $this->partnerRepository->findAutoAssignable('2A247', PartnerType::COMMUNE_SCHS);
         $this->assertCount(1, $partners);
-        $partners = $this->partnerRepository->findAutoAssignable('13000');
+        $partners = $this->partnerRepository->findAutoAssignable('13000', PartnerType::COMMUNE_SCHS);
         $this->assertCount(0, $partners);
-        $partners = $this->partnerRepository->findAutoAssignable('');
+        $partners = $this->partnerRepository->findAutoAssignable('', PartnerType::COMMUNE_SCHS);
         $this->assertNull($partners);
     }
 

--- a/tests/Unit/Service/AutoAssignerTest.php
+++ b/tests/Unit/Service/AutoAssignerTest.php
@@ -29,35 +29,18 @@ class AutoAssignerTest extends KernelTestCase
 
     public function testAutoAssignmentSuccess(): void
     {
-        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-        $signalement = $signalementRepository->findOneBy(['reference' => '2023-1']);
-
-        $signalementManager = $this->createMock(SignalementManager::class);
-        $suiviManager = $this->createMock(SuiviManager::class);
-        $suiviFactory = $this->createMock(SuiviFactory::class);
-        $partnerRepository = $this->entityManager->getRepository(Partner::class);
-        $userManager = $this->createMock(UserManager::class);
-        $parameterBag = $this->createMock(ParameterBagInterface::class);
-        $esaboraBus = $this->createMock(EsaboraBus::class);
-        $autoAssigner = new AutoAssigner(
-            $signalementManager,
-            $this->affectationManager,
-            $suiviManager,
-            $suiviFactory,
-            $partnerRepository,
-            $userManager,
-            $parameterBag,
-            $esaboraBus,
-        );
-
-        $autoAssigner->assign($signalement);
-        $this->assertEquals($autoAssigner->getCountAffectations(), 1);
+        $this->testHelper('2023-1', 1);
     }
 
     public function testAutoAssignmentFailed(): void
     {
+        $this->testHelper('2023-2', 0);
+    }
+
+    private function testHelper($reference, $expectedCount)
+    {
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-        $signalement = $signalementRepository->findOneBy(['reference' => '2023-2']);
+        $signalement = $signalementRepository->findOneBy(['reference' => $reference]);
 
         $signalementManager = $this->createMock(SignalementManager::class);
         $suiviManager = $this->createMock(SuiviManager::class);
@@ -78,6 +61,6 @@ class AutoAssignerTest extends KernelTestCase
         );
 
         $autoAssigner->assign($signalement);
-        $this->assertEquals($autoAssigner->getCountAffectations(), 0);
+        $this->assertEquals($autoAssigner->getCountAffectations(), $expectedCount);
     }
 }

--- a/tests/Unit/Service/AutoAssignerTest.php
+++ b/tests/Unit/Service/AutoAssignerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Partner;
+use App\Entity\Signalement;
+use App\Manager\AffectationManager;
+use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
+use App\Manager\UserManager;
+use App\Messenger\EsaboraBus;
+use App\Service\Signalement\AutoAssigner;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class AutoAssignerTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private AffectationManager $affectationManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $this->affectationManager = self::getContainer()->get(AffectationManager::class);
+    }
+
+    public function testAutoAssignmentSuccess(): void
+    {
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-1']);
+
+        $signalementManager = $this->createMock(SignalementManager::class);
+        $suiviManager = $this->createMock(SuiviManager::class);
+        $partnerRepository = $this->entityManager->getRepository(Partner::class);
+        $userManager = $this->createMock(UserManager::class);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $esaboraBus = $this->createMock(EsaboraBus::class);
+        $autoAssigner = new AutoAssigner(
+            $signalementManager,
+            $this->affectationManager,
+            $suiviManager,
+            $partnerRepository,
+            $userManager,
+            $parameterBag,
+            $esaboraBus,
+        );
+        $affectations = $autoAssigner->assign($signalement);
+
+        $this->assertEquals(\count($affectations), 1);
+    }
+
+    public function testAutoAssignmentFailed(): void
+    {
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2023-2']);
+
+        $signalementManager = $this->createMock(SignalementManager::class);
+        $suiviManager = $this->createMock(SuiviManager::class);
+        $partnerRepository = $this->entityManager->getRepository(Partner::class);
+        $userManager = $this->createMock(UserManager::class);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $esaboraBus = $this->createMock(EsaboraBus::class);
+        $autoAssigner = new AutoAssigner(
+            $signalementManager,
+            $this->affectationManager,
+            $suiviManager,
+            $partnerRepository,
+            $userManager,
+            $parameterBag,
+            $esaboraBus,
+        );
+        $affectations = $autoAssigner->assign($signalement);
+
+        $this->assertEquals(\count($affectations), 0);
+    }
+}

--- a/tests/Unit/Service/AutoAssignerTest.php
+++ b/tests/Unit/Service/AutoAssignerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Service;
 
 use App\Entity\Partner;
 use App\Entity\Signalement;
+use App\Factory\SuiviFactory;
 use App\Manager\AffectationManager;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
@@ -33,6 +34,7 @@ class AutoAssignerTest extends KernelTestCase
 
         $signalementManager = $this->createMock(SignalementManager::class);
         $suiviManager = $this->createMock(SuiviManager::class);
+        $suiviFactory = $this->createMock(SuiviFactory::class);
         $partnerRepository = $this->entityManager->getRepository(Partner::class);
         $userManager = $this->createMock(UserManager::class);
         $parameterBag = $this->createMock(ParameterBagInterface::class);
@@ -41,14 +43,15 @@ class AutoAssignerTest extends KernelTestCase
             $signalementManager,
             $this->affectationManager,
             $suiviManager,
+            $suiviFactory,
             $partnerRepository,
             $userManager,
             $parameterBag,
             $esaboraBus,
         );
-        $affectations = $autoAssigner->assign($signalement);
 
-        $this->assertEquals(\count($affectations), 1);
+        $autoAssigner->assign($signalement);
+        $this->assertEquals($autoAssigner->getCountAffectations(), 1);
     }
 
     public function testAutoAssignmentFailed(): void
@@ -58,6 +61,7 @@ class AutoAssignerTest extends KernelTestCase
 
         $signalementManager = $this->createMock(SignalementManager::class);
         $suiviManager = $this->createMock(SuiviManager::class);
+        $suiviFactory = $this->createMock(SuiviFactory::class);
         $partnerRepository = $this->entityManager->getRepository(Partner::class);
         $userManager = $this->createMock(UserManager::class);
         $parameterBag = $this->createMock(ParameterBagInterface::class);
@@ -66,13 +70,14 @@ class AutoAssignerTest extends KernelTestCase
             $signalementManager,
             $this->affectationManager,
             $suiviManager,
+            $suiviFactory,
             $partnerRepository,
             $userManager,
             $parameterBag,
             $esaboraBus,
         );
-        $affectations = $autoAssigner->assign($signalement);
 
-        $this->assertEquals(\count($affectations), 0);
+        $autoAssigner->assign($signalement);
+        $this->assertEquals($autoAssigner->getCountAffectations(), 0);
     }
 }


### PR DESCRIPTION
## Ticket

#1894   

## Description
Mise en place de l'affectation automatique d'un signalement dès sa création avec les règles suivantes :
- ajout d'une propriété sur les territoires pour autoriser l'affectation automatique
- les partenaires doivent avoir 
  - au moins un agent
  - un code Insee correspondant au signalement
  - un type COMMUNE_SCHS

## Pré-requis
`make load-fixtures`

Dans les fixtures, le territoire de l'Ain autorise l'affectation automatique, le partenaire Partenaire 01-02 (code insee 01173 - commune Gex) correspond.

## Tests
- [ ] Créer un signalement hors du Ain. Le fonctionnement habituel ne change pas.
- [ ] Créer un signalement dans l'Ain, mais pas à Gex. Le fonctionnement habituel ne change pas.
- [ ] Créer un signalement à Gex, dans l'Ain. 
  - [ ] Le signalement est automatiquement accepté et affecté au partenaire.
  - [ ] Vérifier les mails envoyés
  - [ ] Vérifier les suivis
- [ ] Refaire un de ces tests avec le nouveau formulaire
