### PR TITLE
[Sécurité] Ajout d'informations dans footer et GitHub pour contacter l'équipe ou contribuer au projet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contribuer
+
+Les Pull Requests (PR) sont bienvenues.
+
+Pour contribuer au code :
+
+1. Une issue doit être créée sur le repository (à créer si nécessaire).
+
+2. Créez une nouvelle branche dans votre dépôt git local.
+
+3. Faites vos modifications, en prenant soin d'ajouter ou modifier les tests unitaires ou fonctionnels en conséquence.
+
+5. Créez un commit sur votre branche. Celui-ci doit se terminer par le numéro d'une issue existante (Ex : #42).
+
+6. Ouvrez une PR en direction de `develop`. Les informations du template doivent être remplies le plus précisément possible, afin de reproduire le cas d'usage.
+
+7. La PR doit être lue et approuvée par 2 personnes de l'équipe.
+
+8. Le déploiement vers notre environnement `staging` se fera automatiquement à la validation de la PR.
+
+9. Le déploiement sur le site se fera au moment du merge dans la branche `main` (environ une fois toutes les deux semaines, hors `hotfix`).
+
+## Nous contacter
+
+Si vous souhaitez nous envoyer un message, merci d'utiliser le [formulaire de contact du site](https://histologe.beta.gouv.fr/contact).

--- a/README.md
+++ b/README.md
@@ -145,29 +145,3 @@ Une activation de compte sera nécéssaire
 ## Documentation projet
 
 [Consulter la documentation](https://github.com/MTES-MCT/histologe/wiki)
-
-## Contribuer
-
-Les Pull Requests (PR) sont bienvenues.
-
-Pour contribuer au code :
-
-1. Une issue doit être créée sur le repository (à créer si nécessaire).
-
-2. Créez une nouvelle branche dans votre dépôt git local.
-
-3. Faites vos modifications, en prenant soin d'ajouter ou modifier les tests unitaires ou fonctionnels en conséquence.
-
-5. Créez un commit sur votre branche. Celui-ci doit se terminer par le numéro d'une issue existante (Ex : #42).
-
-6. Ouvrez une PR en direction de `develop`. Les informations du template doivent être remplies le plus précisément possible, afin de reproduire le cas d'usage.
-
-7. La PR doit être lue et approuvée par 2 personnes de l'équipe.
-
-8. Le déploiement vers notre environnement `staging` se fera automatiquement à la validation de la PR.
-
-9. Le déploiement sur le site se fera au moment du merge dans la branche `main` (environ une fois toutes les deux semaines, hors `hotfix`).
-
-## Nous contacter
-
-Si vous souhaitez nous envoyer un message, merci d'utiliser le [formulaire de contact du site](https://histologe.beta.gouv.fr/contact).

--- a/README.md
+++ b/README.md
@@ -145,3 +145,7 @@ Une activation de compte sera nécéssaire
 ## Documentation projet
 
 [Consulter la documentation](https://github.com/MTES-MCT/histologe/wiki)
+
+## Contribuer
+
+[Consulter les instructions de contributions](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -145,3 +145,29 @@ Une activation de compte sera nécéssaire
 ## Documentaton projet
 
 [Consulter la documentation](https://github.com/MTES-MCT/histologe/wiki)
+
+## Contribuer
+
+Les Pull Requests (PR) sont bienvenues.
+
+Pour contribuer au code :
+
+1. Une issue doit être créée sur le repository (à créer si nécessaire).
+
+2. Créez une nouvelle branche dans votre dépôt git local.
+
+3. Faites vos modifications, en prenant soin d'ajouter ou modifier les tests unitaires ou fonctionnels en conséquence.
+
+5. Créez un commit sur votre branche. Celui-ci doit se terminer par le numéro d'une issue existante (Ex : #42).
+
+6. Ouvrez une PR en direction de `develop`. Les informations du template doivent être remplies le plus précisément possible, afin de reproduire le cas d'usage.
+
+7. La PR doit être lue et approuvée par 2 personnes de l'équipe.
+
+8. Le déploiement vers notre environnement `staging` se fera automatiquement à la validation de la PR.
+
+9. Le déploiement sur le site se fera au moment du merge dans la branche `main` (environ une fois toutes les deux semaines, hors `hotfix`).
+
+## Nous contacter
+
+Si vous souhaitez nous envoyer un message, merci d'utiliser le [formulaire de contact du site](https://histologe.beta.gouv.fr/contact).

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ php bin/console app:add-user ROLE_USER_PARTNER joe.doe.3@histologe.fr John Doe
 
 Une activation de compte sera nécéssaire
 
-## Documentaton projet
+## Documentation projet
 
 [Consulter la documentation](https://github.com/MTES-MCT/histologe/wiki)
 

--- a/templates/footer.html.twig
+++ b/templates/footer.html.twig
@@ -80,6 +80,11 @@
                             des cookies</a>
                     {% endif %}
                 </li>
+                <li class="fr-footer__bottom-item">
+                    <a class="fr-footer__bottom-link" target="_blank" rel="noreferrer noopener"
+                        href="https://github.com/MTES-MCT/histologe">Code source
+                    </a>
+                </li>
             </ul>
             <div class="fr-footer__bottom-copy">
                 <p>Sauf mention contraire, tous les contenus de ce site sont sous <a


### PR DESCRIPTION
## Ticket

#719   

## Description
Ajout d'informations dans footer et GitHub pour contacter l'équipe ou contribuer au projet

## Tests
- [ ] Vérifier le footer
- [ ] Vérifier le readme en cliquant sur le nom de la branche
