### PR TITLE
[QA] Call to a member function getCodeSuivi() on null / fix duplicate email notif

### DIFF
--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -38,7 +38,9 @@ class SignalementActionController extends AbstractController
                 $statut = Signalement::STATUS_ACTIVE;
                 $description = 'validé';
                 $signalement->setValidatedAt(new DateTimeImmutable());
-                $signalement->setCodeSuivi(md5(uniqid()));
+                if (!$signalement->getCodeSuivi()) {
+                    $signalement->setCodeSuivi(md5(uniqid()));
+                }
                 $toRecipients = $signalement->getMailUsagers();
 
                 foreach ($toRecipients as $toRecipient) {
@@ -75,7 +77,8 @@ class SignalementActionController extends AbstractController
                 ->setDescription('Signalement '.$description)
                 ->setCreatedBy($this->getUser())
                 ->setIsPublic(true)
-                ->setType(SUIVI::TYPE_AUTO);
+                ->setType(SUIVI::TYPE_AUTO)
+                ->setSendMail(false);
             $signalement->setStatut($statut);
             $doctrine->getManager()->persist($signalement);
             $doctrine->getManager()->persist($suivi);

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -544,7 +544,7 @@ class FrontSignalementController extends AbstractController
                 'type' => $type,
             ]);
         }
-        $this->addFlash('error', 'Le lien utilisé invalide, verifier votre saisie.');
+        $this->addFlash('error', 'Le lien utilisé est invalide, verifier votre saisie.');
 
         return $this->redirectToRoute('home');
     }

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -470,7 +470,7 @@ class FrontSignalementController extends AbstractController
 
             return $this->redirectToRoute('front_suivi_signalement');
         }
-        $this->addFlash('error', 'Le lien utilisé est expiré ou invalide, verifier votre saisie.');
+        $this->addFlash('error', 'Le lien utilisé est invalide, verifier votre saisie.');
 
         return $this->redirectToRoute('front_signalement');
     }
@@ -544,9 +544,9 @@ class FrontSignalementController extends AbstractController
                 'type' => $type,
             ]);
         }
-        $this->addFlash('error', 'Le lien utilisé est expiré ou invalide, verifier votre saisie.');
+        $this->addFlash('error', 'Le lien utilisé invalide, verifier votre saisie.');
 
-        return $this->redirectToRoute('front_signalement');
+        return $this->redirectToRoute('home');
     }
 
     #[Route('/suivre-mon-signalement/{code}/response', name: 'front_suivi_signalement_user_response', methods: 'POST')]
@@ -605,9 +605,13 @@ class FrontSignalementController extends AbstractController
                 Votre message a bien été envoyé, vous recevrez un email lorsque votre dossier sera mis à jour.
                 N'hésitez pas à consulter votre page de suivi !
                 SUCCESS);
+            } else {
+                $this->addFlash('error', 'Token CSRF invalide');
             }
         } else {
-            $this->addFlash('error', 'Une erreur est survenue...');
+            $this->addFlash('error', 'Le lien utilisé est expiré ou invalide, verifier votre saisie.');
+
+            return $this->redirectToRoute('home');
         }
 
         if (!empty($email)) {

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -54,6 +54,8 @@ class Suivi
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $context = null;
 
+    private bool $sendMail = true;
+
     public function __construct()
     {
         $this->createdAt = new DateTimeImmutable();
@@ -145,6 +147,18 @@ class Suivi
     public function setContext(?string $context): self
     {
         $this->context = $context;
+
+        return $this;
+    }
+
+    public function getSendMail(): bool
+    {
+        return $this->sendMail;
+    }
+
+    public function setSendMail(bool $sendMail): self
+    {
+        $this->sendMail = $sendMail;
 
         return $this;
     }

--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -80,7 +80,7 @@ class ActivityListener
                     }
                 }
 
-                if ($entity->getIsPublic() && Signalement::STATUS_REFUSED !== $entity->getSignalement()->getStatut()) {
+                if ($entity->getSendMail() && $entity->getIsPublic() && Signalement::STATUS_REFUSED !== $entity->getSignalement()->getStatut()) {
                     $toRecipients = new ArrayCollection($entity->getSignalement()->getMailUsagers());
                     if (!$toRecipients->isEmpty() && Signalement::STATUS_CLOSED !== $entity->getSignalement()->getStatut()) {
                         $toRecipients->removeElement($entity->getCreatedBy()?->getEmail());

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -57,7 +57,9 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
                 ->addSuivi($suivi);
 
             if ('1' == $params['suivi_public']) {
-                $signalement->setCodeSuivi($this->tokenGenerator->generateToken());
+                if (!$signalement->getCodeSuivi()) {
+                    $signalement->setCodeSuivi($this->tokenGenerator->generateToken());
+                }
                 $this->sendMailToUsager($signalement);
             }
             $this->sendMailToPartners($signalement);


### PR DESCRIPTION
## Ticket

#1324

## Description
- Le code suivi d'un signalement ne doit plus changer (correction faite à la validation d'un signalement et à sa cloture)
- En cas d'accès a une URL incorrecte de suivi d'un signalement, redirection vers la homepage et modification du message d'erreur
- A la validation/refus d'un signalement la notification de suivi automatique qui faisait doublon n'est plus transmise

## Tests
- [ ] Soumettre un signalement, l'accepter et le clôturer
- [ ] Vérifier que le code de suivi n'a pas changé (le lien dans l'email de confirmation initial doit toujours fonctionner)
- [ ] Vérifier qu'une seule notification à été envoyer par usager lors de l'acceptation et cloture.

