### PR TITLE
[BO - Export PDF] Prise en compte des nouveaux désordres

### DIFF
--- a/templates/pdf/partial_desordre.html.twig
+++ b/templates/pdf/partial_desordre.html.twig
@@ -1,0 +1,31 @@
+{% if criteres %}
+    {% set firstCritere = criteres|first %}
+    {% if firstCritere is defined %}
+        {% set firstPrecision = firstCritere|first %}
+        {% if firstPrecision is defined %}
+            {% if signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] is defined %}
+                <h5>{{ signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] }}</h5>
+            {% endif %}
+        {% endif %}
+    {% endif %}
+    
+    <ul>
+        {% for critere,precisions in criteres %}
+            <li>
+                {{ critere }}     
+                {% for precision in precisions %}
+                    {% if precision.label is not same as '' %}
+                        <ul class="fr-list fr-list--none">
+                            <li>
+                                {{ precision.label|raw }}
+                                {% if signalement.jsonContent[precision.desordreCritere.slugCritere] is defined %}
+                                    <br>Commentaire usager : <i>{{ signalement.jsonContent[precision.desordreCritere.slugCritere] }}</i>
+                                {% endif %}
+                            </li>
+                        </ul>
+                    {% endif %}
+                {% endfor %}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -201,37 +201,7 @@
                 <h4>Désordres logement</h4>
                 {% if situations[enum('App\\Entity\\Enum\\DesordreCritereZone').LOGEMENT.name] is defined %}
                     {% for situation,criteres in situations[enum('App\\Entity\\Enum\\DesordreCritereZone').LOGEMENT.name] %}
-                        {% if criteres %}
-                            {% set firstCritere = criteres|first %}
-                            {% if firstCritere is defined %}
-                                {% set firstPrecision = firstCritere|first %}
-                                {% if firstPrecision is defined %}
-                                    {% if signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] is defined %}
-                                        <h5>{{ signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] }}</h5>
-                                    {% endif %}
-                                {% endif %}
-                            {% endif %}
-                            
-                            <ul>
-                                {% for critere,precisions in criteres %}
-                                    <li>
-                                        {{ critere }}     
-                                        {% for precision in precisions %}
-                                            {% if precision.label is not same as '' %}
-                                                <ul class="fr-list fr-list--none">
-                                                    <li>
-                                                        {{ precision.label|raw }}
-                                                        {% if signalement.jsonContent[precision.desordreCritere.slugCritere] is defined %}
-                                                            <br>Commentaire usager : <i>{{ signalement.jsonContent[precision.desordreCritere.slugCritere] }}</i>
-                                                        {% endif %}
-                                                    </li>
-                                                </ul>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
+                        {% include 'pdf/partial_desordre.html.twig' %}   
                     {% endfor %}
                 {% else %}
                     <i>Aucun désordre signalé dans le logement</i>
@@ -241,37 +211,7 @@
                 <h4>Désordres bâtiment</h4>
                 {% if situations[enum('App\\Entity\\Enum\\DesordreCritereZone').BATIMENT.name] is defined %}
                     {% for situation,criteres in situations[enum('App\\Entity\\Enum\\DesordreCritereZone').BATIMENT.name] %}
-                        {% if criteres %}
-                            {% set firstCritere = criteres|first %}
-                            {% if firstCritere is defined %}
-                                {% set firstPrecision = firstCritere|first %}
-                                {% if firstPrecision is defined %}
-                                    {% if signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] is defined %}
-                                        <h5>{{ signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] }}</h5>
-                                    {% endif %}
-                                {% endif %}
-                            {% endif %}
-
-                            <ul>
-                                {% for critere,precisions in criteres %}
-                                    <li>
-                                        {{ critere }}
-                                        {% for precision in precisions %}
-                                            {% if precision.label is not same as '' %}
-                                                <ul class="fr-list fr-list--none">
-                                                    <li>
-                                                        {{ precision.label|raw }}
-                                                        {% if signalement.jsonContent[precision.desordreCritere.slugCritere] is defined %}
-                                                            <br>Commentaire usager : <i>{{ signalement.jsonContent[precision.desordreCritere.slugCritere] }}</i>
-                                                        {% endif %}
-                                                    </li>
-                                                </ul>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
+                        {% include 'pdf/partial_desordre.html.twig' %}   
                     {% endfor %}
                 {% else %}
                     <i>Aucun désordre signalé dans le bâtiment</i>

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -8,6 +8,7 @@
     <div class="page">
         <section>
             <h1 style="text-align: right">Signalement #{{ signalement.reference }}</h1>
