### PR TITLE
[BO - Signalement] Affichage des photos dans un album

### DIFF
--- a/assets/controllers/view_signalement.js
+++ b/assets/controllers/view_signalement.js
@@ -5,3 +5,50 @@ document?.querySelector('#btn-display-all-suivis')?.addEventListeners('click tou
     })
     document.querySelector('#btn-display-all-suivis').classList.add('fr-hidden')
 })
+
+document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
+    const swipeId = btn.getAttribute('data-id')
+    btn.addEventListeners('click touchdown', (event) => {
+        document?.querySelectorAll('.photos-album')?.forEach(element => {
+            element.classList?.remove('fr-hidden')
+
+            displayPhotoAlbum(swipeId)
+        })
+    })
+})
+document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
+    btn.addEventListeners('click touchdown', (event) => {
+        document?.querySelectorAll('.photos-album')?.forEach(element => {
+            element.classList?.add('fr-hidden')
+        })
+    })
+})
+document?.querySelectorAll('.photos-album-swipe')?.forEach(btn => {
+    const swipeDirection = Number(btn.getAttribute('data-direction'))
+
+    btn.addEventListeners('click touchdown', (event) => {
+        let currentId = null
+        document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
+            currentId = Number(element.getAttribute('data-id'))
+        })
+        let newIndex = histoPhotoIds.indexOf(currentId)
+        newIndex += Number(swipeDirection)
+        if (newIndex < 0) {
+            newIndex = histoPhotoIds.length - 1
+        }
+        if (newIndex > histoPhotoIds.length - 1) {
+            newIndex = 0
+        }
+        displayPhotoAlbum(histoPhotoIds[newIndex])
+    })
+})
+const displayPhotoAlbum = (photoId) => {
+    document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
+        element.classList?.remove('loop-current')
+        element.classList?.add('fr-hidden')
+    })
+    document?.querySelectorAll('.photos-album-image-item[data-id="'+photoId+'"]')?.forEach(element => {
+        element.classList?.add('loop-current')
+        element.classList?.remove('fr-hidden')
+    })
+}

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -694,9 +694,17 @@ div.photos-album {
                 }
                 div:nth-child(2) {
                     flex: 1;
+                    height: calc(100% - 12rem - 40px);
+
+                    img {
+                        max-width: 100%;
+                        max-height: 100%;
+                    }
                 }
                 div:nth-child(3) {
                     height: 4rem;
+                    display: flex;
+                    align-items: center;
                 }
             }
         }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -646,3 +646,53 @@ a.force-link-color {
 .bloc-list .fr-grid-row .fr-grid-row .fr-col-12 {
     padding: 0 0.75rem;
 }
+
+div.photos-album {
+    position: fixed;
+    left: 0px;
+    top: 0px;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.9);
+    z-index: 2999;
+    padding: 2rem;
+
+    .photos-album-close-button-container {
+        text-align: right;
+    }
+
+    .photos-album-navigation-container {
+        display: flex;
+        height: calc(100% - 4rem);
+
+        > div {
+            height: 100%;
+        }
+
+        div:nth-child(1), div:nth-child(3) {
+            display: flex;
+            align-items: center;
+        }
+
+        div:nth-child(2) {
+            flex: 1;
+
+            .photos-album-image-item {
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                text-align: center;
+    
+                div:nth-child(1) {
+                    height: 4rem;
+                }
+                div:nth-child(2) {
+                    flex: 1;
+                }
+                div:nth-child(3) {
+                    height: 4rem;
+                }
+            }
+        }
+    }
+}

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -656,6 +656,7 @@ div.photos-album {
     background: rgba(0, 0, 0, 0.9);
     z-index: 2999;
     padding: 2rem;
+    color: white;
 
     .photos-album-close-button-container {
         text-align: right;
@@ -669,7 +670,7 @@ div.photos-album {
             height: 100%;
         }
 
-        div:nth-child(1), div:nth-child(3) {
+        > div:nth-child(1), > div:nth-child(3) {
             display: flex;
             align-items: center;
         }
@@ -678,10 +679,15 @@ div.photos-album {
             flex: 1;
 
             .photos-album-image-item {
+                height: 100%;
+                min-height: 100%;
                 display: flex;
                 flex-direction: column;
-                justify-content: center;
-                text-align: center;
+                
+                div {
+                    justify-content: center;
+                    text-align: center;
+                }
     
                 div:nth-child(1) {
                     height: 4rem;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -912,6 +912,16 @@ document?.querySelector('#partner_add_user,#situation_add_critere')?.addEventLis
     container.appendChild(row);
 })
 
+document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
+    const swipeIndex = btn.getAttribute('data-index')
+    btn.addEventListeners('click touchdown', (event) => {
+        document?.querySelectorAll('.photos-album')?.forEach(element => {
+            element.classList?.remove('fr-hidden')
+
+            displayPhotoAlbum(swipeIndex)
+        })
+    })
+})
 document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
     btn.addEventListeners('click touchdown', (event) => {
         document?.querySelectorAll('.photos-album')?.forEach(element => {
@@ -936,16 +946,19 @@ document?.querySelectorAll('.photos-album-swipe')?.forEach(btn => {
             currentIndex = 1
         }
 
-        document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
-            element.classList?.remove('loop-current')
-            element.classList?.add('fr-hidden')
-        })
-        document?.querySelectorAll('.photos-album-image-item[data-index="'+currentIndex+'"]')?.forEach(element => {
-            element.classList?.add('loop-current')
-            element.classList?.remove('fr-hidden')
-        })
+        displayPhotoAlbum(currentIndex)
     })
 })
+const displayPhotoAlbum = (index) => {
+    document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
+        element.classList?.remove('loop-current')
+        element.classList?.add('fr-hidden')
+    })
+    document?.querySelectorAll('.photos-album-image-item[data-index="'+index+'"]')?.forEach(element => {
+        element.classList?.add('loop-current')
+        element.classList?.remove('fr-hidden')
+    })
+}
 
 document?.querySelectorAll('[data-tag-delete]')?.forEach(delBtn => {
     delBtn.addEventListener('click', deleteTagEvent)

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -913,12 +913,12 @@ document?.querySelector('#partner_add_user,#situation_add_critere')?.addEventLis
 })
 
 document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
