### PR TITLE
[FO/BO - Signalement] Mise à jour des types de documents

### DIFF
--- a/migrations/Version20240205143843.php
+++ b/migrations/Version20240205143843.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240205143843 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add description column to file';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file ADD description LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file DROP description');
+    }
+}

--- a/migrations/Version20240205143843.php
+++ b/migrations/Version20240205143843.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use App\Entity\Enum\DocumentType;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -17,6 +18,7 @@ final class Version20240205143843 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE file ADD description LONGTEXT DEFAULT NULL');
+        $this->addSql('UPDATE file SET document_type = \''.DocumentType::AUTRE->name.'\' WHERE document_type IS NULL');
     }
 
     public function down(Schema $schema): void

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Back;
 
+use App\Entity\Enum\DocumentType;
 use App\Entity\File;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
@@ -63,8 +64,9 @@ class SignalementFileController extends AbstractController
             $inputName = isset($files[File::INPUT_NAME_DOCUMENTS])
                 ? File::INPUT_NAME_DOCUMENTS
                 : File::INPUT_NAME_PHOTOS;
-
-            list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName);
+            // TODO : récupérer le document type depuis la requête en fonction de l'endroit d'appel de cette route
+            $documentType = DocumentType::tryFrom($request->get('document_type'));
+            list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName, $documentType);
 
             if ($signalementFileProcessor->isValid()) {
                 $nbFiles = \count($fileList);

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -64,7 +64,7 @@ class SignalementFileController extends AbstractController
             $inputName = isset($files[File::INPUT_NAME_DOCUMENTS])
                 ? File::INPUT_NAME_DOCUMENTS
                 : File::INPUT_NAME_PHOTOS;
-            $documentType = DocumentType::tryFrom($request->get('document_type'));
+            $documentType = DocumentType::tryFrom($request->get('document_type')) ?? DocumentType::AUTRE;
             list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName, $documentType);
 
             if ($signalementFileProcessor->isValid()) {

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -64,7 +64,6 @@ class SignalementFileController extends AbstractController
             $inputName = isset($files[File::INPUT_NAME_DOCUMENTS])
                 ? File::INPUT_NAME_DOCUMENTS
                 : File::INPUT_NAME_PHOTOS;
-            // TODO : récupérer le document type depuis la requête en fonction de l'endroit d'appel de cette route
             $documentType = DocumentType::tryFrom($request->get('document_type'));
             list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName, $documentType);
 

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -64,7 +64,8 @@ class SignalementFileController extends AbstractController
             $inputName = isset($files[File::INPUT_NAME_DOCUMENTS])
                 ? File::INPUT_NAME_DOCUMENTS
                 : File::INPUT_NAME_PHOTOS;
-            $documentType = DocumentType::tryFrom($request->get('document_type')) ?? DocumentType::AUTRE;
+            // $documentType = DocumentType::tryFrom($request->get('document_type')) ?? DocumentType::AUTRE;
+            $documentType = DocumentType::AUTRE;
             list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName, $documentType);
 
             if ($signalementFileProcessor->isValid()) {

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -594,7 +594,7 @@ class FrontSignalementController extends AbstractController
                     if (!empty($descriptionList)) {
                         $description .= '<br>Ajout de pièces au signalement<ul>'
                             .implode('', $descriptionList).'</ul>';
-                        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement); // TODO
+                        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement);
                     }
                 }
 

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -594,7 +594,7 @@ class FrontSignalementController extends AbstractController
                     if (!empty($descriptionList)) {
                         $description .= '<br>Ajout de pièces au signalement<ul>'
                             .implode('', $descriptionList).'</ul>';
-                        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement);
+                        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement, $user);
                     }
                 }
 

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Critere;
 use App\Entity\Criticite;
+use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\Qualification;
 use App\Entity\File;
 use App\Entity\Signalement;
