### PR TITLE
[Sécurité] Ajout en-têtes de sécurité manquantes dont la CSP

### DIFF
--- a/.env
+++ b/.env
@@ -48,7 +48,7 @@ MATOMO_SITE_ID=1
 ZAPIER_OILHI_TOKEN=
 ZAPIER_OILHI_USER_ID=
 ZAPIER_OILHI_CREATE_AIRTABLE_RECORD_ZAP_ID=
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: https://voxusagers.numerique.gouv.fr https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://koumoul.com; font-src 'self';"
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://voxusagers.numerique.gouv.fr https://*.tile.openstreetmap.org https://unpkg.com https://jedonnemonavis.numerique.gouv.fr; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://koumoul.com; font-src 'self';"
 
 ### histologe ###
 

--- a/.env
+++ b/.env
@@ -48,6 +48,7 @@ MATOMO_SITE_ID=1
 ZAPIER_OILHI_TOKEN=
 ZAPIER_OILHI_USER_ID=
 ZAPIER_OILHI_CREATE_AIRTABLE_RECORD_ZAP_ID=
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: https://voxusagers.numerique.gouv.fr https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://koumoul.com; font-src 'self';"
 
 ### histologe ###
 

--- a/.env.sample
+++ b/.env.sample
@@ -34,7 +34,7 @@ MATOMO_SITE_ID=1
 ZAPIER_OILHI_TOKEN=
 ZAPIER_OILHI_ID=
 ZAPIER_OILHI_CREATE_AIRTABLE_RECORD_ZAP_ID=
-SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: https://voxusagers.numerique.gouv.fr https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://koumoul.com; font-src 'self';"
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://voxusagers.numerique.gouv.fr https://*.tile.openstreetmap.org https://unpkg.com https://jedonnemonavis.numerique.gouv.fr; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://koumoul.com; font-src 'self';"
 
 ###> knplabs/knp-snappy-bundle ###
 WKHTMLTOPDF_PATH=wkhtmltopdf

--- a/.env.sample
+++ b/.env.sample
@@ -34,6 +34,7 @@ MATOMO_SITE_ID=1
 ZAPIER_OILHI_TOKEN=
 ZAPIER_OILHI_ID=
 ZAPIER_OILHI_CREATE_AIRTABLE_RECORD_ZAP_ID=
+SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.matomo.cloud https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: https://voxusagers.numerique.gouv.fr https://*.tile.openstreetmap.org https://unpkg.com; connect-src 'self' https://api-adresse.data.gouv.fr https://cdn.matomo.cloud https://koumoul.com; font-src 'self';"
 
 ###> knplabs/knp-snappy-bundle ###
 WKHTMLTOPDF_PATH=wkhtmltopdf

--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,4 +1,6 @@
 add_header X-Frame-Options "deny";
+add_header X-Content-Type-Options: nosniff;
+add_header X-XSS-Protection "1; mode=block";
 
 location ~* ^/_up/.*\.(jpg|jpeg|png)/.*$ {
     try_files $uri /index.php$is_args$args;

--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -2,6 +2,12 @@ add_header X-Frame-Options "deny";
 add_header X-Content-Type-Options: nosniff;
 add_header X-XSS-Protection "1; mode=block";
 
+# Traitement des images sans le paramètre uuid dans l'URL pour un usager
+location ~* ^/_up/.*\.(jpg|jpeg|png)$ {
+    try_files $uri /index.php$is_args$args;
+}
+
+# Traitement des images avec le paramètre uuid dans l'URL pour un utilisateur
 location ~* ^/_up/.*\.(jpg|jpeg|png)/.*$ {
     try_files $uri /index.php$is_args$args;
 }

--- a/public/index.php
+++ b/public/index.php
@@ -11,5 +11,8 @@ return function (array $context) {
         $context['APP_ENV'] = 'dev';
         $context['APP_DEBUG'] = true;
     }*/
+
+    $csp = isset($_SERVER['SECURITY_CSP_HEADER_VALUE']) ? $_SERVER['SECURITY_CSP_HEADER_VALUE'] : "";
+    header('Content-Security-Policy: '.$csp);
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };

