### PR TITLE
[BO - Esabora] SI-SH Reprise des dossiers non sync des derniers territoires

### DIFF
--- a/src/Command/Cron/AbstractSynchronizeEsaboraCommand.php
+++ b/src/Command/Cron/AbstractSynchronizeEsaboraCommand.php
@@ -68,8 +68,9 @@ class AbstractSynchronizeEsaboraCommand extends AbstractCronCommand
         $io = new SymfonyStyle($input, $output);
         $uuidSignalement = $input->getArgument('uuid_signalement') ?? null;
         $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
-            $partnerType,
-            $uuidSignalement
+            partnerType: $partnerType,
+            isSynchronized: true,
+            uuidSignalement: $uuidSignalement
         );
         $countSyncSuccess = 0;
         $countSyncFailed = 0;

--- a/src/Command/Cron/SynchronizeInterventionSISHCommand.php
+++ b/src/Command/Cron/SynchronizeInterventionSISHCommand.php
@@ -57,8 +57,9 @@ class SynchronizeInterventionSISHCommand extends AbstractSynchronizeEsaboraComma
         $io = new SymfonyStyle($input, $output);
         $uuidSignalement = $input->getArgument('uuid_signalement') ?? null;
         $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
-            PartnerType::ARS,
-            $uuidSignalement
+            partnerType: PartnerType::ARS,
+            isSynchronized: true,
+            uuidSignalement: $uuidSignalement
         );
 
         foreach ($affectations as $affectation) {

--- a/src/Command/PushEsaboraDossierCommand.php
+++ b/src/Command/PushEsaboraDossierCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Enum\PartnerType;
+use App\Messenger\EsaboraBus;
+use App\Repository\AffectationRepository;
+use App\Repository\TerritoryRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(
+    name: 'app:push-esabora-dossier',
+    description: 'Push dossier SI-SH or SCHS',
+)]
+class PushEsaboraDossierCommand extends Command
+{
+    public const TERRITORY_NOT_ALLOWED = ['13', '06'];
+
+    public function __construct(
+        private AffectationRepository $affectationRepository,
+        private TerritoryRepository $territoryRepository,
+        private EsaboraBus $esaboraBus,
+        #[Autowire(param: 'kernel.environment')]
+        private string $env
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('service_type', InputArgument::REQUIRED, 'sish or schs')
+            ->addOption('zip', null, InputOption::VALUE_OPTIONAL, 'Territory zip to target')
+            ->addOption('uuid', null, InputOption::VALUE_OPTIONAL, 'Signalement Uuid');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $serviceType = $input->getArgument('service_type');
+        $zip = $input->getOption('zip');
+        $uuid = $input->getOption('uuid');
+
+        if (!\in_array($serviceType, ['sish', 'schs'])) {
+            $io->error('Le service_type doit être soit "sish" soit "schs".');
+
+            return Command::FAILURE;
+        }
+
+        $affectations = null;
+        if ($uuid) {
+            $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
+                partnerType: 'sish' === $serviceType ? PartnerType::ARS : PartnerType::COMMUNE_SCHS,
+                uuidSignalement: $uuid
+            );
+        } elseif ($zip) {
+            $territory = $this->territoryRepository->findOneBy(['zip' => $zip, 'isActive' => 1]);
+            if (null === $territory) {
+                $io->error('Territory does not exist or is not active');
+
+                return Command::FAILURE;
+            } elseif ('prod' === $this->env && \in_array($zip, self::TERRITORY_NOT_ALLOWED)) {
+                $io->error('It is not allowed to synchronize 13 and 06 in the production environment');
+
+                return Command::FAILURE;
+            }
+
+            $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
+                partnerType: 'sish' === $serviceType ? PartnerType::ARS : PartnerType::COMMUNE_SCHS,
+                isSynchronized: false,
+                territory: $territory
+            );
+        }
+
+        if (!$affectations) {
+            $io->warning('No dossier to pushed to Esabora '.$serviceType);
+
+            return Command::FAILURE;
+        }
+
+        foreach ($affectations as $affectation) {
+            $this->esaboraBus->dispatch($affectation);
+            $affectation->setIsSynchronized(true);
+            $this->affectationRepository->save($affectation);
+            $io->success(sprintf(
+                '[%s] Dossier %s pushed to esabora',
+                $affectation->getPartner()->getType()->value,
+                $affectation->getSignalement()->getUuid()
+            ));
+        }
+
+        $this->affectationRepository->save($affectation, true);
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Unit/Command/PushEsaboraDossierCommandTest.php
+++ b/tests/Unit/Command/PushEsaboraDossierCommandTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\PushEsaboraDossierCommand;
+use App\Entity\Enum\PartnerType;
+use App\Entity\Territory;
+use App\Messenger\EsaboraBus;
+use App\Repository\AffectationRepository;
+use App\Repository\TerritoryRepository;
+use App\Tests\FixturesHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class PushEsaboraDossierCommandTest extends TestCase
+{
+    use FixturesHelper;
+    private const ENV = 'dev';
+
+    private MockObject|AffectationRepository $affectationRepository;
+    private MockObject|TerritoryRepository $territoryRepository;
+
+    private MockObject|EsaboraBus $esaboraBus;
+
+    protected function setUp(): void
+    {
+        $this->affectationRepository = $this->createMock(AffectationRepository::class);
+        $this->territoryRepository = $this->createMock(TerritoryRepository::class);
+        $this->esaboraBus = $this->createMock(EsaboraBus::class);
+        parent::setUp();
+    }
+
+    public function testExecuteWithZipOption(): void
+    {
+        $affectation1 = $this->getAffectation(PartnerType::ARS);
+        $affectation2 = $this->getAffectation(PartnerType::ARS);
+
+        $affectation1->setIsSynchronized(false);
+        $affectation2->setIsSynchronized(false);
+
+        $this->territoryRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['zip' => '01', 'isActive' => 1])
+            ->willReturn($this->getTerritory());
+
+        $this->affectationRepository
+            ->expects($this->once())
+            ->method('findAffectationSubscribedToEsabora')
+            ->with(
+                $this->equalTo(PartnerType::ARS),
+                null,
+                null,
+                (new Territory())->setZip('01')->setIsActive(1)->setName('Ain')
+            )
+            ->willReturn([$affectation1, $affectation2]);
+
+        $this->affectationRepository
+            ->expects($this->atMost(3))
+            ->method('save');
+
+        $this->esaboraBus
+            ->expects($this->atMost(2))
+            ->method('dispatch')
+            ->withConsecutive([$affectation1], [$affectation2]);
+
+        $command = new PushEsaboraDossierCommand(
+            $this->affectationRepository,
+            $this->territoryRepository,
+            $this->esaboraBus,
+            self::ENV
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'service_type' => 'sish',
+            '--zip' => '01',
+        ]);
+    }
+
+    public function testExecuteWithUuidOption(): void
+    {
+        $affectation = $this->getAffectation(PartnerType::ARS);
+
+        $this->affectationRepository
+            ->expects($this->once())
+            ->method('findAffectationSubscribedToEsabora')
+            ->with(
+                $this->equalTo(PartnerType::ARS),
+                true,
+                $this->equalTo('00000000-0000-0000-2023-000000000010')
+            )
+            ->willReturn([$affectation]);
+
+        $this->affectationRepository
+            ->expects($this->atMost(2))
+            ->method('save');
+
+        $this->esaboraBus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->equalTo($affectation));
+
+        $command = new PushEsaboraDossierCommand(
+            $this->affectationRepository,
+            $this->territoryRepository,
+            $this->esaboraBus,
+            self::ENV
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'service_type' => 'sish',
+            '--uuid' => '00000000-0000-0000-2023-000000000010',
+        ]);
+    }
+}


