### PR TITLE
[BO][Staging] Des signalements avec qualifications sont non accessibles

### DIFF
--- a/src/Entity/SignalementQualification.php
+++ b/src/Entity/SignalementQualification.php
@@ -28,7 +28,7 @@ class SignalementQualification
     private array $criticites = [];
 
     #[ORM\Column(nullable: true)]
-    private array $desordrePrecisionIds = [];
+    private ?array $desordrePrecisionIds = [];
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $dernierBailAt = null;
@@ -89,7 +89,7 @@ class SignalementQualification
         return $this;
     }
 
-    public function getDesordrePrecisionIds(): array
+    public function getDesordrePrecisionIds(): ?array
     {
         return $this->desordrePrecisionIds;
     }


### PR DESCRIPTION
## Ticket

#2142    

## Description
L'une des dernières migrations applique `null` comme valeur par défaut pour `desordre_precision_ids`, alors que l'attribut de la classe est de type tableau uniquement ce qui provoque l'erreur 500 après que  l'objet `signalementQualification` soit hydraté.

Autoriser donc que l'attribut de la classe puisse accepter `null` comme valeur.

## Changements apportés
* Mise à jour du typage `desordrePrecisionIds`

## Pré-requis

## Tests
- [ ] Mettre à jour un signalement avec `null` pour `signalementQualification::desordre_precision_ids` avant de récupérer la PR et constater l'erreur
- [ ] Récupérer la branche et vérifier que la fiche s'affiche. 
