### PR TITLE
[FO - Signalement] Désordre d'incurie renseigné en tiers pas repris dans le fiche signalement

### DIFF
--- a/src/Command/UpdateSignalementDesordreIncurieCommand.php
+++ b/src/Command/UpdateSignalementDesordreIncurieCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\DesordrePrecision;
+use App\Entity\Enum\SignalementDraftStatus;
+use App\Entity\Signalement;
+use App\Entity\SignalementDraft;
+use App\Manager\DesordreCritereManager;
+use App\Manager\SignalementManager;
+use App\Repository\DesordreCritereRepository;
+use App\Repository\SignalementDraftRepository;
+use App\Service\Signalement\DesordreTraitement\DesordreTraitementProcessor;
+use App\Utils\DataPropertyArrayFilter;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:update-signalement-desordre-incurie',
+    description: 'Recompute desordre incurie',
+)]
+class UpdateSignalementDesordreIncurieCommand extends Command
+{
+    public function __construct(
+        private SignalementDraftRepository $signalementDraftRepository,
+        private SignalementManager $signalementManager,
+        private DesordreCritereManager $desordreCritereManager,
+        private DesordreCritereRepository $desordreCritereRepository,
+        private DesordreTraitementProcessor $desordreTraitementProcessor,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $signalementDrafts = $this->signalementDraftRepository->findBy(
+            ['status' => SignalementDraftStatus::EN_SIGNALEMENT]
+        );
+
+        if (empty($signalementDrafts)) {
+            $io->warning('No signalementDraft transformend in signalement');
+
+            return Command::SUCCESS;
+        }
+        $nbSignalementUpdated = 0;
+
+        /** @var SignalementDraft $signalementDraft */
+        foreach ($signalementDrafts as $signalementDraft) {
+            $payload = $signalementDraft->getPayload();
+
+            $filteredData = DataPropertyArrayFilter::filterByPrefix(
+                $payload,
+                ['desordres_logement_proprete']
+            );
+            if (\count($filteredData) > 0) {
+                $io->info('signalementDraft '.$signalementDraft->getUuid().' has incurie information');
+                // trouver le signalement correspondant
+                $signalements = $signalementDraft->getSignalements();
+                /** @var Signalement $signalement */
+                foreach ($signalements as $signalement) {
+                    $ajoutPrecision = false;
+                    // vérifier s'il a les désordres liés à l'incurie
+                    $io->info('signalement lié '.$signalement->getUuid());
+
+                    $critereSlugDraft = $this->desordreCritereManager->getCriteresSlugsInDraft(
+                        $filteredData,
+                        ['desordres_logement_proprete']
+                    );
+                    $critereToLink = null;
+                    if (\count($critereSlugDraft) > 0) {
+                        $slugCritere = 'desordres_logement_proprete';
+                        $critereToLink = $this->desordreCritereRepository->findOneBy(['slugCritere' => $slugCritere]);
+                        if (null !== $critereToLink) {
+                            if (!$signalement->hasDesordreCritere($critereToLink)) {
+                                $signalement->addDesordreCritere($critereToLink);
+                                $io->info('Ajout du critère '.$critereToLink->getLabelCritere());
+                            } else {
+                                $io->info('Le signalement a déjà le critère '.$critereToLink->getLabelCritere());
+                            }
+                            $desordrePrecisions = $this->desordreTraitementProcessor->findDesordresPrecisionsBy(
+                                $critereToLink,
+                                $payload
+                            );
+                            if (null !== $desordrePrecisions) {
+                                /** @var DesordrePrecision $desordrePrecision */
+                                foreach ($desordrePrecisions as $desordrePrecision) {
+                                    if (null !== $desordrePrecision
+                                    && !$signalement->hasDesordrePrecision($desordrePrecision)) {
+                                        $signalement->addDesordrePrecision($desordrePrecision);
+                                        $io->info('Ajout de la précision '.$desordrePrecision->getLabel());
+                                        $ajoutPrecision = true;
+                                    } else {
+                                        $io->info('Le signalement a déjà la précision '.$desordrePrecision->getLabel());
+                                    }
+                                }
+                                if ($ajoutPrecision) {
+                                    ++$nbSignalementUpdated;
+                                }
+                            } else {
+                                $io->info('Il n\'y a pas de précisions à lier ');
+                            }
+                        } else {
+                            $io->info('Il n\'y a pas de critère à lier ');
+                        }
+                    }
+
+                    if (null !== $critereToLink
+                        && !$signalement->hasDesordreCategorie($critereToLink->getDesordreCategorie())) {
+                        // lier la catégorie BO idoine
+                        $signalement->addDesordreCategory($critereToLink->getDesordreCategorie());
+                        $io->info('Ajout de la catégorie '.$critereToLink->getDesordreCategorie()->getLabel());
+                    } elseif (null !== $critereToLink) {
+                        $io->info(
+                            'Le signalement a déjà la catégorie '.$critereToLink->getDesordreCategorie()->getLabel()
+                        );
+                    }
+                    $this->signalementManager->persist($signalement);
+                }
+            }
+        }
+        $io->success(sprintf(
+            '%s signalements updated.',
+            $nbSignalementUpdated
+        ));
+
+        $this->signalementManager->flush();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Manager/DesordreCritereManager.php
+++ b/src/Manager/DesordreCritereManager.php
@@ -68,6 +68,26 @@ class DesordreCritereManager extends AbstractManager
             $criteresSlugs['desordres_logement_chauffage_type_aucun'] = 1;
         }
 
+        // cas particulier pour desordres_logement_proprete
+        if (
+            (
+                isset($filteredDataOfDraft['desordres_logement_proprete_pieces_piece_a_vivre'])
+                && 1 === $filteredDataOfDraft['desordres_logement_proprete_pieces_piece_a_vivre']
+            )
+                ||
+            (
+                isset($filteredDataOfDraft['desordres_logement_proprete_pieces_cuisine'])
+                && 1 === $filteredDataOfDraft['desordres_logement_proprete_pieces_cuisine']
+            )
+                ||
+            (
+                isset($filteredDataOfDraft['desordres_logement_proprete_pieces_salle_de_bain'])
+                && 1 === $filteredDataOfDraft['desordres_logement_proprete_pieces_salle_de_bain']
+            )
+        ) {
+            $criteresSlugs['desordres_logement_proprete'] = 1;
+        }
+
         return $criteresSlugs;
     }
 }

