### PR TITLE
[BO - Signalement] Mise à disponibilité des rapports de visite

### DIFF
--- a/migrations/Version20240304151459.php
+++ b/migrations/Version20240304151459.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Enum\DocumentType;
+use App\Entity\File;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240304151459 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'rename document types';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE file SET document_type = \''.DocumentType::PROCEDURE_RAPPORT_DE_VISITE->name.'\' WHERE document_type = \'VISITE\' AND file_type = \''.File::FILE_TYPE_DOCUMENT.'\'');
+        $this->addSql('UPDATE file SET document_type = \''.DocumentType::PHOTO_VISITE->name.'\' WHERE document_type = \'VISITE\' AND file_type = \''.File::FILE_TYPE_PHOTO.'\'');
+        $this->addSql('UPDATE file SET document_type = \''.DocumentType::PHOTO_SITUATION->name.'\' WHERE document_type = \'SITUATION\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -174,7 +174,7 @@ class SignalementFileController extends AbstractController
                 $documentType = DocumentType::tryFrom($request->get('documentType'));
                 if (null !== $documentType) {
                     $file->setDocumentType($documentType);
-                    if (DocumentType::SITUATION === $documentType) {
+                    if (DocumentType::PHOTO_SITUATION === $documentType) {
                         $desordreSlug = $request->get('desordreSlug');
                         $desordreCritereSlugs = $signalement->getDesordreCriteres()->map(
                             fn (DesordreCritere $desordreCritere) => $desordreCritere->getSlugCritere()

--- a/src/DataFixtures/Loader/LoadInterventionData.php
+++ b/src/DataFixtures/Loader/LoadInterventionData.php
@@ -11,6 +11,7 @@ use App\Factory\FileFactory;
 use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
+use App\Service\ImageManipulationHandler;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -67,7 +68,7 @@ class LoadInterventionData extends Fixture implements OrderedFixtureInterface
                 $file = $this->fileFactory->createInstanceFrom(
                     filename: $document,
                     title: $document,
-                    type: 'pdf' === pathinfo($document, \PATHINFO_EXTENSION)
+                    type: \in_array(pathinfo($document, \PATHINFO_EXTENSION), ImageManipulationHandler::IMAGE_EXTENSION)
                         ? File::FILE_TYPE_DOCUMENT
                         : File::FILE_TYPE_PHOTO,
                     intervention: $intervention,

--- a/src/DataFixtures/Loader/LoadInterventionData.php
+++ b/src/DataFixtures/Loader/LoadInterventionData.php
@@ -73,7 +73,7 @@ class LoadInterventionData extends Fixture implements OrderedFixtureInterface
                     intervention: $intervention,
                     signalement: $intervention->getSignalement(),
                     user: $user,
-                    documentType: DocumentType::VISITE
+                    documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE
                 );
                 $manager->persist($file);
             }

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -431,7 +431,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                     type: File::FILE_TYPE_PHOTO,
                     signalement: $signalement,
                     // user: $user,
-                    documentType: DocumentType::SITUATION,
+                    documentType: DocumentType::PHOTO_SITUATION,
                     desordreSlug: $document['slug']
                 );
                 $manager->persist($file);

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -30,6 +30,7 @@ use App\Repository\SituationRepository;
 use App\Repository\TagRepository;
 use App\Repository\TerritoryRepository;
 use App\Repository\UserRepository;
+use App\Service\ImageManipulationHandler;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -246,7 +247,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             $file = $this->fileFactory->createInstanceFrom(
                 filename: $document['file'],
                 title: $document['titre'],
-                type: 'pdf' === pathinfo($document['file'], \PATHINFO_EXTENSION)
+                type: \in_array(pathinfo($document['file'], \PATHINFO_EXTENSION), ImageManipulationHandler::IMAGE_EXTENSION)
                     ? File::FILE_TYPE_DOCUMENT
                     : File::FILE_TYPE_PHOTO,
                 signalement: $signalement,

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -39,7 +39,7 @@ enum DocumentType: String
             self::BAILLEUR_REPONSE_BAILLEUR->name => 'Réponse bailleur',
             self::AUTRE->name => 'Autre',
             self::SITUATION->name => 'Photo de désordre',
-            self::VISITE->name => 'Photo de visite',
+            self::VISITE->name => 'Rapport de visite',
         ];
     }
 

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -20,8 +20,8 @@ enum DocumentType: String
     case BAILLEUR_DEVIS_POUR_TRAVAUX = 'BAILLEUR_DEVIS_POUR_TRAVAUX';
     case BAILLEUR_REPONSE_BAILLEUR = 'BAILLEUR_REPONSE_BAILLEUR';
     case AUTRE = 'AUTRE';
-    case SITUATION = 'SITUATION';
-    case VISITE = 'VISITE';
+    case PHOTO_SITUATION = 'PHOTO_SITUATION';
+    case PHOTO_VISITE = 'PHOTO_VISITE';
 
     public static function getLabelList(): array
     {
@@ -38,16 +38,16 @@ enum DocumentType: String
             self::BAILLEUR_DEVIS_POUR_TRAVAUX->name => 'Devis pour travaux',
             self::BAILLEUR_REPONSE_BAILLEUR->name => 'Réponse bailleur',
             self::AUTRE->name => 'Autre',
-            self::SITUATION->name => 'Photo de désordre',
-            self::VISITE->name => 'Rapport de visite',
+            self::PHOTO_SITUATION->name => 'Photo de désordre',
+            self::PHOTO_VISITE->name => 'Photo de visite',
         ];
     }
 
     public static function getPhotosList(): array
     {
         return [
-            self::SITUATION->name => self::SITUATION->label(),
-            self::VISITE->name => self::VISITE->label(),
+            self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
+            self::PHOTO_VISITE->name => self::PHOTO_VISITE->label(),
             self::AUTRE->name => self::AUTRE->label(),
         ];
     }
@@ -66,6 +66,8 @@ enum DocumentType: String
             self::PROCEDURE_SAISINE->name => self::PROCEDURE_SAISINE->label(),
             self::BAILLEUR_DEVIS_POUR_TRAVAUX->name => self::BAILLEUR_DEVIS_POUR_TRAVAUX->label(),
             self::BAILLEUR_REPONSE_BAILLEUR->name => self::BAILLEUR_REPONSE_BAILLEUR->label(),
+            self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
+            self::PHOTO_VISITE->name => self::PHOTO_VISITE->label(),
             self::AUTRE->name => self::AUTRE->label(),
         ];
     }

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -55,7 +55,7 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
                     'show_uploaded_file',
                     ['filename' => $intervention->getFiles()->first()->getFilename()],
                     UrlGeneratorInterface::ABSOLUTE_URL
