### PR TITLE
[BO - Signalement] Liste partenaire a affecter

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -152,7 +152,7 @@ class SignalementController extends AbstractController
                 : null;
         }
 
-        $partners = $signalementManager->findAllPartners($signalement, true);
+        $partners = $signalementManager->findAllPartners($signalement);
 
         $files = $parameterBag->get('files');
 


### PR DESCRIPTION
## Ticket

#2223 

## Description
Retrait de l'affichage des compétences des partenaires dans la liste de la modale d'affectation des partenaires

## Tests
- [ ] Vérifier que dans la liste de la modale d'affectation des partenaires seule le nom du partenaire est affiché