@@ -216,6 +217,7 @@ class FrontSignalementController extends AbstractController
                             filename: $filename,
                             title: $titre,
                             type: 'documents' === $key ? File::FILE_TYPE_DOCUMENT : File::FILE_TYPE_PHOTO,
+                            documentType: DocumentType::AUTRE
                         );
                         if (null !== $file) {
                             $file->setSize($uploadHandlerService->getFileSize($file->getFilename()));
@@ -579,7 +581,11 @@ class FrontSignalementController extends AbstractController
                     if (isset($data['files'])) {
                         $dataFiles = $data['files'];
                         foreach ($dataFiles as $inputName => $files) {
-                            list($files, $descriptions) = $signalementFileProcessor->process($dataFiles, $inputName);
+                            list($files, $descriptions) = $signalementFileProcessor->process(
+                                $dataFiles,
+                                $inputName,
+                                DocumentType::AUTRE
+                            );
                             $fileList = [...$fileList, ...$files];
                             $descriptionList = [...$descriptionList, ...$descriptions];
                         }
@@ -588,7 +594,7 @@ class FrontSignalementController extends AbstractController
                     if (!empty($descriptionList)) {
                         $description .= '<br>Ajout de pièces au signalement<ul>'
                             .implode('', $descriptionList).'</ul>';
-                        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement);
+                        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement); // TODO
                     }
                 }
 
@@ -605,7 +611,10 @@ class FrontSignalementController extends AbstractController
         }
 
         if (!empty($email)) {
-            return $this->redirectToRoute('front_suivi_signalement', ['code' => $signalement->getCodeSuivi(), 'from' => $email]);
+            return $this->redirectToRoute(
+                'front_suivi_signalement',
+                ['code' => $signalement->getCodeSuivi(), 'from' => $email]
+            );
         }
 
         return $this->redirectToRoute('front_suivi_signalement', ['code' => $signalement->getCodeSuivi()]);

--- a/src/DataFixtures/Loader/LoadInterventionData.php
+++ b/src/DataFixtures/Loader/LoadInterventionData.php
@@ -2,6 +2,7 @@
 
 namespace App\DataFixtures\Loader;
 
+use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\ProcedureType;
 use App\Entity\File;
@@ -71,7 +72,8 @@ class LoadInterventionData extends Fixture implements OrderedFixtureInterface
                         : File::FILE_TYPE_PHOTO,
                     intervention: $intervention,
                     signalement: $intervention->getSignalement(),
-                    user: $user
+                    user: $user,
+                    documentType: DocumentType::VISITE
                 );
                 $manager->persist($file);
             }

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -250,7 +250,8 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                     ? File::FILE_TYPE_DOCUMENT
                     : File::FILE_TYPE_PHOTO,
                 signalement: $signalement,
-                user: $user
+                user: $user,
+                documentType: DocumentType::AUTRE
             );
             $manager->persist($file);
         }
@@ -264,7 +265,8 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                     title: 'Blank.pdf',
                     type: File::FILE_TYPE_PHOTO,
                     signalement: $signalement,
-                    user: $user
+                    user: $user,
+                    documentType: DocumentType::AUTRE
                 );
                 $manager->persist($file);
                 ++$countMorePhoto;

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -56,6 +56,9 @@ class File
     #[ORM\Column]
     private ?bool $isVariantsGenerated = null;
 
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $description;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -77,6 +80,19 @@ class File
         $this->uploadedBy = $uploadedBy;
 
         return $this;
+    }
+
+    public function isUsagerFile(): ?bool
+    {
+        return !$this->uploadedBy->isSuperAdmin()
+        && !$this->uploadedBy->isTerritoryAdmin()
+        && !$this->uploadedBy->isPartnerAdmin()
+        && !$this->uploadedBy->isUserPartner();
+    }
+
+    public function isPartnerFile(): ?bool
+    {
+        return !$this->isUsagerFile();
     }
 
     public function getSignalement(): ?Signalement
