### PR TITLE
[BO - Esabora] Taguer les dossiers comme synchronisés uniquement en cas de succès

### DIFF
--- a/src/Command/PushEsaboraDossierCommand.php
+++ b/src/Command/PushEsaboraDossierCommand.php
@@ -87,16 +87,12 @@ class PushEsaboraDossierCommand extends Command
 
         foreach ($affectations as $affectation) {
             $this->esaboraBus->dispatch($affectation);
-            $affectation->setIsSynchronized(true);
-            $this->affectationRepository->save($affectation);
             $io->success(sprintf(
                 '[%s] Dossier %s pushed to esabora',
                 $affectation->getPartner()->getType()->value,
                 $affectation->getSignalement()->getUuid()
             ));
         }
-
-        $this->affectationRepository->save($affectation, true);
 
         return Command::SUCCESS;
     }

--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -168,8 +168,6 @@ class AffectationController extends AbstractController
     {
         $partner = $affectation->getPartner();
         if ($partner->canSyncWithEsabora() || $partner->canSyncWithOilhi()) {
-            $affectation->setIsSynchronized(true);
-            $this->affectationManager->save($affectation);
             $this->interconnectionBus->dispatch($affectation);
         }
     }

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -182,13 +182,6 @@ affectations:
     affected_by: "admin-01@histologe.fr"
     territory: "Pas-de-Calais"
   -
-    signalement: 2024-01
-    partner: "partenaire-62-01@histologe.fr"
-    statut: 0
-    answered_by: "admin-01@histologe.fr"
-    affected_by: "admin-01@histologe.fr"
-    territory: "Pas-de-Calais"
-  -
     signalement: 2023-20
     partner: "partenaire-13-01@histologe.fr"
     statut: 1

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -108,6 +108,7 @@ class AffectationManager extends Manager
 
     public function flagAsSynchronized(DossierMessageInterface $dossierMessage): void
     {
+        /** @var Affectation $affectation */
         $affectation = $this->getRepository()->findOneBy([
             'partner' => $dossierMessage->getPartnerId(),
             'signalement' => $dossierMessage->getSignalementId(),

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -8,6 +8,7 @@ use App\Entity\Enum\MotifRefus;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Messenger\Message\DossierMessageInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
 
@@ -103,5 +104,15 @@ class AffectationManager extends Manager
                 );
             }
         }
+    }
+
+    public function flagAsSynchronized(DossierMessageInterface $dossierMessage): void
+    {
+        $affectation = $this->getRepository()->findOneBy([
+            'partner' => $dossierMessage->getPartnerId(),
+            'signalement' => $dossierMessage->getSignalementId(),
+        ]);
+        $affectation->setIsSynchronized(true);
+        $this->save($affectation);
     }
 }

--- a/src/Messenger/MessageHandler/Esabora/DossierMessageSCHSHandler.php
+++ b/src/Messenger/MessageHandler/Esabora/DossierMessageSCHSHandler.php
@@ -3,6 +3,7 @@
 namespace App\Messenger\MessageHandler\Esabora;
 
 use App\Entity\JobEvent;
+use App\Manager\AffectationManager;
 use App\Manager\JobEventManager;
 use App\Messenger\Message\Esabora\DossierMessageSCHS;
 use App\Repository\PartnerRepository;
@@ -23,6 +24,7 @@ final class DossierMessageSCHSHandler
         private readonly JobEventManager $jobEventManager,
         private readonly SerializerInterface $serializer,
         private readonly PartnerRepository $partnerRepository,
+        private readonly AffectationManager $affectationManager,
     ) {
     }
 
@@ -36,17 +38,22 @@ final class DossierMessageSCHSHandler
     {
         $response = $this->esaboraService->pushDossier($schsDossierMessage);
         $partner = $this->partnerRepository->find($partnerId = $schsDossierMessage->getPartnerId());
+        $status = 200 === $response->getStatusCode() ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED;
 
         $this->jobEventManager->createJobEvent(
             service: AbstractEsaboraService::TYPE_SERVICE,
             action: AbstractEsaboraService::ACTION_PUSH_DOSSIER,
             message: $this->serializer->serialize($schsDossierMessage, 'json'),
             response: $response->getContent(throw: false),
-            status: 200 === $response->getStatusCode() ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED,
+            status: $status,
             codeStatus: $response->getStatusCode(),
             signalementId: $schsDossierMessage->getSignalementId(),
             partnerId: $partnerId,
             partnerType: $partner?->getType(),
         );
+
+        if (JobEvent::STATUS_SUCCESS === $status) {
+            $this->affectationManager->flagAsSynchronized($schsDossierMessage);
+        }
     }
 }

