### PR TITLE
[BO - Export PDF] Retirer la limitation des 20 images

### DIFF
--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -32,22 +32,18 @@ class SignalementFileController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
 
-        if ($signalement->getPhotos()->count() < 21) {
-            $message = (new PdfExportMessage())
-                ->setSignalementId($signalement->getId())
-                ->setUserEmail($user->getEmail());
+        $message = (new PdfExportMessage())
+            ->setSignalementId($signalement->getId())
+            ->setUserEmail($user->getEmail());
 
-            $messageBus->dispatch($message);
+        $messageBus->dispatch($message);
 
-            $this->addFlash('success',
-                sprintf(
-                    'L\'export pdf vous sera envoyé par email à l\'adresse suivante : %s. N\'oubliez pas de regarder vos courriers indésirables (spam) !',
-                    $user->getEmail()
-                )
-            );
-        } else {
-            $this->addFlash('error', 'La fonctionnalité est temporairement désactivée sur ce signalement en raison d\'un trop grand nombre de photos.');
-        }
+        $this->addFlash('success',
+            sprintf(
+                'L\'export pdf vous sera envoyé par email à l\'adresse suivante : %s. N\'oubliez pas de regarder vos courriers indésirables (spam) !',
+                $user->getEmail()
+            )
+        );
 
         return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
     }

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -75,16 +75,10 @@
             {% endif %}
 
             {% if canExportSignalement %}
-                {% if signalement.getPhotos()|length < 21 %}
                     <a href="{{ path('back_signalement_gen_pdf',{uuid:signalement.uuid}) }}"
                        class="fr-btn fr-btn--sm fr-btn--icon-left fr-fi-file-pdf-fill ignore-blank-style"
                        title="Exporter le PDF">Exporter le PDF
                     </a>
-                {% else %}
-                    <a href="#" data-user="Exporter le PDF" data-mail="La fonctionnalité est temporairement désactivée sur ce signalement en raison d'un trop grand nombre de photos."
-                       class="fr-btn fr-btn--sm fr-btn--icon-left fr-fi-file-pdf-fill ignore-blank-style disabled-link part-infos-hover"
-                       title="Exporter le PDF" >Exporter le PDF</a>
-                {% endif %}
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
## Ticket

#2047 

## Description
Retrait de la limitation au signalement contenant moins de 21 image pour pouvoir exporter le signalement en PDF

## Tests
- [ ] Tester un export PDF sur un fichier avec plus de 20 images