+            <h3 style="text-align: right">Déposé le {{ signalement.createdAt|format_datetime(locale='fr') }}</h3>
             {% if signalement.isNotOccupant %}
                 <h3 style="text-align: right">Signalement par un tiers</h3>
 
@@ -17,33 +18,37 @@
             <table style="width: 100%">
                 <tr>
                     <td style="width: 50%">
-                        <h3 style="margin-bottom: 0"> Informations de
-                            l'occupant</h3>
+                        <h3 style="margin-bottom: 0">Informations de l'occupant</h3>
                         <ul style="list-style:none; margin-left:0px;padding-left:0px;">
-                            <li><b>Nom: </b> {{ signalement.nomOccupant }} -
-                                <b>Prénom: </b> {{ signalement.prenomOccupant }}</li>
-                            <li><b>Courriel: </b><a
+                            <li><b>Nom :</b> {{ signalement.nomOccupant }} -
+                                <b>Prénom :</b> {{ signalement.prenomOccupant }}</li>
+                            <li><b>Courriel :</b> <a
                                         href="mailto:{{ signalement.mailOccupant }}">{{ signalement.mailOccupant }}</a>
                             </li>
-                            <li><b>Téléphone: </b><a
+                            <li><b>Téléphone :</b> <a
                                         href="tel:{{ signalement.telOccupant }}">{{ signalement.telOccupant }}</a></li>
                             <li>
-                                <b>Adresse: </b> {{ signalement.adresseOccupant ~', '~signalement.cpOccupant ~' '~ signalement.villeOccupant|upper }}
+                                <b>Adresse :</b> {{ signalement.adresseOccupant ~', '~signalement.cpOccupant ~' '~ signalement.villeOccupant|upper }}
+                                <br>
+                                {{ signalement.etageOccupant ? 'étage ' ~ signalement.etageOccupant ~ ',' : '' }}
+                                {{ signalement.escalierOccupant ? 'escalier ' ~ signalement.escalierOccupant ~ ',' : '' }}
+                                {{ signalement.numAppartOccupant ? 'appartement ' ~ signalement.numAppartOccupant ~ ',' : '' }}
+                                {{ signalement.adresseAutreOccupant ? signalement.adresseAutreOccupant ~ ',' : '' }}
                             </li>
-                            <li><b>Occupant(s): </b> {{ signalement.nbAdultes }}
+                            <li><b>Occupant(s) :</b> {{ signalement.nbAdultes }}
                                 <b>Adulte(s)</b>{% if signalement.nbEnfantsM6 %} - {{ signalement.nbEnfantsM6 }} Enfant(s)
                                 <u><b>moins</b></u> 6 ans{% endif %}{% if signalement.nbEnfantsP6 %} - {{ signalement.nbEnfantsP6 }} Enfant(s)
                                     <u><b>plus</b></u> 6 ans{% endif %}</li>
                             <li><b>Date
-                                    d'entrée: </b> {{ signalement.dateEntree ? signalement.dateEntree|date('d/m/Y') : 'N/R' }}
+                                    d'entrée :</b> {{ signalement.dateEntree ? signalement.dateEntree|date('d/m/Y') : 'N/R' }}
                             </li>
                             <li>
