### PR TITLE
[Algo] Modifier la qualification assurantielle

### DIFF
--- a/src/DataFixtures/Files/DesordrePrecision.yml
+++ b/src/DataFixtures/Files/DesordrePrecision.yml
@@ -261,7 +261,7 @@ desordre_precision:
     is_danger: 1
     label: "Mur porteur fissuré : ne sait pas"
     qualification: ['NON_DECENCE', 'RSD', 'MISE_EN_SECURITE_PERIL']
-    desordre_precision_slug: "desordres_batiment_securite_murs_fissures_details_mur_porteur_non"
+    desordre_precision_slug: "desordres_batiment_securite_murs_fissures_details_mur_porteur_nsp"
     is_suroccupation: 0
   -
     desordre_critere_slug: "desordres_batiment_securite_balcons" 
@@ -915,7 +915,7 @@ desordre_precision:
     coef: 0
     is_danger: 0
     label: "<span>Dans : <b>Une ou des pièces à vivre (salon, chambres)</b></span><br><span class='fr-border--left'>Fuite ou dégat des eaux : non</span>" 
-    qualification: ['ASSURANTIEL']
+    qualification: []
     desordre_precision_slug: "desordres_logement_humidite_piece_a_vivre_details_fuite_non"
     is_suroccupation: 0
   -
@@ -923,7 +923,7 @@ desordre_precision:
     coef: 0
     is_danger: 0
     label: "<span>Dans : <b>La cuisine / le coin cuisine</b></span><br><span class='fr-border--left'>Fuite ou dégat des eaux : non</span>" 
-    qualification: ['ASSURANTIEL']
+    qualification: []
     desordre_precision_slug: "desordres_logement_humidite_cuisine_details_fuite_non"
     is_suroccupation: 0
   -
@@ -931,7 +931,7 @@ desordre_precision:
     coef: 0
     is_danger: 0
     label: "<span>Dans : <b>La salle de bain, salle d'eau et / ou les toilettes</b></span><br><span class='fr-border--left'>Fuite ou dégat des eaux : non</span>" 
-    qualification: ['ASSURANTIEL']
+    qualification: []
     desordre_precision_slug: "desordres_logement_humidite_salle_de_bain_details_fuite_non"
     is_suroccupation: 0
   -

--- a/src/Manager/DesordrePrecisionManager.php
+++ b/src/Manager/DesordrePrecisionManager.php
@@ -41,7 +41,9 @@ class DesordrePrecisionManager extends AbstractManager
         if (isset($data['procedure'])) {
             $procedure = explode(',', $data['procedure']);
             foreach ($procedure as $qualificationLabel) {
-                $qualification[] = Qualification::tryFromLabel($qualificationLabel);
+                if ('' !== trim($qualificationLabel)) {
+                    $qualification[] = Qualification::tryFromLabel(trim($qualificationLabel));
+                }
             }
         }
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -661,6 +661,12 @@ class SignalementManager extends AbstractManager
         if (!empty($signalement->getInformationProcedure())) {
             $informationProcedure = clone $signalement->getInformationProcedure();
         }
+
+        if ($procedureDemarchesRequest->getInfoProcedureAssuranceContactee()
+        !== $informationProcedure->getInfoProcedureAssuranceContactee()) {
+            $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
+        }
+
         $informationProcedure
             ->setInfoProcedureAssuranceContactee($procedureDemarchesRequest->getInfoProcedureAssuranceContactee())
             ->setInfoProcedureReponseAssurance($procedureDemarchesRequest->getInfoProcedureReponseAssurance())

--- a/src/Service/Signalement/Qualification/SignalementQualificationUpdater.php
+++ b/src/Service/Signalement/Qualification/SignalementQualificationUpdater.php
@@ -180,14 +180,8 @@ class SignalementQualificationUpdater
             }
         }
 
