### PR TITLE
[BO - Signalement] Ajout des infos complémentaires à la fiche signalement

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -333,6 +333,7 @@ export default defineComponent({
       result += this.addLineIfNeeded('informations_complementaires_logement_annee_construction', 'Année de construction du logement : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_demande_relogement', 'Demande de relogement ou de logement social : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_occupants_date_emmenagement', 'Date d\'emménagement : ')
+      result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_date_effet_bail', 'Date d\'effet du bail : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_beneficiaire_rsa', 'Bénéficiaire RSA : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_beneficiaire_fsl', 'Bénéficiaire FSL : ')
       result += this.addLineIfNeeded('informations_complementaires_situation_bailleur_revenu_fiscal', 'Revenu fiscal de référence : ', ' €')
@@ -352,6 +353,7 @@ export default defineComponent({
           this.isFormDataSet('informations_complementaires_logement_annee_construction') ||
           this.isFormDataSet('informations_complementaires_situation_occupants_demande_relogement') ||
           this.isFormDataSet('informations_complementaires_situation_occupants_date_emmenagement') ||
+          this.isFormDataSet('informations_complementaires_situation_bailleur_date_effet_bail') ||
           this.isFormDataSet('informations_complementaires_situation_bailleur_beneficiaire_rsa') ||
           this.isFormDataSet('informations_complementaires_situation_bailleur_beneficiaire_fsl') ||
           this.isFormDataSet('informations_complementaires_situation_bailleur_revenu_fiscal') ||

--- a/migrations/Version20231218154729.php
+++ b/migrations/Version20231218154729.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231218154729 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add type_proprio to signalement';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement ADD type_proprio VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP type_proprio');
+    }
+}

--- a/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/bailleur.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/bailleur.json
@@ -78,5 +78,5 @@
   "informations_complementaires_situation_occupants_preavis_depart": "non",
   "informations_complementaires_situation_bailleur_beneficiaire_fsl": "non",
   "informations_complementaires_situation_bailleur_beneficiaire_rsa": "non",
-  "informations_complementaires_situation_occupants_date_emmenagement": "1998-10-10"
+  "informations_complementaires_situation_bailleur_date_effet_bail": "1998-10-10"
 }

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -14,6 +14,7 @@ class CompositionLogementRequest
         #[Assert\NotBlank(message: 'Merci de définir la hauteur du logement.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
         private readonly ?string $compositionLogementHauteur = null,
         private readonly ?string $compositionLogementNbPieces = null,
+        private readonly ?string $nombreEtages = null,
         private readonly ?string $typeLogementRdc = null,
         private readonly ?string $typeLogementDernierEtage = null,
         private readonly ?string $typeLogementSousCombleSansFenetre = null,
@@ -51,6 +52,11 @@ class CompositionLogementRequest
     public function getCompositionLogementNbPieces(): ?string
     {
         return $this->compositionLogementNbPieces;
+    }
+
+    public function getNombreEtages(): ?string
+    {
+        return $this->nombreEtages;
     }
 
     public function getTypeLogementRdc(): ?string

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -29,6 +29,11 @@ class CoordonneesBailleurRequest
         private readonly ?string $codePostal = null,
         #[Assert\NotBlank(message: 'Merci de saisir la ville du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $ville = null,
+        private readonly ?string $beneficiaireRsa = null,
+        private readonly ?string $beneficiaireFsl = null,
+        private readonly ?string $revenuFiscal = null,
+        #[Assert\DateTime('Y-m-d')]
+        private readonly ?string $dateNaissance = null,
     ) {
     }
 
@@ -70,5 +75,25 @@ class CoordonneesBailleurRequest
     public function getVille(): ?string
     {
         return $this->ville;
+    }
+
+    public function getBeneficiaireRsa(): ?string
+    {
+        return $this->beneficiaireRsa;
+    }
+
+    public function getBeneficiaireFsl(): ?string
+    {
+        return $this->beneficiaireFsl;
+    }
+
+    public function getRevenuFiscal(): ?string
+    {
+        return $this->revenuFiscal;
+    }
+
+    public function getDateNaissance(): ?string
+    {
+        return $this->dateNaissance;
     }
 }

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Constraints\Email;
 class CoordonneesFoyerRequest
 {
     public function __construct(
+        private readonly ?string $typeProprio = null,
+        private readonly ?string $nomStructure = null,
         private readonly ?string $civilite = null,
         #[Assert\NotBlank(message: 'Merci de saisir un nom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Length(max: 50, maxMessage: 'Le nom ne doit pas dépasser {{ limit }} caractères.')]
@@ -25,6 +27,16 @@ class CoordonneesFoyerRequest
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephoneBis = null,
     ) {
+    }
+
+    public function getTypeProprio(): ?string
+    {
+        return $this->typeProprio;
+    }
+
+    public function getNomStructure(): ?string
+    {
+        return $this->nomStructure;
     }
 
     public function getCivilite(): ?string

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Constraints\Email;
 class CoordonneesFoyerRequest
 {
     public function __construct(
+        private readonly ?string $civilite = null,
         #[Assert\NotBlank(message: 'Merci de saisir un nom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Length(max: 50, maxMessage: 'Le nom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nom = null,
@@ -24,6 +25,11 @@ class CoordonneesFoyerRequest
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephoneBis = null,
     ) {
+    }
+
+    public function getCivilite(): ?string
+    {
+        return $this->civilite;
     }
 
     public function getNom(): ?string

--- a/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Constraints\Email;
 class CoordonneesTiersRequest
 {
     public function __construct(
+        private readonly ?string $typeProprio = null,
         #[Assert\NotBlank(message: 'Merci de saisir un nom.')]
         #[Assert\Length(max: 50, maxMessage: 'Le nom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nom = null,
@@ -24,6 +25,16 @@ class CoordonneesTiersRequest
         private readonly ?string $lien = null,
         private readonly ?string $structure = null,
     ) {
+    }
+
+    public function getTypeProprio(): ?string
+    {
+        return $this->typeProprio;
+    }
+
+    public function getNomStructure(): ?string
+    {
+        return $this->nomStructure;
     }
 
     public function getNom(): ?string

--- a/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
@@ -32,11 +32,6 @@ class CoordonneesTiersRequest
         return $this->typeProprio;
     }
 
-    public function getNomStructure(): ?string
-    {
-        return $this->nomStructure;
-    }
-
     public function getNom(): ?string
     {
         return $this->nom;

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -22,6 +22,8 @@ class InformationsLogementRequest
         private readonly ?string $bailDpeEtatDesLieux = null,
         #[Assert\NotBlank(message: 'Merci de définir le DPE.', groups: ['LOCATAIRE', 'BAILLEUR', 'BAILLEUR_OCCUPANT'])]
         private readonly ?string $bailDpeDpe = null,
+        private readonly ?string $loyer = null,
+        private readonly ?string $loyersPayes = null,
     ) {
     }
 
@@ -58,5 +60,15 @@ class InformationsLogementRequest
     public function getBailDpeDpe(): ?string
     {
         return $this->bailDpeDpe;
+    }
+
+    public function getLoyer(): ?string
+    {
+        return $this->loyer;
+    }
+
+    public function getLoyersPayes(): ?string
+    {
+        return $this->loyersPayes;
     }
 }

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -24,6 +24,7 @@ class InformationsLogementRequest
         private readonly ?string $bailDpeDpe = null,
         private readonly ?string $loyer = null,
         private readonly ?string $loyersPayes = null,
+        private readonly ?string $anneeConstruction = null,
     ) {
     }
 
