### PR TITLE
[BO - dahsboard] Apparition des widgets NDE pour tous ceux qui ont la compétence, alors que le formulaire n'est pas activé

### DIFF
--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -92,6 +92,16 @@ class UserVoter extends Voter
 
     public function canSeeNde(User $user): bool
     {
-        return $user->isTerritoryAdmin() || \in_array(Qualification::NON_DECENCE_ENERGETIQUE, $user->getPartner()->getCompetence());
+        $experimentationTerritories = $this->parameterBag->get('experimentation_territory');
+        $isExperimentationTerritory = \array_key_exists(
+            $user->getPartner()->getTerritory()->getZip(),
+            $experimentationTerritories
+        );
+        if ($isExperimentationTerritory || $this->parameterBag->get('feature_new_form')) {
+            return $user->isTerritoryAdmin()
+            || \in_array(Qualification::NON_DECENCE_ENERGETIQUE, $user->getPartner()->getCompetence());
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Ticket

#2217   

## Description
Les widgets NDE appraissaient sur le dashboard pour les partenaires ayant la compétence NDE mais n'étant pas dans le territoire d'expérimentation, alors que le nouveau formulaire n'est pas encore activé

## Changements apportés
* Correction du UserVoter

## Pré-requis

## Tests
- [ ] Se connecter avec un admin de territoire d'un territoire hors expé (par exemple le 13), avec le formulaire activé les widgets doivent s'afficher, sans le formulaire activé, les widgets ne doivent pas s'afficher
- [ ] Se connecter avec un admin de terroitre d'un territoire dans l'expé (Yonne 89 par exemple), les widgets doivent s'afficher tout le temps
- [ ] Facultatif : Faire les tests équivalents avec des partenaires ayant la compétence NDE (nécessite d'avoir des partenaires avec la compétence NDE, utiliser `make console app="update-partners-communes-nde" `)
