### PR TITLE
[BO - signalement] Créer la modale d'upload de photos/documents

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -42,4 +42,4 @@ import './controllers/maintenance_banner';
 import './controllers/activate_account/activate_account';
 import './controllers/back_signalement_view/form_edit_modal';
 import './controllers/back_signalement_edit_file/back_signalement_edit_file';
-
+import './controllers/back_signalement_view/back_signalement_view';

--- a/assets/app.ts
+++ b/assets/app.ts
@@ -42,4 +42,4 @@ import './controllers/maintenance_banner';
 import './controllers/activate_account/activate_account';
 import './controllers/back_signalement_view/form_edit_modal';
 import './controllers/back_signalement_edit_file/back_signalement_edit_file';
-import './controllers/back_signalement_view/back_signalement_view';
+import './controllers/back_signalement_view/form_upload_documents';

--- a/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -1,7 +1,7 @@
 function histoUpdateDesordreSelect(target, selectedDocumentType) {
   let desordreSelectBox = document.querySelector('#desordre-slug-select');
   let desordres = JSON.parse(target.getAttribute('data-signalement-desordres'))
-  if ('SITUATION' === selectedDocumentType 
+  if ('PHOTO_SITUATION' === selectedDocumentType 
     && Object.keys(desordres).length > 0){
     const selectedDesordreSlug = target.getAttribute('data-desordreSlug')
     desordreSelectBox.innerHTML = '';

--- a/assets/controllers/back_signalement_view/back_signalement_view.js
+++ b/assets/controllers/back_signalement_view/back_signalement_view.js
@@ -1,0 +1,179 @@
+const modalUploadFiles = document?.querySelector('#fr-modal-upload-files')
+if(modalUploadFiles){
+    const dropArea = document.querySelector('.modal-upload-drop-section')
+    const listContainer = document.querySelector('.modal-upload-list')
+    const fileSelector = document.querySelector('.modal-upload-files-selector')
+    const fileSelectorInput = document.querySelector('.modal-upload-files-selector-input')
+    const addFileRoute = modalUploadFiles.dataset.addFileRoute
+    const addFileToken = modalUploadFiles.dataset.addFileToken
+    const selectTypeToClone = document.querySelector('#select-type-to-clone')
+    const selectDesordreToClone = document.querySelector('#select-desordre-to-clone')
+    const editFileRoute = modalUploadFiles.dataset.editFileRoute
+    const editFileToken = modalUploadFiles.dataset.editFileToken
+
+    fileSelector.onclick = () => fileSelectorInput.click()
+    fileSelectorInput.onchange = () => {
+        [...fileSelectorInput.files].forEach((file) => {
+            uploadFile(file)
+        })
+    }
+
+    dropArea.ondragover = (e) => {
+        e.preventDefault();
+        [...e.dataTransfer.items].forEach((item) => {
+            dropArea.classList.add('drag-over-effect')
+        })
+    }
+
+    dropArea.ondragleave = () => {
+        dropArea.classList.remove('drag-over-effect')
+    }
+
+    dropArea.ondrop = (e) => {
+        e.preventDefault();
+        dropArea.classList.remove('drag-over-effect')
+        if(e.dataTransfer.items){
+            [...e.dataTransfer.items].forEach((item) => {
+                if(item.kind === 'file'){
+                    const file = item.getAsFile()
+                    uploadFile(file)
+                }
+            })
+        }else{
+            [...e.dataTransfer.files].forEach((file) => {
+                uploadFile(file)
+            })
+        }
+    }
+
+    function uploadFile(file){
+        let div = document.createElement('div')
+        div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w')
+        div.innerHTML = initInnerHtml(file)
+        listContainer.prepend(div)
+        let http = new XMLHttpRequest()
+        let data = new FormData()
+        if(modalUploadFiles.dataset.fileType == 'photo'){
+            data.append('signalement-add-file[photos][]', file)
+        }else{
+            data.append('signalement-add-file[documents][]', file)
+        }
+        data.append('_token', addFileToken)
+        http.upload.onprogress = (e) => {
+            let percent_complete = (e.loaded / e.total)*100
+            div.querySelectorAll('span')[0].style.width = percent_complete + '%'
+            div.querySelectorAll('span')[1].innerHTML = Math.round(percent_complete) + '%'
+        }
+        http.onreadystatechange = function() {
+            if (this.readyState == XMLHttpRequest.DONE) {
+                let response = JSON.parse(this.response)
+                if (this.status == 200) {
+                    modalUploadFiles.dataset.hasChanges = true
+                    if(modalUploadFiles.dataset.fileType == 'photo'){
+                        var clone = selectDesordreToClone.cloneNode(true)
+                        clone.id = 'select-desordre-'+response.response
+                    }else{
+                        var clone = selectTypeToClone.cloneNode(true)
+                        clone.id = 'select-type-'+response.response
+                    }
+                    clone.dataset.fileId = response.response
+                    div.querySelector('.select-container').appendChild(clone) 
+                    addEventListenerSelectTypeDesordre(clone)
+                } else {
+                    div.querySelector('.file-error').innerHTML = '<div class="fr-alert fr-alert--error fr-alert--sm">'+response.response+'</div>'
+                }
+            }
+        }
+        http.open('POST', addFileRoute, true)
+        http.setRequestHeader("X-Requested-With", "XMLHttpRequest")
+        http.send(data)
+    }
+
+    function initInnerHtml(file){
+        var innerHTML;
+        if(modalUploadFiles.dataset.fileType == 'photo'){
+            innerHTML = `
+            <div class="fr-col-2">
+                <img class="fr-content-media__img" src="${URL.createObjectURL(file)}">
+            </div>
+            <div class="fr-col-6">`
+        }else{
+            innerHTML = `<div class="fr-col-8">`
+        }
+        innerHTML += `
+            <div class="file-name">
+                <div class="name">${file.name}</div>
+            </div>
+            <div class="file-progress">
+                <span></span>
+            </div>
+            <div class="file-size">
+                <div class="size">${(file.size/(1024*1024)).toFixed(2)} MB</div>
+                <span>0%</span>
+            </div>
+        </div>
+        <div class="fr-col-4 select-container">           
+        </div>
+        <div class="fr-col-12 file-error">
+        </div>
+        `
+        return innerHTML
+    }
+
+    function addEventListenerSelectTypeDesordre(select){
+        select.addEventListener('change', function(){
+            let selectField = this
+            let http = new XMLHttpRequest()
+            let data = new FormData()
+            data.append('file_id', selectField.dataset.fileId)
+            if(modalUploadFiles.dataset.fileType == 'photo'){
+                data.append('documentType', 'SITUATION')
+                data.append('desordreSlug', selectField.value)
+            }else{
+                data.append('documentType', selectField.value)
+            }
+            data.append('_token', editFileToken)
+            http.onreadystatechange = function() {
+                if (this.readyState == XMLHttpRequest.DONE) {
+                    let response = JSON.parse(this.response)
+                    if (this.status != 200) {
+                        let parent = selectField.closest('.modal-upload-list')
+                        parent.querySelector('.file-error').innerHTML = '<div class="fr-alert fr-alert--error fr-alert--sm">'+response.response+'</div>'
+                    }
+                }
+            }
+            http.open('POST', editFileRoute, true)
+            http.setRequestHeader("X-Requested-With", "XMLHttpRequest")
+            http.send(data)
+        })
+    }
+
+    modalUploadFiles.addEventListener('dsfr.conceal', (e) => {
+        document.querySelector('.modal-upload-list').innerHTML = ''
+        if(modalUploadFiles.dataset.hasChanges == "true"){
+            window.location.reload()
+        }
+    })
+
+    let fileType
+    document.querySelectorAll('.open-modal-upload-files-btn').forEach((button) => {
+        button.addEventListener('click', (e) => {
+            fileType = e.target.dataset.fileType
+        })
+    })
+
+    modalUploadFiles.addEventListener('dsfr.disclose', (e) => {
+        modalUploadFiles.querySelectorAll('.type-conditional').forEach((type) => {
+            type.classList.add('fr-hidden')
+        })
+        if(fileType == 'photo'){
+            modalUploadFiles.dataset.fileType = 'photo'
+            modalUploadFiles.querySelector('.type-photo').classList.remove('fr-hidden')
+            fileSelectorInput.setAttribute('accept', 'image/*')
+        }else{
+            modalUploadFiles.dataset.fileType = 'document'
+            modalUploadFiles.querySelector('.type-document').classList.remove('fr-hidden')
+            fileSelectorInput.setAttribute('accept', 'application/*')
+        }
+    })
+}

--- a/assets/controllers/back_signalement_view/back_signalement_view.js
+++ b/assets/controllers/back_signalement_view/back_signalement_view.js
@@ -6,10 +6,13 @@ if(modalUploadFiles){
     const fileSelectorInput = document.querySelector('.modal-upload-files-selector-input')
     const addFileRoute = modalUploadFiles.dataset.addFileRoute
     const addFileToken = modalUploadFiles.dataset.addFileToken
+    const waitingSuiviRoute = modalUploadFiles.dataset.waitingSuiviRoute
     const selectTypeToClone = document.querySelector('#select-type-to-clone')
     const selectDesordreToClone = document.querySelector('#select-desordre-to-clone')
     const editFileRoute = modalUploadFiles.dataset.editFileRoute
     const editFileToken = modalUploadFiles.dataset.editFileToken
+    var nbFiles = 0;
+    var nbFilesProcessed = 0;
 
     fileSelector.onclick = () => fileSelectorInput.click()
     fileSelectorInput.onchange = () => {
@@ -69,6 +72,7 @@ if(modalUploadFiles){
     }
 
     function uploadFile(file){
+        nbFiles++
         let div = document.createElement('div')
         div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w')
         div.innerHTML = initInnerHtml(file)
@@ -110,6 +114,12 @@ if(modalUploadFiles){
                 }
             }
         }
+        http.onloadend = function() {
+            nbFilesProcessed++;
+            if(nbFilesProcessed == nbFiles){
+                fetch(waitingSuiviRoute)
+            }
+        };
         http.open('POST', addFileRoute, true)
         http.setRequestHeader("X-Requested-With", "XMLHttpRequest")
         http.send(data)

--- a/assets/controllers/back_signalement_view/back_signalement_view.js
+++ b/assets/controllers/back_signalement_view/back_signalement_view.js
@@ -13,6 +13,7 @@ if (modalUploadFiles) {
     const editFileRoute = modalUploadFiles.dataset.editFileRoute
     const editFileToken = modalUploadFiles.dataset.editFileToken
     const btnAnnuler = document.querySelector('#close-modal-upload-file')
+    const ancre = document.querySelector('#modal-upload-file-dynamic-content')
 
     fileSelector.onclick = () => fileSelectorInput.click()
     fileSelectorInput.onchange = () => {
@@ -21,6 +22,7 @@ if (modalUploadFiles) {
                 uploadFile(file)
             }
         })
+        ancre.scrollIntoView({block: 'start'});
     }
 
     dropArea.ondragover = (e) => {
@@ -53,6 +55,7 @@ if (modalUploadFiles) {
                 }
             })
         }
+        ancre.scrollIntoView({block: 'start'});
     }
 
     function typeValidation(file) {
@@ -92,6 +95,8 @@ if (modalUploadFiles) {
         http.onreadystatechange = function () {
             if (this.readyState == XMLHttpRequest.DONE) {
                 let response = JSON.parse(this.response)
+                let btnDeleteTmpFile = div.querySelector('a.delete-tmp-file')
+                addEventListenerDeleteTmpFile(btnDeleteTmpFile)
                 if (this.status == 200) {
                     modalUploadFiles.dataset.hasChanges = true
                     if (modalUploadFiles.dataset.fileType == 'photo') {
@@ -108,12 +113,11 @@ if (modalUploadFiles) {
                         div.querySelector('.select-container').appendChild(clone)
                         addEventListenerSelectTypeDesordre(clone)
                     }
-                    let btnDeleteTmpFile = div.querySelector('a.delete-tmp-file')
-                    addEventListenerDeleteTmpFile(btnDeleteTmpFile)
                     btnDeleteTmpFile.href = btnDeleteTmpFile.href.replace('REPLACE', response.response)
-                    btnDeleteTmpFile.classList.remove('fr-hidden')
+                    btnDeleteTmpFile.classList.remove('fr-hidden', 'delete-html')
                 } else {
                     div.querySelector('.file-error').innerHTML = '<div class="fr-alert fr-alert--error fr-alert--sm">' + response.response + '</div>'
+                    btnDeleteTmpFile.classList.remove('fr-hidden')
                 }
             }
         }
@@ -148,7 +152,7 @@ if (modalUploadFiles) {
         <div class="fr-col-3 select-container">           
         </div>
         <div class="fr-col-1">
-            <a href="${deleteTmpFileRoute}" title="Supprimer" class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line fr-hidden delete-tmp-file"></a>         
+            <a href="${deleteTmpFileRoute}" title="Supprimer" class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line fr-hidden delete-tmp-file delete-html"></a>         
         </div>
         <div class="fr-col-12 file-error">
         </div>
@@ -188,6 +192,10 @@ if (modalUploadFiles) {
         button.addEventListener('click', (e) => {
             e.preventDefault()
             button.setAttribute('disabled', '')
+            if (button.classList.contains('delete-html')) {
+                button.closest('.fr-grid-row').remove()
+                return true
+            }
             fetch(button.href)
                 .then((response) => response.json())
                 .then((data) => {

--- a/assets/controllers/back_signalement_view/back_signalement_view.js
+++ b/assets/controllers/back_signalement_view/back_signalement_view.js
@@ -14,7 +14,9 @@ if(modalUploadFiles){
     fileSelector.onclick = () => fileSelectorInput.click()
     fileSelectorInput.onchange = () => {
         [...fileSelectorInput.files].forEach((file) => {
-            uploadFile(file)
+            if(typeValidation(file)){
+                uploadFile(file)
+            }
         })
     }
 
@@ -36,14 +38,34 @@ if(modalUploadFiles){
             [...e.dataTransfer.items].forEach((item) => {
                 if(item.kind === 'file'){
                     const file = item.getAsFile()
-                    uploadFile(file)
+                    if(typeValidation(file)){
+                        uploadFile(file)
+                    }
                 }
             })
         }else{
             [...e.dataTransfer.files].forEach((file) => {
-                uploadFile(file)
+                if(typeValidation(file)){
+                    uploadFile(file)
+                }
             })
         }
+    }
+
+    function typeValidation(file){
+        let splitType = file.type.split('/')[0]
+        let acceptedType = fileSelectorInput.getAttribute('accept').split('/')[0];
+        if(acceptedType == '*'){
+            return true
+        }
+        if(acceptedType == splitType){
+            return true
+        }
+        let div = document.createElement('div')
+        div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
+        div.innerHTML = `Le type du fichier ${file.name} n'est pas accepté (acceptés : ".jpg", ".png", ".gif")`;
+        listContainer.prepend(div)
+        return false;
     }
 
     function uploadFile(file){
@@ -77,8 +99,12 @@ if(modalUploadFiles){
                         clone.id = 'select-type-'+response.response
                     }
                     clone.dataset.fileId = response.response
-                    div.querySelector('.select-container').appendChild(clone) 
-                    addEventListenerSelectTypeDesordre(clone)
+                    if(clone.querySelectorAll('option').length == 1){
+                        clone.remove()
+                    }else{
+                        div.querySelector('.select-container').appendChild(clone) 
+                        addEventListenerSelectTypeDesordre(clone)
+                    }
                 } else {
                     div.querySelector('.file-error').innerHTML = '<div class="fr-alert fr-alert--error fr-alert--sm">'+response.response+'</div>'
                 }
@@ -173,7 +199,7 @@ if(modalUploadFiles){
         }else{
             modalUploadFiles.dataset.fileType = 'document'
             modalUploadFiles.querySelector('.type-document').classList.remove('fr-hidden')
-            fileSelectorInput.setAttribute('accept', 'application/*')
+            fileSelectorInput.setAttribute('accept', '*/*')
         }
     })
 }

--- a/assets/controllers/back_signalement_view/back_signalement_view.js
+++ b/assets/controllers/back_signalement_view/back_signalement_view.js
@@ -127,15 +127,15 @@ if (modalUploadFiles) {
     }
 
     function initInnerHtml(file) {
-        var innerHTML;
+        var innerHTML =`<div class="fr-col-12 file-error"></div>`;
         if (modalUploadFiles.dataset.fileType == 'photo') {
-            innerHTML = `
+            innerHTML += `
             <div class="fr-col-2">
                 <img class="fr-content-media__img" src="${URL.createObjectURL(file)}">
             </div>
             <div class="fr-col-6">`
         } else {
-            innerHTML = `<div class="fr-col-8">`
+            innerHTML += `<div class="fr-col-8">`
         }
         innerHTML += `
             <div class="file-name">
@@ -153,8 +153,6 @@ if (modalUploadFiles) {
         </div>
         <div class="fr-col-1">
             <a href="${deleteTmpFileRoute}" title="Supprimer" class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line fr-hidden delete-tmp-file delete-html"></a>         
-        </div>
-        <div class="fr-col-12 file-error">
         </div>
         `
         return innerHTML

--- a/assets/controllers/back_signalement_view/back_signalement_view.js
+++ b/assets/controllers/back_signalement_view/back_signalement_view.js
@@ -12,8 +12,8 @@ if (modalUploadFiles) {
     const selectDesordreToClone = document.querySelector('#select-desordre-to-clone')
     const editFileRoute = modalUploadFiles.dataset.editFileRoute
     const editFileToken = modalUploadFiles.dataset.editFileToken
-    const btnAnnuler = document.querySelector('#close-modal-upload-file')
     const ancre = document.querySelector('#modal-upload-file-dynamic-content')
+    const btnValidate = document.querySelector('#btn-validate-modal-upload-files')
 
     fileSelector.onclick = () => fileSelectorInput.click()
     fileSelectorInput.onchange = () => {
@@ -210,12 +210,16 @@ if (modalUploadFiles) {
 
 
     modalUploadFiles.addEventListener('dsfr.conceal', (e) => {
-        document.querySelector('.modal-upload-list').innerHTML = ''
-        if (modalUploadFiles.dataset.hasChanges == "true") {
+        if (modalUploadFiles.dataset.validated == "true" && modalUploadFiles.dataset.hasChanges == "true") {
             fetch(waitingSuiviRoute).then((response) => {
                 window.location.reload()
             })
+            return true;
         }
+        document.querySelectorAll('a.delete-tmp-file').forEach((button) => {
+            button.click()
+        })
+        modalUploadFiles.dataset.hasChanges = false
     })
 
     let fileType
@@ -227,6 +231,8 @@ if (modalUploadFiles) {
 
     modalUploadFiles.addEventListener('dsfr.disclose', (e) => {
         listContainer.innerHTML = '';
+        modalUploadFiles.dataset.validated = false
+        modalUploadFiles.dataset.hasChanges = false
         modalUploadFiles.querySelectorAll('.type-conditional').forEach((type) => {
             type.classList.add('fr-hidden')
         })
@@ -241,10 +247,9 @@ if (modalUploadFiles) {
         }
     })
 
-    btnAnnuler.addEventListener('click', (e) => {
-        document.querySelectorAll('a.delete-tmp-file').forEach((button) => {
-            button.click()
-        })
-        modalUploadFiles.dataset.hasChanges = false
+    btnValidate.addEventListener('click', (e) => {
+        modalUploadFiles.dataset.validated = true
     })
+
+
 }

--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -194,7 +194,7 @@ if (modalUploadFiles) {
                 button.closest('.fr-grid-row').remove()
                 return true
             }
-            fetch(button.href)
+            fetch(button.href, { method: 'DELETE' })
                 .then((response) => response.json())
                 .then((data) => {
                     if (data.success) {

--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -165,7 +165,7 @@ if (modalUploadFiles) {
             let data = new FormData()
             data.append('file_id', selectField.dataset.fileId)
             if (modalUploadFiles.dataset.fileType == 'photo') {
-                data.append('documentType', 'SITUATION')
+                data.append('documentType', 'PHOTO_SITUATION')
                 data.append('desordreSlug', selectField.value)
             } else {
                 data.append('documentType', selectField.value)

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -718,7 +718,7 @@ div.photos-album {
 .modal-upload-drop-section {
     border: 1px dashed #929292;
     font-size: 1.4rem;
-    padding: 4rem 0rem;
+    padding: 4rem 0;
     margin: .5rem 0;
     font-weight: bold;
 }
@@ -728,24 +728,24 @@ div.photos-album {
 }
 .modal-upload-list-section{
     font-weight: lighter;
-}
-.modal-upload-list-section .file-name{
-    font-weight: bold;
-} 
-.modal-upload-list-section .file-progress{
-    width: 100%;
-    height: 10px;
-    margin-top: 3px;
-    margin-bottom: 3px;
-    background-color: #e5e5e5;
-}   
-.modal-upload-list-section .file-progress span{
-    display: block;
-    width: 0%;
-    height: 100%;
-    background: #6A6AF4;
-}
-.modal-upload-list-section .file-size{
-    display: flex;
-    justify-content: space-between;
+    .file-name{
+        font-weight: bold;
+    } 
+    .file-progress{
+        width: 100%;
+        height: 10px;
+        margin-top: 3px;
+        margin-bottom: 3px;
+        background-color: #e5e5e5;
+    }   
+    .file-progress span{
+        display: block;
+        width: 0%;
+        height: 100%;
+        background: #6A6AF4;
+    }
+    .file-size{
+        display: flex;
+        justify-content: space-between;
+    }
 }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -709,3 +709,43 @@ div.photos-album {
         }
     }
 }
+.modal-upload-upload-container{
+    text-align: center;
+}
+.modal-upload-upload-container input{
+    display: none;
+}
+.modal-upload-drop-section {
+    border: 1px dashed #929292;
+    font-size: 1.4rem;
+    padding: 4rem 0rem;
+    margin: .5rem 0;
+    font-weight: bold;
+}
+.modal-upload-drop-section.drag-over-effect {
+    border: 2px dashed #929292;
+    color: #929292;
+}
+.modal-upload-list-section{
+    font-weight: lighter;
+}
+.modal-upload-list-section .file-name{
+    font-weight: bold;
+} 
+.modal-upload-list-section .file-progress{
+    width: 100%;
+    height: 10px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+    background-color: #e5e5e5;
+}   
+.modal-upload-list-section .file-progress span{
+    display: block;
+    width: 0%;
+    height: 100%;
+    background: #6A6AF4;
+}
+.modal-upload-list-section .file-size{
+    display: flex;
+    justify-content: space-between;
+}

--- a/migrations/Version20240301152552.php
+++ b/migrations/Version20240301152552.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240301152552 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_waiting_suivi column to file';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file ADD is_waiting_suivi TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file DROP is_waiting_suivi');
+    }
+}

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -63,7 +63,7 @@ class SignalementFileController extends AbstractController
         $this->denyAccessUnlessGranted('FILE_CREATE', $signalement);
         if (!$this->isCsrfTokenValid('signalement_add_file_'.$signalement->getId(), $request->get('_token')) || !$files = $request->files->get('signalement-add-file')) {
             if ($request->isXmlHttpRequest()) {
-                return $this->json(['response' => 'Token CSRF invalide ou paramètre manquant'], 400);
+                return $this->json(['response' => 'Token CSRF invalide ou paramètre manquant'], Response::HTTP_BAD_REQUEST);
             }
             $this->addFlash('error', 'Une erreur est survenu lors du téléchargement');
 
@@ -82,7 +82,7 @@ class SignalementFileController extends AbstractController
                 $errorMessages .= $errorMessage.'<br>';
             }
             if ($request->isXmlHttpRequest()) {
-                return $this->json(['response' => $errorMessages], 400);
+                return $this->json(['response' => $errorMessages], Response::HTTP_BAD_REQUEST);
             }
             $this->addFlash('error error-raw', $errorMessages);
 
@@ -160,7 +160,7 @@ class SignalementFileController extends AbstractController
             }
         }
 
-        return $this->json(['response' => 'error'], 400);
+        return $this->json(['response' => 'error'], Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -175,7 +175,7 @@ class SignalementFileController extends AbstractController
     ): Response {
         if (!$this->isCsrfTokenValid('signalement_edit_file_'.$signalement->getId(), $request->get('_token'))) {
             if ($request->isXmlHttpRequest()) {
-                return $this->json(['response' => 'Token CSRF invalide'], 400);
+                return $this->json(['response' => 'Token CSRF invalide'], Response::HTTP_BAD_REQUEST);
             }
             $this->addFlash('error', 'Une erreur est survenue lors de la modification...');
 
@@ -189,7 +189,7 @@ class SignalementFileController extends AbstractController
         );
         if (null === $file) {
             if ($request->isXmlHttpRequest()) {
-                return $this->json(['response' => 'Document introuvable'], 400);
+                return $this->json(['response' => 'Document introuvable'], Response::HTTP_BAD_REQUEST);
             }
             $this->addFlash('error', 'Ce fichier n\'existe plus');
 
@@ -199,7 +199,7 @@ class SignalementFileController extends AbstractController
         $documentType = DocumentType::tryFrom($request->get('documentType'));
         if (null === $documentType) {
             if ($request->isXmlHttpRequest()) {
-                return $this->json(['response' => 'Type de document invalide'], 400);
+                return $this->json(['response' => 'Type de document invalide'], Response::HTTP_BAD_REQUEST);
             }
             $this->addFlash('error', 'Mauvais type de fichier');
 

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -74,9 +74,8 @@ class SignalementFileController extends AbstractController
         $inputName = isset($files[File::INPUT_NAME_DOCUMENTS])
             ? File::INPUT_NAME_DOCUMENTS
             : File::INPUT_NAME_PHOTOS;
-        // $documentType = DocumentType::tryFrom($request->get('document_type')) ?? DocumentType::AUTRE;
         $documentType = DocumentType::AUTRE;
-        list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName, $documentType);
+        list($fileList) = $signalementFileProcessor->process($files, $inputName, $documentType);
 
         if (!$signalementFileProcessor->isValid()) {
             $errorMessages = '';

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -137,6 +137,7 @@ class SignalementFileController extends AbstractController
         $update->execute();
 
         $entityManager->flush();
+        $this->addFlash('success', 'Les documents ont bien été ajoutés.');
 
         return $this->json(['success' => true]);
     }
@@ -182,6 +183,26 @@ class SignalementFileController extends AbstractController
         }
 
         return $this->json(['response' => 'error'], Response::HTTP_BAD_REQUEST);
+    }
+
+    #[Route('/file/delete-tmp/{id}', name: 'back_signalement_delete_tmpfile')]
+    public function deleteTmpFile(
+        File $file,
+        EntityManagerInterface $entityManager,
+        UploadHandlerService $uploadHandlerService,
+        FileRepository $fileRepository
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted('FILE_DELETE', $file);
+        if (!$file->isIsWaitingSuivi()) {
+            return $this->json(['success' => false], Response::HTTP_BAD_REQUEST);
+        }
+        if (!$uploadHandlerService->deleteSignalementFile($file, $fileRepository)) {
+            return $this->json(['success' => false], Response::HTTP_BAD_REQUEST);
+        }
+        $entityManager->remove($file);
+        $entityManager->flush();
+
+        return $this->json(['success' => true]);
     }
 
     /**

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -185,7 +185,7 @@ class SignalementFileController extends AbstractController
         return $this->json(['response' => 'error'], Response::HTTP_BAD_REQUEST);
     }
 
-    #[Route('/file/delete-tmp/{id}', name: 'back_signalement_delete_tmpfile')]
+    #[Route('/file/delete-tmp/{id}', name: 'back_signalement_delete_tmpfile', methods: ['DELETE'])]
     public function deleteTmpFile(
         File $file,
         EntityManagerInterface $entityManager,

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -19,7 +19,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -60,51 +59,63 @@ class SignalementFileController extends AbstractController
         EntityManagerInterface $entityManager,
         SuiviFactory $suiviFactory,
         SignalementFileProcessor $signalementFileProcessor,
-    ): RedirectResponse {
+    ): Response {
         $this->denyAccessUnlessGranted('FILE_CREATE', $signalement);
-        if ($this->isCsrfTokenValid('signalement_add_file_'.$signalement->getId(), $request->get('_token'))
-            && $files = $request->files->get('signalement-add-file')) {
-            $inputName = isset($files[File::INPUT_NAME_DOCUMENTS])
-                ? File::INPUT_NAME_DOCUMENTS
-                : File::INPUT_NAME_PHOTOS;
-            // $documentType = DocumentType::tryFrom($request->get('document_type')) ?? DocumentType::AUTRE;
-            $documentType = DocumentType::AUTRE;
-            list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName, $documentType);
-
-            if ($signalementFileProcessor->isValid()) {
-                $nbFiles = \count($fileList);
-                $description = (string) $nbFiles;
-                $suivi = $suiviFactory->createInstanceFrom($this->getUser(), $signalement);
-                // TODO : distinguer documents partenaires et documents sur la istuation usager
-                // TODO : afficher la liste des désordres concernés pour l'ajout de photo
-                if (FILE::INPUT_NAME_DOCUMENTS === $inputName) {
-                    $description .= $nbFiles > 1 ? ' documents partenaires ont été ajoutés au signalement :'
-                    : ' document partenaire a été ajouté au signalement :';
-                } else {
-                    $description .= $nbFiles > 1 ? ' photos ont été ajoutés au signalement :'
-                    : ' photo a été ajouté au signalement :';
-                }
-                $suivi->setDescription(
-                    $description
-                    .'<ul>'
-                    .implode('', $descriptionList)
-                    .'</ul>'
-                );
-                $suivi->setType(SUIVI::TYPE_AUTO);
-                $signalementFileProcessor->addFilesToSignalement($fileList, $signalement, $this->getUser());
-
-                $entityManager->persist($suivi);
-                $entityManager->persist($signalement);
-                $entityManager->flush();
-                $this->addFlash('success', 'Envoi de '.ucfirst($inputName).' effectué avec succès !');
-            } else {
-                foreach ($signalementFileProcessor->getErrors() as $errorMessage) {
-                    $this->addFlash('error', $errorMessage);
-                }
+        if (!$this->isCsrfTokenValid('signalement_add_file_'.$signalement->getId(), $request->get('_token')) || !$files = $request->files->get('signalement-add-file')) {
+            if ($request->isXmlHttpRequest()) {
+                return $this->json(['response' => 'Token CSRF invalide ou paramètre manquant'], 400);
             }
-        } else {
             $this->addFlash('error', 'Une erreur est survenu lors du téléchargement');
+
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
         }
+        $inputName = isset($files[File::INPUT_NAME_DOCUMENTS])
+            ? File::INPUT_NAME_DOCUMENTS
+            : File::INPUT_NAME_PHOTOS;
+        // $documentType = DocumentType::tryFrom($request->get('document_type')) ?? DocumentType::AUTRE;
+        $documentType = DocumentType::AUTRE;
+        list($fileList, $descriptionList) = $signalementFileProcessor->process($files, $inputName, $documentType);
+
+        if (!$signalementFileProcessor->isValid()) {
+            $errorMessages = '';
+            foreach ($signalementFileProcessor->getErrors() as $errorMessage) {
+                $errorMessages .= $errorMessage.'<br>';
+            }
+            if ($request->isXmlHttpRequest()) {
+                return $this->json(['response' => $errorMessages], 400);
+            }
+            $this->addFlash('error error-raw', $errorMessages);
+
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
+        }
+        $nbFiles = \count($fileList);
+        $description = (string) $nbFiles;
+        $suivi = $suiviFactory->createInstanceFrom($this->getUser(), $signalement);
+        // TODO : distinguer documents partenaires et documents sur la istuation usager
+        // TODO : afficher la liste des désordres concernés pour l'ajout de photo
+        if (FILE::INPUT_NAME_DOCUMENTS === $inputName) {
+            $description .= $nbFiles > 1 ? ' documents partenaires ont été ajoutés au signalement :'
+            : ' document partenaire a été ajouté au signalement :';
+        } else {
+            $description .= $nbFiles > 1 ? ' photos ont été ajoutés au signalement :'
+            : ' photo a été ajouté au signalement :';
+        }
+        $suivi->setDescription(
+            $description
+            .'<ul>'
+            .implode('', $descriptionList)
+            .'</ul>'
+        );
+        $suivi->setType(SUIVI::TYPE_AUTO);
+        $signalementFileProcessor->addFilesToSignalement($fileList, $signalement, $this->getUser());
+
+        $entityManager->persist($suivi);
+        $entityManager->persist($signalement);
+        $entityManager->flush();
+        if ($request->isXmlHttpRequest()) {
+            return $this->json(['response' => $signalementFileProcessor->getLastFile()->getId()]);
+        }
+        $this->addFlash('success', 'Envoi de '.ucfirst($inputName).' effectué avec succès !');
 
         return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
     }
@@ -161,55 +172,70 @@ class SignalementFileController extends AbstractController
         Request $request,
         FileRepository $fileRepository,
         EntityManagerInterface $entityManager,
-    ): RedirectResponse {
-        if ($this->isCsrfTokenValid('signalement_edit_file_'.$signalement->getId(), $request->get('_token'))) {
-            $file = $fileRepository->findOneBy(
-                [
-                    'id' => $request->get('file_id'),
-                    'signalement' => $signalement,
-                ]
-            );
-            if (null !== $file) {
-                $this->denyAccessUnlessGranted('FILE_EDIT', $file);
-                $documentType = DocumentType::tryFrom($request->get('documentType'));
-                if (null !== $documentType) {
-                    $file->setDocumentType($documentType);
-                    if (DocumentType::PHOTO_SITUATION === $documentType) {
-                        $desordreSlug = $request->get('desordreSlug');
-                        $desordreCritereSlugs = $signalement->getDesordreCriteres()->map(
-                            fn (DesordreCritere $desordreCritere) => $desordreCritere->getSlugCritere()
-                        )->toArray();
-                        $desordrePrecisionSlugs = $signalement->getDesordrePrecisions()->map(
-                            fn (DesordrePrecision $desordrePrecision) => $desordrePrecision->getDesordrePrecisionSlug()
-                        )->toArray();
+    ): Response {
+        if (!$this->isCsrfTokenValid('signalement_edit_file_'.$signalement->getId(), $request->get('_token'))) {
+            if ($request->isXmlHttpRequest()) {
+                return $this->json(['response' => 'Token CSRF invalide'], 400);
+            }
+            $this->addFlash('error', 'Une erreur est survenue lors de la modification...');
 
-                        if (\in_array($desordreSlug, $desordreCritereSlugs)
-                            || \in_array($desordreSlug, $desordrePrecisionSlugs)
-                        ) {
-                            $file->setDesordreSlug($desordreSlug);
-                        }
-                    } else {
-                        if (null !== $file->getDesordreSlug()) {
-                            $file->setDesordreSlug(null);
-                        }
-                    }
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
+        }
+        $file = $fileRepository->findOneBy(
+            [
+                'id' => $request->get('file_id'),
+                'signalement' => $signalement,
+            ]
+        );
+        if (null === $file) {
+            if ($request->isXmlHttpRequest()) {
+                return $this->json(['response' => 'Document introuvable'], 400);
+            }
+            $this->addFlash('error', 'Ce fichier n\'existe plus');
 
-                    $entityManager->persist($file);
-                    $entityManager->flush();
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
+        }
+        $this->denyAccessUnlessGranted('FILE_EDIT', $file);
+        $documentType = DocumentType::tryFrom($request->get('documentType'));
+        if (null === $documentType) {
+            if ($request->isXmlHttpRequest()) {
+                return $this->json(['response' => 'Type de document invalide'], 400);
+            }
+            $this->addFlash('error', 'Mauvais type de fichier');
 
-                    if ('document' === $file->getFileType()) {
-                        $this->addFlash('success', 'Le document a bien été modifié.');
-                    } else {
-                        $this->addFlash('success', 'La photo a bien été modifiée.');
-                    }
-                } else {
-                    $this->addFlash('error', 'Mauvais type de fichier');
-                }
-            } else {
-                $this->addFlash('error', 'Ce fichier n\'existe plus');
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
+        }
+        $file->setDocumentType($documentType);
+        if (DocumentType::PHOTO_SITUATION === $documentType) {
+            $desordreSlug = $request->get('desordreSlug');
+            $desordreCritereSlugs = $signalement->getDesordreCriteres()->map(
+                fn (DesordreCritere $desordreCritere) => $desordreCritere->getSlugCritere()
+            )->toArray();
+            $desordrePrecisionSlugs = $signalement->getDesordrePrecisions()->map(
+                fn (DesordrePrecision $desordrePrecision) => $desordrePrecision->getDesordrePrecisionSlug()
+            )->toArray();
+            if (!$desordreSlug) {
+                $file->setDesordreSlug(null);
+            } elseif (\in_array($desordreSlug, $desordreCritereSlugs)
+                || \in_array($desordreSlug, $desordrePrecisionSlugs)
+            ) {
+                $file->setDesordreSlug($desordreSlug);
             }
         } else {
-            $this->addFlash('error', 'Une erreur est survenue lors de la modification...');
+            if (null !== $file->getDesordreSlug()) {
+                $file->setDesordreSlug(null);
+            }
+        }
+
+        $entityManager->persist($file);
+        $entityManager->flush();
+        if ($request->isXmlHttpRequest()) {
+            return $this->json(['response' => 'success']);
+        }
+        if ('document' === $file->getFileType()) {
+            $this->addFlash('success', 'Le document a bien été modifié.');
+        } else {
+            $this->addFlash('success', 'La photo a bien été modifiée.');
         }
 
         return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -210,7 +210,7 @@ class File
 
     public function setDesordreSlug(?string $desordreSlug): self
     {
-        if (!$this->getSignalement() || !$this->getDocumentType() || DocumentType::SITUATION !== $this->getDocumentType()) {
+        if (!$this->getSignalement() || !$this->getDocumentType() || DocumentType::PHOTO_SITUATION !== $this->getDocumentType()) {
             $this->desordreSlug = null;
 
             return $this;

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -59,10 +59,14 @@ class File
     #[ORM\Column(type: 'text', nullable: true)]
     private ?string $description;
 
+    #[ORM\Column]
+    private ?bool $isWaitingSuivi = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
         $this->isVariantsGenerated = false;
+        $this->isWaitingSuivi = false;
     }
 
     public function getId(): ?int
@@ -206,7 +210,17 @@ class File
 
     public function setDesordreSlug(?string $desordreSlug): self
     {
-        $this->desordreSlug = $desordreSlug;
+        if (!$this->getSignalement() || !$this->getDocumentType() || DocumentType::SITUATION !== $this->getDocumentType()) {
+            $this->desordreSlug = null;
+
+            return $this;
+        }
+        if (!$desordreSlug) {
+            $this->desordreSlug = null;
+        } elseif (\in_array($desordreSlug, $this->getSignalement()->getDesordreCritereSlugs())
+            || \in_array($desordreSlug, $this->getSignalement()->getDesordrePrecisionSlugs())) {
+            $this->desordreSlug = $desordreSlug;
+        }
 
         return $this;
     }
@@ -231,6 +245,18 @@ class File
     public function setDescription(?string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+    public function isIsWaitingSuivi(): ?bool
+    {
+        return $this->isWaitingSuivi;
+    }
+
+    public function setIsWaitingSuivi(bool $isWaitingSuivi): self
+    {
+        $this->isWaitingSuivi = $isWaitingSuivi;
 
         return $this;
     }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2291,4 +2291,14 @@ class Signalement
 
         return $desordreSlug;
     }
+
+    public function getDesordreCritereSlugs()
+    {
+        return $this->getDesordreCriteres()->map(fn (DesordreCritere $desordreCritere) => $desordreCritere->getSlugCritere())->toArray();
+    }
+
+    public function getDesordrePrecisionSlugs()
+    {
+        return $this->getDesordrePrecisions()->map(fn (DesordrePrecision $desordrePrecision) => $desordrePrecision->getDesordrePrecisionSlug())->toArray();
+    }
 }

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -22,11 +22,13 @@ class FileFactory
         ?DocumentType $documentType = null,
         ?string $desordreSlug = null,
         ?string $description = null,
+        ?bool $isWaitingSuivi = false
     ): ?File {
         $file = (new File())
             ->setFilename($filename)
             ->setTitle($title)
-            ->setFileType($type);
+            ->setFileType($type)
+            ->setIsWaitingSuivi($isWaitingSuivi);
         if (null !== $signalement) {
             $file->setSignalement($signalement);
         }

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -60,7 +60,7 @@ class SignalementFileProcessor
 
                         if (\in_array($file->getMimeType(), ImageManipulationHandler::IMAGE_MIME_TYPES)) {
                             $this->imageManipulationHandler->setUseTmpDir(false)->resize($filename)->thumbnail($filename);
-                        }else{
+                        } else {
                             $inputTypeDetection = 'documents';
                         }
                     } else {

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class SignalementFileProcessor
 {
     private array $errors = [];
+    private File $lastFile;
 
     public function __construct(
         private readonly UploadHandlerService $uploadHandlerService,
@@ -97,6 +98,7 @@ class SignalementFileProcessor
             $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
             $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
             $signalement->addFile($file);
+            $this->lastFile = $file;
         }
     }
 
@@ -143,5 +145,10 @@ class SignalementFileProcessor
             'type' => 'documents' === $inputName ? File::FILE_TYPE_DOCUMENT : File::FILE_TYPE_PHOTO,
             'documentType' => $documentType,
         ];
+    }
+
+    public function getLastFile(): File
+    {
+        return $this->lastFile;
     }
 }

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -88,7 +88,9 @@ class SignalementFileProcessor
         Signalement $signalement,
         ?UserInterface $user = null,
         ?Intervention $intervention = null,
-    ): void {
+        ?bool $isWaitingSuivi = false
+    ): array {
+        $list = [];
         foreach ($fileList as $fileItem) {
             $file = $this->fileFactory->createInstanceFrom(
                 filename: $fileItem['file'],
@@ -97,12 +99,16 @@ class SignalementFileProcessor
                 user: $user,
                 intervention: $intervention,
                 documentType: $fileItem['documentType'],
+                isWaitingSuivi: $isWaitingSuivi
             );
             $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
             $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
             $signalement->addFile($file);
             $this->lastFile = $file;
+            $list[] = $file;
         }
+
+        return $list;
     }
 
     public function isValid(): bool

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -49,6 +49,7 @@ class SignalementFileProcessor
                 $this->logger->error($message);
                 $this->errors[] = $message;
             } else {
+                $inputTypeDetection = $inputName;
                 try {
                     if ($file instanceof UploadedFile) {
                         $filename = $this->uploadHandlerService->uploadFromFile(
@@ -59,6 +60,8 @@ class SignalementFileProcessor
 
                         if (\in_array($file->getMimeType(), ImageManipulationHandler::IMAGE_MIME_TYPES)) {
                             $this->imageManipulationHandler->setUseTmpDir(false)->resize($filename)->thumbnail($filename);
+                        }else{
+                            $inputTypeDetection = 'documents';
                         }
                     } else {
                         $filename = $this->uploadHandlerService->moveFromBucketTempFolder($file);
@@ -72,7 +75,7 @@ class SignalementFileProcessor
                 }
                 if (!empty($filename)) {
                     $descriptionList[] = $this->generateListItemDescription($filename, $title, $withTokenGenerated);
-                    $fileList[] = $this->createFileItem($filename, $title, $inputName, $documentType);
+                    $fileList[] = $this->createFileItem($filename, $title, $inputTypeDetection, $documentType);
                 }
             }
         }

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -15,7 +15,7 @@
             <div class="fr-col-12 fr-col-md-8">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-add-files">Fermer</button>
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-upload-files">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <div class="type-conditional type-document">

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -5,6 +5,7 @@
     role="dialog" 
     data-file-type="document"
     data-has-changes="false"
+    data-validated="false"
     data-add-file-route="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}"
     data-add-file-token="{{ csrf_token('signalement_add_file_'~signalement.id) }}"
     data-edit-file-route="{{ path('back_signalement_edit_file',{uuid:signalement.uuid}) }}"
@@ -76,10 +77,10 @@
                     </div>
                     <div class="fr-modal__footer">
                         <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" id="close-modal-upload-file" aria-controls="fr-modal-upload-files">
+                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-upload-files">
                                 Annuler
                             </button>
-                            <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files">
+                            <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files" id="btn-validate-modal-upload-files">
                                 Valider
                             </button>
                         </div>

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -22,14 +22,16 @@
                     <div class="fr-modal__content">
                         <div class="type-conditional type-document">
                             <h1 class="fr-modal__title">
-                                Ajouter des documents partnaires
+                                Ajouter des documents partenaires
                             </h1>
                             <div>
                                 Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
                             </div>
+                            {#
                             <div class="fr-alert fr-alert--info fr-alert--sm">
                                 <p>Pour ajouter des documents de type Bail, DPE, Diagnostic et Etat des lieux, rendez-vous dans la partie "Déclaration usager".</p>
                             </div>
+                            #}
                         </div>
                         <div class="type-conditional type-photo">
                             <h1 class="fr-modal__title">
@@ -39,7 +41,7 @@
                                 Ajouter une ou plusieurs photos au signalement. Pour chaque photo, veuillez sélectionner le désordre auquel elle est rattachée. 
                             </div>
                             <div class="fr-alert fr-alert--warning fr-alert--sm">
-                                <p>Ces photos seront partagées à l'usager. Une fois validées, elles ne pourront plus être supprimées.</p>
+                                <p>Ces photos seront partagées à l'usager.</p>
                             </div>
                         </div>
                         <div class="modal-upload-upload-container fr-mb-4w">
@@ -53,7 +55,7 @@
                             <button class="modal-upload-files-selector fr-btn fr-icon-search-line fr-btn--icon-left fr-btn--secondary">Parcourir les fichiers de l'appareil</button>
                             <input type="file" class="modal-upload-files-selector-input" multiple accept="application/*">
                         </div>
-                        <div class="modal-upload-list-section">
+                        <div class="modal-upload-list-section" id="modal-upload-file-dynamic-content">
                             <div class="modal-upload-list"></div>
                         </div>
                         <div style="display:none">

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -1,0 +1,85 @@
+<dialog 
+    aria-labelledby="fr-modal-upload-files" 
+    id="fr-modal-upload-files" 
+    class="fr-modal" 
+    role="dialog" 
+    data-file-type="document"
+    data-has-changes="false"
+    data-add-file-route="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}"
+    data-add-file-token="{{ csrf_token('signalement_add_file_'~signalement.id) }}"
+    data-edit-file-route="{{ path('back_signalement_edit_file',{uuid:signalement.uuid}) }}"
+    data-edit-file-token="{{ csrf_token('signalement_edit_file_'~signalement.id) }}"
+    >
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-add-files">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <div class="type-conditional type-document">
+                            <h1 class="fr-modal__title">
+                                Ajouter des documents partnaires
+                            </h1>
+                            <div>
+                                Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
+                            </div>
+                            <div class="fr-alert fr-alert--info fr-alert--sm">
+                                <p>Pour ajouter des documents de type Bail, DPE, Diagnostic et Etat des lieux, rendez-vous dans la partie "Déclaration usager".</p>
+                            </div>
+                        </div>
+                        <div class="type-conditional type-photo">
+                            <h1 class="fr-modal__title">
+                                Ajouter des photos de la situation
+                            </h1>
+                            <div>
+                                Ajouter une ou plusieurs photos au signalement. Pour chaque photo, veuillez sélectionner le désordre auquel elle est rattachée. 
+                                Si vous ne trouvez pas le désordre, sélectionnez "Autre"
+                            </div>
+                            <div class="fr-alert fr-alert--warning fr-alert--sm">
+                                <p>Ces photos seront partagées à l'usager. Une fois validées, elles ne pourront plus être supprimées.</p>
+                            </div>
+                        </div>
+                        <div class="modal-upload-upload-container fr-mb-4w">
+                            <div class="modal-upload-drop-section">
+                                <span class="fr-icon-upload-2-line fr-icon--lg fr-text-label--blue-france"></span>
+                                <div class="modal-upload-drop-section-label fr-mt-1w">
+                                    Faites glisser vos documents ici
+                                </div>
+                            </div>
+                            <p class="fr-mb-1w">ou</p>
+                            <button class="modal-upload-files-selector fr-btn fr-icon-search-line fr-btn--icon-left fr-btn--secondary">Parcourir les fichiers de l'appareil</button>
+                            <input type="file" class="modal-upload-files-selector-input" multiple accept="application/*">
+                        </div>
+                        <div class="modal-upload-list-section">
+                            <div class="modal-upload-list"></div>
+                        </div>
+                        <div style="display:none">
+                            {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
+                            <select class="fr-select select-type" data-file-id="" id="select-type-to-clone">
+                                <option value="">Sélectionner un type</option>
+                                {% for key, value in DocumentType.getDocumentsList() %}
+                                    <option value="{{ key }}">{{ value }}</option>
+                                {% endfor %}
+                            </select>
+                            <select class="fr-select select-desordre" data-file-id="" id="select-desordre-to-clone">
+                                <option value="">Sélectionner un désordre</option>
+                                {% for key, value in criteres %}
+                                    <option value="{{ key }}">{{ value }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <button class="fr-btn fr-icon-checkbox-line fr-btn--icon-left" aria-controls="fr-modal-upload-files">
+                                Valider
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -9,6 +9,7 @@
     data-add-file-token="{{ csrf_token('signalement_add_file_'~signalement.id) }}"
     data-edit-file-route="{{ path('back_signalement_edit_file',{uuid:signalement.uuid}) }}"
     data-edit-file-token="{{ csrf_token('signalement_edit_file_'~signalement.id) }}"
+    data-delete-tmp-file-route="{{ path('back_signalement_delete_tmpfile',{id:'REPLACE'}) }}"
     data-waiting-suivi-route="{{ path('back_signalement_file_waiting_suivi',{uuid:signalement.uuid}) }}"
     >
     <div class="fr-container fr-container--fluid fr-container-md">
@@ -36,7 +37,6 @@
                             </h1>
                             <div>
                                 Ajouter une ou plusieurs photos au signalement. Pour chaque photo, veuillez sélectionner le désordre auquel elle est rattachée. 
-                                Si vous ne trouvez pas le désordre, sélectionnez "Autre"
                             </div>
                             <div class="fr-alert fr-alert--warning fr-alert--sm">
                                 <p>Ces photos seront partagées à l'usager. Une fois validées, elles ne pourront plus être supprimées.</p>
@@ -73,8 +73,11 @@
                         </div>
                     </div>
                     <div class="fr-modal__footer">
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn fr-icon-checkbox-line fr-btn--icon-left" aria-controls="fr-modal-upload-files">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" id="close-modal-upload-file" aria-controls="fr-modal-upload-files">
+                                Annuler
+                            </button>
+                            <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files">
                                 Valider
                             </button>
                         </div>

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -9,6 +9,7 @@
     data-add-file-token="{{ csrf_token('signalement_add_file_'~signalement.id) }}"
     data-edit-file-route="{{ path('back_signalement_edit_file',{uuid:signalement.uuid}) }}"
     data-edit-file-token="{{ csrf_token('signalement_edit_file_'~signalement.id) }}"
+    data-waiting-suivi-route="{{ path('back_signalement_file_waiting_suivi',{uuid:signalement.uuid}) }}"
     >
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -10,7 +10,11 @@
                 {% for label, messages in app.flashes %}
                     {% for message in messages %}
                         <div role="alert" class="fr-alert fr-alert--{{ label }} fr-alert--sm">
+                        {% if label is same as('error error-raw')  %}
+                            <p>{{ message|raw }}</p>
+                        {% else %}
                             <p>{{ message }}</p>
+                        {% endif %}
                         </div>
                     {% endfor %}
                 {% endfor %}

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -18,6 +18,9 @@
     {% if canEditNDE %}
         {% include '_partials/_modal_edit_nde.html.twig' %}        
     {% endif %}
+    {% if (is_granted('FILE_CREATE', signalement) and isDocumentsEnabled) %}
+        {% include '_partials/_modal_upload_files.html.twig' %}
+    {% endif %}
     <section id="signalement-{{ signalement.id }}-content"
         class="fr-p-5v fr-background--white
             {{ (isClosedForMe and not is_granted('ROLE_ADMIN_TERRITORY'))

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -6,33 +6,40 @@
             <h3 class="fr-h5">{{ zonetitle }}</h3>
         </div>
         <div class="fr-col-3 fr-col-md-6 fr-text--right">
-            {% if (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted))
-                and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION')
-                %}
-                <form method="POST" enctype="multipart/form-data" class="inline-form"
-                    action="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}">
-                    <label class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left"> Ajouter des documents
-                        <input type="file" accept="application/*" name="signalement-add-file[documents][]"
-                            class="fr-hidden fr-input--file-signalement" multiple>
-                    </label>
-                    <input type="hidden" name="_token"
-                        value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
-                    <input type="hidden" name="document_type"
-                        value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
-                </form>
+            {% if (is_granted('FILE_CREATE', signalement)) %}
+                {% if isDocumentsEnabled %}
+                    <button 
+                    class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left open-modal-upload-files-btn" 
+                    data-fr-opened="false" 
+                    aria-controls="fr-modal-upload-files" 
+                    data-file-type="document">
+                        Ajouter des documents
+                    </button>
+                    <button 
+                    class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-camera-fill open-modal-upload-files-btn" 
+                    data-fr-opened="false" 
+                    aria-controls="fr-modal-upload-files" 
+                    data-file-type="photo">
+                        Ajouter des photos
+                    </button>
+                {% else %}
+                    <form method="POST" enctype="multipart/form-data" class="inline-form" action="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}">
+                        <label class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left"> Ajouter des documents
+                            <input type="file" accept="application/*" name="signalement-add-file[documents][]" class="fr-hidden fr-input--file-signalement" multiple>
+                        </label>
+                        <input type="hidden" name="_token" value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
+                        <input type="hidden" name="document_type" value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
+                    </form>
+                    <form method="POST" enctype="multipart/form-data" class="inline-form" action="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}">
+                        <label class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-camera-fill"> Ajouter des photos
+                            <input type="file" accept="image/*" name="signalement-add-file[photos][]" class="fr-hidden fr-input--file-signalement" multiple>
+                        </label>
+                        <input type="hidden" name="_token" value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
+                        <input type="hidden" name="document_type" value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
+                    </form>
+                {% endif %}
                 
-                <form method="POST" enctype="multipart/form-data" class="inline-form"
-                    action="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}">
-                    <label class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-camera-fill"> Ajouter des
-                        photos
-                        <input type="file" accept="image/*" name="signalement-add-file[photos][]"
-                            class="fr-hidden fr-input--file-signalement" multiple>
-                    </label>
-                    <input type="hidden" name="_token"
-                        value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
-                    <input type="hidden" name="document_type"
-                        value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
-                </form>
+
             {% endif %}
         </div>
     </div>

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -13,6 +13,7 @@ use App\Repository\SuiviRepository;
 use App\Repository\UserRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 
 class SuiviManagerTest extends KernelTestCase
@@ -20,6 +21,7 @@ class SuiviManagerTest extends KernelTestCase
     private const REF_SIGNALEMENT = '2022-8';
     private ManagerRegistry $managerRegistry;
     private SuiviFactory $suiviFactory;
+    private UrlGeneratorInterface $urlGenerator;
     private SignalementUpdatedListener $signalementUpdatedListener;
     private Security $security;
 
@@ -28,6 +30,7 @@ class SuiviManagerTest extends KernelTestCase
         self::bootKernel();
         $this->managerRegistry = self::getContainer()->get(ManagerRegistry::class);
         $this->suiviFactory = static::getContainer()->get(SuiviFactory::class);
+        $this->urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
         $this->signalementUpdatedListener = static::getContainer()->get(SignalementUpdatedListener::class);
         $this->security = static::getContainer()->get(Security::class);
     }
@@ -37,6 +40,7 @@ class SuiviManagerTest extends KernelTestCase
         $suiviManager = new SuiviManager(
             $this->suiviFactory,
             $this->managerRegistry,
+            $this->urlGenerator,
             $this->signalementUpdatedListener,
             $this->security,
             Suivi::class,
@@ -71,6 +75,7 @@ class SuiviManagerTest extends KernelTestCase
         $suiviManager = new SuiviManager(
             $this->suiviFactory,
             $this->managerRegistry,
+            $this->urlGenerator,
             $this->signalementUpdatedListener,
             $this->security,
             Suivi::class,

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -13,8 +13,8 @@ use App\Repository\SuiviRepository;
 use App\Repository\UserRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviManagerTest extends KernelTestCase
 {

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -41,12 +41,15 @@ class FileFactoryTest extends TestCase
         string $fileType,
         DocumentType $documentType
     ): void {
-        $file = (new FileFactory())->createFromFileArray($dataItem);
+        $signalement = $this->getSignalement();
+        $file = (new FileFactory())->createFromFileArray($dataItem, $signalement);
 
         $this->assertEquals($fileType, $file->getFileType());
         $this->assertEquals($documentType, $file->getDocumentType());
         $this->assertEquals($filename, $file->getFilename());
-        if (DocumentType::PHOTO_SITUATION === $file->getDocumentType()) {
+        if (DocumentType::PHOTO_SITUATION === $file->getDocumentType()
+        && (\in_array($dataItem['slug'], $signalement->getDesordreCritereSlugs())
+        || \in_array($dataItem['slug'], $signalement->getDesordrePrecisionSlugs()))) {
             $this->assertNotEmpty($file->getDesordreSlug());
         }
     }


### PR DESCRIPTION
## Ticket

#2200

## Description
- Création de la modale d'upload des document (https://xd.adobe.com/view/3cae505c-cf52-408c-a800-0bdd78e695f2-69fd/screen/0c3f48bb-09e0-49bd-9251-1d45685f6cf8/) qui s'active via le feature flipping `FEATURE_DOCUMENTS_ENABLE`
- Création de la modale d'upload de photos (https://xd.adobe.com/view/3cae505c-cf52-408c-a800-0bdd78e695f2-69fd/screen/2d6299ec-c7ff-4f4b-ae2e-b311cd6932d0/) qui s'active via le feature flipping `FEATURE_DOCUMENTS_ENABLE`

## Pré-requis
`make load-migrations`
`make npm-build`

## Tests
- [ ] Tester l'upload de documents via le bouton "Ajouter des documents" de la fiche signalement avec et sans la feature `FEATURE_DOCUMENTS_ENABLE`
- [ ] Tester l'upload de photos via le bouton "Ajouter des photos" de la fiche signalement avec et sans la feature `FEATURE_DOCUMENTS_ENABLE`