-    const swipeIndex = btn.getAttribute('data-index')
+    const swipeId = btn.getAttribute('data-id')
     btn.addEventListeners('click touchdown', (event) => {
         document?.querySelectorAll('.photos-album')?.forEach(element => {
             element.classList?.remove('fr-hidden')
 
-            displayPhotoAlbum(swipeIndex)
+            displayPhotoAlbum(swipeId)
         })
     })
 })
@@ -930,31 +930,29 @@ document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
     })
 })
 document?.querySelectorAll('.photos-album-swipe')?.forEach(btn => {
-    const swipeValue = btn.getAttribute('data-value')
-    let currentIndex = 0
-    let currentLoopLength = 0
+    const swipeDirection = Number(btn.getAttribute('data-direction'))
+
     btn.addEventListeners('click touchdown', (event) => {
         document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
-            currentIndex = Number(element.getAttribute('data-index'))
-            currentLoopLength = Number(element.getAttribute('data-length'))
+            currentId = Number(element.getAttribute('data-id'))
         })
-        currentIndex += Number(swipeValue)
-        if (currentIndex < 1) {
-            currentIndex = currentLoopLength
+        let newIndex = histoPhotoIds.indexOf(currentId)
+        newIndex += Number(swipeDirection)
+        if (newIndex < 0) {
+            newIndex = histoPhotoIds.length - 1
         }
-        if (currentIndex > currentLoopLength) {
-            currentIndex = 1
+        if (newIndex > histoPhotoIds.length - 1) {
+            newIndex = 0
         }
-
-        displayPhotoAlbum(currentIndex)
+        displayPhotoAlbum(histoPhotoIds[newIndex])
     })
 })
-const displayPhotoAlbum = (index) => {
+const displayPhotoAlbum = (photoId) => {
     document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
         element.classList?.remove('loop-current')
         element.classList?.add('fr-hidden')
     })
-    document?.querySelectorAll('.photos-album-image-item[data-index="'+index+'"]')?.forEach(element => {
+    document?.querySelectorAll('.photos-album-image-item[data-id="'+photoId+'"]')?.forEach(element => {
         element.classList?.add('loop-current')
         element.classList?.remove('fr-hidden')
     })

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -912,52 +912,6 @@ document?.querySelector('#partner_add_user,#situation_add_critere')?.addEventLis
     container.appendChild(row);
 })
 
