### PR TITLE
[BO - Export PDF] Date entree dans les lieux

### DIFF
--- a/migrations/Version20240115155416.php
+++ b/migrations/Version20240115155416.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240115155416 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Delete dateEntreee on signalement if date signalement < date Entree';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE signalement SET date_entree = null WHERE date_entree > created_at');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#2006

## Description
Migration pour remettre la date_entree à null si elle est postérieure à created_at

## Changements apportés
* Nouvelle migration

## Pré-requis

## Tests
- [ ] Soit charger la base de prod, soit modifier quelques date d'entrées de signalement avant de se mettre sur la branche
- [ ] Vérifier en base que les dates d'entrée concernées sont bien à null