-                                <b>Logement: </b> {{ signalement.natureLogement }}
+                                <b>Logement :</b> {{ signalement.natureLogement }}
                                 de {{ signalement.superficie }}m² -
-                                <b>Loyer: </b> {{ signalement.loyer }} €/mois
+                                <b>Loyer :</b> {{ signalement.loyer }} €/mois
                             </li>
                             <li>
-                                <b>Allocataire: </b>
+                                <b>Allocataire :</b>
                                 {% if signalement.isAllocataire %}
                                     <small class="fr-background-alt--green-emeraude fr-rounded fr-p-1v fr-text--bold fr-valid-text fr-display-inline-flex fr-mt-0 fr-px-3v">{{ signalement.isAllocataire }}</small>
                                 {% else %}
@@ -52,10 +57,10 @@
                             </li>
                             {% if signalement.isAllocataire %}
                                 <li>
-                                    <b>N° allocataire: </b> {{ signalement.numAllocataire }}
+                                    <b>N° allocataire :</b> {{ signalement.numAllocataire }}
                                 </li>
                                 <li>
-                                    <b>Montant allocation: </b> {{ signalement.montantAllocation ?? 'N/R' }}
+                                    <b>Montant allocation :</b> {{ signalement.montantAllocation ?? 'N/R' }}
                                     €/mois
                                 </li>
                             {% endif %}
@@ -65,13 +70,13 @@
                         <td>
                             <h3 style="margin-bottom: 0"> Informations du déclarant</h3>
                             <ul style="list-style:none; margin-left:0px;padding-left:0px;">
-                                <li><b>Nom: </b> {{ signalement.nomDeclarant }} -
-                                    <b>Prénom: </b> {{ signalement.prenomDeclarant }}</li>
-                                <li><b>Courriel: </b><a
+                                <li><b>Nom :</b> {{ signalement.nomDeclarant }} -
+                                    <b>Prénom :</b> {{ signalement.prenomDeclarant }}</li>
+                                <li><b>Courriel :</b><a
                                             href="mailto:{{ signalement.mailDeclarant }}">{{ signalement.mailDeclarant }}</a>
                                 </li>
-                                <li><b>Téléphone: </b>{{ signalement.telDeclarant }}</li>
-                                <li><b>Structure: </b> {{ signalement.structureDeclarant }}</li>
+                                <li><b>Téléphone :</b>{{ signalement.telDeclarant }}</li>
+                                <li><b>Structure :</b> {{ signalement.structureDeclarant }}</li>
                                 <li>&nbsp;</li>
                                 <li>&nbsp;</li>
                                 <li>&nbsp;</li>
@@ -94,28 +99,28 @@
                         <h3>Informations propriétaire</h3>
                         <ul style="list-style:none; margin-left:0px;padding-left:0px;">
                             <li>
-                                <b>Propriétaire averti: </b>
+                                <b>Propriétaire averti :</b>
                                 {% if signalement.isProprioAverti %}
                                     {{ picto_yes|raw }}
                                 {% else %}
                                     {{ picto_no|raw }}
                                 {% endif %}
                             </li>
-                            <li><b>Nom: </b> {{ signalement.nomProprio ?? 'N/R' }}
-                            <li><b>Courriel: </b><a
+                            <li><b>Nom :</b> {{ signalement.nomProprio ?? 'N/R' }}
+                            <li><b>Courriel :</b><a
                                         href="mailto:{{ signalement.mailProprio }}">{{ signalement.mailProprio ?? 'N/R' }}</a>
                             </li>
-                            <li><b>Téléphone: </b><a
+                            <li><b>Téléphone :</b><a
                                         href="tel:{{ signalement.telProprio }}">{{ signalement.telProprio ?? 'N/R' }}</a>
                             </li>
