### PR TITLE
[FO - Signalement] Ajout de contrainte de validation sur la longueur des champs (nom et prénom)

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -625,3 +625,6 @@ a.force-link-color {
     font-size: 0.8rem;
     color: #000091;
 }
+.text-word-break-all {
+    word-break: break-all;
+}

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="id">
+  <div :id="id" class="text-word-break-all">
     <div>
       <br>
       <h2 class="fr-h4">Récapitulatif</h2>

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -10,8 +10,10 @@ class CoordonneesBailleurRequest
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de saisir le nom du bailleur.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO'])]
+        #[Assert\Length(max: 255, maxMessage: 'Le nom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nom = null,
         #[Assert\NotBlank(message: 'Merci de saisir le prénom du bailleur.', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
+        #[Assert\Length(max: 255, maxMessage: 'Le prénom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $prenom = null,
         #[Assert\NotBlank(message: 'Merci de saisir l\'email du bailleur', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -10,8 +10,10 @@ class CoordonneesFoyerRequest
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de saisir un nom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\Length(max: 50, maxMessage: 'Le nom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nom = null,
         #[Assert\NotBlank(message: 'Merci de saisir un prénom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\Length(max: 50, maxMessage: 'Le prénom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $prenom = null,
         #[Assert\NotBlank(message: 'Merci de saisir un email', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]

--- a/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
@@ -10,8 +10,10 @@ class CoordonneesTiersRequest
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de saisir un nom.')]
+        #[Assert\Length(max: 50, maxMessage: 'Le nom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nom = null,
         #[Assert\NotBlank(message: 'Merci de saisir un prénom.')]
+        #[Assert\Length(max: 50, maxMessage: 'Le prénom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $prenom = null,
         #[Assert\NotBlank(message: 'Merci de saisir un courriel.')]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -56,13 +56,13 @@ class SignalementDraftRequest
         message: 'Merci de renseigner votre nom.',
         groups: ['TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR', 'SERVICE_SECOURS']
     )]
-    #[Assert\Length(max: 50, maxMessage: 'Votre nom ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 50, maxMessage: 'Votre nom en tant que tiers est limité à {{ limit }} caractères.')]
     private ?string $vosCoordonneesTiersNom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre prénom.',
         groups: ['TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR', 'SERVICE_SECOURS']
     )]
-    #[Assert\Length(max: 50, maxMessage: 'Votre prénom ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 50, maxMessage: 'Votre prénom en tant que tiers est limité {{ limit }} caractères.')]
     private ?string $vosCoordonneesTiersPrenom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre adresse e-mail.',
@@ -87,13 +87,13 @@ class SignalementDraftRequest
         message: 'Merci de renseigner votre nom.',
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
     )]
-    #[Assert\Length(max: 50, maxMessage: 'Votre nom ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 50, maxMessage: 'Votre nom en tant qu\'occupant est limité à {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantNom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre prénom.',
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
     )]
-    #[Assert\Length(max: 50, maxMessage: 'Votre prénom ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 50, maxMessage: 'Votre prénom en tant qu\'occupant est limité à {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantPrenom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre adresse e-mail.',

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -62,7 +62,7 @@ class SignalementDraftRequest
         message: 'Merci de renseigner votre prénom.',
         groups: ['TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR', 'SERVICE_SECOURS']
     )]
-    #[Assert\Length(max: 50, maxMessage: 'Votre prénom en tant que tiers est limité {{ limit }} caractères.')]
+    #[Assert\Length(max: 50, maxMessage: 'Votre prénom en tant que tiers est limité à {{ limit }} caractères.')]
     private ?string $vosCoordonneesTiersPrenom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre adresse e-mail.',

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -56,11 +56,13 @@ class SignalementDraftRequest
         message: 'Merci de renseigner votre nom.',
         groups: ['TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR', 'SERVICE_SECOURS']
     )]
+    #[Assert\Length(max: 50, maxMessage: 'Votre nom ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesTiersNom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre prénom.',
         groups: ['TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR', 'SERVICE_SECOURS']
     )]
+    #[Assert\Length(max: 50, maxMessage: 'Votre prénom ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesTiersPrenom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre adresse e-mail.',
@@ -85,11 +87,13 @@ class SignalementDraftRequest
         message: 'Merci de renseigner votre nom.',
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
     )]
+    #[Assert\Length(max: 50, maxMessage: 'vote nom ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantNom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre prénom.',
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
     )]
