### PR TITLE
[BO - Signalement] Correction de l'affichage Occupant dans les suivis si le mail Occupant et Déclarant est le même

### DIFF
--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -34,9 +34,9 @@
                      data-mail="{{ suivi.createdBy.email }}">
                 {{
                     'ROLE_USAGER' in suivi.createdBy.roles
-                        ? (suivi.createdBy.email is same as signalement.mailDeclarant
-                            ? 'DECLARANT'
-                            : 'OCCUPANT'
+                        ? (suivi.createdBy.email is same as signalement.mailOccupant
+                            ? 'OCCUPANT'
+                            : 'DECLARANT'
                         )
                         : (suivi.createdBy.partner
                             ? (suivi.createdBy.partner.isArchive or ('ROLE_ADMIN' not in suivi.createdBy.roles and suivi.createdBy.partner.territory is not same as(signalement.territory))


### PR DESCRIPTION
## Ticket

#2256   

## Description
Dans le cas où le mail de déclarant et de l'occupant était le même, on affichait Déclarant.
Correction pour afficher Occupant à la place.

## Tests
`Avec la base de prod sur le signalement du ticket`
- [ ] Vérifier qu'il est bien écrit occupant
- [ ] Vérifier sur d'autres signalements
