### PR TITLE
[BO - Signalement] Désordres - Absence de chauffage

### DIFF
--- a/src/DataFixtures/Files/DesordrePrecision.yml
+++ b/src/DataFixtures/Files/DesordrePrecision.yml
@@ -644,7 +644,7 @@ desordre_precision:
     is_danger: 0
     label: "<span>Dans : <b>Tout le logement</b></span>"
     qualification: ['NON_DECENCE', 'RSD']
-    desordre_precision_slug: "desordres_logement_chauffage_aucun_pieces_tout"
+    desordre_precision_slug: "desordres_logement_chauffage_type_aucun_pieces_tout"
     is_suroccupation: 0
   -
     desordre_critere_slug: "desordres_logement_chauffage_type_aucun" 
@@ -652,7 +652,7 @@ desordre_precision:
     is_danger: 0
     label: "<span>Dans : <b>Une ou des pièces à vivre (salon, chambres)</b></span>"
     qualification: ['NON_DECENCE', 'RSD']
-    desordre_precision_slug: "desordres_logement_chauffage_aucun_pieces_piece_a_vivre"
+    desordre_precision_slug: "desordres_logement_chauffage_type_aucun_pieces_piece_a_vivre"
     is_suroccupation: 0
   -
     desordre_critere_slug: "desordres_logement_chauffage_type_aucun" 
@@ -660,7 +660,7 @@ desordre_precision:
     is_danger: 0
     label: "<span>Dans : <b>La cuisine / le coin cuisine</b></span>"
     qualification: ['NON_DECENCE', 'RSD']
-    desordre_precision_slug: "desordres_logement_chauffage_aucun_pieces_cuisine"
+    desordre_precision_slug: "desordres_logement_chauffage_type_aucun_pieces_cuisine"
     is_suroccupation: 0
   -
     desordre_critere_slug: "desordres_logement_chauffage_type_aucun" 
@@ -668,7 +668,7 @@ desordre_precision:
     is_danger: 0
     label: "<span>Dans : <b>La salle de bain, salle d'eau et / ou les toilettes</b></span>"
     qualification: ['NON_DECENCE', 'RSD']
-    desordre_precision_slug: "desordres_logement_chauffage_aucun_pieces_salle_de_bain"
+    desordre_precision_slug: "desordres_logement_chauffage_type_aucun_pieces_salle_de_bain"
     is_suroccupation: 0
   -
     desordre_critere_slug: "desordres_logement_chauffage_details_difficultes_chauffage" 

--- a/src/Manager/DesordreCritereManager.php
+++ b/src/Manager/DesordreCritereManager.php
@@ -52,7 +52,7 @@ class DesordreCritereManager extends AbstractManager
 
     public function getCriteresSlugsInDraft(array $filteredDataOfDraft, array $availableCritereSlugs): array
     {
-        return array_filter($filteredDataOfDraft, function ($value, $slug) use ($availableCritereSlugs) {
+        $criteresSlugs = array_filter($filteredDataOfDraft, function ($value, $slug) use ($availableCritereSlugs) {
             if (\in_array($slug, $availableCritereSlugs)) {
                 if (1 === $value) {
                     return true;
@@ -61,5 +61,13 @@ class DesordreCritereManager extends AbstractManager
 
             return false;
         }, \ARRAY_FILTER_USE_BOTH);
+
+        // cas particulier pour desordres_logement_chauffage_type_aucun
+        if (isset($filteredDataOfDraft['desordres_logement_chauffage_type'])
+            && 'aucun' === $filteredDataOfDraft['desordres_logement_chauffage_type']) {
+            $criteresSlugs['desordres_logement_chauffage_type_aucun'] = 1;
+        }
+
+        return $criteresSlugs;
     }
 }

--- a/src/Service/Signalement/DesordreTraitement/DesordreTraitementPieces.php
+++ b/src/Service/Signalement/DesordreTraitement/DesordreTraitementPieces.php
@@ -25,8 +25,9 @@ class DesordreTraitementPieces implements DesordreTraitementInterface
         $slugPieceAVivre = $slug.'_pieces_piece_a_vivre';
         $slugSalleDeBain = $slug.'_pieces_salle_de_bain';
         $slugTout = $slug.'_pieces_tout';
-        if (\array_key_exists($slugSansDetails1, $payload)
-            && self::CHECKED_CRITERE_VALUE === $payload[$slugSansDetails1]
+        if ((\array_key_exists($slugSansDetails1, $payload)
+            && self::CHECKED_CRITERE_VALUE === $payload[$slugSansDetails1])
+        || 'desordres_logement_chauffage_type_aucun' === $slugSansDetails1
         ) {
             if ('piece_unique' === $payload['composition_logement_piece_unique']
                 || (

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_occupant.json
@@ -1399,7 +1399,7 @@
         {
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
-          "slug": "desordres_logement_chauffage_aucun_pieces",
+          "slug": "desordres_logement_chauffage_type_aucun_pieces",
           "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_chauffage_type === 'aucun' && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 

--- a/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
+++ b/tools/wiremock/src/Resources/Signalement/desordres_profile_tiers.json
@@ -1428,7 +1428,7 @@
         {
           "type": "SignalementFormRoomList",
           "label": "Dans quelle(s) pièce(s) ?",
-          "slug": "desordres_logement_chauffage_aucun_pieces",
+          "slug": "desordres_logement_chauffage_type_aucun_pieces",
           "customCss": "signalement-form-roomlist-under-checkbox",
           "conditional": {
             "show": "formStore.data.desordres_logement_chauffage_type === 1 && formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'" 


### PR DESCRIPTION
## Ticket

#2183    

## Description
Les désordres liés à "aucun type de chauffage" n'étaient pas pris en compte, dû à une forme différente dans le payload. Car ce n'est pas un critère qu'on coche à proprement parler (comme par exemple `"desordres_batiment_proprete_facades": 1`) mais un choix de type de chauffage qu'on met sur "aucun" : `"desordres_logement_chauffage_type": "aucun",`

## Changements apportés
* Mise à jour des fixtures et des questions de désordres car il manquait "_type" par endroit
* Mise à jour de la fonction `getCriteresSlugsInDraft` dans le `DesordreCritereManager` pour prendre en compte ce cas particulier
* Mise à jour de `DesordreTraitementPieces` pour prendre en compte ce cas particulier

## Pré-requis
Recharger les fixtures ou jouer la commande `make console app="import-desordres-tables"`
## Tests
- [ ] Faire un signalement en pièce unique, choisir la zone logement, la catégorie chauffage et choisir type de chauffage à aucun
- [ ] Valider le signalement et vérifier dans le BO qu'on a bien le désordre avec "Tout le logement"
- [ ] Faire un signalement avec plusieurs pièces, et quand on choisit type de chauffage à aucun, ne choisir qu'1 ou 2 endroits où il n'y a pas de chauffage
- [ ] Valider le signalement et vérifier dans le BO qu'on a bien le désordre avec l'endroit sélectionné
