### PR TITLE
[BO - Esabora]Tableau de bord - Normaliser les messages d'erreurs

### DIFF
--- a/assets/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -226,7 +226,7 @@ export default defineComponent({
           responseItem.nom,
           responseItem.action,
           responseItem.status,
-          this.handleErrors(responseItem)
+          responseItem.response
         ]
         this.sharedState.esaboraEvents.push(item)
       }
@@ -234,14 +234,6 @@ export default defineComponent({
     handleChangeTerritoire () {
       this.isLoadingRefresh = true
       requests.initKPI(this.handleInitKPI)
-    },
-    handleErrors (responseItem : any) {
-      const jsonResponse = JSON.parse(responseItem.response)
-      let errorMessage = jsonResponse?.errorReason ?? jsonResponse?.message ?? null
-      if (errorMessage !== null && typeof errorMessage === 'object') {
-        errorMessage = JSON.stringify(errorMessage)
-      }
-      return errorMessage
     }
   }
 })

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -47,6 +47,8 @@ class JobEventRepository extends ServiceEntityRepository
             ->groupBy('p.id, p.nom, s.reference, j.action, j.status, j.codeStatus, j.response')
             ->orderBy('last_event', 'DESC');
 
+        $qb->setMaxResults(1000);
+
         return $qb->getQuery()->getArrayResult();
     }
 

--- a/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
+++ b/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
@@ -29,10 +29,9 @@ class EsaboraEventWidgetLoader extends AbstractWidgetLoader
             $widget->getTerritory()
         );
         foreach ($data as $key => $event) {
+            $data[$key]['response'] = null;
             if (JobEvent::STATUS_FAILED === $event['status']) {
                 $data[$key]['response'] = $this->normalizeErrorMessage($event);
-            } elseif (JobEvent::STATUS_SUCCESS === $event['status']) {
-                $data[$key]['response'] = null;
             }
         }
         $widget->setData($data);

--- a/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
+++ b/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
@@ -3,6 +3,7 @@
 namespace App\Service\DashboardWidget\WidgetLoader;
 
 use App\Entity\Enum\InterfacageType;
+use App\Entity\JobEvent;
 use App\Service\DashboardWidget\Widget;
 use App\Service\DashboardWidget\WidgetDataManagerInterface;
 use App\Service\DashboardWidget\WidgetType;
@@ -22,12 +23,57 @@ class EsaboraEventWidgetLoader extends AbstractWidgetLoader
     public function load(Widget $widget): void
     {
         parent::load($widget);
-        $widget->setData(
-            $this->widgetDataManager->findLastJobEventByInterfacageType(
-                InterfacageType::ESABORA->value,
-                $this->widgetParameter['data'],
-                $widget->getTerritory()
-            )
+        $data = $this->widgetDataManager->findLastJobEventByInterfacageType(
+            InterfacageType::ESABORA->value,
+            $this->widgetParameter['data'],
+            $widget->getTerritory()
         );
+        foreach ($data as $key => $event) {
+            if (JobEvent::STATUS_FAILED === $event['status']) {
+                $data[$key]['response'] = $this->normalizeErrorMessage($event);
+            } elseif (JobEvent::STATUS_SUCCESS === $event['status']) {
+                $data[$key]['response'] = null;
+            }
+        }
+        $widget->setData($data);
+    }
+
+    private function normalizeErrorMessage(array $event): string
+    {
+        $response = json_decode($event['response'], true);
+        if (!$response) {
+            return 'Réponse vide';
+        }
+        if (isset($response['message']) && !\is_array($response['message'])) {
+            return $response['message'];
+        }
+        if (isset($response['message']) && \is_array($response['message'])) {
+            return $this->normalizeErrorList($response['message']);
+        }
+        if (isset($response['errorReason'])) {
+            $errorReason = json_decode($response['errorReason'], true);
+
+            if (isset($errorReason['message']) && !\is_array($errorReason['message'])) {
+                return $errorReason['message'].' ('.$response['statusCode'].')';
+            }
+            if (isset($errorReason['message']) && \is_array($errorReason['message'])) {
+                return $this->normalizeErrorList($errorReason['message']);
+            }
+            if (isset($errorReason['nbResults']) && 0 === $errorReason['nbResults']) {
+                return 'Le dossier n\'a pas été trouvé';
+            }
+        }
+
+        return 'SAS Etat : '.$response['sasEtat'].' ('.$response['statusCode'].')';
+    }
+
+    private function normalizeErrorList(array $messages)
+    {
+        $html = '';
+        foreach ($messages as $msg) {
+            $html .= $msg['error'].' ('.$msg['fieldName'].')<br>';
+        }
+
+        return substr($html, 0, -4);
     }
 }


### PR DESCRIPTION
## Ticket

#1967 

## Description
- Limitation du nombres de résultats retourné au widget "Connexions ESABORA" à 1000 pour éviter erreur sur la masse des données pour les admin
- Conversion des données de réponse retourné par le web service en message clair

## Tests
- [ ] Vérifier que les widget "Connexions ESABORA" s'affiche correctement avec des message d'erreur normalisé sur une copie de la prod de la table job_event
