### PR TITLE
fix validation des numéro de téléphone #1801

### DIFF
--- a/src/Validator/TelephoneFormatValidator.php
+++ b/src/Validator/TelephoneFormatValidator.php
@@ -29,8 +29,8 @@ class TelephoneFormatValidator extends ConstraintValidator
         try {
             $phoneNumberUtil = PhoneNumberUtil::getInstance();
             $phoneNumberParsed = $phoneNumberUtil->parse($value, 'FR');
-            $isValid = $phoneNumberUtil->isValidNumber($phoneNumberParsed);
-            if (!$isValid) {
+            $isPossible = $phoneNumberUtil->isPossibleNumber($phoneNumberParsed);
+            if (!$isPossible) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $value)
                     ->atPath('telephone')


### PR DESCRIPTION
## Ticket

#1801

## Description
Modification de la fonction de validation du numéro de téléphone.
Il semble que la fonction utilisé `isValidNumber` soit trop restrictive dans certains cas (ex : numéro 0700908987 considéré comme invalide)
Je pense que l'utilisattion de la fonction `isPossibleNumber` est acceptable.

Le cas est peut être en lien avec cette explication https://github.com/giggsey/libphonenumber-for-php/issues/517#issuecomment-1284020588


## Tests
- [ ] Tester de soumettre le formulaire avec le numéro de téléphone 0700908987 
