### PR TITLE
Fixer des contraintes de longueur et de complexité des mots de passe

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -27,4 +27,5 @@ import './controllers/form_visite';
 import './controllers/view_signalement';
 import './controllers/cookie_banner';
 import './controllers/maintenance_banner';
+import './controllers/activate_account/activate_account';
 

--- a/assets/controllers/activate_account/activate_account.js
+++ b/assets/controllers/activate_account/activate_account.js
@@ -79,11 +79,11 @@ function canSubmitFormReinitPassword() {
         messageSpecial.classList.add('fr-message--valid')
     }
     if(!canSubmit){
-        groupInputPasswordRepeat.classList.add('fr-input-group--error')
+        groupInputPassword.classList.add('fr-input-group--error')
         groupInputPasswordRepeat.classList.add('fr-input-group--error')
         submitBtn.disabled = true;
     }else{
-        groupInputPasswordRepeat.classList.remove('fr-input-group--error')
+        groupInputPassword.classList.remove('fr-input-group--error')
         groupInputPasswordRepeat.classList.remove('fr-input-group--error')
     }
     return canSubmit;

--- a/assets/controllers/activate_account/activate_account.js
+++ b/assets/controllers/activate_account/activate_account.js
@@ -1,0 +1,90 @@
+document?.querySelectorAll('.fr-password-toggle')?.forEach(pwdToggle => {
+    pwdToggle.addEventListeners('click touchdown', (event) => {
+        ['fr-fi-eye-off-fill', 'fr-fi-eye-fill'].map(c => {
+            event.target.classList.toggle(c);
+        })
+        let pwd = event.target.parentElement.querySelector('[name^="password"]');
+        "text" !== pwd.type ? pwd.type = "text" : pwd.type = "password";
+    })
+})
+document?.querySelector('form[name="login-creation-mdp-form"]')?.querySelectorAll('[name^="password"]').forEach(pwd => {
+    pwd.addEventListener('input', canSubmitFormReinitPassword)
+})
+document?.querySelector('form[name="login-creation-mdp-form"]')?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const modalCgu = document.getElementById("fr-modal-cgu-bo");
+    dsfr(modalCgu).modal.conceal();
+    if(canSubmitFormReinitPassword()){
+        event.target.submit();
+    }
+})
+
+function canSubmitFormReinitPassword() {
+    const pass = document?.querySelector('form[name="login-creation-mdp-form"] #login-password').value;
+    const repeat = document?.querySelector('form[name="login-creation-mdp-form"] #login-password-repeat').value;
+    const pwdMatchError = document?.querySelector('form[name="login-creation-mdp-form"] #password-match-error');
+    const submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter');
+    const messageLength = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length');
+    const messageMaj = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj');
+    const messageMin = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min');
+    const messageNb = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb');
+    const messageSpecial = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special');
+    const groupInputPassword = document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password');
+    const groupInputPasswordRepeat = document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat');
+    let canSubmit = true;
+    pwdMatchError.classList.add('fr-hidden')
+    submitBtn.disabled = false;
+    if (pass !== repeat) {
+        canSubmit = false;
+        pwdMatchError.classList.remove('fr-hidden')
+    }
+    if (pass.length < 8) {
+        messageLength.classList.remove('fr-message--info', 'fr-message--valid')
+        messageLength.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageLength.classList.remove('fr-message--info', 'fr-message--valid')
+        messageLength.classList.add('fr-message--valid')
+    }
+    if (!/[A-Z]/.test(pass)) {
+        messageMaj.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMaj.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageMaj.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMaj.classList.add('fr-message--valid')
+    }
+    if(!/[a-z]/.test(pass)){
+        messageMin.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMin.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageMin.classList.remove('fr-message--info', 'fr-message--valid')
+        messageMin.classList.add('fr-message--valid')
+    }
+    if(!/[0-9]/.test(pass)){
+        messageNb.classList.remove('fr-message--info', 'fr-message--valid')
+        messageNb.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageNb.classList.remove('fr-message--info', 'fr-message--valid')
+        messageNb.classList.add('fr-message--valid')
+    }
+    if(!/[^a-zA-Z0-9]/.test(pass)){
+        messageSpecial.classList.remove('fr-message--info', 'fr-message--valid')
+        messageSpecial.classList.add('fr-message--error')
+        canSubmit = false;
+    }else{
+        messageSpecial.classList.remove('fr-message--info', 'fr-message--valid')
+        messageSpecial.classList.add('fr-message--valid')
+    }
+    if(!canSubmit){
+        groupInputPasswordRepeat.classList.add('fr-input-group--error')
+        groupInputPasswordRepeat.classList.add('fr-input-group--error')
+        submitBtn.disabled = true;
+    }else{
+        groupInputPasswordRepeat.classList.remove('fr-input-group--error')
+        groupInputPasswordRepeat.classList.remove('fr-input-group--error')
+    }
+    return canSubmit;
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -968,27 +968,29 @@ document?.querySelector('form[name="login-creation-mdp-form"]')?.querySelectorAl
         let repeat = document?.querySelector('form[name="login-creation-mdp-form"] #login-password-repeat').value;
         let pwdMatchError = document?.querySelector('form[name="login-creation-mdp-form"] #password-match-error');
         let submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter');
-        submitBtn.addEventListener('click', (e) => {
-            e.preventDefault()
-        })
+        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')
+        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.remove('fr-input-group--error')
+        pwdMatchError.classList.add('fr-hidden')
         if (pass !== repeat) {
-            document?.querySelector('form[name="login-creation-mdp-form"]').querySelectorAll('.fr-input-group').forEach(iptGroup => {
-                iptGroup.classList.add('fr-input-group--error')
-                iptGroup.querySelector('.fr-input').classList.add('fr-input--error')
-            })
+            document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.add('fr-input-group--error')
+            document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.add('fr-input-group--error')
             submitBtn.disabled = true;
             pwdMatchError.classList.remove('fr-hidden')
         } else {
-            document?.querySelector('form[name="login-creation-mdp-form"]').querySelectorAll('.fr-input-group--error,.fr-input--error').forEach(iptError => {
-                ['fr-input-group--error', 'fr-input--error'].map(c => {
-                    iptError.classList.remove(c)
-                });
-            })
-            pwdMatchError.classList.add('fr-hidden');
+            //TODO : ajouter tous les controle de contraintes de mot de passe
+            //
             submitBtn.disabled = false;
         }
     })
 })