@@ -202,6 +218,18 @@ class File
     public function setIsVariantsGenerated(bool $isVariantsGenerated): self
     {
         $this->isVariantsGenerated = $isVariantsGenerated;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
 
         return $this;
     }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -84,15 +84,15 @@ class File
 
     public function isUsagerFile(): ?bool
     {
-        return !$this->uploadedBy->isSuperAdmin()
-        && !$this->uploadedBy->isTerritoryAdmin()
-        && !$this->uploadedBy->isPartnerAdmin()
-        && !$this->uploadedBy->isUserPartner();
+        return !$this->isPartnerFile();
     }
 
     public function isPartnerFile(): ?bool
     {
-        return !$this->isUsagerFile();
+        return $this->uploadedBy->isSuperAdmin()
+        || $this->uploadedBy->isTerritoryAdmin()
+        || $this->uploadedBy->isPartnerAdmin()
+        || $this->uploadedBy->isUserPartner();
     }
 
     public function getSignalement(): ?Signalement

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -356,16 +356,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function isPartnerAdmin(): bool
-    {
-        return \in_array('ROLE_ADMIN_PARTNER', $this->getRoles());
-    }
-
-    public function isUserPartner(): bool
-    {
-        return \in_array(self::ROLE_USER_PARTNER, $this->getRoles());
-    }
-
     /**
      * @see UserInterface
      */
@@ -395,12 +385,22 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function isSuperAdmin(): bool
     {
-        return \in_array('ROLE_ADMIN', $this->roles);
+        return \in_array(self::ROLE_ADMIN, $this->roles);
     }
 
     public function isTerritoryAdmin(): bool
     {
-        return \in_array('ROLE_ADMIN_TERRITORY', $this->roles);
+        return \in_array(self::ROLE_ADMIN_TERRITORY, $this->roles);
+    }
+
+    public function isPartnerAdmin(): bool
+    {
+        return \in_array(self::ROLE_ADMIN_PARTNER, $this->getRoles());
+    }
+
+    public function isUserPartner(): bool
+    {
+        return \in_array(self::ROLE_USER_PARTNER, $this->getRoles());
     }
 
     public function getTerritory(): ?Territory

--- a/src/EventSubscriber/SignalementCreatedSubscriber.php
+++ b/src/EventSubscriber/SignalementCreatedSubscriber.php
@@ -3,6 +3,7 @@
 namespace App\EventSubscriber;
 
 use App\Event\SignalementCreatedEvent;
+use App\Manager\FileManager;
 use App\Manager\UserManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -10,6 +11,7 @@ class SignalementCreatedSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private UserManager $userManager,
+        private FileManager $fileManager,
     ) {
     }
 
@@ -24,7 +26,14 @@ class SignalementCreatedSubscriber implements EventSubscriberInterface
     {
         $signalement = $event->getSignalement();
 
-        $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::OCCUPANT);
-        $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::DECLARANT);
+        $userOccupant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::OCCUPANT);
+        $userDeclarant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::DECLARANT);
+
+        if ($signalement->getIsNotOccupant()) {
+            $user = $userDeclarant;
+        } else {
+            $user = $userOccupant;
+        }
+        $this->fileManager->updateSignalementFilesUser($signalement, $user);
     }
 }

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -20,6 +20,7 @@ class FileFactory
         ?Intervention $intervention = null,
         ?DocumentType $documentType = null,
         ?string $desordreSlug = null,