-document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
-    const swipeId = btn.getAttribute('data-id')
-    btn.addEventListeners('click touchdown', (event) => {
-        document?.querySelectorAll('.photos-album')?.forEach(element => {
-            element.classList?.remove('fr-hidden')
-
-            displayPhotoAlbum(swipeId)
-        })
-    })
-})
-document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
-    btn.addEventListeners('click touchdown', (event) => {
-        document?.querySelectorAll('.photos-album')?.forEach(element => {
-            element.classList?.add('fr-hidden')
-        })
-    })
-})
-document?.querySelectorAll('.photos-album-swipe')?.forEach(btn => {
-    const swipeDirection = Number(btn.getAttribute('data-direction'))
-
-    btn.addEventListeners('click touchdown', (event) => {
-        document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
-            currentId = Number(element.getAttribute('data-id'))
-        })
-        let newIndex = histoPhotoIds.indexOf(currentId)
-        newIndex += Number(swipeDirection)
-        if (newIndex < 0) {
-            newIndex = histoPhotoIds.length - 1
-        }
-        if (newIndex > histoPhotoIds.length - 1) {
-            newIndex = 0
-        }
-        displayPhotoAlbum(histoPhotoIds[newIndex])
-    })
-})
-const displayPhotoAlbum = (photoId) => {
-    document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
-        element.classList?.remove('loop-current')
-        element.classList?.add('fr-hidden')
-    })
-    document?.querySelectorAll('.photos-album-image-item[data-id="'+photoId+'"]')?.forEach(element => {
-        element.classList?.add('loop-current')
-        element.classList?.remove('fr-hidden')
-    })
-}
-
 document?.querySelectorAll('[data-tag-delete]')?.forEach(delBtn => {
     delBtn.addEventListener('click', deleteTagEvent)
 });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -912,10 +912,41 @@ document?.querySelector('#partner_add_user,#situation_add_critere')?.addEventLis
     container.appendChild(row);
 })
 
+document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
+    btn.addEventListeners('click touchdown', (event) => {
+        document?.querySelectorAll('.photos-album')?.forEach(element => {
+            element.classList?.add('fr-hidden')
+        })
+    })
+})
+document?.querySelectorAll('.photos-album-swipe')?.forEach(btn => {
+    const swipeValue = btn.getAttribute('data-value')
+    let currentIndex = 0
+    let currentLoopLength = 0
+    btn.addEventListeners('click touchdown', (event) => {
+        document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
+            currentIndex = Number(element.getAttribute('data-index'))
+            currentLoopLength = Number(element.getAttribute('data-length'))
+        })
+        currentIndex += Number(swipeValue)
+        if (currentIndex < 1) {
+            currentIndex = currentLoopLength
+        }
+        if (currentIndex > currentLoopLength) {
+            currentIndex = 1
+        }
 
-/*document?.querySelectorAll('[data-tag-add]')?.forEach(addBtn => {
-    addBtn.addEventListener('click', addTagEvent)
-});*/
+        document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
+            element.classList?.remove('loop-current')
+            element.classList?.add('fr-hidden')
+        })
+        document?.querySelectorAll('.photos-album-image-item[data-index="'+currentIndex+'"]')?.forEach(element => {
+            element.classList?.add('loop-current')
+            element.classList?.remove('fr-hidden')
+        })
+    })
+})
+
 document?.querySelectorAll('[data-tag-delete]')?.forEach(delBtn => {
     delBtn.addEventListener('click', deleteTagEvent)
 });

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -18,4 +18,29 @@ enum DocumentType: String
     case AUTRE = 'AUTRE';
     case SITUATION = 'SITUATION';
     case VISITE = 'VISITE';
+
+    public function label(): string
+    {
+        return self::getLabel($this);
+    }
+
+    public static function getLabel(self $value): string
+    {
+        return match ($value) {
+            self::SITUATION_FOYER_BAIL => 'Bail',
+            self::SITUATION_FOYER_DPE => 'DPE',
+            self::SITUATION_FOYER_ETAT_DES_LIEUX => 'Etat des lieux',
+            self::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE => 'Diagnostic plomb-amiante',
+            self::PROCEDURE_MISE_EN_DEMEURE => 'Mise en demeure',
+            self::PROCEDURE_RAPPORT_DE_VISITE => 'Rapport de visite',
+            self::PROCEDURE_ARRETE_MUNICIPAL => 'Arrêté municipal',
+            self::PROCEDURE_ARRETE_PREFECTORAL => 'Arrêté préfectoral',
+            self::PROCEDURE_SAISINE => 'Saisine',
+            self::BAILLEUR_DEVIS_POUR_TRAVAUX => 'Devis pour travaux',
+            self::BAILLEUR_REPONSE_BAILLEUR => 'Réponse du bailleur',
+            self::AUTRE => 'Autre',
+            self::SITUATION => 'Désordre',
+            self::VISITE => 'Visite',
+        };
+    }
 }

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -27,6 +27,8 @@
             ? 'signalement-invalid'
             : ''
             }}">