@@ -70,5 +71,10 @@ class InformationsLogementRequest
     public function getLoyersPayes(): ?string
     {
         return $this->loyersPayes;
+    }
+
+    public function getAnneeConstruction(): ?string
+    {
+        return $this->anneeConstruction;
     }
 }

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -15,7 +15,9 @@ class InformationsLogementRequest
         private readonly ?string $compositionLogementEnfants = null,
         #[Assert\NotBlank(message: 'Merci de définir la date d\'arrivée', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\DateTime('Y-m-d')]
-        private readonly ?string $bailDpeDateEmmenagement = null,
+        private readonly ?string $dateEntree = null,
+        #[Assert\DateTime('Y-m-d')]
+        private readonly ?string $bailleurDateEffetBail = null,
         #[Assert\NotBlank(message: 'Merci de définir le bail.', groups: ['LOCATAIRE', 'BAILLEUR'])]
         private readonly ?string $bailDpeBail = null,
         #[Assert\NotBlank(message: 'Merci de définir l\'état des lieux.', groups: ['LOCATAIRE', 'BAILLEUR'])]
@@ -43,9 +45,14 @@ class InformationsLogementRequest
         return $this->compositionLogementEnfants;
     }
 
-    public function getBailDpeDateEmmenagement(): ?string
+    public function getDateEntree(): ?string
     {
-        return $this->bailDpeDateEmmenagement;
+        return $this->dateEntree;
+    }
+
+    public function getBailleurDateEffetBail(): ?string
+    {
+        return $this->bailleurDateEffetBail;
     }
 
     public function getBailDpeBail(): ?string

--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -14,6 +14,8 @@ class ProcedureDemarchesRequest
         private readonly ?string $infoProcedureReponseAssurance = null,
         #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux ', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
         private readonly ?string $infoProcedureDepartApresTravaux = null,
+        private readonly ?string $preavisDepart = null,
+        private readonly ?string $demandeRelogement = null,
     ) {
     }
 
@@ -35,5 +37,15 @@ class ProcedureDemarchesRequest
     public function getInfoProcedureDepartApresTravaux(): ?string
     {
         return $this->infoProcedureDepartApresTravaux;
+    }
+
+    public function getPreavisDepart(): ?string
+    {
+        return $this->preavisDepart;
+    }
+
+    public function getDemandeRelogement(): ?string
+    {
+        return $this->demandeRelogement;
     }
 }

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -85,6 +85,7 @@ class SignalementDraftRequest
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
     )]
     private ?string $vosCoordonneesOccupantCivilite = null;
+    private ?string $vosCoordonneesOccupantNomOrganisme = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre nom.',
         groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
@@ -453,6 +454,18 @@ class SignalementDraftRequest
     public function setVosCoordonneesOccupantCivilite(?string $vosCoordonneesOccupantCivilite): self
     {
         $this->vosCoordonneesOccupantCivilite = $vosCoordonneesOccupantCivilite;
+
+        return $this;
+    }
+
+    public function getVosCoordonneesOccupantNomOrganisme(): ?string
+    {
+        return $this->vosCoordonneesOccupantNomOrganisme;
+    }
+
+    public function setVosCoordonneesOccupantNomOrganisme(?string $vosCoordonneesOccupantNomOrganisme): self
+    {
+        $this->vosCoordonneesOccupantNomOrganisme = $vosCoordonneesOccupantNomOrganisme;
 
         return $this;
     }

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -21,6 +21,9 @@ class SituationFoyerRequest
         private readonly ?string $travailleurSocialQuitteLogement = null,
         #[Assert\NotBlank(['message' => 'Veuillez définir le champ accompagnement par un travailleur social', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
         private readonly ?string $travailleurSocialAccompagnementDeclarant = null,
+        private readonly ?string $beneficiaireRsa = null,
+        private readonly ?string $beneficiaireFsl = null,
+        private readonly ?string $revenuFiscal = null,
     ) {
     }
 
@@ -62,5 +65,20 @@ class SituationFoyerRequest
     public function getTravailleurSocialAccompagnementDeclarant(): ?string
     {
         return $this->travailleurSocialAccompagnementDeclarant;
+    }
+
+    public function getBeneficiaireRsa(): ?string
+    {
+        return $this->beneficiaireRsa;
+    }
+
+    public function getBeneficiaireFsl(): ?string
+    {
+        return $this->beneficiaireFsl;
+    }
+
+    public function getRevenuFiscal(): ?string
+    {
+        return $this->revenuFiscal;
     }
 }

--- a/src/Entity/Enum/ProprioType.php
+++ b/src/Entity/Enum/ProprioType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum ProprioType: string
+{
+    case PARTICULIER = 'PARTICULIER';
+    case ORGANISME_SOCIETE = 'ORGANISME_SOCIETE';
+
+    public function label(): string
+    {
+        return self::getLabelList()[$this->name];
+    }
+
+    public static function getLabelList(): array
+    {
+        return [
+            'PARTICULIER' => 'Particulier',
+            'ORGANISME_SOCIETE' => 'Organisme / Société',
+        ];
+    }
+}

