### PR TITLE
[Sécurité] Ne pas afficher le champ details d'un signalement en raw

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -628,3 +628,7 @@ a.force-link-color {
 .text-word-break-all {
     word-break: break-all;
 }
+
+.white-space-pre-line {
+    white-space: pre-line;
+}

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -78,7 +78,7 @@
     <div v-else-if="formStore.currentScreen?.slug === 'validation_signalement' && formStore.data[idMessageAdministration] !== undefined">
       <br>
       <h3 class="fr-h6">Précisions sur les désordres</h3>
-      <p style="white-space: pre-line;">{{ formStore.data[idMessageAdministration] }}</p>
+      <p class="white-space-pre-line">{{ formStore.data[idMessageAdministration] }}</p>
     </div>
   </div>
 </template>

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -78,7 +78,7 @@
     <div v-else-if="formStore.currentScreen?.slug === 'validation_signalement' && formStore.data[idMessageAdministration] !== undefined">
       <br>
       <h3 class="fr-h6">Précisions sur les désordres</h3>
-      <p>{{ formStore.data[idMessageAdministration] }}</p>
+      <p style="white-space: pre-line;">{{ formStore.data[idMessageAdministration] }}</p>
     </div>
   </div>
 </template>

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -250,7 +250,7 @@ export default defineComponent({
       if (this.isFormDataSet('coordonnees_bailleur_prenom')) {
         result += this.formStore.data.coordonnees_bailleur_prenom + ' '
       }
-      result += this.formStore.data.coordonnees_bailleur_nom
+      result += this.formStore.data.coordonnees_bailleur_nom + '<br>'
       result += this.addLineIfNeeded('coordonnees_bailleur_email', 'Adresse email : ')
       result += this.addLineIfNeeded('coordonnees_bailleur_tel', 'Numéro de téléphone : ')
       result += this.addLineIfNeeded('coordonnees_bailleur_tel_secondaire', 'Numéro de téléphone secondaire : ')

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -250,7 +250,7 @@ export default defineComponent({
       if (this.isFormDataSet('coordonnees_bailleur_prenom')) {
         result += this.formStore.data.coordonnees_bailleur_prenom + ' '
       }
-      result += this.formStore.data.coordonnees_bailleur_nom + '<br>'
+      result += this.addLineIfNeeded('coordonnees_bailleur_nom')
       result += this.addLineIfNeeded('coordonnees_bailleur_email', 'Adresse email : ')
       result += this.addLineIfNeeded('coordonnees_bailleur_tel', 'Numéro de téléphone : ')
       result += this.addLineIfNeeded('coordonnees_bailleur_tel_secondaire', 'Numéro de téléphone secondaire : ')

--- a/templates/back/signalement/view/user-declaration.html.twig
+++ b/templates/back/signalement/view/user-declaration.html.twig
@@ -28,7 +28,7 @@
         <br>
         <ul class="fr-background-alt--blue-france fr-list--icon-img">
             <li class="fr-p-5v">
-                {{ signalement.details }}
+                {{ signalement.details|nl2br }}
             </li>
         </ul>
     </div>
@@ -109,7 +109,7 @@
         <br>
         <ul class="fr-background-alt--blue-france fr-list--icon-img">
             <li class="fr-p-5v">
-                {{ signalement.details }}
+                {{ signalement.details|nl2br }}
             </li>
         </ul>
     </div>

--- a/templates/back/signalement/view/user-declaration.html.twig
+++ b/templates/back/signalement/view/user-declaration.html.twig
@@ -28,7 +28,7 @@
         <br>
         <ul class="fr-background-alt--blue-france fr-list--icon-img">
             <li class="fr-p-5v">
-                {{ signalement.details|raw }}
+                {{ signalement.details }}
             </li>
         </ul>
     </div>
@@ -109,7 +109,7 @@
         <br>
         <ul class="fr-background-alt--blue-france fr-list--icon-img">
             <li class="fr-p-5v">
-                {{ signalement.details|raw }}
+                {{ signalement.details }}
             </li>
         </ul>
     </div>

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -85,7 +85,7 @@
         </section>
         <section>
             <h3>Description par l'occupant</h3>
-            <text>{{ signalement.details|raw }}</text>
+            <text>{{ signalement.details|nl2br }}</text>
         </section>
         <section>
             <table style="width: 100%">


### PR DESCRIPTION
## Ticket

#2062

## Description
Échappement de l'affichage du champ "details" d'un signalement en BO
Ajout d'un saut de ligne manquant dans le récap du nouveau formulaire

## Tests
- [ ] Vérifier que le code html/js envoyé dans le champ details du signalement et bien échappé à l'affichage
