### PR TITLE
[BO - Edition] Recalcul Suroccupation

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -620,7 +620,16 @@ class SignalementManager extends AbstractManager
             ->setTravailleurSocialQuitteLogement($situationFoyerRequest->getTravailleurSocialQuitteLogement())
             ->setTravailleurSocialAccompagnementDeclarant(
                 $situationFoyerRequest->getTravailleurSocialAccompagnementDeclarant()
-            );
+            )
+            ->setLogementSocialAllocationCaisse($situationFoyerRequest->getIsAllocataire());
+
+        if ('non' === $situationFoyerRequest->getIsAllocataire()) {
+            $situationFoyer->setLogementSocialAllocation('non');
+        } elseif ('nsp' === $situationFoyerRequest->getIsAllocataire()) {
+            $situationFoyer->setLogementSocialAllocation(null);
+        } else {
+            $situationFoyer->setLogementSocialAllocation('oui');
+        }
         $signalement->setSituationFoyer($situationFoyer);
 
         $informationComplementaire = new InformationComplementaire();


### PR DESCRIPTION
## Ticket

#2175   

## Description
Quand on changeait la valeur d'allocataire dans Situation du foyer, le tag Suroccupation n'était pas mis à jour, car les valeurs `setLogementSocialAllocationCaisse` et  `setLogementSocialAllocation` de situationFoyer n'étaient pas mises à jour

## Changements apportés
* Mise à jour du SignalementManager

## Pré-requis

## Tests
- [ ] Faire un signalement avec une toute petite superficie et un grand nombre de pièce (ou vice-versa) pour avoir le tag `Suroccupation` soit si on est allocataire, soit si on le l'est pas, mais pas dans tous les cas
- [ ] Editer la valeur allocataire du signalement et vérifier que le tag `suroccupation` se met à jour comme il faut
