### PR TITLE
[FO - Formulaire] Suppression de la vérification de l'ouverture de Stop Punaises

### DIFF
--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -72,8 +72,7 @@ const formStore: FormStore = reactive({
     ajaxurlGetSignalementDraft: '',
     platformName: '',
     urlApiAdress: 'https://api-adresse.data.gouv.fr/search/?q=',
-    ajaxurlCheckTerritory: '',
-
+    ajaxurlCheckTerritory: ''
   },
   screenData: [],
   currentScreen: null,
@@ -94,11 +93,6 @@ const formStore: FormStore = reactive({
   validationErrors: {}, // Les erreurs de validation
   updateData (key: string, value: any) {
     formStore.data[key] = value
-  },
-  isTerritoryOpenedOnStopPunaises (): boolean {
-    console.log(formStore.data.adresse_logement_adresse_detail_insee)
-    // TODO : trouver le meilleur moyen de relier histologe et stop-punaises
-    return true
   },
   shouldShowField (conditional: string) {
     return computed(() => eval(conditional)).value

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -522,13 +522,13 @@
           "slug": "desordres_batiment_nuisibles_punaises_details",
           "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
-            "show": "formStore.data.desordres_batiment_nuisibles_punaises === 1 && formStore.isTerritoryOpenedOnStopPunaises()" 
+            "show": "formStore.data.desordres_batiment_nuisibles_punaises === 1" 
           },
           "components": {
             "body": [
               {
                 "type": "SignalementFormInfo",
-                "label": "Le saviez-vous ? Sur votre département, le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
+                "label": "Le saviez-vous ? Le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
                 "slug": "desordres_batiment_nuisibles_punaises_details_info"
               }
             ]
@@ -2275,7 +2275,7 @@
           "slug": "desordres_logement_nuisibles_punaises_details",
           "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
-            "show": "formStore.data.desordres_logement_nuisibles_punaises === 1 && formStore.isTerritoryOpenedOnStopPunaises()" 
+            "show": "formStore.data.desordres_logement_nuisibles_punaises === 1" 
           },
           "components": {
             "body": [
@@ -2296,7 +2296,7 @@
               },
               {
                 "type": "SignalementFormInfo",
-                "label": "Le saviez-vous ? Sur votre département, le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
+                "label": "Le saviez-vous ? Le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
                 "slug": "desordres_logement_nuisibles_punaises_details_info"
               }
             ]

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -535,13 +535,13 @@
           "slug": "desordres_batiment_nuisibles_punaises_details",
           "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
-            "show": "formStore.data.desordres_batiment_nuisibles_punaises === 1 && formStore.isTerritoryOpenedOnStopPunaises()" 
+            "show": "formStore.data.desordres_batiment_nuisibles_punaises === 1" 
           },
           "components": {
             "body": [
               {
                 "type": "SignalementFormInfo",
-                "label": "Le saviez-vous ? Sur votre département, le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
+                "label": "Le saviez-vous ? Le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
                 "slug": "desordres_batiment_nuisibles_punaises_details_info"
               }
             ]
@@ -2247,7 +2247,7 @@
           "slug": "desordres_logement_nuisibles_punaises_details",
           "customCss": "signalement-form-subscreen-under-checkbox",
           "conditional": {
-            "show": "formStore.data.desordres_logement_nuisibles_punaises === 1 && formStore.isTerritoryOpenedOnStopPunaises()" 
+            "show": "formStore.data.desordres_logement_nuisibles_punaises === 1" 
           },
           "components": {
             "body": [
@@ -2272,7 +2272,7 @@
               },
               {
                 "type": "SignalementFormInfo",
-                "label": "Le saviez-vous ? Sur votre département, le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
+                "label": "Le saviez-vous ? Le service Stop Punaises vous permet de trouver une entreprise labellisée pour traiter les punaises de lit. <a href='http://stop-punaises.beta.gouv.fr/' target='_blank'>Cliquez ici pour y accéder.</a>",
                 "slug": "desordres_logement_nuisibles_punaises_details_info"
               }
             ]


### PR DESCRIPTION
## Ticket

#2057   

## Description
Puisque la plateforme Stop Punaises est à présent ouverte sur l'ensemble du territoire, on modifie le message et on affiche la plateforme pour tout le monde.

## Tests
- [ ] Signalement en tant qu'occupant, vérifier l'info qui apparait en batiment et en logement
- [ ] Signalement en tant que tiers, vérifier l'info qui apparait en batiment et en logement
