### PR TITLE
[BO - Signalement] Correction de l'enregistrement de la valeur isAllocataire

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -599,11 +599,7 @@ class SignalementManager extends AbstractManager
                     $situationFoyerRequest->getIsRelogement()
                 )
             )
-            ->setIsAllocataire(
-                $this->signalementInputValueMapper->map(
-                    $situationFoyerRequest->getIsAllocataire()
-                )
-            )
+            ->setIsAllocataire($situationFoyerRequest->getIsAllocataire())
             ->setNumAllocataire($situationFoyerRequest->getNumAllocataire());
 
         if (!empty($situationFoyerRequest->getDateNaissanceOccupant())) {

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -38,8 +38,8 @@
                                     <option value="" {{isAllocataire in [null, ''] ? 'selected' : '' }}></option>
                                     <option value="CAF" {{ isAllocataire is same as 'CAF' ? 'selected' : '' }}>CAF</option>
                                     <option value="MSA" {{ isAllocataire is same as 'MSA' ? 'selected' : '' }}>MSA</option>
-                                    <option value="1" {{ isAllocataire in ['Oui', '1'] ? 'selected' : '' }}>Oui</option>
-                                    <option value="0" {{ isAllocataire in ['Non', '0'] ? 'selected' : '' }}>Non</option>
+                                    <option value="oui" {{ isAllocataire in ['Oui', '1'] ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ isAllocataire in ['Non', '0'] ? 'selected' : '' }}>Non</option>
                                 </select>
                             </div>
 

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -531,9 +531,9 @@
                     <div class="fr-col-12 fr-col-md-6">
                         <strong>Allocataire :</strong>
                         {% if signalement.isAllocataire in [null, ''] %}
-                        {% elseif signalement.isAllocataire in ['Oui', '1'] %}
+                        {% elseif signalement.isAllocataire in ['oui', '1'] %}
                              {{ static_picto_yes|raw }}
-                        {% elseif signalement.isAllocataire in ['Non', '0',] %}
+                        {% elseif signalement.isAllocataire in ['non', '0'] %}
                              {{ static_picto_no|raw }}
                         {% elseif signalement.isAllocataire %}
                             <p class="fr-badge fr-badge--info fr-badge--no-icon">{{ signalement.isAllocataire }}</p>
@@ -547,7 +547,7 @@
                             {{ signalement.naissanceOccupants}}
                         {% endif %}
                     </div>
-                    {% if signalement.isAllocataire %}
+                    {% if signalement.isAllocataire and signalement.isAllocataire not in ['non', '0'] %}
                         <div class="fr-col-12 fr-col-md-6">
                             <strong>N° allocataire :</strong>
                             {{ signalement.numAllocataire }}


### PR DESCRIPTION
## Ticket

#2254   

## Description
Dans le BO, la valeur de isAllocataire ne s'enregistre pas correctement (et du coup, n'affiche pas la valeur du numéro d'allocataire)

## Tests
- [ ] Faire un signalement, vérifier que la valeur est bien reprise
- [ ] Vérifier que la valeur est éditable et reprise dans l'affichage
