### PR TITLE
[Sécurité] Correction typo X-Content-Type-Options

### DIFF
--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,5 +1,5 @@
 add_header X-Frame-Options "deny";
-add_header X-Content-Type-Options: nosniff;
+add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
 
 # Traitement des images sans le paramètre uuid dans l'URL pour un usager


### PR DESCRIPTION
## Ticket

#2113    

## Description
Erreur de non reconnaissance de header remonté par dashlord

## Changements apportés
* Correction typo

## Pré-requis
```bash
docker compose build histologe_nginx
make down && make run
```

## Tests
- [ ] Exécuter la commande ci dessous afin de vérifier la présence de `X-Content-Type-Options: nosniff`
```bash
 curl -I http://127.0.0.1:8080
```

