### PR TITLE
 Mettre en place la déconnexion automatique des sessions d'accès après une durée déterminée

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -41,6 +41,7 @@ security:
             remember_me:
                 secret: '%kernel.secret%'
                 always_remember_me: true
+                lifetime: 2592000 # 30 days in seconds
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -40,7 +40,6 @@ security:
                 lifetime: 7200
             remember_me:
                 secret: '%kernel.secret%'
-                #always_remember_me: true
                 lifetime: 2592000 # 30 days in seconds
 
             # activate different ways to authenticate

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -40,7 +40,7 @@ security:
                 lifetime: 7200
             remember_me:
                 secret: '%kernel.secret%'
-                always_remember_me: true
+                #always_remember_me: true
                 lifetime: 2592000 # 30 days in seconds
 
             # activate different ways to authenticate

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -44,7 +44,14 @@
                     <p id="login-password-error-desc-error" class="fr-error-text fr-hidden fr-col-12">
                         Veuillez saisir votre mot de passe.
                     </p>
-
+                </div>
+                <div class="fr-checkbox-group">
+                    <p>
+                        <input name="_remember_me" id="_remember_me" type="checkbox" >
+                        <label class="fr-label" for="_remember_me">
+                            Se souvenir de moi
+                        </label>
+                    </p>
                 </div>
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
                 <div class="fr-form-group">

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -49,7 +49,7 @@
                     <p>
                         <input name="_remember_me" id="_remember_me" type="checkbox" >
                         <label class="fr-label" for="_remember_me">
-                            Se souvenir de moi
+                            Garder ma session ouverte pendant 1 mois.
                         </label>
                     </p>
                 </div>


### PR DESCRIPTION
## Ticket

#734 

## Description
Configuration de la durée du cookie a 1 mois (au lieu de 1  an par défaut) et ajout d'une case à cocher "Se souvenir de moi" sur le formulaire de connexion

## Tests
- [ ] Se connecter en cochant la case "Se souvenir de moi" et vérifier la date d'expiration du cookie REMEMBERME à + un mois
![rememberme](https://github.com/MTES-MCT/histologe/assets/7130780/db3374c8-877e-43f7-bac3-6de6e8d9fb7b)
- [ ] Se connecter sans cocher la case et vérifier que le cookie REMEMBERME n'est pas crée

