### PR TITLE
[FO - Fiche signalement] Documents non accessible pour usagers

### DIFF
--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -32,7 +32,11 @@ class FileVoter extends Voter
     {
         /** @var User $user */
         $user = $token->getUser();
-        if (!$user instanceof UserInterface || (!$subject instanceof Signalement && !$subject instanceof File)) {
+        if (!$user instanceof UserInterface && self::VIEW === $attribute) {
+            return $this->canView($subject);
+        }
+
+        if (!$subject instanceof Signalement && !$subject instanceof File) {
             return false;
         }
         if (self::DELETE !== $attribute &&


### PR DESCRIPTION
## Ticket

#2317    

## Description
Permet la visualisation des documents pour les usagers (voir thread mattermost pour le choix technique)
Régression https://github.com/MTES-MCT/histologe/releases/tag/2.0.2


## Changements apportés
* Mise à jour du voter
* Mise à jour des templates afin que la route soit la même que les agents

## Pré-requis

## Tests
- [ ] En tant qu'agent, sur la fiche signalement ajouter des photos et des suivi avec documents
- [ ] En tant qu'usager sur la fiche de suivi ajouter des photos
