### PR TITLE
[BO - Esabora] Synchronisation - Ignorer les dossiers archivés

### DIFF
--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -196,3 +196,21 @@ affectations:
     affected_by: "admin-01@histologe.fr"
     territory: "Bouches-du-Rhône"
     created_at: '-15 days'
+  -
+    signalement: 2024-04
+    partner: "partenaire-13-05@histologe.fr"
+    statut: 3
+    answered_by: ""
+    affected_by: "admin-territoire-13-01@histologe.fr"
+    motif_cloture: ""
+    territory: "Bouches-du-Rhône"
+    is_synchronized: true
+  -
+    signalement: 2024-04
+    partner: "partenaire-13-06@histologe.fr"
+    statut: 1
+    answered_by: ""
+    affected_by: "admin-territoire-13-01@histologe.fr"
+    motif_cloture: ""
+    territory: "Bouches-du-Rhône"
+    is_synchronized: true

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -1745,3 +1745,41 @@ signalements:
     qualifications:
       - "RSD"
       - "NON_DECENCE"
+  -
+    uuid: "00000000-0000-0000-2024-000000000004"
+    details: "Actuellement locataire, j'attire votre attention sur certaines conditions de non-décence et de confort qui affectent ma qualité de vie quotidienne."
+    is_proprio_averti: 1
+    is_logement_social: 0
+    nb_adultes: "2"
+    nb_enfants_m6: "0"
+    nb_enfants_p6: "2"
+    is_allocataire: ""
+    nature_logement: "maison"
+    superficie: 100
+    phone_number: 0621127286
+    adresse_occupant: "17 Boulevard saade - quai joliette"
+    cp_occupant: "13002"
+    ville_occupant: "MARSEILLE"
+    statut: 7
+    reference: "2024-04"
+    geoloc: "{\"lng\":\"43.301787\", \"lat\":\"5.364626\"}"
+    created_at: "2024-01-01 16:06:33"
+    score: 0
+    insee_occupant: "13202"
+    is_rsa: 0
+    nb_occupants_logement: 4
+    territory: "Bouches-du-Rhône"
+    mode_contact_proprio: "[\"\",\"t\\u00e9l\\u00e9phone\"]"
+    situations:
+      - "le confort du logement"
+    criteres:
+      - "De l’air s’infiltre dans mon logement."
+      - "Mes factures de chauffage sont anormalement élevées."
+      - "Mon logement est mal isolé."
+    criticites:
+      - "Infiltration ou fuite d'air dans plus de deux des éléments suivants : toit, charpente, façades, murs extérieurs. Sensation de courant d'air régulière ou très fréquente."
+      - "Ma facture est trop élevée et le chauffage est limité dans le logement."
+      - "Le DPE indique une étiquette énergie F ou G ou n’a pas été fait. J’ai tout le temps la sensation d'avoir froid en hiver et/ou très chaud en été."
+    qualifications:
+      - "RSD"
+      - "NON_DECENCE"

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -104,8 +104,12 @@ class AffectationRepository extends ServiceEntityRepository
         ?Territory $territory = null,
     ): array {
         $qb = $this->createQueryBuilder('a');
-        $qb = $qb->innerJoin('a.partner', 'p')
+        $qb = $qb
+            ->innerJoin('a.partner', 'p')
+            ->innerJoin('a.signalement', 's')
             ->where('p.esaboraUrl IS NOT NULL AND p.esaboraToken IS NOT NULL AND p.isEsaboraActive = 1')
+            ->andWhere('s.statut != :signalement_statut')
+            ->setParameter('signalement_statut', Signalement::STATUS_ARCHIVED)
             ->andWhere('p.type = :partner_type')
             ->setParameter('partner_type', $partnerType);
 

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -48,20 +48,20 @@ class BackStatistiquesControllerTest extends WebTestCase
     public function provideRoutesStatistiquesDatas(): \Generator
     {
         yield 'Super Admin' => ['back_statistiques_filter', [], self::USER_SUPER_ADMIN, [
-            ['result' => 38, 'label' => 'count_signalement'],
-            ['result' => 65.8, 'label' => 'average_criticite'],
+            ['result' => 39, 'label' => 'count_signalement'],
+            ['result' => 64.1, 'label' => 'average_criticite'],
         ]];
         yield 'Responsable Territoire' => ['back_statistiques_filter', [], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 24, 'label' => 'count_signalement'],
-            ['result' => 94.3, 'label' => 'average_criticite'],
+            ['result' => 25, 'label' => 'count_signalement'],
+            ['result' => 90.6, 'label' => 'average_criticite'],
         ]];
         yield 'Partner' => ['back_statistiques_filter', [], self::USER_PARTNER, [
             ['result' => 3, 'label' => 'count_signalement'],
             ['result' => 100, 'label' => 'average_criticite'],
         ]];
         yield 'RT - filtered with commune Arles' => ['back_statistiques_filter', ['communes' => '["Arles"]'], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 24, 'label' => 'count_signalement'],
-            ['result' => 94.3, 'label' => 'average_criticite'],
+            ['result' => 25, 'label' => 'count_signalement'],
+            ['result' => 90.6, 'label' => 'average_criticite'],
             ['result' => 0, 'label' => 'count_signalement_filtered'],
             ['result' => 0, 'label' => 'average_criticite_filtered'],
         ]];


### PR DESCRIPTION
## Ticket

#2269    

## Description
Les signalements archivés ne devraient pas être synchronisé

## Changements apportés
* Ajout d'un filtre pour ignorer les signalement archivé dans la requête
* Ajout d'un signalement archivé affecté à un partenaire SCHS qui sync dans les fixtures
* Mise à jour des tests (statistiques sur signalements archivés)

## Pré-requis
```
make mock-start
```

## Tests
- [ ] Lancer une synchronisation sish,vous ne devez pas trouver dans l'ouput le signalement archivé (2024-04) bien qu'il soit affecté à partenaire ARS et sync et taggé comme synchronisé 
```
make console app="sync-esabora-sish"
```
- [ ] Lancer une synchronisation schs,vous ne devez pas trouver dans l'ouput le signalement archivé (2024-04) bien qu'il soit affecté à partenaire Commmune SCHS et taggé comme synchronisé
```
make console app="sync-esabora-schs"
```

- [ ] Lancer une synchronisation sish intervention,vous ne devez pas trouver dans l'ouput le signalement archivé (2024-04) bien qu'il soit affecté à partenaire Commmune SCHS et taggé comme synchronisé

```
make console app="sync-esabora-sish-intervention"
```