### PR TITLE
[Relances auto] Correction requête pour ne pas exclure les abandons de procédures NULL

### DIFF
--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -18,6 +18,7 @@ class Suivi
 
     public const DEFAULT_PERIOD_INACTIVITY = 30;
     public const DEFAULT_PERIOD_RELANCE = 45;
+    public const LIMIT_DAILY_RELANCES = 45;
 
     public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';
     public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été cloturé pour';

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -18,7 +18,7 @@ class Suivi
 
     public const DEFAULT_PERIOD_INACTIVITY = 30;
     public const DEFAULT_PERIOD_RELANCE = 45;
-    public const LIMIT_DAILY_RELANCES = 45;
+    public const LIMIT_DAILY_RELANCES = 400;
 
     public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';
     public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été cloturé pour';

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -221,7 +221,7 @@ class SuiviRepository extends ServiceEntityRepository
         ) su ON s.id = su.signalement_id
         WHERE s.statut NOT IN (:status_need_validation, :status_closed, :status_archived, :status_refused)
         AND s.is_imported != 1
-        AND s.is_usager_abandon_procedure != 1
+        AND (s.is_usager_abandon_procedure != 1 OR s.is_usager_abandon_procedure IS NULL)
         GROUP BY s.id
         HAVING DATEDIFF(NOW(), IFNULL(last_posted_at, s.created_at)) > :day_period
         ORDER BY last_posted_at';
@@ -257,7 +257,7 @@ class SuiviRepository extends ServiceEntityRepository
                 WHERE su_last.id IS NULL AND su.max_date_suivi_technique < DATE_SUB(NOW(), INTERVAL :day_period DAY)
                 AND s.statut NOT IN (:status_need_validation, :status_closed, :status_archived, :status_refused)
                 AND s.is_imported != 1
-                AND s.is_usager_abandon_procedure != 1';
+                AND (s.is_usager_abandon_procedure != 1 OR s.is_usager_abandon_procedure IS NULL)';
 
         $statement = $connection->prepare($sql);
 
@@ -344,7 +344,7 @@ class SuiviRepository extends ServiceEntityRepository
         }
 
         if ($excludeUsagerAbandonProcedure) {
-            $whereExcludeUsagerAbandonProcedure = 'AND s.is_usager_abandon_procedure != 1 ';
+            $whereExcludeUsagerAbandonProcedure = 'AND (s.is_usager_abandon_procedure != 1 OR s.is_usager_abandon_procedure IS NULL)';
         }
         if ($dayPeriod > 0) {
             $whereLastSuiviDelay = 'AND su.max_date_suivi < DATE_SUB(NOW(), INTERVAL '.$dayPeriod.' DAY) ';

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -199,6 +199,7 @@ class SuiviRepository extends ServiceEntityRepository
 
     public function findSignalementsLastSuiviPublic(
         int $period = Suivi::DEFAULT_PERIOD_RELANCE,
+        int $limit = Suivi::LIMIT_DAILY_RELANCES,
     ): array {
         $connection = $this->getEntityManager()->getConnection();
 
@@ -224,7 +225,8 @@ class SuiviRepository extends ServiceEntityRepository
         AND (s.is_usager_abandon_procedure != 1 OR s.is_usager_abandon_procedure IS NULL)
         GROUP BY s.id
         HAVING DATEDIFF(NOW(), IFNULL(last_posted_at, s.created_at)) > :day_period
-        ORDER BY last_posted_at';
+        ORDER BY last_posted_at
+        LIMIT '.$limit;
 
         $statement = $connection->prepare($sql);
 
@@ -233,6 +235,7 @@ class SuiviRepository extends ServiceEntityRepository
 
     public function findSignalementsLastSuiviTechnical(
         int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
+        int $limit = Suivi::LIMIT_DAILY_RELANCES,
     ): array {
         $connection = $this->getEntityManager()->getConnection();
 
@@ -257,7 +260,8 @@ class SuiviRepository extends ServiceEntityRepository
                 WHERE su_last.id IS NULL AND su.max_date_suivi_technique < DATE_SUB(NOW(), INTERVAL :day_period DAY)
                 AND s.statut NOT IN (:status_need_validation, :status_closed, :status_archived, :status_refused)
                 AND s.is_imported != 1
-                AND (s.is_usager_abandon_procedure != 1 OR s.is_usager_abandon_procedure IS NULL)';
+                AND (s.is_usager_abandon_procedure != 1 OR s.is_usager_abandon_procedure IS NULL)
+                LIMIT '.$limit;
 
         $statement = $connection->prepare($sql);
 


### PR DESCRIPTION
## Ticket

#2181   

## Description
Certains signalements (voir ticket joint) ne recevaient pas de relance automatique.
Après étude, les signalements dont la valeur de `is_usager_abandon_procedure` était à NULL n'était pas retourné.
Etrangeté de MySQL qui ne considère pas les valeurs `NULL` dans `!= 1`

## Tests
- [ ] Mettre `is_usager_abandon_procedure` à `NULL` pour un ou plusieurs signalements
- [ ] Exécuter la commande make console app="ask-feedback-usager"
- [ ] Vérifier que le signalement est bien concerné par les relances qui sont envoyées