+        ?string $description = null,
     ): ?File {
         $file = (new File())
             ->setFilename($filename)
@@ -39,10 +40,16 @@ class FileFactory
 
         if (null !== $documentType) {
             $file->setDocumentType($documentType);
+        } else {
+            $file->setDocumentType(DocumentType::AUTRE);
         }
 
         if (null !== $desordreSlug) {
             $file->setDesordreSlug($desordreSlug);
+        }
+
+        if (null !== $description) {
+            $file->setDescription($description);
         }
 
         return $file;
@@ -53,6 +60,7 @@ class FileFactory
      *                    - 'slug' (string): The slug value.
      *                    - 'file' (string): The file path.
      *                    - 'titre' (string): The title of the file.
+     *                    - 'description' (string): The description of the file.
      */
     public function createFromFileArray(
         array $file,
@@ -62,6 +70,7 @@ class FileFactory
     ): ?File {
         $documentType = SignalementDocumentTypeMapper::map($file['slug']);
         $desordreSlug = DocumentType::SITUATION === $documentType ? $file['slug'] : null;
+        $fileDescription = $file['description'] ?? null;
 
         return $this->createInstanceFrom(
             filename: $file['file'],
@@ -73,7 +82,8 @@ class FileFactory
             user: $user,
             intervention: $intervention,
             documentType: SignalementDocumentTypeMapper::map($file['slug']),
-            desordreSlug: $desordreSlug
+            desordreSlug: $desordreSlug,
+            description: $fileDescription,
         );
     }
 }

--- a/src/Manager/FileManager.php
+++ b/src/Manager/FileManager.php
@@ -56,4 +56,16 @@ class FileManager extends AbstractManager
 
         return $file;
     }
+
+    public function updateSignalementFilesUser(
+        Signalement $signalement,
+        User $user,
+    ) {
+        foreach ($signalement->getFiles() as $file) {
+            if (null === $file->getUploadedBy()) {
+                $file->setUploadedBy($user);
+                $this->save($file);
+            }
+        }
+    }
 }

--- a/src/Manager/FileManager.php
+++ b/src/Manager/FileManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Manager;
 
+use App\Entity\Enum\DocumentType;
 use App\Entity\File;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -25,19 +26,31 @@ class FileManager extends AbstractManager
         string $type = null,
         ?Signalement $signalement = null,
         ?User $user = null,
-        bool $flush = false
+        bool $flush = false,
+        ?DocumentType $documentType = null,
+        ?string $description = null
     ): File {
         /** @var FileRepository $fileRepository */
         $fileRepository = $this->getRepository();
         $file = $fileRepository->findOneBy(['filename' => $filename]);
         if (null === $file) {
-            $file = $this->fileFactory->createInstanceFrom($filename, $title, $type, $signalement, $user);
+            $file = $this->fileFactory->createInstanceFrom(
+                filename: $filename,
+                title: $title,
+                type: $type,
+                signalement: $signalement,
+                user: $user,
+                documentType: $documentType,
+                description: $description
+            );
         }
 
         $file
             ->setTitle($title)
             ->setFileType($type)
-            ->setSignalement($signalement);
+            ->setSignalement($signalement)
+            ->setDocumentType($documentType ?? DocumentType::AUTRE)
+            ->setDescription($description);
 
         $this->save($file, $flush);
 

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -3,6 +3,7 @@
 namespace App\Manager;
 
 use App\Dto\Request\Signalement\VisiteRequest;
+use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\ProcedureType;
 use App\Entity\Enum\Qualification;
@@ -208,6 +209,7 @@ class InterventionManager extends AbstractManager
         /** @var User $user */
         $user = $this->security->getUser();
 
+        // TODO : quand la modale sera fait, le documentType pourra être différent
         return $this->fileFactory->createInstanceFrom(
             filename: $document,
             title: $document,
@@ -215,7 +217,8 @@ class InterventionManager extends AbstractManager
                 ? File::FILE_TYPE_DOCUMENT
                 : File::FILE_TYPE_PHOTO,
             signalement: $intervention->getSignalement(),
-            user: $user
+            user: $user,
+            documentType: DocumentType::VISITE
         );
     }
 }

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Signalement;
 
+use App\Entity\Enum\DocumentType;
 use App\Entity\File;
 use App\Entity\Intervention;
 use App\Entity\Signalement;
@@ -29,8 +30,11 @@ class SignalementFileProcessor
     ) {
     }
 
