### PR TITLE
[Securité] Revoir les actions sur les utilisateurs et partenaires

### DIFF
--- a/assets/controllers/form_partner.js
+++ b/assets/controllers/form_partner.js
@@ -88,15 +88,12 @@ document.querySelectorAll('.btn-edit-partner-user').forEach(swbtn => {
     }
 
     rolesSelect.innerHTML = "";
-    //on copie les option de rolesSelectHidden dans rolesSelect
     for (let i = 0; i < rolesSelectHidden.length; i++) {
       rolesSelect.options[rolesSelect.options.length] = new Option(rolesSelectHidden[i].text, rolesSelectHidden[i].value);
     }
-    //si userRole n'est pas dans la liste des options de rolesSelect on l'ajoute
     if (!Array.from(rolesSelect.options).map(option => option.value).includes(userRole)) {
       rolesSelect.options[rolesSelect.options.length] = new Option(rolesMapping[userRole], userRole);
     }
-    //on selectionne l'option correspondant à userRole
     rolesSelect.value = userRole;
 
     document.querySelector('#user_edit_form').addEventListener('submit', (e) => {

--- a/assets/controllers/form_partner.js
+++ b/assets/controllers/form_partner.js
@@ -79,19 +79,25 @@ document.querySelectorAll('.btn-edit-partner-user').forEach(swbtn => {
       document.querySelector('#user_edit_is_mailing_active-2').checked = true
     }
 
-    const userRoles = target.getAttribute('data-userrole').split(',')
+    const userRole = target.getAttribute('data-userrole')
     const rolesSelect = document.querySelector('#user_edit_roles')
-    if (userRoles.includes('ROLE_ADMIN')) {
-      rolesSelect.value  = 'ROLE_ADMIN'
-    } else if (userRoles.includes('ROLE_ADMIN_TERRITORY')) {
-      rolesSelect.value  = 'ROLE_ADMIN_TERRITORY'
-    } else if (userRoles.includes('ROLE_ADMIN_PARTNER')) {
-      rolesSelect.value  = 'ROLE_ADMIN_PARTNER'
-    } else if (userRoles.includes('ROLE_USER_PARTNER')) {
-      rolesSelect.value  = 'ROLE_USER_PARTNER'
-    } else {
-      rolesSelect.value  = 'ROLE_USER_PARTNER'
+    const rolesSelectHidden = document.querySelector('#user_edit_roles_hidden')
+    const rolesMapping = {
+      'ROLE_ADMIN': 'Super Admin',
+      'ROLE_ADMIN_TERRITORY': 'Responsable Territoire'
     }
+
+    rolesSelect.innerHTML = "";
+    //on copie les option de rolesSelectHidden dans rolesSelect
+    for (let i = 0; i < rolesSelectHidden.length; i++) {
+      rolesSelect.options[rolesSelect.options.length] = new Option(rolesSelectHidden[i].text, rolesSelectHidden[i].value);
+    }
+    //si userRole n'est pas dans la liste des options de rolesSelect on l'ajoute
+    if (!Array.from(rolesSelect.options).map(option => option.value).includes(userRole)) {
+      rolesSelect.options[rolesSelect.options.length] = new Option(rolesMapping[userRole], userRole);
+    }
+    //on selectionne l'option correspondant à userRole
+    rolesSelect.value = userRole;
 
     document.querySelector('#user_edit_form').addEventListener('submit', (e) => {
       histoUpdateSubmitButton('#user_edit_form_submit', 'Edition en cours...')

--- a/src/Controller/Back/BackArchivedAccountController.php
+++ b/src/Controller/Back/BackArchivedAccountController.php
@@ -17,18 +17,19 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/comptes-archives')]
 class BackArchivedAccountController extends AbstractController
 {
     #[Route('/', name: 'back_account_index', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
     public function index(
         Request $request,
         UserRepository $userRepository,
         TerritoryRepository $territoryRepository,
         PartnerRepository $partnerRepository
     ): Response {
-        $this->denyAccessUnlessGranted('USER_REACTIVE', $this->getUser());
         $page = $request->get('page') ?? 1;
 
         $isNoneTerritory = 'none' == $request->get('territory');
@@ -80,6 +81,7 @@ class BackArchivedAccountController extends AbstractController
     }
 
     #[Route('/{id}/reactiver', name: 'back_account_reactiver', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
     public function reactiver(
         Request $request,
         User $user,
@@ -88,8 +90,6 @@ class BackArchivedAccountController extends AbstractController
         EntityManagerInterface $entityManager,
         NotificationMailerRegistry $notificationMailerRegistry,
     ): Response {
-        $this->denyAccessUnlessGranted('USER_REACTIVE', $this->getUser());
-
         $isUserUnlinked = (!$user->getTerritory() || !$user->getPartner());
 
         if (User::STATUS_ARCHIVE !== $user->getStatut() && !$isUserUnlinked) {

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -510,11 +510,11 @@ class PartnerController extends AbstractController
     }
 
     #[Route('/checkmail', name: 'back_partner_check_user_email', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN_PARTNER')]
     public function checkMail(
         Request $request,
         UserRepository $userRepository
     ): Response {
-        $this->denyAccessUnlessGranted('USER_CHECKMAIL', $this->getUser());
         if ($this->isCsrfTokenValid('partner_checkmail', $request->request->get('_token'))) {
             $userExist = $userRepository->findOneBy(['email' => $request->get('email')]);
             if ($userExist && !\in_array('ROLE_USAGER', $userExist->getRoles())) {

--- a/src/Security/Voter/PartnerVoter.php
+++ b/src/Security/Voter/PartnerVoter.php
@@ -17,8 +17,8 @@ class PartnerVoter extends Voter
     public const DELETE = 'PARTNER_DELETE';
     public const USER_CREATE = 'USER_CREATE';
 
-    public function __construct(private Security $security) {
-
+    public function __construct(private Security $security)
+    {
     }
 
     protected function supports(string $attribute, $subject): bool
@@ -52,9 +52,10 @@ class PartnerVoter extends Voter
 
     private function canDelete(Partner $partner, User $user): bool
     {
-        if(!$this->security->isGranted('ROLE_ADMIN_TERRITORY')){
+        if (!$this->security->isGranted('ROLE_ADMIN_TERRITORY')) {
             return false;
         }
+
         return $this->canManage($partner, $user);
     }
 
@@ -71,12 +72,13 @@ class PartnerVoter extends Voter
         if (!$user->getPartner()) {
             return false;
         }
-        if($this->security->isGranted('ROLE_ADMIN_PARTNER') && $user->getPartner() === $partner) {
+        if ($this->security->isGranted('ROLE_ADMIN_PARTNER') && $user->getPartner() === $partner) {
             return true;
         }
-        if($this->security->isGranted('ROLE_ADMIN_TERRITORY') && $user->getTerritory() === $partner->getTerritory()) {
+        if ($this->security->isGranted('ROLE_ADMIN_TERRITORY') && $user->getTerritory() === $partner->getTerritory()) {
             return true;
         }
+
         return false;
     }
 }

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -56,7 +56,7 @@ class UserVoter extends Voter
 
     private function canDelete(User $subject, User $user): bool
     {
-        return $this->canManage($subject, $user);
+        return $this->canFullManage($subject, $user);
     }
 
     private function canEdit(User $subject, User $user): bool
@@ -76,7 +76,7 @@ class UserVoter extends Voter
         return $this->security->isGranted('ROLE_ADMIN_PARTNER') && $user->getTerritory() === $subject->getPartner()->getTerritory();
     }
 
-    private function canTransfer(User $subject, User $user): bool
+    private function canFullManage(User $subject, User $user): bool
     {
         if (!$user->getTerritory()) {
             return false;
@@ -86,6 +86,11 @@ class UserVoter extends Voter
         }
 
         return $this->security->isGranted('ROLE_ADMIN_TERRITORY') && $user->getTerritory() === $subject->getPartner()->getTerritory();
+    }
+
+    private function canTransfer(User $subject, User $user): bool
+    {
+        return $this->canFullManage($subject, $user);
     }
 
     private function canCheckMail()

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -4,6 +4,7 @@ namespace App\Security\Voter;
 
 use App\Entity\Enum\Qualification;
 use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -19,7 +20,10 @@ class UserVoter extends Voter
     public const CHECKMAIL = 'USER_CHECKMAIL';
     public const SEE_NDE = 'USER_SEE_NDE';
 
-    public function __construct(private ParameterBagInterface $parameterBag)
+    public function __construct(
+        private Security $security,
+        private ParameterBagInterface $parameterBag
+        )
     {
     }
 
@@ -36,7 +40,7 @@ class UserVoter extends Voter
         if (!$user instanceof UserInterface) {
             return false;
         }
-        if ($user->isSuperAdmin()) {
+        if ($this->security->isGranted('ROLE_ADMIN')) {
             return true;
         }
 
@@ -68,11 +72,8 @@ class UserVoter extends Voter
 
     private function canEdit(User $subject, User $user): bool
     {
-        if ($this->canDelete($subject, $user)) {
-            return true;
-        }
-
-        return $subject->getId() === $user->getId();
+        return $this->security->isGranted('ROLE_ADMIN_PARTNER') && $user->getTerritory() === $subject->getPartner()->getTerritory();
+        //TODO check si tout le monde a un territoir et un partenaire (ce n'est pas le cas mais voir comment gérer les regles)
     }
 
     private function canTransfer(User $subject, User $user): bool

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -13,7 +13,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class UserVoter extends Voter
 {
     public const EDIT = 'USER_EDIT';
-    public const REACTIVE = 'USER_REACTIVE';
     public const TRANSFER = 'USER_TRANSFER';
     public const DELETE = 'USER_DELETE';
     public const CHECKMAIL = 'USER_CHECKMAIL';
@@ -27,7 +26,7 @@ class UserVoter extends Voter
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::CHECKMAIL, self::REACTIVE, self::EDIT, self::TRANSFER, self::DELETE, self::SEE_NDE])
+        return \in_array($attribute, [self::CHECKMAIL, self::EDIT, self::TRANSFER, self::DELETE, self::SEE_NDE])
             && $subject instanceof User;
     }
 
@@ -77,10 +76,16 @@ class UserVoter extends Voter
         return $this->security->isGranted('ROLE_ADMIN_PARTNER') && $user->getTerritory() === $subject->getPartner()->getTerritory();
     }
 
-    // TODO
     private function canTransfer(User $subject, User $user): bool
     {
-        return $user->isTerritoryAdmin() && $user->getTerritory() === $subject->getTerritory();
+        if (!$user->getTerritory()) {
+            return false;
+        }
+        if (!$user->getPartner()) {
+            return false;
+        }
+
+        return $this->security->isGranted('ROLE_ADMIN_TERRITORY') && $user->getTerritory() === $subject->getPartner()->getTerritory();
     }
 
     private function canCheckMail()

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -12,7 +12,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserVoter extends Voter
 {
-    public const CREATE = 'USER_CREATE';
     public const EDIT = 'USER_EDIT';
     public const REACTIVE = 'USER_REACTIVE';
     public const TRANSFER = 'USER_TRANSFER';
@@ -28,7 +27,7 @@ class UserVoter extends Voter
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::CHECKMAIL, self::CREATE, self::REACTIVE, self::EDIT, self::TRANSFER, self::DELETE, self::SEE_NDE])
+        return \in_array($attribute, [self::CHECKMAIL, self::REACTIVE, self::EDIT, self::TRANSFER, self::DELETE, self::SEE_NDE])
             && $subject instanceof User;
     }
 
@@ -48,18 +47,12 @@ class UserVoter extends Voter
 
         return match ($attribute) {
             self::CHECKMAIL => $this->canCheckMail(),
-            self::CREATE => $this->canCreate($subject, $user),
             self::EDIT => $this->canEdit($subject, $user),
             self::TRANSFER => $this->canTransfer($subject, $user),
             self::DELETE => $this->canDelete($subject, $user),
             self::SEE_NDE => $this->canSeeNde($user),
             default => false,
         };
-    }
-
-    private function canCreate(User $subject, User $user): bool
-    {
-        return $this->canManage($subject, $user);
     }
 
     private function canDelete(User $subject, User $user): bool

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -15,7 +15,6 @@ class UserVoter extends Voter
     public const EDIT = 'USER_EDIT';
     public const TRANSFER = 'USER_TRANSFER';
     public const DELETE = 'USER_DELETE';
-    public const CHECKMAIL = 'USER_CHECKMAIL';
     public const SEE_NDE = 'USER_SEE_NDE';
 
     public function __construct(
@@ -26,7 +25,7 @@ class UserVoter extends Voter
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::CHECKMAIL, self::EDIT, self::TRANSFER, self::DELETE, self::SEE_NDE])
+        return \in_array($attribute, [self::EDIT, self::TRANSFER, self::DELETE, self::SEE_NDE])
             && $subject instanceof User;
     }
 
@@ -45,7 +44,6 @@ class UserVoter extends Voter
         }
 
         return match ($attribute) {
-            self::CHECKMAIL => $this->canCheckMail(),
             self::EDIT => $this->canEdit($subject, $user),
             self::TRANSFER => $this->canTransfer($subject, $user),
             self::DELETE => $this->canDelete($subject, $user),
@@ -91,11 +89,6 @@ class UserVoter extends Voter
     private function canTransfer(User $subject, User $user): bool
     {
         return $this->canFullManage($subject, $user);
-    }
-
-    private function canCheckMail()
-    {
-        return $this->security->isGranted('ROLE_ADMIN_PARTNER');
     }
 
     public function canSeeNde(User $user): bool

--- a/templates/_partials/_modal_user_edit.html.twig
+++ b/templates/_partials/_modal_user_edit.html.twig
@@ -36,8 +36,12 @@
                                 <div class="fr-grid-row fr-grid-row--gutters">
                                     <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
                                         <label for="user_edit_roles" class="fr-label">Rôle</label>
-                                        <select id="user_edit_roles" name="user_edit[roles]" required="required"
-                                                class="fr-select">
+                                        <select id="user_edit_roles" name="user_edit[roles]" required="required" class="fr-select">                                           
+                                        </select>
+                                        <p class="fr-error-text fr-hidden">
+                                            Vous devez sélectionner le rôle de l'utilisateur
+                                        </p>
+                                        <select id="user_edit_roles_hidden" class="fr-hidden">
                                             <option value="" selected="selected">--- Selectionnez ---</option>
                                             {% if is_granted('ROLE_ADMIN') %}
                                                 <option value="ROLE_ADMIN">
@@ -52,9 +56,6 @@
                                             <option value="ROLE_ADMIN_PARTNER">Administrateur</option>
                                             <option value="ROLE_USER_PARTNER">Utilisateur</option>
                                         </select>
-                                        <p class="fr-error-text fr-hidden">
-                                            Vous devez sélectionner le rôle de l'utilisateur
-                                        </p>
                                     </div>
                                     <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
                                         <label for="user_edit_email" class="fr-label">Courriel</label>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -156,7 +156,7 @@
                             data-fr-opened="false" 
                             data-usernom="{{ user.nom }}" 
                             data-userprenom="{{ user.prenom }}" 
-                            data-userrole="{{ user.roles|join(',') }}" 
+                            data-userrole="{{ user.roles[0] }}" 
                             data-userismailingactive="{{ user.isMailingActive }}" 
                             data-userid="{{ user.id }}" 
                             data-useremail="{{ user.email }}"></a>

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -87,7 +87,7 @@ class PartnerControllerTest extends WebTestCase
     public function testPartnerEditFormSubmit(): void
     {
         /** @var Partner $partner */
-        $partner = $this->partnerRepository->findOneBy(['nom' => 'Partenaire 01-03']);
+        $partner = $this->partnerRepository->findOneBy(['nom' => 'Partenaire 13-02']);
 
         $route = $this->router->generate('back_partner_edit', ['id' => $partner->getId()]);
         $this->client->request('GET', $route);

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -247,7 +247,7 @@ class PartnerControllerTest extends WebTestCase
 
     public function testDeleteUserAccount(): void
     {
-        $user = $this->userRepository->findOneBy(['email' => 'user-974-01@histologe.fr']);
+        $user = $this->userRepository->findOneBy(['email' => 'user-13-01@histologe.fr']);
         $userId = $user->getId();
 
         $this->client->request('POST', $this->router->generate('back_partner_user_delete'), [


### PR DESCRIPTION
## Ticket

#2247

## Description
- Lors de la modification d'un admin territoire par un admin partenaire le rôle du premier est préservé.
- Lors de la création/modification d'un utilisateur le role est contrôlé (impossible d'attribuer un role supérieur au sien)
- Lors du transfert d'un utilisateur contrôle du partenaire cible (doit être dans le même territoire que l'utilisateur - hors super admin)
- Simplification/Correction des Voters User et Partner et de leurs appels

## Tests
- [ ] Vérifier que l'ajout/modification de partenaire fonctionne correctement
- [ ] Vérifier que l'ajout/modification/transfert/suppression d'utilisateur fonctionne correctement
