### PR TITLE
[FO- Nouveau formulaire] Réduire la contrainte du numéro d'appartement

### DIFF
--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -17,7 +17,7 @@ class AdresseOccupantRequest
         private readonly ?string $etage = null,
         #[Assert\Length(max: 3, maxMessage: 'L\'escalier ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $escalier = null,
-        #[Assert\Length(max: 30, maxMessage: 'Le numéro d\'appartement ne peut pas dépasser {{ limit }} caractères.')]
+        #[Assert\Length(max: 5, maxMessage: 'Le numéro d\'appartement ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $numAppart = null,
         #[Assert\Length(max: 255, maxMessage: 'Le champ Autre ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $autre = null,

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -36,7 +36,7 @@ class SignalementDraftRequest
     private ?string $adresseLogementComplementAdresseEscalier = null;
     #[Assert\Length(max: 5)]
     private ?string $adresseLogementComplementAdresseEtage = null;
-    #[Assert\Length(max: 30)]
+    #[Assert\Length(max: 5, maxMessage: 'Le numéro d\'appartement ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $adresseLogementComplementAdresseNumeroAppartement = null;
     #[Assert\Length(max: 255)]
     private ?string $adresseLogementComplementAdresseAutre = null;

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -71,9 +71,9 @@
 
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="numAppart">Numéro d'appartement
-                                            <span class="fr-hint-text">30 caractères maximum</span>
+                                            <span class="fr-hint-text">5 caractères maximum</span>
                                         </label>
-                                        <input class="fr-input" type="text" name="numAppart" value="{{ signalement.numAppartOccupant }}" maxlength="30">
+                                        <input class="fr-input" type="text" name="numAppart" value="{{ signalement.numAppartOccupant }}" maxlength="5">
                                     </div>
 
                                     <div class="fr-input-group">

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -116,10 +116,10 @@
                 "type": "SignalementFormTextfield",
                 "label": "Numéro d'appartement",
                 "slug": "adresse_logement_complement_adresse_numero_appartement",
-                "description": "30 caractères maximum",
+                "description": "5 caractères maximum",
                 "validate": {
                   "required": false,
-                  "maxLength": 30
+                  "maxLength": 5
                 }
               },
               {


### PR DESCRIPTION
## Ticket

#2270

## Description
Restriction de la limitation du champ "Numéro d'appartement" à 5 caractères au dépôt et à l'édition du signalement

## Tests
- [ ] Vérifier que l'on ne peux pas renseigner plus de 5 caractères sur le champ numéro d'appartement