--- a/src/Messenger/MessageHandler/Esabora/DossierMessageSISHHandler.php
+++ b/src/Messenger/MessageHandler/Esabora/DossierMessageSISHHandler.php
@@ -2,6 +2,7 @@
 
 namespace App\Messenger\MessageHandler\Esabora;
 
+use App\Manager\AffectationManager;
 use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Service\Esabora\Handler\DossierSISHHandlerInterface;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
@@ -16,7 +17,8 @@ final class DossierMessageSISHHandler
         #[TaggedIterator(
             'app.dossier_sish_handler',
             defaultPriorityMethod: 'getPriority'
-        )] iterable $dossierSISHHandlers
+        )] iterable $dossierSISHHandlers,
+        private AffectationManager $affectationManager
     ) {
         $this->dossierSISHHandlers = $dossierSISHHandlers;
     }
@@ -27,5 +29,7 @@ final class DossierMessageSISHHandler
         foreach ($this->dossierSISHHandlers as $dossierSISHHandler) {
             $dossierSISHHandler->handle($dossierMessageSISH);
         }
+
+        $this->affectationManager->flagAsSynchronized($dossierMessageSISH);
     }
 }

--- a/src/Messenger/MessageHandler/Esabora/DossierMessageSISHHandler.php
+++ b/src/Messenger/MessageHandler/Esabora/DossierMessageSISHHandler.php
@@ -28,8 +28,9 @@ final class DossierMessageSISHHandler
         /** @var DossierSISHHandlerInterface $dossierSISHHandler */
         foreach ($this->dossierSISHHandlers as $dossierSISHHandler) {
             $dossierSISHHandler->handle($dossierMessageSISH);
+            if ($dossierSISHHandler->canFlagAsSynchronized()) {
+                $this->affectationManager->flagAsSynchronized($dossierMessageSISH);
+            }
         }
-
-        $this->affectationManager->flagAsSynchronized($dossierMessageSISH);
     }
 }

--- a/src/Messenger/MessageHandler/Oilhi/DossierMessageHandler.php
+++ b/src/Messenger/MessageHandler/Oilhi/DossierMessageHandler.php
@@ -3,6 +3,7 @@
 namespace App\Messenger\MessageHandler\Oilhi;
 
 use App\Entity\JobEvent;
+use App\Manager\AffectationManager;
 use App\Manager\JobEventManager;
 use App\Messenger\Message\Oilhi\DossierMessage;
 use App\Repository\PartnerRepository;
@@ -19,6 +20,7 @@ class DossierMessageHandler
         private JobEventManager $jobEventManager,
         private HookZapierService $hookZapierService,
         private PartnerRepository $partnerRepository,
+        private AffectationManager $affectationManager,
     ) {
     }
 
@@ -40,5 +42,9 @@ class DossierMessageHandler
             partnerId: $partnerId,
             partnerType: $partner?->getType(),
         );
+
+        if (JobEvent::STATUS_SUCCESS === $status) {
+            $this->affectationManager->flagAsSynchronized($dossierMessage);
+        }
     }
 }

--- a/src/Service/Esabora/Handler/DossierSISHHandlerInterface.php
+++ b/src/Service/Esabora/Handler/DossierSISHHandlerInterface.php
@@ -10,5 +10,7 @@ interface DossierSISHHandlerInterface
 {
     public function handle(DossierMessageSISH $dossierMessageSISH): void;
 
+    public function canFlagAsSynchronized(): bool;
+
     public static function getPriority(): int;
 }

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -70,12 +70,9 @@ class AutoAssigner
                         if ($affectation instanceof Affectation) {
                             $this->affectationManager->persist($affectation);
                             if ($partner->canSyncWithEsabora()) {
-                                $affectation->setIsSynchronized(true);
-                                $this->affectationManager->save($affectation, false);
                                 $this->interconnectionBus->dispatch($affectation);
-                            } else {
-                                $this->affectationManager->save($affectation, false);
                             }
+                            $this->affectationManager->save($affectation, false);
                         }
                     }
                     $this->affectationManager->flush();

