### PR TITLE
manage notificationMailer Exception #1807

### DIFF
--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -23,7 +23,8 @@
                                         </label>
                                         <input class="fr-input search-address-autocomplete" type="text" id="edit-address-search"
                                             data-fr-adresse-bo-autocomplete="true" data-form-id="form-edit-address" 
-                                            data-form-lat="{{ signalement.geoloc.lat }}" data-form-lng="{{ signalement.geoloc.lng }}" 
+                                            data-form-lat="{% if signalement.geoloc.lat is defined %}{{ signalement.geoloc.lat }}{% endif %}" 
+                                            data-form-lng="{% if signalement.geoloc.lng is defined %}{{ signalement.geoloc.lng }}{% endif %}" 
                                             {% if is_granted('ROLE_ADMIN') is not same as true %}data-form-limit="{{ signalement.territory.zip }}" {% endif %}>
                                         <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france search-address-autocomplete-list">
                                         </div>
@@ -48,8 +49,8 @@
                                     </div>
 
                                     <input type="hidden" name="insee" value="{{ signalement.inseeOccupant }}">
-                                    <input type="hidden" name="geolocLat" value="{{ signalement.geoloc.lat }}">
-                                    <input type="hidden" name="geolocLng" value="{{ signalement.geoloc.lng }}">
+                                    <input type="hidden" name="geolocLat" value="{% if signalement.geoloc.lat is defined %}{{ signalement.geoloc.lat }}{% endif %}">
+                                    <input type="hidden" name="geolocLng" value="{% if signalement.geoloc.lng is defined %}{{ signalement.geoloc.lng }}{% endif %}">
                                 </div>
                                 <div class="fr-col-12 fr-col-md-6">
                                     <h2 class="fr-h5">Complément d'adresse</h2>


### PR DESCRIPTION
## Ticket

#1807 

## Description
- Fix d'un crash lors de la fermeture / réouverture d'un signalement avec notification si l'email enregistré n'est pas au bon format 
- Fix d'un warning quand FEATURE_NEW_FORM_ENABLE=1 sur des signalements qui n'ont pas de latitude/longitude

## Tests
- [ ] Sur copie de la base de prod fermer/réouvrir le signalement 2021-1754 sur dept 24
- [ ] Sur copie de la bas de prod aller sur la fiche signalement du 2021-1729
