### PR TITLE
[BO - Signalement] Rapport de visite non modifiable

### DIFF
--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -107,7 +107,7 @@ class SignalementFileController extends AbstractController
     ): JsonResponse {
         $this->denyAccessUnlessGranted('FILE_DELETE', $signalement);
         if ($this->isCsrfTokenValid('signalement_delete_file_'.$signalement->getId(), $request->get('_token'))) {
-            if ($uploadHandlerService->deleteFile($signalement, $type, $filename, $fileRepository)) {
+            if ($uploadHandlerService->deleteSignalementFile($signalement, $type, $filename, $fileRepository)) {
                 return $this->json(['response' => 'success']);
             }
         }

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -120,7 +120,7 @@ class UploadHandlerService
         $this->moveFilePath($distantFolder.$variantNames[ImageManipulationHandler::SUFFIX_THUMB]);
     }
 
-    public function deleteFile(Signalement $signalement, string $type, string $filename, FileRepository $fileRepository)
+    public function deleteSignalementFile(Signalement $signalement, string $type, string $filename, FileRepository $fileRepository): bool
     {
         $fileType = 'documents' === $type ? File::FILE_TYPE_DOCUMENT : File::FILE_TYPE_PHOTO;
 
@@ -133,23 +133,27 @@ class UploadHandlerService
 
         if (!$fileCollection->isEmpty()) {
             $file = $fileCollection->current();
-            if ($this->fileStorage->fileExists($file->getFilename())) {
-                $this->fileStorage->delete($file->getFilename());
-            }
-            $variantNames = ImageManipulationHandler::getVariantNames($filename);
-            if ($this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE])) {
-                $this->fileStorage->delete($variantNames[ImageManipulationHandler::SUFFIX_RESIZE]);
-            }
-            if ($this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
-                $this->fileStorage->delete($variantNames[ImageManipulationHandler::SUFFIX_THUMB]);
-            }
-
+            $this->deleteFileInBucket($file);
             $fileRepository->remove($file, true);
 
             return true;
         }
 
         return false;
+    }
+
+    public function deleteFileInBucket(File $file): void
+    {
+        if ($this->fileStorage->fileExists($file->getFilename())) {
+            $this->fileStorage->delete($file->getFilename());
+        }
+        $variantNames = ImageManipulationHandler::getVariantNames($file->getFilename());
+        if ($this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE])) {
+            $this->fileStorage->delete($variantNames[ImageManipulationHandler::SUFFIX_RESIZE]);
+        }
+        if ($this->fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
+            $this->fileStorage->delete($variantNames[ImageManipulationHandler::SUFFIX_THUMB]);
+        }
     }
 
     public function uploadFromFilename(string $filename): ?string

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -60,7 +60,7 @@
                 {% endif %}
             {% endif %}
         </div>
-        <div class="fr-mb-3v">
+        <div class="fr-mb-3v fr-display-inline-flex">
             <strong>Rapport :</strong>
             {% if signalement.interventions is empty or intervention.files is empty %}
                 <span class="fr-badge fr-badge--no-icon" title="Non disponible">Non disponible</span>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -74,11 +74,6 @@
                         target="_blank">Voir le rapport de visite
                     </a>
                 </li>
-                <li>
-                    <a href="{{ path('back_signalement_visite_deleterapport',{uuid:signalement.uuid, intervention:intervention.id}) }}?_token={{ csrf_token('delete_rapport') }}" title="Supprimer le rapport"
-                        class="fr-btn fr-btn--secondary fr-background--white fr-fi-delete-line ">
-                    </a>
-                </li>
             </ul>
             {% endif %}
         </div>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -63,9 +63,9 @@
         <div class="fr-mb-3v fr-display-inline-flex">
             <strong>Rapport :</strong>
             {% if signalement.interventions is empty or intervention.files is empty %}
-                <span class="fr-badge fr-badge--no-icon" title="Non disponible">Non disponible</span>
+                <span class="fr-badge fr-badge--no-icon" title="Non disponible">Non disponible</span> 
             {% else %}
-            <ul class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm">
+            <ul class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm fr-ml-0-5v">
                 <li>
                     <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
                         class="fr-btn"

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -61,20 +61,17 @@
             {% endif %}
         </div>
         <div class="fr-mb-3v fr-display-inline-flex">
-            <strong>Rapport :</strong>
+            <strong>Rapport : </strong>
             {% if signalement.interventions is empty or intervention.files is empty %}
                 <span class="fr-badge fr-badge--no-icon" title="Non disponible">Non disponible</span> 
             {% else %}
-            <ul class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm fr-ml-0-5v">
-                <li>
-                    <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
-                        class="fr-btn"
-                        title="Afficher le document"
-                        rel="noopener"
-                        target="_blank">Voir le rapport de visite
-                    </a>
-                </li>
-            </ul>
+                <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
+                    class="fr-btn fr-btn--sm"
+                    title="Afficher le document"
+                    rel="noopener"
+                    target="_blank">
+                    <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
+                </a>
             {% endif %}
         </div>
     </div>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -65,11 +65,21 @@
             {% if signalement.interventions is empty or intervention.files is empty %}
                 <span class="fr-badge fr-badge--no-icon" title="Non disponible">Non disponible</span>
             {% else %}
-                <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
-                    class="fr-btn fr-btn--sm fr-fi-file-line fr-btn--icon-left"
-                   title="Afficher le document"
-                   rel="noopener"
-                   target="_blank">Voir le rapport de visite</a>
+            <ul class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm">
+                <li>
+                    <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
+                        class="fr-btn"
+                        title="Afficher le document"
+                        rel="noopener"
+                        target="_blank">Voir le rapport de visite
+                    </a>
+                </li>
+                <li>
+                    <a href="{{ path('back_signalement_visite_deleterapport',{uuid:signalement.uuid, intervention:intervention.id}) }}?_token={{ csrf_token('delete_rapport') }}" title="Supprimer le rapport"
+                        class="fr-btn fr-btn--secondary fr-background--white fr-fi-delete-line ">
+                    </a>
+                </li>
+            </ul>
             {% endif %}
         </div>
     </div>

--- a/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
+++ b/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
@@ -104,4 +104,16 @@
     </legend>
     <input type="file" accept="application/*" name="visite-{{ formType }}[rapport]">
 </fieldset>
+{% elseif intervention is defined and intervention.files|length %}
+<fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
+	<ul class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm">
+		<li>
+			<a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ intervention.signalement.uuid }}" class="fr-btn" title="Afficher le document" rel="noopener" target="_blank">Voir le rapport de visite
+			</a>
+		</li>
+		<li>
+			<a href="{{ path('back_signalement_visite_deleterapport',{uuid:intervention.signalement.uuid, intervention:intervention.id}) }}?_token={{ csrf_token('delete_rapport') }}" title="Supprimer le rapport" class="fr-btn fr-btn--secondary fr-background--white fr-fi-delete-line "></a>
+		</li>
+	</ul>
+</fieldset>
 {% endif %}


### PR DESCRIPTION
## Ticket

#2071 

## Description
Ajout d'un bouton permettant de supprimer le rapport d'une visite (ce qui permet ensuite d'en uploader un autre via le bouton "Editer le rapport"

## Changements apportés
* Refactoring dans `UploadHandlerService` pour avoir une fonction `deleteFileInBucket`
 
## Tests
- [ ] Créer une visite passé sur un signalement, lui ajouter un document rapport, tester sa suppression et l'ajout d'un autre doc de remplacement
