### PR TITLE
[BO - Signalement] Affichage champs obligatoires / facultatifs et des erreurs à l'édition

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -40,5 +40,6 @@ import './controllers/view_signalement';
 import './controllers/cookie_banner';
 import './controllers/maintenance_banner';
 import './controllers/activate_account/activate_account';
+import './controllers/back_signalement_view/form_edit_modal';
 import './controllers/back_signalement_edit_file/back_signalement_edit_file';
 

--- a/assets/controllers/back_signalement_view/form_edit_modal.js
+++ b/assets/controllers/back_signalement_view/form_edit_modal.js
@@ -24,6 +24,9 @@ function handleEditSignalementModalForm(element) {
     element.addEventListener('submit', (event) => {
         event.preventDefault();
         const formElement = document.getElementById(event.target.id);
+        const submitElement = document.querySelector(`.fr-modal--opened [type="submit"]`);
+        submitElement.disabled = true;
+        submitElement.classList.add('fr-btn--loading', 'fr-btn--icon-left', 'fr-icon-refresh-line');
         clearErrors();
         submitPayload(formElement);
     });
@@ -49,6 +52,7 @@ async function submitPayload(formElement) {
             location.reload();
         } else if (response.status === 400) {
             const errors = responseData.errors;
+            const submitElement = document.querySelector(`.fr-modal--opened [type="submit"]`);
             let firstErrorElement = true;
             for (const property in errors) {
                 const inputElement = document.querySelector(`.fr-modal--opened [name="${property}"]`);
@@ -73,6 +77,8 @@ async function submitPayload(formElement) {
                     firstErrorElement = false;
                 }
             }
+            submitElement.disabled = false;
+            submitElement.classList.remove('fr-btn--loading', 'fr-btn--icon-left', 'fr-icon-refresh-line');
         } else {
             alert(responseData.message);
         }

--- a/assets/controllers/back_signalement_view/form_edit_modal.js
+++ b/assets/controllers/back_signalement_view/form_edit_modal.js
@@ -1,0 +1,83 @@
+import * as Sentry from '@sentry/browser'
+
+const modalElements = document.querySelectorAll('[data-ajax-form] dialog');
+
+modalElements.forEach((modalElement) => {
+    modalElement.addEventListener('dsfr.conceal', (event) => {
+        event.preventDefault();
+        const divErrorElements = document.querySelectorAll('.fr-input-group--error');
+        divErrorElements.forEach((divErrorElement) => {
+            divErrorElement.classList.remove('fr-input-group--error');
+            let pErrorElement = divErrorElement.querySelector('.fr-error-text');
+            if (pErrorElement) {
+                pErrorElement.remove();
+            }
+        })
+    })
+})
+
+function handleEditSignalementModalForm(element) {
+    element.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const formElement = document.getElementById(event.target.id);
+        submitPayload(formElement);
+    });
+}
+
+async function submitPayload(formElement) {
+    try {
+        const formData = new FormData(formElement);
+        const payload = {};
+        formData.forEach((value, key) => {
+            payload[key] = value;
+        });
+
+        const response = await fetch(formElement.action, {
+            method: 'POST',
+            body: JSON.stringify(payload),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+        const responseData = await response.json();
+
+        if (response.ok) {
+            location.reload();
+        } else {
+            if (responseData.code === 400) {
+                const errors = responseData.errors;
+                let firstErrorElement = true;
+                for (const property in errors) {
+                    const inputElement = document.querySelector(`.fr-modal--opened [name="${property}"]`);
+                    inputElement.setAttribute('aria-describedby', `${property}-desc-error`);
+                    inputElement.parentElement.classList.add('fr-input-group--error');
+
+                    const existingErrorElement = document.getElementById(`${property}-desc-error`);
+                    if (!existingErrorElement) {
+                        let pElement = document.createElement('p');
+                        pElement.classList.add('fr-error-text');
+                        pElement.id = `${property}-desc-error`;
+
+                        let messageError = '';
+                        errors[property].errors.forEach((error) => {
+                            messageError = messageError + error;
+                        })
+                        pElement.innerHTML = messageError;
+                        inputElement.insertAdjacentElement('afterend', pElement);
+                    }
+                    if (firstErrorElement) {
+                        inputElement.focus();
+                        firstErrorElement = false;
+                    }
+                }
+            } else {
+                alert(responseData.message);
+            }
+        }
+    } catch (error) {
+        alert('Une erreur s\'est produite. Veuillez actualiser la page.');
+        Sentry.captureException(new Error(error));
+    }
+}
+
+modalElements.forEach(modalElement => handleEditSignalementModalForm(modalElement));

--- a/assets/controllers/back_signalement_view/form_edit_modal.js
+++ b/assets/controllers/back_signalement_view/form_edit_modal.js
@@ -40,39 +40,36 @@ async function submitPayload(formElement) {
             }
         });
         const responseData = await response.json();
-
         if (response.ok) {
             location.reload();
-        } else {
-            if (responseData.code === 400) {
-                const errors = responseData.errors;
-                let firstErrorElement = true;
-                for (const property in errors) {
-                    const inputElement = document.querySelector(`.fr-modal--opened [name="${property}"]`);
-                    inputElement.setAttribute('aria-describedby', `${property}-desc-error`);
-                    inputElement.parentElement.classList.add('fr-input-group--error');
+        } else if (response.status === 400) {
+            const errors = responseData.errors;
+            let firstErrorElement = true;
+            for (const property in errors) {
+                const inputElement = document.querySelector(`.fr-modal--opened [name="${property}"]`);
+                inputElement.setAttribute('aria-describedby', `${property}-desc-error`);
+                inputElement.parentElement.classList.add('fr-input-group--error');
 
-                    const existingErrorElement = document.getElementById(`${property}-desc-error`);
-                    if (!existingErrorElement) {
-                        let pElement = document.createElement('p');
-                        pElement.classList.add('fr-error-text');
-                        pElement.id = `${property}-desc-error`;
+                const existingErrorElement = document.getElementById(`${property}-desc-error`);
+                if (!existingErrorElement) {
+                    let pElement = document.createElement('p');
+                    pElement.classList.add('fr-error-text');
+                    pElement.id = `${property}-desc-error`;
 
-                        let messageError = '';
-                        errors[property].errors.forEach((error) => {
-                            messageError = messageError + error;
-                        })
-                        pElement.innerHTML = messageError;
-                        inputElement.insertAdjacentElement('afterend', pElement);
-                    }
-                    if (firstErrorElement) {
-                        inputElement.focus();
-                        firstErrorElement = false;
-                    }
+                    let messageError = '';
+                    errors[property].errors.forEach((error) => {
+                        messageError = messageError + error;
+                    })
+                    pElement.innerHTML = messageError;
+                    inputElement.insertAdjacentElement('afterend', pElement);
                 }
-            } else {
-                alert(responseData.message);
+                if (firstErrorElement) {
+                    inputElement.focus();
+                    firstErrorElement = false;
+                }
             }
+        } else {
+            alert(responseData.message);
         }
     } catch (error) {
         alert('Une erreur s\'est produite. Veuillez actualiser la page.');

--- a/assets/controllers/back_signalement_view/form_edit_modal.js
+++ b/assets/controllers/back_signalement_view/form_edit_modal.js
@@ -5,21 +5,26 @@ const modalElements = document.querySelectorAll('[data-ajax-form] dialog');
 modalElements.forEach((modalElement) => {
     modalElement.addEventListener('dsfr.conceal', (event) => {
         event.preventDefault();
-        const divErrorElements = document.querySelectorAll('.fr-input-group--error');
-        divErrorElements.forEach((divErrorElement) => {
-            divErrorElement.classList.remove('fr-input-group--error');
-            let pErrorElement = divErrorElement.querySelector('.fr-error-text');
-            if (pErrorElement) {
-                pErrorElement.remove();
-            }
-        })
+        clearErrors();
     })
 })
+
+function clearErrors() {
+    const divErrorElements = document.querySelectorAll('.fr-input-group--error');
+    divErrorElements.forEach((divErrorElement) => {
+        divErrorElement.classList.remove('fr-input-group--error');
+        let pErrorElement = divErrorElement.querySelector('.fr-error-text');
+        if (pErrorElement) {
+            pErrorElement.remove();
+        }
+    })
+}
 
 function handleEditSignalementModalForm(element) {
     element.addEventListener('submit', (event) => {
         event.preventDefault();
         const formElement = document.getElementById(event.target.id);
+        clearErrors();
         submitPayload(formElement);
     });
 }

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -40,16 +40,16 @@ export const requests = {
       timeout: 0 // TODO: va nécéssiter d'apporter quelques retouches sur l'UX
     })
     axiosInstance
-        .post(ajaxUrl, data, config)
-        .then(response => {
-          const responseData = response.data
-          functionReturn(responseData)
-        })
-        .catch(error => {
-          console.error(error)
-          Sentry.captureException(new Error('Something wrong happened with the upload.'))
-          functionReturn(error)
-        })
+      .post(ajaxUrl, data, config)
+      .then(response => {
+        const responseData = response.data
+        functionReturn(responseData)
+      })
+      .catch(error => {
+        console.error(error)
+        Sentry.captureException(new Error('Something wrong happened with the upload.'))
+        functionReturn(error)
+      })
   },
   doRequestPut (ajaxUrl: string, data: any, functionReturn: Function) {
     axios

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -34,7 +34,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
-    ): Response {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid('signalement_edit_address_'.$signalement->getId(), $payload['_token'])) {
@@ -71,7 +71,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
-    ): Response {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(
@@ -157,7 +157,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
-    ): Response {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(
@@ -204,7 +204,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
-    ): Response {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(
@@ -219,9 +219,10 @@ class SignalementEditController extends AbstractController
             );
 
             $validationGroups = ['Default'];
-            if ($signalement->getProfileDeclarant()) {
-                $validationGroups[] = $signalement->getProfileDeclarant()->value;
-            }
+            $validationGroups[] = null !== $signalement->getCreatedFrom()
+                ? $signalement->getProfileDeclarant()->value :
+                'EDIT_'.$signalement->getProfileDeclarant()->value;
+
             $errorMessage = FormHelper::getErrorsFromRequest(
                 $validator, $informationsLogementRequest, $validationGroups
             );
@@ -251,7 +252,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SignalementDraftRequestSerializer $serializer,
         ValidatorInterface $validator,
-    ): Response {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(
@@ -266,9 +267,9 @@ class SignalementEditController extends AbstractController
             );
 
             $validationGroups = ['Default'];
-            if ($signalement->getProfileDeclarant()) {
-                $validationGroups[] = $signalement->getProfileDeclarant()->value;
-            }
+            $validationGroups[] = null !== $signalement->getCreatedFrom()
+                ? $signalement->getProfileDeclarant()->value :
+                'EDIT_'.$signalement->getProfileDeclarant()->value;
 
             $errorMessage = FormHelper::getErrorsFromRequest(
                 $validator, $compositionLogementRequest, $validationGroups
@@ -298,7 +299,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
-    ): Response {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(
@@ -313,9 +314,10 @@ class SignalementEditController extends AbstractController
             );
 
             $validationGroups = ['Default'];
-            if ($signalement->getProfileDeclarant()) {
-                $validationGroups[] = $signalement->getProfileDeclarant()->value;
-            }
+            $validationGroups[] = null !== $signalement->getCreatedFrom()
+                ? $signalement->getProfileDeclarant()->value :
+                'EDIT_'.$signalement->getProfileDeclarant()->value;
+
             $errorMessage = FormHelper::getErrorsFromRequest($validator, $situationFoyerRequest, $validationGroups);
 
             if (empty($errorMessage)) {
@@ -343,7 +345,7 @@ class SignalementEditController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
-    ): Response {
+    ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(
@@ -357,9 +359,10 @@ class SignalementEditController extends AbstractController
                 'json'
             );
             $validationGroups = ['Default'];
-            if ($signalement->getProfileDeclarant()) {
-                $validationGroups[] = $signalement->getProfileDeclarant()->value;
-            }
+            $validationGroups[] = null !== $signalement->getCreatedFrom()
+                ? $signalement->getProfileDeclarant()->value :
+                'EDIT_'.$signalement->getProfileDeclarant()->value;
+
             $errorMessage = FormHelper::getErrorsFromRequest($validator, $procedureDemarchesRequest, $validationGroups);
 
             if (empty($errorMessage)) {

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -113,7 +113,6 @@ class SignalementEditController extends AbstractController
         SerializerInterface $serializer,
         ValidatorInterface $validator,
     ): JsonResponse {
-        $payload = $request->getPayload()->all();
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(

--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -4,7 +4,7 @@ namespace App\Dto\Request\Signalement;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-class AdresseOccupantRequest
+class AdresseOccupantRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de saisir une adresse.')]

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -3,39 +3,113 @@
 namespace App\Dto\Request\Signalement;
 
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class CompositionLogementRequest
+class CompositionLogementRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de définir le type de logement.')]
         private readonly ?string $type = null,
-        #[Assert\NotBlank(message: 'Merci de préciser le type de logement autre.', groups: ['TYPE_LOGEMENT_AUTRE'])]
+        #[Assert\When(
+            expression: 'this.getType() == "autre"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser le type de logement autre.'),
+            ],
+        )]
         private readonly ?string $typeLogementNatureAutrePrecision = null,
+        #[Assert\NotBlank(message: 'Merci de selectioner pièce unique ou plusieurs pièces.')]
+        #[Assert\Choice(
+            options: ['piece_unique', 'plusieurs_pieces'],
+            message: 'Merci de selectioner pièce unique ou plusieurs pièces.')]
         private readonly ?string $typeCompositionLogement = null,
-        #[Assert\NotBlank(message: 'Merci de saisir la superficie du logement.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(
+            message: 'Merci de saisir la superficie du logement.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs de superficie.')]
         private readonly ?string $superficie = null,
-        #[Assert\NotBlank(message: 'Merci de définir la hauteur du logement.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+        #[Assert\NotBlank(
+            message: 'Merci de définir la hauteur du logement.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
         private readonly ?string $compositionLogementHauteur = null,
-        #[Assert\NotBlank(message: 'Merci de définir le nombre de pièces à vivre.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
-        #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
+        #[Assert\NotBlank(
+            message: 'Merci de définir le nombre de pièces à vivre.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+        #[Assert\Positive(
+            message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
         private readonly ?string $compositionLogementNbPieces = null,
         private readonly ?string $nombreEtages = null,
+        #[Assert\When(
+            expression: 'this.getType() == "appartement"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser si le logement est au rez-de-chaussée.'),
+            ],
+        )]
         private readonly ?string $typeLogementRdc = null,
+        #[Assert\When(
+            expression: 'this.getType() == "appartement" && this.getTypeLogementRdc() == "non"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser si le logement est au dernier étage.'),
+            ],
+        )]
         private readonly ?string $typeLogementDernierEtage = null,
+        #[Assert\When(
+            expression: 'this.getType() == "appartement" && this.getTypeLogementDernierEtage() == "oui"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser si le logement est sous comble et sans fenêtre.'),
+            ],
+        )]
         private readonly ?string $typeLogementSousCombleSansFenetre = null,
+        #[Assert\When(
+            expression: 'this.getType() == "appartement" && this.getTypeLogementRdc() == "non" && this.getTypeLogementDernierEtage() == "non"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser si le logement est au sous-sol et sans fenêtre.'),
+            ],
+        )]
         private readonly ?string $typeLogementSousSolSansFenetre = null,
-        #[Assert\NotBlank(message: 'Merci de définir si une pièce fait plus de 9m².', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER'])]
+        #[Assert\NotBlank(
+            message: 'Merci de définir si une pièce fait plus de 9m².',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER'])]
         private readonly ?string $typeLogementCommoditesPieceAVivre9m = null,
-        #[Assert\NotBlank(message: 'Merci de définir si il y a une cuisine.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+        #[Assert\NotBlank(
+            message: 'Merci de définir si il y a une cuisine.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
         private readonly ?string $typeLogementCommoditesCuisine = null,
+        #[Assert\When(
+            expression: 'this.getTypeLogementCommoditesCuisine() == "non"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser s\'il y a une cuisine collective.'),
+            ],
+        )]
         private readonly ?string $typeLogementCommoditesCuisineCollective = null,
-        #[Assert\NotBlank(message: 'Merci de définir si il y a une salle de bain.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+        #[Assert\NotBlank(
+            message: 'Merci de définir si il y a une salle de bain.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
         private readonly ?string $typeLogementCommoditesSalleDeBain = null,
+        #[Assert\When(
+            expression: 'this.getTypeLogementCommoditesSalleDeBain() == "non"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser s\'il y a une salle de bain collective.'),
+            ],
+        )]
         private readonly ?string $typeLogementCommoditesSalleDeBainCollective = null,
-        #[Assert\NotBlank(message: 'Merci de définir si il y a des WC.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+        #[Assert\NotBlank(
+            message: 'Merci de définir si il y a des WC.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
         private readonly ?string $typeLogementCommoditesWc = null,
+        #[Assert\When(
+            expression: 'this.getTypeLogementCommoditesWc() == "non"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser s\'il y a des wc collectifs.'),
+            ],
+        )]
         private readonly ?string $typeLogementCommoditesWcCollective = null,
+
+        #[Assert\When(
+            expression: 'this.getTypeLogementCommoditesWc() == "oui" && this.getTypeLogementCommoditesCuisine() == "oui"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser s\'il y a des wc dans la cuisine.'),
+            ],
+        )]
         private readonly ?string $typeLogementCommoditesWcCuisine = null,
     ) {
     }
@@ -133,5 +207,19 @@ class CompositionLogementRequest
     public function getTypeLogementCommoditesWcCuisine(): ?string
     {
         return $this->typeLogementCommoditesWcCuisine;
+    }
+
+    #[Assert\Callback]
+    public function validate(ExecutionContextInterface $context, mixed $payload): void
+    {
+        if ($this->getTypeLogementDernierEtage() === $this->getTypeLogementRdc()) {
+            $context->buildViolation('Merci de bien préciser si le logement est au rez-de-chaussée ou dernier étage.')
+                ->atPath('typeLogementRdc')
+                ->addViolation();
+
+            $context->buildViolation('Merci de bien préciser si le logement est au rez-de-chaussée ou dernier étage.')
+                ->atPath('typeLogementDernierEtage')
+                ->addViolation();
+        }
     }
 }

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -17,10 +17,13 @@ class CompositionLogementRequest implements RequestInterface
             ],
         )]
         private readonly ?string $typeLogementNatureAutrePrecision = null,
