### PR TITLE
[Relances automatiques] Modification du nombre de relances max par type de relance

### DIFF
--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -18,7 +18,7 @@ class Suivi
 
     public const DEFAULT_PERIOD_INACTIVITY = 30;
     public const DEFAULT_PERIOD_RELANCE = 45;
-    public const LIMIT_DAILY_RELANCES = 400;
+    public const LIMIT_DAILY_RELANCES = 200;
 
     public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';
     public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été cloturé pour';


### PR DESCRIPTION
## Ticket

#2181   

## Description
Modification du nombre de relances max par type de relance : on passe de 400 à 200 (donc 3 x 400 à 3 x 200)

## Tests
- [ ] `make console app="ask-feedback-usager"`