+    #[Assert\Length(max: 50, maxMessage: 'votre prénom ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantPrenom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre adresse e-mail.',
@@ -105,14 +109,18 @@ class SignalementDraftRequest
     private ?string $vosCoordonneesOccupantTel = null;
     #[AppAssert\TelephoneFormat]
     private ?string $vosCoordonneesOccupantTelSecondaire = null;
+    #[Assert\Length(max: 50, maxMessage: 'Le nom de l\'occupant ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesOccupantNom = null;
+    #[Assert\Length(max: 50, maxMessage: 'Le prénom de l\'occupant ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesOccupantPrenom = null;
     private ?string $coordonneesOccupantEmail = null;
     #[AppAssert\TelephoneFormat]
     private ?string $coordonneesOccupantTel = null;
     #[AppAssert\TelephoneFormat]
     private ?string $coordonneesOccupantTelSecondaire = null;
+    #[Assert\Length(max: 255, maxMessage: 'Le nom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesBailleurNom = null;
+    #[Assert\Length(max: 255, maxMessage: 'Le prénom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesBailleurPrenom = null;
     #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
     private ?string $coordonneesBailleurEmail = null;

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -87,13 +87,13 @@ class SignalementDraftRequest
         message: 'Merci de renseigner votre nom.',
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
     )]
-    #[Assert\Length(max: 50, maxMessage: 'vote nom ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 50, maxMessage: 'Votre nom ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantNom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre prénom.',
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
     )]
-    #[Assert\Length(max: 50, maxMessage: 'votre prénom ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 50, maxMessage: 'Votre prénom ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantPrenom = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre adresse e-mail.',

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -94,9 +94,11 @@ class Signalement
     private $dateEntree;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Assert\Length(max: 255)]
     private $nomProprio;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Assert\Length(max: 255)]
     private ?string $prenomProprio;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
@@ -138,9 +140,11 @@ class Signalement
     private $isNotOccupant;
 
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
+    #[Assert\Length(max: 50)]
     private $nomDeclarant;
 
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
+    #[Assert\Length(max: 50)]
     private $prenomDeclarant;
 
     #[ORM\Column(type: 'string', length: 128, nullable: true)]
@@ -163,10 +167,12 @@ class Signalement
 
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 50)]
     private $nomOccupant;
 
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 50)]
     private $prenomOccupant;
 
     #[ORM\Column(type: 'string', length: 128, nullable: true)]

--- a/src/Form/SignalementType.php
+++ b/src/Form/SignalementType.php
@@ -534,7 +534,7 @@ class SignalementType extends AbstractType
             ->add('nomDeclarant', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
-                    'maxlength' => '200',
+                    'maxlength' => '50',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',
@@ -545,7 +545,7 @@ class SignalementType extends AbstractType
             ->add('prenomDeclarant', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
-                    'maxlength' => '200',
+                    'maxlength' => '50',
                 ],
                 'label_attr' => [
                     'class' => 'fr-label',

--- a/templates/_partials/_signalement_steps_tabs.html.twig
+++ b/templates/_partials/_signalement_steps_tabs.html.twig
@@ -695,7 +695,7 @@
             <em class="fr-fi-information-line fr-text-label--blue-france"> Acceptez les conditions
                 d'utilisation du service et validez votre signalement.</em>
         </header>
-        <div class="fr-grid-row">
+        <div class="fr-grid-row text-word-break-all">
             <div class="fr-col-12 fr-col-md-4">
                 <ul>
                     <li>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -13,12 +13,12 @@
                             </h1>
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nom">Nom</label>
-                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomProprio }}">
+                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomProprio }}" maxlength="255">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="prenom">Prénom</label>
-                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomProprio }}">
+                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomProprio }}" maxlength="255">
                             </div>
 
                             <div class="fr-input-group">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
