### PR TITLE
[BO - Signalement] Déplacement de l'info concernant le relogement

### DIFF
--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -15,7 +15,6 @@ class ProcedureDemarchesRequest
         #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux ', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
         private readonly ?string $infoProcedureDepartApresTravaux = null,
         private readonly ?string $preavisDepart = null,
-        private readonly ?string $demandeRelogement = null,
     ) {
     }
 
@@ -42,10 +41,5 @@ class ProcedureDemarchesRequest
     public function getPreavisDepart(): ?string
     {
         return $this->preavisDepart;
-    }
-
-    public function getDemandeRelogement(): ?string
-    {
-        return $this->demandeRelogement;
     }
 }

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -8,8 +8,10 @@ class SituationFoyerRequest
 {
     public function __construct(
         private readonly ?string $isLogementSocial = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ demande relogement', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ demande relogement', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
         private readonly ?string $isRelogement = null,
+        #[Assert\NotBlank(['message' => 'Veuillez définir le champ demande relogement', 'groups' => ['TIERS_PARTICULIER', 'TIERS_PRO']])]
+        private readonly ?string $demandeRelogement = null,
         #[Assert\NotBlank(['message' => 'Veuillez définir le champ allocataire', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
         private readonly ?string $isAllocataire = null,
         #[Assert\DateTime('Y-m-d')]
@@ -35,6 +37,11 @@ class SituationFoyerRequest
     public function getIsRelogement(): ?string
     {
         return $this->isRelogement;
+    }
+
+    public function getDemandeRelogement(): ?string
+    {
+        return $this->demandeRelogement;
     }
 
     public function getIsAllocataire(): ?string

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -10,8 +10,6 @@ class SituationFoyerRequest
         private readonly ?string $isLogementSocial = null,
         #[Assert\NotBlank(['message' => 'Veuillez définir le champ demande relogement', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
         private readonly ?string $isRelogement = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ demande relogement', 'groups' => ['TIERS_PARTICULIER', 'TIERS_PRO']])]
-        private readonly ?string $demandeRelogement = null,
         #[Assert\NotBlank(['message' => 'Veuillez définir le champ allocataire', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
         private readonly ?string $isAllocataire = null,
         #[Assert\DateTime('Y-m-d')]
@@ -37,11 +35,6 @@ class SituationFoyerRequest
     public function getIsRelogement(): ?string
     {
         return $this->isRelogement;
-    }
-
-    public function getDemandeRelogement(): ?string
-    {
-        return $this->demandeRelogement;
     }
 
     public function getIsAllocataire(): ?string

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -598,7 +598,11 @@ class SignalementManager extends AbstractManager
                 $situationFoyerRequest->getIsRelogement()
             )
         );
