### PR TITLE
[Signalement - bail-dpe] Ajouter bouton upload état des lieux

### DIFF
--- a/src/DataFixtures/Files/signalement_draft_payload/locataire.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/locataire.json
@@ -24,7 +24,9 @@
       "key": "documents",
       "file": "Capture-d-ecran-dpe-2.png",
       "titre": "Capture d’écran DPE 2.png"
-    },
+    }
+  ],
+  "bail_dpe_etat_des_lieux_upload": [
     {
       "key": "documents",
       "file": "Capture-d-ecran-dpe-3.png",

--- a/src/Service/Signalement/SignalementDocumentTypeMapper.php
+++ b/src/Service/Signalement/SignalementDocumentTypeMapper.php
@@ -20,6 +20,10 @@ class SignalementDocumentTypeMapper
             return DocumentType::SITUATION_FOYER_DPE;
         }
 
+        if (str_contains($value, 'dpe_etat_des_lieux')) {
+            return DocumentType::SITUATION_FOYER_ETAT_DES_LIEUX;
+        }
+
         return DocumentType::AUTRE;
     }
 }

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -64,6 +64,18 @@ class FileFactoryTest extends TestCase
             DocumentType::SITUATION_FOYER_DPE,
         ];
 
+        yield 'Etat des lieux document' => [
+            [
+                'key' => 'documents',
+                'file' => 'dummy-filename-dpe.pdf',
+                'titre' => 'dummy-filename-dpe-titre.pdf',
+                'slug' => 'bail_dpe_etat_des_lieux_upload',
+            ],
+            'dummy-filename-dpe.pdf',
+            File::FILE_TYPE_DOCUMENT,
+            DocumentType::SITUATION_FOYER_ETAT_DES_LIEUX,
+        ];
+
         yield 'Bail document' => [
             [
                 'key' => 'photos',

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -704,17 +704,6 @@
           }
         },
         {
-          "type": "SignalementFormUpload",
-          "slug": "bail_dpe_dpe_upload",
-          "label": "Ajouter le DPE (facultatif)",
-          "conditional": {
-            "show": "formStore.data.bail_dpe_dpe === 'oui'"
-          },
-          "validate": {
-            "required": false
-          }
-        },
-        {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_etat_des_lieux",
           "label": "Avez-vous réalisé un état des lieux à l'entrée des locataires ?",
@@ -739,6 +728,17 @@
           "label": "D'après la loi, un état des lieux du logement doit être réalisé le jour de la remise des clés. C'est important pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/F31270' target='_blank' rel='noopener'>le site du service public.</a>",
           "conditional": {
             "show": "formStore.data.bail_dpe_etat_des_lieux === 'non' || formStore.data.bail_dpe_etat_des_lieux === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_etat_des_lieux_upload",
+          "label": "Ajouter l'état des lieux (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
+          },
+          "validate": {
+            "required": false
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -753,6 +753,17 @@
           }
         },
         {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_etat_des_lieux_upload",
+          "label": "Ajouter l'état des lieux (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_dpe",
           "label": "Avez-vous reçu le DPE du logement ? (diagnostic performance énergie)",


### PR DESCRIPTION
## Ticket

#2139   

## Description
De la même manière que pour le bail ou le DPE, ajouter un bouton d'upload pour l'état des lieux quand on coche "Oui" à la question Avez-vous fait un état des lieux quand vous avez emménagé ? (ou Avez-vous réalisé un état des lieux à l'entrée des locataires ? pour les bailleurs)

## Changements apportés
* Modification des json de questions
* Modification d'une fixture
* Ajout d'un test
* Modification du SignalementDocumentTypeMapper

## Pré-requis

## Tests
- [ ] LFaire un signalement en tant que locataire, vérifier qu'on peut ajouter un fichier pour l'état des lieux. Ajouter un fichier et finir le signalement. Dans le BO, vérifier que le document de l'état des lieux est accessible. Dans la bdd, vérifier qu'il est bien typé
- [ ] Idem en tant que bailleur