--- a/src/Entity/Model/InformationComplementaire.php
+++ b/src/Entity/Model/InformationComplementaire.php
@@ -7,6 +7,7 @@ class InformationComplementaire
     public function __construct(
         private ?string $informationsComplementairesSituationOccupantsBeneficiaireRsa = null,
         private ?string $informationsComplementairesSituationOccupantsBeneficiaireFsl = null,
+        private ?string $informationsComplementairesSituationOccupantsRevenuFiscal = null,
         private ?string $informationsComplementairesSituationOccupantsDateNaissance = null,
         private ?string $informationsComplementairesSituationOccupantsDemandeRelogement = null,
         private ?string $informationsComplementairesSituationOccupantsDateEmmenagement = null,
@@ -43,6 +44,18 @@ class InformationComplementaire
     public function setInformationsComplementairesSituationOccupantsBeneficiaireFsl(?string $informationsComplementairesSituationOccupantsBeneficiaireFsl): self
     {
         $this->informationsComplementairesSituationOccupantsBeneficiaireFsl = $informationsComplementairesSituationOccupantsBeneficiaireFsl;
+
+        return $this;
+    }
+
+    public function getInformationsComplementairesSituationOccupantsRevenuFiscal(): ?string
+    {
+        return $this->informationsComplementairesSituationOccupantsRevenuFiscal;
+    }
+
+    public function setInformationsComplementairesSituationOccupantsRevenuFiscal(?string $informationsComplementairesSituationOccupantsRevenuFiscal): self
+    {
+        $this->informationsComplementairesSituationOccupantsRevenuFiscal = $informationsComplementairesSituationOccupantsRevenuFiscal;
 
         return $this;
     }
@@ -208,6 +221,7 @@ class InformationComplementaire
         return [
             'informations_complementaires_situation_occupants_beneficiaire_rsa' => $this->informationsComplementairesSituationOccupantsBeneficiaireRsa,
             'informations_complementaires_situation_occupants_beneficiaire_fsl' => $this->informationsComplementairesSituationOccupantsBeneficiaireFsl,
+            'informations_complementaires_situation_occupants_revenu_fiscal' => $this->informationsComplementairesSituationOccupantsRevenuFiscal,
             'informations_complementaires_situation_occupants_date_naissance' => $this->informationsComplementairesSituationOccupantsDateNaissance,
             'informations_complementaires_situation_occupants_demande_relogement' => $this->informationsComplementairesSituationOccupantsDemandeRelogement,
             'informations_complementaires_situation_occupants_date_emmenagement' => $this->informationsComplementairesSituationOccupantsDateEmmenagement,

--- a/src/Entity/Model/InformationComplementaire.php
+++ b/src/Entity/Model/InformationComplementaire.php
@@ -12,6 +12,7 @@ class InformationComplementaire
         private ?string $informationsComplementairesSituationOccupantsDateEmmenagement = null,
         private ?string $informationsComplementairesSituationOccupantsLoyersPayes = null,
         private ?string $informationsComplementairesSituationOccupantsPreavisDepart = null,
+        private ?string $informationsComplementairesSituationBailleurDateEffetBail = null,
         private ?string $informationsComplementairesSituationBailleurBeneficiaireRsa = null,
         private ?string $informationsComplementairesSituationBailleurBeneficiaireFsl = null,
         private ?string $informationsComplementairesSituationBailleurRevenuFiscal = null,
@@ -102,6 +103,18 @@ class InformationComplementaire
     public function setInformationsComplementairesSituationOccupantsPreavisDepart(?string $informationsComplementairesSituationOccupantsPreavisDepart): self
     {
         $this->informationsComplementairesSituationOccupantsPreavisDepart = $informationsComplementairesSituationOccupantsPreavisDepart;
+
+        return $this;
+    }
+
+    public function getInformationsComplementairesSituationBailleurDateEffetBail(): ?string
+    {
+        return $this->informationsComplementairesSituationBailleurDateEffetBail;
+    }
+
+    public function setInformationsComplementairesSituationBailleurDateEffetBail(?string $informationsComplementairesSituationBailleurDateEffetBail): self
+    {
+        $this->informationsComplementairesSituationBailleurDateEffetBail = $informationsComplementairesSituationBailleurDateEffetBail;
 
         return $this;
     }
@@ -200,6 +213,7 @@ class InformationComplementaire
             'informations_complementaires_situation_occupants_date_emmenagement' => $this->informationsComplementairesSituationOccupantsDateEmmenagement,
             'informations_complementaires_situation_occupants_loyers_payes' => $this->informationsComplementairesSituationOccupantsLoyersPayes,
             'informations_complementaires_situation_occupants_preavis_depart' => $this->informationsComplementairesSituationOccupantsPreavisDepart,
+            'informations_complementaires_situation_bailleur_date_effet_bail' => $this->informationsComplementairesSituationBailleurDateEffetBail,
             'informations_complementaires_situation_bailleur_beneficiaire_rsa' => $this->informationsComplementairesSituationBailleurBeneficiaireRsa,
             'informations_complementaires_situation_bailleur_beneficiaire_fsl' => $this->informationsComplementairesSituationBailleurBeneficiaireFsl,
             'informations_complementaires_situation_bailleur_revenu_fiscal' => $this->informationsComplementairesSituationBailleurRevenuFiscal,

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\MotifRefus;
 use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Enum\ProprioType;
 use App\Entity\Model\InformationComplementaire;
 use App\Entity\Model\InformationProcedure;
 use App\Entity\Model\SituationFoyer;
@@ -91,6 +92,9 @@ class Signalement
 
     #[ORM\Column(type: 'date', nullable: true)]
     private $dateEntree;
+
+    #[ORM\Column(type: 'string', nullable: true, enumType: ProprioType::class)]
+    private ?ProprioType $typeProprio = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Assert\Length(max: 255)]
@@ -686,6 +690,18 @@ class Signalement
     public function setDateEntree(?DateTimeInterface $dateEntree): self
     {
         $this->dateEntree = $dateEntree;
+
+        return $this;
+    }
+
+    public function getTypeProprio(): ?ProprioType
+    {
+        return $this->typeProprio;
+    }
+
+    public function setTypeProprio(?ProprioType $typeProprio): self
+    {
+        $this->typeProprio = $typeProprio;
 
         return $this;
     }

--- a/src/Factory/Signalement/InformationComplementaireFactory.php
+++ b/src/Factory/Signalement/InformationComplementaireFactory.php
@@ -33,6 +33,7 @@ class InformationComplementaireFactory
             informationsComplementairesSituationOccupantsDateEmmenagement: $data['informations_complementaires_situation_occupants_date_emmenagement'] ?? null,
             informationsComplementairesSituationOccupantsLoyersPayes: $data['informations_complementaires_situation_occupants_loyers_payes'] ?? null,
             informationsComplementairesSituationOccupantsPreavisDepart: $data['informations_complementaires_situation_occupants_preavis_depart'] ?? null,
+            informationsComplementairesSituationBailleurDateEffetBail: $data['informations_complementaires_situation_bailleur_date_effet_bail'] ?? null,
             informationsComplementairesSituationBailleurBeneficiaireRsa: $data['informations_complementaires_situation_bailleur_beneficiaire_rsa'] ?? null,
             informationsComplementairesSituationBailleurBeneficiaireFsl: $data['informations_complementaires_situation_bailleur_beneficiaire_fsl'] ?? null,
             informationsComplementairesSituationBailleurRevenuFiscal: $data['informations_complementaires_situation_bailleur_revenu_fiscal'] ?? null,

--- a/src/Factory/Signalement/InformationComplementaireFactory.php
+++ b/src/Factory/Signalement/InformationComplementaireFactory.php
@@ -28,6 +28,7 @@ class InformationComplementaireFactory
         return new InformationComplementaire(
             informationsComplementairesSituationOccupantsBeneficiaireRsa: $data['informations_complementaires_situation_occupants_beneficiaire_rsa'] ?? null,
             informationsComplementairesSituationOccupantsBeneficiaireFsl: $data['informations_complementaires_situation_occupants_beneficiaire_fsl'] ?? null,
+            informationsComplementairesSituationOccupantsRevenuFiscal: $data['informations_complementaires_situation_occupants_revenu_fiscal'] ?? null,
             informationsComplementairesSituationOccupantsDateNaissance: $data['informations_complementaires_situation_occupants_date_naissance'] ?? null,
             informationsComplementairesSituationOccupantsDemandeRelogement: $data['informations_complementaires_situation_occupants_demande_relogement'] ?? null,
             informationsComplementairesSituationOccupantsDateEmmenagement: $data['informations_complementaires_situation_occupants_date_emmenagement'] ?? null,

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -505,7 +505,7 @@ class SignalementManager extends AbstractManager
             ->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($situationFoyerRequest->getBeneficiaireFsl());
         if ($situationFoyerRequest->getRevenuFiscal()) {
             $informationComplementaire
-                ->setInformationsComplementairesSituationBailleurRevenuFiscal($situationFoyerRequest->getRevenuFiscal());
+                ->setInformationsComplementairesSituationOccupantsRevenuFiscal($situationFoyerRequest->getRevenuFiscal());
         }
         $signalement->setInformationComplementaire($informationComplementaire);
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -405,7 +405,8 @@ class SignalementManager extends AbstractManager
             $informationComplementaire = clone $signalement->getInformationComplementaire();
         }
         $informationComplementaire
-            ->setInformationsComplementairesSituationOccupantsLoyersPayes($informationsLogementRequest->getLoyersPayes());
+            ->setInformationsComplementairesSituationOccupantsLoyersPayes($informationsLogementRequest->getLoyersPayes())
+            ->setInformationsComplementairesLogementAnneeConstruction($informationsLogementRequest->getAnneeConstruction());
         $signalement->setInformationComplementaire($informationComplementaire);
 
         $this->save($signalement);

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -14,6 +14,7 @@ use App\Dto\Request\Signalement\SituationFoyerRequest;
 use App\Dto\SignalementAffectationListView;
 use App\Entity\Affectation;
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Model\InformationComplementaire;
 use App\Entity\Model\InformationProcedure;
 use App\Entity\Model\SituationFoyer;
 use App\Entity\Model\TypeCompositionLogement;
@@ -354,6 +355,9 @@ class SignalementManager extends AbstractManager
         if (is_numeric($informationsLogementRequest->getNombrePersonnes())) {
             $signalement->setNbOccupantsLogement($informationsLogementRequest->getNombrePersonnes());
         }
+        if (is_numeric($informationsLogementRequest->getLoyer())) {
+            $signalement->setLoyer($informationsLogementRequest->getLoyer());
+        }
 
         $typeCompositionLogement = new TypeCompositionLogement();
         if (!empty($signalement->getTypeCompositionLogement())) {
@@ -367,6 +371,14 @@ class SignalementManager extends AbstractManager
             ->setBailDpeEtatDesLieux($informationsLogementRequest->getBailDpeEtatDesLieux())
             ->setBailDpeDpe($informationsLogementRequest->getBailDpeDpe());
         $signalement->setTypeCompositionLogement($typeCompositionLogement);
+
+        $informationComplementaire = new InformationComplementaire();
+        if (!empty($signalement->getInformationComplementaire())) {
+            $informationComplementaire = clone $signalement->getInformationComplementaire();
+        }
+        $informationComplementaire
+            ->setInformationsComplementairesSituationOccupantsLoyersPayes($informationsLogementRequest->getLoyersPayes());
+        $signalement->setInformationComplementaire($informationComplementaire);
 
         $this->save($signalement);
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -459,6 +459,19 @@ class SignalementManager extends AbstractManager
         $signalement->setSituationFoyer($situationFoyer);
 
         // TODO : mise à jour du désordre suroccupation si allocataire change
+        
+        $informationComplementaire = new InformationComplementaire();
+        if (!empty($signalement->getInformationComplementaire())) {
+            $informationComplementaire = clone $signalement->getInformationComplementaire();
+        }
+        $informationComplementaire
+            ->setInformationsComplementairesSituationOccupantsBeneficiaireRsa($situationFoyerRequest->getBeneficiaireRsa())
+            ->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($situationFoyerRequest->getBeneficiaireFsl());
+        if ($situationFoyerRequest->getRevenuFiscal()) {
+            $informationComplementaire
+                ->setInformationsComplementairesSituationBailleurRevenuFiscal($situationFoyerRequest->getRevenuFiscal());
+        }
+        $signalement->setInformationComplementaire($informationComplementaire);
 
         $this->save($signalement);
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -412,6 +412,14 @@ class SignalementManager extends AbstractManager
 
         // TODO : mise à jour des désordres liés à la composition du logement
 
+        $informationComplementaire = new InformationComplementaire();
+        if (!empty($signalement->getInformationComplementaire())) {
+            $informationComplementaire = clone $signalement->getInformationComplementaire();
+        }
+        $informationComplementaire
+            ->setInformationsComplementairesLogementNombreEtages($compositionLogementRequest->getNombreEtages());
+        $signalement->setInformationComplementaire($informationComplementaire);
+
         $this->save($signalement);
     }
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -346,6 +346,21 @@ class SignalementManager extends AbstractManager
             ->setCodePostalProprio($coordonneesBailleurRequest->getCodePostal())
             ->setVilleProprio($coordonneesBailleurRequest->getVille());
 
+        $informationComplementaire = new InformationComplementaire();
+        if (!empty($signalement->getInformationComplementaire())) {
+            $informationComplementaire = clone $signalement->getInformationComplementaire();
+        }
+        $informationComplementaire
+            ->setInformationsComplementairesSituationBailleurBeneficiaireRsa($coordonneesBailleurRequest->getBeneficiaireRsa())
+            ->setInformationsComplementairesSituationBailleurBeneficiaireFsl($coordonneesBailleurRequest->getBeneficiaireFsl())
+            ->setInformationsComplementairesSituationBailleurRevenuFiscal($coordonneesBailleurRequest->getRevenuFiscal());
+        if ($coordonneesBailleurRequest->getDateNaissance()) {
+            $informationComplementaire->setInformationsComplementairesSituationBailleurDateNaissance(
+                $coordonneesBailleurRequest->getDateNaissance()
+            );
+        }
+        $signalement->setInformationComplementaire($informationComplementaire);
+
         $this->save($signalement);
     }
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -386,6 +386,11 @@ class SignalementManager extends AbstractManager
         if (is_numeric($informationsLogementRequest->getLoyer())) {
             $signalement->setLoyer($informationsLogementRequest->getLoyer());
         }