+document?.querySelector('form[name="login-creation-mdp-form"]')?.addEventListener('submit', (event) => {
+    //TODO : check constraints
+
+    let modalCgu = document.getElementById("fr-modal-cgu-bo");
+    dsfr(modalCgu).modal.conceal();
+})
+
+
 document.querySelector('#modal-dpe-opener')?.addEventListener('click', (event) => {
     let urlDpe = event.target.getAttribute('data-dpe-url');
     fetch(urlDpe).then(r => {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -963,31 +963,15 @@ document?.querySelectorAll('.fr-password-toggle')?.forEach(pwdToggle => {
     })
 })
 document?.querySelector('form[name="login-creation-mdp-form"]')?.querySelectorAll('[name^="password"]').forEach(pwd => {
-    pwd.addEventListener('input', () => {
-        let pass = document?.querySelector('form[name="login-creation-mdp-form"] #login-password').value;
-        let repeat = document?.querySelector('form[name="login-creation-mdp-form"] #login-password-repeat').value;
-        let pwdMatchError = document?.querySelector('form[name="login-creation-mdp-form"] #password-match-error');
-        let submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter');
-        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')
-        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.remove('fr-input-group--error')
-        pwdMatchError.classList.add('fr-hidden')
-        if (pass !== repeat) {
-            document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.add('fr-input-group--error')
-            document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.add('fr-input-group--error')
-            submitBtn.disabled = true;
-            pwdMatchError.classList.remove('fr-hidden')
-        } else {
-            //TODO : ajouter tous les controle de contraintes de mot de passe
-            //
-            submitBtn.disabled = false;
-        }
-    })
+    pwd.addEventListener('input', canSubmitFormReinitPassword)
 })
 document?.querySelector('form[name="login-creation-mdp-form"]')?.addEventListener('submit', (event) => {
-    //TODO : check constraints
-
+    event.preventDefault();
     let modalCgu = document.getElementById("fr-modal-cgu-bo");
     dsfr(modalCgu).modal.conceal();
+    if(canSubmitFormReinitPassword()){
+        event.target.submit();
+    }
 })
 
 
@@ -1020,6 +1004,57 @@ document.querySelector('#modal-dpe-opener')?.addEventListener('click', (event) =
         })
     })
 })
