### PR TITLE
[BUG] route : front_suivi_signalement_user_response

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -396,7 +396,8 @@ class FrontSignalementController extends AbstractController
             $fromEmail = \is_array($requestEmail) ? array_pop($requestEmail) : $requestEmail;
             $suiviAuto = $request->get('suiviAuto');
 
-            list($user, $type) = $userManager->getUserAndTypeForSignalementAndEmail($signalement, $fromEmail);
+            $user = $userManager->getOrCreateUserForSignalementAndEmail($signalement, $fromEmail);
+            $type = $userManager->getUserTypeForSignalementAndUser($signalement, $user);
             if ($user && $suiviAuto) {
                 $description = '';
                 if (Suivi::ARRET_PROCEDURE === $suiviAuto) {
@@ -457,7 +458,7 @@ class FrontSignalementController extends AbstractController
         if ($signalement = $signalementRepository->findOneByCodeForPublic($code)) {
             if ($this->isCsrfTokenValid('signalement_front_response_'.$signalement->getUuid(), $request->get('_token'))) {
                 $email = $request->get('signalement_front_response')['email'];
-                list($user) = $userManager->getUserAndTypeForSignalementAndEmail($signalement, $email);
+                $user = $userManager->getOrCreateUserForSignalementAndEmail($signalement, $email);
                 $suivi = $suiviFactory->createInstanceFrom(
                     user: $user,
                     signalement: $signalement,

--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -16,7 +16,6 @@ use App\Manager\UserManager;
 use App\Repository\CommuneRepository;
 use App\Repository\SignalementDraftRepository;
 use App\Repository\SignalementRepository;
-use App\Repository\UserRepository;
 use App\Serializer\SignalementDraftRequestSerializer;
 use App\Service\ImageManipulationHandler;
 use App\Service\Mailer\NotificationMail;
@@ -397,19 +396,7 @@ class FrontSignalementController extends AbstractController
             $fromEmail = \is_array($requestEmail) ? array_pop($requestEmail) : $requestEmail;
             $suiviAuto = $request->get('suiviAuto');
 
-            /** @var User $userOccupant */
-            $userOccupant = $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
-            /** @var User $userDeclarant */
-            $userDeclarant = $userManager->createUsagerFromSignalement($signalement, UserManager::DECLARANT);
-            $type = null;
-            $user = null;
-            if ($userOccupant && $fromEmail === $userOccupant->getEmail()) {
-                $type = UserManager::OCCUPANT;
-                $user = $userOccupant;
-            } elseif ($userDeclarant && $fromEmail === $userDeclarant->getEmail()) {
-                $type = UserManager::DECLARANT;
-                $user = $userDeclarant;
-            }
+            list($user, $type) = $userManager->getUserAndTypeForSignalementAndEmail($signalement, $fromEmail);
             if ($user && $suiviAuto) {
                 $description = '';
                 if (Suivi::ARRET_PROCEDURE === $suiviAuto) {
@@ -461,7 +448,7 @@ class FrontSignalementController extends AbstractController
     public function postUserResponse(
         string $code,
         SignalementRepository $signalementRepository,
-        UserRepository $userRepository,
+        UserManager $userManager,
         Request $request,
         EntityManagerInterface $entityManager,
         SuiviFactory $suiviFactory,
@@ -470,7 +457,7 @@ class FrontSignalementController extends AbstractController
         if ($signalement = $signalementRepository->findOneByCodeForPublic($code)) {
             if ($this->isCsrfTokenValid('signalement_front_response_'.$signalement->getUuid(), $request->get('_token'))) {
                 $email = $request->get('signalement_front_response')['email'];
-                $user = $userRepository->findOneBy(['email' => $email]);
+                list($user) = $userManager->getUserAndTypeForSignalementAndEmail($signalement, $email);
                 $suivi = $suiviFactory->createInstanceFrom(
                     user: $user,
                     signalement: $signalement,

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -168,19 +168,34 @@ class UserManager extends AbstractManager
         return null;
     }
 
-    public function getUserAndTypeForSignalementAndEmail(Signalement $signalement, ?string $email): array
+    public function getOrCreateUserForSignalementAndEmail(Signalement $signalement, ?string $email): ?User
     {
         /** @var User $userOccupant */
         $userOccupant = $this->createUsagerFromSignalement($signalement, self::OCCUPANT);
         /** @var User $userDeclarant */
         $userDeclarant = $this->createUsagerFromSignalement($signalement, self::DECLARANT);
         if ($userOccupant && $email === $userOccupant->getEmail()) {
-            return [$userOccupant, self::OCCUPANT];
+            return $userOccupant;
         } elseif ($userDeclarant && $email === $userDeclarant->getEmail()) {
-            return [$userDeclarant, self::DECLARANT];
+            return $userDeclarant;
         }
 
-        return [null, null];
+        return null;
+    }
+
+    public function getUserTypeForSignalementAndUser(Signalement $signalement, ?User $user): ?string
+    {
+        if (!$user) {
+            return null;
+        }
+
+        if ($user->getEmail() === $signalement->getMailOccupant()) {
+            return self::OCCUPANT;
+        } elseif ($user->getEmail() === $signalement->getMailDeclarant()) {
+            return self::DECLARANT;
+        }
+
+        return null;
     }
 
     public function getSystemUser(): ?User

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -127,16 +127,16 @@ class UserManager extends AbstractManager
     public function createUsagerFromSignalement(Signalement $signalement, string $type = self::OCCUPANT): ?User
     {
         $mail = (self::OCCUPANT === $type)
-        ? $signalement->getMailOccupant()
-        : $signalement->getMailDeclarant();
+            ? $signalement->getMailOccupant()
+            : $signalement->getMailDeclarant();
 
         $prenom = (self::OCCUPANT === $type)
-        ? $signalement->getPrenomOccupant()
-        : $signalement->getPrenomDeclarant();
+            ? $signalement->getPrenomOccupant()
+            : $signalement->getPrenomDeclarant();
 
         $nom = (self::OCCUPANT === $type)
-        ? $signalement->getNomOccupant()
-        : $signalement->getNomDeclarant();
+            ? $signalement->getNomOccupant()
+            : $signalement->getNomDeclarant();
 
         if (null !== $mail) {
             /** @var User $user */
@@ -166,6 +166,21 @@ class UserManager extends AbstractManager
         }
 
         return null;
+    }
+
+    public function getUserAndTypeForSignalementAndEmail(Signalement $signalement, ?string $email): array
+    {
+        /** @var User $userOccupant */
+        $userOccupant = $this->createUsagerFromSignalement($signalement, self::OCCUPANT);
+        /** @var User $userDeclarant */
+        $userDeclarant = $this->createUsagerFromSignalement($signalement, self::DECLARANT);
+        if ($userOccupant && $email === $userOccupant->getEmail()) {
+            return [$userOccupant, self::OCCUPANT];
+        } elseif ($userDeclarant && $email === $userDeclarant->getEmail()) {
+            return [$userDeclarant, self::DECLARANT];
+        }
+
+        return [null, null];
     }
 
     public function getSystemUser(): ?User

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -50,7 +50,7 @@
             {% else %}
                 {# si le suivi est de 2024 ou posterieur on indique annonyme #}
                 {% if suivi.createdAt|date('Y') >= 2024 %}
-                    Utilisateur inconnu
+                    Occupant ou déclarant
                 {% else %}
                     <strong>{{ signalement.isNotOccupant ? signalement.nomDeclarant|upper~' '~signalement.prenomDeclarant|capitalize : signalement.nomOccupant|upper~' '~signalement.prenomOccupant|capitalize }}</strong>
                     <br>

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -29,6 +29,7 @@
                 Suivi automatique
 
             {% elseif suivi.createdBy is not null %}
+                <strong>{{ suivi.createdBy.nomComplet|capitalize }}</strong>
                 <div class="part-infos-hover"
                      data-user="{{ suivi.createdBy.nomComplet }}"
                      data-mail="{{ suivi.createdBy.email }}">
@@ -47,9 +48,14 @@
                 }}
                 </div>
             {% else %}
-                <strong>{{ signalement.isNotOccupant ? signalement.nomDeclarant|upper~' '~signalement.prenomDeclarant|capitalize : signalement.nomOccupant|upper~' '~signalement.prenomOccupant|capitalize }}</strong>
-                <br>
-                {{ signalement.isNotOccupant ? 'DECLARANT':'OCCUPANT'}}
+                {# si le suivi est de 2024 ou posterieur on indique annonyme #}
+                {% if suivi.createdAt|date('Y') >= 2024 %}
+                    Utilisateur inconnu
+                {% else %}
+                    <strong>{{ signalement.isNotOccupant ? signalement.nomDeclarant|upper~' '~signalement.prenomDeclarant|capitalize : signalement.nomOccupant|upper~' '~signalement.prenomOccupant|capitalize }}</strong>
+                    <br>
+                    {{ signalement.isNotOccupant ? 'DECLARANT':'OCCUPANT'}}
+                {% endif %}
             {% endif %}
         </div>
 

--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -49,7 +49,7 @@
                 {% endif %}
                 <small class="{{ classe }}">{{ signalement.lastSuiviBy }}</small> <br>
             {% else %}
-                Aucun
+                Utilisateur inconnu
             {% endif %}
         </td>
         <td>

--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -49,7 +49,7 @@
                 {% endif %}
                 <small class="{{ classe }}">{{ signalement.lastSuiviBy }}</small> <br>
             {% else %}
-                Utilisateur inconnu
+                Occupant ou déclarant
             {% endif %}
         </td>
         <td>

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -95,7 +95,7 @@
             {% for suivi in signalement.suivis|reverse %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if not suivi.createdBy %}fr-background-alt--orange-terre-battue{% endif %}">
                     <div class="fr-col-12 fr-col-md-2">
-                        <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): (suivi.createdAt|date('Y') >= 2024) ? 'Utilisateur inconnu' : 'Vous' }}]</small>
+                        <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): (suivi.createdAt|date('Y') >= 2024) ? 'Occupant ou déclarant' : 'Vous' }}]</small>
                         <br>
                         <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
                     </div>

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -95,7 +95,7 @@
             {% for suivi in signalement.suivis|reverse %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if not suivi.createdBy %}fr-background-alt--orange-terre-battue{% endif %}">
                     <div class="fr-col-12 fr-col-md-2">
-                        <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): (suivi.createdAt|date('Y') >= 2024) ? 'Aucun' : 'Vous' }}]</small>
+                        <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): (suivi.createdAt|date('Y') >= 2024) ? 'Utilisateur inconnu' : 'Vous' }}]</small>
                         <br>
                         <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
                     </div>

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -95,8 +95,8 @@
             {% for suivi in signalement.suivis|reverse %}
                 <div class="fr-grid-row fr-grid-row--middle fr-stripped fr-rounded fr-p-5v {% if not suivi.createdBy %}fr-background-alt--orange-terre-battue{% endif %}">
                     <div class="fr-col-12 fr-col-md-2">
-                        <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): 'Vous' }}
-                            ]</small> <br>
+                        <small>[{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): (suivi.createdAt|date('Y') >= 2024) ? 'Aucun' : 'Vous' }}]</small>
+                        <br>
                         <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
                     </div>
                     <div class="fr-col-12 fr-col-md-10">


### PR DESCRIPTION
## Ticket

#2248

## Description
Sur la fiche signalement usager lors de la soumission d'un message/document : contrôle de l'email passé en parametre afin de ne pas permettre l'enregistrement du suivi/file avec l'id d'un utilisateur n'étant pas sur le signalement

## Tests
- [ ] Vérifier que la soumission fonctionne toujours quand l'email correspond à l'occupant/déclarant et que l'user est enregistré sur le suivi/document
- [ ] Vérifier que la soumission fonctionne quand le paramètre email n'est pas fournit sans que l'user soit enregistré sur le suivi/document
- [ ] Vérifier que la soumission fonctionne quand le paramètre email ne correspond ni à l'occupant ni au déclarant (ex admin-01@histologe.fr) sans que l'user soit enregistré sur le suivi/document
