### PR TITLE
[BO - Signalement] Enlever l'obligation sur le champ "details"

### DIFF
--- a/migrations/Version20231218162844.php
+++ b/migrations/Version20231218162844.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231218162844 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make details nullable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement CHANGE details details LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement CHANGE details details LONGTEXT NOT NULL');
+    }
+}

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -53,8 +53,7 @@ class Signalement
     #[ORM\ManyToMany(targetEntity: Criticite::class, inversedBy: 'signalements')]
     private $criticites;
 
-    #[ORM\Column(type: 'text')]
-    #[Assert\NotBlank]
+    #[ORM\Column(type: 'text', nullable: true)]
     private $details;
 
     #[ORM\Column(type: 'boolean', nullable: true)]


### PR DESCRIPTION
## Ticket

#2040 

## Description
Retrait de la contrainte NotBlank sur le chjamp détails de l'entité Signalement et conversion du champ en nullable

## Tests
- [ ] Vider à la main en base le champ détail d'un signalement et vérifier qu'il est possible de modifier le signalement en BO (sous l'édition en sa forme actuelle et non pas avec les modales)
