### PR TITLE
[BO - signalement] Erreur sur l'attribution de désordres liés à la composition du logement

### DIFF
--- a/src/Command/UpdateSignalementDesordresCommand.php
+++ b/src/Command/UpdateSignalementDesordresCommand.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\DesordrePrecision;
+use App\Entity\Signalement;
+use App\Manager\SignalementManager;
+use App\Repository\DesordrePrecisionRepository;
+use App\Service\Signalement\DesordreTraitement\DesordreCompositionLogementLoader;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:update-signalement-desordres',
+    description: 'Recompute composition desordres for signalement',
+)]
+class UpdateSignalementDesordresCommand extends Command
+{
+    public function __construct(
+        private SignalementManager $signalementManager,
+        private DesordrePrecisionRepository $desordrePrecisionRepository,
+        private DesordreCompositionLogementLoader $desordreCompositionLogementLoader,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $signalements = $this->addSignalementsByDesordrePrecisionSlug(
+            'desordres_type_composition_logement_piece_unique_superficie'
+        );
+        $signalements = array_merge($signalements, $this->addSignalementsByDesordrePrecisionSlug(
+            'desordres_type_composition_logement_plusieurs_pieces_aucune_piece_9'
+        ));
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_piece_unique_hauteur')
+        );
+        $signalements = array_merge($signalements, $this->addSignalementsByDesordrePrecisionSlug(
+            'desordres_type_composition_logement_plusieurs_pieces_hauteur'
+        ));
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_cuisine_collective_oui')
+        );
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_cuisine_collective_non')
+        );
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_douche_collective_oui')
+        );
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_douche_collective_non')
+        );
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_wc_collectif_oui')
+        );
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_wc_collectif_non')
+        );
+        $signalements = array_merge(
+            $signalements,
+            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_wc_cuisine_ensemble')
+        );
+
+        if (empty($signalements)) {
+            $io->warning('No signalement with one of this desordrePrecision ');
+
+            return Command::SUCCESS;
+        }
+        $signalements = array_unique($signalements);
+        $io->info(\count($signalements).' signalements with one of this desordrePrecision');
+
+        /** @var Signalement $signalement */
+        foreach ($signalements as $signalement) {
+            if (null === $signalement->getCreatedFrom()) {
+                foreach ($signalement->getDesordreCategories() as $desordreCategorie) {
+                    $signalement->removeDesordreCategory($desordreCategorie);
+                }
+                foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
+                    $signalement->removeDesordreCritere($desordreCritere);
+                }
+                foreach ($signalement->getDesordrePrecisions() as $desordrePrecision) {
+                    $signalement->removeDesordrePrecision($desordrePrecision);
+                }
+            } else {
+                $this->desordreCompositionLogementLoader->load(
+                    $signalement,
+                    $signalement->getTypeCompositionLogement()
+                );
+            }
+
+            $this->signalementManager->persist($signalement);
+
+            $io->success(sprintf(
+                'Signalement %s updated.%sNb desordrePrecisions : %sNb desordreCriteres: %sNb desordreCategories: %s',
+                $signalement->getUuid(),
+                \PHP_EOL,
+                \count($signalement->getDesordrePrecisions()).\PHP_EOL,
+                \count($signalement->getDesordreCriteres()).\PHP_EOL,
+                \count($signalement->getDesordreCategories()).\PHP_EOL,
+            ));
+        }
+
+        $this->signalementManager->flush();
+
+        return Command::SUCCESS;
+    }
+
+    private function addSignalementsByDesordrePrecisionSlug(string $desordrePrecisionSlug): array
+    {
+        /** @var DesordrePrecision $desordrePrecision */
+        $desordrePrecision = $this->desordrePrecisionRepository->findOneBy(
+            ['desordrePrecisionSlug' => $desordrePrecisionSlug]
+        );
+
+        return $desordrePrecision->getSignalement()->toArray();
+    }
+}

