### PR TITLE
[Performance] Mise en place outil APM (Application performance monitoring) pour monitorer la plateforme

### DIFF
--- a/.env
+++ b/.env
@@ -65,6 +65,8 @@ S3_URL_BUCKET=
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_TRACES_SAMPLE_RATE=
 ###< sentry/sentry-symfony ###
 
 ### wiremock ###

--- a/.env.sample
+++ b/.env.sample
@@ -69,6 +69,8 @@ S3_URL_BUCKET=
 
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_TRACES_SAMPLE_RATE=
 ###< sentry/sentry-symfony ###
 
 ###> symfony/messenger ###

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -1,9 +1,21 @@
 when@prod:
     sentry:
-        dsn: '%env(SENTRY_DSN)%'
+        dsn: '%env(resolve:SENTRY_DSN)%'
         register_error_listener: false # Disables the ErrorListener to avoid duplicated log in sentry
         options:
-          environment: '%kernel.environment%'
+          environment: '%env(resolve:SENTRY_ENVIRONMENT)%' # prod|staging
+          # Specify a fixed sample rate:
+          traces_sample_rate: '%env(float:SENTRY_TRACES_SAMPLE_RATE)%' # Between 0 and 1
+        tracing:
+          enabled: true
+          dbal: # DB queries
+            enabled: true
+          cache: # cache pools
+            enabled: true
+          twig: # templating engine
+            enabled: true
+          http_client: # Symfony HTTP client
+            enabled: true
 
     monolog:
       handlers:


### PR DESCRIPTION
## Ticket

#973    

## Description
Configurer la partie https://docs.sentry.io/platforms/php/guides/symfony/performance/

![image](https://github.com/MTES-MCT/histologe/assets/5757116/2f812602-5280-47fc-9fc3-6ec8748b546d)


## Changements apportés
* Rendre l'environnement configurable
* Ajout d'options pour le monitoring de la performance

## Pré-requis
On peut aussi aller à 100% du trafic en production sachant qu'on a pas de millions d'utilisateurs

```
# SENTRY_ENVIRONMENT=
# SENTRY_TRACES_SAMPLE_RATE= 
```
Review app configuré avec 100% du traffic
https://histologe-staging-pr2209.osc-fr1.scalingo.io/

## Tests
- [ ] https://sentry.incubateur.net/organizations/betagouv/performance/