-    public function process(array $files, string $inputName): array
-    {
+    public function process(
+        array $files,
+        string $inputName,
+        ?DocumentType $documentType = DocumentType::AUTRE
+    ): array {
         $fileList = $descriptionList = [];
         $withTokenGenerated = false;
         foreach ($files[$inputName] as $key => $file) {
@@ -67,7 +71,7 @@ class SignalementFileProcessor
                 }
                 if (!empty($filename)) {
                     $descriptionList[] = $this->generateListItemDescription($filename, $title, $withTokenGenerated);
-                    $fileList[] = $this->createFileItem($filename, $title, $inputName);
+                    $fileList[] = $this->createFileItem($filename, $title, $inputName, $documentType);
                 }
             }
         }
@@ -88,6 +92,7 @@ class SignalementFileProcessor
                 type: $fileItem['type'],
                 user: $user,
                 intervention: $intervention,
+                documentType: $fileItem['documentType'],
             );
             $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
             $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
@@ -114,7 +119,8 @@ class SignalementFileProcessor
 
         $fileUrl = $this->urlGenerator->generate(
             'show_uploaded_file',
-            ['folder' => '_up', 'filename' => $filename])
+            ['folder' => '_up', 'filename' => $filename]
+        )
             .$queryTokenUrl;
 
         return '<li><a class="fr-link" target="_blank" href="'
@@ -124,13 +130,18 @@ class SignalementFileProcessor
             .'</a></li>';
     }
 
-    private function createFileItem(string $filename, string $title, string $inputName): array
-    {
+    private function createFileItem(
+        string $filename,
+        string $title,
+        string $inputName,
+        DocumentType $documentType
+    ): array {
         return [
             'file' => $filename,
             'title' => $title,
             'date' => new \DateTimeImmutable(),
             'type' => 'documents' === $inputName ? File::FILE_TYPE_DOCUMENT : File::FILE_TYPE_PHOTO,
+            'documentType' => $documentType,
         ];
     }
 }

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -17,6 +17,8 @@
                     </label>
                     <input type="hidden" name="_token"
                         value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
+                    <input type="hidden" name="document_type"
+                        value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
                 </form>
                 
                 <form method="POST" enctype="multipart/form-data" class="inline-form"
@@ -28,6 +30,8 @@
                     </label>
                     <input type="hidden" name="_token"
                         value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
+                    <input type="hidden" name="document_type"
+                        value="{{ enum('App\\Entity\\Enum\\DocumentType').VISITE.name }}">
                 </form>
             {% endif %}
         </div>

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -69,14 +69,13 @@
                  data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
                  style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
                 <button class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" data-id={{ photo.id }} title="Voir la photo"></button>
-                {% if importedBy is not same as 'user'
-                    and (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted)) %}
-                    {% if photo.uploadedBy is not defined or (photo.uploadedBy is not null and photo.uploadedBy.id is same as(app.user.id)) %}
-                        <button title="Supprimer la photo"
-                                data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'photos',filename:photo.filename}) }}"
-                                data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"
-                                class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line signalement-file-delete"></button>
-                    {% endif %}
+                {% if (importedBy is not same as 'user' and (photo.uploadedBy is not null and photo.isPartnerFile)) 
+                    and (canEditSignalement) 
+                    and (is_granted('ROLE_ADMIN_TERRITORY') or is_granted('ROLE_ADMIN') or photo.uploadedBy.id is same as(app.user.id)) %}
+                    <button title="Supprimer la photo"
+                        data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'photos',filename:photo.filename}) }}"
+                        data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"
+                        class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line signalement-file-delete"></button>
                 {% endif %}
             </div>
         </div>
@@ -110,10 +109,10 @@
             <a href="{{ asset('_up/'~doc.filename~'/'~signalement.uuid) }}"
                 class="fr-btn fr-btn--sm fr-icon-eye-fill img-box" title="Afficher le document"
                 target="_blank" rel="noopener"></a>