--- a/public/index.php
+++ b/public/index.php
@@ -5,14 +5,9 @@ use App\Kernel;
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
-    /*dump($_SERVER['REMOTE_ADDR']);*/
-/*    if($_SERVER['REMOTE_ADDR'] === '37.165.161.217')
-    {
-        $context['APP_ENV'] = 'dev';
-        $context['APP_DEBUG'] = true;
-    }*/
+    if (null !== $csp = $_SERVER['SECURITY_CSP_HEADER_VALUE'] ?? null) {
+        header('Content-Security-Policy: '.$csp);
+    }
 
-    $csp = isset($_SERVER['SECURITY_CSP_HEADER_VALUE']) ? $_SERVER['SECURITY_CSP_HEADER_VALUE'] : "";
-    header('Content-Security-Policy: '.$csp);
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };


### PR DESCRIPTION
## Ticket

#1952    

## Description
En-têtes de sécurité manquantes https://dashlord.incubateur.net/url/histologe-beta-gouv-fr/securite/
Présentation des différentes directives utilisés de CSP (Content Security Policy)

| Directive        | Signification                                      |
| ----------------- | -------------------------------------------------- |
| `default-src`     | Sources par défaut pour toutes les catégories.    |
| `script-src`      | Sources autorisées pour les scripts.               |
| `style-src`       | Sources autorisées pour les styles.                |
| `img-src`         | Sources autorisées pour les images.                |
| `font-src`        | Sources autorisées pour les polices de caractères. |
| `connect-src`     | Sources autorisées pour les connexions réseau.     |

## Changements apportés
* Activation de la protection XSS avec la directive X-XSS-Protection.
* Activation de la protection qui empêche le navigateur de deviner le type de contenu
* Ajout de la directive Content-Security-Policy (CSP) pour contrôler les sources autorisées par la plateforme
 
## Pré-requis
* Exécuter `docker compose build histologe_nginx` 
* Executer `make down && make run`
* Executer `make tools-run` et activer matomo `MATOMO_ENABLE=1`

* Copier cette ligne dans `.env.local` (en local matomo est remplacé par l'url du container matomo `localhost:8083`

```bash
SECURITY_CSP_HEADER_VALUE="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8083 https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: blob: https://voxusagers.numerique.gouv.fr https://*.tile.openstreetmap.org https://unpkg.com https://jedonnemonavis.numerique.gouv.fr; connect-src 'self' https://api-adresse.data.gouv.fr http://localhost:8083 https://koumoul.com; font-src 'self';"

```
* Re-Executer `make down && make run`   (dans le doute) https://mattermost.incubateur.net/betagouv/pl/ptghnjyr37gc8d3ad35aa337ar

## Tests
- [ ] Vérifier que la politique de sécurité n’empêche pas le bon fonctionnement du site (avec l'inspecteur ouvert)
   * Test de bon fonctionnement sur l'auto-complétion des adresses
   * Déposer un signalement et vérifier que le bouton [Je donne mon avis] s'affiche. (à faire sur le nouveau formulaire)
   * Vérifier que le tracking matomo continue de fonctionner
   * Vérifier que la cartographie s'affiche
   * Sur la fiche signalement vérifier cliquer le bouton [Consulter DPE] et vérifier que l'appel http est effectué.

- [ ] Vérifier à l'aide d'une requête CURL la présence des 3 en-têtes manquantes
```bash
curl -I http://localhost:8080
````

```
Content-Security-Policy: default-src ....
X-Content-Type-Options:: nosniff
X-XSS-Protection: 1; mode=block
```

- [ ] Vérifier que la politique CSP ne bloque pas des ressources légitimes 

Exemple d'erreur :
![image](https://github.com/MTES-MCT/histologe/assets/5757116/49c14722-d14a-46a6-b0f2-5b4ede93c21a)

## Documentation
* [Content Security Policy (CSP) Quick Reference Guide](https://content-security-policy.com/)
* [Sécurité HTTP - Content Security Policy (CSP)](https://developer.mozilla.org/fr/docs/Web/HTTP/CSP#tester_une_r%C3%A8gle_csp)
* [Règle de sécurité du contenu](https://web.dev/articles/csp?hl=fr)