@@ -14,12 +14,12 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nom">Nom</label>
-                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomOccupant }}">
+                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomOccupant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="prenom">Prénom</label>
-                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomOccupant }}">
+                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomOccupant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -14,12 +14,12 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nom">Nom</label>
-                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomDeclarant }}">
+                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomDeclarant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="prenom">Prénom</label>
-                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomDeclarant }}">
+                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomDeclarant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-<div class="fr-container--fluid">
+<div class="fr-container--fluid text-word-break-all">
     <div class="fr-grid-row fr-grid-row--gutters">
         {% if signalement.isNotOccupant %}
             {% if isNewFormEnabled %}

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -17,12 +17,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille",
-          "slug": "vos_coordonnees_tiers_nom"
+          "slug": "vos_coordonnees_tiers_nom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom",
-          "slug": "vos_coordonnees_tiers_prenom"
+          "slug": "vos_coordonnees_tiers_prenom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormEmailfield",
@@ -65,7 +71,8 @@
           "label": "Nom de famille (facultatif)",
           "slug": "coordonnees_occupant_nom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -73,7 +80,8 @@
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_occupant_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -35,12 +35,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille",
-          "slug": "vos_coordonnees_occupant_nom"
+          "slug": "vos_coordonnees_occupant_nom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom",
-          "slug": "vos_coordonnees_occupant_prenom"
+          "slug": "vos_coordonnees_occupant_prenom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormEmailfield",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -24,12 +24,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille",
-          "slug": "vos_coordonnees_occupant_nom"
+          "slug": "vos_coordonnees_occupant_nom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom",
-          "slug": "vos_coordonnees_occupant_prenom"
+          "slug": "vos_coordonnees_occupant_prenom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormEmailfield",
@@ -75,14 +81,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille ou de l'organisme",
-          "slug": "coordonnees_bailleur_nom"
+          "slug": "coordonnees_bailleur_nom",
+          "validate": {
+            "maxLength": 255
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_bailleur_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -90,7 +90,7 @@
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false,
-            "maxLength": 50
+            "maxLength": 255
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -17,12 +17,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille",
-          "slug": "vos_coordonnees_tiers_nom"
+          "slug": "vos_coordonnees_tiers_nom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom",
-          "slug": "vos_coordonnees_tiers_prenom"
+          "slug": "vos_coordonnees_tiers_prenom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormEmailfield",
@@ -65,7 +71,8 @@
           "label": "Nom de famille (facultatif)",
           "slug": "coordonnees_occupant_nom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -73,7 +80,8 @@
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_occupant_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -81,7 +89,8 @@
           "label": "Adresse email (facultatif)",
           "slug": "coordonnees_occupant_email",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -123,7 +132,8 @@
           "label": "Nom de famille ou de l'organisme (facultatif)",
           "slug": "coordonnees_bailleur_nom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {
@@ -131,7 +141,8 @@
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_bailleur_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {
@@ -139,7 +150,8 @@
           "label": "Adresse email (facultatif)",
           "slug": "coordonnees_bailleur_email",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -31,12 +31,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille",
-          "slug": "vos_coordonnees_tiers_nom"
+          "slug": "vos_coordonnees_tiers_nom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom",
-          "slug": "vos_coordonnees_tiers_prenom"
+          "slug": "vos_coordonnees_tiers_prenom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormEmailfield",
@@ -79,7 +85,8 @@
           "label": "Nom de famille (facultatif)",
           "slug": "coordonnees_occupant_nom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -87,7 +94,8 @@
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_occupant_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -135,14 +143,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille ou de l'organisme",
-          "slug": "coordonnees_bailleur_nom"
+          "slug": "coordonnees_bailleur_nom",
+          "validate": {
+            "maxLength": 255
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_bailleur_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -14,12 +14,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille",
-          "slug": "vos_coordonnees_tiers_nom"
+          "slug": "vos_coordonnees_tiers_nom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom",
-          "slug": "vos_coordonnees_tiers_prenom"
+          "slug": "vos_coordonnees_tiers_prenom",
+          "validate": {
+            "maxLength": 50
+          }
         },
         {
           "type": "SignalementFormEmailfield",
@@ -62,7 +68,8 @@
           "label": "Nom de famille (facultatif)",
           "slug": "coordonnees_occupant_nom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -70,7 +77,8 @@
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_occupant_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 50
           }
         },
         {
@@ -118,14 +126,18 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Nom de famille ou de l'organisme",
-          "slug": "coordonnees_bailleur_nom"
+          "slug": "coordonnees_bailleur_nom",
+          "validate": {
+            "maxLength": 255
+          }
         },
         {
           "type": "SignalementFormTextfield",
           "label": "Prénom (facultatif)",
           "slug": "coordonnees_bailleur_prenom",
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {


### PR DESCRIPTION
## Ticket

#2015 

## Description
Ajout de contraintes de validation sur la longueur de tous les nom et prénom des signalement

## Changements apportés
* Ajout de contraintes sur les nom et prénom de façon globales (ancien et nouveau formulaire, ancienne et nouvelle édition) autant coté client que serveur

## Tests
- [ ] Vérifier qu'il n'est pas possible de soumettre l'ancien ou le nouveau formulaire avec des nom prénom dépassant les limites de la base de données (50 caractère ou 255 pour le bailleur)
- [ ] Vérifier qu'il n'est pas possible d'éditer des nom prénom d'un signalement avec les modale ou l'ancien formulaire d'édition en dépassant les limite de la base de données
