### PR TITLE
Import/Mise à jour des données de la table commune

### DIFF
--- a/migrations/Version20240104143200.php
+++ b/migrations/Version20240104143200.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240104143200 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique index on commune.code_postal/commune.code_insee';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX code_postal_code_insee_unique ON commune (code_postal, code_insee)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX code_postal_code_insee_unique ON commune');
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -572,7 +572,8 @@ forms.forEach((form) => {
                             nextTabBtn.disabled = false;
                             setTimeout(() => {nextTabBtn.click()}, 50)
                         } else {
-                           dsfr(document.querySelector('#fr-modal-closed-territory')).modal.disclose();
+                            document.getElementById('fr-modal-closed-territory-content').innerHTML = r.message;
+                            dsfr(document.querySelector('#fr-modal-closed-territory')).modal.disclose();
                         }
                     })
                 } else {

--- a/src/Command/UpdateCommunesCommand.php
+++ b/src/Command/UpdateCommunesCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Command;
+
+use App\DataFixtures\Loader\LoadCommuneData;
+use App\Entity\Commune;
+use App\Entity\Territory;
+use App\Factory\CommuneFactory;
+use App\Service\Import\CsvParser;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[
+    AsCommand(
+        name: 'app:update-communes',
+        description: 'Update communes from csv file'
+    )
+]
+class UpdateCommunesCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private readonly ParameterBagInterface $params,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CsvParser $csvParser,
+        private readonly CommuneFactory $communeFactory,
+        private array $territories = [],
+        private array $communes = [],
+        private array $csvData = []
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+        $list = $this->entityManager->getRepository(Commune::class)->findAll();
+        foreach ($list as $commune) {
+            $this->communes[$commune->getCodePostal().'-'.$commune->getCodeInsee()] = $commune;
+        }
+        $list = $this->entityManager->getRepository(Territory::class)->findAll();
+        foreach ($list as $territory) {
+            $this->territories[$territory->getZip()] = $territory;
+        }
+        $this->csvData = $this->csvParser->parse($this->params->get('kernel.project_dir').LoadCommuneData::COMMUNE_LIST_CSV_PATH);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $nbUpdate = 0;
+        $nbInsert = 0;
+        $nbDelete = 0;
+
+        foreach ($this->csvData as $rowData) {
+            $itemCodeCommune = $rowData[LoadCommuneData::INDEX_CSV_CODE_COMMUNE];
+            $itemCodePostal = $rowData[LoadCommuneData::INDEX_CSV_CODE_POSTAL];
+            $itemNomCommune = $rowData[LoadCommuneData::INDEX_CSV_NOM_COMMUNE];
+
+            $keyCommune = $itemCodePostal.'-'.$itemCodeCommune;
+            if (isset($this->communes[$keyCommune])) {
+                if ($this->communes[$keyCommune]->getNom() != $itemNomCommune) {
+                    $this->communes[$keyCommune]->setNom($itemNomCommune);
+                    ++$nbUpdate;
+                }
+                unset($this->communes[$keyCommune]);
+                continue;
+            }
+
+            $zipCode = LoadCommuneData::getZipCodeByCodeCommune($itemCodeCommune);
+            $new = $this->communeFactory->createInstanceFrom(territory: $this->territories[$zipCode], nom: $itemNomCommune, codePostal: $itemCodePostal, codeInsee: $itemCodeCommune);
+            $this->entityManager->persist($new);
+            ++$nbInsert;
+            unset($this->communes[$keyCommune]);
+        }
+
+        foreach ($this->communes as $commune) {
+            $this->entityManager->remove($commune);
+            ++$nbDelete;
+        }
+
+        $this->entityManager->flush();
+
+        $this->io->success(sprintf('Inserted %d communes', $nbInsert));
+        $this->io->success(sprintf('Updated %d communes', $nbUpdate));
+        $this->io->success(sprintf('Deleted %d communes', $nbDelete));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/UpdateCommunesCommand.php
+++ b/src/Command/UpdateCommunesCommand.php
@@ -73,7 +73,12 @@ class UpdateCommunesCommand extends Command
             }
 
             $zipCode = LoadCommuneData::getZipCodeByCodeCommune($itemCodeCommune);
