### PR TITLE
[FO] Empêcher toutes accès lors de la phase de maintenance

### DIFF
--- a/src/EventListener/MaintenanceListener.php
+++ b/src/EventListener/MaintenanceListener.php
@@ -43,7 +43,11 @@ class MaintenanceListener
     {
         $uri = $requestEvent->getRequest()->getRequestUri();
 
-        return str_starts_with($uri, '/signalement') && !$this->authorizationChecker->isGranted(User::ROLE_ADMIN);
+        return (str_starts_with($uri, '/signalement')
+                || str_starts_with($uri, '/suivre-mon-signalement')
+                || str_starts_with($uri, '/mot-de-pass-perdu')
+                || str_starts_with($uri, '/activation'))
+            && !$this->authorizationChecker->isGranted(User::ROLE_ADMIN);
     }
 
     private function redirect(string $routeName, RequestEvent $requestEvent): void

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -10,9 +10,9 @@
                 <p class="fr-callout__text fr-mb-5v">
                     Entrez vos identifiants et cliquez sur connexion.
                 </p>
-                <em class="fr-fi-information-line fr-text--light fr-text-label--blue-france"> Vous pouvez également <a
-                            href="{{ path('login_activation') }}">activer votre compte</a> ou
-                    <a href="{{ path('login_mdp_perdu') }}">récupérer votre mot de passe</a> si nécessaire</em>
+                <em class="fr-fi-information-line fr-text--light fr-text-label--blue-france disabled-link"> Vous pouvez également
+                    <a {% if maintenance is defined and not maintenance.enable %}href="{{ path('login_activation') }}"{% endif %}>activer votre compte</a> ou
+                    <a {% if maintenance is defined and not maintenance.enable %}href="{{ path('login_mdp_perdu') }}"{% endif %}>récupérer votre mot de passe</a> si nécessaire</em>
             </header>
             <form class="needs-validation fr-mt-5v fr-col-md-6" name="login-form" method="POST" novalidate="">
                 {% if error %}

--- a/tests/Functional/EventListener/MaintenanceListenerTest.php
+++ b/tests/Functional/EventListener/MaintenanceListenerTest.php
@@ -13,14 +13,26 @@ class MaintenanceListenerTest extends WebTestCase
         self::ensureKernelShutdown();
     }
 
-    public function testMaintenanceRedirect()
+    /**
+     * @dataProvider provideRoutes
+     */
+    public function testMaintenanceRedirect(string $routeName, array $parameters = [])
     {
         $client = static::createClient();
         $_ENV['MAINTENANCE_ENABLE'] = '1';
         /** @var UrlGeneratorInterface $generatorUrl */
         $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
-        $client->request('GET', $generatorUrl->generate('front_signalement'));
+        $client->request('GET', $generatorUrl->generate($routeName, $parameters));
         $this->assertTrue($client->getResponse()->isRedirect());
+    }
+
+    public function provideRoutes(): \Generator
+    {
+        yield 'Lock dépot signalement' => ['front_signalement'];
+        yield 'Lock demande activation' => ['login_activation'];
+        yield 'Lock Mot de passe perdu' => ['login_mdp_perdu'];
+        yield 'Lock Mise à jour mot de passe' => ['activate_account', ['uuid' => '123456778', 'token' => '000000000']];
+        yield 'Fiche signalement' => ['front_suivi_signalement', ['code' => '123456778']];
     }
 
     public function testNonMaintenanceRequest()


### PR DESCRIPTION
## Ticket

#2237    

## Description
Il faudrait aussi empêcher les actions lié à la gestion du compte et la fiche usager

## Changements apportés
* Rendre inaccessible les pages suivantes:
       * Fiche usager signalement 
       * Mot de passe perdu
       * Activation
## Pré-requis

## Tests
- [ ] Activer le mode maintenance `MAINTENANCE_ENABLE=1`essayer d'activer un compte ou demander un nouveau de passe ou de mettre à jour un mot de passe ou d’accéder à une fiche  usager

