### PR TITLE
[FO - Nouveaux formulaire] Soumission du formulaire sans le traitement des fichiers (asynchrone)

### DIFF
--- a/.docker/php-worker/supervisord.conf
+++ b/.docker/php-worker/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:messenger-consume]
-command=php /app/bin/console messenger:consume async --time-limit=600 -vv
+command=php /app/bin/console messenger:consume async_priority_high async --time-limit=600 -vv
 user=root
 numprocs=1
 autostart=true

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 postdeploy: ./scripts/postdeploy.sh
-worker: php bin/console messenger:consume async
+worker: php bin/console messenger:consume async_priority_high async
 clock: php bin/console app:scheduled-task

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -6,6 +6,12 @@ framework:
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
             async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            async_priority_high:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                failure_transport: failed_high_priority
+                options:
+                    queue_name: high
+            failed_high_priority: 'doctrine://default?queue_name=failed_high_priority'
             failed: 'doctrine://default?queue_name=failed'
             sync: 'sync://'
 
@@ -15,7 +21,9 @@ framework:
             App\Messenger\Message\Esabora\DossierMessageSCHS: async
             App\Messenger\Message\Esabora\DossierMessageSISH: async
             App\Messenger\Message\Oilhi\DossierMessage: async
-            App\Messenger\Message\PdfExportMessage: async
+            App\Messenger\Message\PdfExportMessage: async_priority_high
+            App\Messenger\Message\SignalementDraftFileMessage: async_priority_high
+
 
 
 when@test:
@@ -25,3 +33,4 @@ when@test:
                 # replace with your transport name here (e.g., my_transport: 'in-memory://')
                 # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
                 async: 'in-memory://'
+                async_priority_high: 'in-memory://'

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -2,6 +2,9 @@ when@prod:
     sentry:
         dsn: '%env(resolve:SENTRY_DSN)%'
         register_error_listener: false # Disables the ErrorListener to avoid duplicated log in sentry
+        messenger:
+            enabled: true # flushes Sentry messages at the end of each message handling
+            capture_soft_fails: true # captures exceptions marked for retry too
         options:
           environment: '%env(resolve:SENTRY_ENVIRONMENT)%' # prod|staging
           # Specify a fixed sample rate:

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -179,3 +179,91 @@ signalements:
     qualifications:
       - "RSD"
       - "NON_DECENCE"
