### PR TITLE
[BO - Signalement] TAG NDE

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -162,10 +162,7 @@ class SignalementController extends AbstractController
         $listQualificationStatusesLabelsCheck = [];
         if (null !== $signalement->getSignalementQualifications()) {
             foreach ($signalement->getSignalementQualifications() as $qualification) {
-                if (
-                    Qualification::NON_DECENCE_ENERGETIQUE !== $qualification->getQualification()
-                    && !$qualification->isPostVisite()
-                ) {
+                if (!$qualification->isPostVisite()) {
                     $listQualificationStatusesLabelsCheck[] = $qualification->getStatus()->label();
                 }
             }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -269,13 +269,13 @@ class SignalementManager extends AbstractManager
         $signalement = $signalementQualification->getSignalement();
         // // mise à jour du signalement
         if (QualificationNDERequest::RADIO_VALUE_AFTER_2023 === $qualificationNDERequest->getDateEntree()
-            && $signalement->getDateEntree()->format('Y') < '2023'
+            && ($signalement->getDateEntree()->format('Y') < '2023' || null === $signalement->getDateEntree())
         ) {
             $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_AFTER_2023));
         }
 
         if (QualificationNDERequest::RADIO_VALUE_BEFORE_2023 === $qualificationNDERequest->getDateEntree()
-            && $signalement->getDateEntree()->format('Y') >= '2023'
+            && ($signalement->getDateEntree()->format('Y') >= '2023' || null === $signalement->getDateEntree())
         ) {
             $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_BEFORE_2023));
         }

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -77,7 +77,7 @@
                                             </div>
                                             <div class="fr-radio-group">
                                                 <input type="radio" id="signalement-edit-nde-dpe-2" name="dpe" value='null' {% if signalementQualificationNDE.details and signalementQualificationNDE.details.DPE is null %}checked{% endif %}>
-                                                <label class="fr-label" for="signalement-edit-nde-dpe-2">Ne sais pas
+                                                <label class="fr-label" for="signalement-edit-nde-dpe-2">Ne sait pas
                                                 </label>
                                             </div>
                                         </div>

--- a/templates/_partials/signalement/qualification.html.twig
+++ b/templates/_partials/signalement/qualification.html.twig
@@ -9,6 +9,8 @@
     or qualificationStatusLabel is same as 'Suspicion Manquement à la salubrité'
     or qualificationStatusLabel is same as 'Suspicion Non décence/RSD'
     or qualificationStatusLabel is same as 'Suspicion RSD'
+    or qualificationStatusLabel is same as 'Non décence énergétique à vérifier'
+    or qualificationStatusLabel is same as 'Non décence énergétique avérée'
     or qualificationStatusLabel is same as 'Non décence'
     or qualificationStatusLabel is same as 'RSD' %}
 
@@ -26,5 +28,5 @@
     {% if inlist %}
         <br>
     {% endif %}
-    <small class="fr-badge {% if inlist %}fr-badge--sm{% endif %} fr-badge--{{ typeBadge }} fr-badge--no-icon fr-mb-1v">{{ qualificationStatusLabel|replace({'Suspicion ': ''}) }}</small>
+    <small class="fr-badge {% if inlist %}fr-badge--sm{% endif %} fr-badge--{{ typeBadge }} fr-badge--no-icon fr-mb-1v">{{ qualificationStatusLabel|replace({'Suspicion ': '', ' à vérifier': '', ' avérée': ''}) }}</small>
 {% endif %}

--- a/templates/back/signalement/view/address-qualifications.html.twig
+++ b/templates/back/signalement/view/address-qualifications.html.twig
@@ -29,11 +29,6 @@
     
     <div class="fr-col-12 fr-col-md-6">
         <h3 class="fr-h5">Situation(s) suspectée(s) à la déclaration usager</h3>
-        {% if can_see_nde_qualification(signalementQualificationNDE) and is_granted('USER_SEE_NDE', app.user) %}
-            <small class="fr-badge fr-badge--info fr-badge--no-icon fr-mb-1v">
-                Non décence énergétique
-            </small>
-        {% endif %}
         {% for qualificationStatusLabel in listQualificationStatusesLabelsCheck %}
             {% include '_partials/signalement/qualification.html.twig' with { 'inlist': false } %}
         {% endfor %}


### PR DESCRIPTION
## Ticket

#2184   

## Description
Le TAG NDE doit s afficher pour tous dès lors que la NDE est constatée

## Changements apportés
* Suppression de contraintes

## Pré-requis

## Tests
- [ ] Faire un signalement avec une qualification NDE (choisir `Il est difficile de chauffer le logement` par exemple et mettre une consommation élevée si DPE) ni dans le puy de Dôme, ni dans l'Yonne (à Marseille pour avoir des partenaires par exemple)
- [ ] En admin vérifier l'affichage du tag et affecter des partenaires
- [ ] Se connecter en navigation privé avec un partenaire qui n'a pas la compétence NDE
- [ ] En admin faire varifier les statuts de la NDE, et avec le partenaire vérifier que la qualification s'affiche bien
