### PR TITLE
[BUG Notification] envoyer email de suivi unique quand email occupant et déclarant sont identique

### DIFF
--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -923,7 +923,7 @@ class Signalement
             $usagers[] = $this->getMailOccupant();
         }
 
-        if (!empty($this->getMailDeclarant())) {
+        if (!empty($this->getMailDeclarant() && !\in_array($this->getMailDeclarant(), $usagers))) {
             $usagers[] = $this->getMailDeclarant();
         }
 

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -81,17 +81,15 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
     private function sendMailToUsager(Signalement $signalement): void
     {
         $toRecipients = $signalement->getMailUsagers();
-        if (!empty($toRecipients)) {
-            foreach ($toRecipients as $toRecipient) {
-                $this->notificationMailerRegistry->send(
-                    new NotificationMail(
-                        type: NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_USAGER,
-                        to: [$toRecipient],
-                        territory: $signalement->getTerritory(),
-                        signalement: $signalement
-                    )
-                );
-            }
+        foreach ($toRecipients as $toRecipient) {
+            $this->notificationMailerRegistry->send(
+                new NotificationMail(
+                    type: NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_USAGER,
+                    to: [$toRecipient],
+                    territory: $signalement->getTerritory(),
+                    signalement: $signalement
+                )
+            );
         }
     }
 

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace App\EventSubscriber;
 
-use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Signalement;
 use App\Entity\SignalementDraft;
 use App\Event\SignalementDraftCompletedEvent;
@@ -51,21 +50,14 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
             ->build();
 
         $this->signalementManager->save($signalement);
-        $this->sendNotifications($signalementDraft, $signalement);
+        $this->sendNotifications($signalement);
         $this->processFiles($signalementDraft, $signalement);
         $this->autoAssigner->assign($signalement);
     }
 
-    private function sendNotifications(SignalementDraft $signalementDraft, Signalement $signalement): void
+    private function sendNotifications(Signalement $signalement): void
     {
-        if (ProfileDeclarant::LOCATAIRE === $signalement->getProfileDeclarant()
-            || ProfileDeclarant::BAILLEUR_OCCUPANT === $signalementDraft->getProfileDeclarant()
-        ) {
-            $toRecipients = [$signalement->getMailDeclarant()];
-        } else {
-            $toRecipients = $signalement->getMailUsagers();
-        }
-
+        $toRecipients = $signalement->getMailUsagers();
         foreach ($toRecipients as $toRecipient) {
             $this->notificationMailerRegistry->send(
                 new NotificationMail(

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -15,7 +15,6 @@ use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use DateTimeInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 
 class VisiteNotifier
@@ -32,20 +31,18 @@ class VisiteNotifier
 
     public function notifyUsagers(Intervention $intervention, NotificationMailerType $notificationMailerType, ?DateTimeInterface $previousDate = null): void
     {
-        $toRecipients = new ArrayCollection($intervention->getSignalement()->getMailUsagers());
-        if (!$toRecipients->isEmpty()) {
-            foreach ($toRecipients as $toRecipient) {
-                $this->notificationMailerRegistry->send(
-                    new NotificationMail(
-                        type: $notificationMailerType,
-                        to: $toRecipient,
-                        territory: $intervention->getSignalement()->getTerritory(),
-                        signalement: $intervention->getSignalement(),
-                        intervention: $intervention,
-                        previousVisiteDate: $previousDate,
-                    )
-                );
-            }
+        $toRecipients = $intervention->getSignalement()->getMailUsagers();
+        foreach ($toRecipients as $toRecipient) {
+            $this->notificationMailerRegistry->send(
+                new NotificationMail(
+                    type: $notificationMailerType,
+                    to: $toRecipient,
+                    territory: $intervention->getSignalement()->getTerritory(),
+                    signalement: $intervention->getSignalement(),
+                    intervention: $intervention,
+                    previousVisiteDate: $previousDate,
+                )
+            );
         }
     }
 


### PR DESCRIPTION
## Ticket

#2282

## Description
Lorsque l'email usager et déclarant d'un signalement est le même, une seule notification est envoyé à l'usager

## Changements apportés
- Modification de la fonction `getMailUsagers` du Signalement
- Optimisation de quelques process d’envois d'email

## Tests
- [ ] Faire un signalement en tant que locataire et vérifier que les notifications de suivi sont bien unique
- [ ] Faire un signalement en tant que tiers et vérifier que le déclarant et l’occupant continue d'être notifié séparément