-        $signalement->setIsAllocataire($situationFoyerRequest->getIsAllocataire());
+        $signalement->setIsAllocataire(
+            $this->signalementInputValueMapper->map(
+                $situationFoyerRequest->getIsAllocataire()
+            )
+        );
 
         if (!empty($situationFoyerRequest->getDateNaissanceOccupant())) {
             $dateNaissance = new \DateTimeImmutable($situationFoyerRequest->getDateNaissanceOccupant());
@@ -648,6 +652,12 @@ class SignalementManager extends AbstractManager
             ->setInformationsComplementairesSituationOccupantsBeneficiaireFsl(
                 $situationFoyerRequest->getBeneficiaireFsl()
             );
+        if ($signalement->getIsNotOccupant()) {
+            $informationComplementaire
+                ->setInformationsComplementairesSituationOccupantsDemandeRelogement(
+                    $situationFoyerRequest->getDemandeRelogement()
+                );
+        }
         if ($situationFoyerRequest->getRevenuFiscal()) {
             $informationComplementaire
                 ->setInformationsComplementairesSituationOccupantsRevenuFiscal(
@@ -688,10 +698,6 @@ class SignalementManager extends AbstractManager
         if (!empty($signalement->getInformationComplementaire())) {
             $informationComplementaire = clone $signalement->getInformationComplementaire();
         }
-        $informationComplementaire
-            ->setInformationsComplementairesSituationOccupantsDemandeRelogement(
-                $procedureDemarchesRequest->getDemandeRelogement()
-            );
         $signalement->setInformationComplementaire($informationComplementaire);
 
         if ($assuranceContacteeUpdated) {

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -588,28 +588,28 @@ class SignalementManager extends AbstractManager
         Signalement $signalement,
         SituationFoyerRequest $situationFoyerRequest
     ) {
-        $signalement->setIsLogementSocial(
-            $this->signalementInputValueMapper->map(
-                $situationFoyerRequest->getIsLogementSocial()
+        $signalement
+            ->setIsLogementSocial(
+                $this->signalementInputValueMapper->map(
+                    $situationFoyerRequest->getIsLogementSocial()
+                )
             )
-        );
-        $signalement->setIsRelogement(
-            $this->signalementInputValueMapper->map(
-                $situationFoyerRequest->getIsRelogement()
+            ->setIsRelogement(
+                $this->signalementInputValueMapper->map(
+                    $situationFoyerRequest->getIsRelogement()
+                )
             )
-        );
-        $signalement->setIsAllocataire(
-            $this->signalementInputValueMapper->map(
-                $situationFoyerRequest->getIsAllocataire()
+            ->setIsAllocataire(
+                $this->signalementInputValueMapper->map(
+                    $situationFoyerRequest->getIsAllocataire()
+                )
             )
-        );
+            ->setNumAllocataire($situationFoyerRequest->getNumAllocataire());
 
         if (!empty($situationFoyerRequest->getDateNaissanceOccupant())) {
             $dateNaissance = new \DateTimeImmutable($situationFoyerRequest->getDateNaissanceOccupant());
             $signalement->setDateNaissanceOccupant($dateNaissance);
         }
-
-        $signalement->setNumAllocataire($situationFoyerRequest->getNumAllocataire());
 
         $situationFoyer = new SituationFoyer();
         if (!empty($signalement->getSituationFoyer())) {
@@ -639,6 +639,12 @@ class SignalementManager extends AbstractManager
         } else {
             $situationFoyer->setLogementSocialAllocation('oui');
         }
+        if (!$signalement->getIsNotOccupant()) {
+            $situationFoyer
+                ->setLogementSocialDemandeRelogement(
+                    $situationFoyerRequest->getIsRelogement()
+                );
+        }
         $signalement->setSituationFoyer($situationFoyer);
 
         $informationComplementaire = new InformationComplementaire();
@@ -655,7 +661,7 @@ class SignalementManager extends AbstractManager
         if ($signalement->getIsNotOccupant()) {
             $informationComplementaire
                 ->setInformationsComplementairesSituationOccupantsDemandeRelogement(
-                    $situationFoyerRequest->getDemandeRelogement()
+                    $situationFoyerRequest->getIsRelogement()
                 );
         }
         if ($situationFoyerRequest->getRevenuFiscal()) {

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -122,7 +122,6 @@ class SignalementBuilder
     {
         $this->signalement
             ->setSituationFoyer($this->situationFoyerFactory->createFromSignalementDraftPayload($this->payload))
-            ->setIsRelogement($this->evalBoolean($this->signalementDraftRequest->getLogementSocialDemandeRelogement()))
             ->setIsPreavisDepart(
                 $this->evalBoolean($this->signalementDraftRequest->getTravailleurSocialPreavisDepart())
             )
@@ -497,7 +496,8 @@ class SignalementBuilder
 
     private function isDemandeRelogement(): ?bool
     {
-        if (ProfileDeclarant::LOCATAIRE === $this->signalementDraft->getProfileDeclarant()) {
+        if (ProfileDeclarant::LOCATAIRE === $this->signalementDraft->getProfileDeclarant()
+            || ProfileDeclarant::BAILLEUR_OCCUPANT === $this->signalementDraft->getProfileDeclarant()) {
             return $this->evalBoolean($this->signalementDraftRequest->getLogementSocialDemandeRelogement());
         }
 

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -49,16 +49,6 @@
                                     <option value="nsp" {{ infoProcedureDepartApresTravaux is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
-
-                            <div class="fr-select-group">
-                                {% set demandeRelogement = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement : null %}
-                                <label class="fr-label" for="demandeRelogement">Demande logement social / relogement</label>
-                                <select class="fr-select" name="demandeRelogement">
-                                    <option value="" {{ demandeRelogement not in ['oui', 'non'] ? 'selected' : '' }}></option>
-                                    <option value="oui" {{ demandeRelogement is same as 'oui' ? 'selected' : '' }}>Oui</option>
-                                    <option value="non" {{ demandeRelogement is same as 'non' ? 'selected' : '' }}>Non</option>
-                                </select>
-                            </div>
                         </div>
                         
                         <div class="fr-modal__footer">

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -23,12 +23,11 @@
                             </div>
 
                             <div class="fr-select-group">
-                                {% set isRelogement = signalement.isRelogement %}
                                 <label class="fr-label" for="isRelogement">Demande relogement</label>
                                 <select class="fr-select" name="isRelogement">
-                                    <option value="" {{ isRelogement is null ? 'selected' : '' }}></option>
-                                    <option value="oui" {{ isRelogement is same as true ? 'selected' : '' }}>Oui</option>
-                                    <option value="non" {{ isRelogement is same as false ? 'selected' : '' }}>Non</option>
+                                    <option value=""></option>
+                                    <option value="oui" {{ signalement.isRelogement is same as true ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ signalement.isRelogement is same as false ? 'selected' : '' }}>Non</option>
                                 </select>
                             </div>
 

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -23,7 +23,7 @@
                             </div>
 
                             <div class="fr-select-group">
-                                <label class="fr-label" for="isRelogement">Demande relogement</label>
+                                <label class="fr-label" for="isRelogement">Demande logement social / relogement</label>
                                 <select class="fr-select" name="isRelogement">
                                     <option value=""></option>
                                     <option value="oui" {{ signalement.isRelogement is same as true ? 'selected' : '' }}>Oui</option>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -520,33 +520,14 @@
                             {{ static_picto_no|raw }}
                         {% endif %}
                     </div>
-                    {% if signalement.isNotOccupant %}
                     <div class="fr-col-12">
                         <strong>Demande logement social / relogement :</strong>
-                        {% if signalement.informationComplementaire %}
-                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'oui' %}
-                                {{ static_picto_yes|raw }}
-                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'non' %}
-                                {{ static_picto_no|raw }}
-                            {% else %}
-                                Ne sait pas
-                            {% endif %}
-                        {% else %}
-                            N/C
-                        {% endif %}
-                    </div>
-                    {% else %}
-                    <div class="fr-col-12 fr-col-md-6">
-                        <strong>Demande relogement :</strong>
-                        {% if signalement.isRelogement is null %}
-                            
-                        {% elseif signalement.isRelogement %}
+                        {% if signalement.isRelogement is same as true %}
                             {{ static_picto_yes|raw }}
-                        {% else %}
+                        {% elseif signalement.isRelogement is same as false %}
                             {{ static_picto_no|raw }}
                         {% endif %}
                     </div>
-                    {% endif %}
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Allocataire :</strong>
                         {% if signalement.isAllocataire in [null, ''] %}

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -520,6 +520,22 @@
                             {{ static_picto_no|raw }}
                         {% endif %}
                     </div>
+                    {% if signalement.isNotOccupant %}
+                    <div class="fr-col-12">
+                        <strong>Demande logement social / relogement :</strong>
+                        {% if signalement.informationComplementaire %}
+                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'oui' %}
+                                {{ static_picto_yes|raw }}
+                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'non' %}
+                                {{ static_picto_no|raw }}
+                            {% else %}
+                                Ne sait pas
+                            {% endif %}
+                        {% else %}
+                            N/C
+                        {% endif %}
+                    </div>
+                    {% else %}
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Demande relogement :</strong>
                         {% if signalement.isRelogement is null %}
@@ -530,6 +546,7 @@
                             {{ static_picto_no|raw }}
                         {% endif %}
                     </div>
+                    {% endif %}
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Allocataire :</strong>
                         {% if signalement.isAllocataire in [null, ''] %}
@@ -691,18 +708,6 @@
                                 {{ static_picto_yes|raw }}
                             {% else %}
                                 {{signalement.informationProcedure.infoProcedureDepartApresTravaux(false)}}
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                    <div class="fr-col-12">
-                        <strong>Demande logement social / relogement :</strong>
-                        {% if signalement.informationComplementaire %}
-                            {% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'oui' %}
-                                {{ static_picto_yes|raw }}
-                            {% elseif signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement is same as 'non' %}
-                                {{ static_picto_no|raw }}
-                            {% else %}
-                                {{signalement.informationComplementaire.informationsComplementairesSituationOccupantsDemandeRelogement}}
                             {% endif %}
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Ticket

#2161   

## Description
L'info concernant les demandes de relogement est posée de deux manières différentes dans le formulaire, selon qu'on soit occupant ou tiers.
Les deux réponses étaient affichées dans 2 blocs différents dans le BO.
On regroupe donc les deux réponses, affichées selon le profil, dans le même bloc `Situation du foyer`.

## Tests
- [ ] Signalement en tant qu'occupant : vérifier que l'information s'affiche bien dans le bloc `Situation du foyer`, qu'on peut l'éditer correctement
- [ ] Signalement en tant que tiers : vérifier que l'information s'affiche bien dans `Situation du foyer`, qu'on peut l'éditer correctement
- [ ] Vérifier que l'édition du bloc `Procédures et démarches` est toujours fonctionnel
