### PR TITLE
[Nouveau formulaire] Ajout message d'erreur si timeout axios

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -158,7 +158,11 @@ export default defineComponent({
           for (const index in requestResponse.violations) {
             errorMessage += requestResponse.violations[index].title + '\n'
           }
-          alert(errorMessage)
+          if (errorMessage.length > 0) {
+            alert(errorMessage)
+          } else {
+            alert("Oups... Une erreur est survenue. Nous nous excusons pour ce désagrément, nos équipes ont été prévenues. Veuillez réessayer ultérieurement ou soumettre un nouveau formulaire. Merci de votre compréhension.")
+          }
           return
         }
         if (requestResponse.signalementReference) {


### PR DESCRIPTION
## Ticket

#2134 

## Description
La pop d'alerte de message est vide si timeout axios

## Changements apportés
* Ajout d'un message si vide

## Pré-requis

## Tests
- [ ] Baisser le timeout et déposer un nouveau formulaire afin de constater qu'un message est bien présent sur la pop up