--- a/src/Command/UpdateSignalementDesordresCommand.php
+++ b/src/Command/UpdateSignalementDesordresCommand.php
@@ -31,47 +31,23 @@ class UpdateSignalementDesordresCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $signalements = $this->addSignalementsByDesordrePrecisionSlug(
-            'desordres_type_composition_logement_piece_unique_superficie'
-        );
-        $signalements = array_merge($signalements, $this->addSignalementsByDesordrePrecisionSlug(
-            'desordres_type_composition_logement_plusieurs_pieces_aucune_piece_9'
-        ));
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_piece_unique_hauteur')
-        );
-        $signalements = array_merge($signalements, $this->addSignalementsByDesordrePrecisionSlug(
-            'desordres_type_composition_logement_plusieurs_pieces_hauteur'
-        ));
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_cuisine_collective_oui')
-        );
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_cuisine_collective_non')
-        );
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_douche_collective_oui')
-        );
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_douche_collective_non')
-        );
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_wc_collectif_oui')
-        );
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_wc_collectif_non')
-        );
-        $signalements = array_merge(
-            $signalements,
-            $this->addSignalementsByDesordrePrecisionSlug('desordres_type_composition_logement_wc_cuisine_ensemble')
-        );
+        $slugsPrecisions = [
+            'desordres_type_composition_logement_piece_unique_superficie',
+            'desordres_type_composition_logement_plusieurs_pieces_aucune_piece_9',
+            'desordres_type_composition_logement_piece_unique_hauteur',
+            'desordres_type_composition_logement_plusieurs_pieces_hauteur',
+            'desordres_type_composition_logement_cuisine_collective_oui',
+            'desordres_type_composition_logement_cuisine_collective_non',
+            'desordres_type_composition_logement_douche_collective_oui',
+            'desordres_type_composition_logement_douche_collective_non',
+            'desordres_type_composition_logement_wc_collectif_oui',
+            'desordres_type_composition_logement_wc_collectif_non',
+            'desordres_type_composition_logement_wc_cuisine_ensemble',
+        ];
+        $signalements = [];
+        foreach ($slugsPrecisions as $slugPrecision) {
+            $signalements = array_merge($signalements, $this->addSignalementsByDesordrePrecisionSlug($slugPrecision));
+        }
 
         if (empty($signalements)) {
             $io->warning('No signalement with one of this desordrePrecision ');

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2209,7 +2209,7 @@ class Signalement
 
     public function __toString(): string
     {
-        return $this->reference;
+        return $this->reference.' : '.$this->uuid;
     }
 
     public function hasQualificaton(Qualification $qualification): bool

--- a/src/Service/Signalement/DesordreTraitement/DesordreCompositionLogementLoader.php
+++ b/src/Service/Signalement/DesordreTraitement/DesordreCompositionLogementLoader.php
@@ -61,7 +61,7 @@ class DesordreCompositionLogementLoader
                     'desordres_type_composition_logement_piece_unique_superficie'
                 );
             }