+  -
+    territory: "Pas-de-Calais"
+    uuid: "00000000-0000-0000-2024-000000000003"
+    reference: "2024-03"
+    details: "Ma maison avait l'air bien, mais en fait c'est une véritable passoire."
+    is_proprio_averti: 1
+    is_allocataire: "0"
+    nature_logement: "maison"
+    type_logement: "MAISON"
+    superficie: 67
+    loyer: null
+    date_entree: "2020-12-01"
+    nom_proprio: "Habitat-PDC"
+    is_logement_social: 0
+    nom_occupant: "Mapaire"
+    prenom_occupant: "Nawell"
+    tel_occupant: "+330240556677"
+    phone_number: "+330240556677"
+    mail_occupant: "nawell.mapaire@yopmail.com"
+    adresse_occupant: "49 Rue du Général Chanzy"
+    cp_occupant: "62100"
+    ville_occupant: "Calais"
+    statut: 1
+    geoloc: "{\"lat\": 50.94877, \"lng\": 1.85867}"
+    mode_contact_proprio: "[]"
+    insee_occupant: "62193"
+    nb_pieces_logement: 5
+    nb_occupants_logement: 4
+    score: 35.194711538462
+    created_from_uuid: '00000000-0000-0000-2024-locataire002'
+    profile_declarant: "LOCATAIRE"
+    civilite_occupant: "mme"
+    type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"oui\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"
+    situation_foyer: "{\"logement_social_allocation\": \"non\", \"logement_social_date_naissance\": null, \"logement_social_allocation_caisse\": null, \"travailleur_social_accompagnement\": \"non\", \"logement_social_demande_relogement\": \"non\", \"logement_social_montant_allocation\": null, \"logement_social_numero_allocataire\": null, \"travailleur_social_quitte_logement\": \"non\", \"travailleur_social_accompagnement_declarant\": null}"
+    information_procedure: "{\"utilisation_service_ok_visite\": true, \"info_procedure_bailleur_prevenu\": \"oui\", \"info_procedure_reponse_assurance\": null, \"info_procedure_assurance_contactee\": \"non\", \"info_procedure_depart_apres_travaux\": \"oui\", \"utilisation_service_ok_demande_logement\": true, \"utilisation_service_ok_prevenir_bailleur\": true}"
+    information_complementaire: "{\"informations_complementaires_logement_montant_loyer\": null, \"informations_complementaires_logement_nombre_etages\": null, \"informations_complementaires_logement_annee_construction\": null, \"informations_complementaires_situation_bailleur_revenu_fiscal\": null, \"informations_complementaires_situation_occupants_loyers_payes\": null, \"informations_complementaires_situation_bailleur_date_naissance\": null, \"informations_complementaires_situation_occupants_date_naissance\": null, \"informations_complementaires_situation_bailleur_beneficiaire_fsl\": null, \"informations_complementaires_situation_bailleur_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_beneficiaire_fsl\": null, \"informations_complementaires_situation_occupants_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_date_emmenagement\": null, \"informations_complementaires_situation_occupants_demande_relogement\": null}"
+    score_logement: 13.990384615385
+    score_batiment: 50
+    created_at: "2024-01-11 14:00"
+    desordre_categorie:
+      - "Usage / entretien"
+      - "Etanchéité / isolation"
+      - "Sécurite risques particuliers"
+      - "Structure du bâti"
+      - "Aération / humidité"
+      - "Chauffage / confort"
+    desordre_critere:
+      - "desordres_batiment_proprete_interieur"
+      - "desordres_batiment_proprete_facades"
+      - "desordres_batiment_isolation_murs"
+      - "desordres_batiment_isolation_porte_fenetres"
+      - "desordres_batiment_isolation_dernier_etage_toit"
+      - "desordres_batiment_isolation_infiltration_eau"
+      - "desordres_batiment_maintenance_petites_reparations"
+      - "desordres_batiment_securite_elements_toit"
+      - "desordres_batiment_securite_toit"
+      - "desordres_batiment_securite_murs_fissures"
+      - "desordres_batiment_securite_balcons"
+      - "desordres_batiment_incendie_odeur_gaz"
+      - "desordres_logement_aeration_aucune_aeration"
+      - "desordres_logement_chauffage_details_fenetres_permeables"
+      - "desordres_logement_chauffage_details_difficultes_chauffage"
+    desordre_precision:
+      - "desordres_batiment_proprete_interieur"
+      - "desordres_batiment_proprete_facades"
+      - "desordres_batiment_isolation_murs"
+      - "desordres_batiment_isolation_porte_fenetres"
+      - "desordres_batiment_isolation_dernier_etage_toit_sous_combles"
+      - "desordres_batiment_isolation_infiltration_eau_au_sol_non"
+      - "desordres_batiment_maintenance_petites_reparations"
+      - "desordres_batiment_securite_elements_toit"
+      - "desordres_batiment_securite_toit"
+      - "desordres_batiment_securite_murs_fissures_details_mur_porteur_oui"
+      - "desordres_batiment_securite_balcons"
+      - "desordres_batiment_incendie_odeur_gaz"
+      - "desordres_logement_aeration_aucune_aeration_pieces_salle_de_bain"
+      - "desordres_logement_chauffage_details_fenetres_permeables_pieces_cuisine"
+      - "desordres_logement_chauffage_details_difficultes_chauffage_pieces_piece_a_vivre"
+      - "desordres_logement_chauffage_details_difficultes_chauffage_pieces_cuisine"
+      - "desordres_logement_humidite_piece_a_vivre_details_machine_non"
+      - "desordres_logement_humidite_piece_a_vivre_details_moisissure_apres_nettoyage_oui"
+      - "desordres_logement_humidite_piece_a_vivre_details_fuite_non"
+      - "desordres_logement_securite_sol_dangereux_pieces_piece_a_vivre"
+      - "desordres_logement_securite_balcons_pieces_salle_de_bain"
+      - "desordres_logement_securite_plomb_pieces_salle_de_bain_diagnostique_oui"
+    qualifications:
+      - "RSD"
+      - "NON_DECENCE"

