### PR TITLE
[BO - Signalement] Mauvaise donnée affichée dans partie procédure

### DIFF
--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -65,8 +65,9 @@
                                 <label class="fr-label" for="infoProcedureDepartApresTravaux">Souhaite garder le logement après travaux</label>
                                 <select class="fr-select" name="infoProcedureDepartApresTravaux">
                                     <option value="" disabled hidden>Sélectionnez un choix</option>
-                                    <option value="oui" {{ infoProcedureDepartApresTravaux is same as 'oui' ? 'selected' : '' }}>Oui</option>
-                                    <option value="non" {{ infoProcedureDepartApresTravaux is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    {# Careful : reversed regarding the question in the form #}
+                                    <option value="non" {{ infoProcedureDepartApresTravaux is same as 'non' ? 'selected' : '' }}>Oui</option>
+                                    <option value="oui" {{ infoProcedureDepartApresTravaux is same as 'oui' ? 'selected' : '' }}>Non</option>
                                     <option value="nsp" {{ infoProcedureDepartApresTravaux is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>


### PR DESCRIPTION
## Ticket

#2010   

## Description
Affichage de la vraie valeur pour "souhaite garder le logement après travaux" dans la modale d'édition de la partie "Informations procédures"

## Changements apportés
* Changement du twig de la modale

## Pré-requis

## Tests
- [ ] Faire un signalement avec le nouveau formulaire
- [ ] Editer la partie "Informations procédures" plusieurs fois
- [ ] Vérifier que l'affichagee entre la modale, la fiche signalement et la base est cohérent