-                ).'/'.$intervention->getSignalement()->getUuid();
+                ).'?t=___TOKEN___';
 
                 $description .= '<a href="'.$urlDocument.'" title="Afficher le document" rel="noopener" target="_blank">Afficher le document</a>';
             }

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -48,7 +48,7 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
             $description .= '<br>Commentaire opérateur :<br>';
             $description .= $intervention->getDetails();
 
-            if (!empty($intervention->getFiles())) {
+            if (!$intervention->getFiles()->isEmpty()) {
                 $description .= '<br>Rapport de visite : ';
 
                 $urlDocument = $this->urlGenerator->generate(

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -9,6 +9,7 @@ use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Workflow\Event\Event;
 
 class InterventionConfirmedSubscriber implements EventSubscriberInterface
@@ -19,6 +20,7 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
         private Security $security,
         private VisiteNotifier $visiteNotifier,
         private SuiviManager $suiviManager,
+        private UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
@@ -45,6 +47,19 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
             }
             $description .= '<br>Commentaire opérateur :<br>';
             $description .= $intervention->getDetails();
+
+            if (!empty($intervention->getFiles())) {
+                $description .= '<br>Rapport de visite : ';
+
+                $urlDocument = $this->urlGenerator->generate(
+                    'show_uploaded_file',
+                    ['filename' => $intervention->getFiles()->first()->getFilename()],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                ).'/'.$intervention->getSignalement()->getUuid();
+
+                $description .= '<a href="'.$urlDocument.'" title="Afficher le document" rel="noopener" target="_blank">Afficher le document</a>';
+            }
+
             $isUsagerNotified = $event->getContext()['isUsagerNotified'] ?? true;
             $suivi = $this->suiviManager->createSuivi(
                 user: $currentUser,

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -37,7 +37,7 @@ class InterventionEditedSubscriber implements EventSubscriberInterface
             $description .= 'Commentaire opérateur :<br>';
             $description .= $intervention->getDetails();
 
-            if (!empty($intervention->getFiles())) {
+            if (!$intervention->getFiles()->isEmpty()) {
                 $description .= '<br>Rapport de visite : ';
 
                 $urlDocument = $this->urlGenerator->generate(

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -48,7 +48,7 @@ class InterventionEditedSubscriber implements EventSubscriberInterface
 
                 $description .= '<a href="'.$urlDocument.'" title="Afficher le document" rel="noopener" target="_blank">Afficher le document</a>';
             }
-            
+
             $suivi = $this->suiviManager->createSuivi(
                 user: $currentUser,
                 signalement: $intervention->getSignalement(),

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -9,12 +9,14 @@ use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class InterventionEditedSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly VisiteNotifier $visiteNotifier,
         private readonly SuiviManager $suiviManager,
+        private UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
@@ -34,6 +36,19 @@ class InterventionEditedSubscriber implements EventSubscriberInterface
             $description = 'Edition de la conclusion de la visite par '.$partnerName.'.<br>';
             $description .= 'Commentaire opérateur :<br>';
             $description .= $intervention->getDetails();
+
+            if (!empty($intervention->getFiles())) {
+                $description .= '<br>Rapport de visite : ';
+
+                $urlDocument = $this->urlGenerator->generate(
+                    'show_uploaded_file',
+                    ['filename' => $intervention->getFiles()->first()->getFilename()],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                ).'/'.$intervention->getSignalement()->getUuid();
+
+                $description .= '<a href="'.$urlDocument.'" title="Afficher le document" rel="noopener" target="_blank">Afficher le document</a>';
+            }
+            
             $suivi = $this->suiviManager->createSuivi(
                 user: $currentUser,
                 signalement: $intervention->getSignalement(),

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -44,7 +44,7 @@ class InterventionEditedSubscriber implements EventSubscriberInterface
                     'show_uploaded_file',
                     ['filename' => $intervention->getFiles()->first()->getFilename()],
                     UrlGeneratorInterface::ABSOLUTE_URL
-                ).'/'.$intervention->getSignalement()->getUuid();
+                ).'?t=___TOKEN___';
 
                 $description .= '<a href="'.$urlDocument.'" title="Afficher le document" rel="noopener" target="_blank">Afficher le document</a>';
             }

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -70,7 +70,7 @@ class FileFactory
         ?Intervention $intervention = null,
     ): ?File {
         $documentType = SignalementDocumentTypeMapper::map($file['slug']);
-        $desordreSlug = DocumentType::SITUATION === $documentType ? $file['slug'] : null;
+        $desordreSlug = DocumentType::PHOTO_SITUATION === $documentType ? $file['slug'] : null;
         $fileDescription = $file['description'] ?? null;
 
         return $this->createInstanceFrom(

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -13,8 +13,10 @@ use App\Entity\Signalement;
 use App\Entity\User;
 use App\Factory\FileFactory;
 use App\Repository\InterventionRepository;
+use App\Service\ImageManipulationHandler;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\Persistence\ManagerRegistry;
+use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Workflow\WorkflowInterface;
@@ -30,6 +32,7 @@ class InterventionManager extends AbstractManager
         private readonly FileFactory $fileFactory,
         private readonly Security $security,
         private readonly LoggerInterface $logger,
+        private readonly FilesystemOperator $fileStorage,
         string $entityName = Intervention::class
     ) {
         parent::__construct($managerRegistry, $entityName);
@@ -209,13 +212,16 @@ class InterventionManager extends AbstractManager
         /** @var User $user */
         $user = $this->security->getUser();
 
+        $fileType = File::FILE_TYPE_DOCUMENT;
+        if (\in_array($this->fileStorage->mimeType($document), ImageManipulationHandler::IMAGE_MIME_TYPES)) {
+            $fileType = File::FILE_TYPE_PHOTO;
+        }
+
         // TODO : quand la modale sera fait, le documentType pourra être différent
         return $this->fileFactory->createInstanceFrom(
             filename: $document,
             title: $document,
-            type: 'pdf' === pathinfo($document, \PATHINFO_EXTENSION)
-                ? File::FILE_TYPE_DOCUMENT
-                : File::FILE_TYPE_PHOTO,
+            type: $fileType,
             signalement: $intervention->getSignalement(),
             user: $user,
             documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -218,7 +218,7 @@ class InterventionManager extends AbstractManager
                 : File::FILE_TYPE_PHOTO,
             signalement: $intervention->getSignalement(),
             user: $user,
-            documentType: DocumentType::VISITE
+            documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE
         );
     }
 }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -757,7 +757,7 @@ class SignalementManager extends AbstractManager
     public function getPhotosBySlug(Signalement $signalement, string $desordrePrecisionSlug): ?array
     {
         $photos = $signalement->getPhotos()->filter(function (File $file) use ($desordrePrecisionSlug) {
-            return DocumentType::SITUATION === $file->getDocumentType()
+            return DocumentType::PHOTO_SITUATION === $file->getDocumentType()
             && $file->getDesordreSlug() === $desordrePrecisionSlug;
         });
 

--- a/src/Service/Signalement/SignalementDocumentTypeMapper.php
+++ b/src/Service/Signalement/SignalementDocumentTypeMapper.php
@@ -13,7 +13,7 @@ class SignalementDocumentTypeMapper
         }
 
         if (str_starts_with($value, 'desordres_')) {
-            return DocumentType::SITUATION;
+            return DocumentType::PHOTO_SITUATION;
         }
 
         if (str_contains($value, 'dpe_bail')) {

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -23,7 +23,7 @@
                 <div>
                     {% if photo.documentType is not same as null
                         and photo.documentType is not same as enum('App\\Entity\\Enum\\DocumentType').AUTRE %}
-                        {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').SITUATION
+                        {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION
                                 and photo.desordreSlug is not same as null %}
                             {{ signalement.getDesordreLabel(photo.desordreSlug) }}
                         {% else %}

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -141,25 +141,25 @@
             <a href="{{ asset('_up/'~doc.filename~'/'~signalement.uuid) }}"
                 class="fr-btn fr-btn--sm fr-icon-eye-fill img-box" title="Afficher le document {{ doc.filename }}"
                 target="_blank" rel="noopener"></a>           
-               {% if is_granted('FILE_EDIT', doc) %}
-                    {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
-                    {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
-                    <button class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-edit-line btn-signalement-file-edit"
-                        id="file_edit_{{ doc.id }}" 
-                        title="Editer le document {{ doc.filename }}"
-                        aria-controls="fr-modal-edit-file"
-                        data-fr-opened="false" 
-                        data-filename="{{ doc.filename }}" 
-                        data-type="document" 
-                        data-file-id="{{ doc.id}}" 
-                        data-documentType="{{ doc.documentType.name }}" 
-                        data-documentType-list="{{ DocumentType.getDocumentsList() | json_encode }}"
-                        data-createdAt="{{ doc.createdAt is defined ? doc.createdAt|date('d.m.Y') : 'N/R' }}"
-                        data-partner-name="{{ doc.uploadedBy and doc.uploadedBy.partner ? doc.uploadedBy.partner.nom ~ ' - ' : '' }}"
-                        data-user-name="{{ doc.uploadedBy.nomComplet ?? 'N/R' }}"
-                    ></button>
-                {% endif %}       
-            {% if is_granted('FILE_DELETE', doc) %}
+            {% if is_granted('FILE_EDIT', doc) and doc.intervention is null %}
+                {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
+                {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
+                <button class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-edit-line btn-signalement-file-edit"
+                    id="file_edit_{{ doc.id }}" 
+                    title="Editer le document {{ doc.filename }}"
+                    aria-controls="fr-modal-edit-file"
+                    data-fr-opened="false" 
+                    data-filename="{{ doc.filename }}" 
+                    data-type="document" 
+                    data-file-id="{{ doc.id}}" 
+                    data-documentType="{{ doc.documentType.name }}" 
+                    data-documentType-list="{{ DocumentType.getDocumentsList() | json_encode }}"
+                    data-createdAt="{{ doc.createdAt is defined ? doc.createdAt|date('d.m.Y') : 'N/R' }}"
+                    data-partner-name="{{ doc.uploadedBy and doc.uploadedBy.partner ? doc.uploadedBy.partner.nom ~ ' - ' : '' }}"
+                    data-user-name="{{ doc.uploadedBy.nomComplet ?? 'N/R' }}"
+                ></button>
+            {% endif %}       
+            {% if is_granted('FILE_DELETE', doc) and doc.intervention is null %}
                 <button title="Supprimer le document {{ doc.filename }}"
                     data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'documents',filename:doc.filename}) }}"
                     data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -109,8 +109,7 @@
 </div>
 
 {% for index, doc in signalement.files|filter(
-    doc => doc.fileType == 'document' 
-            and doc.intervention is null
+    doc => doc.fileType == 'document'
             and (
                 (importedBy is same as 'user' and (doc.uploadedBy is null or doc.isUsagerFile ))
                 or (importedBy is same as 'partner' and (doc.uploadedBy is not null and doc.isPartnerFile))
@@ -130,7 +129,11 @@
                     {{ doc.uploadedBy and doc.uploadedBy.partner ? doc.uploadedBy.partner.nom ~ ' - ' : '' }}{{ doc.uploadedBy.nomComplet ?? 'N/R' }}
                 </div>
                 <div class="fr-col-12 fr-col-lg-4">
+                    {% if doc.intervention is null %}
                     <i>{{ doc.title|truncate_filename(45) }}</i>
+                    {% else %}
+                    <i>Rapport de visite du {{ doc.intervention.scheduledAt|date('d/m/Y') }}</i>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/tests/Functional/Manager/FileManagerTest.php
+++ b/tests/Functional/Manager/FileManagerTest.php
@@ -51,7 +51,7 @@ class FileManagerTest extends KernelTestCase
             type: File::FILE_TYPE_PHOTO,
             signalement: $signalement = $signalementRepository->findOneBy(['reference' => '2023-12']),
             description: $desc,
-            documentType: DocumentType::VISITE
+            documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE
         );
 
         $this->assertEquals('blank.jpg', $file->getFilename());
@@ -59,6 +59,6 @@ class FileManagerTest extends KernelTestCase
         $this->assertEquals('photo', $file->getFileType());
         $this->assertEquals($signalement->getReference(), $file->getSignalement()->getReference());
         $this->assertEquals($desc, $file->getDescription());
-        $this->assertEquals(DocumentType::VISITE, $file->getDocumentType());
+        $this->assertEquals(DocumentType::PROCEDURE_RAPPORT_DE_VISITE, $file->getDocumentType());
     }
 }

--- a/tests/Functional/Manager/InterventionManagerTest.php
+++ b/tests/Functional/Manager/InterventionManagerTest.php
@@ -14,6 +14,8 @@ use App\Repository\InterventionRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\Persistence\ManagerRegistry;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -30,6 +32,7 @@ class InterventionManagerTest extends KernelTestCase
     private FileFactory $fileFactory;
     private Security $security;
     private LoggerInterface $logger;
+    private MockObject|FilesystemOperator $fileStorage;
 
     private ?InterventionManager $interventionManager = null;
 
@@ -48,6 +51,7 @@ class InterventionManagerTest extends KernelTestCase
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
         $this->logger = static::getContainer()->get(LoggerInterface::class);
+        $this->fileStorage = $this->createMock(FilesystemOperator::class);
 
         $this->interventionManager = new InterventionManager(
             $this->managerRegistry,
@@ -57,7 +61,8 @@ class InterventionManagerTest extends KernelTestCase
             $this->signalementQualificationUpdater,
             $this->fileFactory,
             $this->security,
-            $this->logger
+            $this->logger,
+            $this->fileStorage
         );
     }
 

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -280,7 +280,7 @@ class SignalementManagerTest extends KernelTestCase
         $photos = $this->signalementManager->getPhotosBySlug($signalement, $desordrePrecisionSlug);
         $this->assertCount(1, $photos);
         $firstKey = array_keys($photos)[0];
-        $this->assertEquals(DocumentType::SITUATION, $photos[$firstKey]->getDocumentType());
+        $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[$firstKey]->getDocumentType());
         $this->assertEquals('Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png', $photos[$firstKey]->getTitle());
 
         $desordrePrecisionSlug = 'desordres_batiment_isolation_murs';

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -46,7 +46,7 @@ class FileFactoryTest extends TestCase
         $this->assertEquals($fileType, $file->getFileType());
         $this->assertEquals($documentType, $file->getDocumentType());
         $this->assertEquals($filename, $file->getFilename());
-        if (DocumentType::SITUATION === $file->getDocumentType()) {
+        if (DocumentType::PHOTO_SITUATION === $file->getDocumentType()) {
             $this->assertNotEmpty($file->getDesordreSlug());
         }
     }
@@ -122,7 +122,7 @@ class FileFactoryTest extends TestCase
             ],
             'dummy-filename-desordre.pdf',
             File::FILE_TYPE_DOCUMENT,
-            DocumentType::SITUATION,
+            DocumentType::PHOTO_SITUATION,
         ];
 
         yield 'Désordre photos pdf' => [
@@ -134,7 +134,7 @@ class FileFactoryTest extends TestCase
             ],
             'dummy-filename-desordre.pdf',
             File::FILE_TYPE_DOCUMENT,
-            DocumentType::SITUATION,
+            DocumentType::PHOTO_SITUATION,
         ];
     }
 }


### PR DESCRIPTION
## Ticket

#1983 
#2307

## Description
Lorsqu'un rapport de visite est saisi ou édité, le fichier de rapport de visite n'apparaissait pas dans les suivis générés automatiquement.
Le rapport de visite n'était pas non plus accessible via la liste des documents de la procédure.

## Changements apportés
* Ajout d'un lien vers le rapport dans les suivis générés lors de la confirmation ou l'édition d'une visite
* Ajout du rapport de visite dans la partie document des signalements
* Migration pour modifier les types possibles de photos et documents, pour que ce soit plus parlant

## Tests
- [ ] `make load-migrations` : les documents prennent le bon type
- [ ] Je crée une visite dans le passé en ajoutant un rapport de visite. Il est bien accessible dans le suivi : BO et Fiche usager
- [ ] J'édite une visite déjà effectuée. Idem
- [ ] Les documents sont bien accessibles dans la liste des documents
- [ ] Je ne peux pas éditer le rapport de visite directement dans la liste des documents
