### PR TITLE
[FO - Comptes utilisateurs] Bloquer l'activation pour les usagers

### DIFF
--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -30,7 +30,7 @@ class UserAccountController extends AbstractController
         $title = 'Activation de votre compte';
         if ($request->isMethod('POST') && $email = $request->request->get('email')) {
             $user = $userRepository->findOneBy(['email' => $email]);
-            if ($user && User::STATUS_ARCHIVE != $user->getStatut()) {
+            if ($user && User::STATUS_ARCHIVE != $user->getStatut() && !\in_array('ROLE_USAGER', $user->getRoles())) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_FROM_FO,
@@ -72,7 +72,7 @@ class UserAccountController extends AbstractController
         $title = 'Récupération de votre mot de passe';
         if ($request->isMethod('POST') && $email = $request->request->get('email')) {
             $user = $userRepository->findOneBy(['email' => $email]);
-            if ($user && User::STATUS_ARCHIVE != $user->getStatut()) {
+            if ($user && User::STATUS_ARCHIVE != $user->getStatut() && !\in_array('ROLE_USAGER', $user->getRoles())) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_LOST_PASSWORD,


### PR DESCRIPTION
## Ticket

#1816   

## Description
Lorsqu'un usager crée un signalement, on lui crée un compte utilisateur avec le ROLE_USAGER.
Jusqu'à présent, aucun test ne venait bloquait sa progression quand :
- il demande un nouveau mot de passe
- il tente d'activer son compte

## Changements apportés
Ajout d'un test lors de ces deux procédures pour éviter qu'il puisse accéder au BO

## Tests
- [ ] Essayer de récupérer le mot de passe d'un ROLE_USAGER => bloqué
- [ ] Essayer de récupérer le mot de passe d'un autre rôle => réussite
- [ ] Essayer d'activer le compte d'un ROLE_USAGER => bloqué
- [ ] Essayer d'activer le compte d'un autre rôle => réussite
