### PR TITLE
[INFRA] Migration de MySQL 5.7 vers 8.0

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@
 APP_ENV=dev
 APP_SECRET=
 MAILER_DSN=smtp://histologe_mailer:1025
-DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=5.7&charset=utf8"
+DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=8.0&charset=utf8"
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 
 ###> knplabs/knp-snappy-bundle ###

--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ APP_SECRET=
 MAILER_DSN=smtp://histologe_mailer:1025
 # MAILER_DSN=sendinblue+api://KEY@default
 # MAILER_DSN=sendinblue+smtp://USERNAME:PASSWORD@default
-DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=5.7&charset=utf8"
+DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=8.0&charset=utf8"
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 HISTOLOGE_URL=http://localhost:8080
 WIREMOCK_HOSTNAME=histologe_wiremock

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     services:
       # https://docs.docker.com/samples/library/mysql/
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: histologe

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Service|Version
 Nginx | 1.20.2
 PHP | 8.1.x (latest)
 Node.js | 18.x
-MySQL | 5.7.38
+MySQL | 8.0
 Redis | 7.0.x (latest)
 
 ### URL(s)

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -6,7 +6,7 @@ doctrine:
                 url: '%env(resolve:DATABASE_URL)%'
                 # IMPORTANT: You MUST configure your server version,
                 # either here or in the DATABASE_URL env var (see .env file)
-                server_version: '5.7.38'
+                server_version: '8.0'
         types:
             type_composition_logement: App\Entity\DoctrineType\Signalement\TypeCompositionLogementType
             situation_foyer: App\Entity\DoctrineType\Signalement\SituationFoyerType

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 
 services:
   histologe_mysql:
-    image: 'mysql:5.7.38'
+    image: 'mysql:8.0'
     command: --max_allowed_packet=32505856
     container_name: histologe_mysql
     restart: always

--- a/scripts/sync-db.sh
+++ b/scripts/sync-db.sh
@@ -18,7 +18,7 @@ install-scalingo-cli
 
 # Install additional tools to interact with the database:
 echo ">>> Install additional tools to interact with the database"
-dbclient-fetcher mysql 5.7
+dbclient-fetcher mysql 8.0
 
 # Login to Scalingo, using the token stored in `DUPLICATE_API_TOKEN`:
 echo ">>> Login to Scalingo"


### PR DESCRIPTION
## Ticket

#2102   

## Description
Scalingo nous propose de passer rapidement à MySQL 8, puisqu'ils vont arrêter la maintenance de MySQL 5.7 et migreront à partir du 1er juillet.
Par ailleurs, on pourra en profiter pour utiliser des fonctionnalités plus avancées à présent.

Afin de passer en MySQL 8, il y avait 2 vérifications à faire sur les tables (cf ici : https://doc.scalingo.com/databases/mysql/mysql-8-prerequisites) :
- Toutes les tables utilisent le moteur InnoDB
- Toutes les tables ont des clés primaires
C'est bien le cas.

J'ai fait pas mal de tests, le passage à la version 8 semble indolore.
Lors du passage sur develop (lors du merge), il faudra 
- faire une sauvegarde de la base
- passer MySQL en version 8 via le dashboard Scalingo sur l'app de staging
- faire des tests sur staging

## Changements apportés
* Modification de la version de MySQL dans tous les fichiers de conf, environnements et doc.

## Pré-requis
`make build`

**Attention :** quand vous revenez sur une autre branche, il faut faire
```
docker volume rm histologe_dbdata
make build
```

## Tests
- [ ] Faire des tests de navigation sur différentes pages sensibles (statistiques, listes de signalements, exports, actions utilisateurs...)
