### PR TITLE
[BO - Signalement] Affichage du bloc bailleur pour l'ancien formulaire

### DIFF
--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -101,7 +101,7 @@
             </div>
         </div>
 
-        {% if signalement.profileDeclarant and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT %}
+        {% if not signalement.profileDeclarant or signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT %}
            <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
                 {% include 'back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig' %}
                 <div class="fr-p-3v fr-background-alt--grey">


### PR DESCRIPTION
## Ticket

#2003   

## Description
Modification de la condition d'affichage du bloc BAILLEUR pour les signalements faits avec l'ancien formulaire

## Tests
- [ ] Vérifier la présence du bloc pour un signalement fait avec l'ancien formulaire
- [ ] Vérifier l'absence du bloc pour un signalement fait avec le nouveau formulaire, en tant que bailleur occupant
- [ ] Vérifier la présence du bloc pour un singalement fait avec le nouveau formulaire, en tant qu'autre profil