--- a/src/DataFixtures/Files/SignalementDraft.yml
+++ b/src/DataFixtures/Files/SignalementDraft.yml
@@ -22,6 +22,12 @@ signalements_draft:
     payload: 'locataire.json'
     status: 'EN_SIGNALEMENT'
   -
+    uuid: '00000000-0000-0000-2024-locataire002'
+    profile_declarant: 'LOCATAIRE'
+    email_declarant: 'locataire-03@histologe.fr'
+    payload: 'locataire.json'
+    status: 'EN_SIGNALEMENT'
+  -
     uuid: '00000000-0000-0000-2023-locataire004'
     profile_declarant: 'LOCATAIRE'
     email_declarant: 'tous-les-desordres-locataire@histologe.fr'

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -226,7 +226,7 @@ class SignalementDraftRequest
     #[Assert\DateTime('Y')]
     private ?string $informationsComplementairesLogementAnneeConstruction = null;
     private ?string $messageAdministration = null;
-    private ?array $files = null;
+    private array $files = [];
     private ?array $categorieDisorders = null;
 
     public function getProfil(): ?string

--- a/src/Messenger/Message/SignalementDraftFileMessage.php
+++ b/src/Messenger/Message/SignalementDraftFileMessage.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Messenger\Message;
+
+class SignalementDraftFileMessage
+{
+    public function __construct(private ?int $signalementDraftId, private ?int $signalementId)
+    {
+    }
+
+    public function getSignalementDraftId(): ?int
+    {
+        return $this->signalementDraftId;
+    }
+
+    public function getSignalementId(): ?int
+    {
+        return $this->signalementId;
+    }
+}

--- a/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Messenger\MessageHandler;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Factory\FileFactory;
+use App\Messenger\Message\SignalementDraftFileMessage;
+use App\Repository\SignalementDraftRepository;
+use App\Repository\SignalementRepository;
+use App\Serializer\SignalementDraftRequestSerializer;
+use App\Service\UploadHandlerService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class SignalementDraftFileMessageHandler
+{
+    public function __construct(
+        private SignalementRepository $signalementRepository,
+        private SignalementDraftRepository $signalementDraftRepository,
+        private SignalementDraftRequestSerializer $signalementDraftRequestSerializer,
+        private FileFactory $fileFactory,
+        private UploadHandlerService $uploadHandlerService,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SignalementDraftFileMessage $signalementDraftFileMessage): void
+    {
+        try {
+            $this->logger->info('Start handling SignalementDraftFileMessage', [
+                'signalementDraftId' => $signalementDraftFileMessage->getSignalementDraftId(),
+                'signalementId' => $signalementDraftFileMessage->getSignalementId(),
+            ]);
+
+            $signalementDraft = $this->signalementDraftRepository->find(
+                $signalementDraftFileMessage->getSignalementDraftId()
+            );
+
+            /** @var SignalementDraftRequest $signalementDraftRequest */
+            $signalementDraftRequest = $this->signalementDraftRequestSerializer->denormalize(
+                $signalementDraft->getPayload(),
+                SignalementDraftRequest::class
+            );
+
+            $signalement = $this->signalementRepository->find($signalementDraftFileMessage->getSignalementId());
+
+            if ($files = $signalementDraftRequest->getFiles()) {
+                foreach ($files as $key => $fileList) {
+                    foreach ($fileList as $fileItem) {
+                        $fileItem['slug'] = $key;
+                        $file = $this->fileFactory->createFromFileArray(file: $fileItem);
+                        $this->uploadHandlerService->moveFromBucketTempFolder($file->getFilename());
+                        $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
+                        $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
+                        $signalement->addFile($file);
+                    }
+                }
+                $this->signalementRepository->save($signalement, true);
+            }
+
+            $this->logger->info('SignalementDraftFileMessage handled successfully', [
+                'signalementId' => $signalementDraftFileMessage->getSignalementId(),
+                'nbFiles' => \count($signalementDraftRequest->getFiles()),
+            ]);
+        } catch (\Throwable $exception) {
+            \Sentry\captureException($exception);
+            $this->logger->error('Error handling SignalementDraftFileMessage', [
+                'signalementId' => $signalementDraftFileMessage->getSignalementId(),
+                'error_message' => $exception->getMessage(),
+                'error_trace' => $exception->getTraceAsString(),
+            ]);
+        }
+    }
+}

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -308,24 +308,6 @@ class SignalementBuilder
         return $this;
     }
 
