### PR TITLE
[Front - Nouveau formulaire] Enregistrement facultatif du lien déclarant - occupant

### DIFF
--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -355,6 +355,10 @@ class SignalementBuilder
             return null;
         }
 
+        if (empty($this->signalementDraftRequest->getVosCoordonneesTiersLien())) {
+            return null;
+        }
+
         $tiersLien = OccupantLink::from(strtoupper($this->signalementDraftRequest->getVosCoordonneesTiersLien()));
 
         if (OccupantLink::VOISIN === $tiersLien) {

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -36,6 +36,7 @@
                                 <label class="fr-label" for="lien">Lien avec l'occupant</label>
                                 <select class="fr-select" name="lien">
                                     <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="" {{ signalement.lienDeclarantOccupant is same as '' ? 'selected' : '' }}>N/C</option>
                                     <option value="PROCHE" {{ signalement.lienDeclarantOccupant is same as 'PROCHE' ? 'selected' : '' }}>Proche</option>
                                     <option value="VOISIN" {{ signalement.lienDeclarantOccupant is same as 'VOISIN' ? 'selected' : '' }}>Voisinage</option>
                                     <option value="SECOURS" {{ signalement.lienDeclarantOccupant is same as 'SECOURS' ? 'selected' : '' }}>Service de secours</option>


### PR DESCRIPTION
## Ticket

#2019    

## Description
Le lien entre déclarant et occupant a été rendu facultatif. Mais il y avait un bug à l'enregistrement si il n'était pas renseigné.

## Tests
- [ ] Faire un signalement en tant que tiers particulier sans remplir le lien entre déclarant et occupant et vérifier que l'enregistrement fonctionne