+
+function canSubmitFormReinitPassword() {
+    let pass = document?.querySelector('form[name="login-creation-mdp-form"] #login-password').value;
+    let repeat = document?.querySelector('form[name="login-creation-mdp-form"] #login-password-repeat').value;
+    let pwdMatchError = document?.querySelector('form[name="login-creation-mdp-form"] #password-match-error');
+    let submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter');
+    let canSubmit = true;
+    document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')
+    document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.remove('fr-input-group--error')
+    document?.querySelectorAll('form[name="login-creation-mdp-form"] .password-input-messages').forEach((el) => {
+        el.classList.remove('fr-message--error');
+        el.classList.add('fr-message--info');
+    });
+    pwdMatchError.classList.add('fr-hidden')
+    submitBtn.disabled = false;
+    if (pass !== repeat) {
+        canSubmit = false;
+        pwdMatchError.classList.remove('fr-hidden')
+    }
+    if (pass.length < 8) {
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.add('fr-message--error')
+        canSubmit = false;
+    }
+    if (!/[A-Z]/.test(pass)) {
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.add('fr-message--error')
+        canSubmit = false;
+    }
+    if(!/[a-z]/.test(pass)){
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.add('fr-message--error')
+        canSubmit = false;
+    }
+    if(!/[0-9]/.test(pass)){
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.add('fr-message--error')
+        canSubmit = false;
+    }
+    if(!/[!@#$%^&*(),.?":{}|<>]/.test(pass)){
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.add('fr-message--error')
+        canSubmit = false;
+    }
+    if(!canSubmit){
+        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')
+        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.add('fr-input-group--error')
+        submitBtn.disabled = true;
+    }
+    return canSubmit;
+}
 
 const refetchAddress = (form) => {
     // If the code postal is manually edited, we reinit the insee/geoloc and fetch the first result

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1056,7 +1056,7 @@ function canSubmitFormReinitPassword() {
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.remove('fr-message--info')
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.add('fr-message--valid')
     }
-    if(!/[!@#$%^&*(),.?":{}|<>]/.test(pass)){
+    if(!/[^a-zA-Z0-9]/.test(pass)){
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.remove('fr-message--info')
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.add('fr-message--error')
         canSubmit = false;
@@ -1065,7 +1065,7 @@ function canSubmitFormReinitPassword() {
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.add('fr-message--valid')
     }
     if(!canSubmit){
-        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')
+        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.add('fr-input-group--error')
         document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.add('fr-input-group--error')
         submitBtn.disabled = true;
     }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -953,27 +953,6 @@ document?.querySelectorAll('[data-delete]')?.forEach(actionBtn => {
         }
     })
 });
-document?.querySelectorAll('.fr-password-toggle')?.forEach(pwdToggle => {
-    pwdToggle.addEventListeners('click touchdown', (event) => {
-        ['fr-fi-eye-off-fill', 'fr-fi-eye-fill'].map(c => {
-            event.target.classList.toggle(c);
-        })
-        let pwd = event.target.parentElement.querySelector('[name^="password"]');
-        "text" !== pwd.type ? pwd.type = "text" : pwd.type = "password";
-    })
-})
-document?.querySelector('form[name="login-creation-mdp-form"]')?.querySelectorAll('[name^="password"]').forEach(pwd => {
-    pwd.addEventListener('input', canSubmitFormReinitPassword)
-})
-document?.querySelector('form[name="login-creation-mdp-form"]')?.addEventListener('submit', (event) => {
-    event.preventDefault();
-    let modalCgu = document.getElementById("fr-modal-cgu-bo");
-    dsfr(modalCgu).modal.conceal();
-    if(canSubmitFormReinitPassword()){
-        event.target.submit();
-    }
-})
-
 
 document.querySelector('#modal-dpe-opener')?.addEventListener('click', (event) => {
     let urlDpe = event.target.getAttribute('data-dpe-url');
@@ -1004,73 +983,6 @@ document.querySelector('#modal-dpe-opener')?.addEventListener('click', (event) =
         })
     })
 })
