### PR TITLE
[QA - Sentry] Vérification sur nom et prénom avant de retourner le Nom complet

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -278,7 +278,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function getNomComplet()
     {
-        return mb_strtoupper($this->nom).' '.ucfirst($this->prenom);
+        return mb_strtoupper($this->nom ?? '').' '.ucfirst($this->prenom ?? '');
     }
 
     public function getStatut(): ?int


### PR DESCRIPTION
## Ticket

#2051   

## Description
On a une erreur Sentry lorsque le prénom est vide.
J'ai tenté de reproduire en supprimant le prénom d'un utilisateur, mais je n'ai pas d'erreur.
J'ai ajouté un test et testé les dommages collatéraux.

## Tests
- [ ] Supprimer le prénom d'un utilisateur et afficher le nom complet (par exemple : photos dans la page signalement, ou boutons dans la liste des utilisateurs d'un partenaire)
