### PR TITLE
[SISH - Visite] Message notification

### DIFF
--- a/src/Service/Intervention/InterventionDescriptionGenerator.php
+++ b/src/Service/Intervention/InterventionDescriptionGenerator.php
@@ -26,14 +26,20 @@ class InterventionDescriptionGenerator
     {
         $labelVisite = strtolower($intervention->getType()->label());
         $partnerName = $intervention->getPartner() ? $intervention->getPartner()->getNom() : 'Non renseigné';
+        $today = new \DateTimeImmutable();
+        $isInPast = $today > $intervention->getScheduledAt()
+            && Intervention::STATUS_DONE === $intervention->getStatus();
 
         return sprintf(
-            '%s programmée : une %s du logement situé %s est prévue le %s.<br>La %s sera effectuée par %s.',
+            '%s %s : une %s du logement situé %s %s le %s.<br>La %s %s par %s.',
             ucfirst($labelVisite),
+            $isInPast ? 'réalisée' : 'programmée',
             $labelVisite,
             $intervention->getSignalement()->getAdresseOccupant(),
+            $isInPast ? 'a été effectuée' : 'est prévue',
             $intervention->getScheduledAt()->format('d/m/Y'),
             $labelVisite,
+            $isInPast ? 'a été réalisée' : 'sera effectuée',
             $partnerName
         );
     }

--- a/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
+++ b/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
@@ -51,7 +51,8 @@ class InterventionDescriptionGeneratorTest extends TestCase
             ->setDetails('Test description')
             ->setType(InterventionType::ARRETE_PREFECTORAL);
 
-        $this->assertEquals('Test description',
+        $this->assertEquals(
+            'Test description',
             InterventionDescriptionGenerator::generate(
                 $intervention,
                 InterventionCreatedEvent::NAME
@@ -69,19 +70,31 @@ class InterventionDescriptionGeneratorTest extends TestCase
 
     public function provideVisiteIntervention(): \Generator
     {
-        yield 'Visite de contrôle' => [
+        yield 'Visite de contrôle dans le passé' => [
             $this->getIntervention(
                 InterventionType::VISITE_CONTROLE,
                 new \DateTimeImmutable('2023-09-01'),
-                Intervention::STATUS_PLANNED
+                Intervention::STATUS_DONE
             ),
-            'Visite de contrôle programmée :',
+            'Visite de contrôle réalisée :',
             '25 rue du test',
             '01/09/2023',
             'ARS',
         ];
 
-        yield 'Visite' => [
+        yield 'Visite dans le passé' => [
+            $this->getIntervention(
+                InterventionType::VISITE,
+                new \DateTimeImmutable('2023-10-01'),
+                Intervention::STATUS_DONE
+            ),
+            'Visite réalisée',
+            '25 rue du test',
+            '01/10/2023',
+            'ARS',
+        ];
+
+        yield 'Visite dans le passé mais au status planned' => [
             $this->getIntervention(
                 InterventionType::VISITE,
                 new \DateTimeImmutable('2023-10-01'),
@@ -90,6 +103,31 @@ class InterventionDescriptionGeneratorTest extends TestCase
             'Visite programmée',
             '25 rue du test',
             '01/10/2023',
+            'ARS',
+        ];
+
+        $dateInFutur = (new \DateTimeImmutable())->add(new \DateInterval('P10D'));
+        yield 'Visite de contrôle dans le futur' => [
+            $this->getIntervention(
+                InterventionType::VISITE_CONTROLE,
+                $dateInFutur,
+                Intervention::STATUS_PLANNED
+            ),
+            'Visite de contrôle programmée :',
+            '25 rue du test',
+            $dateInFutur->format('d/m/Y'),
+            'ARS',
+        ];
+
+        yield 'Visite dans le futur' => [
+            $this->getIntervention(
+                InterventionType::VISITE,
+                $dateInFutur,
+                Intervention::STATUS_PLANNED
+            ),
+            'Visite programmée',
+            '25 rue du test',
+            $dateInFutur->format('d/m/Y'),
             'ARS',
         ];
     }


### PR DESCRIPTION
## Ticket

#1815    

## Description
Changer le message quand la visite envoyée par SISH est dans le passé.

## Changements apportés
* Changement de `InterventionDescriptionGenerator` et du test associé

## Pré-requis
`make mock-start`

## Tests
- [ ] `make console app="sync-esabora-sish-intervention"`
- [ ] Aller vérifier les suivis créés dans le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012
