### PR TITLE
[BO - Notifications] Les liens redirigent vers le tableau de bord

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run tests
         run: |
-          composer require --dev dama/doctrine-test-bundle
+          composer require --dev dama/doctrine-test-bundle:7.3
           ./vendor/bin/phpunit --stop-on-failure --testdox -d memory_limit=-1
         env:
           DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db

--- a/templates/back/notifications/index.html.twig
+++ b/templates/back/notifications/index.html.twig
@@ -57,7 +57,12 @@
                     </td>
                     <td>{{ notification.suivi.signalement.reference }}</td>
                     <td>{{ notification.suivi.createdAt|format_datetime(locale='fr') }}</td>
-                    <td>{{ notification.suivi.description|replace({'&t=___TOKEN___':''})|replace({'?t=___TOKEN___':''})|raw }}</td>
+                    <td>{{ notification.suivi.description
+                        |replace({'&t=___TOKEN___':'/'~notification.signalement.uuid})
+                        |replace({'?t=___TOKEN___':'/'~notification.signalement.uuid})
+                        |replace({'?folder=_up':'/'~notification.signalement.uuid~'?variant=resize'})
+                        |raw }}
+                    </td>
                     <td>{{ notification.suivi.createdBy ? notification.suivi.createdBy.nomComplet : notification.signalement.nomOccupant|upper~' '~notification.signalement.prenomOccupant|capitalize }}</td>
                     <td class="fr-text--right">
                         <a href="{{ path('back_signalement_view',{uuid:notification.suivi.signalement.uuid}) }}#suivis"


### PR DESCRIPTION
## Ticket

#2011   

## Description
Suite  à la sécurité mise en place au niveau des accès aux fichiers, un oubli identifié dans la page notification qui redirige donc les liens des fichiers vers le tableau de bord

### Pour rappel la route en question
```php
    #[Route('/_up/{filename}/{uuid?}', name: 'show_uploaded_file')]
```
## Changements apportés
* Mise à jour du lien avec l'uuid du signalement sur la page notification

## Pré-requis

## Tests
- [ ] Ajouter des images et aller dans la page de notification
- [ ] Ajouter un suivi avec un document et aller à la page de notification
