### PR TITLE
[Esabora] Envoi des nouveaux désordres lors du push vers Esabora

### DIFF
--- a/src/Factory/Interconnection/Esabora/AbstractDossierMessageFactory.php
+++ b/src/Factory/Interconnection/Esabora/AbstractDossierMessageFactory.php
@@ -36,4 +36,42 @@ abstract class AbstractDossierMessageFactory implements DossierMessageFactoryInt
 
         return $piecesJointes;
     }
+
+    protected function buildDesordresCreatedFrom(Signalement $signalement): string
+    {
+        if (!$signalement->getDesordreCriteres()->isEmpty()) {
+            $criticitesArranged = [];
+            foreach ($signalement->getDesordrePrecisions() as $desordrePrecision) {
+                $zone = $desordrePrecision->getDesordreCritere()->getZoneCategorie();
+                $labelCategorieBO = $desordrePrecision->getDesordreCritere()->getDesordreCategorie()->getLabel();
+                $labelCritere = $desordrePrecision->getDesordreCritere()->getLabelCritere();
+                $criticitesArranged[$zone->value][$labelCategorieBO][$labelCritere][] = $desordrePrecision;
+            }
+        }
+        if (empty($criticitesArranged)) {
+            return '';
+        }
+
+        $commentaireDesordres = '';
+        foreach ($criticitesArranged as $listZoneCategorie) {
+            foreach ($listZoneCategorie as $labelCategorie => $listCritere) {
+                foreach ($listCritere as $labelCritere => $listPrecision) {
+                    $commentaireDesordres .= \PHP_EOL.$labelCritere;
+                    if (\count($listPrecision) > 0) {
+                        $commentairePrecision = '';
+                        foreach ($listPrecision as $desordrePrecision) {
+                            if ('' != $desordrePrecision->getLabel()) {
+                                $commentairePrecision .= $desordrePrecision->getLabel().' ; ';
+                            }
+                        }
+                        if (!empty($commentairePrecision)) {
+                            $commentaireDesordres .= ' : '.$commentairePrecision;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $commentaireDesordres;
+    }
 }

--- a/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
@@ -60,20 +60,23 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
         $commentaire = 'Points signalés:'.\PHP_EOL;
 
         if ($signalement->getCreatedFrom()) {
-            if (!$signalement->getDesordreCriteres()->isEmpty()) {
-                foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
-                    $commentaire .= \PHP_EOL.$desordreCritere->getLabelCritere();
-                }
-            }
+            $commentaire .= $this->buildDesordresCreatedFrom($signalement);
         } else {
             foreach ($signalement->getCriticites() as $criticite) {
                 $commentaire .= \PHP_EOL.$criticite->getCritere()->getLabel().' => Etat '.$criticite->getScoreLabel();
             }
         }
 
-        $commentaire .= \PHP_EOL.'Propriétaire averti: '.$signalement->getIsProprioAverti() ? 'OUI' : 'NON';
-        $commentaire .= \PHP_EOL.'Adultes: '.$signalement->getNbAdultes().' Adulte(s)';
-        $commentaire .= $this->buildNbEnfants($signalement);
+        $commentaire .= \PHP_EOL.'Propriétaire averti : ';
+        $commentaire .= $signalement->getIsProprioAverti() ? 'OUI' : 'NON';
+
+        if ($signalement->getCreatedFrom()) {
+            $commentaire .= \PHP_EOL.'Nb personnes : '.$signalement->getTypeCompositionLogement()->getCompositionLogementNombrePersonnes();
+            $commentaire .= \PHP_EOL.'Enfants moins de 6 ans : '.$signalement->getTypeCompositionLogement()->getCompositionLogementEnfants();
+        } else {
+            $commentaire .= \PHP_EOL.'Adultes : '.$signalement->getNbAdultes().' Adulte(s)';
+            $commentaire .= $this->buildNbEnfants($signalement);
+        }
 
         foreach ($signalement->getAffectations() as $affectation) {
             $commentaire .= \PHP_EOL.$affectation->getPartner()->getNom().' => '.$affectation->getAffectationLabel();

--- a/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
@@ -59,8 +59,16 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
     {
         $commentaire = 'Points signalés:'.\PHP_EOL;
 
-        foreach ($signalement->getCriticites() as $criticite) {
-            $commentaire .= \PHP_EOL.$criticite->getCritere()->getLabel().' => Etat '.$criticite->getScoreLabel();
+        if ($signalement->getCreatedFrom()) {
+            if (!$signalement->getDesordreCriteres()->isEmpty()) {
+                foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
+                    $commentaire .= \PHP_EOL.$desordreCritere->getLabelCritere();
+                }
+            }
+        } else {
+            foreach ($signalement->getCriticites() as $criticite) {
+                $commentaire .= \PHP_EOL.$criticite->getCritere()->getLabel().' => Etat '.$criticite->getScoreLabel();
+            }
         }
 
         $commentaire .= \PHP_EOL.'Propriétaire averti: '.$signalement->getIsProprioAverti() ? 'OUI' : 'NON';

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -208,6 +208,17 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
     private function buildProblemes(Signalement $signalement): ?string
     {
         $commentaire = null;
+
+        if ($signalement->getCreatedFrom()) {
+            if (!$signalement->getDesordreCriteres()->isEmpty()) {
+                foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
+                    $commentaire .= \PHP_EOL.$desordreCritere->getLabelCritere();
+                }
+            }
+
+            return $commentaire;
+        }
+
         foreach ($signalement->getCriticites() as $criticite) {
             $commentaire .= $criticite->getCritere()->getLabel().' => Etat '.$criticite->getScoreLabel().\PHP_EOL;
         }

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -210,16 +210,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
         $commentaire = null;
 
         if ($signalement->getCreatedFrom()) {
-            if (!$signalement->getDesordreCriteres()->isEmpty()) {
-                foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
-                    if (!empty($commentaire)) {
-                        $commentaire .= \PHP_EOL;
-                    }
-                    $commentaire .= $desordreCritere->getLabelCritere();
-                }
-            }
-
-            return $commentaire;
+            return $this->buildDesordresCreatedFrom($signalement);
         }
 
         foreach ($signalement->getCriticites() as $criticite) {

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -212,7 +212,10 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
         if ($signalement->getCreatedFrom()) {
             if (!$signalement->getDesordreCriteres()->isEmpty()) {
                 foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
-                    $commentaire .= \PHP_EOL.$desordreCritere->getLabelCritere();
+                    if (!empty($commentaire)) {
+                        $commentaire .= \PHP_EOL;
+                    }
+                    $commentaire .= $desordreCritere->getLabelCritere();
                 }
             }
 


### PR DESCRIPTION
## Ticket

#2283   

## Description
Les désordres des signalements du nouveau formulaire n'étaient pas envoyés, depuis le changement de structure.

## Tests
- [ ] Créer un signalement dans le 13 et affecter à SCHS et ARS
- [ ] Vérifier en BDD le json envoyé dans la requête (table `job_event`)
