### PR TITLE
[BO - Signalement] Correction de l'édition de la composition du logement avec une superficie vide

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -422,7 +422,7 @@ class SignalementManager extends AbstractManager
     public function updateFromCompositionLogementRequest(Signalement $signalement, CompositionLogementRequest $compositionLogementRequest)
     {
         $signalement->setNatureLogement($compositionLogementRequest->getType());
-        $signalement->setSuperficie($compositionLogementRequest->getSuperficie());
+        $signalement->setSuperficie(!empty($compositionLogementRequest->getSuperficie()) ? $compositionLogementRequest->getSuperficie() : null);
 
         $typeCompositionLogement = new TypeCompositionLogement();
         if (!empty($signalement->getTypeCompositionLogement())) {


### PR DESCRIPTION
## Ticket

#2104   

## Description
Quand la superficie n'est pas renseignée, le formulaire plantait parce qu'il attendait un null|float

## Tests
- [ ] Editer un signalement en modifiant la superficie avec différents types de données
