### PR TITLE
manage NotEnabledTransitionException #2050

### DIFF
--- a/tests/Functional/Manager/InterventionManagerTest.php
+++ b/tests/Functional/Manager/InterventionManagerTest.php
@@ -14,6 +14,7 @@ use App\Repository\InterventionRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Workflow\WorkflowInterface;
@@ -28,6 +29,7 @@ class InterventionManagerTest extends KernelTestCase
     private SignalementQualificationUpdater $signalementQualificationUpdater;
     private FileFactory $fileFactory;
     private Security $security;
+    private LoggerInterface $logger;
 
     private ?InterventionManager $interventionManager = null;
 
@@ -45,6 +47,7 @@ class InterventionManagerTest extends KernelTestCase
         $this->security = static::getContainer()->get('security.helper');
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $this->logger = static::getContainer()->get(LoggerInterface::class);
 
         $this->interventionManager = new InterventionManager(
             $this->managerRegistry,
@@ -54,6 +57,7 @@ class InterventionManagerTest extends KernelTestCase
             $this->signalementQualificationUpdater,
             $this->fileFactory,
             $this->security,
+            $this->logger
         );
     }
 


### PR DESCRIPTION
## Ticket

#2050 

## Description
Gestion de l'erreur "NotEnabledTransitionException" en cas de tentative d'annulation d'une visite déjà annulé.

## Tests
- [ ] Créer une visite a venir sur une fiche signalement, ouvrir la même page du signalement sur deux onglets différents, annulé la visite via les deux onglets. La première annulation doit afficher un message flash de succés la seconde un message flash d'erreur (sans crasher l page)