-                            <li><b>Adresse: </b> {{ signalement.adresseProprio ?? 'N/R' }}</li>
+                            <li><b>Adresse :</b> {{ signalement.adresseProprio ?? 'N/R' }}</li>
                         </ul>
                     </td>
                     <td>
                         <h3>Informations logement</h3>
                         <ul style="list-style:none; margin-left:0px;padding-left:0px;">
                             <li>
-                                <b>Bail en cours: </b>
+                                <b>Bail en cours :</b>
                                 {% if signalement.isBailEnCours %}
                                     {{ picto_yes|raw }}
                                 {% else %}
@@ -123,7 +128,7 @@
                                 {% endif %}
                             </li>
                             <li>
-                                <b>Logement social: </b>
+                                <b>Logement social :</b>
                                 {% if signalement.isLogementSocial %}
                                     {{ picto_yes|raw }}
                                 {% else %}
@@ -131,7 +136,7 @@
                                 {% endif %}
                             </li>
                             <li>
-                                <b>Demande de relogement: </b>
+                                <b>Demande de relogement :</b>
                                 {% if signalement.isRelogement %}
                                     {{ picto_yes|raw }}
                                 {% else %}
@@ -139,7 +144,7 @@
                                 {% endif %}
                             </li>
                             <li>
-                                <b>Preavis de départ: </b>
+                                <b>Preavis de départ :</b>
                                 {% if signalement.isPreavisDepart %}
                                     {{ picto_yes|raw }}
                                 {% else %}
@@ -192,39 +197,118 @@
     <div class="page" style="padding-top: 25px!important;">
         <section>
             <h2>Problème(s) signalé(s)</h2>
-            <ul style="list-style:none; margin-left:0px;padding-left:0px;">
-                {% for situation,criteres in situations %}
-                    <li>
-                        <h3><b>{{ situation|capitalize }}</b></h3>
-                        <ul style="list-style:none;">
-                            {% for critere,criticite in criteres %}
-                                {% if criticite.score is same as(1) %}
-                                    {% set icon = 'moyen' %}
-                                {% elseif criticite.score is same as(2) %}
-                                    {% set icon = 'grave' %}
-                                {% else %}
-                                    {% set icon = 'tres-grave' %}
+            {% if signalement.createdFrom %}
+                <h4>Désordres logement</h4>
+                {% if situations[enum('App\\Entity\\Enum\\DesordreCritereZone').LOGEMENT.name] is defined %}
+                    {% for situation,criteres in situations[enum('App\\Entity\\Enum\\DesordreCritereZone').LOGEMENT.name] %}
+                        {% if criteres %}
+                            {% set firstCritere = criteres|first %}
+                            {% if firstCritere is defined %}
+                                {% set firstPrecision = firstCritere|first %}
+                                {% if firstPrecision is defined %}
+                                    {% if signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] is defined %}
+                                        <h5>{{ signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] }}</h5>
+                                    {% endif %}
                                 {% endif %}
