### PR TITLE
[BO - signalement] Création d'un désordre par erreur si superficie non définie

### DIFF
--- a/src/Service/Signalement/DesordreTraitement/DesordreCompositionLogementLoader.php
+++ b/src/Service/Signalement/DesordreTraitement/DesordreCompositionLogementLoader.php
@@ -48,7 +48,9 @@ class DesordreCompositionLogementLoader
         }
 
         if ('piece_unique' === $typeCompositionLogement->getCompositionLogementPieceUnique()) {
-            if ($typeCompositionLogement->getCompositionLogementSuperficie() < 9) {
+            if (null !== $typeCompositionLogement->getCompositionLogementSuperficie()
+                && $typeCompositionLogement->getCompositionLogementSuperficie() < 9
+            ) {
                 $this->addDesordreCriterePrecisionBySlugs(
                     'desordres_type_composition_logement_piece_unique',
                     'desordres_type_composition_logement_piece_unique_superficie'
@@ -205,7 +207,8 @@ class DesordreCompositionLogementLoader
             && $this->signalement->hasDesordrePrecision($precisionToLink)) {
             $this->signalement->removeDesordrePrecision($precisionToLink);
         }
-        if ($this->signalement->hasDesordreCategorie($critereToLink->getDesordreCategorie())
+
+        if (null !== $critereToLink && $this->signalement->hasDesordreCategorie($critereToLink->getDesordreCategorie())
             && !$this->hasDesordreCritereInCategorie($this->signalement, $critereToLink->getDesordreCategorie())) {
             $this->signalement->removeDesordreCategory($critereToLink->getDesordreCategorie());
         }


### PR DESCRIPTION
## Ticket

#2207    

## Description
Sur un signalement fait pas un tiers, la superficie n'est pas obligatoire. Si c'est une pièce unique, on a le désordre suivant par erreur
"La superficie du logement < 9m"
et du coup, les scores et qualifs qui vont avec.
![image](https://github.com/MTES-MCT/histologe/assets/33071753/1432b7e2-e9da-4901-9fec-0352445954dc)


Dans le calcul des désordres liés à la composition du logement, vérifier que la superficie est bien définie.
DesordreCompositionLogementLoader->load() ligne 51

## Changements apportés
* Ajout d'une condition avant d'ajouter le désordre 

## Pré-requis

## Tests
- [ ] Créer un signalement tiers sans superficie avec pour nombre de pièce égale à 1 et vérifier que le désordre `La superficie du logement < 9m` n'existe pas
- [ ] Editer le signalement en mettant une superficie et un nombre de pièce égale à 1, vérifier la présence du désordre