-    public function withFiles(): self
-    {
-        if ($files = $this->signalementDraftRequest->getFiles()) {
-            foreach ($files as $key => $fileList) {
-                foreach ($fileList as $fileItem) {
-                    $fileItem['slug'] = $key;
-                    $file = $this->fileFactory->createFromFileArray(file: $fileItem);
-                    $this->uploadHandlerService->moveFromBucketTempFolder($file->getFilename());
-                    $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
-                    $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
-                    $this->signalement->addFile($file);
-                }
-            }
-        }
-
-        return $this;
-    }
-
     public function build(): Signalement
     {
         return $this->signalement;

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -48,8 +48,8 @@ class BackStatistiquesControllerTest extends WebTestCase
     public function provideRoutesStatistiquesDatas(): \Generator
     {
         yield 'Super Admin' => ['back_statistiques_filter', [], self::USER_SUPER_ADMIN, [
-            ['result' => 37, 'label' => 'count_signalement'],
-            ['result' => 66.6, 'label' => 'average_criticite'],
+            ['result' => 38, 'label' => 'count_signalement'],
+            ['result' => 65.8, 'label' => 'average_criticite'],
         ]];
         yield 'Responsable Territoire' => ['back_statistiques_filter', [], self::USER_ADMIN_TERRITOIRE, [
             ['result' => 24, 'label' => 'count_signalement'],

--- a/tests/Functional/Messenger/MessageHandler/PdfExportMessageHandlerTest.php
+++ b/tests/Functional/Messenger/MessageHandler/PdfExportMessageHandlerTest.php
@@ -29,7 +29,7 @@ class PdfExportMessageHandlerTest extends WebTestCase
 
         $messageBus->dispatch($message);
 
-        $transport = $container->get('messenger.transport.async');
+        $transport = $container->get('messenger.transport.async_priority_high');
         $envelopes = $transport->get();
         $this->assertCount(1, $envelopes);
 

--- a/tests/Functional/Messenger/MessageHandler/SignalementDraftFileMessageHandlerTest.php
+++ b/tests/Functional/Messenger/MessageHandler/SignalementDraftFileMessageHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Tests\Functional\Messenger\MessageHandler;
+
+use App\Messenger\Message\SignalementDraftFileMessage;
+use App\Messenger\MessageHandler\SignalementDraftFileMessageHandler;
+use App\Repository\SignalementDraftRepository;
+use App\Repository\SignalementRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class SignalementDraftFileMessageHandlerTest extends KernelTestCase
+{
+    private MessageBusInterface $messageBus;
+    private SignalementDraftRepository $signalementDraftRepository;
+    private SignalementRepository $signalementRepository;
+    private SignalementDraftFileMessageHandler $signalementDraftFileMessageHandler;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->messageBus = static::getContainer()->get(MessageBusInterface::class);
+        $this->signalementDraftRepository = static::getContainer()->get(SignalementDraftRepository::class);
+        $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $this->signalementDraftFileMessageHandler =
+            static::getContainer()->get(SignalementDraftFileMessageHandler::class);
+    }
+
+    public function testHandleMessageWithSuccess(): void
+    {
+        $signalementDraft = $this->signalementDraftRepository->findOneBy(
+            ['uuid' => '00000000-0000-0000-2024-locataire002']
+        );
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2024-000000000003']);
+        $this->assertCount(0, $signalement->getFiles());
+        $message = new SignalementDraftFileMessage($signalementDraft->getId(), $signalement->getId());
+
+        $this->messageBus->dispatch($message);
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $envelopes = $transport->get();
+        $this->assertCount(1, $envelopes);
+
+        $handler = $this->signalementDraftFileMessageHandler;
+        $handler($message);
+        $this->assertCount(7, $signalement->getFiles());
+    }
+
+    public function testHandleMessageWithFailure(): void
+    {
+        $signalementDraft = $this->signalementDraftRepository->findOneBy([
+            'uuid' => '00000000-0000-0000-2024-locataire002',
+        ]);
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2024-000000000003']);
+        $message = new SignalementDraftFileMessage($signalementDraft->getId(), $signalement->getId());
+
+        $this->expectException(\Throwable::class);
+
+        $this->messageBus->dispatch($message, ['simulate_exception' => true]);
+        $transport = static::getContainer()->get('messenger.transport.failed_high_priority');
+        $envelopes = $transport->get();
+        $this->assertCount(1, $envelopes);
+
+        $handler = $this->signalementDraftFileMessageHandler;
+        $handler($message);
+        $this->assertCount(0, $signalement->getFiles());
+    }
+}

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -113,10 +113,8 @@ class SignalementBuilderTest extends KernelTestCase
             ->withProcedure()
             ->withInformationComplementaire()
             ->withDesordres()
-            ->withFiles()
             ->build();
 
-        $this->assertCount(7, $signalement->getFiles());
         $this->assertNotEmpty($signalement->getUuid());
         $this->assertNotEmpty($signalement->getReference());
         $this->assertNotEmpty($signalement->getCodeSuivi());
@@ -221,7 +219,6 @@ class SignalementBuilderTest extends KernelTestCase
             ->withProcedure()
             ->withInformationComplementaire()
             ->withDesordres()
-            ->withFiles()
             ->build();
 
         $this->assertCount(12, $signalement->getDesordreCategories());


### PR DESCRIPTION
## Ticket

#2240   

Review app : https://histologe-staging-pr2245.osc-fr1.scalingo.io

## Description
Les temps de traitements peuvent être assez longs lors de la soumission d'un draft

## Changements apportés
* Déplacement de la logique vers un message handler
* Mise en place d'une queue dédiée et prioritaire pour le traitement des images et pdf 
* Mise à jour du container phpworker pour la prise en charge de la nouvelle queue
* Mise à jour du worker scalingo

## Pré-requis
Mettez à jour le container phpworker

```
docker compose build histologe_phpworker
```
```
make worker-stop
```

## Tests
- [ ] Soumettez un signalement avec quelques images et constatez que les temps de traitement sont très légèrement supérieurs aux requêtes précédentes avec un signalement sans images
- [ ] Soumettez un signalement avec beaucoup d'images (> 20) et constatez que les temps de traitement sont très légèrement supérieurs à la requête précédente (voir requêtes 54) avec un signalement sans images
![image](https://github.com/MTES-MCT/histologe/assets/5757116/c70a905b-5f9d-45f3-b7df-268bfecb3e1a)
- [ ] Lancez des exports et vérifiez que votre file d'attente possède des messages high priority
![image](https://github.com/MTES-MCT/histologe/assets/5757116/1aa7dcc6-d560-4437-ae07-3454d027df03)

- [ ] Lancez maintenant le worker `make worker-start` et vérifiez que la pile se vide. Une fois le message high traité, retournez sur le signalement
- [ ] Retournez sur le signalement et vérifiez que vous ayez toutes vos images et documents
![image](https://github.com/MTES-MCT/histologe/assets/5757116/3d60315f-5423-4e62-a62d-ecdcfc1c5cbb)

- [ ] Refaite un test avec le worker allumé cette fois ci 