-        #[Assert\NotBlank(message: 'Merci de selectioner pièce unique ou plusieurs pièces.')]
+        #[Assert\NotBlank(
+            message: 'Merci de selectioner pièce unique ou plusieurs pièces.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
         #[Assert\Choice(
             options: ['piece_unique', 'plusieurs_pieces'],
-            message: 'Merci de selectioner pièce unique ou plusieurs pièces.')]
+            message: 'Merci de sélectionner pièce unique ou plusieurs pièces.')]
         private readonly ?string $typeCompositionLogement = null,
         #[Assert\NotBlank(
             message: 'Merci de saisir la superficie du logement.',
@@ -43,6 +46,9 @@ class CompositionLogementRequest implements RequestInterface
         private readonly ?string $nombreEtages = null,
         #[Assert\When(
             expression: 'this.getType() == "appartement"',
+            groups: [
+                'LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS',
+            ],
             constraints: [
                 new Assert\NotBlank(message: 'Merci de préciser si le logement est au rez-de-chaussée.'),
             ],
@@ -50,6 +56,9 @@ class CompositionLogementRequest implements RequestInterface
         private readonly ?string $typeLogementRdc = null,
         #[Assert\When(
             expression: 'this.getType() == "appartement" && this.getTypeLogementRdc() == "non"',
+            groups: [
+                'LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS',
+            ],
             constraints: [
                 new Assert\NotBlank(message: 'Merci de préciser si le logement est au dernier étage.'),
             ],
@@ -218,7 +227,7 @@ class CompositionLogementRequest implements RequestInterface
     #[Assert\Callback]
     public function validate(ExecutionContextInterface $context): void
     {
-        if ($this->getTypeLogementDernierEtage() === $this->getTypeLogementRdc()) {
+        if ('oui' === $this->getTypeLogementDernierEtage() && 'oui' === $this->getTypeLogementRdc()) {
             $context->buildViolation('Merci de bien préciser si le logement est au rez-de-chaussée ou dernier étage.')
                 ->atPath('typeLogementRdc')
                 ->addViolation();

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -18,7 +18,7 @@ class CompositionLogementRequest implements RequestInterface
         )]
         private readonly ?string $typeLogementNatureAutrePrecision = null,
         #[Assert\NotBlank(
-            message: 'Merci de selectioner pièce unique ou plusieurs pièces.',
+            message: 'Merci de sélectioner pièce unique ou plusieurs pièces.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
         )]
         #[Assert\Choice(

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -29,11 +29,14 @@ class CompositionLogementRequest implements RequestInterface
         private readonly ?string $superficie = null,
         #[Assert\NotBlank(
             message: 'Merci de définir la hauteur du logement.',
-            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+            groups: [
+                'LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS', ]
+        )]
         private readonly ?string $compositionLogementHauteur = null,
         #[Assert\NotBlank(
             message: 'Merci de définir le nombre de pièces à vivre.',
-            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
         #[Assert\Positive(
             message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
         private readonly ?string $compositionLogementNbPieces = null,
@@ -72,7 +75,8 @@ class CompositionLogementRequest implements RequestInterface
         private readonly ?string $typeLogementCommoditesPieceAVivre9m = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si il y a une cuisine.',
-            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
         private readonly ?string $typeLogementCommoditesCuisine = null,
         #[Assert\When(
             expression: 'this.getTypeLogementCommoditesCuisine() == "non"',
@@ -83,7 +87,8 @@ class CompositionLogementRequest implements RequestInterface
         private readonly ?string $typeLogementCommoditesCuisineCollective = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si il y a une salle de bain.',
-            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
         private readonly ?string $typeLogementCommoditesSalleDeBain = null,
         #[Assert\When(
             expression: 'this.getTypeLogementCommoditesSalleDeBain() == "non"',
@@ -94,7 +99,8 @@ class CompositionLogementRequest implements RequestInterface
         private readonly ?string $typeLogementCommoditesSalleDeBainCollective = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si il y a des WC.',
-            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS'])]
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
         private readonly ?string $typeLogementCommoditesWc = null,
         #[Assert\When(
             expression: 'this.getTypeLogementCommoditesWc() == "non"',
@@ -210,7 +216,7 @@ class CompositionLogementRequest implements RequestInterface
     }
 
     #[Assert\Callback]
-    public function validate(ExecutionContextInterface $context, mixed $payload): void
+    public function validate(ExecutionContextInterface $context): void
     {
         if ($this->getTypeLogementDernierEtage() === $this->getTypeLogementRdc()) {
             $context->buildViolation('Merci de bien préciser si le logement est au rez-de-chaussée ou dernier étage.')

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -6,28 +6,32 @@ use App\Validator as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Email;
 
-class CoordonneesBailleurRequest
+class CoordonneesBailleurRequest implements RequestInterface
 {
     public function __construct(
-        #[Assert\NotBlank(message: 'Merci de saisir le nom du bailleur.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO'])]
+        #[Assert\NotBlank(
+            message: 'Merci de saisir le nom du bailleur.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO'])]
         #[Assert\Length(max: 255, maxMessage: 'Le nom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nom = null,
         #[Assert\NotBlank(message: 'Merci de saisir le prénom du bailleur.', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         #[Assert\Length(max: 255, maxMessage: 'Le prénom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $prenom = null,
-        #[Assert\NotBlank(message: 'Merci de saisir l\'email du bailleur', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
+        #[Assert\NotBlank(message: 'Merci de saisir l\'email du bailleur.', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
         private readonly ?string $mail = null,
-        #[Assert\NotBlank(message: 'Merci de saisir le numéro de téléphone du bailleur', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
+        #[Assert\NotBlank(
+            message: 'Merci de saisir le numéro de téléphone du bailleur.',
+            groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephone = null,
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephoneBis = null,
-        #[Assert\NotBlank(message: 'Merci de saisir l\'adresse du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci de saisir l\'adresse du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $adresse = null,
-        #[Assert\NotBlank(message: 'Merci de saisir le code postal du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci de saisir le code postal du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $codePostal = null,
-        #[Assert\NotBlank(message: 'Merci de saisir la ville du bailleur', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci de saisir la ville du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $ville = null,
         private readonly ?string $beneficiaireRsa = null,
         private readonly ?string $beneficiaireFsl = null,

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -6,22 +6,35 @@ use App\Validator as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Email;
 
-class CoordonneesFoyerRequest
+class CoordonneesFoyerRequest implements RequestInterface
 {
     public function __construct(
         private readonly ?string $typeProprio = null,
+        #[Assert\When(
+            expression: 'this.getTypeProprio() == "ORGANISME_SOCIETE"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de saisir un nom de structure.'),
+            ],
+        )]
         private readonly ?string $nomStructure = null,
+        #[Assert\NotBlank(message: 'Merci de selectionner une civilité.', groups: ['LOCATAIRE'])]
         private readonly ?string $civilite = null,
-        #[Assert\NotBlank(message: 'Merci de saisir un nom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(
+            message: 'Merci de saisir un nom.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
         #[Assert\Length(max: 50, maxMessage: 'Le nom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nom = null,
-        #[Assert\NotBlank(message: 'Merci de saisir un prénom.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(
+            message: 'Merci de saisir un prénom.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
         #[Assert\Length(max: 50, maxMessage: 'Le prénom ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $prenom = null,
-        #[Assert\NotBlank(message: 'Merci de saisir un email', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci de saisir un email.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
         private readonly ?string $mail = null,
-        #[Assert\NotBlank(message: 'Merci de saisir un numéro de téléphone', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(
+            message: 'Merci de saisir un numéro de téléphone.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephone = null,
         #[AppAssert\TelephoneFormat]

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -17,7 +17,7 @@ class CoordonneesFoyerRequest implements RequestInterface
             ],
         )]
         private readonly ?string $nomStructure = null,
-        #[Assert\NotBlank(message: 'Merci de selectionner une civilité.', groups: ['LOCATAIRE'])]
+        #[Assert\NotBlank(message: 'Merci de sélectionner une civilité.', groups: ['LOCATAIRE'])]
         private readonly ?string $civilite = null,
         #[Assert\NotBlank(
             message: 'Merci de saisir un nom.',

--- a/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
@@ -6,7 +6,7 @@ use App\Validator as AppAssert;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Email;
 
-class CoordonneesTiersRequest
+class CoordonneesTiersRequest implements RequestInterface
 {
     public function __construct(
         private readonly ?string $typeProprio = null,
@@ -23,6 +23,12 @@ class CoordonneesTiersRequest
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephone = null,
         private readonly ?string $lien = null,
+        #[Assert\When(
+            expression: 'this.getLien() == "PRO" || this.getLien() == "SECOURS"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de saisir un nom de structure.'),
+            ],
+        )]
         private readonly ?string $structure = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -10,7 +10,7 @@ class InformationsLogementRequest implements RequestInterface
         #[Assert\NotBlank(message: 'Merci de définir le nombre de personnes.')]
         private readonly ?string $nombrePersonnes = null,
         #[Assert\NotBlank(
-            message: 'Merci de définir le nombre d\'enfants.',
+            message: 'Merci de définir si il y a des enfants de moins de 6 ans',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
         private readonly ?string $compositionLogementEnfants = null,
         #[Assert\NotBlank(message: 'Merci de définir la date d\'arrivée.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
@@ -18,11 +18,11 @@ class InformationsLogementRequest implements RequestInterface
         private readonly ?string $dateEntree = null,
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $bailleurDateEffetBail = null,
-        #[Assert\NotBlank(message: 'Merci de définir le bail.', groups: ['LOCATAIRE', 'BAILLEUR'])]
+        #[Assert\NotBlank(message: 'Merci d\'indiquer si un bail existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR'])]
         private readonly ?string $bailDpeBail = null,
-        #[Assert\NotBlank(message: 'Merci de définir l\'état des lieux.', groups: ['LOCATAIRE', 'BAILLEUR'])]
+        #[Assert\NotBlank(message: 'Merci d\'indiquer si un état des lieux existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR'])]
         private readonly ?string $bailDpeEtatDesLieux = null,
-        #[Assert\NotBlank(message: 'Merci de définir le DPE.', groups: ['LOCATAIRE', 'BAILLEUR', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci d\'indiquer si un DPE existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR', 'BAILLEUR_OCCUPANT'])]
         private readonly ?string $bailDpeDpe = null,
         private readonly ?string $loyer = null,
         private readonly ?string $loyersPayes = null,

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -4,14 +4,16 @@ namespace App\Dto\Request\Signalement;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-class InformationsLogementRequest
+class InformationsLogementRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de définir le nombre de personnes.')]
         private readonly ?string $nombrePersonnes = null,
-        #[Assert\NotBlank(message: 'Merci de définir le nombre d\'enfants.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
+        #[Assert\NotBlank(
+            message: 'Merci de définir le nombre d\'enfants.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
         private readonly ?string $compositionLogementEnfants = null,
-        #[Assert\NotBlank(message: 'Merci de définir la date d\'arrivée', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\NotBlank(message: 'Merci de définir la date d\'arrivée.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $dateEntree = null,
         #[Assert\DateTime('Y-m-d')]

--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -7,22 +7,23 @@ use Symfony\Component\Validator\Constraints as Assert;
 class ProcedureDemarchesRequest implements RequestInterface
 {
     public function __construct(
-        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si le bailleur a été averti.', 'groups' => ['LOCATAIRE']])]
+        #[Assert\NotBlank(message: 'Merci d\'indiquer si le bailleur a été averti.', groups : ['LOCATAIRE'])]
         private readonly ?string $isProprioAverti = null,
-        #[Assert\NotBlank([
-            'message' => 'Merci d\'indiquer si l\'assurance a été contactée.',
-            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR'], ])]
+        #[Assert\NotBlank(
+            message: 'Merci d\'indiquer si l\'assurance a été contactée.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']
+        )]
         private readonly ?string $infoProcedureAssuranceContactee = null,
         #[Assert\When(
             expression: 'this.getInfoProcedureAssuranceContactee() == "oui"',
             constraints: [
-                new Assert\NotBlank(message: 'Merci de noter la réponde de l\'assurance.'),
+                new Assert\NotBlank(message: 'Merci de noter la réponse de l\'assurance.'),
             ],
         )]
         private readonly ?string $infoProcedureReponseAssurance = null,
-        #[Assert\NotBlank([
-            'message' => 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux.',
-            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT'], ])]
+        #[Assert\NotBlank(
+            message : 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         private readonly ?string $infoProcedureDepartApresTravaux = null,
         private readonly ?string $preavisDepart = null,
     ) {

--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -4,15 +4,25 @@ namespace App\Dto\Request\Signalement;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-class ProcedureDemarchesRequest
+class ProcedureDemarchesRequest implements RequestInterface
 {
     public function __construct(
-        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si le bailleur a été averti', 'groups' => ['LOCATAIRE']])]
+        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si le bailleur a été averti.', 'groups' => ['LOCATAIRE']])]
         private readonly ?string $isProprioAverti = null,
-        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'assurance a été contactée', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']])]
+        #[Assert\NotBlank([
+            'message' => 'Merci d\'indiquer si l\'assurance a été contactée.',
+            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR'], ])]
         private readonly ?string $infoProcedureAssuranceContactee = null,
+        #[Assert\When(
+            expression: 'this.getInfoProcedureAssuranceContactee() == "oui"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de noter la réponde de l\'assurance.'),
+            ],
+        )]
         private readonly ?string $infoProcedureReponseAssurance = null,
-        #[Assert\NotBlank(['message' => 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux ', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
+        #[Assert\NotBlank([
+            'message' => 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux.',
+            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT'], ])]
         private readonly ?string $infoProcedureDepartApresTravaux = null,
         private readonly ?string $preavisDepart = null,
     ) {

--- a/src/Dto/Request/Signalement/RequestInterface.php
+++ b/src/Dto/Request/Signalement/RequestInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Dto\Request\Signalement;
+
+interface RequestInterface
+{
+}

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -4,22 +4,42 @@ namespace App\Dto\Request\Signalement;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-class SituationFoyerRequest
+class SituationFoyerRequest implements RequestInterface
 {
     public function __construct(
         private readonly ?string $isLogementSocial = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ demande relogement', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT']])]
+        #[Assert\NotBlank([
+            'message' => 'Veuillez définir le champ demande relogement.',
+            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT'], ])]
         private readonly ?string $isRelogement = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ allocataire', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
+        #[Assert\NotBlank([
+            'message' => 'Veuillez définir le champ allocataire.',
+            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO'], ])]
         private readonly ?string $isAllocataire = null,
         #[Assert\DateTime('Y-m-d')]
+        #[Assert\When(
+            expression: 'this.getIsAllocataire() == "oui" || this.getIsAllocataire() == "CAF" || this.getIsAllocataire() == "MSA"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser la date de naissance.'),
+            ],
+        )]
         private readonly ?string $dateNaissanceOccupant = null,
         private readonly ?string $numAllocataire = null,
         private readonly ?string $logementSocialMontantAllocation = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ souhaite quitter le logement', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
+        #[Assert\NotBlank([
+            'message' => 'Veuillez définir le champ souhaite quitter le logement.',
+            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO'], ])]
         private readonly ?string $travailleurSocialQuitteLogement = null,
+        #[Assert\When(
+            expression: 'this.getTravailleurSocialQuitteLogement() == "oui"',
+            constraints: [
+                new Assert\NotBlank(message: 'Merci de préciser s\'il y a un préavis de départ.'),
+            ],
+        )]
         private readonly ?string $travailleurSocialPreavisDepart = null,
-        #[Assert\NotBlank(['message' => 'Veuillez définir le champ accompagnement par un travailleur social', 'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']])]
+        #[Assert\NotBlank([
+            'message' => 'Veuillez définir le champ accompagnement par un travailleur social.',
+            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO'], ])]
         private readonly ?string $travailleurSocialAccompagnementDeclarant = null,
         private readonly ?string $beneficiaireRsa = null,
         private readonly ?string $beneficiaireFsl = null,

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -9,12 +9,12 @@ class SituationFoyerRequest implements RequestInterface
     public function __construct(
         private readonly ?string $isLogementSocial = null,
         #[Assert\NotBlank(
-            message: 'Veuillez définir le champ demande relogement.',
+            message: 'Veuillez préciser si une demande de relogement a été faite.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
         )]
         private readonly ?string $isRelogement = null,
         #[Assert\NotBlank(
-            message: 'Veuillez définir le champ allocataire.',
+            message: 'Veuillez préciser si l\'occupant est allocataire.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']
         )]
         private readonly ?string $isAllocataire = null,
@@ -40,7 +40,7 @@ class SituationFoyerRequest implements RequestInterface
         )]
         private readonly ?string $travailleurSocialPreavisDepart = null,
         #[Assert\NotBlank(
-            message: 'Veuillez définir le champ accompagnement par un travailleur social.',
+            message: 'Veuillez préciser si l\'occupant est accompagné par un travailleur social.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
         )]
         private readonly ?string $travailleurSocialAccompagnementDeclarant = null,

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -8,13 +8,15 @@ class SituationFoyerRequest implements RequestInterface
 {
     public function __construct(
         private readonly ?string $isLogementSocial = null,
-        #[Assert\NotBlank([
-            'message' => 'Veuillez définir le champ demande relogement.',
-            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT'], ])]
+        #[Assert\NotBlank(
+            message: 'Veuillez définir le champ demande relogement.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
+        )]
         private readonly ?string $isRelogement = null,
-        #[Assert\NotBlank([
-            'message' => 'Veuillez définir le champ allocataire.',
-            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO'], ])]
+        #[Assert\NotBlank(
+            message: 'Veuillez définir le champ allocataire.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']
+        )]
         private readonly ?string $isAllocataire = null,
         #[Assert\DateTime('Y-m-d')]
         #[Assert\When(
@@ -26,9 +28,9 @@ class SituationFoyerRequest implements RequestInterface
         private readonly ?string $dateNaissanceOccupant = null,
         private readonly ?string $numAllocataire = null,
         private readonly ?string $logementSocialMontantAllocation = null,
-        #[Assert\NotBlank([
-            'message' => 'Veuillez définir le champ souhaite quitter le logement.',
-            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO'], ])]
+        #[Assert\NotBlank(message: 'Veuillez définir le champ souhaite quitter le logement.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
+        )]
         private readonly ?string $travailleurSocialQuitteLogement = null,
         #[Assert\When(
             expression: 'this.getTravailleurSocialQuitteLogement() == "oui"',
@@ -37,9 +39,10 @@ class SituationFoyerRequest implements RequestInterface
             ],
         )]
         private readonly ?string $travailleurSocialPreavisDepart = null,