+        if (!empty($informationsLogementRequest->getDateEntree())) {
+            $signalement->setDateEntree(new \DateTimeImmutable($informationsLogementRequest->getDateEntree()));
+        } else {
+            $signalement->setDateEntree(null);
+        }
 
         $typeCompositionLogement = new TypeCompositionLogement();
         if (!empty($signalement->getTypeCompositionLogement())) {
@@ -394,7 +399,6 @@ class SignalementManager extends AbstractManager
         $typeCompositionLogement
             ->setCompositionLogementNombrePersonnes($informationsLogementRequest->getNombrePersonnes())
             ->setCompositionLogementEnfants($informationsLogementRequest->getCompositionLogementEnfants())
-            ->setBailDpeDateEmmenagement($informationsLogementRequest->getBailDpeDateEmmenagement())
             ->setBailDpeBail($informationsLogementRequest->getBailDpeBail())
             ->setBailDpeEtatDesLieux($informationsLogementRequest->getBailDpeEtatDesLieux())
             ->setBailDpeDpe($informationsLogementRequest->getBailDpeDpe());
@@ -406,7 +410,10 @@ class SignalementManager extends AbstractManager
         }
         $informationComplementaire
             ->setInformationsComplementairesSituationOccupantsLoyersPayes($informationsLogementRequest->getLoyersPayes())
