### PR TITLE
[BO] Correction effet de bord transformation de chaîne vide à null

### DIFF
--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -16,6 +16,7 @@ use App\Entity\User;
 use App\EventListener\SignalementUpdatedListener;
 use App\Factory\SuiviFactory;
 use App\Manager\SignalementManager;
+use App\Serializer\SignalementDraftRequestSerializer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -255,7 +256,7 @@ class SignalementEditController extends AbstractController
         Signalement $signalement,
         Request $request,
         SignalementManager $signalementManager,
-        SerializerInterface $serializer,
+        SignalementDraftRequestSerializer $serializer,
         ValidatorInterface $validator,
         SignalementUpdatedListener $listener
     ): Response {
@@ -275,6 +276,10 @@ class SignalementEditController extends AbstractController
             if ('autre' == $compositionLogementRequest->getType()) {
                 $validationGroups[] = 'TYPE_LOGEMENT_AUTRE';
             }
+            if ($signalement->getProfileDeclarant()) {
+                $validationGroups[] = $signalement->getProfileDeclarant()->value;
+            }
+
             $errorMessage = $this->getErrorMessage($validator, $compositionLogementRequest, $validationGroups);
 
             if (empty($errorMessage)) {

--- a/src/Serializer/SignalementDraftRequestNormalizer.php
+++ b/src/Serializer/SignalementDraftRequestNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace App\Serializer;
 
+use App\Dto\Request\Signalement\CompositionLogementRequest;
 use App\Dto\Request\Signalement\SignalementDraftRequest;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\SignalementDraft;
@@ -46,7 +47,7 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
 
                 $transformedData[SignalementDraftRequest::FILE_UPLOAD_KEY][$keyUpdated] = $data[$key];
             } else {
-                $transformedData[$key] = $value;
+                $transformedData[$key] = !empty($value) ? $value : null;
             }
         }
 
@@ -87,6 +88,7 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
         return [
             SignalementDraftRequest::class => true,
             TypeCompositionLogement::class => true,
+            CompositionLogementRequest::class => true,
         ];
     }
 }


### PR DESCRIPTION
## Ticket

#2160    

## Description
Commentaire de @hmeneuvrier lié à [ce lien](https://github.com/MTES-MCT/histologe/pull/2186)
> En éditant un signalement pour un profil tiers particulier, la superficie et le nombre de pièces sont obligatoires, ce que je trouve étrange étant donné qu'ils ne sont pas obligatoires sur le FO (au moins la superficie).
![image](https://github.com/MTES-MCT/histologe/assets/5757116/836ed3e6-d0fa-421f-a687-c15e0ff4222a)

En fait, c'est la contrainte positive qui bloque la chaîne vide comparée à 0. Quant aux chaînes de caractères avec de vraies valeurs, elles ne s'appliqueront pas à la contrainte positive (il faudrait que ce soit de vrais nombres (float, int)).
Et Il manquait la contrainte lié au profile

![image](https://github.com/MTES-MCT/histologe/assets/5757116/31859fba-5d9c-4b5b-8dd1-e180a543a890)

## Remarque
Il y aura un travail à faire à terme au niveau des types de données des payload et des DTO (pas urgent vu l'usage via des formulaires). En effet, lorsque l'on ne passe pas par le formulaire avec une vraie chaîne non vide, cela provoque une erreur 500 car une fonction attend un float. Autant traiter le problème à la racine pour éviter de caster à chaque fois.

## Changements apportés
* Comportement ajouté dans le sérializeur : mettre à null si la requête envoie une chaîne vide.
* Utilisation du sérializeur personnalisé.
* Ajout du profile group au type de composition.

## Pré-requis

## Tests
- [ ] Soumettre un signalement avec une superficie chaîne vide pour les utilisateurs dont la superficie n'est pas obligatoire (les tiers).
- [ ] Éditer la composition du logement sans saisir la superficie.
- [ ] Soumettre un signalement avec une superficie pour les utilisateurs dont la superficie est obligatoire (occupant).
- [ ] Éditer la composition du logement sans saisir la superficie (Message indiquant que c'est obligatoire).
- [ ] Éditer la composition du logement en saisissant la superficie.
