### PR TITLE
[HOTFIX] [BO] Pouvoir supprimer les photo/document d'un signalement

### DIFF
--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -2,6 +2,10 @@ add_header X-Frame-Options "deny";
 add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
 
+location ~* ^/bo/signalements/.*\/delete$ {
+    try_files $uri /index.php$is_args$args;
+}
+
 # Traitement des images sans le paramètre uuid dans l'URL pour un usager
 location ~* ^/_up/.*\.(jpg|jpeg|png)$ {
     try_files $uri /index.php$is_args$args;


### PR DESCRIPTION
## Ticket

#2136   

## Description
La conf actuelle empêche la suppression de photo et de document (Erreur 404) sachant que la requête de suppresson ne devrait pas respecter les deux directives déjà présentes 

## Changements apportés
* Ajout d'une nouvelle directives qui renvoie la requête de suppression à symfony 

## Pré-requis
```
 docker compose build histologe_nginx && make down && make run
```
## Tests
- [ ] Ajout, affichage et suppression d'une image en tant qu’utilisateur
- [ ] Ajout, affichage et suppression d'un document en tant qu'usager
