### PR TITLE
[BO - Signalement] Accès Désordres Impossible

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -30,7 +30,6 @@ img.huechange { filter: hue-rotate(120deg); }
 .signalement-invalid::before {
     content: '';
     position: absolute;
-    z-index: 1000;
     line-height: 100vh;
     top: 0;
     left: 0;

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -19,7 +19,7 @@
             <button class="fr-btn fr-fi-filter-line" id="tags_select_tooltip_btn"></button>
         </div>
     </div>
-{%endif %}
+{% endif %}
 
 <template id="tags_tooltip_template">
     <div class="fr-grid-row fr-grid-row--middle fr-background-alt--grey fr-p-3v fr-rounded fr-text--left fr-my-1v">

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -1,23 +1,25 @@
-<div class="fr-grid-row fr-mt-3v">
-    <div class="fr-col-10 fr-col-md-11" id="tags_active_container">
-        {% set visible = 'fr-hidden' %}
-        {% for tag in signalement.tags %}
-            <span class="fr-badge fr-badge--blue-ecume fr-badge--icon-close-line fr-icon-close-line fr-mr-1v" data-value="{{ tag.id }}"
-                data-tag-delete="{{ path('back_signalement_switch_value',{uuid:signalement.uuid}) }}"
-                data-token="{{ csrf_token('signalement_switch_value_'~signalement.uuid) }}"
-                data-remove-url="{{ path('back_tag_delete',{id:tag.id}) }}?_token={{ csrf_token('signalement_delete_tag') }}">{{ tag.label }}&nbsp;&nbsp;<span
-                        class="fr-fi-delete-line fr-icon--sm fr-mt-2v fr-text-label--red-marianne tag--deleter fr-hidden"></span></span>
-        {% else %}
-            {% set visible = '' %}
-        {% endfor %}
-        <em class="fr-text-default--warning fr-fi-close-line fr-icon--xs {{ visible }}">
-            <small>Aucune étiquette attribuée à ce signalement.</small>
-        </em>
+{% if canEditSignalement %}
+    <div class="fr-grid-row fr-mt-3v">
+        <div class="fr-col-10 fr-col-md-11" id="tags_active_container">
+            {% set visible = 'fr-hidden' %}
+            {% for tag in signalement.tags %}
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--icon-close-line fr-icon-close-line fr-mr-1v" data-value="{{ tag.id }}"
+                    data-tag-delete="{{ path('back_signalement_switch_value',{uuid:signalement.uuid}) }}"
+                    data-token="{{ csrf_token('signalement_switch_value_'~signalement.uuid) }}"
+                    data-remove-url="{{ path('back_tag_delete',{id:tag.id}) }}?_token={{ csrf_token('signalement_delete_tag') }}">{{ tag.label }}&nbsp;&nbsp;<span
+                            class="fr-fi-delete-line fr-icon--sm fr-mt-2v fr-text-label--red-marianne tag--deleter fr-hidden"></span></span>
+            {% else %}
+                {% set visible = '' %}
+            {% endfor %}
+            <em class="fr-text-default--warning fr-fi-close-line fr-icon--xs {{ visible }}">
+                <small>Aucune étiquette attribuée à ce signalement.</small>
+            </em>
+        </div>
+        <div class="fr-col-2 fr-col-md-1 fr-text--right">
+            <button class="fr-btn fr-fi-filter-line" id="tags_select_tooltip_btn"></button>
+        </div>
     </div>
-    <div class="fr-col-2 fr-col-md-1 fr-text--right">
-        <button class="fr-btn fr-fi-filter-line" id="tags_select_tooltip_btn"></button>
-    </div>
-</div>
+{%endif %}
 
 <template id="tags_tooltip_template">
     <div class="fr-grid-row fr-grid-row--middle fr-background-alt--grey fr-p-3v fr-rounded fr-text--left fr-my-1v">

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -1008,7 +1008,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "La prodécure",
+    "label": "La procédure",
     "description": "<p>Vous avez presque terminé ! <br>Répondez aux dernières questions puis envoyez votre signalement.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_procedure",
     "screenCategory": "Procédure",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -885,7 +885,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "La prodécure",
+    "label": "La procédure",
     "description": "<p>Vous avez presque terminé ! <br>Répondez aux dernières questions puis envoyez votre signalement.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_procedure",
     "screenCategory": "Procédure",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -1036,7 +1036,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "La prodécure",
+    "label": "La procédure",
     "description": "<p>Vous avez presque terminé ! <br>Répondez aux dernières questions puis envoyez votre signalement.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_procedure",
     "screenCategory": "Procédure",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -950,7 +950,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "La prodécure",
+    "label": "La procédure",
     "description": "<p>Vous avez presque terminé ! <br>Répondez aux dernières questions puis envoyez votre signalement.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_procedure",
     "screenCategory": "Procédure",

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -915,7 +915,7 @@
   },
   {
     "type": "SignalementFormScreen",
-    "label": "La prodécure",
+    "label": "La procédure",
     "description": "<p>Vous avez presque terminé ! <br>Répondez aux dernières questions puis envoyez votre signalement.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_procedure",
     "screenCategory": "Procédure",


### PR DESCRIPTION
## Ticket

#2241    

## Description
Les désordres et les photos ne sont pas cliquables qui est contraignant pour la qualification des désordres
![image](https://github.com/MTES-MCT/histologe/assets/5757116/27e91253-26a0-4101-a9cd-b4c91bb06385)

## Changements apportés
* Suppression du z-index 

## Pré-requis
```m̀ake npm-build```

## Tests
- [ ] Déposer un signalement avec photo et désordre et vérifier que ces derniers soient cliquables