### PR DESCRIPTION
## Ticket

#2022   

## Description
Les derniers territoires ouverts sont restés non sync depuis leur ouvertures, une reprise des dossiers affectés à l'ARS  est nécessaire.
https://mattermost.incubateur.net/betagouv/pl/qqh13c8pupn69qnepgc8qajhge

> [!CAUTION]
> 13 et 06 ont un fonctionnement différent avec 2 ARS (à renseigner dans https://github.com/MTES-MCT/histologe/issues/1680)
> *Mail du 11/07/2023 15:45*  
![image](https://github.com/MTES-MCT/histologe/assets/5757116/f8483831-35d3-4578-9420-933c705cd575)


## Changements apportés
* Ajout d'une commande pour synchroniser un dossier ou un territoire **(pas possible pour le 13 et le 06 en prod)**

## Pré-requis
```
make mock-start
make work-start
```

### Avoir un dossier affecté mais non sync
* Désactiver la synchronisation [d'un partenaire ARS](http://localhost:8080/bo/partenaires/7/voir) 
* Affecter `PARTENAIRE 13-06 ESABORA ARS` [au dossier 2023-9](http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000009) (celui ci aura la colonne `is_synchronized` à 0)
* Réactiver la synchronisation afin de pouvoir pousser le dossier avec la commande

### Ou désynchroniser les affectations via SQL
```sql
UPDATE `affectation` set is_synchronized = 0;
```
## Tests
- [ ] Exécuter la commande de sync pour le territoire du 13
 ```sh 
make console app="push-esabora-dossier sish --zip=13"
```
- [ ] Exécuter la commande pour un dossier SISH 
```sh
make console app="push-esabora-dossier sish --uuid=00000000-0000-0000-2023-000000000012"
```
- [ ] Exécuter la commande pour un dossier SCHS
```sh
make console app="push-esabora-dossier schs --uuid=00000000-0000-0000-2023-000000000012"
```
- [ ] Vider le cache du dashboard et vérifier que tout est OK dans le widget `Esabora` 
```sh
 make clear-pool pool=dashboard.cache
```

![image](https://github.com/MTES-MCT/histologe/assets/5757116/d7628e35-b96c-4ceb-95d7-4f9eddea4f01)
