### PR TITLE
 [BO - Désordres] Affichage du type de chauffage

### DIFF
--- a/src/Entity/Enum/ChauffageType.php
+++ b/src/Entity/Enum/ChauffageType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Entity\Enum;
+
+enum ChauffageType: string
+{
+    case ELECTRIQUE = 'ELECTRIQUE';
+    case GAZ = 'GAZ';
+    case AUCUN = 'AUCUN';
+    case NSP = 'NSP';
+
+    public function label(): string
+    {
+        return self::getLabelList()[$this->name];
+    }
+
+    public static function getLabelList(): array
+    {
+        return [
+            'ELECTRIQUE' => 'Chauffage électrique',
+            'GAZ' => 'Chauffage au gaz, bois, éthanol ou fioul',
+            'AUCUN' => 'Aucun radiateur ou moyen de chauffage fixe',
+            'NSP' => 'Type de chauffage inconnu',
+        ];
+    }
+
+    public static function fromLabel(string $label): self
+    {
+        $key = self::getKeyFromLabel($label);
+
+        return self::from($key);
+    }
+
+    public static function tryFromLabel(string $label): ?self
+    {
+        $key = self::getKeyFromLabel($label);
+
+        return self::tryFrom($key);
+    }
+
+    private static function getKeyFromLabel(string $label): string|int|false
+    {
+        $label = trim($label);
+
+        return array_search($label, self::getLabelList());
+    }
+}

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -138,7 +138,8 @@ class SignalementBuilder
             $this->processDesordresByZone('logement');
             $this->processDesordresTypeComposition();
         }
