### PR TITLE
[BO - Esabora] Revue des contraintes SCHS

### DIFF
--- a/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
@@ -33,6 +33,10 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
         $numeroAppartement = !empty($signalement->getNumAppartOccupant())
             ? substr($signalement->getNumAppartOccupant(), 0, 6)
             : null;
+        $nomUsager = !empty($signalement->getNomOccupant()) ? $signalement->getNomOccupant() : null;
+        $prenomUsager = !empty($signalement->getNomOccupant())
+            ? substr($signalement->getPrenomOccupant(), 0, 25)
+            : null;
 
         return (new DossierMessageSCHS())
             ->setUrl($partner->getEsaboraUrl())
@@ -40,8 +44,8 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
             ->setPartnerId($partner->getId())
             ->setSignalementId($signalement->getId())
             ->setReference($signalement->getUuid())
-            ->setNomUsager($signalement->getNomOccupant())
-            ->setPrenomUsager(substr($signalement->getPrenomOccupant(), 0, 25))
+            ->setNomUsager($nomUsager)
+            ->setPrenomUsager($prenomUsager)
             ->setMailUsager($signalement->getMailOccupant())
             ->setTelephoneUsager($signalement->getTelOccupantDecoded(true))
             ->setAdresseSignalement($address['street'])

--- a/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
@@ -30,6 +30,9 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
         $partner = $affectation->getPartner();
         $address = AddressParser::parse($signalement->getAdresseOccupant());
         $etage = $signalement->getEtageOccupant() ? EtageParser::parse($signalement->getEtageOccupant()) : null;
+        $numeroAppartement = !empty($signalement->getNumAppartOccupant())
+            ? substr($signalement->getNumAppartOccupant(), 0, 6)
+            : null;
 
         return (new DossierMessageSCHS())
             ->setUrl($partner->getEsaboraUrl())
@@ -38,14 +41,14 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
             ->setSignalementId($signalement->getId())
             ->setReference($signalement->getUuid())
             ->setNomUsager($signalement->getNomOccupant())
-            ->setPrenomUsager($signalement->getPrenomOccupant())
+            ->setPrenomUsager(substr($signalement->getPrenomOccupant(), 0, 25))
             ->setMailUsager($signalement->getMailOccupant())
             ->setTelephoneUsager($signalement->getTelOccupantDecoded(true))
             ->setAdresseSignalement($address['street'])
             ->setCodepostaleSignalement($signalement->getCpOccupant())
             ->setVilleSignalement($signalement->getVilleOccupant())
             ->setEtageSignalement($etage)
-            ->setNumeroAppartementSignalement($signalement->getNumAppartOccupant())
+            ->setNumeroAppartementSignalement($numeroAppartement)
             ->setNumeroAdresseSignalement($address['number'])
             ->setLatitudeSignalement($signalement->getGeoloc()['lat'] ?? 0)
             ->setLongitudeSignalement($signalement->getGeoloc()['lng'] ?? 0)

--- a/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
@@ -34,7 +34,7 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
             ? substr($signalement->getNumAppartOccupant(), 0, 5)
             : null;
         $nomUsager = !empty($signalement->getNomOccupant()) ? $signalement->getNomOccupant() : null;
-        $prenomUsager = !empty($signalement->getNomOccupant())
+        $prenomUsager = !empty($signalement->getPrenomOccupant())
             ? substr($signalement->getPrenomOccupant(), 0, 25)
             : null;
 

--- a/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
@@ -31,7 +31,7 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
         $address = AddressParser::parse($signalement->getAdresseOccupant());
         $etage = $signalement->getEtageOccupant() ? EtageParser::parse($signalement->getEtageOccupant()) : null;
         $numeroAppartement = !empty($signalement->getNumAppartOccupant())
-            ? substr($signalement->getNumAppartOccupant(), 0, 6)
+            ? substr($signalement->getNumAppartOccupant(), 0, 5)
             : null;
         $nomUsager = !empty($signalement->getNomOccupant()) ? $signalement->getNomOccupant() : null;
         $prenomUsager = !empty($signalement->getNomOccupant())


### PR DESCRIPTION
## Ticket

#2274    

## Description
![image](https://github.com/MTES-MCT/histologe/assets/5757116/fc9608be-4760-4003-8fdc-136e4c5a61d6)

Après la réception de la dernière version 1.5, tronquer certaines données  (numéro appartement et prénom) qui pourraient empêcher l'envoi du dossier

https://github.com/MTES-MCT/histologe/wiki/Esabora/_compare/afa5f60bcba3629c4a80e619ace3377a591bac6b...e4a176d0b6f6d5aab12f1113fbf5916e4cb4e249#diff-ea2859ede85fe148055587646d12c111ea20095845b1616ebb34a6e45fb6cbe6R35


Pour le reste c'est pas utile (soit des champs standardisé ou on est aligné au niveau des contraintes)

## Changements apportés
* Récupérer les 6 premiers caractères du numéro d'appartement
* Les 25 premiers caractères d'un prénom

## Pré-requis
```
make worker-start
make mock-start
```
## Tests
![image](https://github.com/MTES-MCT/histologe/assets/5757116/a7a4d134-6122-4226-a767-bc3416fa4200)

- [ ] Editer le prénom en dépassant 25 caractères ainsi que le numéro d'appartement en dépassant 5 caractères d'un signalement du 13
- [ ] Affecter le partenaire Partenaire 13-05 ESABORA SCHS à votre signalement
- [ ] Vérifier dans la table job_event que le `prenomUsager` et le `numeroAppartementSignalement` ont bien été tronqué
**EDIT**
- [ ] Créer un signalement dans le 13 en tant que tiers secours sans les informations d'occupant
- [ ] Affecter le partenaire Partenaire 13-05 ESABORA SCHS à votre signalement