-            {% if (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted))
-                and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION')
-                %}
-            <button title="Supprimer le document"
+            {% if (importedBy is not same as 'user' and (doc.uploadedBy is not null and doc.isPartnerFile)) 
+                and (canEditSignalement) 
+                and (is_granted('ROLE_ADMIN_TERRITORY') or is_granted('ROLE_ADMIN') or doc.uploadedBy.id is same as(app.user.id)) %}
+                <button title="Supprimer le document"
                     data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'documents',filename:doc.filename}) }}"
                     data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"
                     class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line signalement-file-delete"></button>

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -31,7 +31,7 @@
                     <input type="hidden" name="_token"
                         value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
                     <input type="hidden" name="document_type"
-                        value="{{ enum('App\\Entity\\Enum\\DocumentType').VISITE.name }}">
+                        value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
                 </form>
             {% endif %}
         </div>
@@ -58,8 +58,8 @@
         photo => photo.fileType == 'photo'
                 and photo.intervention is null
                 and (
-                    (importedBy is same as 'user' and photo.uploadedBy is null)
-                    or (importedBy is same as 'partner' and photo.uploadedBy is not null)
+                    (importedBy is same as 'user' and (photo.uploadedBy is null or photo.isUsagerFile ))
+                    or (importedBy is same as 'partner' and (photo.uploadedBy is not null and photo.isPartnerFile))
                     or importedBy is same as 'all'
                 )
         ) %}
@@ -87,8 +87,8 @@
     doc => doc.fileType == 'document' 
             and doc.intervention is null
             and (
-                (importedBy is same as 'user' and doc.uploadedBy is null)
-                or (importedBy is same as 'partner' and doc.uploadedBy is not null)
+                (importedBy is same as 'user' and (doc.uploadedBy is null or doc.isUsagerFile ))
+                or (importedBy is same as 'partner' and (doc.uploadedBy is not null and doc.isPartnerFile))
                 or importedBy is same as 'all'
             )
     ) %}

--- a/tests/Functional/Manager/FileManagerTest.php
+++ b/tests/Functional/Manager/FileManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Manager;
 
+use App\Entity\Enum\DocumentType;
 use App\Entity\File;
 use App\Entity\Signalement;
 use App\Factory\FileFactory;
@@ -31,5 +32,33 @@ class FileManagerTest extends KernelTestCase
         $this->assertEquals('Blank', $file->getTitle());
         $this->assertEquals('document', $file->getFileType());
         $this->assertEquals($signalement->getReference(), $file->getSignalement()->getReference());
+        $this->assertEquals(DocumentType::AUTRE, $file->getDocumentType());
+    }
+
+    public function testCreatePhotoVisite(): void
+    {
+        $fileFactory = static::getContainer()->get(FileFactory::class);
+        /** @var ManagerRegistry $managerRegistry */
+        $managerRegistry = static::getContainer()->get(ManagerRegistry::class);
+        $fileManager = new FileManager($fileFactory, $managerRegistry);
+
+        $signalementRepository = $managerRegistry->getRepository(Signalement::class);
+
+        $desc = 'une photo de la cave plein de moisissure';
+        $file = $fileManager->createOrUpdate(
+            filename: 'blank.jpg',
+            title: 'Blank',
+            type: File::FILE_TYPE_PHOTO,
+            signalement: $signalement = $signalementRepository->findOneBy(['reference' => '2023-12']),
+            description: $desc,
+            documentType: DocumentType::VISITE
+        );
+
+        $this->assertEquals('blank.jpg', $file->getFilename());
+        $this->assertEquals('Blank', $file->getTitle());
+        $this->assertEquals('photo', $file->getFileType());
+        $this->assertEquals($signalement->getReference(), $file->getSignalement()->getReference());
+        $this->assertEquals($desc, $file->getDescription());
+        $this->assertEquals(DocumentType::VISITE, $file->getDocumentType());
     }
 }

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -29,6 +29,7 @@ class FileFactoryTest extends TestCase
         $this->assertInstanceOf(Signalement::class, $file->getSignalement());
         $this->assertInstanceOf(User::class, $file->getUploadedBy());
         $this->assertInstanceOf(\DateTimeImmutable::class, $file->getCreatedAt());
