### PR TITLE
[Performance] Script de synchronisation de base de donnée

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -14,6 +14,9 @@
     },
     {
       "command": "0 5 * * * php bin/console app:notify-visits"
+    },
+    {
+      "command": "0 1 * * * sh /app/scripts/sync-db.sh"
     }
   ]
 }

--- a/scripts/sync-db.sh
+++ b/scripts/sync-db.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-if [ "${APP}" == "histologe" ]; then
+if [ "${APP}" = "histologe" ]; then
     echo "This script cannot run in production."
     exit 1
 fi

--- a/scripts/sync-db.sh
+++ b/scripts/sync-db.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+if [ "${APP}" == "histologe" ]; then
+    echo "This script cannot run in production."
+    exit 1
+fi
+
+if [ -z "${RUN_SYNC_DB}" ] || [ "${RUN_SYNC_DB}" -ne 1 ]; then
+    echo "RUN_SYNC_DB environment variable is not set to 1. The script will not run."
+    exit 1
+fi
+
+archive_name="backup.tar.gz"
+
+# Install the Scalingo CLI tool in the container:
+echo ">>> Install the Scalingo CLI tool in the container"
+install-scalingo-cli
+
+# Install additional tools to interact with the database:
+echo ">>> Install additional tools to interact with the database"
+dbclient-fetcher mysql 5.7
+
+# Login to Scalingo, using the token stored in `DUPLICATE_API_TOKEN`:
+echo ">>> Login to Scalingo"
+scalingo login --api-token "${DUPLICATE_API_TOKEN}"
+
+# Retrieve the addon id:
+echo ">>> Retrieve the addon id"
+addon_id="$( scalingo --app "${DUPLICATE_SOURCE_APP}" addons \
+             | grep "${DUPLICATE_ADDON_KIND}" \
+             | cut -d "|" -f 3 \
+             | tr -d " " )"
+
+# Download the latest backup available for the specified addon:
+echo ">>> Download the latest backup available for the specified addon"
+scalingo --app "${DUPLICATE_SOURCE_APP}" --addon "${addon_id}" \
+    backups-download --output "${archive_name}"
+
+# Extract the archive containing the downloaded backup:
+echo ">>> Extraction the archive containing the downloaded backup"
+backup_file_name="$( tar --extract --verbose --file="${archive_name}" --directory="/app/" \
+                     | cut -d " " -f 2 | cut -d "/" -f 2 )"
+
+# Hack to make sure to get sql file
+backup_file_name="$(ls /app/*.sql)"
+
+# Remove CREATE and USE instruction from backup
+echo ">>> Remove CREATE and USE instruction"
+sed -i '/CREATE DATABASE/d' "${backup_file_name}"
+sed -i '/^USE/d' "${backup_file_name}"
+
+# Loading database
+echo ">>> Loading database"
+mysql -u ${DATABASE_USER} --password=${DATABASE_PASSWORD} -h ${DATABASE_HOST} -P ${DATABASE_PORT} ${DATABASE_NAME} < "${backup_file_name}"
+echo ">>> Done, thank you"


### PR DESCRIPTION
## Ticket

#1152    

## Description
Metabase sera déconnecté de la production afin d’être connecté à l'application histologe-preprod, ce script servira à faire la mise à jour de la base de prod de prod vers la preprod

## Changements apportés
* Ajout d'un script de synchro
* Définition d'un cron
* Ajout de variables d'environnements uniquement pour histologe-preprod ou review app si besoin **MAIS NE FONCTIONNERA PAS EN PRODUCTON**

| Variable d'environnement         | Description            |
|------------------------------------------|------------------------------|
| RUN_SYNC_DB               |  Permet d’exécuter le script                |
| DUPLICATE_ADDON_KIND      | Permet de définir le type d'addon scalingo            |
| DUPLICATE_API_TOKEN       | Token d’autorisation  d'API Scalingo  (doit être généré sur un compte ayant acces au projet)           |
| DUPLICATE_SOURCE_APP      | L'application source ou il faudrait aller chercher un backup de base donnée                |
| DATABASE_USER             | User de la base de donnée cible               |
| DATABASE_PASSWORD         |   Mot de passe de la base de données cible                           |
| DATABASE_HOST             |  Nom d'hôte de la base de données cible                            |
| DATABASE_PORT             |  Port de la base de données cible                            |
| DATABASE_NAME             |  Nom de la base de données cible                            |

## Tests
- [ ] Lancer le script sur la review app 
```bash
scalingo -a histologe-preprod-pr2066 run sh /app/scripts/sync-db.sh
```
- [ ] Se connecter à la review app et vérifier que vous avez bien des données de prod https://histologe-preprod-pr2066.osc-fr1.scalingo.io/

## Documentation
https://doc.scalingo.com/databases/mysql/dump-restore
https://doc.scalingo.com/platform/databases/duplicate