-        if (0 == $score) {
-            $this->addQualificationScore0(
-                $signalement,
-                $desordrePrecisionsQualifications,
-                $isInsalubriteObligatoire
-            );
-        } elseif (0 < $score && $score <= 10) {
-            $this->addQualificationScore1To10(
+        if (0 <= $score && $score <= 10) {
+            $this->addQualificationScore0To10(
                 $signalement,
                 $desordrePrecisionsQualifications,
                 $isInsalubriteObligatoire
@@ -259,7 +253,7 @@ class SignalementQualificationUpdater
         $signalement->addSignalementQualification($signalementQualification);
     }
 
-    private function addQualificationScore0(
+    private function addQualificationScore0To10(
         Signalement $signalement,
         array $desordrePrecisionsQualifications,
         bool $isInsalubriteObligatoire,
@@ -284,45 +278,14 @@ class SignalementQualificationUpdater
                 Qualification::INSALUBRITE,
                 QualificationStatus::INSALUBRITE_CHECK
             );
-        } else {
-            if (
-                !\in_array(Qualification::NON_DECENCE->value, $desordrePrecisionsQualifications)
-                && !\in_array(Qualification::RSD->value, $desordrePrecisionsQualifications)
-                && \in_array(Qualification::ASSURANTIEL->value, $desordrePrecisionsQualifications)
-            ) {
-                $this->addOneQualification(
-                    $signalement,
-                    Qualification::ASSURANTIEL,
-                    QualificationStatus::ASSURANTIEL_CHECK
-                );
-            }
         }
-    }
-
-    private function addQualificationScore1To10(
-        Signalement $signalement,
-        array $desordrePrecisionsQualifications,
-        bool $isInsalubriteObligatoire,
-    ): void {
-        if (\in_array(Qualification::NON_DECENCE->value, $desordrePrecisionsQualifications)) {
+        if (\in_array(Qualification::ASSURANTIEL->value, $desordrePrecisionsQualifications)
+        && 'oui' !== $signalement->getInformationProcedure()->getInfoProcedureAssuranceContactee()
+        ) {
             $this->addOneQualification(
                 $signalement,
-                Qualification::NON_DECENCE,
-                QualificationStatus::NON_DECENCE_CHECK
-            );
-        }
-        if (\in_array(Qualification::RSD->value, $desordrePrecisionsQualifications)) {
-            $this->addOneQualification(
-                $signalement,
-                Qualification::RSD,
-                QualificationStatus::RSD_CHECK
-            );
-        }
-        if ($isInsalubriteObligatoire) {
-            $this->addOneQualification(
-                $signalement,
-                Qualification::INSALUBRITE,
-                QualificationStatus::INSALUBRITE_CHECK
+                Qualification::ASSURANTIEL,
+                QualificationStatus::ASSURANTIEL_CHECK
             );
         }
     }

--- a/tests/Functional/Service/Signalement/Qualification/QualificationServiceTest.php
+++ b/tests/Functional/Service/Signalement/Qualification/QualificationServiceTest.php
@@ -103,7 +103,8 @@ class QualificationServiceTest extends KernelTestCase
         int $score,
         array $listDesordrePrecision,
         array $qualificationsToCheck,
-        array $qualificationsStatusToCheck
+        array $qualificationsStatusToCheck,
+        string $isAssuranceContactee = 'non'
     ): void {
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
         $desordrePrecisionRepository = $this->entityManager->getRepository(DesordrePrecision::class);
@@ -117,6 +118,9 @@ class QualificationServiceTest extends KernelTestCase
         }
         // set new DesordrePrecisions
         $signalement->setScore($score);
+
+        $signalement->getInformationProcedure()->setInfoProcedureAssuranceContactee($isAssuranceContactee);
+
         foreach ($listDesordrePrecision as $desordrePrecisionSlug) {
             $signalement->addDesordrePrecision($desordrePrecisionRepository->findOneBy(
                 ['desordrePrecisionSlug' => $desordrePrecisionSlug]
@@ -145,80 +149,39 @@ class QualificationServiceTest extends KernelTestCase
         ];
 
         $listSlugDesordrePrecision = [
+            'desordres_type_composition_logement_cuisine_collective_oui',
             'desordres_logement_humidite_piece_a_vivre_details_fuite_oui',
         ];
-        yield 'Score 0, ASSURANTIEL' => [
-            0,
+        yield 'Score 1, NON_DECENCE et ASSURANTIEL car assurance non contactée' => [
+            1,
             $listSlugDesordrePrecision,
-            [Qualification::ASSURANTIEL],
-            [QualificationStatus::ASSURANTIEL_CHECK],
+            [Qualification::NON_DECENCE, Qualification::ASSURANTIEL],
+            [QualificationStatus::NON_DECENCE_CHECK, QualificationStatus::ASSURANTIEL_CHECK],
+            'non',
         ];
 
         $listSlugDesordrePrecision = [
             'desordres_type_composition_logement_cuisine_collective_oui',
+            'desordres_logement_humidite_piece_a_vivre_details_fuite_oui',
         ];
-        yield 'Score 0, NON DECENCE' => [
-            0,
+        yield 'Score 1, NON_DECENCE et ASSURANTIEL car ne sait pas' => [
+            1,
+            $listSlugDesordrePrecision,
+            [Qualification::NON_DECENCE, Qualification::ASSURANTIEL],
+            [QualificationStatus::NON_DECENCE_CHECK, QualificationStatus::ASSURANTIEL_CHECK],
+            'nsp',
+        ];
+
+        $listSlugDesordrePrecision = [
+            'desordres_type_composition_logement_cuisine_collective_oui',
+            'desordres_logement_humidite_piece_a_vivre_details_fuite_oui',
+        ];
+        yield 'Score 1, NON_DECENCE et pas ASSURANTIEL car assurance contactée' => [
+            1,
             $listSlugDesordrePrecision,
             [Qualification::NON_DECENCE],
             [QualificationStatus::NON_DECENCE_CHECK],
-        ];
-
-        $listSlugDesordrePrecision = [
-            'desordres_type_composition_logement_plusieurs_pieces_aucune_piece_9',
-        ];
-        yield 'Score 0, NON DECENCE et RSD' => [
-            0,
-            $listSlugDesordrePrecision,
-            [Qualification::NON_DECENCE, Qualification::RSD],
-            [QualificationStatus::NON_DECENCE_CHECK, QualificationStatus::RSD_CHECK],
-        ];
-
-        $listSlugDesordrePrecision = [
-            'desordres_batiment_accessibilite_acces_batiment',
-        ];
-        yield 'Score 0, RSD' => [
-            0,
-            $listSlugDesordrePrecision,
-            [Qualification::RSD],
-            [QualificationStatus::RSD_CHECK],
-        ];
-
-        $listSlugDesordrePrecision = [
-            'desordres_type_composition_logement_sous_combles',
-            'desordres_batiment_accessibilite_acces_batiment',
-        ];
-        yield 'Score 0, RSD et INSALUBRITE OBLIGATOIRE' => [
-            0,
-            $listSlugDesordrePrecision,
-            [Qualification::RSD, Qualification::INSALUBRITE],
-            [QualificationStatus::RSD_CHECK, QualificationStatus::INSALUBRITE_CHECK],
-        ];
-
-        $listSlugDesordrePrecision = [
-            'desordres_type_composition_logement_sous_combles',
-            'desordres_type_composition_logement_cuisine_collective_oui',
-        ];
-        yield 'Score 0, NON DECENCE et INSALUBRITE OBLIGATOIRE' => [
-            0,
-            $listSlugDesordrePrecision,
-            [Qualification::NON_DECENCE, Qualification::INSALUBRITE],
-            [QualificationStatus::NON_DECENCE_CHECK, QualificationStatus::INSALUBRITE_CHECK],
-        ];
-
-        $listSlugDesordrePrecision = [
-            'desordres_type_composition_logement_sous_combles',
-            'desordres_type_composition_logement_plusieurs_pieces_aucune_piece_9',
-        ];
-        yield 'Score 0, NON DECENCE et RSD et INSALUBRITE OBLIGATOIRE' => [
-            0,
-            $listSlugDesordrePrecision,
-            [Qualification::NON_DECENCE, Qualification::RSD, Qualification::INSALUBRITE],
-            [
-                QualificationStatus::NON_DECENCE_CHECK,
-                QualificationStatus::RSD_CHECK,
-                QualificationStatus::INSALUBRITE_CHECK,
-            ],
+            'oui',
         ];
 
         $listSlugDesordrePrecision = [


### PR DESCRIPTION
## Ticket

#2150    

## Description
Supprimer la tranche score = 0
Revoir la tranche score entre 0 et 10 pour inclure l'assurantiel (voir ci-dessous)
Retirer la qualification "Assurantiel" dans le cas où Dégâts des eaux = NON -> à jour dans le [tableau](https://docs.google.com/spreadsheets/d/12uJcJAWNm9W5R_A6Eh5vwhtLy2ThBNz3CCdkws-ZeIs/edit#gid=1647854560) lignes 115 à 117
Penser à l'édition BO de "Procédure et démarche" -> si on bascule Contact assurance en Oui ou en Non

## Changements apportés
* Mise à jour des fixtures
* 

## Pré-requis

## Tests
- [ ] Faire un signalement avec seulement le désordre `Le logement est humide et a des traces de moisissures` et a `Fuite ou dégâts des eaux` choisir 'oui' (pour 1 ou plusieurs pièces
- [ ] Valider le signalement (qui doit avoir un score inférieur à 10
- [ ] Modifier le bloc procédures et démarches, "assurance contactée", si l'assurance est contactée, la qualf assurantielle n'apparait pas, sinon elle apparait
