### PR TITLE
[QA - Sentry] setKey on Array / TypeError

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -138,10 +138,12 @@ class FrontSignalementController extends AbstractController
         if (null !== ($files = $request->files->get('signalement'))) {
             try {
                 foreach ($files as $key => $file) {
-                    $res = $uploadHandlerService->toTempFolder($file)->setKey($key);
-                    if (!isset($res['error'])
-                        && \in_array($file->getMimeType(), ImageManipulationHandler::IMAGE_MIME_TYPES)
-                    ) {
+                    $res = $uploadHandlerService->toTempFolder($file);
+                    if (isset($res['error'])) {
+                        throw new \Exception($res['error']);
+                    }
+                    $res = $uploadHandlerService->setKey($key);
+                    if (\in_array($file->getMimeType(), ImageManipulationHandler::IMAGE_MIME_TYPES)) {
                         $imageManipulationHandler->resize($res['filePath'])->thumbnail();
                     }
 

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -139,7 +139,7 @@ class FrontSignalementController extends AbstractController
             try {
                 foreach ($files as $key => $file) {
                     $res = $uploadHandlerService->toTempFolder($file);
-                    if (isset($res['error'])) {
+                    if (\is_array($res) && isset($res['error'])) {
                         throw new \Exception($res['error']);
                     }
                     $res = $uploadHandlerService->setKey($key);
@@ -204,11 +204,13 @@ class FrontSignalementController extends AbstractController
             $signalement = new Signalement();
             $dataDateBail = $dataHasDPE = $dataDateDPE = $dataConsoSizeYear = $dataConsoSize = $dataConsoYear = null;
             $listNDECriticites = [];
-
             if (isset($data['files'])) {
                 $dataFiles = $data['files'];
                 foreach ($dataFiles as $key => $files) {
                     foreach ($files as $titre => $file) {
+                        if (\is_array($file)) {
+                            continue;
+                        }
                         $filename = $uploadHandlerService->moveFromBucketTempFolder($file);
                         $file = $fileFactory->createInstanceFrom(
                             filename: $filename,

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -57,7 +57,6 @@ class UploadHandlerService
             $fileResource = fopen($file->getPathname(), 'r');
             $this->fileStorage->writeStream($distantFolder.$newFilename, $fileResource);
             fclose($fileResource);
-            // throw new FileException('Erreur lors du téléversement.');
         } catch (FileException $e) {
             $this->logger->error($e->getMessage());
 

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -57,6 +57,7 @@ class UploadHandlerService
             $fileResource = fopen($file->getPathname(), 'r');
             $this->fileStorage->writeStream($distantFolder.$newFilename, $fileResource);
             fclose($fileResource);
+            // throw new FileException('Erreur lors du téléversement.');
         } catch (FileException $e) {
             $this->logger->error($e->getMessage());
 


### PR DESCRIPTION
## Ticket

#2211 #2212

## Description
- Correction de l'erreur "Error: Call to a member function setKey() on array" si l'upload d'une image ne se passe pas correctement
- Correction de l'erreur "Argument https://github.com/MTES-MCT/histologe/pull/1 ($filename) must be of type string, array given" lors de la soumission du formulaire

## Tests
Je n'ai pas su reproduire les erreurs via une utilisation normale, voici comment on peux tester :
- [ ] Tester que l'upload d'image ne provoque pas l'erreur "setKey" aprés avoir ajouté `throw new FileException('DEBUG');`  sous la ligne 59 de `src/Service/UploadHandlerService.php`
- [ ] Tester que la soumission de l'ancien formulaire (contenant des document) ne provoque pas d'erreur en transformant le champ en array (ex `signalement[files][photos][OIG3.jpg]` => `signalement[files][photos][OIG3.jpg][]`
