### PR TITLE
[Ouverture] Enable auto-affectation in Seine St-Denis 93

### DIFF
--- a/migrations/Version20240103121522.php
+++ b/migrations/Version20240103121522.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240103121522 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enable auto-affectation in Seine St-Denis';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'UPDATE territory SET is_auto_affectation_enabled = 1 WHERE zip = \'93\''
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(
+            'UPDATE territory SET is_auto_affectation_enabled = 0 WHERE zip = \'93\''
+        );
+    }
+}


### PR DESCRIPTION
## Ticket

#2083    

## Description
Migration pour rendre la Seine-St-Denis en auto-affectation

## Changements apportés
* Migration

## Pré-requis

## Tests
- [ ] Jouer la migration, et vérifier en base que le 93 est bien en auto-affectation.

