### PR TITLE
[BO - Signalement] Créer des suivis automatiques lors de la modification d'un signalement

### DIFF
--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -407,7 +407,6 @@ class SignalementEditController extends AbstractController
         $suivi->setType(SUIVI::TYPE_AUTO);
 
         $this->entityManager->persist($suivi);
-        $this->entityManager->persist($signalement);
         $this->entityManager->flush();
     }
 }

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -59,7 +59,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'L\'adresse du logement a été modifiée par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'L\'adresse du logement a bien été modifiée.');
             } else {
@@ -99,7 +98,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'Les coordonnées du tiers déclarant ont été modifiées par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'Les coordonnées du tiers déclarant ont bien été modifiées.');
             } else {
@@ -143,7 +141,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'Les coordonnées du foyer ont été modifiées par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'Les coordonnées du foyer ont bien été modifiées.');
             } else {
@@ -187,7 +184,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'Les coordonnées du bailleur ont été modifiées par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'Les coordonnées du bailleur ont bien été modifiées.');
             } else {
@@ -231,7 +227,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'Les informations sur le logement ont été modifiées par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'Les informations du logement ont bien été modifiées.');
             } else {
@@ -275,7 +270,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'La composition du logement a été modifée par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'La composition du logement a bien été modifiée.');
             } else {
@@ -319,7 +313,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'La situation du foyer a été modifiée par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'La situation du foyer a bien été modifiée.');
             } else {
@@ -363,7 +356,6 @@ class SignalementEditController extends AbstractController
                 $this->addSuivi(
                     signalement: $signalement,
                     description: 'Les procédures et démarches ont été modifiées par ',
-                    isPublic: false,
                 );
                 $this->addFlash('success', 'Les procédures et démarches ont bien été modifiées.');
             } else {
@@ -393,14 +385,12 @@ class SignalementEditController extends AbstractController
     private function addSuivi(
         Signalement $signalement,
         string $description,
-        bool $isPublic,
     ): void {
         /** @var User $user */
         $user = $this->getUser();
         $suivi = $this->suiviFactory->createInstanceFrom(
             user: $user,
             signalement: $signalement,
-            isPublic: $isPublic
         );
 
         $suivi->setDescription($description.$user->getNomComplet());

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -13,6 +13,7 @@ use App\Dto\Request\Signalement\SituationFoyerRequest;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
+use App\EventListener\SignalementUpdatedListener;
 use App\Factory\SuiviFactory;
 use App\Manager\SignalementManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -42,6 +43,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_edit_address_'.$signalement->getId(), $request->get('_token'))) {
@@ -56,7 +58,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromAdresseOccupantRequest($signalement, $adresseOccupantRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'L\'adresse du logement a été modifiée par ',
                 );
@@ -78,6 +81,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid(
@@ -95,7 +99,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesTiersRequest($signalement, $coordonneesTiersRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'Les coordonnées du tiers déclarant ont été modifiées par ',
                 );
@@ -117,6 +122,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid(
@@ -138,7 +144,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesFoyerRequest($signalement, $coordonneesFoyerRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'Les coordonnées du foyer ont été modifiées par ',
                 );
@@ -160,6 +167,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid(
@@ -181,7 +189,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCoordonneesBailleurRequest($signalement, $coordonneesBailleurRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'Les coordonnées du bailleur ont été modifiées par ',
                 );
@@ -203,6 +212,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid(
@@ -224,7 +234,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromInformationsLogementRequest($signalement, $informationsLogementRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'Les informations sur le logement ont été modifiées par ',
                 );
@@ -246,6 +257,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid(
@@ -267,7 +279,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCompositionLogementRequest($signalement, $compositionLogementRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'La composition du logement a été modifée par ',
                 );
@@ -289,6 +302,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid(
@@ -310,7 +324,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromSituationFoyerRequest($signalement, $situationFoyerRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'La situation du foyer a été modifiée par ',
                 );
@@ -332,6 +347,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
+        SignalementUpdatedListener $listener
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid(
@@ -353,7 +369,8 @@ class SignalementEditController extends AbstractController
 
             if (empty($errorMessage)) {
                 $signalementManager->updateFromProcedureDemarchesRequest($signalement, $procedureDemarchesRequest);
-                $this->addSuivi(
+                $this->addSuiviIfNeeded(
+                    listener: $listener,
                     signalement: $signalement,
                     description: 'Les procédures et démarches ont été modifiées par ',
                 );
@@ -382,21 +399,24 @@ class SignalementEditController extends AbstractController
         return $errorMessage;
     }
 
-    private function addSuivi(
+    private function addSuiviIfNeeded(
+        SignalementUpdatedListener $listener,
         Signalement $signalement,
         string $description,
     ): void {
-        /** @var User $user */
-        $user = $this->getUser();
-        $suivi = $this->suiviFactory->createInstanceFrom(
-            user: $user,
-            signalement: $signalement,
-        );
+        if ($listener->updateOccurred()) {
+            /** @var User $user */
+            $user = $this->getUser();
+            $suivi = $this->suiviFactory->createInstanceFrom(
+                user: $user,
+                signalement: $signalement,
+            );
 
-        $suivi->setDescription($description.$user->getNomComplet());
-        $suivi->setType(SUIVI::TYPE_AUTO);
+            $suivi->setDescription($description.$user->getNomComplet());
+            $suivi->setType(SUIVI::TYPE_AUTO);
 
-        $this->entityManager->persist($suivi);
-        $this->entityManager->flush();
+            $this->entityManager->persist($suivi);
+            $this->entityManager->flush();
+        }
     }
 }

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -67,13 +67,17 @@ class SignalementFileController extends AbstractController
             list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName);
 
             if ($signalementFileProcessor->isValid()) {
+                $nbFiles = \count($fileList);
+                $description = (string) $nbFiles;
                 $suivi = $suiviFactory->createInstanceFrom($this->getUser(), $signalement);
                 // TODO : distinguer documents partenaires et documents sur la istuation usager
                 // TODO : afficher la liste des désordres concernés pour l'ajout de photo
                 if (FILE::INPUT_NAME_DOCUMENTS === $inputName) {
-                    $description = 'Un ou plusieurs documents partenaires ont été ajoutés au signalement :';
+                    $description .= $nbFiles > 1 ? ' documents partenaires ont été ajoutés au signalement :'
+                    : ' document partenaire a été ajouté au signalement :';
                 } else {
-                    $description = 'Une ou plusieurs photos ont été ajoutées au signalement :';
+                    $description .= $nbFiles > 1 ? ' photos ont été ajoutés au signalement :'
+                    : ' photo a été ajouté au signalement :';
                 }
                 $suivi->setDescription(
                     $description
@@ -130,7 +134,6 @@ class SignalementFileController extends AbstractController
                 $suivi->setType(SUIVI::TYPE_AUTO);
 
                 $entityManager->persist($suivi);
-                $entityManager->persist($signalement);
                 $entityManager->flush();
 
                 return $this->json(['response' => 'success']);

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Signalement;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+
+#[AsDoctrineListener(event: Events::onFlush)]
+class SignalementUpdatedListener
+{
+    private $updateOccurred = false;
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            Events::onFlush,
+        ];
+    }
+
+    public function onFlush(OnFlushEventArgs $args): void
+    {
+        $unitOfWork = $args->getObjectManager()->getUnitOfWork();
+
+        foreach ($unitOfWork->getScheduledEntityUpdates() as $entity) {
+            $changes = $unitOfWork->getEntityChangeSet($entity);
+
+            if ($entity instanceof Signalement) {
+                foreach ($changes as $key => $change) {
+                    if ($change[0] != $change[1]) {
+                        $this->updateOccurred = true;
+                    }
+                }
+            }
+        }
+    }
+
+    public function updateOccurred(): bool
+    {
+        return $this->updateOccurred;
+    }
+}

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -12,13 +12,6 @@ class SignalementUpdatedListener
 {
     private $updateOccurred = false;
 
-    public function getSubscribedEvents(): array
-    {
-        return [
-            Events::onFlush,
-        ];
-    }
-
     public function postUpdate(Signalement $signalement, PostUpdateEventArgs $event): void
     {
         $unitOfWork = $event->getObjectManager()->getUnitOfWork();

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -3,11 +3,11 @@
 namespace App\EventListener;
 
 use App\Entity\Signalement;
-use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
-use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Events;
 
-#[AsDoctrineListener(event: Events::onFlush)]
+#[AsEntityListener(event: Events::postUpdate, method: 'postUpdate', entity: Signalement::class)]
 class SignalementUpdatedListener
 {
     private $updateOccurred = false;
@@ -19,19 +19,14 @@ class SignalementUpdatedListener
         ];
     }
 
-    public function onFlush(OnFlushEventArgs $args): void
+    public function postUpdate(Signalement $signalement, PostUpdateEventArgs $event): void
     {
-        $unitOfWork = $args->getObjectManager()->getUnitOfWork();
+        $unitOfWork = $event->getObjectManager()->getUnitOfWork();
 
-        foreach ($unitOfWork->getScheduledEntityUpdates() as $entity) {
-            $changes = $unitOfWork->getEntityChangeSet($entity);
-
-            if ($entity instanceof Signalement) {
-                foreach ($changes as $key => $change) {
-                    if ($change[0] != $change[1]) {
-                        $this->updateOccurred = true;
-                    }
-                }
+        foreach ($unitOfWork->getEntityChangeSet($signalement) as $change) {
+            if ($change[0] != $change[1]) {
+                $this->updateOccurred = true;
+                break;
             }
         }
     }


### PR DESCRIPTION
## Ticket

#2054   

## Description
Ajout de suivis automatiques lorsqu'on modifie les différents blocs d'un signalement
| Déclencheur | Auteur | Contenu | Partagé à l'usager 
| :--- | :--- | :--- | :---: | 
| Edition de l'adresse | Nom de l'agent + nom du partenaire | L'adresse du logement a été modifiée par {{nom partenaire}} | Non
| Edition des coordonnées occupant | Nom de l'agent + nom du partenaire | Les coordonnées du foyer ont été modifiées par {{nom partenaire}} | Non
| Edition des coordonnées tiers déclarant | Nom de l'agent + nom du partenaire | Les coordonnées du tiers déclarant ont été modifiées par {{nom partenaire}} | Non
| Edition des coordonnées bailleur | Nom de l'agent + nom du partenaire | Les coordonnées du bailleur ont été modifiées par {{nom partenaire}} | Non
| Edition des info logement | Nom de l'agent + nom du partenaire | Les informations sur le logement ont été modifiées par {{nom partenaire}} | Non
| Edition de la composition du logement | Nom de l'agent + nom du partenaire | La composition du logement a été modifiée par {{nom partenaire}} | Non
| Edition de la situation du foyer | Nom de l'agent + nom du partenaire | La situation du foyer a été modifiée par {{nom partenaire}} | Non
| Edition de la procédure et démarches | Nom de l'agent + nom du partenaire | Les procédures et démarches ont été modifiées par {{nom partenaire}} | Non

Légères modifications lors des suivis automatiques d'ajout/suppression de documents et photos (le gros du boulot sera à faire lors du traitement du ticket #947 )

## Changements apportés
* Modification sur SignalementEditController
* Modification sur SignalementFileController

## Pré-requis

## Tests
- [ ] Modifier un signalement, et vérifier les suivis créés
