### PR TITLE
[BO - Document] Migration Sept 2022- Anonymiser les documents n'appartenant pas au bon territoire

### DIFF
--- a/migrations/Version20231213171924.php
+++ b/migrations/Version20231213171924.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231213171924 extends AbstractMigration
+{
+    private const ROLE_SUPER_AMIN = '%ROLE_ADMIN%';
+
+    public function getDescription(): string
+    {
+        return 'remove user relation for files uploaded by a user from a different territory';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+        UPDATE file
+        SET uploaded_by_id = NULL
+        WHERE uploaded_by_id IN (
+            SELECT uploaded_by_id FROM (
+                SELECT f.uploaded_by_id
+                FROM file f
+                INNER JOIN signalement s ON s.id = f.signalement_id
+                INNER JOIN user u ON u.id = f.uploaded_by_id
+                WHERE u.territory_id != s.territory_id
+                AND u.roles NOT LIKE :role_super_admin
+            ) AS subquery
+        )', ['role_super_admin' => self::ROLE_SUPER_AMIN]);
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20231213171924.php
+++ b/migrations/Version20231213171924.php
@@ -9,7 +9,7 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20231213171924 extends AbstractMigration
 {
-    private const ROLE_SUPER_AMIN = '%ROLE_ADMIN%';
+    private const ROLE_SUPER_AMIN = '["ROLE_ADMIN"]';
 
     public function getDescription(): string
     {


### PR DESCRIPTION
## Ticket

#2029    

## Description
Problème remonté par le 06, ~ 1700 fichiers sont rattaché à un utilisateur qui n'est pas du bon territoire. Il n'existe pas de bug à l'heure actuelle. Problème provenant sans doute lors de la migration (sept - oct 2022)  des territoires vers la plateforme unique

https://histologe-metabase.osc-fr1.scalingo.io/question/1103-fichiers-dont-lutilisateur-nappartient-pas-au-bon-territoire

## Changements apportés
* Ajout d'une migration pour supprimer la relation

## Pré-requis

## Tests
- [ ] Exécuter `make load-data` 
- [ ] Exécuter la requête et le résultat doit être égale à 0

```sql
SELECT COUNT(*)
FROM file f
INNER JOIN signalement s ON     s.id = f.signalement_id 
INNER JOIN user u ON u.id = f.uploaded_by_id 
WHERE u.territory_id != s.territory_id 
AND u.roles NOT LIKE '["ROLE_ADMIN"]';

```