--- a/src/Service/Signalement/DesordreTraitement/DesordreTraitementPieces.php
+++ b/src/Service/Signalement/DesordreTraitement/DesordreTraitementPieces.php
@@ -28,6 +28,7 @@ class DesordreTraitementPieces implements DesordreTraitementInterface
         if ((\array_key_exists($slugSansDetails1, $payload)
             && self::CHECKED_CRITERE_VALUE === $payload[$slugSansDetails1])
         || 'desordres_logement_chauffage_type_aucun' === $slugSansDetails1
+        || 'desordres_logement_proprete' === $slugSansDetails1
         ) {
             if ('piece_unique' === $payload['composition_logement_piece_unique']
                 || (


### PR DESCRIPTION
## Ticket

#2305    

## Description
Correction sur la prise en compte des désordres liés à l'incurie

## Changements apportés
* Correction dans le DesordreCritereManager et DesordreTraitementPieces pour prendre en compte les désordres
* Création d'une commande pour corriger l'existant

## Pré-requis
**Avant de descendre la branche**
* faire un ou des signalements en tiers déclarant en renseignant des désordres liés à l'incurie (logement  /propreté)
* vérifier que les désordres n'apparaissent pas dans le BO


## Tests
- [ ] Lancer la commande `make console app="update-signalement-desordre-incurie"`
- [ ] Vérifier que pour les signalements faits précédemment les désordres liés à l'incurie apparaissent bien maintenant
- [ ] Refaire un signalement en tiers déclarant et vérifier que les désordres liés à l'incurie apparaissent dans le BO