-            ->setInformationsComplementairesLogementAnneeConstruction($informationsLogementRequest->getAnneeConstruction());
+            ->setInformationsComplementairesLogementAnneeConstruction($informationsLogementRequest->getAnneeConstruction())
+            ->setInformationsComplementairesSituationBailleurDateEffetBail(
+                !empty($informationsLogementRequest->getBailleurDateEffetBail()) ? $informationsLogementRequest->getBailleurDateEffetBail() : null
+            );
         $signalement->setInformationComplementaire($informationComplementaire);
 
         $this->save($signalement);

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -326,7 +326,9 @@ class SignalementManager extends AbstractManager
 
     public function updateFromCoordonneesFoyerRequest(Signalement $signalement, CoordonneesFoyerRequest $coordonneesFoyerRequest)
     {
-        $signalement->setNomOccupant($coordonneesFoyerRequest->getNom())
+        $signalement
+            ->setCiviliteOccupant($coordonneesFoyerRequest->getCivilite())
+            ->setNomOccupant($coordonneesFoyerRequest->getNom())
             ->setPrenomOccupant($coordonneesFoyerRequest->getPrenom())
             ->setMailOccupant($coordonneesFoyerRequest->getMail())
             ->setTelOccupant($coordonneesFoyerRequest->getTelephone())

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -495,7 +495,7 @@ class SignalementManager extends AbstractManager
         $signalement->setSituationFoyer($situationFoyer);
 
         // TODO : mise à jour du désordre suroccupation si allocataire change
-        
+
         $informationComplementaire = new InformationComplementaire();
         if (!empty($signalement->getInformationComplementaire())) {
             $informationComplementaire = clone $signalement->getInformationComplementaire();

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -14,6 +14,8 @@ use App\Dto\Request\Signalement\SituationFoyerRequest;
 use App\Dto\SignalementAffectationListView;
 use App\Entity\Affectation;
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Enum\ProprioType;
 use App\Entity\Model\InformationComplementaire;
 use App\Entity\Model\InformationProcedure;
 use App\Entity\Model\SituationFoyer;
@@ -326,6 +328,11 @@ class SignalementManager extends AbstractManager
 
     public function updateFromCoordonneesFoyerRequest(Signalement $signalement, CoordonneesFoyerRequest $coordonneesFoyerRequest)
     {
+        if (ProfileDeclarant::BAILLEUR_OCCUPANT == $signalement->getProfileDeclarant()) {
+            $signalement
+                ->setTypeProprio($coordonneesFoyerRequest->getTypeProprio() ? ProprioType::from($coordonneesFoyerRequest->getTypeProprio()) : null)
+                ->setStructureDeclarant($coordonneesFoyerRequest->getNomStructure());
+        }
         $signalement
             ->setCiviliteOccupant($coordonneesFoyerRequest->getCivilite())
             ->setNomOccupant($coordonneesFoyerRequest->getNom())

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -481,6 +481,15 @@ class SignalementManager extends AbstractManager
             ->setInfoProcedureDepartApresTravaux($procedureDemarchesRequest->getInfoProcedureDepartApresTravaux());
         $signalement->setInformationProcedure($informationProcedure);
 
+        $informationComplementaire = new InformationComplementaire();
+        if (!empty($signalement->getInformationComplementaire())) {
+            $informationComplementaire = clone $signalement->getInformationComplementaire();
+        }
+        $informationComplementaire
+            ->setInformationsComplementairesSituationOccupantsPreavisDepart($procedureDemarchesRequest->getPreavisDepart())
+            ->setInformationsComplementairesSituationOccupantsDemandeRelogement($procedureDemarchesRequest->getDemandeRelogement());
+        $signalement->setInformationComplementaire($informationComplementaire);
+
         $this->save($signalement);
     }
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -316,6 +316,10 @@ class SignalementManager extends AbstractManager
 
     public function updateFromCoordonneesTiersRequest(Signalement $signalement, CoordonneesTiersRequest $coordonneesTiersRequest)
     {
+        if (ProfileDeclarant::BAILLEUR == $signalement->getProfileDeclarant()) {
+            $signalement
+                ->setTypeProprio($coordonneesTiersRequest->getTypeProprio() ? ProprioType::from($coordonneesTiersRequest->getTypeProprio()) : null);
+        }
         $signalement->setNomDeclarant($coordonneesTiersRequest->getNom())
             ->setPrenomDeclarant($coordonneesTiersRequest->getPrenom())
             ->setMailDeclarant($coordonneesTiersRequest->getMail())

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -5,6 +5,7 @@ namespace App\Service\Signalement;
 use App\Dto\Request\Signalement\SignalementDraftRequest;
 use App\Entity\Enum\OccupantLink;
 use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Enum\ProprioType;
 use App\Entity\Model\SituationFoyer;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\Signalement;
@@ -445,6 +446,7 @@ class SignalementBuilder
     {
         if ($this->isBailleurOccupant()) {
             $this->signalement
+                ->setStructureDeclarant($this->signalementDraftRequest->getVosCoordonneesOccupantNomOrganisme())
                 ->setAdresseProprio($this->signalementDraftRequest->getAdresseLogementAdresse())
                 ->setVilleProprio($this->signalementDraftRequest->getAdresseLogementAdresseDetailCommune())
                 ->setCodePostalProprio($this->signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal())
@@ -452,7 +454,10 @@ class SignalementBuilder
                 ->setNomProprio($this->signalementDraftRequest->getVosCoordonneesOccupantNom())
                 ->setPrenomProprio($this->signalementDraftRequest->getVosCoordonneesOccupantPrenom())
                 ->setTelProprio($this->signalementDraftRequest->getVosCoordonneesOccupantTel())
-                ->setTelProprioSecondaire($this->signalementDraftRequest->getVosCoordonneesOccupantTelSecondaire());
+                ->setTelProprioSecondaire($this->signalementDraftRequest->getVosCoordonneesOccupantTelSecondaire())
+                ->setTypeProprio(
+                    ProprioType::from(strtoupper($this->signalementDraftRequest->getSignalementConcerneProfilDetailBailleurProprietaire()))
+                );
         } elseif ($this->isBailleur()) {
             $this->signalement
                 ->setStructureDeclarant($this->signalementDraftRequest->getVosCoordonneesTiersNomOrganisme())
@@ -460,7 +465,10 @@ class SignalementBuilder
                 ->setPrenomProprio($this->signalementDraftRequest->getVosCoordonneesTiersPrenom())
                 ->setTelProprio($this->signalementDraftRequest->getVosCoordonneesTiersTel())
                 ->setMailProprio($this->signalementDraftRequest->getVosCoordonneesTiersEmail())
-                ->setTelProprioSecondaire($this->signalementDraftRequest->getVosCoordonneesTiersTelSecondaire());
+                ->setTelProprioSecondaire($this->signalementDraftRequest->getVosCoordonneesTiersTelSecondaire())
+                ->setTypeProprio(
+                    ProprioType::from(strtoupper($this->signalementDraftRequest->getSignalementConcerneProfilDetailBailleurBailleur()))
+                );
         } else {
             $this->signalement
                 ->setAdresseProprio($this->signalementDraftRequest->getCoordonneesBailleurAdresseDetailNumero())

--- a/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
@@ -49,6 +49,11 @@
                                 <input class="fr-input" type="number" name="compositionLogementNbPieces" value="{{ signalement.typeCompositionLogement.compositionLogementNbPieces ?? 0 }}">
                             </div>
 
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="nombreEtages">Nombre d'étages</label>
+                                <input class="fr-input" type="number" name="nombreEtages" value="{{ signalement.informationComplementaire.informationsComplementairesLogementNombreEtages ?? 1 }}">
+                            </div>
+
                             <div class="fr-select-group">
                                 {% set typeLogementRdc = 'nsp' %}
                                 {% if signalement.typeCompositionLogement %}

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -65,6 +65,52 @@
                                 <input class="fr-input" type="text" disabled name="ville-visible" value="{{ signalement.villeProprio }}">
                                 <input type="hidden" name="ville" value="{{ signalement.villeProprio }}">
                             </div>
+
+                            <div class="fr-select-group">
+                                {% set bailleurBeneficiaireRsa = 'nsp' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'oui' %}
+                                        {% set bailleurBeneficiaireRsa = 'oui' %}
+                                    {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'non' %}
+                                        {% set bailleurBeneficiaireRsa = 'non' %}
+                                    {% endif %}
+                                {% endif %}
+                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA</label>
+                                <select class="fr-select" name="beneficiaireRsa">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="oui" {{ bailleurBeneficiaireRsa is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ bailleurBeneficiaireRsa is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ bailleurBeneficiaireRsa is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
+
+                            <div class="fr-select-group">
+                                {% set bailleurBeneficiaireFsl = 'nsp' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'oui' %}
+                                        {% set bailleurBeneficiaireFsl = 'oui' %}
+                                    {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'non' %}
+                                        {% set bailleurBeneficiaireFsl = 'non' %}
+                                    {% endif %}
+                                {% endif %}
+                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL</label>
+                                <select class="fr-select" name="beneficiaireFsl">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="oui" {{ bailleurBeneficiaireFsl is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ bailleurBeneficiaireFsl is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ bailleurBeneficiaireFsl is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence</label>
+                                <input class="fr-input" type="text" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? '0' }}">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="dateNaissance">Date de naissance</label>
+                                <input class="fr-input" type="date" name="dateNaissance" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? '' }}">
+                            </div>
                         </div>
                         
                         <div class="fr-modal__footer">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
@@ -12,6 +12,16 @@
                                 Modifier les coordonnées du foyer
                             </h1>
 
+                            <div class="fr-select-group">
+                                <label class="fr-label" for="civilite">Civilité</label>
+                                <select class="fr-select" name="civilite">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="" {{ signalement.civiliteOccupant is same as '' ? 'selected' : '' }}>N/C</option>
+                                    <option value="mme" {{ signalement.civiliteOccupant is same as 'mme' ? 'selected' : '' }}>Madame</option>
+                                    <option value="mr" {{ signalement.civiliteOccupant is same as 'mr' ? 'selected' : '' }}>Monsieur</option>
+                                </select>
+                            </div>
+
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nom">Nom</label>
                                 <input class="fr-input" type="text" name="nom" value="{{ signalement.nomOccupant }}" maxlength="50">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
@@ -12,6 +12,22 @@
                                 Modifier les coordonnées du foyer
                             </h1>
 
+                            {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT %}
+                            <div class="fr-select-group">
+                                <label class="fr-label" for="typeProprio">Type</label>
+                                <select class="fr-select" name="typeProprio">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="" {{ signalement.typeProprio is same as '' ? 'selected' : '' }}>N/C</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\ProprioType').PARTICULIER.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').PARTICULIER ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').PARTICULIER.label }}</option>
+                                </select>
+                            </div>
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="nomStructure">Nom de la structure</label>
+                                <input class="fr-input" type="text" name="nomStructure" value="{{ signalement.structureDeclarant }}">
+                            </div>
+                            {% endif %}
+
                             <div class="fr-select-group">
                                 <label class="fr-label" for="civilite">Civilité</label>
                                 <select class="fr-select" name="civilite">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -12,6 +12,18 @@
                                 Modifier les coordonnées du tiers déclarant
                             </h1>
 
+                            {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
+                            <div class="fr-select-group">
+                                <label class="fr-label" for="typeProprio">Type</label>
+                                <select class="fr-select" name="typeProprio">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="" {{ signalement.typeProprio is same as '' ? 'selected' : '' }}>N/C</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\ProprioType').PARTICULIER.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').PARTICULIER ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').PARTICULIER.label }}</option>
+                                </select>
+                            </div>
+                            {% endif %}
+
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nom">Nom</label>
                                 <input class="fr-input" type="text" name="nom" value="{{ signalement.nomDeclarant }}" maxlength="50">

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -152,6 +152,15 @@
                                     <option value="nsp" {{ loyersPayes is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
+
+                            <div class="fr-input-group">
+                                {% set anneeConstruction = 0 %}
+                                {% if signalement.informationComplementaire %}
+                                    {% set anneeConstruction = signalement.informationComplementaire.informationsComplementairesLogementAnneeConstruction %}
+                                {% endif %}
+                                <label class="fr-label" for="anneeConstruction">Année de construction</label>
+                                <input class="fr-input" type="number" name="anneeConstruction" value="{{ anneeConstruction }}">
+                            </div>
                         </div>
                         
                         <div class="fr-modal__footer">

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -60,12 +60,21 @@
                             </div>
 
                             <div class="fr-input-group">
-                                {% set bailDpeDateEmmenagement = '' %}
-                                {% if signalement.typeCompositionLogement %}
-                                    {% set bailDpeDateEmmenagement = signalement.typeCompositionLogement.bailDpeDateEmmenagement %}
+                                {% set dateEntree = '' %}
+                                {% if signalement.dateEntree %}
+                                    {% set dateEntree = signalement.dateEntree.format('Y-m-d') %}
                                 {% endif %}
-                                <label class="fr-label" for="bailDpeDateEmmenagement">Date arrivée</label>
-                                <input class="fr-input" type="date" name="bailDpeDateEmmenagement" value="{{ bailDpeDateEmmenagement }}">
+                                <label class="fr-label" for="dateEntree">Date arrivée</label>
+                                <input class="fr-input" type="date" name="dateEntree" value="{{ dateEntree }}">
+                            </div>
+
+                            <div class="fr-input-group">
+                                {% set bailleurDateEffetBail = '' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% set bailleurDateEffetBail = signalement.informationComplementaire.informationsComplementairesSituationBailleurDateEffetBail %}
+                                {% endif %}
+                                <label class="fr-label" for="bailleurDateEffetBail">Date d'effet du bail</label>
+                                <input class="fr-input" type="date" name="bailleurDateEffetBail" value="{{ bailleurDateEffetBail }}">
                             </div>
 
                             <div class="fr-select-group">

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -127,6 +127,31 @@
                                     <option value="nsp" {{ bailDpeDpe is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="loyer">Montant du loyer</label>
+                                <input class="fr-input" type="number" name="loyer" value="{{ signalement.loyer }}">
+                            </div>
+
+                            <div class="fr-select-group">
+                                {% set loyersPayes = 'nsp' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsLoyersPayes is same as 'oui' %}
+                                        {% set loyersPayes = 'oui' %}
+                                    {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsLoyersPayes is same as 'non' %}
+                                        {% set loyersPayes = 'non' %}
+                                    {% else %}
+                                        {% set loyersPayes = 'nsp' %}
+                                    {% endif %}
+                                {% endif %}
+                                <label class="fr-label" for="loyersPayes">Paiement loyers à jour</label>
+                                <select class="fr-select" name="loyersPayes">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="oui" {{ loyersPayes is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ loyersPayes is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ loyersPayes is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
                         </div>
                         
                         <div class="fr-modal__footer">

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -71,6 +71,42 @@
                                     <option value="nsp" {{ infoProcedureDepartApresTravaux is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
+
+                            <div class="fr-select-group">
+                                {% set preavisDepart = 'nsp' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsPreavisDepart is same as 'oui' %}
+                                        {% set preavisDepart = 'oui' %}
+                                    {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsPreavisDepart is same as 'non' %}
+                                        {% set preavisDepart = 'non' %}
+                                    {% endif %}
+                                {% endif %}
+                                <label class="fr-label" for="preavisDepart">Préavis de départ</label>
+                                <select class="fr-select" name="preavisDepart">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="oui" {{ preavisDepart is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ preavisDepart is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ preavisDepart is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
+
+                            <div class="fr-select-group">
+                                {% set demandeRelogement = 'nsp' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'oui' %}
+                                        {% set demandeRelogement = 'oui' %}
+                                    {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'non' %}
+                                        {% set demandeRelogement = 'non' %}
+                                    {% endif %}
+                                {% endif %}
+                                <label class="fr-label" for="demandeRelogement">Demande logement social / relogement</label>
+                                <select class="fr-select" name="demandeRelogement">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="oui" {{ demandeRelogement is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ demandeRelogement is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ demandeRelogement is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
                         </div>
                         
                         <div class="fr-modal__footer">

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -121,6 +121,49 @@
                                     <option value="nsp" {{ travailleurSocialAccompagnementDeclarant is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
+
+                            <div class="fr-select-group">
+                                {% set beneficiaireRsa = 'nsp' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa is same as 'oui' %}
+                                        {% set beneficiaireRsa = 'oui' %}
+                                    {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa is same as 'non' %}
+                                        {% set beneficiaireRsa = 'non' %}
+                                    {% endif %}
+                                {% endif %}
+                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA</label>
+                                <select class="fr-select" name="beneficiaireRsa">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="oui" {{ beneficiaireRsa is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ beneficiaireRsa is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ beneficiaireRsa is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
+
+                            <div class="fr-select-group">
+                                {% set beneficiaireFsl = 'nsp' %}
+                                {% if signalement.informationComplementaire %}
+                                    {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireFsl is same as 'oui' %}
+                                        {% set beneficiaireFsl = 'oui' %}
+                                    {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireFsl is same as 'non' %}
+                                        {% set beneficiaireFsl = 'non' %}
+                                    {% endif %}
+                                {% endif %}
+                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL</label>
+                                <select class="fr-select" name="beneficiaireFsl">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="oui" {{ beneficiaireFsl is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ beneficiaireFsl is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ beneficiaireFsl is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
+
+                            {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT  %}
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence</label>
+                                <input class="fr-input" type="text" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? '0' }}">
+                            </div>
+                            {% endif %}
                         </div>
                         
                         <div class="fr-modal__footer">

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -161,7 +161,7 @@
                             {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT  %}
                             <div class="fr-input-group">
                                 <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence</label>
-                                <input class="fr-input" type="text" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? '0' }}">
+                                <input class="fr-input" type="text" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ?? '0' }}">
                             </div>
                             {% endif %}
                         </div>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -629,6 +629,34 @@
                             N/C
                         {% endif %}
                     </div>
+                    <div class="fr-col-12">
+                        <strong>Préavis de départ :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsPreavisDepart is same as 'oui' %}
+                                {{ static_picto_yes|raw }}
+                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsPreavisDepart is same as 'non' %}
+                                {{ static_picto_no|raw }}
+                            {% else %}
+                                Ne sait pas
+                            {% endif %}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
+                    <div class="fr-col-12">
+                        <strong>Demande logement social / relogement :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'oui' %}
+                                {{ static_picto_yes|raw }}
+                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'non' %}
+                                {{ static_picto_no|raw }}
+                            {% else %}
+                                Ne sait pas
+                            {% endif %}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -339,6 +339,15 @@
                             N/C
                         {% endif %}
                     </div>
+        
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Nombre d'étages :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {{ signalement.informationComplementaire.informationsComplementairesLogementNombreEtages ?? 'N/C' }}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
 
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>RDC :</strong>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -34,11 +34,18 @@
                         {% endif %}
                     </div>
                     
-                    
                     {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR  %}
                         <div class="fr-col-12">
                             <strong>Type de déclarant :</strong> {{ signalement.profileDeclarant.label }}
                         </div>
+                        <div class="fr-col-12">
+                            <strong>Type de bailleur :</strong> {{ signalement.typeProprio.label }}
+                        </div>
+                        {% if signalement.typeProprio and signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
+                        <div class="fr-col-12">
+                            <strong>Nom de la structure :</strong> {{ signalement.structureDeclarant }}
+                        </div>
+                        {% endif %}
                     {% endif %}
 
                     <div class="fr-col-12 fr-col-md-6">
@@ -89,6 +96,14 @@
                         <div class="fr-col-12">
                             <strong>Type de déclarant :</strong> {{ signalement.profileDeclarant.label }}
                         </div>
+                        <div class="fr-col-12">
+                            <strong>Type de bailleur :</strong> {{ signalement.typeProprio ? signalement.typeProprio.label : 'N/C' }}
+                        </div>
+                        {% if signalement.typeProprio and signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
+                        <div class="fr-col-12">
+                            <strong>Nom de la structure :</strong> {{ signalement.structureDeclarant }}
+                        </div>
+                        {% endif %}
                     {% endif %}
 
                     <div class="fr-col-12 fr-col-md-6">

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -277,8 +277,16 @@
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Date arrivée :</strong>
-                        {% if signalement.typeCompositionLogement %}
-                            {{ signalement.typeCompositionLogement.bailDpeDateEmmenagement }}
+                        {% if signalement.dateEntree %}
+                            {{ signalement.dateEntree.format('d/m/Y') ?? 'N/C' }}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Date d'effet du bail :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateEffetBail ?? 'N/C' }}
                         {% else %}
                             N/C
                         {% endif %}

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -92,6 +92,9 @@
                     {% endif %}
 
                     <div class="fr-col-12 fr-col-md-6">
+                        <strong>Civilité :</strong> {{ signalement.civiliteOccupant is same as 'mme' ? 'Madame' : signalement.civiliteOccupant is same as 'mr' ? 'Monsieur' : 'N/C' }}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
                         <strong>Nom :</strong> {{ signalement.nomOccupant }}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -122,7 +122,7 @@
                 <div class="fr-p-3v fr-background-alt--grey">
                     <div class="fr-grid-row">
                         <div class="fr-col-12 fr-col-md-9">
-                            <h4 class="fr-h6">Coordonnées du bailleur</h4>
+                            <h4 class="fr-h6">Informations sur le bailleur</h4>
                         </div>
                         <div class="fr-col-12 fr-col-md-3 fr-text--right">
                             {% if isNewFormEnabled %}
@@ -161,6 +161,50 @@
                         </div>
                         <div class="fr-col-12">
                             <strong>Adresse :</strong> {{ signalement.adresseProprio ? signalement.adresseProprio ~ ', ' ~ signalement.codePostalProprio ~ ' ' ~ signalement.villeProprio : 'N/C' }}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Bénéficiaire RSA :</strong>
+                            {% if signalement.informationComplementaire %}
+                                {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'oui' %}
+                                    {{ static_picto_yes|raw }}
+                                {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa is same as 'non' %}
+                                    {{ static_picto_no|raw }}
+                                {% else %}
+                                    Ne sait pas
+                                {% endif %}
+                            {% else %}
+                                N/C
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Bénéficiaire FSL :</strong>
+                            {% if signalement.informationComplementaire %}
+                                {% if signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'oui' %}
+                                    {{ static_picto_yes|raw }}
+                                {% elseif signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl is same as 'non' %}
+                                    {{ static_picto_no|raw }}
+                                {% else %}
+                                    Ne sait pas
+                                {% endif %}
+                            {% else %}
+                                N/C
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Revenu fiscal de référence :</strong>
+                            {% if signalement.informationComplementaire %}
+                                {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? 'N/C' }} €
+                            {% else %}
+                                N/C
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Date de naissance :</strong>
+                            {% if signalement.informationComplementaire %}
+                                {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? 'N/C' }}
+                            {% else %}
+                                N/C
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -268,6 +268,23 @@
                             N/C
                         {% endif %}
                     </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Montant du loyer :</strong> {{ signalement.loyer ?? 'N/C' }} €
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Paiement loyers à jour :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsLoyersPayes is same as 'oui' %}
+                                {{ static_picto_yes|raw }}
+                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsLoyersPayes is same as 'non' %}
+                                {{ static_picto_no|raw }}
+                            {% else %}
+                                Ne sait pas
+                            {% endif %}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -39,13 +39,19 @@
                             <strong>Type de déclarant :</strong> {{ signalement.profileDeclarant.label }}
                         </div>
                         <div class="fr-col-12">
-                            <strong>Type de bailleur :</strong> {{ signalement.typeProprio.label }}
+                            <strong>Type de bailleur :</strong> {{ signalement.typeProprio ? signalement.typeProprio.label : 'N/C' }}
                         </div>
                         {% if signalement.typeProprio and signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
                         <div class="fr-col-12">
                             <strong>Nom de la structure :</strong> {{ signalement.structureDeclarant }}
                         </div>
                         {% endif %}
+                        
+                    {% elseif signalement.lienDeclarantOccupant %}
+                        <div class="fr-col-12 fr-col-md-6">
+                            <strong>Lien :</strong>
+                            {{ signalement.lienDeclarantOccupant|signalement_lien_declarant_occupant }}
+                        </div>
                     {% endif %}
 
                     <div class="fr-col-12 fr-col-md-6">
@@ -61,17 +67,6 @@
                     <div class="fr-col-12">
                         <strong>Tél. :</strong> {{ signalement.telDeclarantDecoded }}
                     </div>
-                    {% if signalement.lienDeclarantOccupant %}
-                    <div class="fr-col-12 fr-col-md-6">
-                        <strong>Lien :</strong>
-                        {{ signalement.lienDeclarantOccupant|signalement_lien_declarant_occupant }}
-                    </div>
-                    {% endif %}
-                    {% if signalement.structureDeclarant %}
-                    <div class="fr-col-12 fr-col-md-6">
-                        <strong>Structure :</strong> {{ signalement.structureDeclarant }}
-                    </div>
-                    {% endif %}
                 </div>
             </div>
         </div>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -326,7 +326,7 @@
                         {% endif %}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
-                        <strong>Montant du loyer :</strong> {{ signalement.loyer ?? 'N/C' }} €
+                        <strong>Montant du loyer :</strong> {{ signalement.loyer ? signalement.loyer ~ ' €' : 'N/C' }}
                     </div>
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Paiement loyers à jour :</strong>
@@ -338,6 +338,14 @@
                             {% else %}
                                 Ne sait pas
                             {% endif %}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Année de construction :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {{ signalement.informationComplementaire.informationsComplementairesLogementAnneeConstruction }}
                         {% else %}
                             N/C
                         {% endif %}
@@ -652,7 +660,7 @@
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Revenu fiscal de référence :</strong>
                         {% if signalement.informationComplementaire %}
-                            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? 'N/C' }} €
+                            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ? signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ~ ' €' : 'N/C' }}
                         {% else %}
                             N/C
                         {% endif %}

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -563,6 +563,44 @@
                             N/C
                         {% endif %}
                     </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Bénéficiaire RSA :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa is same as 'oui' %}
+                                {{ static_picto_yes|raw }}
+                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa is same as 'non' %}
+                                {{ static_picto_no|raw }}
+                            {% else %}
+                                Ne sait pas
+                            {% endif %}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Bénéficiaire FSL :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireFsl is same as 'oui' %}
+                                {{ static_picto_yes|raw }}
+                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireFsl is same as 'non' %}
+                                {{ static_picto_no|raw }}
+                            {% else %}
+                                Ne sait pas
+                            {% endif %}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
+                    {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT  %}
+                    <div class="fr-col-12 fr-col-md-6">
+                        <strong>Revenu fiscal de référence :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? 'N/C' }} €
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -459,7 +459,7 @@
                     {% if signalement.typeCompositionLogement %}
                         <div class="fr-col-12 fr-col-md-6">
                             <strong>Au moins une des pièces à vivre > 9m² :</strong>
-                            {{ signalement.typeCompositionLogement.typeLogementCommoditesPieceAVivre9m is same as 'nsp' ? 'Ne sait pas' : signalement.typeCompositionLogement.typeLogementCommoditesPieceAVivre9m }}
+                            {{ signalement.typeCompositionLogement.typeLogementCommoditesPieceAVivre9m is same as 'nsp' ? 'Ne sait pas' : signalement.typeCompositionLogement.typeLogementCommoditesPieceAVivre9m ?? 'N/C' }}
                             {% include '_partials/signalement/display_alert.html.twig' with { 'display': signalement.typeCompositionLogement.typeLogementCommoditesPieceAVivre9m is same as 'non' } %}
                         </div>
                     {% endif %}
@@ -668,7 +668,7 @@
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Revenu fiscal de référence :</strong>
                         {% if signalement.informationComplementaire %}
-                            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ? signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ~ ' €' : 'N/C' }}
+                            {{ signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ~ ' €' : 'N/C' }}
                         {% else %}
                             N/C
                         {% endif %}

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -1129,7 +1129,7 @@
               {
                 "type": "SignalementFormDate",
                 "label": "Quelle est la date d'effet du bail ?",
-                "slug": "informations_complementaires_situation_occupants_date_emmenagement",
+                "slug": "informations_complementaires_situation_bailleur_date_effet_bail",
                 "validate": {
                   "required": false
                 }


### PR DESCRIPTION
## Ticket

#2037    

## Description
Toutes les informations qui étaient dans la partie cachée des "informations complémentaires" étaient (en partie) enregistrées, mais n'étaient pas affichées, ni éditables.

## Changements apportés
* Gestion des différents champs dans différentes zones de la fiche signalement
* Ajout d'une colonne typeProprio dans l'entité Signalement
* Correction de la date d'emménagement pour son affichage et son édition dans la fiche
* Ajout civilité quand nécessaire
* Séparation date d'emmenagement et date d'effet du bail dans l'enregistrement des données

## Pré-requis
`make load-migrations`

## Tests
- [ ] Faire un formulaire en locataire, remplir toutes les infos (dont informations complémentaires) et vérifier que les infos sont visibles et éditables dans la fiche signalement
- [ ] Idem bailleur occupant
- [ ] Idem bailleur
- [ ] Idem vieux formulaire