-                                <li>{% if criticite.critere.isDanger %}<p class="fr-badge fr-badge--warning">
-                                    danger</p>&nbsp;&nbsp;{% endif %}<b>{{ critere }}</b>
-                                    <ul style="list-style:none;">
-                                        <li class="fr-grid-row fr-grid-row--middle fr-w-100">
-                                            <div class="fr-col-md-2 fr-col-lg-1 fr-col--middle">
-                                                {# <img src={{asset('img/{{ icon }}-actif.svg') }} alt=""
-                                                 width="50"
-                                                 class=" fr-text--center"> #}
-                                            </div>
-                                            <div class="fr-col-md-10 fr-col-lg-11 fr-pl-5v fr-rounded">
-                                                {{ criticite.label|capitalize }}
-                                            </div>
-                                        </li>
-                                    </ul>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </li>
-                {% endfor %}
-            </ul>
+                            {% endif %}
+                            
+                            <ul>
+                                {% for critere,precisions in criteres %}
+                                    <li>
+                                        {{ critere }}     
+                                        {% for precision in precisions %}
+                                            {% if precision.label is not same as '' %}
+                                                <ul class="fr-list fr-list--none">
+                                                    <li>
+                                                        {{ precision.label|raw }}
+                                                        {% if signalement.jsonContent[precision.desordreCritere.slugCritere] is defined %}
+                                                            <br>Commentaire usager : <i>{{ signalement.jsonContent[precision.desordreCritere.slugCritere] }}</i>
+                                                        {% endif %}
+                                                    </li>
+                                                </ul>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    {% endfor %}
+                {% else %}
+                    <i>Aucun désordre signalé dans le logement</i>
+                {% endif %}
+
+                
+                <h4>Désordres bâtiment</h4>
+                {% if situations[enum('App\\Entity\\Enum\\DesordreCritereZone').BATIMENT.name] is defined %}
+                    {% for situation,criteres in situations[enum('App\\Entity\\Enum\\DesordreCritereZone').BATIMENT.name] %}
+                        {% if criteres %}
+                            {% set firstCritere = criteres|first %}
+                            {% if firstCritere is defined %}
+                                {% set firstPrecision = firstCritere|first %}
+                                {% if firstPrecision is defined %}
+                                    {% if signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] is defined %}
+                                        <h5>{{ signalement.jsonContent[firstPrecision.desordreCritere.slugCategorie] }}</h5>
+                                    {% endif %}
+                                {% endif %}
+                            {% endif %}
+
+                            <ul>
+                                {% for critere,precisions in criteres %}
+                                    <li>
+                                        {{ critere }}
+                                        {% for precision in precisions %}
+                                            {% if precision.label is not same as '' %}
+                                                <ul class="fr-list fr-list--none">
+                                                    <li>
+                                                        {{ precision.label|raw }}
+                                                        {% if signalement.jsonContent[precision.desordreCritere.slugCritere] is defined %}
+                                                            <br>Commentaire usager : <i>{{ signalement.jsonContent[precision.desordreCritere.slugCritere] }}</i>
+                                                        {% endif %}
+                                                    </li>
+                                                </ul>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    {% endfor %}
+                {% else %}
+                    <i>Aucun désordre signalé dans le bâtiment</i>
+                {% endif %}
+
+            {% else %}
+                <ul style="list-style:none; margin-left:0px;padding-left:0px;">
+                    {% for situation,criteres in situations %}
+                        <li>
+                            <h3><b>{{ situation|capitalize }}</b></h3>
+                            <ul style="list-style:none;">
+                                {% for critere,criticite in criteres %}
+                                    {% if criticite.score is same as(1) %}
+                                        {% set icon = 'moyen' %}
+                                    {% elseif criticite.score is same as(2) %}
+                                        {% set icon = 'grave' %}
+                                    {% else %}
+                                        {% set icon = 'tres-grave' %}
+                                    {% endif %}
+                                    <li>{% if criticite.critere.isDanger %}<p class="fr-badge fr-badge--warning">
+                                        danger</p>&nbsp;&nbsp;{% endif %}<b>{{ critere }}</b>
+                                        <ul style="list-style:none;">
+                                            <li class="fr-grid-row fr-grid-row--middle fr-w-100">
+                                                <div class="fr-col-md-2 fr-col-lg-1 fr-col--middle">
+                                                </div>
+                                                <div class="fr-col-md-10 fr-col-lg-11 fr-pl-5v fr-rounded">
+                                                    {{ criticite.label|capitalize }}
+                                                </div>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
         </section>
     </div>
 


### PR DESCRIPTION
## Ticket

#2141
#1554

## Description
Les nouveaux désordres n'étaient pas mis en place dans l'export PDF.

## Changement apportés
Ajout aussi de la date de création du signalement et du complément d'adresse.

## Pré-requis
Si déjà lancé :
`make worker-stop`
`make worker-start`

## Tests
- [ ] Faire un export d'un nouveau signalement et vérifier les données
- [ ] Faire un export d'un ancien signalement et vérifier les données
