### PR TITLE
[BO - Signalement] Ajout de marges verticales dans les blocs d'information

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -642,3 +642,7 @@ a.force-link-color {
 .white-space-pre-line {
     white-space: pre-line;
 }
+
+.bloc-list .fr-grid-row .fr-grid-row .fr-col-12 {
+    padding: 0 0.75rem;
+}

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-<div class="fr-container--fluid text-word-break-all">
+<div class="bloc-list fr-container--fluid text-word-break-all">
     <div class="fr-grid-row fr-grid-row--gutters">
         {% if signalement.isNotOccupant %}
             {% if isNewFormEnabled %}


### PR DESCRIPTION
## Ticket

#2173   

## Description
Ajout de gouttières dans les blocs d'information pour éviter que certaines informations soient collées, selon les tailles d'écran et les informations affichées.

## Tests
- [ ] Diminuer la taille de l'écran pour vérifier que les informations affichées ne sont pas collées
