### PR TITLE
Gérer les signalements sur des territoires non-ouverts

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -11,6 +11,7 @@
       :data-ajaxurl-handle-upload="sharedProps.ajaxurlHandleUpload"
       :data-ajaxurl-get-signalement-draft="sharedProps.ajaxurlGetSignalementDraft"
       :data-ajaxurl-platform-name="sharedProps.platformName"
+      :data-ajaxurl-check-territory="sharedProps.ajaxurlCheckTerritory"
       >
       <div v-if="isLoadingInit" class="loading fr-m-10w fr-grid-row fr-grid-row--center">
         Initialisation du formulaire...
@@ -84,6 +85,7 @@ export default defineComponent({
       this.sharedProps.ajaxurlPostSignalementDraft = initElements.dataset.ajaxurlPostSignalementDraft
       this.sharedProps.ajaxurlPutSignalementDraft = initElements.dataset.ajaxurlPutSignalementDraft
       this.sharedProps.ajaxurlHandleUpload = initElements.dataset.ajaxurlHandleUpload
+      this.sharedProps.ajaxurlCheckTerritory = initElements.dataset.ajaxurlCheckTerritory
       if (initElements.dataset.ajaxurlGetSignalementDraft !== undefined) {
         this.sharedProps.ajaxurlGetSignalementDraft = initElements.dataset.ajaxurlGetSignalementDraft
         requests.initWithExistingData(this.handleInitData)

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -86,6 +86,7 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
+    isTerritoryToCheck: { type: Boolean, default: false },
     clickEvent: Function
   },
   data () {
@@ -141,7 +142,7 @@ export default defineComponent({
         this.formStore.data[this.id + '_detail_insee'] = this.suggestions[index].properties.citycode
         this.formStore.data[this.id + '_detail_geoloc_lng'] = this.suggestions[index].geometry.coordinates[0]
         this.formStore.data[this.id + '_detail_geoloc_lat'] = this.suggestions[index].geometry.coordinates[1]
-        if(this.id == "adresse_logement_adresse"){
+        if(this.isTerritoryToCheck){
           requests.checkTerritory(this.suggestions[index].properties.postcode, this.suggestions[index].properties.citycode, this.handleTerritoryChecked);
         }
         this.suggestions.length = 0

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -48,6 +48,13 @@
       :error="formStore.validationErrors[idSubscreen]"
       @update:modelValue="handleSubscreenModelUpdate"
     />
+
+    <SignalementFormModal 
+      v-model="isModalOpen"
+      id="check_territory_modal"
+      :label="modalLabel"
+      :description="modalDescription"
+    />
   </div>
 </template>
 
@@ -60,13 +67,15 @@ import subscreenData from './../address_subscreen.json'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormSubscreen from './SignalementFormSubscreen.vue'
+import SignalementFormModal from './SignalementFormModal.vue'
 
 export default defineComponent({
   name: 'SignalementFormAddress',
   components: {
     SignalementFormTextfield,
     SignalementFormButton,
-    SignalementFormSubscreen
+    SignalementFormSubscreen,
+    SignalementFormModal
   },
   props: {
     id: { type: String, default: null },
@@ -91,7 +100,10 @@ export default defineComponent({
       actionShow: 'show:' + this.id + '_detail',
       screens: { body: updatedSubscreenData },
       suggestions: [] as any[],
-      formStore
+      formStore,
+      isModalOpen: false,
+      modalLabel: '',
+      modalDescription: ''
     }
   },
   created () {
@@ -143,12 +155,16 @@ export default defineComponent({
     },
     onAddressFound (requestResponse: any) {
       this.suggestions = requestResponse.features
-      // TODO : que faire si code postal dans département non ouvert ?
-      // TODO : répertorier les exclusions de code postal du 69 ?
-      // TODO : vérifier si dans territoire expé NDE pour comportement différent ?
     },
     onTerritoryChecked (requestResponse: any) {
-      console.log(requestResponse);
+      if(!requestResponse.success) {
+          this.modalLabel = requestResponse.label
+          this.modalDescription = requestResponse.message
+          this.isModalOpen = true
+
+          this.formStore.data[this.id] = ''
+      }
+      // TODO : vérifier si dans territoire expé NDE pour comportement différent ?
     }
   },
   emits: ['update:modelValue']

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -129,6 +129,7 @@ export default defineComponent({
         this.formStore.data[this.id + '_detail_insee'] = this.suggestions[index].properties.citycode
         this.formStore.data[this.id + '_detail_geoloc_lng'] = this.suggestions[index].geometry.coordinates[0]
         this.formStore.data[this.id + '_detail_geoloc_lat'] = this.suggestions[index].geometry.coordinates[1]
+        requests.checkTerritory(this.suggestions[index].properties.postcode, this.suggestions[index].properties.citycode, this.onTerritoryChecked);
         this.suggestions.length = 0
       }
       const subscreen = document.querySelector('#' + this.idSubscreen)
@@ -145,6 +146,9 @@ export default defineComponent({
       // TODO : que faire si code postal dans département non ouvert ?
       // TODO : répertorier les exclusions de code postal du 69 ?
       // TODO : vérifier si dans territoire expé NDE pour comportement différent ?
+    },
+    onTerritoryChecked (requestResponse: any) {
+      console.log(requestResponse);
     }
   },
   emits: ['update:modelValue']

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -113,7 +113,7 @@ export default defineComponent({
         clearTimeout(this.idFetchTimeout)
         this.idFetchTimeout = setTimeout(() => {
           if (newValue.length > 10) {
-            requests.validateAddress(newValue, this.onAddressFound)
+            requests.validateAddress(newValue, this.handleAddressFound)
           }
         }, 200)
       }
@@ -141,7 +141,9 @@ export default defineComponent({
         this.formStore.data[this.id + '_detail_insee'] = this.suggestions[index].properties.citycode
         this.formStore.data[this.id + '_detail_geoloc_lng'] = this.suggestions[index].geometry.coordinates[0]
         this.formStore.data[this.id + '_detail_geoloc_lat'] = this.suggestions[index].geometry.coordinates[1]
-        requests.checkTerritory(this.suggestions[index].properties.postcode, this.suggestions[index].properties.citycode, this.onTerritoryChecked);
+        if(this.id == "adresse_logement_adresse"){
+          requests.checkTerritory(this.suggestions[index].properties.postcode, this.suggestions[index].properties.citycode, this.handleTerritoryChecked);
+        }
         this.suggestions.length = 0
       }
       const subscreen = document.querySelector('#' + this.idSubscreen)
@@ -153,10 +155,10 @@ export default defineComponent({
         buttonShow.classList.add('fr-hidden')
       }
     },
-    onAddressFound (requestResponse: any) {
+    handleAddressFound (requestResponse: any) {
       this.suggestions = requestResponse.features
     },
-    onTerritoryChecked (requestResponse: any) {
+    handleTerritoryChecked (requestResponse: any) {
       if(!requestResponse.success) {
           this.modalLabel = requestResponse.label
           this.modalDescription = requestResponse.message

--- a/assets/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -1,11 +1,11 @@
 <template>
-  <dialog aria-labelledby="fr-modal-title-modal-back-home" role="dialog" :id="id" class="fr-modal">
+  <dialog :class="{ 'fr-modal--opened': modelValue }" aria-labelledby="fr-modal-title-modal-back-home" role="dialog" :id="id" class="fr-modal" ref="modalDialog">
     <div class="fr-container fr-container--fluid fr-container-md">
       <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
           <div class="fr-modal__body">
             <div class="fr-modal__header">
-              <button class="fr-btn--close fr-btn fr-btn--icon-right fr-icon-close-line" title="Fermer la fenêtre modale" :aria-controls="id">Fermer</button>
+              <button class="fr-btn--close fr-btn fr-btn--icon-right fr-icon-close-line" title="Fermer la fenêtre modale" :aria-controls="id" @click="closeModal">Fermer</button>
             </div>
             <div class="fr-modal__content">
               <h1>{{ label }}</h1>
@@ -19,14 +19,39 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, Ref } from 'vue'
 
 export default defineComponent({
   name: 'SignalementFormModal',
   props: {
     id: String,
     label: String,
-    description: String
+    description: String,
+    modelValue: Boolean
+  },
+  methods: {
+    closeModal() {
+      this.$emit('update:modelValue', false);
+    },
+    onEscapeKey(event: any) {
+      if (event.key === 'Escape') {
+        this.closeModal();
+      }
+    },
+    onClickOutside(event: any) {
+      const modalDialog = this.$refs.modalDialog as Ref<HTMLElement>;
+      if (modalDialog && event.target == modalDialog) {
+        this.closeModal();
+      }
+    }
+  },
+  mounted() {
+    document.addEventListener('keyup', this.onEscapeKey);
+    document.addEventListener('click', this.onClickOutside);
+  },
+  beforeUnmount() {
+    document.removeEventListener('keyup', this.onEscapeKey);
+    document.removeEventListener('click', this.onClickOutside);
   }
 })
 </script>

--- a/assets/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -33,12 +33,12 @@ export default defineComponent({
     closeModal() {
       this.$emit('update:modelValue', false);
     },
-    onEscapeKey(event: any) {
+    handleEscapeKey(event: any) {
       if (event.key === 'Escape') {
         this.closeModal();
       }
     },
-    onClickOutside(event: any) {
+    handleClickOutside(event: any) {
       const modalDialog = this.$refs.modalDialog as Ref<HTMLElement>;
       if (modalDialog && event.target == modalDialog) {
         this.closeModal();
@@ -46,12 +46,12 @@ export default defineComponent({
     }
   },
   mounted() {
-    document.addEventListener('keyup', this.onEscapeKey);
-    document.addEventListener('click', this.onClickOutside);
+    document.addEventListener('keyup', this.handleEscapeKey);
+    document.addEventListener('click', this.handleClickOutside);
   },
   beforeUnmount() {
-    document.removeEventListener('keyup', this.onEscapeKey);
-    document.removeEventListener('click', this.onClickOutside);
+    document.removeEventListener('keyup', this.handleEscapeKey);
+    document.removeEventListener('click', this.handleClickOutside);
   }
 })
 </script>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -32,6 +32,7 @@
         :disabled="component.disabled"
         :multiple="component.multiple"
         :ariaControls="component.ariaControls"
+        :isTerritoryToCheck="component.isTerritoryToCheck"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -92,6 +92,11 @@ export const requests = {
     requests.doRequestGet(url, functionReturn)
   },
 
+  checkTerritory(postcode: string, citycode: string, functionReturn: Function) {
+    const url = (formStore.props.ajaxurlCheckTerritory as string) + '?cp=' + postcode + '&insee=' + citycode
+    requests.doRequestGet(url, functionReturn)
+  },
+
   uploadFile (formData: FormData, functionReturn: Function, functionProgress: Function) {
     const url = formStore.props.ajaxurlHandleUpload
     const config = {

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -71,7 +71,9 @@ const formStore: FormStore = reactive({
     ajaxurlHandleUpload: '',
     ajaxurlGetSignalementDraft: '',
     platformName: '',
-    urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q='
+    urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q=',
+    ajaxurlCheckTerritory: '',
+
   },
   screenData: [],
   currentScreen: null,

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -28,7 +28,7 @@ class SignalementDraftRequest
     private ?string $adresseLogementAdresseDetailCodePostal = null;
     #[Assert\NotBlank(message: 'Merci de saisir une ville.')]
     private ?string $adresseLogementAdresseDetailCommune = null;
-    #[Assert\NotBlank(message: 'Merci de saisir une code INSEE.')]
+    #[Assert\NotBlank(message: 'Merci de saisir un code INSEE.')]
     private ?string $adresseLogementAdresseDetailInsee = null;
     private ?float $adresseLogementAdresseDetailGeolocLat = null;
     private ?float $adresseLogementAdresseDetailGeolocLng = null;

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -6,6 +6,7 @@ use App\Validator as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Email;
 
+#[AppAssert\IsTerritoryActive]
 class SignalementDraftRequest
 {
     public const PREFIX_PROPERTIES_TYPE_COMPOSITION = ['type_logement', 'composition_logement', 'bail_dpe'];
@@ -27,6 +28,7 @@ class SignalementDraftRequest
     private ?string $adresseLogementAdresseDetailCodePostal = null;
     #[Assert\NotBlank(message: 'Merci de saisir une ville.')]
     private ?string $adresseLogementAdresseDetailCommune = null;
+    #[Assert\NotBlank(message: 'Merci de saisir une code INSEE.')]
     private ?string $adresseLogementAdresseDetailInsee = null;
     private ?float $adresseLogementAdresseDetailGeolocLat = null;
     private ?float $adresseLogementAdresseDetailGeolocLng = null;

--- a/src/Validator/IsTerritoryActive.php
+++ b/src/Validator/IsTerritoryActive.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class IsTerritoryActive extends Constraint
+{
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/IsTerritoryActiveValidator.php
+++ b/src/Validator/IsTerritoryActiveValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Validator;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Commune;
+use App\Service\Signalement\PostalCodeHomeChecker;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class IsTerritoryActiveValidator extends ConstraintValidator
+{
+    public function __construct(private readonly EntityManagerInterface $em, private readonly PostalCodeHomeChecker $postalCodeHomeChecker)
+    {
+    }
+
+    public function validate($obj, Constraint $constraint): void
+    {
+        if (!$obj instanceof SignalementDraftRequest) {
+            throw new UnexpectedValueException($obj, SignalementDraftRequest::class);
+        }
+
+        if (!$constraint instanceof IsTerritoryActive) {
+            throw new UnexpectedValueException($constraint, IsTerritoryActive::class);
+        }
+
+        $postalCode = $obj->getAdresseLogementAdresseDetailCodePostal();
+        $inseeCode = $obj->getAdresseLogementAdresseDetailInsee();
+        if ($postalCode && $inseeCode) {
+            $communes = $this->em->getRepository(Commune::class)->findBy(['codePostal' => $postalCode, 'codeInsee' => $inseeCode]);
+            if (!\count($communes)) {
+                $message = 'Le code postal "'.$postalCode.'" et le code INSEE "'.$inseeCode.'" ne sont pas cohérent.';
+                $this->context
+                    ->buildViolation($message)
+                    ->atPath('adresseLogementAdresseDetailCodePostal')
+                    ->addViolation();
+            }
+
+            if (!$this->postalCodeHomeChecker->isActive($postalCode, $inseeCode)) {
+                $message = 'Le territoire n\'est pas actif pour le code postal "'.$postalCode.'" et le code INSEE "'.$inseeCode.'".';
+                $this->context
+                    ->buildViolation($message)
+                    ->atPath('adresseLogementAdresseDetailCodePostal')
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/src/Validator/IsTerritoryActiveValidator.php
+++ b/src/Validator/IsTerritoryActiveValidator.php
@@ -31,7 +31,7 @@ class IsTerritoryActiveValidator extends ConstraintValidator
         if ($postalCode && $inseeCode) {
             $communes = $this->em->getRepository(Commune::class)->findBy(['codePostal' => $postalCode, 'codeInsee' => $inseeCode]);
             if (!\count($communes)) {
-                $message = 'Le code postal "'.$postalCode.'" et le code INSEE "'.$inseeCode.'" ne sont pas cohérent.';
+                $message = 'Le code postal "'.$postalCode.'" et le code INSEE "'.$inseeCode.'" ne sont pas cohérents.';
                 $this->context
                     ->buildViolation($message)
                     ->atPath('adresseLogementAdresseDetailCodePostal')

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -22,6 +22,7 @@
            data-ajaxurl-get-signalement-draft="{{ path('informations_signalement_draft', {uuid: uuid_signalement}) }}"
          {% endif %}
          data-platform-name="{{ platform.name }}"
+         data-ajaxurl-check-territory="{{ path('front_signalement_check_territory') }}"
         ></div>
   </div>
 {% endblock %}

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -82,7 +82,8 @@
           "type": "SignalementFormAddress",
           "label": "Adresse du logement",
           "slug": "adresse_logement_adresse",
-          "description": "Tapez l'adresse puis sélectionnez-la dans la liste"
+          "description": "Tapez l'adresse puis sélectionnez-la dans la liste",
+          "isTerritoryToCheck": true
         },
         {
           "type": "SignalementFormSubscreen",


### PR DESCRIPTION
## Ticket

#1532 

## Description
Ajout d'un contrôle de la paire "code postal/code INSEE" lors de la sélection d'une adresse sur le nouveau formulaire afin de pouvoir afficher (via modale) si le territoire n'est pas ouvert.
Ajout d'un contrôle identique coté serveur.

## Changements apportés
* Appel de la route "front_signalement_check_territory" lors de la sélection d'une des adresse proposé du nouveau formulaire et eventuel affichage d'une modale d'erreur si le territoire n'est pas actif.
* Ajout d'une contrainte de validation "IsTerritoryActive" pour appliquer un contrôle similaire coté serveur.
* Ajout d'un contrôle de cohérence entre le code postal et code INSEE

## Tests
- [ ] Tester le nouveau formulaire en sélectionnant une adresse sur un territoire non actif.
- [ ] Tester la route "envoi_nouveau_signalement_draft" ou "mise_a_jour_nouveau_signalement_draft" en envoyant les donnée d'une adresse d'un territoire non ouvert et vérifier que le contrôle fonctionne aussi coté serveur.
