### PR TITLE
[OPS] Réduire le nombre transactions envoyés à Sentry sur le projet histologe-front

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ S3_URL_BUCKET=
 SENTRY_DSN=
 SENTRY_DSN_FRONT=https://06f9905de7b646ec902183ce78384f18@sentry.incubateur.net/142
 SENTRY_ENVIRONMENT=prod
-SENTRY_TRACES_SAMPLE_RATE=1.0
+SENTRY_TRACES_SAMPLE_RATE=0.2
 ###< sentry/sentry-symfony ###
 
 ### wiremock ###


### PR DESCRIPTION
## Ticket

#2295    

## Description
Réduire le nombre de transaction sur le projet histologe-front (au build), pour le projet back c'est via la variable d'environnement
## Changements apportés
* Mise à jour du fichier env utilisé lors de la phase de build ( npm run-build)

## Pré-requis
Editer votre fichier .env.local 
## Tests
- [ ] OK pour make npm-build 