-        #[Assert\NotBlank([
-            'message' => 'Veuillez définir le champ accompagnement par un travailleur social.',
-            'groups' => ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO'], ])]
+        #[Assert\NotBlank(
+            message: 'Veuillez définir le champ accompagnement par un travailleur social.',
+            groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
+        )]
         private readonly ?string $travailleurSocialAccompagnementDeclarant = null,
         private readonly ?string $beneficiaireRsa = null,
         private readonly ?string $beneficiaireFsl = null,

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -258,7 +258,7 @@ class Signalement
     private $codeSuivi;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    private $lienDeclarantOccupant;
+    private ?string $lienDeclarantOccupant = null;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
     private $isConsentementTiers;
@@ -1978,7 +1978,19 @@ class Signalement
 
     public function getProfileDeclarant(): ?ProfileDeclarant
     {
-        return $this->profileDeclarant;
+        if (null !== $this->createdFrom) {
+            return $this->profileDeclarant;
+        }
+
+        if (false === $this->isNotOccupant) {
+            return ProfileDeclarant::LOCATAIRE;
+        }
+
+        if (\in_array($this->lienDeclarantOccupant, ['PROFESSIONNEL', 'pro', 'assistante sociale', 'curatrice'])) {
+            return ProfileDeclarant::TIERS_PRO;
+        }
+
+        return ProfileDeclarant::TIERS_PARTICULIER;
     }
 
     public function setProfileDeclarant(?ProfileDeclarant $profileDeclarant): self

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -69,6 +69,7 @@ class SignalementManager extends AbstractManager
         private DesordrePrecisionRepository $desordrePrecisionRepository,
         private DesordreCritereRepository $desordreCritereRepository,
         private DesordreCompositionLogementLoader $desordreCompositionLogementLoader,
+        private SuiviManager $suiviManager,
         string $entityName = Signalement::class
     ) {
         parent::__construct($managerRegistry, $entityName);
@@ -339,6 +340,11 @@ class SignalementManager extends AbstractManager
             ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre());
 
         $this->save($signalement);
+
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'L\'adresse du logement a été modifiée par '
+        );
     }
 
     public function updateFromCoordonneesTiersRequest(
@@ -361,6 +367,10 @@ class SignalementManager extends AbstractManager
             ->setStructureDeclarant($coordonneesTiersRequest->getStructure());
 
         $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'Les coordonnées du tiers déclarant ont été modifiées par ',
+        );
     }
 
     public function updateFromCoordonneesFoyerRequest(
@@ -385,6 +395,10 @@ class SignalementManager extends AbstractManager
             ->setTelOccupantBis($coordonneesFoyerRequest->getTelephoneBis());
 
         $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'Les coordonnées du foyer ont été modifiées par ',
+        );
     }
 
     public function updateFromCoordonneesBailleurRequest(
@@ -422,6 +436,10 @@ class SignalementManager extends AbstractManager
         $signalement->setInformationComplementaire($informationComplementaire);
 
         $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'Les coordonnées du bailleur ont été modifiées par ',
+        );
     }
 
     public function updateFromInformationsLogementRequest(
@@ -476,6 +494,10 @@ class SignalementManager extends AbstractManager
         $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
 
         $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'Les informations sur le logement ont été modifiées par ',
+        );
     }
 
     private function updateDesordresAndScoreWithSuroccupationChanges(
@@ -582,6 +604,10 @@ class SignalementManager extends AbstractManager
         $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
 
         $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'La composition du logement a été modifée par ',
+        );
     }
 
     public function updateFromSituationFoyerRequest(
@@ -671,6 +697,10 @@ class SignalementManager extends AbstractManager
         $this->updateDesordresAndScoreWithSuroccupationChanges($signalement);
         $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
         $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'La situation du foyer a été modifiée par ',
+        );
     }
 
     public function updateFromProcedureDemarchesRequest(
@@ -707,6 +737,10 @@ class SignalementManager extends AbstractManager
         }
 
         $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'Les procédures et démarches ont été modifiées par ',
+        );
     }
 
     public function findSignalementAffectationList(User|UserInterface|null $user, array $options): array

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -5,14 +5,18 @@ namespace App\Manager;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
+use App\EventListener\SignalementUpdatedListener;
 use App\Factory\SuiviFactory;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class SuiviManager extends Manager
 {
     public function __construct(
         private readonly SuiviFactory $suiviFactory,
         protected ManagerRegistry $managerRegistry,
+        protected SignalementUpdatedListener $signalementUpdatedListener,
+        protected Security $security,
         string $entityName = Suivi::class
     ) {
         parent::__construct($managerRegistry, $entityName);
@@ -42,5 +46,24 @@ class SuiviManager extends Manager
         $this->save($suivi);
 
         return $suivi;
+    }
+
+    public function addSuiviIfNeeded(
+        Signalement $signalement,
+        string $description,
+    ): void {
+        if ($this->signalementUpdatedListener->updateOccurred()) {
+            /** @var User $user */
+            $user = $this->security->getUser();
+            $this->createSuivi(
+                user: $user,
+                signalement: $signalement,
+                params: [
+                    'type' => Suivi::TYPE_AUTO,
+                    'description' => $description.$user->getNomComplet(),
+                ],
+                flush: true
+            );
+        }
     }
 }

--- a/src/Serializer/SignalementDraftRequestNormalizer.php
+++ b/src/Serializer/SignalementDraftRequestNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace App\Serializer;
 
-use App\Dto\Request\Signalement\CompositionLogementRequest;
+use App\Dto\Request\Signalement\RequestInterface;
 use App\Dto\Request\Signalement\SignalementDraftRequest;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\SignalementDraft;
@@ -47,7 +47,11 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
 
                 $transformedData[SignalementDraftRequest::FILE_UPLOAD_KEY][$keyUpdated] = $data[$key];
             } else {
-                $transformedData[$key] = !empty($value) ? $value : null;
+                if ('isProprioAverti' === $key) {
+                    $transformedData[$key] = $value;
+                } else {
+                    $transformedData[$key] = !empty($value) ? $value : null;
+                }
             }
         }
 
@@ -88,7 +92,7 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
         return [
             SignalementDraftRequest::class => true,
             TypeCompositionLogement::class => true,
-            CompositionLogementRequest::class => true,
+            RequestInterface::class => true,
         ];
     }
 }

--- a/src/Service/FormHelper.php
+++ b/src/Service/FormHelper.php
@@ -2,7 +2,9 @@
 
 namespace App\Service;
 
+use App\Dto\Request\Signalement\RequestInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class FormHelper
 {
@@ -19,6 +21,22 @@ class FormHelper
                         $errors[$childForm->getName().'_'.uniqid()] = $childError;
                     }
                 }
+            }
+        }
+
+        return $errors;
+    }
+
+    public static function getErrorsFromRequest(
+        ValidatorInterface $validator,
+        RequestInterface $request,
+        ?array $validationGroups = []
+    ): array {
+        $errors = [];
+        $violations = $validator->validate($request, null, $validationGroups);
+        if (\count($violations) > 0) {
+            foreach ($violations as $violation) {
+                $errors['errors'][$violation->getPropertyPath()]['errors'][] = $violation->getMessage();
             }
         }
 

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -53,7 +53,6 @@ class SignalementBuilder
         private FileFactory $fileFactory,
         private UploadHandlerService $uploadHandlerService,
         private Security $security,
-        private SignalementInputValueMapper $signalementInputValueMapper,
         private DesordreCategorieRepository $desordreCategorieRepository,
         private DesordreCritereRepository $desordreCritereRepository,
         private DesordrePrecisionRepository $desordrePrecisionRepository,
@@ -446,7 +445,7 @@ class SignalementBuilder
             return null;
         }
 
-        return $this->signalementInputValueMapper->map($value);
+        return SignalementInputValueMapper::map($value);
     }
 
     private function isConstructionAvant1949(?string $dateConstruction): ?bool
@@ -490,7 +489,7 @@ class SignalementBuilder
     private function resolveIsAllocataire(): ?string
     {
         if ($this->evalBoolean($this->signalementDraftRequest->getLogementSocialAllocation())) {
-            return $this->signalementInputValueMapper->map(
+            return SignalementInputValueMapper::map(
                 $this->signalementDraftRequest->getLogementSocialAllocationCaisse()
             );
         }

--- a/src/Service/Signalement/SignalementInputValueMapper.php
+++ b/src/Service/Signalement/SignalementInputValueMapper.php
@@ -12,7 +12,7 @@ class SignalementInputValueMapper
         'msa' => 'MSA',
     ];
 
-    public function map(string $value)
+    public static function map(?string $value): mixed
     {
         return self::MAPPING_VALUES[$value] ?? null;
     }

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -8,6 +8,7 @@ use App\Service\Esabora\EsaboraPartnerTypeSubscription;
 use App\Service\Files\ImageBase64Encoder;
 use App\Service\Notification\NotificationCounter;
 use App\Service\Signalement\Qualification\QualificationStatusService;
+use App\Utils\AttributeParser;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -72,6 +73,7 @@ class AppExtension extends AbstractExtension
             new TwigFunction('can_see_nde_qualification', [QualificationStatusService::class, 'canSeenNDEQualification']),
             new TwigFunction('can_see_nde_edit_zone', [QualificationStatusService::class, 'canSeenNDEEditZone']),
             new TwigFunction('can_edit_esabora_credentials', [EsaboraPartnerTypeSubscription::class, 'isSubscribed']),
+            new TwigFunction('show_label_facultatif', [AttributeParser::class, 'showLabelAsFacultatif']),
         ];
     }
 }

--- a/src/Utils/AttributeParser.php
+++ b/src/Utils/AttributeParser.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Utils;
+
+use App\Entity\Enum\ProfileDeclarant;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class AttributeParser
+{
+    public static function showLabelAsFacultatif(
+        string $class,
+        string $field,
+        ?ProfileDeclarant $profileDeclarant = null
+    ): string {
+        $reflector = new \ReflectionClass($class);
+        /** @var \ReflectionAttribute[] $attributes */
+        $attributes = $reflector->getProperty($field)->getAttributes(NotBlank::class);
+        if (null === $profileDeclarant) {
+            return empty($attributes) ? '(facultatif)' : '';
+        }
+
+        $groups = [];
+        if (!empty($attributes)) {
+            $groups = $attributes[0]->getArguments()['groups'] ?? [];
+        }
+
+        return !empty($groups) && !\in_array($profileDeclarant->value, $groups) ? '(facultatif)' : '';
+    }
+}

--- a/src/Validator/TelephoneFormatValidator.php
+++ b/src/Validator/TelephoneFormatValidator.php
@@ -33,13 +33,11 @@ class TelephoneFormatValidator extends ConstraintValidator
             if (!$isPossible) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $value)
-                    ->atPath('telephone')
                     ->addViolation();
             }
         } catch (NumberParseException $e) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $value)
-                ->atPath('telephone')
                 ->addViolation();
         }
     }

--- a/templates/back/signalement/view/address-qualifications.html.twig
+++ b/templates/back/signalement/view/address-qualifications.html.twig
@@ -1,5 +1,5 @@
 <div class="fr-grid-row fr-mt-3w">
-    <div class="fr-col-12 fr-col-md-6">
+    <div class="fr-col-12 fr-col-md-6" data-ajax-form>
         {% if isNewFormEnabled and canEditSignalement %}
             {% include 'back/signalement/view/edit-modals/edit-address.html.twig' %}
         {% endif %}

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -56,31 +56,31 @@
                                     <h2 class="fr-h5">Complément d'adresse (facultatif)</h2>
 
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="etage">Etage
+                                        <label class="fr-label" for="adresseEtage">Etage
                                             <span class="fr-hint-text">5 caractères maximum</span>
                                         </label>
-                                        <input class="fr-input" type="text" name="etage" value="{{ signalement.etageOccupant }}" maxlength="5">
+                                        <input class="fr-input" type="text" id="adresseEtage" name="etage" value="{{ signalement.etageOccupant }}" maxlength="5">
                                     </div>
 
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="escalier">Escalier
+                                        <label class="fr-label" for="adresseEscalier">Escalier
                                             <span class="fr-hint-text">3 caractères maximum</span>
                                         </label>
-                                        <input class="fr-input" type="text" name="escalier" value="{{ signalement.escalierOccupant }}" maxlength="3">
+                                        <input class="fr-input" type="text" id="adresseEscalier" name="escalier" value="{{ signalement.escalierOccupant }}" maxlength="3">
                                     </div>
 
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="numAppart">Numéro d'appartement
+                                        <label class="fr-label" for="adresseNumAppart">Numéro d'appartement
                                             <span class="fr-hint-text">5 caractères maximum</span>
                                         </label>
-                                        <input class="fr-input" type="text" name="numAppart" value="{{ signalement.numAppartOccupant }}" maxlength="5">
+                                        <input class="fr-input" type="text" id="adresseNumAppart" name="numAppart" value="{{ signalement.numAppartOccupant }}" maxlength="5">
                                     </div>
 
                                     <div class="fr-input-group">
-                                        <label class="fr-label" for="autre">Autre (résidence, lieu-dit...)
+                                        <label class="fr-label" for="adresseAutre">Autre (résidence, lieu-dit...)
                                             <span class="fr-hint-text">255 caractères maximum</span>
                                         </label>
-                                        <input class="fr-input" type="text" name="autre" value="{{ signalement.adresseAutreOccupant }}" maxlength="255">
+                                        <input class="fr-input" type="text" id="adresseAutre" name="autre" value="{{ signalement.adresseAutreOccupant }}" maxlength="255">
                                     </div>
                                 </div>
                             </div>

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -53,7 +53,7 @@
                                     <input type="hidden" name="geolocLng" value="{% if signalement.geoloc.lng is defined %}{{ signalement.geoloc.lng }}{% endif %}">
                                 </div>
                                 <div class="fr-col-12 fr-col-md-6">
-                                    <h2 class="fr-h5">Complément d'adresse</h2>
+                                    <h2 class="fr-h5">Complément d'adresse (facultatif)</h2>
 
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="etage">Etage

--- a/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
@@ -86,7 +86,7 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nombreEtages">Nombre d'étages</label>
+                                <label class="fr-label" for="nombreEtages">Nombre d'étages (facultatif)</label>
                                 <input class="fr-input" type="number" id="nombreEtages" name="nombreEtages" value="{{ signalement.informationComplementaire.informationsComplementairesLogementNombreEtages ?? 1 }}">
                             </div>
 

--- a/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
@@ -11,10 +11,10 @@
                             <h1 id="fr-modal-title-modal-edit-composition-logement" class="fr-modal__title">
                                 Modifier la composition du logement
                             </h1>
-
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-select-group">
                                 <label class="fr-label" for="type">Type</label>
-                                <select class="fr-select" name="type">
+                                <select class="fr-select" id="type" name="type">
                                     <option value="" disabled hidden>Sélectionnez un choix</option>
                                     <option value="appartement" {{ signalement.natureLogement is same as 'appartement' ? 'selected' : '' }}>Appartement</option>
                                     <option value="maison" {{ signalement.natureLogement is same as 'maison' ? 'selected' : '' }}>Maison</option>
@@ -28,13 +28,13 @@
                                     {% set autrePrecision = signalement.typeCompositionLogement.typeLogementNatureAutrePrecision %}
                                 {% endif %}
                                 <label class="fr-label" for="typeLogementNatureAutrePrecision">Précision (si autre)</label>
-                                <input class="fr-input" type="text" name="typeLogementNatureAutrePrecision" value="{{ autrePrecision }}" maxlength="50">
+                                <input class="fr-input" type="text" id="typeLogementNatureAutrePrecision" name="typeLogementNatureAutrePrecision" value="{{ autrePrecision }}" maxlength="50">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set compositionLogementPieceUnique = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.compositionLogementPieceUnique : null %}
                                 <label class="fr-label" for="typeCompositionLogement">Logement</label>
-                                <select class="fr-select" name="typeCompositionLogement">
+                                <select class="fr-select" id="typeCompositionLogement" name="typeCompositionLogement">
                                     <option value="" {{ compositionLogementPieceUnique not in ['piece_unique', 'plusieurs_pieces'] ? 'selected' : '' }}></option>
                                     <option value="piece_unique" {{ compositionLogementPieceUnique is same as 'piece_unique' ? 'selected' : '' }}>Pièce unique</option>
                                     <option value="plusieurs_pieces" {{ compositionLogementPieceUnique is same as 'plusieurs_pieces' ? 'selected' : '' }}>Plusieurs pièces</option>
@@ -42,14 +42,20 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="superficie">Superficie totale (m²)</label>
-                                <input class="fr-input" type="number" name="superficie" value="{{ signalement.superficie }}">
+                                <label class="fr-label" for="superficie">Superficie totale (m²)
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CompositionLogementRequest',
+                                        'superficie',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="number" id="superficie" name="superficie" value="{{ signalement.superficie }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set compositionLogementHauteur = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.compositionLogementHauteur : null %}
                                 <label class="fr-label" for="compositionLogementHauteur">Hauteur > 2m</label>
