### PR TITLE
[BO - Signalement] Bloquer l'édition pour les agents qui n'ont pas accepté l'affectation

### DIFF
--- a/templates/back/signalement/view/address-qualifications.html.twig
+++ b/templates/back/signalement/view/address-qualifications.html.twig
@@ -1,9 +1,11 @@
 <div class="fr-grid-row fr-mt-3w">
     <div class="fr-col-12 fr-col-md-6">
-        {% include 'back/signalement/view/edit-modals/edit-address.html.twig' %}
+        {% if isNewFormEnabled and canEditSignalement %}
+            {% include 'back/signalement/view/edit-modals/edit-address.html.twig' %}
+        {% endif %}
         <h3 class="fr-h5">
             Adresse du logement
-            {% if isNewFormEnabled %}
+            {% if isNewFormEnabled and canEditSignalement %}
             <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-address" class="fr-ml-6v fr-btn--icon-left fr-icon-edit-line fr-a-edit">
                 Modifier
             </a>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -19,7 +19,7 @@
 <div class="fr-container--fluid text-word-break-all">
     <div class="fr-grid-row fr-grid-row--gutters">
         {% if signalement.isNotOccupant %}
-            {% if isNewFormEnabled %}
+            {% if isNewFormEnabled and canEditSignalement %}
             {% include 'back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig' %}
             {% endif %}
         <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
@@ -29,7 +29,7 @@
                         <h4 class="fr-h6">Coordonnées du tiers déclarant</h4>
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                        {% if isNewFormEnabled %}
+                        {% if isNewFormEnabled and canEditSignalement %}
                         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-tiers" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
@@ -73,7 +73,7 @@
         {% endif %}
 
         <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
-            {% if isNewFormEnabled %}
+            {% if isNewFormEnabled and canEditSignalement %}
                 {% include 'back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig' %}
             {% endif %}
             <div class="fr-p-3v fr-background-alt--grey">
@@ -82,7 +82,7 @@
                         <h4 class="fr-h6">Coordonnées du foyer</h4>
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                        {% if isNewFormEnabled %}
+                        {% if isNewFormEnabled and canEditSignalement %}
                         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-foyer" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
@@ -129,7 +129,7 @@
         {% if not signalement.profileDeclarant or (signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT 
         and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR) %}
            <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
-                {% if isNewFormEnabled %}
+                {% if isNewFormEnabled and canEditSignalement %}
                     {% include 'back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig' %}
                 {% endif %}
                 <div class="fr-p-3v fr-background-alt--grey">
@@ -138,7 +138,7 @@
                             <h4 class="fr-h6">Informations sur le bailleur</h4>
                         </div>
                         <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                            {% if isNewFormEnabled %}
+                            {% if isNewFormEnabled and canEditSignalement %}
                             <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-bailleur" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                             {% endif %}
                         </div>
@@ -225,7 +225,7 @@
         {% endif %}
 
         <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
-            {% if isNewFormEnabled %}
+            {% if isNewFormEnabled and canEditSignalement %}
             {% include 'back/signalement/view/edit-modals/edit-informations-logement.html.twig' %}
             {% endif %}
             <div class="fr-p-3v fr-background-alt--grey">
@@ -234,7 +234,7 @@
                         <h4 class="fr-h6">Informations sur le logement</h4>
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                        {% if isNewFormEnabled %}
+                        {% if isNewFormEnabled and canEditSignalement %}
                         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-informations-logement" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
@@ -360,7 +360,7 @@
         </div>
 
         <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
-            {% if isNewFormEnabled %}
+            {% if isNewFormEnabled and canEditSignalement %}
             {% include 'back/signalement/view/edit-modals/edit-composition-logement.html.twig' %}
             {% endif %}
             <div class="fr-p-3v fr-background-alt--grey">
@@ -369,7 +369,7 @@
                         <h4 class="fr-h6">Composition du logement</h4>
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                        {% if isNewFormEnabled %}
+                        {% if isNewFormEnabled and canEditSignalement %}
                         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-composition-logement" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
@@ -548,7 +548,7 @@
         </div>
 
         <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
-            {% if isNewFormEnabled %}
+            {% if isNewFormEnabled and canEditSignalement %}
             {% include 'back/signalement/view/edit-modals/edit-situation-foyer.html.twig' %}
             {% endif %}
             <div class="fr-p-3v fr-background-alt--grey">
@@ -557,7 +557,7 @@
                         <h4 class="fr-h6">Situation du foyer</h4>
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                        {% if isNewFormEnabled %}
+                        {% if isNewFormEnabled and canEditSignalement %}
                         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-situation-foyer" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>
@@ -684,7 +684,7 @@
         </div>
 
         <div class="fr-col-12 fr-col-md-6 fr-mb-1v fr-lh-2">
-            {% if isNewFormEnabled %}
+            {% if isNewFormEnabled and canEditSignalement %}
             {% include 'back/signalement/view/edit-modals/edit-procedure-demarches.html.twig' %}
             {% endif %}
             <div class="fr-p-3v fr-background-alt--grey">
@@ -693,7 +693,7 @@
                         <h4 class="fr-h6">Procédure et démarches</h4>
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
-                        {% if isNewFormEnabled %}
+                        {% if isNewFormEnabled and canEditSignalement %}
                         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-procedure-demarches" class="fr-btn--icon-left fr-icon-edit-line">Modifier</a>
                         {% endif %}
                     </div>

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -5,22 +5,20 @@
         <h3 class="fr-h5">Suivis</h3>
     </div>
     <div class="fr-col-3 fr-col-md-6 fr-text--right">
+        {% if 
+                (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted))
+                and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION')
+                and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
+                and not isClosedForMe
+                %}
         <button class="fr-btn fr-btn--icon-left fr-icon-quote-line" data-fr-opened="false"
                 aria-controls="fr-modal-add-suivi">
             Ajouter un suivi
         </button>
+        {% include '_partials/signalement/add_suivi.html.twig' %}
+        {% endif %}
     </div>
 </div>
-
-
-{% if 
-        (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted))
-        and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION')
-        and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
-        and not isClosedForMe
-        %}
-    {% include '_partials/signalement/add_suivi.html.twig' %}
-{% endif %}
 
 {% for suivi in signalement.suivis|reverse %}
     <div class="fr-grid-row fr-grid-row--middle fr-background-alt--blue-france fr-p-3v fr-mb-3v suivi-item {% if loop.index > 3 %}fr-hidden{% endif %}">


### PR DESCRIPTION
## Ticket

#2174   

## Description
Un agent qui n'a pas encore accepté une affectation ne peut pas éditer un signalement, ni ajouter de suivi

## Tests
- [ ] Affecter un partenaire à un signalement, vérifier ce que l'agent du partenaire peut faire
