### PR TITLE
[BO - Signalement] Correction enregistrement date dernier bail

### DIFF
--- a/src/Factory/SignalementQualificationFactory.php
+++ b/src/Factory/SignalementQualificationFactory.php
@@ -56,7 +56,7 @@ class SignalementQualificationFactory
         $dataDateBailToSave = null;
         if ('Je ne sais pas' !== $dataDateBail) {
             if (null !== $signalement->getDateEntree() && $signalement->getDateEntree()->format('Y') >= 2023) {
-                $signalementQualification->setDernierBailAt($signalement->getDateEntree());
+                $signalementQualification->setDernierBailAt(new DateTimeImmutable($signalement->getDateEntree()->format('Y-m-d')));
             } elseif (!empty($dataDateBail)) {
                 $signalementQualification->setDernierBailAt(new DateTimeImmutable($dataDateBail));
             }

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -283,7 +283,7 @@
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Date d'effet du bail :</strong>
                         {% if signalement.informationComplementaire %}
-                            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateEffetBail ?? 'N/C' }}
+                            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateEffetBail ? signalement.informationComplementaire.informationsComplementairesSituationBailleurDateEffetBail|date("d/m/Y") : 'N/C' }}
                         {% else %}
                             N/C
                         {% endif %}


### PR DESCRIPTION
## Ticket

#2189   

## Description
Lorsqu'on sauvegarde la situation du foyer, la date de dernier bail est mise à jour en fonction de la date d'entrée ou de la date de bail.
Si la date d'entrée était après 2023, lors de la sauvegarde de la situation du foyer, il y avait un souci de typage de la date. (DateTimeInterface vs DateTimeImmutable)

J'en ai profité pour corriger l'affichage de la date d'effet du bail qui s'affichait au format YYYY-MM-DD

## Tests
- [ ] Mettre différentes dates (avant ou après 2023) dans la date d'arrivée dans le logement, et enregistrer
- [ ] Avec ces différentes dates, enregistrer la situation du foyer, et vérifier qu'il n'y a pas de blocage
- [ ] Vérifier l'affichage de la date d'effet du bail 