-                                <select class="fr-select" name="compositionLogementHauteur">
+                                <select class="fr-select" id="compositionLogementHauteur" name="compositionLogementHauteur">
                                     <option value="" {{ compositionLogementHauteur not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ compositionLogementHauteur is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ compositionLogementHauteur is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -59,18 +65,18 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="compositionLogementNbPieces">Nombre de pièces à vivre</label>
-                                <input class="fr-input" type="number" name="compositionLogementNbPieces" value="{{ signalement.typeCompositionLogement.compositionLogementNbPieces ?? 0 }}">
+                                <input class="fr-input" type="number" id="compositionLogementNbPieces" name="compositionLogementNbPieces" value="{{ signalement.typeCompositionLogement.compositionLogementNbPieces ?? 0 }}">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nombreEtages">Nombre d'étages</label>
-                                <input class="fr-input" type="number" name="nombreEtages" value="{{ signalement.informationComplementaire.informationsComplementairesLogementNombreEtages ?? 1 }}">
+                                <input class="fr-input" type="number" id="nombreEtages" name="nombreEtages" value="{{ signalement.informationComplementaire.informationsComplementairesLogementNombreEtages ?? 1 }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementRdc = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementRdc : null %}
                                 <label class="fr-label" for="typeLogementRdc">Est au RDC ?</label>
-                                <select class="fr-select" name="typeLogementRdc">
+                                <select class="fr-select" id="typeLogementRdc" name="typeLogementRdc">
                                     <option value="" {{ typeLogementRdc not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementRdc is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementRdc is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -80,7 +86,7 @@
                             <div class="fr-select-group">
                                 {% set typeLogementDernierEtage = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementDernierEtage : null %}
                                 <label class="fr-label" for="typeLogementDernierEtage">Est au dernier étage ?</label>
-                                <select class="fr-select" name="typeLogementDernierEtage">
+                                <select class="fr-select" id="typeLogementDernierEtage" name="typeLogementDernierEtage">
                                     <option value="" {{ typeLogementDernierEtage not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementDernierEtage is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementDernierEtage is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -90,7 +96,7 @@
                             <div class="fr-select-group">
                                 {% set typeLogementSousCombleSansFenetre = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementSousCombleSansFenetre : null %}
                                 <label class="fr-label" for="typeLogementSousCombleSansFenetre">Combles sans fenêtres ?</label>
-                                <select class="fr-select" name="typeLogementSousCombleSansFenetre">
+                                <select class="fr-select" id="typeLogementSousCombleSansFenetre" name="typeLogementSousCombleSansFenetre">
                                     <option value="" {{ typeLogementSousCombleSansFenetre not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementSousCombleSansFenetre is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementSousCombleSansFenetre is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -100,7 +106,7 @@
                             <div class="fr-select-group">
                                 {% set typeLogementSousSolSansFenetre = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementSousSolSansFenetre : null %}
                                 <label class="fr-label" for="typeLogementSousSolSansFenetre">Sous-sol sans fenêtres ?</label>
-                                <select class="fr-select" name="typeLogementSousSolSansFenetre">
+                                <select class="fr-select" id="typeLogementSousSolSansFenetre" name="typeLogementSousSolSansFenetre">
                                     <option value="" {{ typeLogementSousSolSansFenetre not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementSousSolSansFenetre is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementSousSolSansFenetre is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -109,8 +115,14 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesPieceAVivre9m = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesPieceAVivre9m : null %}
-                                <label class="fr-label" for="typeLogementCommoditesPieceAVivre9m">Au moins une des pièces à vivre > 9m² ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesPieceAVivre9m">
+                                <label class="fr-label" for="typeLogementCommoditesPieceAVivre9m">Au moins une des pièces à vivre > 9m² ?
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CompositionLogementRequest',
+                                        'typeLogementCommoditesPieceAVivre9m',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="typeLogementCommoditesPieceAVivre9m" name="typeLogementCommoditesPieceAVivre9m">
                                     <option value="" {{ typeLogementCommoditesPieceAVivre9m not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesPieceAVivre9m is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesPieceAVivre9m is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -121,7 +133,7 @@
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesCuisine = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesCuisine : null %}
                                 <label class="fr-label" for="typeLogementCommoditesCuisine">Cuisine (ou coin cuisine) dans le logement ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesCuisine">
+                                <select class="fr-select" id="typeLogementCommoditesCuisine" name="typeLogementCommoditesCuisine">
                                     <option value="" {{ typeLogementCommoditesCuisine not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesCuisine is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesCuisine is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -130,8 +142,8 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesCuisineCollective = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesCuisineCollective : null %}
-                                <label class="fr-label" for="typeLogementCommoditesCuisineCollective">Cuisine (ou coin cuisine) collective ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesCuisineCollective">
+                                <label class="fr-label" for="typeLogementCommoditesCuisineCollective">Cuisine (ou coin cuisine) collective ? (si pas de cuisine)</label>
+                                <select class="fr-select" id="typeLogementCommoditesCuisineCollective" name="typeLogementCommoditesCuisineCollective">
                                     <option value="" {{ typeLogementCommoditesCuisineCollective not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesCuisineCollective is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesCuisineCollective is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -141,7 +153,7 @@
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesSalleDeBain = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesSalleDeBain : null %}
                                 <label class="fr-label" for="typeLogementCommoditesSalleDeBain">SDB (baignoire ou douche) dans le logement ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesSalleDeBain">
+                                <select class="fr-select" id="typeLogementCommoditesSalleDeBain" name="typeLogementCommoditesSalleDeBain">
                                     <option value="" {{ typeLogementCommoditesSalleDeBain not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesSalleDeBain is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesSalleDeBain is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -150,8 +162,8 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesSalleDeBainCollective = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesSalleDeBainCollective : null %}
-                                <label class="fr-label" for="typeLogementCommoditesSalleDeBainCollective">SDB (baignoire ou douche) collective ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesSalleDeBainCollective">
+                                <label class="fr-label" for="typeLogementCommoditesSalleDeBainCollective">SDB (baignoire ou douche) collective ? (si pas de salle de bain)</label>
+                                <select class="fr-select" id="typeLogementCommoditesSalleDeBainCollective" name="typeLogementCommoditesSalleDeBainCollective">
                                     <option value="" {{ typeLogementCommoditesSalleDeBainCollective not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesSalleDeBainCollective is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesSalleDeBainCollective is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -161,7 +173,7 @@
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesWc = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesWc : null %}
                                 <label class="fr-label" for="typeLogementCommoditesWc">WC dans le logement ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesWc">
+                                <select class="fr-select" id="typeLogementCommoditesWc" name="typeLogementCommoditesWc">
                                     <option value="" {{ typeLogementCommoditesWc not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesWc is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesWc is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -170,8 +182,8 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesWcCollective = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesWcCollective : null %}
-                                <label class="fr-label" for="typeLogementCommoditesWcCollective">WC collectifs ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesWcCollective">
+                                <label class="fr-label" for="typeLogementCommoditesWcCollective">WC collectifs ? (si pas de wc)</label>
+                                <select class="fr-select" id="typeLogementCommoditesWcCollective" name="typeLogementCommoditesWcCollective">
                                     <option value="" {{ typeLogementCommoditesWcCollective not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesWcCollective is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesWcCollective is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -180,8 +192,8 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesWcCuisine = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesWcCuisine : null %}
-                                <label class="fr-label" for="typeLogementCommoditesWcCuisine">WC et cuisine dans la même pièce ?</label>
-                                <select class="fr-select" name="typeLogementCommoditesWcCuisine">
+                                <label class="fr-label" for="typeLogementCommoditesWcCuisine">WC et cuisine dans la même pièce ? (si cuisine et wc)</label>
+                                <select class="fr-select" id="typeLogementCommoditesWcCuisine" name="typeLogementCommoditesWcCuisine">
                                     <option value="" {{ typeLogementCommoditesWcCuisine not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesWcCuisine is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesWcCuisine is same as 'non' ? 'selected' : '' }}>Non</option>

--- a/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
@@ -13,8 +13,8 @@
                             </h1>
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-select-group">
-                                <label class="fr-label" for="type">Type</label>
-                                <select class="fr-select" id="type" name="type">
+                                <label class="fr-label" for="compositionLogementType">Type</label>
+                                <select class="fr-select" id="compositionLogementType" name="type">
                                     <option value="" disabled hidden>Sélectionnez un choix</option>
                                     <option value="appartement" {{ signalement.natureLogement is same as 'appartement' ? 'selected' : '' }}>Appartement</option>
                                     <option value="maison" {{ signalement.natureLogement is same as 'maison' ? 'selected' : '' }}>Maison</option>
@@ -27,14 +27,22 @@
                                 {% if signalement.typeCompositionLogement %}
                                     {% set autrePrecision = signalement.typeCompositionLogement.typeLogementNatureAutrePrecision %}
                                 {% endif %}
-                                <label class="fr-label" for="typeLogementNatureAutrePrecision">Précision (si autre)</label>
-                                <input class="fr-input" type="text" id="typeLogementNatureAutrePrecision" name="typeLogementNatureAutrePrecision" value="{{ autrePrecision }}" maxlength="50">
+                                <label class="fr-label" for="compositionLogementTypeLogementNatureAutrePrecision">Précision (si autre)</label>
+                                <input class="fr-input" type="text" id="compositionLogementTypeLogementNatureAutrePrecision" name="typeLogementNatureAutrePrecision" value="{{ autrePrecision }}" maxlength="50">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set compositionLogementPieceUnique = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.compositionLogementPieceUnique : null %}
-                                <label class="fr-label" for="typeCompositionLogement">Logement</label>
-                                <select class="fr-select" id="typeCompositionLogement" name="typeCompositionLogement">
+                                <label class="fr-label" for="compositionLogementTypeCompositionLogement">
+                                    Logement
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CompositionLogementRequest',
+                                        'typeCompositionLogement',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="compositionLogementTypeCompositionLogement" name="typeCompositionLogement">
                                     <option value="" {{ compositionLogementPieceUnique not in ['piece_unique', 'plusieurs_pieces'] ? 'selected' : '' }}></option>
                                     <option value="piece_unique" {{ compositionLogementPieceUnique is same as 'piece_unique' ? 'selected' : '' }}>Pièce unique</option>
                                     <option value="plusieurs_pieces" {{ compositionLogementPieceUnique is same as 'plusieurs_pieces' ? 'selected' : '' }}>Plusieurs pièces</option>
@@ -42,19 +50,28 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="superficie">Superficie totale (m²)
+                                <label class="fr-label" for="compositionLogementSuperficie">Superficie totale (m²)
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CompositionLogementRequest',
                                         'superficie',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <input class="fr-input" type="number" id="superficie" name="superficie" value="{{ signalement.superficie }}">
+                                <input class="fr-input" type="number" id="compositionLogementSuperficie" name="superficie" value="{{ signalement.superficie }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set compositionLogementHauteur = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.compositionLogementHauteur : null %}
-                                <label class="fr-label" for="compositionLogementHauteur">Hauteur > 2m</label>
+                                <label class="fr-label" for="compositionLogementHauteur">
+                                    Hauteur > 2m
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CompositionLogementRequest',
+                                        'compositionLogementHauteur',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
                                 <select class="fr-select" id="compositionLogementHauteur" name="compositionLogementHauteur">
                                     <option value="" {{ compositionLogementHauteur not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ compositionLogementHauteur is same as 'oui' ? 'selected' : '' }}>Oui</option>
@@ -75,54 +92,60 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementRdc = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementRdc : null %}
-                                <label class="fr-label" for="typeLogementRdc">Est au RDC ?</label>
-                                <select class="fr-select" id="typeLogementRdc" name="typeLogementRdc">
-                                    <option value="" {{ typeLogementRdc not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <label class="fr-label" for="compositionLogementTypeLogementRdc">Est au RDC ?</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementRdc" name="typeLogementRdc">
+                                    <option value="" {{ typeLogementRdc not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementRdc is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementRdc is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ typeLogementRdc is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementDernierEtage = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementDernierEtage : null %}
-                                <label class="fr-label" for="typeLogementDernierEtage">Est au dernier étage ?</label>
-                                <select class="fr-select" id="typeLogementDernierEtage" name="typeLogementDernierEtage">
-                                    <option value="" {{ typeLogementDernierEtage not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <label class="fr-label" for="compositionLogementTypeLogementDernierEtage">Est au dernier étage ? (si n'est pas au RDC)</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementDernierEtage" name="typeLogementDernierEtage">
+                                    <option value="" {{ typeLogementDernierEtage not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementDernierEtage is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementDernierEtage is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ typeLogementDernierEtage is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementSousCombleSansFenetre = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementSousCombleSansFenetre : null %}
-                                <label class="fr-label" for="typeLogementSousCombleSansFenetre">Combles sans fenêtres ?</label>
-                                <select class="fr-select" id="typeLogementSousCombleSansFenetre" name="typeLogementSousCombleSansFenetre">
-                                    <option value="" {{ typeLogementSousCombleSansFenetre not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <label class="fr-label" for="compositionLogementTypeLogementSousCombleSansFenetre">Combles sans fenêtres ? (si dernier étage)</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementSousCombleSansFenetre" name="typeLogementSousCombleSansFenetre">
+                                    <option value="" {{ typeLogementSousCombleSansFenetre not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementSousCombleSansFenetre is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementSousCombleSansFenetre is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ typeLogementSousCombleSansFenetre is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementSousSolSansFenetre = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementSousSolSansFenetre : null %}
-                                <label class="fr-label" for="typeLogementSousSolSansFenetre">Sous-sol sans fenêtres ?</label>
-                                <select class="fr-select" id="typeLogementSousSolSansFenetre" name="typeLogementSousSolSansFenetre">
-                                    <option value="" {{ typeLogementSousSolSansFenetre not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <label class="fr-label" for="compositionLogementTypeLogementSousSolSansFenetre">Sous-sol sans fenêtres ? (si n'est pas au RDC et n'est pas au dernier étage)</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementSousSolSansFenetre" name="typeLogementSousSolSansFenetre">
+                                    <option value="" {{ typeLogementSousSolSansFenetre not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementSousSolSansFenetre is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementSousSolSansFenetre is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ typeLogementSousSolSansFenetre is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesPieceAVivre9m = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesPieceAVivre9m : null %}
-                                <label class="fr-label" for="typeLogementCommoditesPieceAVivre9m">Au moins une des pièces à vivre > 9m² ?
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesPieceAVivre9m">Au moins une des pièces à vivre > 9m² ?
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CompositionLogementRequest',
                                         'typeLogementCommoditesPieceAVivre9m',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom
+                                    )
                                     }}
                                 </label>
-                                <select class="fr-select" id="typeLogementCommoditesPieceAVivre9m" name="typeLogementCommoditesPieceAVivre9m">
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesPieceAVivre9m" name="typeLogementCommoditesPieceAVivre9m">
                                     <option value="" {{ typeLogementCommoditesPieceAVivre9m not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesPieceAVivre9m is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesPieceAVivre9m is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -132,18 +155,19 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesCuisine = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesCuisine : null %}
-                                <label class="fr-label" for="typeLogementCommoditesCuisine">Cuisine (ou coin cuisine) dans le logement ?</label>
-                                <select class="fr-select" id="typeLogementCommoditesCuisine" name="typeLogementCommoditesCuisine">
-                                    <option value="" {{ typeLogementCommoditesCuisine not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesCuisine">Cuisine (ou coin cuisine) dans le logement ?</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesCuisine" name="typeLogementCommoditesCuisine">
+                                    <option value="" {{ typeLogementCommoditesCuisine not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesCuisine is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesCuisine is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ typeLogementCommoditesCuisine is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesCuisineCollective = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesCuisineCollective : null %}
-                                <label class="fr-label" for="typeLogementCommoditesCuisineCollective">Cuisine (ou coin cuisine) collective ? (si pas de cuisine)</label>
-                                <select class="fr-select" id="typeLogementCommoditesCuisineCollective" name="typeLogementCommoditesCuisineCollective">
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesCuisineCollective">Cuisine (ou coin cuisine) collective ? (si pas de cuisine)</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesCuisineCollective" name="typeLogementCommoditesCuisineCollective">
                                     <option value="" {{ typeLogementCommoditesCuisineCollective not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesCuisineCollective is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesCuisineCollective is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -152,18 +176,19 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesSalleDeBain = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesSalleDeBain : null %}
-                                <label class="fr-label" for="typeLogementCommoditesSalleDeBain">SDB (baignoire ou douche) dans le logement ?</label>
-                                <select class="fr-select" id="typeLogementCommoditesSalleDeBain" name="typeLogementCommoditesSalleDeBain">
-                                    <option value="" {{ typeLogementCommoditesSalleDeBain not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesSalleDeBain">SDB (baignoire ou douche) dans le logement ?</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesSalleDeBain" name="typeLogementCommoditesSalleDeBain">
+                                    <option value="" {{ typeLogementCommoditesSalleDeBain not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesSalleDeBain is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesSalleDeBain is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ typeLogementCommoditesSalleDeBain is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesSalleDeBainCollective = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesSalleDeBainCollective : null %}
-                                <label class="fr-label" for="typeLogementCommoditesSalleDeBainCollective">SDB (baignoire ou douche) collective ? (si pas de salle de bain)</label>
-                                <select class="fr-select" id="typeLogementCommoditesSalleDeBainCollective" name="typeLogementCommoditesSalleDeBainCollective">
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesSalleDeBainCollective">SDB (baignoire ou douche) collective ? (si pas de salle de bain)</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesSalleDeBainCollective" name="typeLogementCommoditesSalleDeBainCollective">
                                     <option value="" {{ typeLogementCommoditesSalleDeBainCollective not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesSalleDeBainCollective is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesSalleDeBainCollective is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -172,18 +197,19 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesWc = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesWc : null %}
-                                <label class="fr-label" for="typeLogementCommoditesWc">WC dans le logement ?</label>
-                                <select class="fr-select" id="typeLogementCommoditesWc" name="typeLogementCommoditesWc">
-                                    <option value="" {{ typeLogementCommoditesWc not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesWc">WC dans le logement ?</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesWc" name="typeLogementCommoditesWc">
+                                    <option value="" {{ typeLogementCommoditesWc not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesWc is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesWc is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ typeLogementCommoditesWc is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesWcCollective = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesWcCollective : null %}
-                                <label class="fr-label" for="typeLogementCommoditesWcCollective">WC collectifs ? (si pas de wc)</label>
-                                <select class="fr-select" id="typeLogementCommoditesWcCollective" name="typeLogementCommoditesWcCollective">
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesWcCollective">WC collectifs ? (si pas de wc)</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesWcCollective" name="typeLogementCommoditesWcCollective">
                                     <option value="" {{ typeLogementCommoditesWcCollective not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesWcCollective is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesWcCollective is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -192,8 +218,8 @@
 
                             <div class="fr-select-group">
                                 {% set typeLogementCommoditesWcCuisine = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.typeLogementCommoditesWcCuisine : null %}
-                                <label class="fr-label" for="typeLogementCommoditesWcCuisine">WC et cuisine dans la même pièce ? (si cuisine et wc)</label>
-                                <select class="fr-select" id="typeLogementCommoditesWcCuisine" name="typeLogementCommoditesWcCuisine">
+                                <label class="fr-label" for="compositionLogementTypeLogementCommoditesWcCuisine">WC et cuisine dans la même pièce ? (si cuisine et wc)</label>
+                                <select class="fr-select" id="compositionLogementTypeLogementCommoditesWcCuisine" name="typeLogementCommoditesWcCuisine">
                                     <option value="" {{ typeLogementCommoditesWcCuisine not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ typeLogementCommoditesWcCuisine is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ typeLogementCommoditesWcCuisine is same as 'non' ? 'selected' : '' }}>Non</option>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -11,34 +11,63 @@
                             <h1 id="fr-modal-title-modal-edit-coordonnees-bailleur" class="fr-modal__title">
                                 Modifier les coordonnées du bailleur
                             </h1>
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nom">Nom</label>
-                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomProprio }}" maxlength="255">
+                                <label class="fr-label" for="nom">Nom
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
+                                        'nom',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="text" id="nom" name="nom" value="{{ signalement.nomProprio }}" maxlength="255">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="prenom">Prénom</label>
-                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomProprio }}" maxlength="255">
+                                <label class="fr-label" for="prenom">Prénom
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
+                                        'prenom',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="text" id="prenom" name="prenom" value="{{ signalement.prenomProprio }}" maxlength="255">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="mail">Courriel</label>
-                                <input class="fr-input" type="text" name="mail" value="{{ signalement.mailProprio }}">
+                                <label class="fr-label" for="mail">Courriel
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
+                                        'mail',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="text" id="mail" name="mail" value="{{ signalement.mailProprio }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephone">Téléphone</label>
-                                <input class="fr-input" type="text" name="telephone" value="{{ signalement.telProprioDecoded }}">
+                                <label class="fr-label" for="telephone">Téléphone
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
+                                        'telephone',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="text" id="telephone" name="telephone" value="{{ signalement.telProprioDecoded }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephoneBis">Téléphone sec.</label>
-                                <input class="fr-input" type="text" name="telephoneBis" value="{{ signalement.telProprioSecondaireDecoded }}">
+                                <label class="fr-label" for="telephoneBis">Téléphone sec. (facultatif)</label>
+                                <input class="fr-input" type="text" id="telephoneBis" name="telephoneBis" value="{{ signalement.telProprioSecondaireDecoded }}">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="edit-coordonnees-bailleur-search">
-                                    Adresse
+                                    Adresse {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
+                                        'adresse',
+                                        signalement.profileDeclarant)
+                                    }}
                                     <span class="fr-hint-text">Tapez l'adresse et sélectionnez-la dans la liste</span>
                                 </label>
                                 <input class="fr-input search-address-autocomplete" type="text" id="edit-coordonnees-bailleur-search"
@@ -67,8 +96,8 @@
 
                             <div class="fr-select-group">
                                 {% set bailleurBeneficiaireRsa = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa : null %}
-                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA</label>
-                                <select class="fr-select" name="beneficiaireRsa">
+                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA (facultatif)</label>
+                                <select class="fr-select" id="beneficiaireRsa" name="beneficiaireRsa">
                                     <option value="" {{ bailleurBeneficiaireRsa not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailleurBeneficiaireRsa is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailleurBeneficiaireRsa is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -77,8 +106,8 @@
 
                             <div class="fr-select-group">
                                 {% set bailleurBeneficiaireFsl = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl : null %}
-                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL</label>
-                                <select class="fr-select" name="beneficiaireFsl">
+                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL (facultatif)</label>
+                                <select class="fr-select" id="beneficiaireFsl" name="beneficiaireFsl">
                                     <option value="" {{ bailleurBeneficiaireFsl not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailleurBeneficiaireFsl is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailleurBeneficiaireFsl is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -86,13 +115,13 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence</label>
-                                <input class="fr-input" type="text" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? '0' }}">
+                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence (facultatif)</label>
+                                <input class="fr-input" type="text" id="revenuFiscal" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? '0' }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="dateNaissance">Date de naissance</label>
-                                <input class="fr-input" type="date" name="dateNaissance" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? '' }}">
+                                <label class="fr-label" for="dateNaissance">Date de naissance (facultatif)</label>
+                                <input class="fr-input" type="date" id="dateNaissance" name="dateNaissance" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? '' }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -13,52 +13,52 @@
                             </h1>
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nom">Nom
+                                <label class="fr-label" for="coordonneesBailleurNom">Nom
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
                                         'nom',
                                         signalement.profileDeclarant)
                                     }}
                                 </label>
-                                <input class="fr-input" type="text" id="nom" name="nom" value="{{ signalement.nomProprio }}" maxlength="255">
+                                <input class="fr-input" type="text" id="coordonneesBailleurNom" name="nom" value="{{ signalement.nomProprio }}" maxlength="255">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="prenom">Prénom
+                                <label class="fr-label" for="coordonneesBailleurPrenom">Prénom
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
                                         'prenom',
                                         signalement.profileDeclarant)
                                     }}
                                 </label>
-                                <input class="fr-input" type="text" id="prenom" name="prenom" value="{{ signalement.prenomProprio }}" maxlength="255">
+                                <input class="fr-input" type="text" id="coordonneesBailleurPrenom" name="prenom" value="{{ signalement.prenomProprio }}" maxlength="255">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="mail">Courriel
+                                <label class="fr-label" for="coordonneesBailleurMail">Courriel
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
                                         'mail',
                                         signalement.profileDeclarant)
                                     }}
                                 </label>
-                                <input class="fr-input" type="text" id="mail" name="mail" value="{{ signalement.mailProprio }}">
+                                <input class="fr-input" type="text" id="coordonneesBailleurMail" name="mail" value="{{ signalement.mailProprio }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephone">Téléphone
+                                <label class="fr-label" for="coordonneesBailleurTelephone">Téléphone
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
                                         'telephone',
                                         signalement.profileDeclarant)
                                     }}
                                 </label>
-                                <input class="fr-input" type="text" id="telephone" name="telephone" value="{{ signalement.telProprioDecoded }}">
+                                <input class="fr-input" type="text" id="coordonneesBailleurTelephone" name="telephone" value="{{ signalement.telProprioDecoded }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephoneBis">Téléphone sec. (facultatif)</label>
-                                <input class="fr-input" type="text" id="telephoneBis" name="telephoneBis" value="{{ signalement.telProprioSecondaireDecoded }}">
+                                <label class="fr-label" for="coordonneesBailleurTelephoneBis">Téléphone sec. (facultatif)</label>
+                                <input class="fr-input" type="text" id="coordonneesBailleurTelephoneBis" name="telephoneBis" value="{{ signalement.telProprioSecondaireDecoded }}">
                             </div>
 
                             <div class="fr-input-group">
@@ -96,8 +96,8 @@
 
                             <div class="fr-select-group">
                                 {% set bailleurBeneficiaireRsa = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireRsa : null %}
-                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA (facultatif)</label>
-                                <select class="fr-select" id="beneficiaireRsa" name="beneficiaireRsa">
+                                <label class="fr-label" for="coordonneesBailleurBeneficiaireRsa">Bénéficiaire RSA (facultatif)</label>
+                                <select class="fr-select" id="coordonneesBailleurBeneficiaireRsa" name="beneficiaireRsa">
                                     <option value="" {{ bailleurBeneficiaireRsa not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailleurBeneficiaireRsa is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailleurBeneficiaireRsa is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -106,8 +106,8 @@
 
                             <div class="fr-select-group">
                                 {% set bailleurBeneficiaireFsl = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationBailleurBeneficiaireFsl : null %}
-                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL (facultatif)</label>
-                                <select class="fr-select" id="beneficiaireFsl" name="beneficiaireFsl">
+                                <label class="fr-label" for="coordonneesBailleurBeneficiaireFsl">Bénéficiaire FSL (facultatif)</label>
+                                <select class="fr-select" id="coordonneesBailleurBeneficiaireFsl" name="beneficiaireFsl">
                                     <option value="" {{ bailleurBeneficiaireFsl not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailleurBeneficiaireFsl is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailleurBeneficiaireFsl is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -115,13 +115,13 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence (facultatif)</label>
-                                <input class="fr-input" type="text" id="revenuFiscal" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? '0' }}">
+                                <label class="fr-label" for="coordonneesBailleurRevenuFiscal">Revenu fiscal de référence (facultatif)</label>
+                                <input class="fr-input" type="text" id="coordonneesBailleurRevenuFiscal" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurRevenuFiscal ?? '0' }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="dateNaissance">Date de naissance (facultatif)</label>
-                                <input class="fr-input" type="date" id="dateNaissance" name="dateNaissance" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? '' }}">
+                                <label class="fr-label" for="coordonneesBailleurDateNaissance">Date de naissance (facultatif)</label>
+                                <input class="fr-input" type="date" id="coordonneesBailleurDateNaissance" name="dateNaissance" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? '' }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
@@ -17,8 +17,8 @@
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT %}
                             <div class="fr-select-group">
-                                <label class="fr-label" for="typeProprio">Type</label>
-                                <select class="fr-select" id="typeProprio" name="typeProprio">
+                                <label class="fr-label" for="coordonneesFoyerTypeProprio">Type</label>
+                                <select class="fr-select" id="coordonneesFoyerTypeProprio" name="typeProprio">
                                     <option value="" disabled hidden>Sélectionnez un choix</option>
                                     <option value="" {{ signalement.typeProprio is same as '' ? 'selected' : '' }}>N/C</option>
                                     <option value="{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.label }}</option>
@@ -26,18 +26,18 @@
                                 </select>
                             </div>
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nomStructure">Nom de la structure </label>
-                                <input class="fr-input" type="text" id="nomStructure" name="nomStructure" value="{{ signalement.structureDeclarant }}">
+                                <label class="fr-label" for="coordonneesFoyerNomStructure">Nom de la structure </label>
+                                <input class="fr-input" type="text" id="coordonneesFoyerNomStructure" name="nomStructure" value="{{ signalement.structureDeclarant }}">
                             </div>
                             {% endif %}
 
                             <div class="fr-select-group">
-                                <label class="fr-label" for="civilite">Civilité {{ show_label_facultatif(
+                                <label class="fr-label" for="coordonneesFoyerCivilite">Civilité {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
                                         'civilite',
                                         signalement.profileDeclarant)  }}
                                 </label>
-                                <select class="fr-select" id="civilite" name="civilite">
+                                <select class="fr-select" id="coordonneesFoyerCivilite" name="civilite">
                                     <option value="" {{ signalement.civiliteOccupant not in ['mme', 'mr'] ? 'selected' : '' }}></option>
                                     <option value="mme" {{ signalement.civiliteOccupant is same as 'mme' ? 'selected' : '' }}>Madame</option>
                                     <option value="mr" {{ signalement.civiliteOccupant is same as 'mr' ? 'selected' : '' }}>Monsieur</option>
@@ -45,46 +45,46 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nom">Nom {{ show_label_facultatif(
+                                <label class="fr-label" for="coordonneesFoyerNom">Nom {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
                                         'nom',
                                         signalement.profileDeclarant)  }}</label>
-                                <input class="fr-input" type="text" id="nom" name="nom" value="{{ signalement.nomOccupant }}" maxlength="50">
+                                <input class="fr-input" type="text" id="coordonneesFoyerNom" name="nom" value="{{ signalement.nomOccupant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="prenom">Prénom
+                                <label class="fr-label" for="coordonneesFoyerPrenom">Prénom
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
                                         'prenom',
                                         signalement.profileDeclarant)  }}
                                 </label>
-                                <input class="fr-input" type="text" id="prenom" name="prenom" value="{{ signalement.prenomOccupant }}" maxlength="50">
+                                <input class="fr-input" type="text" id="coordonneesFoyerPrenom" name="prenom" value="{{ signalement.prenomOccupant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="mail">Courriel
+                                <label class="fr-label" for="coordonneesFoyerMail">Courriel
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
                                         'mail',
                                         signalement.profileDeclarant)  }}
                                 </label>
-                                <input class="fr-input" type="text" id="mail" name="mail" value="{{ signalement.mailOccupant }}">
+                                <input class="fr-input" type="text" id="coordonneesFoyerMail" name="mail" value="{{ signalement.mailOccupant }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephone">Téléphone
+                                <label class="fr-label" for="coordonneesFoyerTelephone">Téléphone
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
                                         'telephone',
                                         signalement.profileDeclarant)  }}
                                 </label>
-                                <input class="fr-input" type="text" id="telephone" name="telephone" value="{{ signalement.telOccupantDecoded }}">
+                                <input class="fr-input" type="text" id="coordonneesFoyerTelephone" name="telephone" value="{{ signalement.telOccupantDecoded }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephoneBis">Téléphone sec. (facultatif)</label>
-                                <input class="fr-input" type="text" id="telephoneBis" name="telephoneBis" value="{{ signalement.telOccupantBisDecoded }}">
+                                <label class="fr-label" for="coordonneesFoyerTelephoneBis">Téléphone sec. (facultatif)</label>
+                                <input class="fr-input" type="text" id="coordonneesFoyerTelephoneBis" name="telephoneBis" value="{{ signalement.telOccupantBisDecoded }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
@@ -2,7 +2,10 @@
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-coordonnees-foyer" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_foyer',{uuid:signalement.uuid}) }}">
+                <form method="POST"
+                      id="form-edit-coordonnees-foyer"
+                      enctype="application/json"
+                      action="{{ path('back_signalement_edit_coordonnees_foyer',{uuid:signalement.uuid}) }}">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-foyer">Fermer</button>
@@ -11,11 +14,11 @@
                             <h1 id="fr-modal-title-modal-edit-coordonnees-foyer" class="fr-modal__title">
                                 Modifier les coordonnées du foyer
                             </h1>
-
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT %}
                             <div class="fr-select-group">
                                 <label class="fr-label" for="typeProprio">Type</label>
-                                <select class="fr-select" name="typeProprio">
+                                <select class="fr-select" id="typeProprio" name="typeProprio">
                                     <option value="" disabled hidden>Sélectionnez un choix</option>
                                     <option value="" {{ signalement.typeProprio is same as '' ? 'selected' : '' }}>N/C</option>
                                     <option value="{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.label }}</option>
@@ -23,14 +26,18 @@
                                 </select>
                             </div>
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nomStructure">Nom de la structure</label>
-                                <input class="fr-input" type="text" name="nomStructure" value="{{ signalement.structureDeclarant }}">
+                                <label class="fr-label" for="nomStructure">Nom de la structure </label>
+                                <input class="fr-input" type="text" id="nomStructure" name="nomStructure" value="{{ signalement.structureDeclarant }}">
                             </div>
                             {% endif %}
 
                             <div class="fr-select-group">
-                                <label class="fr-label" for="civilite">Civilité</label>
-                                <select class="fr-select" name="civilite">
+                                <label class="fr-label" for="civilite">Civilité {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
+                                        'civilite',
+                                        signalement.profileDeclarant)  }}
+                                </label>
+                                <select class="fr-select" id="civilite" name="civilite">
                                     <option value="" {{ signalement.civiliteOccupant not in ['mme', 'mr'] ? 'selected' : '' }}></option>
                                     <option value="mme" {{ signalement.civiliteOccupant is same as 'mme' ? 'selected' : '' }}>Madame</option>
                                     <option value="mr" {{ signalement.civiliteOccupant is same as 'mr' ? 'selected' : '' }}>Monsieur</option>
@@ -38,28 +45,46 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nom">Nom</label>
-                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomOccupant }}" maxlength="50">
+                                <label class="fr-label" for="nom">Nom {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
+                                        'nom',
+                                        signalement.profileDeclarant)  }}</label>
+                                <input class="fr-input" type="text" id="nom" name="nom" value="{{ signalement.nomOccupant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="prenom">Prénom</label>
-                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomOccupant }}" maxlength="50">
+                                <label class="fr-label" for="prenom">Prénom
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
+                                        'prenom',
+                                        signalement.profileDeclarant)  }}
+                                </label>
+                                <input class="fr-input" type="text" id="prenom" name="prenom" value="{{ signalement.prenomOccupant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="mail">Courriel</label>
-                                <input class="fr-input" type="text" name="mail" value="{{ signalement.mailOccupant }}">
+                                <label class="fr-label" for="mail">Courriel
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
+                                        'mail',
+                                        signalement.profileDeclarant)  }}
+                                </label>
+                                <input class="fr-input" type="text" id="mail" name="mail" value="{{ signalement.mailOccupant }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephone">Téléphone</label>
-                                <input class="fr-input" type="text" name="telephone" value="{{ signalement.telOccupantDecoded }}">
+                                <label class="fr-label" for="telephone">Téléphone
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesFoyerRequest',
+                                        'telephone',
+                                        signalement.profileDeclarant)  }}
+                                </label>
+                                <input class="fr-input" type="text" id="telephone" name="telephone" value="{{ signalement.telOccupantDecoded }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephoneBis">Téléphone sec.</label>
-                                <input class="fr-input" type="text" name="telephoneBis" value="{{ signalement.telOccupantBisDecoded }}">
+                                <label class="fr-label" for="telephoneBis">Téléphone sec. (facultatif)</label>
+                                <input class="fr-input" type="text" id="telephoneBis" name="telephoneBis" value="{{ signalement.telOccupantBisDecoded }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -14,8 +14,8 @@
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
                             <div class="fr-select-group">