-
-function canSubmitFormReinitPassword() {
-    let pass = document?.querySelector('form[name="login-creation-mdp-form"] #login-password').value;
-    let repeat = document?.querySelector('form[name="login-creation-mdp-form"] #login-password-repeat').value;
-    let pwdMatchError = document?.querySelector('form[name="login-creation-mdp-form"] #password-match-error');
-    let submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter');
-    let canSubmit = true;
-    document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')
-    document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.remove('fr-input-group--error')
-    document?.querySelectorAll('form[name="login-creation-mdp-form"] #password-input-messages .message-password').forEach((el) => {
-        el.classList.remove('fr-message--error', 'fr-message--valid');
-        el.classList.add('fr-message--info');
-    });
-    pwdMatchError.classList.add('fr-hidden')
-    submitBtn.disabled = false;
-    if (pass !== repeat) {
-        canSubmit = false;
-        pwdMatchError.classList.remove('fr-hidden')
-    }
-    console.log(pass);
-    if (pass.length < 8) {
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.add('fr-message--error')
-        canSubmit = false;
-    }else{
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.add('fr-message--valid')
-    }
-    if (!/[A-Z]/.test(pass)) {
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.add('fr-message--error')
-        canSubmit = false;
-    }else{
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.add('fr-message--valid')
-    }
-    if(!/[a-z]/.test(pass)){
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.add('fr-message--error')
-        canSubmit = false;
-    }else{
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.add('fr-message--valid')
-    }
-    if(!/[0-9]/.test(pass)){
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.add('fr-message--error')
-        canSubmit = false;
-    }else{
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.add('fr-message--valid')
-    }
-    if(!/[^a-zA-Z0-9]/.test(pass)){
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.add('fr-message--error')
-        canSubmit = false;
-    }else{
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.remove('fr-message--info')
-        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.add('fr-message--valid')
-    }
-    if(!canSubmit){
-        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.add('fr-input-group--error')
-        document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.add('fr-input-group--error')
-        submitBtn.disabled = true;
-    }
-    return canSubmit;
-}
 
 const refetchAddress = (form) => {
     // If the code postal is manually edited, we reinit the insee/geoloc and fetch the first result

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1013,8 +1013,8 @@ function canSubmitFormReinitPassword() {
     let canSubmit = true;
     document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')
     document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password-repeat').classList.remove('fr-input-group--error')
-    document?.querySelectorAll('form[name="login-creation-mdp-form"] .password-input-messages').forEach((el) => {
-        el.classList.remove('fr-message--error');
+    document?.querySelectorAll('form[name="login-creation-mdp-form"] #password-input-messages .message-password').forEach((el) => {
+        el.classList.remove('fr-message--error', 'fr-message--valid');
         el.classList.add('fr-message--info');
     });
     pwdMatchError.classList.add('fr-hidden')
@@ -1023,30 +1023,46 @@ function canSubmitFormReinitPassword() {
         canSubmit = false;
         pwdMatchError.classList.remove('fr-hidden')
     }
+    console.log(pass);
     if (pass.length < 8) {
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.remove('fr-message--info')
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.add('fr-message--error')
         canSubmit = false;
+    }else{
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length').classList.add('fr-message--valid')
     }
     if (!/[A-Z]/.test(pass)) {
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.remove('fr-message--info')
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.add('fr-message--error')
         canSubmit = false;
+    }else{
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj').classList.add('fr-message--valid')
     }
     if(!/[a-z]/.test(pass)){
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.remove('fr-message--info')
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.add('fr-message--error')
         canSubmit = false;
+    }else{
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min').classList.add('fr-message--valid')
     }
     if(!/[0-9]/.test(pass)){
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.remove('fr-message--info')
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.add('fr-message--error')
         canSubmit = false;
+    }else{
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-nb').classList.add('fr-message--valid')
     }
     if(!/[!@#$%^&*(),.?":{}|<>]/.test(pass)){
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.remove('fr-message--info')
         document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.add('fr-message--error')
         canSubmit = false;
+    }else{
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.remove('fr-message--info')
+        document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-special').classList.add('fr-message--valid')
     }
     if(!canSubmit){
         document?.querySelector('form[name="login-creation-mdp-form"] .fr-input-group-password').classList.remove('fr-input-group--error')

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -192,9 +192,7 @@ class AddUserCommand extends Command
             );
         }
 
-        $password = $this->hasher->hashPassword($user, 'histologe');
-
-        $user->setPassword($password)->setStatut(User::STATUS_ACTIVE);
+        $user->setPassword('histologe-HI1')->setStatut(User::STATUS_ACTIVE);
 
         /** @var ConstraintViolationList $errors */
         $errors = $this->validator->validate($user, null, ['Default', 'password']);
@@ -204,6 +202,9 @@ class AddUserCommand extends Command
 
             return Command::FAILURE;
         }
+
+        $password = $this->hasher->hashPassword($user, $user->getPassword());
+        $user->setPassword($password);
 
         $this->entityManager->persist($user);
         $this->entityManager->flush();

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -64,9 +64,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[Assert\Regex(pattern: '/[A-Z]/', message: 'Le mot de passe doit contenir au moins une lettre majuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[a-z]/', message: 'Le mot de passe doit contenir au moins une lettre minuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[0-9]/', message: 'Le mot de passe doit contenir au moins un chiffre.', groups: ['password'])]
-    #[Assert\Regex(pattern: '/[!@#$%^&*(),.?":{}|<>]/', message: 'Le mot de passe doit contenir au moins un caractère spécial.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[^a-zA-Z0-9]/', message: 'Le mot de passe doit contenir au moins un caractère spécial.', groups: ['password'])]
     #[Assert\NotCompromisedPassword(message: 'Ce mot de passe est compromis, veuillez en choisir un autre.', groups: ['password'])]
-    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas contenir votre email.', groups: ['password'])]
+    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas être votre email.', groups: ['password'])]
     private $password;
 
     #[ORM\Column(length: 255, nullable: true)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -60,7 +60,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column(type: 'string', nullable: true)]
     #[Assert\NotBlank(groups: ['password'])]
-    #[Assert\Length(min: 8, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caratères', groups: ['password'])]
+    #[Assert\Length(min: 8, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caratères.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[A-Z]/', message: 'Le mot de passe doit contenir au moins une lettre majuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[a-z]/', message: 'Le mot de passe doit contenir au moins une lettre minuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[0-9]/', message: 'Le mot de passe doit contenir au moins un chiffre.', groups: ['password'])]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -60,9 +60,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column(type: 'string', nullable: true)]
     #[Assert\NotBlank(groups: ['password'])]
-    #[Assert\Length(min: 8, max: 200, minMessage: 'Votre mot de passe doit contenir au moins {{ limit }} caratères', groups: ['password'])]
+    #[Assert\Length(min: 8, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caratères', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[A-Z]/', message: 'Le mot de passe doit contenir au moins une lettre majuscule.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[a-z]/', message: 'Le mot de passe doit contenir au moins une lettre minuscule.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[0-9]/', message: 'Le mot de passe doit contenir au moins un chiffre.', groups: ['password'])]
+    #[Assert\Regex(pattern: '/[!@#$%^&*(),.?":{}|<>]/', message: 'Le mot de passe doit contenir au moins un caractère spécial.', groups: ['password'])]
     #[Assert\NotCompromisedPassword(message: 'Ce mot de passe est compromis, veuillez en choisir un autre.', groups: ['password'])]
-    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Votre mot de passe ne doit pas contenir votre email.', groups: ['password'])]
+    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas contenir votre email.', groups: ['password'])]
     private $password;
 
     #[ORM\Column(length: 255, nullable: true)]

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -24,7 +24,7 @@
                     </em>
                 {% endif %}
             </header>
-            <form class="needs-validation fr-mt-5v fr-col-md-6" name="login-creation-mdp-form" method="POST"
+            <form class="fr-mt-5v fr-col-md-6" name="login-creation-mdp-form" method="POST"
                   novalidate="">
                 <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-cgu-bo" class="fr-modal" role="dialog">
                     <div class="fr-container fr-container--fluid fr-container-md">
@@ -63,41 +63,43 @@
                     </label>
                     <div class="fr-input">{{ user.email }}</div>
                 </div>
-                <div class="fr-input-group fr-grid-row fr-grid-row--middle">
+                <div class="fr-input-group fr-input-group-password fr-grid-row fr-grid-row--middle">
                     <label class="fr-label fr-col-12" for="login-password">
                         Mot de passe
-                        <span class="fr-hint-text">Choisissez un mot de passe <u>fort et unique</u> <em>(minimum 8 caratères)</em></span>
+                        <span class="fr-hint-text">Choisissez un mot de passe <u>fort et unique</u></span>
                     </label>
-                    <input class="fr-input fr-col-11" aria-describedby="login-password-error-desc-error" type="password"
-                           id="login-password" name="password" required minlength="8">
-                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
-                          title="Afficher/Cacher le mot de passe"></span>
-                    <p id="login-password-error-desc-error" class="fr-error-text fr-hidden fr-col-12">
-                        Veuillez saisir votre mot de passe.
-                    </p>
+                    <input class="fr-input fr-col-11" type="password" id="login-password" name="password" required minlength="8">
+                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                    <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
+                        <p class="fr-message">Votre mot de passe doit contenir :</p>
+                        <p class="fr-message fr-message--info" id="password-input-message-info-length">8 caractères minimum</p>
+                        <p class="fr-message fr-message--info" id="password-input-message-info-maj">1 caractère majuscule minimum</p>
+                        <p class="fr-message fr-message--info" id="password-input-message-info-min">1 caractère minuscule minimum</p>
+                        <p class="fr-message fr-message--info" id="password--input-message-info-nb">1 chiffre minimum</p>
+                        <p class="fr-message fr-message--info" id="password-input-message-info-special">1 caractère spécial minimum</p>
+                    </div>
                 </div>
-                <div class="fr-input-group fr-grid-row fr-grid-row--middle">
+                <div class="fr-input-group fr-input-group-password-repeat fr-grid-row fr-grid-row--middle">
                     <label class="fr-label fr-col-12" for="login-password-repeat">
                         Confirmation du mot de passe
                         <span class="fr-hint-text">Saisissez à nouveau votre mot de passe</span>
                     </label>
-                    <input class="fr-input fr-col-11" aria-describedby="login-password-error-desc-error" type="password"
-                           id="login-password-repeat" name="password-repeat" required minlength="8">
-                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
-                          title="Afficher/Cacher le mot de passe"></span>
-                    <p id="login-password-error-desc-error" class="fr-error-text fr-hidden fr-col-12">
-                        Veuillez confirmer votre mot de passe.
-                    </p>
-                </div>
-                <input type="hidden" name="_csrf_token" value="{{ csrf_token('create_password_'~ user.uuid) }}">
-                <div class="fr-form-group fr-hidden" id="password-match-error">
-                    <p class="fr-error-text fr-col-12">
+                    <input class="fr-input fr-col-11" type="password" id="login-password-repeat" name="password-repeat" required minlength="8">
+                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                    <p id="password-match-error" class="fr-error-text fr-hidden fr-col-12">
                         Les mots de passes ne correspondent pas.
                     </p>
                 </div>
+                <input type="hidden" name="_csrf_token" value="{{ csrf_token('create_password_'~ user.uuid) }}">
                 <div class="fr-form-group">
                     <button class="fr-btn fr-icon-checkbox-circle-fill fr-btn--icon-right" disabled
-                            aria-controls="fr-modal-cgu-bo" data-fr-opened="false" id="submitter">
+                            {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE')  %}
+                            aria-controls="fr-modal-cgu-bo" data-fr-opened="false" type="button"
+                            {% else %}
+                            type="submit" 
+                            {% endif %}
+                             id="submitter" 
+                            >
                         Confirmer
                     </button>
                 </div>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -72,11 +72,11 @@
                     <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
                     <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
                         <p class="fr-message">Votre mot de passe doit contenir :</p>
-                        <p class="fr-message fr-message--info" id="password-input-message-info-length">8 caractères minimum</p>
-                        <p class="fr-message fr-message--info" id="password-input-message-info-maj">1 caractère majuscule minimum</p>
-                        <p class="fr-message fr-message--info" id="password-input-message-info-min">1 caractère minuscule minimum</p>
-                        <p class="fr-message fr-message--info" id="password--input-message-info-nb">1 chiffre minimum</p>
-                        <p class="fr-message fr-message--info" id="password-input-message-info-special">1 caractère spécial minimum</p>
+                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">8 caractères minimum</p>
+                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-maj">1 caractère majuscule minimum</p>
+                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-min">1 caractère minuscule minimum</p>
+                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-nb">1 chiffre minimum</p>
+                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-special">1 caractère spécial minimum</p>
                     </div>
                 </div>
                 <div class="fr-input-group fr-input-group-password-repeat fr-grid-row fr-grid-row--middle">

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -4,9 +4,11 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\User;
 use App\Tests\FixturesHelper;
-use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class UserTest extends TestCase
+class UserTest extends KernelTestCase
 {
     use FixturesHelper;
 
@@ -16,5 +18,46 @@ class UserTest extends TestCase
         $this->assertEquals('John', $user->getPrenom());
         $this->assertEquals('Doe', $user->getNom());
         $this->assertEquals('DOE John', $user->getNomComplet());
+    }
+
+    /**
+     * @dataProvider provideInvalidPassword
+     */
+    public function testPasswordValidationError(string $expectedResult, string $password)
+    {
+        /** @var ValidatorInterface $validator */
+        $validator = static::getContainer()->get(ValidatorInterface::class);
+
+        $user = new User();
+        $user->setPassword($password);
+
+        $errors = $validator->validate($user, null, ['password']);
+
+        /** @var ConstraintViolationList $errors */
+        $errorsAsString = (string) $errors;
+        $this->assertStringContainsString($expectedResult, $errorsAsString);
+    }
+
+    public function testPasswordValidationSuccess()
+    {
+        /** @var ValidatorInterface $validator */
+        $validator = static::getContainer()->get(ValidatorInterface::class);
+
+        $user = new User();
+        $user->setPassword('histologe-H1');
+
+        $errors = $validator->validate($user, null, ['password']);
+
+        $this->assertCount(0, $errors);
+    }
+
+    public function provideInvalidPassword(): \Generator
+    {
+        yield 'blank' => ['Cette valeur ne doit pas être vide', ''];
+        yield 'short' => ['Le mot de passe doit contenir au moins 8 caratères', 'short'];
+        yield 'no_uppercase' => ['Le mot de passe doit contenir au moins une lettre majuscule', 'nouppercase'];
+        yield 'no_lowercase' => ['Le mot de passe doit contenir au moins une lettre minuscule', 'NOLOWERCASE'];
+        yield 'no_digit' => ['Le mot de passe doit contenir au moins un chiffre', 'NoDigitNoDigit'];
+        yield 'no_special' => ['Le mot de passe doit contenir au moins un caractère spécial', 'NoSpecial'];
     }
 }


### PR DESCRIPTION
## Ticket

#721 #2145

## Description
Ajout de contraintes de validation pour des mot de passe plus fort : 
- 8 caractères minimum
- 1 caractère majuscule minimum
- 1 caractère minuscule minimum
- 1 chiffre minimum
- 1 caractère spécial minimum

Suppression de l'affichage de la modale CGU lors de la modification d'un mot de passe
Modification du mot de passe par défaut de la commande `app:add-user` pour matcher les contraintes

## Tests
- [ ] Vérifier que l'activation de compte / modification du mot de passe fonctionne correctement
- [ ] Vérifier que les indicateurs de contrainte évoluent correctement au fur et à mesure de la complétion du champs
- [ ] Vérifier que les contraintes sont bien vérifiées coté serveur (en soumettant des valeur incorrecte après avoir désactivé le javascript)
