### PR TITLE
[BO - Nouveau formulaire] Suppression du timeout à l'upload

### DIFF
--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -37,7 +37,7 @@ export const requests = {
   },
   doRequestPostUpload (ajaxUrl: string, data: any, functionReturn: Function, config: any) {
     const axiosInstance = axios.create({
-      timeout: 120000
+      timeout: 0 // TODO: va nécéssiter d'apporter quelques retouches sur l'UX
     })
     axiosInstance
         .post(ajaxUrl, data, config)
@@ -47,7 +47,7 @@ export const requests = {
         })
         .catch(error => {
           console.error(error)
-          Sentry.captureException(new Error('The file upload timed out.'))
+          Sentry.captureException(new Error('Something wrong happened with the upload.'))
           functionReturn(error)
         })
   },


### PR DESCRIPTION
## Ticket

#2261 

## Description
Suite au rallongement de la durée du timeout sur l'upload, il y'a quelques evenements qui dépasse les 120s. 
Un timeout sur un upload n'est pas adapté du aux différentes vitesse de connexion des uns et des autres. 
La suite dans [le thread suivant](https://mattermost.incubateur.net/betagouv/pl/6xqqozugqjbf8fzzffu8po1mxe)

## Changements apportés
* Suppression du timeout 

## Pré-requis
`make npm build`

## Tests
![image](https://github.com/MTES-MCT/histologe/assets/5757116/75af273e-9e90-46fd-8417-9b1750f7e34b)

- [ ] Uploader en connexion lente plusieurs photos dans les désordres de sorte à dépasser les 120 secondes 