+        $this->assertEquals(DocumentType::AUTRE, $file->getDocumentType());
     }
 
     /**

--- a/tests/Unit/Service/Signalement/SignalementFileProcessorTest.php
+++ b/tests/Unit/Service/Signalement/SignalementFileProcessorTest.php
@@ -117,7 +117,7 @@ class SignalementFileProcessorTest extends TestCase
         $signalement = $this->getSignalement();
         [$fileList, $descriptionList] = $signalementFileProcessor->process(self::FILE_LIST, 'photos');
         $this->assertNotEmpty($descriptionList);
-        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement);
+        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement); // TODO
         $this->assertNotNull($signalement->getFiles());
     }
 }


### PR DESCRIPTION
## Ticket

#2155 
#2203 
#2202   

## Description
Mise à jour des types de documents dans les possibilités actuelles
Ajouter une colonne description pour les fichiers (utilisée pour les photos de visite)
Migration pour passer les documents et photos existantes en type "Autre"
Mise à jour du uploadedBy sur les fichiers lors de la création de signalement et de l'ajout de suivis
Mise à jour de l'affichage du bouton "supprrimer le fichier" en fonction des specs https://github.com/MTES-MCT/histologe/wiki/Ajout-documents#bo---supprimer-les-documents-et-photos

## Changements apportés
* Création d'une migration
* Mise à jour des controllers
* Mise à jour des loaders de fixtures
* Mise à jour de l'entité File pour ajouter la description et des fonctions isUsagerFile et isPartnerFile
* Mise à jour de la FileFactory
* Mise à jour des FileManager et InterventionMmanager
* Mise à jour du SignalementFileProcessor
* Mise à jour des tests

![Filtres listing signalement - Gestion de doc - FO (1)](https://github.com/MTES-MCT/histologe/assets/97226289/98f401c2-8681-45f0-ae47-bfbbabc496cc)
![Filtres listing signalement - Gestion de doc - BO](https://github.com/MTES-MCT/histologe/assets/97226289/a19b4254-6bf7-4dda-a126-07e4c0a7e04c)

## Pré-requis
```
docker compose exec -ti histologe_phpfpm php bin/console doctrine:migrations:execute --down 'DoctrineMigrations\Version20240205143843'
docker compose exec -ti histologe_phpfpm php bin/console doctrine:migrations:execute --up 'DoctrineMigrations\Version20240205143843'
```

## Tests
- [ ] Vérifier la table files en base qu'il y ait bien la colonne description et que tous les fichiers aient un document_type AUTRE s'ils n'avaient pas de document_type
- [ ] Faire un signalement en locataire depuis le nouveau formulaire en ajoutant des photos de désordres, et tous les documents demandés (bail, état des lieux, dpe, diagnostique plomb dans le désordre logement/sécurité) -> vérifier en base le document_type des photos et documents, et le uploaded_by_id
- [ ] Dans le BO, ajouter photo et document, et vérifier le document_type en base
- [ ] Dans le BO, ajouter une visite dans le passé avec un fichier rapport de visite et vérifier le document_type en base
- [ ] Faire un suivi visible à l'usager
- [ ] En usager, depuis la page de suivi usager, ajouter photo et document, et vérifier le type en base (et le uploaded_by_id)
- [ ] Sur un ancien signalement, ajouter des photos et documents avec plusieurs agents puis vérifier qu'on ne peut supprimer que les documents partenaires, que si le signalement est en cours, et que si soit on est admin territoire ou super admin, soit on est agent mais c'est notre fichier
- [ ] Idem sur un nouveau signalement