-                                <label class="fr-label" for="typeProprio">Type</label>
-                                <select class="fr-select" name="typeProprio">
+                                <label class="fr-label" for="coordonneesTiersTypeProprio">Type</label>
+                                <select class="fr-select" id="coordonneesTiersTypeProprio" name="typeProprio">
                                     <option value="" disabled hidden>Sélectionnez un choix</option>
                                     <option value="" {{ signalement.typeProprio is same as '' ? 'selected' : '' }}>N/C</option>
                                     <option value="{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.label }}</option>
@@ -25,29 +25,29 @@
                             {% endif %}
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="nom">Nom</label>
-                                <input class="fr-input" type="text" id="nom" name="nom" value="{{ signalement.nomDeclarant }}" maxlength="50">
+                                <label class="fr-label" for="coordonneesTiersNom">Nom</label>
+                                <input class="fr-input" type="text" id="coordonneesTiersNom" name="nom" value="{{ signalement.nomDeclarant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="prenom">Prénom</label>
-                                <input class="fr-input" type="text" id"prenom" name="prenom" value="{{ signalement.prenomDeclarant }}" maxlength="50">
+                                <label class="fr-label" for="coordonneesTiersPrenom">Prénom</label>
+                                <input class="fr-input" type="text" id="coordonneesTiersPrenom" name="prenom" value="{{ signalement.prenomDeclarant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="mail">Courriel</label>
-                                <input class="fr-input" type="text" id="mail" name="mail" value="{{ signalement.mailDeclarant }}">
+                                <label class="fr-label" for="coordonneesTiersMail">Courriel</label>
+                                <input class="fr-input" type="text" id="coordonneesTiersMail" name="mail" value="{{ signalement.mailDeclarant }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="telephone">Téléphone</label>
-                                <input class="fr-input" type="text" id="telephone" name="telephone" value="{{ signalement.telDeclarantDecoded }}">
+                                <label class="fr-label" for="coordonneesTiersTelephone">Téléphone</label>
+                                <input class="fr-input" type="text" id="coordonneesTiersTelephone" name="telephone" value="{{ signalement.telDeclarantDecoded }}">
                             </div>
 
                             <div class="fr-select-group">
-                                <label class="fr-label" for="lien">Lien avec l'occupant</label>
+                                <label class="fr-label" for="coordonneesTiersLien">Lien avec l'occupant (facultatif)</label>
                                 {% set OccupantLink = enum('\\App\\Entity\\Enum\\OccupantLink') %}