-            $new = $this->communeFactory->createInstanceFrom(territory: $this->territories[$zipCode], nom: $itemNomCommune, codePostal: $itemCodePostal, codeInsee: $itemCodeCommune);
+            $new = $this->communeFactory->createInstanceFrom(
+                territory: $this->territories[$zipCode],
+                nom: $itemNomCommune,
+                codePostal: $itemCodePostal,
+                codeInsee: $itemCodeCommune
+            );
             $this->entityManager->persist($new);
             ++$nbInsert;
             unset($this->communes[$keyCommune]);

--- a/src/Command/UpdatePartnerAndCommuneNDECommand.php
+++ b/src/Command/UpdatePartnerAndCommuneNDECommand.php
@@ -2,7 +2,6 @@
 
 namespace App\Command;
 
-use App\Entity\Commune;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\Qualification;
 use App\Entity\Territory;
@@ -122,14 +121,15 @@ class UpdatePartnerAndCommuneNDECommand extends Command
     private function updateCommunes(array $inseeCommunes)
     {
         foreach ($inseeCommunes as $codeInsee) {
-            /** @var Commune $commune */
-            $commune = $this->communeRepository->findOneBy(['codeInsee' => $codeInsee]);
-            if ($commune) {
+            $communes = $this->communeRepository->findBy(['codeInsee' => $codeInsee]);
+            if (!\count($communes)) {
+                $this->io->warning('No commune with insee code : '.$codeInsee);
+                continue;
+            }
+            foreach ($communes as $commune) {
                 $this->io->text('<info>Update commune setIsZonePermisLouer </info> : '.$commune->getNom());
                 $commune->setIsZonePermisLouer(true);
                 $this->entityManager->persist($commune);
-            } else {
-                $this->io->warning('No commune with insee code : '.$codeInsee);
             }
         }
         $this->entityManager->flush();

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -80,6 +80,12 @@ class FrontSignalementController extends AbstractController
         }
 
         $inseeCode = $request->get('insee');
+        if (!empty($inseeCode)) {
+            $commune = $communeRepository->findOneBy(['codePostal' => $postalCode, 'codeInsee' => $inseeCode]);
+            if (!$commune) {
+                return $this->json(['success' => false, 'message' => 'Le paramètre code postal et le code insee ne sont pas cohérent', 'label' => 'Erreur']);
+            }
+        }
         if ($postalCodeHomeChecker->isActive($postalCode, $inseeCode)) {
             return $this->json(['success' => true]);
         }

--- a/src/Entity/Commune.php
+++ b/src/Entity/Commune.php
@@ -4,8 +4,10 @@ namespace App\Entity;
 
 use App\Repository\CommuneRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 
 #[ORM\Entity(repositoryClass: CommuneRepository::class)]
+#[UniqueConstraint(name: 'code_postal_code_insee_unique', columns: ['code_postal', 'code_insee'])]
 class Commune
 {
     #[ORM\Id]

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -191,14 +191,16 @@ class PartnerType extends AbstractType
 
                 $zonesPdlList = explode(',', $form->get('zones_pdl')?->getData());
                 foreach ($zonesPdlList as $zonePdl) {
-                    /** @var Commune $commune */
-                    $commune = $this->communeManager->findOneBy(['codeInsee' => trim($zonePdl)]);
-                    if ($commune && $commune->getTerritory() === $territory) {
-                        $commune->setIsZonePermisLouer(true);
-                    } elseif (null === $commune) {
+                    $communes = $this->communeManager->findBy(['codeInsee' => trim($zonePdl)]);
+                    if (!\count($communes)) {
                         $form->get('zones_pdl')->addError(new FormError('Il n\'existe pas de commune avec le code insee '.trim($zonePdl)));
-                    } elseif ($commune->getTerritory() !== $territory) {
-                        $form->get('zones_pdl')->addError(new FormError('La commune avec le code insee '.trim($zonePdl).' ne fait pas partie du territoire du partenaire'));
+                    }
+                    foreach ($communes as $commune) {
+                        if ($commune->getTerritory() === $territory) {
+                            $commune->setIsZonePermisLouer(true);
+                        } elseif ($commune->getTerritory() !== $territory) {
+                            $form->get('zones_pdl')->addError(new FormError('La commune avec le code insee '.trim($zonePdl).' ne fait pas partie du territoire du partenaire'));
+                        }
                     }
                 }
             }

--- a/src/Validator/IsTerritoryActiveValidator.php
+++ b/src/Validator/IsTerritoryActiveValidator.php
@@ -29,8 +29,8 @@ class IsTerritoryActiveValidator extends ConstraintValidator
         $postalCode = $obj->getAdresseLogementAdresseDetailCodePostal();
         $inseeCode = $obj->getAdresseLogementAdresseDetailInsee();
         if ($postalCode && $inseeCode) {
-            $communes = $this->em->getRepository(Commune::class)->findBy(['codePostal' => $postalCode, 'codeInsee' => $inseeCode]);
-            if (!\count($communes)) {
+            $commune = $this->em->getRepository(Commune::class)->findOneBy(['codePostal' => $postalCode, 'codeInsee' => $inseeCode]);
+            if (!$commune) {
                 $message = 'Le code postal "'.$postalCode.'" et le code INSEE "'.$inseeCode.'" ne sont pas cohérents.';
                 $this->context
                     ->buildViolation($message)

--- a/templates/_partials/_modal_closed_territory.html.twig
+++ b/templates/_partials/_modal_closed_territory.html.twig
@@ -10,7 +10,21 @@
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-title-modal-closed-territory" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Avertissement</h1>
-                        <div id="fr-modal-closed-territory-content"></div>
+                        <div id="fr-modal-closed-territory-content">
+                            <p>
+                                Nous ne pouvons malheureusement pas traiter votre demande.<br>
+                                Le service {{ platform.name }} n'est pas encore ouvert dans votre département...
+                                Nous faisons tout pour le rendre disponible dès que possible !
+                                <br>
+                                En attendant, nous vous invitons à contacter gratuitement le service "Info logement indigne" au numéro suivant :
+                            </p>
+                            <p class="fr-text--center">
+                                <a href="tel:+33806706806" class="fr-link">
+                                    <span class="fr-icon-phone-line"></span>
+                                    0806 706 806
+                                </a>
+                            </p>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/templates/_partials/_modal_closed_territory.html.twig
+++ b/templates/_partials/_modal_closed_territory.html.twig
@@ -10,19 +10,7 @@
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-title-modal-closed-territory" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Avertissement</h1>
-                        <p>
-                            Nous ne pouvons malheureusement pas traiter votre demande.<br>
-                            Le service {{ platform.name }} n'est pas encore ouvert dans votre département...
-                            Nous faisons tout pour le rendre disponible dès que possible !
-                            <br>
-                            En attendant, nous vous invitons à contacter gratuitement le service "Info logement indigne" au numéro suivant :
-                        </p>
-                        <p class="fr-text--center">
-                            <a href="tel:+33806706806" class="fr-link">
-                                <span class="fr-icon-phone-line"></span>
-                                0806 706 806
-                            </a>
-                        </p>
+                        <div id="fr-modal-closed-territory-content"></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Ticket

#2081 

## Description
- Correction des fixtures de chargements des communes
- Commande `update-communes` de mise à jour des communes
- Remise en place du contrôle de cohérence code postal / code insee. L'erreur existante étant due au données non importées par erreur (cas d'un même code INSEE sur plusieurs code postaux)

## Changements apportés
* Ajout d'une contrainte d'unicité sur la paire "code_postal" et "code_insee" de la table commune
* Impact du fait que plusieurs ligne de commune peuvent avoir le même code INSEE, changement de `findOneBy` en `findBy`

## Pré-requis
Jouer la migration `make execute-migration name=Version20240104143200 direction=up`

## Tests
- [ ] Lancer la commande `make console app="update-communes"` sur une copie de la prod et vérifier que des communes sont ajoutés (718)
- [ ] Modifier des données dans la table commune et vérifier que le lancement de la commande fait les bon changement (mise à jour / ajout / suppression)
