### PR TITLE
[bug] La commande de maj des commune ne dépends plus des fixtures

### DIFF
--- a/src/Command/UpdateCommunesCommand.php
+++ b/src/Command/UpdateCommunesCommand.php
@@ -2,11 +2,11 @@
 
 namespace App\Command;
 
-use App\DataFixtures\Loader\LoadCommuneData;
 use App\Entity\Commune;
 use App\Entity\Territory;
 use App\Factory\CommuneFactory;
 use App\Service\Import\CsvParser;
+use App\Utils\ImportCommune;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -48,7 +48,7 @@ class UpdateCommunesCommand extends Command
         foreach ($list as $territory) {
             $this->territories[$territory->getZip()] = $territory;
         }
-        $this->csvData = $this->csvParser->parse($this->params->get('kernel.project_dir').LoadCommuneData::COMMUNE_LIST_CSV_PATH);
+        $this->csvData = $this->csvParser->parse($this->params->get('kernel.project_dir').ImportCommune::COMMUNE_LIST_CSV_PATH);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -58,9 +58,9 @@ class UpdateCommunesCommand extends Command
         $nbDelete = 0;
 
         foreach ($this->csvData as $rowData) {
-            $itemCodeCommune = $rowData[LoadCommuneData::INDEX_CSV_CODE_COMMUNE];
-            $itemCodePostal = $rowData[LoadCommuneData::INDEX_CSV_CODE_POSTAL];
-            $itemNomCommune = $rowData[LoadCommuneData::INDEX_CSV_NOM_COMMUNE];
+            $itemCodeCommune = $rowData[ImportCommune::INDEX_CSV_CODE_COMMUNE];
+            $itemCodePostal = $rowData[ImportCommune::INDEX_CSV_CODE_POSTAL];
+            $itemNomCommune = $rowData[ImportCommune::INDEX_CSV_NOM_COMMUNE];
 
             $keyCommune = $itemCodePostal.'-'.$itemCodeCommune;
             if (isset($this->communes[$keyCommune])) {
@@ -72,7 +72,7 @@ class UpdateCommunesCommand extends Command
                 continue;
             }
 
-            $zipCode = LoadCommuneData::getZipCodeByCodeCommune($itemCodeCommune);
+            $zipCode = ImportCommune::getZipCodeByCodeCommune($itemCodeCommune);
             $new = $this->communeFactory->createInstanceFrom(
                 territory: $this->territories[$zipCode],
                 nom: $itemNomCommune,

--- a/src/Utils/ImportCommune.php
+++ b/src/Utils/ImportCommune.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Utils;
+
+class ImportCommune
+{
+    // File found here: https://www.data.gouv.fr/fr/datasets/codes-postaux/
+    public const COMMUNE_LIST_CSV_PATH = '/src/DataFixtures/Files/codespostaux.csv';
+
+    public const INDEX_CSV_CODE_POSTAL = 0;
+    public const INDEX_CSV_CODE_COMMUNE = 1;
+    public const INDEX_CSV_NOM_COMMUNE = 2;
+
+    public static function getZipCodeByCodeCommune($itemCodeCommune)
+    {
+        $codeCommune = $itemCodeCommune;
+        $codeCommune = str_pad($codeCommune, 5, '0', \STR_PAD_LEFT);
+        $zipCode = substr($codeCommune, 0, 2);
+        if ('97' == $zipCode) {
+            $zipCode = substr($codeCommune, 0, 3);
+        }
+
+        return $zipCode;
+    }
+}


### PR DESCRIPTION
## Ticket

#2107

## Description
Fix de la commande update-communes afin qu'elle ne dépende plus du DoctrineFixtureBundle

## Tests
- [ ] Lancer les fixtures `make load-fixtures`
- [ ] Lancer la commande `make console app="update-communes"`
