### PR TITLE
[BO - Nouveau formulaire] Timeout upload multiple avec de nombreux fichiers

### DIFF
--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -35,6 +35,22 @@ export const requests = {
         functionReturn(error)
       })
   },
+  doRequestPostUpload (ajaxUrl: string, data: any, functionReturn: Function, config: any) {
+    const axiosInstance = axios.create({
+      timeout: 120000
+    })
+    axiosInstance
+        .post(ajaxUrl, data, config)
+        .then(response => {
+          const responseData = response.data
+          functionReturn(responseData)
+        })
+        .catch(error => {
+          console.error(error)
+          Sentry.captureException(new Error('The file upload timed out.'))
+          functionReturn(error)
+        })
+  },
   doRequestPut (ajaxUrl: string, data: any, functionReturn: Function) {
     axios
       .put(ajaxUrl, data, { timeout: AXIOS_TIMEOUT })
@@ -110,6 +126,6 @@ export const requests = {
         functionProgress(progress)
       }
     }
-    requests.doRequestPost(url, formData, functionReturn, config)
+    requests.doRequestPostUpload(url, formData, functionReturn, config)
   }
 }


### PR DESCRIPTION
## Ticket

#2255   

## Description
Le timeout de 30 sec est assez limité pour de l'upload multiple car la même instance axios est utilisé pour les différents upload

## Changements apportés
* Ajout d'une méthode dédiée pour gérer l'uplad de fichier avec une création d'une nouvelle instance avec un timeout de 120s

## Pré-requis
```
make npm-build
```


## Tests
- [ ] Déposer au moins 30 photos sur un désordre et déposer votre signalement