### PR TITLE
[BO - Signalement] Remplacement du terme Bailleur occupant par Propriétaire occupant

### DIFF
--- a/src/Entity/Enum/ProfileDeclarant.php
+++ b/src/Entity/Enum/ProfileDeclarant.php
@@ -20,7 +20,7 @@ enum ProfileDeclarant: string
     {
         return [
             'LOCATAIRE' => 'Locataire',
-            'BAILLEUR_OCCUPANT' => 'Bailleur occupant',
+            'BAILLEUR_OCCUPANT' => 'Propriétaire occupant',
             'TIERS_PARTICULIER' => 'Tiers particulier',
             'TIERS_PRO' => 'Tiers professionnel',
             'SERVICE_SECOURS' => 'Service de secours',


### PR DESCRIPTION
## Ticket

#2243    

## Description
La notion de Bailleur occupant n'existe pas, on affiche plutôt Propriétaire occupant.
J'ai tenté de voir les endroits où c'était utilisé :
- la fiche signalement BO
- l'envoi à Oilhi

## Tests
- [ ] Faire un signalement en tant que propriétaire occupant, vérifier que l'affichage est correct dans le BO