+
+        {% include 'back/signalement/view/photos-album.html.twig' %}
         
         {% include 'back/signalement/view/header.html.twig' %}
         

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -1,4 +1,4 @@
-<div class="photos-album">
+<div class="photos-album fr-hidden">
     <div class="photos-album-close-button-container">
         <button class="photos-album-btn-close fr-btn fr-btn--tertiary-no-outline">Fermer</button>
     </div>

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -1,0 +1,47 @@
+<div class="photos-album">
+    <div class="photos-album-close-button-container">
+        <button class="fr-btn fr-btn--tertiary-no-outline">Fermer</button>
+    </div>
+
+    <div class="photos-album-navigation-container">
+        <div>
+            <button class="fr-btn">&lt;</button>
+        </div>
+        <div>
+            <div class="photos-album-image-item">
+                <div>
+                    TITRE
+                </div>
+                <div>
+                    IMG
+                </div>
+                <div>
+                    CAPTION
+                </div>
+            </div>
+        </div>
+        <div>
+            <button class="fr-btn">&gt;</button>
+        </div>
+    </div>
+
+{#
+    <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
+        {% for index, photo in signalement.files|filter(
+            photo => photo.fileType == 'photo'
+                    and photo.intervention is null
+            ) %}
+            <div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
+                <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
+                    data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
+                    data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
+                    style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
+                    <a href="{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=resize') }}"
+                        class="fr-btn fr-btn--sm fr-icon-eye-line img-box" title="Voir la photo"
+                        target="_blank" rel="noopener"></a>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+#}
+</div>

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -6,11 +6,11 @@
     {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null )|length %}
     <div class="photos-album-navigation-container">
         <div>
-            <button class="fr-btn photos-album-swipe" data-value="-1">&lt;</button>
+            <button class="fr-btn photos-album-swipe" data-direction="-1">&lt;</button>
         </div>
         <div>
             {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %}
-            <div class="photos-album-image-item {{ loop.index > 1 ? 'fr-hidden' : 'loop-current' }}" data-index="{{ loop.index }}" data-length="{{ loopLength }}">
+            <div class="photos-album-image-item {{ loop.index > 1 ? 'fr-hidden' : 'loop-current' }}" data-id="{{ photo.id }}">
                 <div>
                     Photo de la situation - {{ loop.index }} / {{ loopLength }}
                 </div>
@@ -21,13 +21,19 @@
                         >
                 </div>
                 <div>
-                    Photo ajoutée par : {{ photo.uploadedBy.nomComplet ?? 'N/R' }}
+                    Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
                 </div>
             </div>
             {% endfor %}
         </div>
         <div>
-            <button class="fr-btn photos-album-swipe" data-value="1">&gt;</button>
+            <button class="fr-btn photos-album-swipe" data-direction="1">&gt;</button>
         </div>
     </div>
+    <script type="text/javascript">
+        const histoPhotoIds = []
+        {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %}
+            histoPhotoIds.push({{photo.id}})
+        {% endfor %}
+    </script>
 </div>

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -21,6 +21,23 @@
                         >
                 </div>
                 <div>
+                    {% if photo.documentType is not same as null
+                        and photo.documentType is not same as enum('App\\Entity\\Enum\\DocumentType').AUTRE %}
+
+                        {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').SITUATION
+                                and photo.desordreSlug is not same as null %}
+                            {% for key, photoList in photos %}
+                                {% for desordrePhoto in photoList %}
+                                    {% if desordrePhoto.id is same as photo.id %}
+                                        {{ key }}
+                                    {% endif %}
+                                {% endfor %}
+                            {% endfor %}
+                        {% else %}
+                            {{ photo.documentType.label() }}
+                        {% endif %}
+                        <br>
+                    {% endif %}
                     Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
                 </div>
             </div>

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -1,47 +1,33 @@
 <div class="photos-album">
     <div class="photos-album-close-button-container">
-        <button class="fr-btn fr-btn--tertiary-no-outline">Fermer</button>
+        <button class="photos-album-btn-close fr-btn fr-btn--tertiary-no-outline">Fermer</button>
     </div>
 