-        // enregistre des données spécifiques dans jsonContent si elles existent (slug du critère pour affichage)
+        // enregistre des données spécifiques dans jsonContent si elles existent
+        // (slug du critère ou de la catégorie pour affichage)
         if (isset($this->payload['desordres_logement_nuisibles_autres_details_type_nuisibles'])) {
             $jsonContent['desordres_logement_nuisibles_autres'] =
             $this->payload['desordres_logement_nuisibles_autres_details_type_nuisibles'];
@@ -146,6 +147,17 @@ class SignalementBuilder
         if (isset($this->payload['desordres_batiment_nuisibles_autres_details_type_nuisibles'])) {
             $jsonContent['desordres_batiment_nuisibles_autres'] =
             $this->payload['desordres_batiment_nuisibles_autres_details_type_nuisibles'];
+        }
+        if (isset($this->payload['desordres_logement_chauffage_type'])) {
+            if ('electrique' === $this->payload['desordres_logement_chauffage_type']) {
+                $jsonContent['desordres_logement_chauffage'] = 'Chauffage électrique';
+            } elseif ('gaz' === $this->payload['desordres_logement_chauffage_type']) {
+                $jsonContent['desordres_logement_chauffage'] = 'Chauffage au gaz, bois, éthanol ou fioul';
+            } elseif ('aucun' === $this->payload['desordres_logement_chauffage_type']) {
+                $jsonContent['desordres_logement_chauffage'] = 'Aucun radiateur ou moyen de chauffage fixe';
+            } else {
+                $jsonContent['desordres_logement_chauffage'] = 'Type de chauffage inconnu';
+            }
         }
 
         if (isset($jsonContent)) {

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -3,6 +3,7 @@
 namespace App\Service\Signalement;
 
 use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Enum\ChauffageType;
 use App\Entity\Enum\OccupantLink;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\ProprioType;
@@ -149,15 +150,8 @@ class SignalementBuilder
             $this->payload['desordres_batiment_nuisibles_autres_details_type_nuisibles'];
         }
         if (isset($this->payload['desordres_logement_chauffage_type'])) {
-            if ('electrique' === $this->payload['desordres_logement_chauffage_type']) {
-                $jsonContent['desordres_logement_chauffage'] = 'Chauffage électrique';
-            } elseif ('gaz' === $this->payload['desordres_logement_chauffage_type']) {
-                $jsonContent['desordres_logement_chauffage'] = 'Chauffage au gaz, bois, éthanol ou fioul';
-            } elseif ('aucun' === $this->payload['desordres_logement_chauffage_type']) {
-                $jsonContent['desordres_logement_chauffage'] = 'Aucun radiateur ou moyen de chauffage fixe';
-            } else {
-                $jsonContent['desordres_logement_chauffage'] = 'Type de chauffage inconnu';
-            }
+            $chauffageType = ChauffageType::tryFrom(strtoupper($this->payload['desordres_logement_chauffage_type']));
+            $jsonContent['desordres_logement_chauffage'] = $chauffageType->label();
         }
 
         if (isset($jsonContent)) {

--- a/templates/back/signalement/view/user-declaration-desordre.html.twig
+++ b/templates/back/signalement/view/user-declaration-desordre.html.twig
@@ -3,26 +3,37 @@
     <h3 class="fr-accordion__title">
         <button class="fr-accordion__btn" aria-expanded="false" aria-controls="{{ zone }}-collapse-{{ loop.index }}"><strong>{{ situation|capitalize }}</strong></button>
     </h3>
-    <div class="fr-collapse" id="{{ zone }}-collapse-{{ loop.index }}">
+    <div class="fr-collapse" id="{{ zone }}-collapse-{{ loop.index }}">  
+        {# Affichage des données spécifiques liées à la catégorie #}
+        {% set firstCritere = criteres|first %}
+        {% if firstCritere is defined %}
+            {% set firstPrecision = firstCritere|first %}
+            {% if firstPrecision is defined %}
+                {% if signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] is defined %}
+                    {{ signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] }}
+                {% endif %}
+            {% endif %}
+        {% endif %}    
         <ul>
-            {% for critere,criticites in criteres %}
+            {% for critere,precisions in criteres %}
                 <li>
-                    {{ critere }}
-                    {% for criticite in criticites %}
-                        {% if criticite.label is not same as '' %}
+                    {{ critere }}     
+                    {% for precision in precisions %}
+                        {% if precision.label is not same as '' %}
                             <ul class="fr-list fr-list--none">
                                 <li>
-                                    {{ criticite.label|raw }}                                
-                                    {% if signalement.jsonContent[criticite.desordreCritere.slugCritere] is defined %}
-                                        <br>Commentaire usager : <i>{{ signalement.jsonContent[criticite.desordreCritere.slugCritere] }}</i>
+                                    {{ precision.label|raw }}                
+                                    {# Affichage des données spécifiques liées au critère                 #}
+                                    {% if signalement.jsonContent[precision.desordreCritere.slugCritere] is defined %}
+                                        <br>Commentaire usager : <i>{{ signalement.jsonContent[precision.desordreCritere.slugCritere] }}</i>
                                     {% endif %}
                                 </li>
                             </ul>                                            
                         {% endif %}
                         {# ajout des photos liées spécifiquement à ce critère ou à cette précision #}
-                        {% if photos[criticite.desordreCritere.slugCritere] is defined %}    
+                        {% if photos[precision.desordreCritere.slugCritere] is defined %}    
                             <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">                    
-                                {% for photo in photos[criticite.desordreCritere.slugCritere] %}
+                                {% for photo in photos[precision.desordreCritere.slugCritere] %}
                                     {% include 'back/signalement/view/user-declaration-desordre-photo.html.twig' %}   
                                 {% endfor %}
                             </div>


### PR DESCRIPTION
## Ticket

#2166   

## Description
On affiche le type de chauffage sélectionné par l'usager

## Changements apportés
* Changement du SignalementBuilder pour enregistrer le type de chauffage dans jsonContent (comme on a fait pour la précision sur les nuisibles)
* Modification du twig d'affichage de désordre pour afficher d'éventuels éléments liés à une catégorie de désordres.

## Pré-requis

## Tests
- [ ] Faire un signalement avec des désordres de chauffage dans le logement (sauf aucun car ticket #2183 )
- [ ] Dans le BO vérifier que le type de chauffage sélectionné s'affiche bien 