--- a/tests/Unit/Messenger/MessageHandler/Esabora/DossierMessageHandlerTest.php
+++ b/tests/Unit/Messenger/MessageHandler/Esabora/DossierMessageHandlerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Unit\Messenger\MessageHandler\Esabora;
 
 use App\Entity\Partner;
+use App\Manager\AffectationManager;
 use App\Manager\JobEventManager;
 use App\Messenger\MessageHandler\Esabora\DossierMessageSCHSHandler;
 use App\Repository\PartnerRepository;
@@ -53,11 +54,18 @@ class DossierMessageHandlerTest extends TestCase
             ->with($dossierMessage->getPartnerId())
             ->willReturn(new Partner());
 
+        $affectationManagerMock = $this->createMock(AffectationManager::class);
+        $affectationManagerMock
+            ->expects($this->once())
+            ->method('flagAsSynchronized')
+            ->with($dossierMessage);
+
         $dossierMessageHandler = new DossierMessageSCHSHandler(
             $esaboraServiceMock,
             $jobEventManagerMock,
             $serializerMock,
             $partnerRepositoryMock,
+            $affectationManagerMock
         );
 
         $dossierMessageHandler($dossierMessage);

--- a/tests/Unit/Messenger/MessageHandler/Oilhi/DossierMessageHandlerTest.php
+++ b/tests/Unit/Messenger/MessageHandler/Oilhi/DossierMessageHandlerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Unit\Messenger\MessageHandler\Oilhi;
 
 use App\Entity\Partner;
+use App\Manager\AffectationManager;
 use App\Manager\JobEventManager;
 use App\Messenger\Message\Oilhi\DossierMessage;
 use App\Messenger\MessageHandler\Oilhi\DossierMessageHandler;
@@ -61,11 +62,18 @@ class DossierMessageHandlerTest extends TestCase
             ->with($dossierMessage->getPartnerId())
             ->willReturn(new Partner());
 
+        $affectationManagerMock = $this->createMock(AffectationManager::class);
+        $affectationManagerMock
+            ->expects($this->once())
+            ->method('flagAsSynchronized')
+            ->with($dossierMessage);
+
         $dossierMessageHandler = new DossierMessageHandler(
             $serializerMock,
             $jobEventManagerMock,
             $hookZapierServiceMock,
             $partnerRepositoryMock,
+            $affectationManagerMock
         );
 
         $dossierMessageHandler($dossierMessage);


### PR DESCRIPTION
## Ticket

#2277    

## Description
L'envoi de dossier se fait de manière asynchrone, il est donc pas pertinent de le tagger synchronisé au moment du dispatching il faut plutôt le faire quand tout s'est bien passé afin d'éviter des messages  comme 
`Le dossier n'a pas été trouvé` lors de la synchronisation

Ainsi on pourra trouver des dossiers affectés mais non synchronisé  à envoyer  d'un territoire en exécutant la commande
```
php bin/console app:push-esabora-dossier schs --zip=69
``` 

## Changements apportés
* Déplacement de la logique dans une méthode
* Appel de la méthode de synchronisation dans chaque handler 

## Pré-requis
```
make worker-start
make mock-start
```
## Tests
- [ ] Choisissez un signalement du 13 et affecter un partenaire Partenaire 13-06 ESABORA ARS
 et Partenaire 13-05 ESABORA SCHS
- [ ] Choississer un signalement du 62 et affecter le partenaire Partenaire 62-01

Vérifier que vos affectations sont bien tagué comme synchronisé

```
SELECT * FROM `affectation` WHERE is_synchronized = 1;
```

Que les événements esabora s'affiche toujours bien dans le tableau de bord
```
 make clear-pool pool="dashboard.cache"
````

Que l'evenement oilhi est bien enregistré dans la table job_event

```
SELECT * FROM `job_event` where service like 'oilhi';
```
