### PR TITLE
[BO - Cartographie] Correction pour éviter l'absence d'affichage si le nom de l'occupant est vide

### DIFF
--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -83,7 +83,7 @@ async function getMarkers(offset) {
                         city: signalement.villeOccupant,
                         reference: signalement.reference,
                         score: signalement.score,
-                        name: signalement.nomOccupant.toUpperCase() +' '+ signalement.prenomOccupant,
+                        name: signalement.nomOccupant ? signalement.nomOccupant.toUpperCase() : '' +' '+ signalement.prenomOccupant,
                         url: `/bo/signalements/${signalement.uuid}`,
                         criteres: crit,
                         details: `${signalement.details}`


### PR DESCRIPTION
## Ticket

#2106   

## Description
Dans le nouveau formulaire, selon les profils, le nom de l'occupant est facultatif.
Sur la cartographie, lorsqu'on affiche les signalements, on met le nom de l'occupant en majuscule.
Si on appelle la méthode pour mettre en majuscule sur du vide, on a une erreur JS.

## Tests
- [ ] Raccourci : supprimer le nom de l'occupant dans un signalement via la BDD et vérifier que la carto s'affiche toujours
- [ ] Proprement : dans le nouveau formulaire, faire un signalement en tiers service de secours et ne pas remplir le nom de l'occupant, puis vérifier qu'il s'affiche tout de même dans la carto