+    {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null )|length %}
     <div class="photos-album-navigation-container">
         <div>
-            <button class="fr-btn">&lt;</button>
+            <button class="fr-btn photos-album-swipe" data-value="-1">&lt;</button>
         </div>
         <div>
-            <div class="photos-album-image-item">
+            {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %}
+            <div class="photos-album-image-item {{ loop.index > 1 ? 'fr-hidden' : 'loop-current' }}" data-index="{{ loop.index }}" data-length="{{ loopLength }}">
                 <div>
-                    TITRE
+                    Photo de la situation - {{ loop.index }} / {{ loopLength }}
                 </div>
                 <div>
-                    IMG
+                    <img
+                        src="{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=resize') }}"
+                        alt="Photo ajoutée par : {{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
+                        >
                 </div>
                 <div>
-                    CAPTION
+                    Photo ajoutée par : {{ photo.uploadedBy.nomComplet ?? 'N/R' }}
                 </div>
             </div>
+            {% endfor %}
         </div>
         <div>
-            <button class="fr-btn">&gt;</button>
+            <button class="fr-btn photos-album-swipe" data-value="1">&gt;</button>
         </div>
     </div>
-
-{#
-    <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
-        {% for index, photo in signalement.files|filter(
-            photo => photo.fileType == 'photo'
-                    and photo.intervention is null
-            ) %}
-            <div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
-                <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
-                    data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
-                    data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
-                    style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
-                    <a href="{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=resize') }}"
-                        class="fr-btn fr-btn--sm fr-icon-eye-line img-box" title="Voir la photo"
-                        target="_blank" rel="noopener"></a>
-                </div>
-            </div>
-        {% endfor %}
-    </div>
-#}
 </div>

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -1,6 +1,6 @@
 <div class="photos-album fr-hidden">
     <div class="photos-album-close-button-container">
-        <button class="photos-album-btn-close fr-btn fr-btn--tertiary-no-outline">Fermer</button>
+        <button class="photos-album-btn-close fr-btn">Fermer</button>
     </div>
 
     {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null )|length %}

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -64,7 +64,7 @@
                  data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
                  data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
                  style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
-                <button class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" data-index={{ loop.index }} title="Voir la photo"></button>
+                <button class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" data-id={{ photo.id }} title="Voir la photo"></button>
                 {% if importedBy is not same as 'user'
                     and (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted)) %}
                     {% if photo.uploadedBy is not defined or (photo.uploadedBy is not null and photo.uploadedBy.id is same as(app.user.id)) %}

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -64,9 +64,7 @@
                  data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
                  data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
                  style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
-                <a href="{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=resize') }}"
-                    class="fr-btn fr-btn--sm fr-icon-eye-line img-box" title="Voir la photo"
-                    target="_blank" rel="noopener"></a>
+                <button class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" data-index={{ loop.index }} title="Voir la photo"></button>
                 {% if importedBy is not same as 'user'
                     and (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted)) %}
                     {% if photo.uploadedBy is not defined or (photo.uploadedBy is not null and photo.uploadedBy.id is same as(app.user.id)) %}

--- a/templates/back/signalement/view/user-declaration-desordre-photo.html.twig
+++ b/templates/back/signalement/view/user-declaration-desordre-photo.html.twig
@@ -3,8 +3,6 @@
         data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
         data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
         style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
-        <a href="{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=resize') }}"
-            class="fr-btn fr-btn--sm fr-icon-eye-line img-box" title="Voir la photo"
-            target="_blank" rel="noopener"></a>
+        <button class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" data-id={{ photo.id }} title="Voir la photo"></button>
     </div>
 </div>


### PR DESCRIPTION
## Ticket

#2095    

## Description
Mise en place d'un album photo pour visionner les photos liées à un signalement.
Voir "Mode album" dans les specs : https://github.com/MTES-MCT/histologe/wiki/Ajout-documents

- Quand on clique sur une photo, ça ouvre l'album sur la photo cliquée.
- Quand on clique sur précédent / suivant, on se déplace dans la liste des photos
- Des informations sur la photo sont affichées

## Tests
- [ ] Ouvrir un signalement fait avec l'ancien formulaire, vérifier que tout s'affiche bien
- [ ] Ouvrir un signalement fait avec le nouveau formulaire, vérifier que tout s'affiche bien
- [ ] Ajouter des photos dans le BO et vérifier que tout s'affiche toujours bien