-                                <select class="fr-select" id="lien" name="lien">
+                                <select class="fr-select" id="coordonneesTiersLien" name="lien">
                                     <option value="" {{ signalement.lienDeclarantOccupant not in OccupantLink.names() ? 'selected' : '' }}></option>
                                     <option value="PROCHE" {{ signalement.lienDeclarantOccupant is same as 'PROCHE' ? 'selected' : '' }}>Proche</option>
                                     <option value="VOISIN" {{ signalement.lienDeclarantOccupant is same as 'VOISIN' ? 'selected' : '' }}>Voisinage</option>
@@ -59,8 +59,8 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="structure">Structure (si lien avec l'occupant: professionnel(le) ou service de secours)</label>
-                                <input class="fr-input" type="text" id="structure" name="structure" value="{{ signalement.structureDeclarant }}">
+                                <label class="fr-label" for="coordonneesTiersStructure">Structure (si lien avec l'occupant: professionnel(le) ou service de secours)</label>
+                                <input class="fr-input" type="text" id="coordonneesTiersStructure" name="structure" value="{{ signalement.structureDeclarant }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -11,7 +11,7 @@
                             <h1 id="fr-modal-title-modal-edit-coordonnees-tiers" class="fr-modal__title">
                                 Modifier les coordonnées du tiers déclarant
                             </h1>
-
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
                             <div class="fr-select-group">
                                 <label class="fr-label" for="typeProprio">Type</label>
@@ -26,28 +26,28 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="nom">Nom</label>
-                                <input class="fr-input" type="text" name="nom" value="{{ signalement.nomDeclarant }}" maxlength="50">
+                                <input class="fr-input" type="text" id="nom" name="nom" value="{{ signalement.nomDeclarant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="prenom">Prénom</label>
-                                <input class="fr-input" type="text" name="prenom" value="{{ signalement.prenomDeclarant }}" maxlength="50">
+                                <input class="fr-input" type="text" id"prenom" name="prenom" value="{{ signalement.prenomDeclarant }}" maxlength="50">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="mail">Courriel</label>
-                                <input class="fr-input" type="text" name="mail" value="{{ signalement.mailDeclarant }}">
+                                <input class="fr-input" type="text" id="mail" name="mail" value="{{ signalement.mailDeclarant }}">
                             </div>
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="telephone">Téléphone</label>
-                                <input class="fr-input" type="text" name="telephone" value="{{ signalement.telDeclarantDecoded }}">
+                                <input class="fr-input" type="text" id="telephone" name="telephone" value="{{ signalement.telDeclarantDecoded }}">
                             </div>
 
                             <div class="fr-select-group">
                                 <label class="fr-label" for="lien">Lien avec l'occupant</label>
                                 {% set OccupantLink = enum('\\App\\Entity\\Enum\\OccupantLink') %}
-                                <select class="fr-select" name="lien">
+                                <select class="fr-select" id="lien" name="lien">
                                     <option value="" {{ signalement.lienDeclarantOccupant not in OccupantLink.names() ? 'selected' : '' }}></option>
                                     <option value="PROCHE" {{ signalement.lienDeclarantOccupant is same as 'PROCHE' ? 'selected' : '' }}>Proche</option>
                                     <option value="VOISIN" {{ signalement.lienDeclarantOccupant is same as 'VOISIN' ? 'selected' : '' }}>Voisinage</option>
@@ -59,8 +59,8 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="structure">Structure (professionnels ou service de secours)</label>
-                                <input class="fr-input" type="text" name="structure" value="{{ signalement.structureDeclarant }}">
+                                <label class="fr-label" for="structure">Structure (si lien avec l'occupant: professionnel(le) ou service de secours)</label>
+                                <input class="fr-input" type="text" id="structure" name="structure" value="{{ signalement.structureDeclarant }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -11,7 +11,7 @@
                             <h1 id="fr-modal-title-modal-edit-informations-logement" class="fr-modal__title">
                                 Modifier les informations du logement
                             </h1>
-
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-input-group">
                                 {% set nombrePersonnes = 0 %}
                                 {% if signalement.typeCompositionLogement %}
@@ -19,8 +19,14 @@
                                 {% else %}
                                     {% set nombrePersonnes = signalement.nbPersonsDeprecated %}
                                 {% endif %}
-                                <label class="fr-label" for="nombrePersonnes">Nb. personnes</label>
-                                <input class="fr-input" type="number" name="nombrePersonnes" value="{{ nombrePersonnes }}">
+                                <label class="fr-label" for="nombrePersonnes">Nb. personnes
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'nombrePersonnes',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="number" id="nombrePersonnes" name="nombrePersonnes" value="{{ nombrePersonnes }}">
                             </div>
 
                             <div class="fr-select-group">
@@ -34,8 +40,14 @@
                                         {% set compositionLogementEnfants = 'non' %}
                                     {% endif %}
                                 {% endif %}
-                                <label class="fr-label" for="compositionLogementEnfants">Enfants -6 ans</label>
-                                <select class="fr-select" name="compositionLogementEnfants">
+                                <label class="fr-label" for="compositionLogementEnfants">Enfants -6 ans
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'compositionLogementEnfants',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="compositionLogementEnfants" name="compositionLogementEnfants">
                                     <option value="" {{ compositionLogementEnfants not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ compositionLogementEnfants is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ compositionLogementEnfants is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -47,8 +59,14 @@
                                 {% if signalement.dateEntree %}
                                     {% set dateEntree = signalement.dateEntree.format('Y-m-d') %}
                                 {% endif %}
-                                <label class="fr-label" for="dateEntree">Date arrivée</label>
-                                <input class="fr-input" type="date" name="dateEntree" value="{{ dateEntree }}">
+                                <label class="fr-label" for="dateEntree">Date arrivée
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'dateEntree',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="date" id="dateEntree" name="dateEntree" value="{{ dateEntree }}">
                             </div>
 
                             <div class="fr-input-group">
@@ -56,14 +74,14 @@
                                 {% if signalement.informationComplementaire %}
                                     {% set bailleurDateEffetBail = signalement.informationComplementaire.informationsComplementairesSituationBailleurDateEffetBail %}
                                 {% endif %}
-                                <label class="fr-label" for="bailleurDateEffetBail">Date d'effet du bail</label>
-                                <input class="fr-input" type="date" name="bailleurDateEffetBail" value="{{ bailleurDateEffetBail }}">
+                                <label class="fr-label" for="bailleurDateEffetBail">Date d'effet du bail (facultatif)</label>
+                                <input class="fr-input" type="date" id="bailleurDateEffetBail" name="bailleurDateEffetBail" value="{{ bailleurDateEffetBail }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set bailDpeBail = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeBail : null %}
-                                <label class="fr-label" for="bailDpeBail">Bail</label>
-                                <select class="fr-select" name="bailDpeBail">
+                                <label class="fr-label" for="bailDpeBail">Bail (facultatif)</label>
+                                <select class="fr-select" id="bailDpeBail" name="bailDpeBail">
                                     <option value="" {{ bailDpeBail not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailDpeBail is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailDpeBail is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -73,8 +91,8 @@
 
                             <div class="fr-select-group">
                                 {% set bailDpeEtatDesLieux = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeEtatDesLieux : null %}
-                                <label class="fr-label" for="bailDpeEtatDesLieux">Etat des lieux</label>
-                                <select class="fr-select" name="bailDpeEtatDesLieux">
+                                <label class="fr-label" for="bailDpeEtatDesLieux">Etat des lieux (facultatif)</label>
+                                <select class="fr-select" id=bailDpeEtatDesLieux" name="bailDpeEtatDesLieux">
                                     <option value="" {{ bailDpeEtatDesLieux not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailDpeEtatDesLieux is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailDpeEtatDesLieux is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -84,8 +102,8 @@
 
                             <div class="fr-select-group">
                                 {% set bailDpeDpe = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeDpe : null %}
-                                <label class="fr-label" for="bailDpeDpe">DPE</label>
-                                <select class="fr-select" name="bailDpeDpe">
+                                <label class="fr-label" for="bailDpeDpe">DPE (facultatif)</label>
+                                <select class="fr-select" id="bailDpeDpe" name="bailDpeDpe">
                                     <option value="" {{ bailDpeDpe not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailDpeDpe is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailDpeDpe is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -94,14 +112,14 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="loyer">Montant du loyer</label>
-                                <input class="fr-input" type="number" name="loyer" value="{{ signalement.loyer }}">
+                                <label class="fr-label" for="loyer">Montant du loyer (facultatif)</label>
+                                <input class="fr-input" type="number" id="loyer" name="loyer" value="{{ signalement.loyer }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set loyersPayes = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsLoyersPayes : null %}
-                                <label class="fr-label" for="loyersPayes">Paiement loyers à jour</label>
-                                <select class="fr-select" name="loyersPayes">
+                                <label class="fr-label" for="loyersPayes">Paiement loyers à jour (facultatif)</label>
+                                <select class="fr-select" id="loyersPayes" name="loyersPayes">
                                     <option value="" {{ loyersPayes not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ loyersPayes is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ loyersPayes is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -113,8 +131,8 @@
                                 {% if signalement.informationComplementaire %}
                                     {% set anneeConstruction = signalement.informationComplementaire.informationsComplementairesLogementAnneeConstruction %}
                                 {% endif %}
-                                <label class="fr-label" for="anneeConstruction">Année de construction</label>
-                                <input class="fr-input" type="number" name="anneeConstruction" value="{{ anneeConstruction }}">
+                                <label class="fr-label" for="anneeConstruction">Année de construction (facultatif)</label>
+                                <input class="fr-input" type="number" id="anneeConstruction" name="anneeConstruction" value="{{ anneeConstruction }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -49,7 +49,7 @@
                                     }}
                                 </label>
                                 <select class="fr-select" id="informationLogementCompositionLogementEnfants" name="compositionLogementEnfants">
-                                    <option value="" {{ compositionLogementEnfants not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
+                                    <option value="" {{ compositionLogementEnfants not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ compositionLogementEnfants is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ compositionLogementEnfants is same as 'non' ? 'selected' : '' }}>Non</option>
                                 </select>

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -19,14 +19,14 @@
                                 {% else %}
                                     {% set nombrePersonnes = signalement.nbPersonsDeprecated %}
                                 {% endif %}
-                                <label class="fr-label" for="nombrePersonnes">Nb. personnes
+                                <label class="fr-label" for="informationLogementNombrePersonnes">Nb. personnes
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
                                         'nombrePersonnes',
                                         signalement.profileDeclarant)
                                     }}
                                 </label>
-                                <input class="fr-input" type="number" id="nombrePersonnes" name="nombrePersonnes" value="{{ nombrePersonnes }}">
+                                <input class="fr-input" type="number" id="informationLogementNombrePersonnes" name="nombrePersonnes" value="{{ nombrePersonnes }}">
                             </div>
 
                             <div class="fr-select-group">
@@ -40,15 +40,16 @@
                                         {% set compositionLogementEnfants = 'non' %}
                                     {% endif %}
                                 {% endif %}
-                                <label class="fr-label" for="compositionLogementEnfants">Enfants -6 ans
+                                <label class="fr-label" for="informationLogementCompositionLogementEnfants">Enfants -6 ans
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
                                         'compositionLogementEnfants',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <select class="fr-select" id="compositionLogementEnfants" name="compositionLogementEnfants">
-                                    <option value="" {{ compositionLogementEnfants not in ['oui', 'non'] ? 'selected' : '' }}></option>
+                                <select class="fr-select" id="informationLogementCompositionLogementEnfants" name="compositionLogementEnfants">
+                                    <option value="" {{ compositionLogementEnfants not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ compositionLogementEnfants is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ compositionLogementEnfants is same as 'non' ? 'selected' : '' }}>Non</option>
                                 </select>
@@ -59,14 +60,15 @@
                                 {% if signalement.dateEntree %}
                                     {% set dateEntree = signalement.dateEntree.format('Y-m-d') %}
                                 {% endif %}
-                                <label class="fr-label" for="dateEntree">Date arrivée
+                                <label class="fr-label" for="informationLogementDateEntree">Date arrivée
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
                                         'dateEntree',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <input class="fr-input" type="date" id="dateEntree" name="dateEntree" value="{{ dateEntree }}">
+                                <input class="fr-input" type="date" id="informationLogementDateEntree" name="dateEntree" value="{{ dateEntree }}">
                             </div>
 
                             <div class="fr-input-group">
@@ -74,14 +76,21 @@
                                 {% if signalement.informationComplementaire %}
                                     {% set bailleurDateEffetBail = signalement.informationComplementaire.informationsComplementairesSituationBailleurDateEffetBail %}
                                 {% endif %}
-                                <label class="fr-label" for="bailleurDateEffetBail">Date d'effet du bail (facultatif)</label>
-                                <input class="fr-input" type="date" id="bailleurDateEffetBail" name="bailleurDateEffetBail" value="{{ bailleurDateEffetBail }}">
+                                <label class="fr-label" for="informationLogementBailleurDateEffetBail">Date d'effet du bail (facultatif)</label>
+                                <input class="fr-input" type="date" id="informationLogementBailleurDateEffetBail" name="bailleurDateEffetBail" value="{{ bailleurDateEffetBail }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set bailDpeBail = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeBail : null %}
-                                <label class="fr-label" for="bailDpeBail">Bail (facultatif)</label>
-                                <select class="fr-select" id="bailDpeBail" name="bailDpeBail">
+                                <label class="fr-label" for="informationLogementBailDpeBail">Bail
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'bailDpeBail',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="informationLogementBailDpeBail" name="bailDpeBail">
                                     <option value="" {{ bailDpeBail not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailDpeBail is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailDpeBail is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -91,8 +100,15 @@
 
                             <div class="fr-select-group">
                                 {% set bailDpeEtatDesLieux = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeEtatDesLieux : null %}
-                                <label class="fr-label" for="bailDpeEtatDesLieux">Etat des lieux (facultatif)</label>
-                                <select class="fr-select" id=bailDpeEtatDesLieux" name="bailDpeEtatDesLieux">
+                                <label class="fr-label" for="informationLogementBailDpeEtatDesLieux">Etat des lieux
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'bailDpeEtatDesLieux',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="informationLogementBailDpeEtatDesLieux" name="bailDpeEtatDesLieux">
                                     <option value="" {{ bailDpeEtatDesLieux not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailDpeEtatDesLieux is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailDpeEtatDesLieux is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -102,8 +118,15 @@
 
                             <div class="fr-select-group">
                                 {% set bailDpeDpe = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeDpe : null %}
-                                <label class="fr-label" for="bailDpeDpe">DPE (facultatif)</label>
-                                <select class="fr-select" id="bailDpeDpe" name="bailDpeDpe">
+                                <label class="fr-label" for="informationLogementBailDpeDpe">DPE
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'bailDpeDpe',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="informationLogementBailDpeDpe" name="bailDpeDpe">
                                     <option value="" {{ bailDpeDpe not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ bailDpeDpe is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ bailDpeDpe is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -112,14 +135,14 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="loyer">Montant du loyer (facultatif)</label>
-                                <input class="fr-input" type="number" id="loyer" name="loyer" value="{{ signalement.loyer }}">
+                                <label class="fr-label" for="informationLogementLoyer">Montant du loyer (facultatif)</label>
+                                <input class="fr-input" type="number" id="informationLogementLoyer" name="loyer" value="{{ signalement.loyer }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set loyersPayes = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsLoyersPayes : null %}
-                                <label class="fr-label" for="loyersPayes">Paiement loyers à jour (facultatif)</label>
-                                <select class="fr-select" id="loyersPayes" name="loyersPayes">
+                                <label class="fr-label" for="informationLogementLoyersPayes">Paiement loyers à jour (facultatif)</label>
+                                <select class="fr-select" id="informationLogementLoyersPayes" name="loyersPayes">
                                     <option value="" {{ loyersPayes not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ loyersPayes is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ loyersPayes is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -131,8 +154,8 @@
                                 {% if signalement.informationComplementaire %}
                                     {% set anneeConstruction = signalement.informationComplementaire.informationsComplementairesLogementAnneeConstruction %}
                                 {% endif %}
-                                <label class="fr-label" for="anneeConstruction">Année de construction (facultatif)</label>
-                                <input class="fr-input" type="number" id="anneeConstruction" name="anneeConstruction" value="{{ anneeConstruction }}">
+                                <label class="fr-label" for="informationLogementAnneeConstruction">Année de construction (facultatif)</label>
+                                <input class="fr-input" type="number" id="informationLogementAnneeConstruction" name="anneeConstruction" value="{{ anneeConstruction }}">
                             </div>
                         </div>
                         

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -11,11 +11,11 @@
                             <h1 id="fr-modal-title-modal-edit-procedure-demarches" class="fr-modal__title">
                                 Modifier procédure et démarches
                             </h1>
-
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-select-group">
                                 {% set isProprioAverti = signalement.isProprioAverti %}
                                 <label class="fr-label" for="isProprioAverti">Bailleur averti</label>
-                                <select class="fr-select" name="isProprioAverti">
+                                <select class="fr-select" id="isProprioAverti" name="isProprioAverti">
                                     <option value="" {{ isProprioAverti is same as null ? 'selected' : '' }}></option>
                                     <option value="1" {{ isProprioAverti is same as true ? 'selected' : '' }}>Oui</option>
                                     <option value="0" {{ isProprioAverti is same as false ? 'selected' : '' }}>Non</option>
@@ -25,7 +25,7 @@
                             <div class="fr-select-group">
                                 {% set infoProcedureAssuranceContactee = signalement.informationProcedure ? signalement.informationProcedure.infoProcedureAssuranceContactee : null %}
                                 <label class="fr-label" for="infoProcedureAssuranceContactee">Contact assurance</label>
-                                <select class="fr-select" name="infoProcedureAssuranceContactee">
+                                <select class="fr-select" id="infoProcedureAssuranceContactee" name="infoProcedureAssuranceContactee">
                                     <option value="" {{ infoProcedureAssuranceContactee not in ['oui', 'non', 'pas_assurance_logement'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ infoProcedureAssuranceContactee is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ infoProcedureAssuranceContactee is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -34,14 +34,14 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="infoProcedureReponseAssurance">Réponse assurance</label>
+                                <label class="fr-label" for="infoProcedureReponseAssurance">Réponse assurance (si assurance contactée)</label>
                                 <textarea class="fr-input fr-input--no-resize" name="infoProcedureReponseAssurance">{{ signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance ? signalement.informationProcedure.infoProcedureReponseAssurance : '' }}</textarea>
                             </div>
 
                             <div class="fr-input-group">
                                 {% set infoProcedureDepartApresTravaux = signalement.informationProcedure ? signalement.informationProcedure.infoProcedureDepartApresTravaux : null %}
                                 <label class="fr-label" for="infoProcedureDepartApresTravaux">Souhaite garder le logement après travaux</label>
-                                <select class="fr-select" name="infoProcedureDepartApresTravaux">
+                                <select class="fr-select" id="infoProcedureDepartApresTravaux" name="infoProcedureDepartApresTravaux">
                                     {# Careful : reversed regarding the question in the form #}
                                     <option value="" {{ infoProcedureDepartApresTravaux not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="non" {{ infoProcedureDepartApresTravaux is same as 'non' ? 'selected' : '' }}>Oui</option>

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -14,8 +14,15 @@
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-select-group">
                                 {% set isProprioAverti = signalement.isProprioAverti %}
-                                <label class="fr-label" for="isProprioAverti">Bailleur averti</label>
-                                <select class="fr-select" id="isProprioAverti" name="isProprioAverti">
+                                <label class="fr-label" for="procedureDemarchesIsProprioAverti">Bailleur averti
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
+                                        'isRelogement',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="procedureDemarchesIsProprioAverti" name="isProprioAverti">
                                     <option value="" {{ isProprioAverti is same as null ? 'selected' : '' }}></option>
                                     <option value="1" {{ isProprioAverti is same as true ? 'selected' : '' }}>Oui</option>
                                     <option value="0" {{ isProprioAverti is same as false ? 'selected' : '' }}>Non</option>
@@ -24,8 +31,16 @@
 
                             <div class="fr-select-group">
                                 {% set infoProcedureAssuranceContactee = signalement.informationProcedure ? signalement.informationProcedure.infoProcedureAssuranceContactee : null %}
-                                <label class="fr-label" for="infoProcedureAssuranceContactee">Contact assurance</label>
-                                <select class="fr-select" id="infoProcedureAssuranceContactee" name="infoProcedureAssuranceContactee">
+                                <label class="fr-label" for="procedureDemarchesInfoProcedureAssuranceContactee">
+                                    Contact assurance
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\ProcedureDemarchesRequest',
+                                        'infoProcedureAssuranceContactee',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="procedureDemarchesInfoProcedureAssuranceContactee" name="infoProcedureAssuranceContactee">
                                     <option value="" {{ infoProcedureAssuranceContactee not in ['oui', 'non', 'pas_assurance_logement'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ infoProcedureAssuranceContactee is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ infoProcedureAssuranceContactee is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -34,14 +49,21 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="infoProcedureReponseAssurance">Réponse assurance (si assurance contactée)</label>
-                                <textarea class="fr-input fr-input--no-resize" name="infoProcedureReponseAssurance">{{ signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance ? signalement.informationProcedure.infoProcedureReponseAssurance : '' }}</textarea>
+                                <label class="fr-label" for="procedureDemarchesInfoProcedureReponseAssurance">Réponse assurance (si assurance contactée)</label>
+                                <textarea class="fr-input fr-input--no-resize" id="procedureDemarchesInfoProcedureReponseAssurance" name="infoProcedureReponseAssurance">{{ signalement.informationProcedure and signalement.informationProcedure.infoProcedureReponseAssurance ? signalement.informationProcedure.infoProcedureReponseAssurance : '' }}</textarea>
                             </div>
 
                             <div class="fr-input-group">
                                 {% set infoProcedureDepartApresTravaux = signalement.informationProcedure ? signalement.informationProcedure.infoProcedureDepartApresTravaux : null %}
-                                <label class="fr-label" for="infoProcedureDepartApresTravaux">Souhaite garder le logement après travaux</label>
-                                <select class="fr-select" id="infoProcedureDepartApresTravaux" name="infoProcedureDepartApresTravaux">
+                                <label class="fr-label" for="procedureDemarchesInfoProcedureDepartApresTravaux">Souhaite garder le logement après travaux
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\ProcedureDemarchesRequest',
+                                        'infoProcedureDepartApresTravaux',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="procedureDemarchesInfoProcedureDepartApresTravaux" name="infoProcedureDepartApresTravaux">
                                     {# Careful : reversed regarding the question in the form #}
                                     <option value="" {{ infoProcedureDepartApresTravaux not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="non" {{ infoProcedureDepartApresTravaux is same as 'non' ? 'selected' : '' }}>Oui</option>

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -11,11 +11,11 @@
                             <h1 id="fr-modal-title-modal-edit-situation-foyer" class="fr-modal__title">
                                 Modifier la situation du foyer
                             </h1>
-
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-select-group">
                                 {% set isLogementSocial = signalement.isLogementSocial %}
                                 <label class="fr-label" for="isLogementSocial">Logement social</label>
-                                <select class="fr-select" name="isLogementSocial">
+                                <select class="fr-select" id="isLogementSocial" name="isLogementSocial">
                                     <option value="nsp" {{ isLogementSocial is null ? 'selected' : '' }}>Je ne sais pas</option>
                                     <option value="oui" {{ isLogementSocial is same as true ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ isLogementSocial is same as false ? 'selected' : '' }}>Non</option>
@@ -23,8 +23,14 @@
                             </div>
 
                             <div class="fr-select-group">
-                                <label class="fr-label" for="isRelogement">Demande logement social / relogement</label>
-                                <select class="fr-select" name="isRelogement">
+                                <label class="fr-label" for="isRelogement">Demande logement social / relogement
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
+                                        'isRelogement',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="isRelogement" name="isRelogement">
                                     <option value=""></option>
                                     <option value="oui" {{ signalement.isRelogement is same as true ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ signalement.isRelogement is same as false ? 'selected' : '' }}>Non</option>
@@ -33,8 +39,14 @@
 
                             <div class="fr-select-group">
                                 {% set isAllocataire = signalement.isAllocataire %}
-                                <label class="fr-label" for="isAllocataire">Allocataire</label>
-                                <select class="fr-select" name="isAllocataire">
+                                <label class="fr-label" for="isAllocataire">Allocataire
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
+                                        'isAllocataire',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="isAllocataire" name="isAllocataire">
                                     <option value="" {{isAllocataire in [null, ''] ? 'selected' : '' }}></option>
                                     <option value="CAF" {{ isAllocataire is same as 'CAF' ? 'selected' : '' }}>CAF</option>
                                     <option value="MSA" {{ isAllocataire is same as 'MSA' ? 'selected' : '' }}>MSA</option>
@@ -44,13 +56,13 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="dateNaissanceOccupant">Date de naissance</label>
-                                <input class="fr-input" type="date" name="dateNaissanceOccupant" value="{{ signalement.dateNaissanceOccupant.format('Y-m-d') ?? signalement.naissanceOccupants ?? '' }}">
+                                <label class="fr-label" for="dateNaissanceOccupant">Date de naissance (si allocataire)</label>
+                                <input class="fr-input" type="date" id="dateNaissanceOccupant" name="dateNaissanceOccupant" value="{{ signalement.dateNaissanceOccupant.format('Y-m-d') ?? signalement.naissanceOccupants ?? '' }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="numAllocataire">N° allocataire</label>
-                                <input class="fr-input" type="text" name="numAllocataire" value="{{ signalement.numAllocataire }}">
+                                <label class="fr-label" for="numAllocataire">N° allocataire (facultatif)</label>
+                                <input class="fr-input" type="text" id="numAllocataire" name="numAllocataire" value="{{ signalement.numAllocataire }}">
                             </div>
 
                             <div class="fr-input-group">
@@ -58,14 +70,20 @@
                                 {% if signalement.situationFoyer and signalement.situationFoyer.logementSocialMontantAllocation %}
                                     {% set logementSocialMontantAllocation = signalement.situationFoyer.logementSocialMontantAllocation %}
                                 {% endif %}
-                                <label class="fr-label" for="logementSocialMontantAllocation">Montant allocation (€)</label>
-                                <input class="fr-input" type="text" name="logementSocialMontantAllocation" value="{{ logementSocialMontantAllocation }}">
+                                <label class="fr-label" for="logementSocialMontantAllocation">Montant allocation (€) (facultatif)</label>
+                                <input class="fr-input" type="text" id="logementSocialMontantAllocation" name="logementSocialMontantAllocation" value="{{ logementSocialMontantAllocation }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set travailleurSocialQuitteLogement = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialQuitteLogement : null %}
-                                <label class="fr-label" for="travailleurSocialQuitteLogement">Souhaite quitter le logement</label>
-                                <select class="fr-select" name="travailleurSocialQuitteLogement">
+                                <label class="fr-label" for="travailleurSocialQuitteLogement">Souhaite quitter le logement
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
+                                        'travailleurSocialQuitteLogement',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="travailleurSocialQuitteLogement" name="travailleurSocialQuitteLogement">
                                     <option value="" {{ travailleurSocialQuitteLogement not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ travailleurSocialQuitteLogement is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ travailleurSocialQuitteLogement is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -82,8 +100,8 @@
                                         {% set travailleurSocialPreavisDepart = 'non' %}
                                     {% endif %}
                                 {% endif %}
-                                <label class="fr-label" for="travailleurSocialPreavisDepart">Préavis de départ</label>
-                                <select class="fr-select" name="travailleurSocialPreavisDepart">
+                                <label class="fr-label" for="travailleurSocialPreavisDepart">Préavis de départ (si souhaite quitter le logement)</label>
+                                <select class="fr-select" id="travailleurSocialPreavisDepart" name="travailleurSocialPreavisDepart">
                                     <option value="" {{ travailleurSocialPreavisDepart not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ travailleurSocialPreavisDepart is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ travailleurSocialPreavisDepart is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -93,8 +111,15 @@
 
                             <div class="fr-select-group">
                                 {% set travailleurSocialAccompagnementDeclarant = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementDeclarant : null %}
-                                <label class="fr-label" for="travailleurSocialAccompagnementDeclarant">Accompagnement par un ou une travailleuse sociale</label>
-                                <select class="fr-select" name="travailleurSocialAccompagnementDeclarant">
+                                <label class="fr-label" for="travailleurSocialAccompagnementDeclarant">
+                                    Accompagnement par un ou une travailleuse sociale
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
+                                        'travailleurSocialAccompagnementDeclarant',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="travailleurSocialAccompagnementDeclarant" name="travailleurSocialAccompagnementDeclarant">
                                     <option value="" {{ travailleurSocialAccompagnementDeclarant not in ['1', '0'] ? 'selected' : '' }}></option>
                                     <option value="1" {{ travailleurSocialAccompagnementDeclarant is same as '1' ? 'selected' : '' }}>Oui</option>
                                     <option value="0" {{ travailleurSocialAccompagnementDeclarant is same as '0' ? 'selected' : '' }}>Non</option>
@@ -103,8 +128,8 @@
 
                             <div class="fr-select-group">
                                 {% set beneficiaireRsa = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa : null %}
-                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA</label>
-                                <select class="fr-select" name="beneficiaireRsa">
+                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA (facultatif)</label>
+                                <select class="fr-select" id="beneficiaireRsa" name="beneficiaireRsa">
                                     <option value="" {{ beneficiaireRsa not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ beneficiaireRsa is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ beneficiaireRsa is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -113,8 +138,8 @@
 
                             <div class="fr-select-group">
                                 {% set beneficiaireFsl = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireFsl : null %}
-                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL</label>
-                                <select class="fr-select" name="beneficiaireFsl">
+                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL (facultatif)</label>
+                                <select class="fr-select" id="beneficiaireFsl" name="beneficiaireFsl">
                                     <option value="" {{ beneficiaireFsl not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ beneficiaireFsl is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ beneficiaireFsl is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -123,8 +148,8 @@
 
                             {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT  %}
                             <div class="fr-input-group">
-                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence</label>
-                                <input class="fr-input" type="text" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ?? '0' }}">
+                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence (facultatif)</label>
+                                <input class="fr-input" type="text" id="revenuFiscal" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ?? '0' }}">
                             </div>
                             {% endif %}
                         </div>

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -14,8 +14,8 @@
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-select-group">
                                 {% set isLogementSocial = signalement.isLogementSocial %}
-                                <label class="fr-label" for="isLogementSocial">Logement social</label>
-                                <select class="fr-select" id="isLogementSocial" name="isLogementSocial">
+                                <label class="fr-label" for="situationFoyerIsLogementSocial">Logement social</label>
+                                <select class="fr-select" id="situationFoyerIsLogementSocial" name="isLogementSocial">
                                     <option value="nsp" {{ isLogementSocial is null ? 'selected' : '' }}>Je ne sais pas</option>
                                     <option value="oui" {{ isLogementSocial is same as true ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ isLogementSocial is same as false ? 'selected' : '' }}>Non</option>
@@ -23,14 +23,15 @@
                             </div>
 
                             <div class="fr-select-group">
-                                <label class="fr-label" for="isRelogement">Demande logement social / relogement
+                                <label class="fr-label" for="situationFoyerIsRelogement">Demande logement social / relogement
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
                                         'isRelogement',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <select class="fr-select" id="isRelogement" name="isRelogement">
+                                <select class="fr-select" id="situationFoyerIsRelogement" name="isRelogement">
                                     <option value=""></option>
                                     <option value="oui" {{ signalement.isRelogement is same as true ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ signalement.isRelogement is same as false ? 'selected' : '' }}>Non</option>
@@ -39,14 +40,15 @@
 
                             <div class="fr-select-group">
                                 {% set isAllocataire = signalement.isAllocataire %}
-                                <label class="fr-label" for="isAllocataire">Allocataire
+                                <label class="fr-label" for="situationFoyerIsAllocataire">Allocataire
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
                                         'isAllocataire',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <select class="fr-select" id="isAllocataire" name="isAllocataire">
+                                <select class="fr-select" id="situationFoyerIsAllocataire" name="isAllocataire">
                                     <option value="" {{isAllocataire in [null, ''] ? 'selected' : '' }}></option>
                                     <option value="CAF" {{ isAllocataire is same as 'CAF' ? 'selected' : '' }}>CAF</option>
                                     <option value="MSA" {{ isAllocataire is same as 'MSA' ? 'selected' : '' }}>MSA</option>
@@ -56,13 +58,13 @@
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="dateNaissanceOccupant">Date de naissance (si allocataire)</label>
-                                <input class="fr-input" type="date" id="dateNaissanceOccupant" name="dateNaissanceOccupant" value="{{ signalement.dateNaissanceOccupant.format('Y-m-d') ?? signalement.naissanceOccupants ?? '' }}">
+                                <label class="fr-label" for="situationFoyerDateNaissanceOccupant">Date de naissance (si allocataire)</label>
+                                <input class="fr-input" type="date" id="situationFoyerDateNaissanceOccupant" name="dateNaissanceOccupant" value="{{ signalement.dateNaissanceOccupant.format('Y-m-d') ?? signalement.naissanceOccupants ?? '' }}">
                             </div>
 
                             <div class="fr-input-group">
-                                <label class="fr-label" for="numAllocataire">N° allocataire (facultatif)</label>
-                                <input class="fr-input" type="text" id="numAllocataire" name="numAllocataire" value="{{ signalement.numAllocataire }}">
+                                <label class="fr-label" for="situationFoyerNumAllocataire">N° allocataire (facultatif)</label>
+                                <input class="fr-input" type="text" id="situationFoyerNumAllocataire" name="numAllocataire" value="{{ signalement.numAllocataire }}">
                             </div>
 
                             <div class="fr-input-group">
@@ -70,20 +72,21 @@
                                 {% if signalement.situationFoyer and signalement.situationFoyer.logementSocialMontantAllocation %}
                                     {% set logementSocialMontantAllocation = signalement.situationFoyer.logementSocialMontantAllocation %}
                                 {% endif %}
-                                <label class="fr-label" for="logementSocialMontantAllocation">Montant allocation (€) (facultatif)</label>
-                                <input class="fr-input" type="text" id="logementSocialMontantAllocation" name="logementSocialMontantAllocation" value="{{ logementSocialMontantAllocation }}">
+                                <label class="fr-label" for="situationFoyerLogementSocialMontantAllocation">Montant allocation (€) (facultatif)</label>
+                                <input class="fr-input" type="text" id="situationFoyerLogementSocialMontantAllocation" name="logementSocialMontantAllocation" value="{{ logementSocialMontantAllocation }}">
                             </div>
 
                             <div class="fr-select-group">
                                 {% set travailleurSocialQuitteLogement = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialQuitteLogement : null %}
-                                <label class="fr-label" for="travailleurSocialQuitteLogement">Souhaite quitter le logement
+                                <label class="fr-label" for="situationFoyerTravailleurSocialQuitteLogement">Souhaite quitter le logement
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
                                         'travailleurSocialQuitteLogement',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <select class="fr-select" id="travailleurSocialQuitteLogement" name="travailleurSocialQuitteLogement">
+                                <select class="fr-select" id="situationFoyerTravailleurSocialQuitteLogement" name="travailleurSocialQuitteLogement">
                                     <option value="" {{ travailleurSocialQuitteLogement not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ travailleurSocialQuitteLogement is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ travailleurSocialQuitteLogement is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -100,8 +103,8 @@
                                         {% set travailleurSocialPreavisDepart = 'non' %}
                                     {% endif %}
                                 {% endif %}
-                                <label class="fr-label" for="travailleurSocialPreavisDepart">Préavis de départ (si souhaite quitter le logement)</label>
-                                <select class="fr-select" id="travailleurSocialPreavisDepart" name="travailleurSocialPreavisDepart">
+                                <label class="fr-label" for="situationFoyerTravailleurSocialPreavisDepart">Préavis de départ (si souhaite quitter le logement)</label>
+                                <select class="fr-select" id="situationFoyerTravailleurSocialPreavisDepart" name="travailleurSocialPreavisDepart">
                                     <option value="" {{ travailleurSocialPreavisDepart not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ travailleurSocialPreavisDepart is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ travailleurSocialPreavisDepart is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -111,25 +114,27 @@
 
                             <div class="fr-select-group">
                                 {% set travailleurSocialAccompagnementDeclarant = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementDeclarant : null %}
-                                <label class="fr-label" for="travailleurSocialAccompagnementDeclarant">
+                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementDeclarant">
                                     Accompagnement par un ou une travailleuse sociale
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
                                         'travailleurSocialAccompagnementDeclarant',
-                                        signalement.profileDeclarant)
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <select class="fr-select" id="travailleurSocialAccompagnementDeclarant" name="travailleurSocialAccompagnementDeclarant">
-                                    <option value="" {{ travailleurSocialAccompagnementDeclarant not in ['1', '0'] ? 'selected' : '' }}></option>
+                                <select class="fr-select" id="situationFoyerTravailleurSocialAccompagnementDeclarant" name="travailleurSocialAccompagnementDeclarant">
+                                    <option value="" {{ travailleurSocialAccompagnementDeclarant not in ['1', '0', 'nsp'] ? 'selected' : '' }}></option>
                                     <option value="1" {{ travailleurSocialAccompagnementDeclarant is same as '1' ? 'selected' : '' }}>Oui</option>
                                     <option value="0" {{ travailleurSocialAccompagnementDeclarant is same as '0' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ travailleurSocialAccompagnementDeclarant is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 
                             <div class="fr-select-group">
                                 {% set beneficiaireRsa = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa : null %}
-                                <label class="fr-label" for="beneficiaireRsa">Bénéficiaire RSA (facultatif)</label>
-                                <select class="fr-select" id="beneficiaireRsa" name="beneficiaireRsa">
+                                <label class="fr-label" for="situationFoyerBeneficiaireRsa">Bénéficiaire RSA (facultatif)</label>
+                                <select class="fr-select" id="situationFoyerBeneficiaireRsa" name="beneficiaireRsa">
                                     <option value="" {{ beneficiaireRsa not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ beneficiaireRsa is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ beneficiaireRsa is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -138,8 +143,8 @@
 
                             <div class="fr-select-group">
                                 {% set beneficiaireFsl = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireFsl : null %}
-                                <label class="fr-label" for="beneficiaireFsl">Bénéficiaire FSL (facultatif)</label>
-                                <select class="fr-select" id="beneficiaireFsl" name="beneficiaireFsl">
+                                <label class="fr-label" for="situationFoyerBeneficiaireFsl">Bénéficiaire FSL (facultatif)</label>
+                                <select class="fr-select" id="situationFoyerBeneficiaireFsl" name="beneficiaireFsl">
                                     <option value="" {{ beneficiaireFsl not in ['oui', 'non'] ? 'selected' : '' }}></option>
                                     <option value="oui" {{ beneficiaireFsl is same as 'oui' ? 'selected' : '' }}>Oui</option>
                                     <option value="non" {{ beneficiaireFsl is same as 'non' ? 'selected' : '' }}>Non</option>
@@ -148,8 +153,8 @@
 
                             {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT  %}
                             <div class="fr-input-group">
-                                <label class="fr-label" for="revenuFiscal">Revenu fiscal de référence (facultatif)</label>
-                                <input class="fr-input" type="text" id="revenuFiscal" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ?? '0' }}">
+                                <label class="fr-label" for="situationFoyerRevenuFiscal">Revenu fiscal de référence (facultatif)</label>
+                                <input class="fr-input" type="text" id="situationFoyerRevenuFiscal" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ?? '0' }}">
                             </div>
                             {% endif %}
                         </div>

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-<div class="bloc-list fr-container--fluid text-word-break-all">
+<div class="bloc-list fr-container--fluid text-word-break-all" data-ajax-form>
     <div class="fr-grid-row fr-grid-row--gutters">
         {% if signalement.isNotOccupant %}
             {% if isNewFormEnabled and canEditSignalement %}

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -20,7 +20,6 @@ use App\Service\Signalement\CriticiteCalculator;
 use App\Service\Signalement\DesordreTraitement\DesordreCompositionLogementLoader;
 use App\Service\Signalement\Qualification\QualificationStatusService;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
-use App\Service\Signalement\SignalementInputValueMapper;
 use App\Specification\Signalement\SuroccupationSpecification;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -48,7 +47,6 @@ class SignalementManagerTest extends WebTestCase
     private ParameterBagInterface $parameterBag;
     private SignalementManager $signalementManager;
     private CsrfTokenManagerInterface $csrfTokenManager;
-    private SignalementInputValueMapper $signalementInputValueMapper;
     private SuroccupationSpecification $suroccupationSpecification;
     private CriticiteCalculator $criticiteCalculator;
     private SignalementQualificationUpdater $signalementQualificationUpdater;
@@ -73,7 +71,6 @@ class SignalementManagerTest extends WebTestCase
         $this->signalementExportFactory = static::getContainer()->get(SignalementExportFactory::class);
         $this->parameterBag = static::getContainer()->get(ParameterBagInterface::class);
         $this->csrfTokenManager = static::getContainer()->get(CsrfTokenManagerInterface::class);
-        $this->signalementInputValueMapper = static::getContainer()->get(SignalementInputValueMapper::class);
         $this->suroccupationSpecification = static::getContainer()->get(SuroccupationSpecification::class);
         $this->criticiteCalculator = static::getContainer()->get(CriticiteCalculator::class);
         $this->signalementQualificationUpdater = static::getContainer()->get(SignalementQualificationUpdater::class);
@@ -92,7 +89,6 @@ class SignalementManagerTest extends WebTestCase
             $this->signalementExportFactory,
             $this->parameterBag,
             $this->csrfTokenManager,
-            $this->signalementInputValueMapper,
             $this->suroccupationSpecification,
             $this->criticiteCalculator,
             $this->signalementQualificationUpdater,
@@ -273,7 +269,7 @@ class SignalementManagerTest extends WebTestCase
         /** @var ValidatorInterface $validator */
         $validator = static::getContainer()->get(ValidatorInterface::class);
         $errors = $validator->validate($emptyCompositionLogementRequest, null, ['Default', 'LOCATAIRE']);
-        $this->assertCount(10, $errors);
+        $this->assertCount(8, $errors);
         /** @var ConstraintViolationList $errors */
         $errorsAsString = (string) $errors;
         $this->assertStringContainsString('Merci de définir le nombre de pièces à vivre', $errorsAsString);

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -8,10 +8,12 @@ use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Signalement;
 use App\Entity\Territory;
+use App\Entity\User;
 use App\Factory\SignalementAffectationListViewFactory;
 use App\Factory\SignalementExportFactory;
 use App\Factory\SignalementFactory;
 use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
 use App\Repository\DesordreCritereRepository;
 use App\Repository\DesordrePrecisionRepository;
 use App\Service\Signalement\CriticiteCalculator;
@@ -23,7 +25,7 @@ use App\Specification\Signalement\SuroccupationSpecification;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Faker\Factory;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -31,7 +33,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class SignalementManagerTest extends KernelTestCase
+class SignalementManagerTest extends WebTestCase
 {
     public const TERRITORY_13 = 13;
 
@@ -53,11 +55,12 @@ class SignalementManagerTest extends KernelTestCase
     private DesordrePrecisionRepository $desordrePrecisionRepository;
     private DesordreCritereRepository $desordreCritereRepository;
     private DesordreCompositionLogementLoader $desordreCompositionLogementLoader;
+    private SuiviManager $suiviManager;
 
     protected function setUp(): void
     {
-        $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $client = static::createClient();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->security = static::getContainer()->get('security.helper');
         $this->signalementFactory = static::getContainer()->get(SignalementFactory::class);
@@ -77,6 +80,7 @@ class SignalementManagerTest extends KernelTestCase
         $this->desordrePrecisionRepository = static::getContainer()->get(DesordrePrecisionRepository::class);
         $this->desordreCritereRepository = static::getContainer()->get(DesordreCritereRepository::class);
         $this->desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
+        $this->suiviManager = static::getContainer()->get(SuiviManager::class);
 
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
@@ -95,7 +99,10 @@ class SignalementManagerTest extends KernelTestCase
             $this->desordrePrecisionRepository,
             $this->desordreCritereRepository,
             $this->desordreCompositionLogementLoader,
+            $this->suiviManager,
         );
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
     }
 
     public function testFindAllPartnersAffectedAndNotAffectedBySignalementLocalization()
@@ -266,7 +273,7 @@ class SignalementManagerTest extends KernelTestCase
         /** @var ValidatorInterface $validator */
         $validator = static::getContainer()->get(ValidatorInterface::class);
         $errors = $validator->validate($emptyCompositionLogementRequest, null, ['Default', 'LOCATAIRE']);
-        $this->assertCount(7, $errors);
+        $this->assertCount(10, $errors);
         /** @var ConstraintViolationList $errors */
         $errorsAsString = (string) $errors;
         $this->assertStringContainsString('Merci de définir le nombre de pièces à vivre', $errorsAsString);

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -6,24 +6,30 @@ use App\Entity\Enum\MotifCloture;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
+use App\EventListener\SignalementUpdatedListener;
 use App\Factory\SuiviFactory;
 use App\Manager\SuiviManager;
 use App\Repository\SuiviRepository;
 use App\Repository\UserRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class SuiviManagerTest extends KernelTestCase
 {
     private const REF_SIGNALEMENT = '2022-8';
     private ManagerRegistry $managerRegistry;
     private SuiviFactory $suiviFactory;
+    private SignalementUpdatedListener $signalementUpdatedListener;
+    private Security $security;
 
     protected function setUp(): void
     {
         self::bootKernel();
         $this->managerRegistry = self::getContainer()->get(ManagerRegistry::class);
         $this->suiviFactory = static::getContainer()->get(SuiviFactory::class);
+        $this->signalementUpdatedListener = static::getContainer()->get(SignalementUpdatedListener::class);
+        $this->security = static::getContainer()->get(Security::class);
     }
 
     public function testCreateSuivi(): void
@@ -31,6 +37,8 @@ class SuiviManagerTest extends KernelTestCase
         $suiviManager = new SuiviManager(
             $this->suiviFactory,
             $this->managerRegistry,
+            $this->signalementUpdatedListener,
+            $this->security,
             Suivi::class,
         );
 
@@ -63,6 +71,8 @@ class SuiviManagerTest extends KernelTestCase
         $suiviManager = new SuiviManager(
             $this->suiviFactory,
             $this->managerRegistry,
+            $this->signalementUpdatedListener,
+            $this->security,
             Suivi::class,
         );
 

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -22,7 +22,6 @@ use App\Service\Signalement\DesordreTraitement\DesordreTraitementProcessor;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use App\Service\Signalement\ReferenceGenerator;
 use App\Service\Signalement\SignalementBuilder;
-use App\Service\Signalement\SignalementInputValueMapper;
 use App\Service\Signalement\ZipcodeProvider;
 use App\Service\Token\TokenGeneratorInterface;
 use App\Service\UploadHandlerService;
@@ -56,7 +55,6 @@ class SignalementBuilderTest extends KernelTestCase
         $fileFactory = static::getContainer()->get(FileFactory::class);
         $uploadHandlerService = static::getContainer()->get(UploadHandlerService::class);
         $security = static::getContainer()->get(Security::class);
-        $signalementInputValueMapper = static::getContainer()->get(SignalementInputValueMapper::class);
         $desordreCategorieRepository = static::getContainer()->get(DesordreCategorieRepository::class);
         $this->desordreCritereRepository = static::getContainer()->get(DesordreCritereRepository::class);
         $this->desordrePrecisionRepository = static::getContainer()->get(DesordrePrecisionRepository::class);
@@ -79,7 +77,6 @@ class SignalementBuilderTest extends KernelTestCase
             $fileFactory,
             $uploadHandlerService,
             $security,
-            $signalementInputValueMapper,
             $desordreCategorieRepository,
             $this->desordreCritereRepository,
             $this->desordrePrecisionRepository,

--- a/tests/Unit/Entity/SignalementTest.php
+++ b/tests/Unit/Entity/SignalementTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Entity;
 
+use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\Qualification;
 use App\Entity\SignalementQualification;
 use App\Tests\FixturesHelper;
@@ -37,5 +38,34 @@ class SignalementTest extends KernelTestCase
                 Qualification::NON_DECENCE_ENERGETIQUE));
 
         $this->assertFalse($signalement->hasQualificaton(Qualification::RSD));
+    }
+
+    public function testGetProfileDeclarant(): void
+    {
+        $signalement = $this->getSignalement($this->getTerritory('Pas-de-calais', '62'));
+        $this->assertEquals(ProfileDeclarant::TIERS_PARTICULIER, $signalement->getProfileDeclarant());
+    }
+
+    /** @dataProvider provideProfileDeclarant */
+    public function testResolveProfileDeclarant(
+        bool $isNotOccupant,
+        ProfileDeclarant $profileDeclarant,
+        ?string $lienDeclarant = null
+    ): void {
+        $signalement = $this->getSignalement($this->getTerritory('Pas-de-calais', '62'));
+        $signalement->setIsNotOccupant($isNotOccupant);
+        $signalement->setLienDeclarantOccupant($lienDeclarant);
+
+        $this->assertEquals($profileDeclarant, $signalement->getProfileDeclarant());
+    }
+
+    public function provideProfileDeclarant(): \Generator
+    {
+        yield 'isOccupant LOCATION' => [false, ProfileDeclarant::LOCATAIRE];
+        yield 'isNotOccupant TIERS PROFESSIONNEL' => [true, ProfileDeclarant::TIERS_PRO, 'PROFESSIONNEL'];
+        yield 'isNotOccupant TIERS PRO' => [true, ProfileDeclarant::TIERS_PRO, 'pro'];
+        yield 'isNotOccupant TIERS assistance sociale' => [true, ProfileDeclarant::TIERS_PRO, 'assistante sociale'];
+        yield 'isNotOccupant TIERS curatrice' => [true, ProfileDeclarant::TIERS_PRO, 'curatrice'];
+        yield 'isNotOccupant PARTICULIER' => [true, ProfileDeclarant::TIERS_PARTICULIER];
     }
 }

--- a/tests/Unit/Service/Signalement/SignalementInputValueMapperTest.php
+++ b/tests/Unit/Service/Signalement/SignalementInputValueMapperTest.php
@@ -12,8 +12,7 @@ class SignalementInputValueMapperTest extends TestCase
      */
     public function testMap(string $inputValue, bool|string|null $mappedInputValue): void
     {
-        $signalementInputValueMapper = new SignalementInputValueMapper();
-        $this->assertEquals($mappedInputValue, $signalementInputValueMapper->map($inputValue));
+        $this->assertEquals($mappedInputValue, SignalementInputValueMapper::map($inputValue));
     }
 
     public function provideInputValue(): \Generator

--- a/tests/Unit/Utils/AttributeParserTest.php
+++ b/tests/Unit/Utils/AttributeParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Unit\Utils;
+
+use App\Dto\Request\Signalement\CoordonneesBailleurRequest;
+use App\Entity\Enum\ProfileDeclarant;
+use App\Utils\AttributeParser;
+use PHPUnit\Framework\TestCase;
+
+class AttributeParserTest extends TestCase
+{
+    public function testShowLabelAsFacultatif(): void
+    {
+        $label = AttributeParser::showLabelAsFacultatif(
+            CoordonneesBailleurRequest::class,
+            'nom',
+            ProfileDeclarant::SERVICE_SECOURS
+        );
+
+        $this->assertEquals('(facultatif)', $label);
+    }
+
+    public function testDoNotShowLabelAsFacultatif(): void
+    {
+        $label = AttributeParser::showLabelAsFacultatif(
+            CoordonneesBailleurRequest::class,
+            'nom',
+            ProfileDeclarant::LOCATAIRE
+        );
+
+        $this->assertEmpty($label);
+    }
+}

--- a/tests/Unit/Utils/AttributeParserTest.php
+++ b/tests/Unit/Utils/AttributeParserTest.php
@@ -3,31 +3,57 @@
 namespace App\Tests\Unit\Utils;
 
 use App\Dto\Request\Signalement\CoordonneesBailleurRequest;
+use App\Dto\Request\Signalement\InformationsLogementRequest;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Utils\AttributeParser;
 use PHPUnit\Framework\TestCase;
 
 class AttributeParserTest extends TestCase
 {
-    public function testShowLabelAsFacultatif(): void
-    {
-        $label = AttributeParser::showLabelAsFacultatif(
-            CoordonneesBailleurRequest::class,
-            'nom',
-            ProfileDeclarant::SERVICE_SECOURS
-        );
+    /**
+     * @dataProvider provideData
+     */
+    public function testShowLabelAsFacultatif(
+        string $dto,
+        string $field,
+        ProfileDeclarant $profileDeclarant,
+        bool $isNewForm,
+        string $result,
+    ): void {
+        $label = AttributeParser::showLabelAsFacultatif($dto, $field, $profileDeclarant, $isNewForm);
 
-        $this->assertEquals('(facultatif)', $label);
+        $this->assertEquals($result, $label);
     }
 
-    public function testDoNotShowLabelAsFacultatif(): void
+    public function provideData(): \Generator
     {
-        $label = AttributeParser::showLabelAsFacultatif(
+        yield 'New form - show label as facultatif' => [
             CoordonneesBailleurRequest::class,
             'nom',
-            ProfileDeclarant::LOCATAIRE
-        );
-
-        $this->assertEmpty($label);
+            ProfileDeclarant::SERVICE_SECOURS,
+            true,
+            '(facultatif)',
+        ];
+        yield 'New form - do not show label as facultatif' => [
+            CoordonneesBailleurRequest::class,
+            'nom',
+            ProfileDeclarant::LOCATAIRE,
+            true,
+            '',
+        ];
+        yield 'Old form - show label as facultatif' => [
+            InformationsLogementRequest::class,
+            'compositionLogementEnfants',
+            ProfileDeclarant::LOCATAIRE,
+            false,
+            '(facultatif)',
+        ];
+        yield 'Old form - do not show label as facultatif' => [
+            InformationsLogementRequest::class,
+            'nombrePersonnes',
+            ProfileDeclarant::LOCATAIRE,
+            false,
+            '',
+        ];
     }
 }


### PR DESCRIPTION
## Ticket

#2168    

## Description
Améliorer l'UX en affichant les erreurs dans la modale et mentionner les champs facultatifs 

## Changements apportés
* Soumission des formulaires en mode AJAX (à l'aide d'un l'attribut `data-ajax-form`)
* Adaptation du contrôleur `SignalementEditController`
* Revues des contraintes suite au document fourni dans le ticket (Merci Hélène :-))
* Ajout des contraintes manquantes
* Affichage de la mention facultatif de manière dynamique quand nécessaire
* Retourner un profil déclarant pour un ancien dossier
* Liaison des label aux champs

## Pré-requis
* `make npm-build` 
* Charger la collection postman pour créer les signalements `POST puis PUT`
![image](https://github.com/MTES-MCT/histologe/assets/5757116/6422a7e1-e39e-4a00-829e-5d3f25a02617)

## Tests
S'appuyer sur le fichiers pour vérifier les contraintes https://docs.google.com/spreadsheets/d/1hvhNHY5ZS-MtgbEBo8WCUrj4aKExJqMxGANP3Z1zDEg/edit?usp=sharing

- [ ] Créer un signalement pour chaque type de profil et éditer chaque modal en provoquant des erreurs afin de vérifier que les erreurs s'affichent bien dans la modale.
- [ ] **[Postman]** Créer un signalement pour chaque type de profil et éditer chaque modal puis soumettez le formulaire.
- [ ] Soumettez une modale en modifiant le token csrf, une alerte doit s'afficher.
- [ ] Faire des éditions avec un ancien formulaire (les nouveaux champs ne doivent pas être bloquant)