### PR TITLE
[BO - Désordres] Label critère - Structure Equipements

### DIFF
--- a/src/DataFixtures/Files/DesordreCritere.yml
+++ b/src/DataFixtures/Files/DesordreCritere.yml
@@ -264,7 +264,7 @@ desordre_critere:
     label_categorie: "Type et composition du logement"
     zone_categorie: "LOGEMENT"
     slug_critere: "desordres_type_composition_logement_wc"
-    label_critere: "Le logement n'a pas de WC ou WC et cuisine dans la même pièce"
+    label_critere: "Problème de structure / équipement"
   -
     desordre_categorie_label: "Suroccupation" 
     slug_categorie: "desordres_type_composition_logement"


### PR DESCRIPTION
## Ticket

#2165    

## Description
Changement du label d'un critère dans les fixtures

:warning: j'ai mis à jour la bdd de staging avec la commande, donc le test ici ne concerne que la fixture

## Changements apportés
* Changement d'une fixture

## Pré-requis

## Tests
- [ ] En local, faire ou éditer un signalement en choisissant "WC et cuisine dans la même pièce", vérifier le label du critère dans l'affichage des désordres
