### PR TITLE
[Matomo] Ajout de test pour éviter le tracking précis Matomo

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -58,7 +58,7 @@
         <script>
             var _paq = window._paq = window._paq || [];
             /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-            {% if app.user is not null and 'ROLE_ADMIN' not in app.user.roles %}
+            {% if app.user is not null and 'ROLE_ADMIN' not in app.user.roles and 'ROLE_USAGER' not in app.user.roles %}
                 _paq.push(['setCustomDimension', customDimensionId = 1, customDimensionValue = '{{ app.user.roles|first}}' ]);
                 _paq.push(['setCustomDimension', customDimensionId = 2, customDimensionValue = '{{ app.user.territory.name }}' ]);
                 _paq.push(['setCustomDimension', customDimensionId = 3, customDimensionValue = '{{ app.user.partner.nom }}' ]);


### PR DESCRIPTION
## Ticket

#2033   

## Description
Certaines personnes parviennent à se connecter en ROLE_USAGER mais le tracking avancé Matomo n'est pas d'actualité pour ces personnes. On désactive donc l'envoi de données complémentaires pour ces personnes.

## Tests
- [ ] Se logger avec un usager via l'activation de compte : l'accueil s'affiche bien, mais les données Matomo de type `setCustomDimension` ne sont pas présentes
- [ ] Se logger avec un agent : l'accueil s'affiche bien, et les données Matomo de type `setCustomDimension` sont présentes