-            if ('oui' !== $typeCompositionLogement->getCompositionLogementHauteur()) {
+            if ('non' === $typeCompositionLogement->getCompositionLogementHauteur()) {
                 $this->addDesordreCriterePrecisionBySlugs(
                     'desordres_type_composition_logement_piece_unique',
                     'desordres_type_composition_logement_piece_unique_hauteur'
@@ -73,7 +73,7 @@ class DesordreCompositionLogementLoader
                 );
             }
         } else {
-            if ('oui' !== $typeCompositionLogement->getTypeLogementCommoditesPieceAVivre9m()) {
+            if ('non' === $typeCompositionLogement->getTypeLogementCommoditesPieceAVivre9m()) {
                 $this->addDesordreCriterePrecisionBySlugs(
                     'desordres_type_composition_logement_plusieurs_pieces',
                     'desordres_type_composition_logement_plusieurs_pieces_aucune_piece_9'
@@ -84,7 +84,7 @@ class DesordreCompositionLogementLoader
                     'desordres_type_composition_logement_plusieurs_pieces_aucune_piece_9'
                 );
             }
-            if ('oui' !== $typeCompositionLogement->getCompositionLogementHauteur()) {
+            if ('non' === $typeCompositionLogement->getCompositionLogementHauteur()) {
                 $this->addDesordreCriterePrecisionBySlugs(
                     'desordres_type_composition_logement_plusieurs_pieces',
                     'desordres_type_composition_logement_plusieurs_pieces_hauteur'
@@ -97,8 +97,8 @@ class DesordreCompositionLogementLoader
             }
         }
 
-        if ('oui' !== $typeCompositionLogement->getTypeLogementCommoditesCuisine()) {
-            if ('oui' !== $typeCompositionLogement->getTypeLogementCommoditesCuisineCollective()) {
+        if ('non' === $typeCompositionLogement->getTypeLogementCommoditesCuisine()) {
+            if ('non' === $typeCompositionLogement->getTypeLogementCommoditesCuisineCollective()) {
                 $this->addDesordreCriterePrecisionBySlugs(
                     'desordres_type_composition_logement_cuisine',
                     'desordres_type_composition_logement_cuisine_collective_non'
@@ -120,8 +120,8 @@ class DesordreCompositionLogementLoader
             );
         }
 
-        if ('oui' !== $typeCompositionLogement->getTypeLogementCommoditesSalleDeBain()) {
-            if ('oui' !== $typeCompositionLogement->getTypeLogementCommoditesSalleDeBainCollective()) {
+        if ('non' === $typeCompositionLogement->getTypeLogementCommoditesSalleDeBain()) {
+            if ('non' === $typeCompositionLogement->getTypeLogementCommoditesSalleDeBainCollective()) {
                 $this->addDesordreCriterePrecisionBySlugs(
                     'desordres_type_composition_logement_douche',
                     'desordres_type_composition_logement_douche_collective_non'
@@ -143,8 +143,8 @@ class DesordreCompositionLogementLoader
             );
         }
 
-        if ('oui' !== $typeCompositionLogement->getTypeLogementCommoditesWc()) {
-            if ('oui' !== $typeCompositionLogement->getTypeLogementCommoditesWcCollective()) {
+        if ('non' === $typeCompositionLogement->getTypeLogementCommoditesWc()) {
+            if ('non' === $typeCompositionLogement->getTypeLogementCommoditesWcCollective()) {
                 $this->addDesordreCriterePrecisionBySlugs(
                     'desordres_type_composition_logement_wc',
                     'desordres_type_composition_logement_wc_collectif_non'

--- a/src/Service/Signalement/DesordreTraitement/DesordreCompositionLogementLoader.php
+++ b/src/Service/Signalement/DesordreTraitement/DesordreCompositionLogementLoader.php
@@ -23,6 +23,9 @@ class DesordreCompositionLogementLoader
         TypeCompositionLogement $typeCompositionLogement,
     ): void {
         $this->signalement = $signalement;
+        if (null === $this->signalement->getCreatedFrom()) {
+            return;
+        }
         if ('oui' === $typeCompositionLogement->getTypeLogementSousCombleSansFenetre()) {
             $this->addDesordreCriterePrecisionBySlugs(
                 'desordres_type_composition_logement_sous_combles',


### PR DESCRIPTION
## Ticket

#2312   

## Description
Après analyse, pour le problème des désordres liés à la composition du logement, on affectait les désordres au signalement si la réponse à certaines questions était différente de "oui". Je change ce fonctionnement pour n'avoir le désordre que si on répond "non".

## Changements apportés
* correction du DesordreCompositionLogementLoader.php pour ne pas lier les désordres si on répond "je ne sais pas", ou si c'est un signalemnt créé avec l'ancien formulaire
* création d'une commande pour corriger l'existant

## Pré-requis
**Avant de descendre la branche :** 
Faire un signalement en tiers (si possible tiers pro car il manque une question), et répondre le plus possible "je ne sais pas" (pour hauteur, pièce 9m, wc, sdb et cuisine) 
Vérifier que les désordres liés apparaissent dans la liste
Editer un signalement fait avec l'ancien formulaire. Editer la composition du logement. 
Vérifier en base que ce signalement se retrouve lié à des desordrePrecision, desordreCritere, desordreCategorie

**Descendre la branche**
`make composer`

## Tests
- [ ] Jouer la commande `make console app="update-signalement-desordres"`
- [ ] Vérifier en base que le signalement fait avec l'ancien formulaire n'est plus lié à des desordrePrecision, desordreCritere, desordreCategorie
- [ ] Aller voir le signalement créé préalablement en tiers, et vérifier que les désordres ont été corrigés
- [ ] Ouvrir un signalement créé avec l'ancien formulaire, modifier la composition du logement. -> vérifier en base qu'aucun desordre du nouveau formulaire n'a été lié
- [ ] Ouvrir un signalement créé avec le nouveau formulaire, éditer la composition du logement en mettant "je ne sais pas", vérifier que ça ne créé pas un désordre
