### PR TITLE
[Oilhi] Supprimer champs problématiques à l'enregistrement Airtable

### DIFF
--- a/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
+++ b/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
@@ -15,6 +15,7 @@ use App\Entity\Signalement;
 use App\Entity\Situation;
 use App\Factory\Interconnection\DossierMessageFactoryInterface;
 use App\Messenger\Message\Oilhi\DossierMessage;
+use App\Service\HtmlCleaner;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -146,18 +147,17 @@ class DossierMessageFactory implements DossierMessageFactoryInterface
             }
 
             if (!$signalement->getDesordrePrecisions()->isEmpty()) {
-                $precisions = implode(
-                    ', ',
-                    $signalement
-                        ->getDesordrePrecisions()
-                        ->filter(function (DesordrePrecision $desordrePrecision) {
-                            return ' - ' !== $desordrePrecision->getLabel();
-                        })
-                        ->map(function (DesordrePrecision $desordrePrecision) {
-                            return $desordrePrecision->getLabel();
-                        })->toArray()
-                );
-                $desordres['precisions'] = str_replace('-', '', $precisions);
+                $precisionsList = $signalement
+                    ->getDesordrePrecisions()
+                    ->filter(function (DesordrePrecision $desordrePrecision) {
+                        return ' - ' !== $desordrePrecision->getLabel();
+                    })
+                    ->map(function (DesordrePrecision $desordrePrecision) {
+                        if (!empty($desordrePrecision->getLabel())) {
+                            return HtmlCleaner::clean($desordrePrecision->getLabel());
+                        }
+                    })->toArray();
+                $desordres['precisions'] = implode(',', array_filter($precisionsList));
             }
 
             return $desordres;

--- a/src/Service/Oilhi/HookZapierService.php
+++ b/src/Service/Oilhi/HookZapierService.php
@@ -33,6 +33,7 @@ class HookZapierService
     public function pushDossier(DossierMessage $dossierMessage): ResponseInterface|JsonResponse
     {
         $payload = $this->normalizer->normalize($dossierMessage);
+        $payload = $this->removeUselessFields($payload);
         $payload['token'] = $this->token;
         $options = [
             'headers' => [
@@ -57,5 +58,16 @@ class HookZapierService
         ];
 
         return (new JsonResponse($response))->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * Utile pour le traitement interne mais inutile à l'enregistrement dans Airtable.
+     */
+    private function removeUselessFields(array $payload): array
+    {
+        unset($payload['signalementId']);
+        unset($payload['partnerId']);
+
+        return $payload;
     }
 }


### PR DESCRIPTION
## Ticket

#2323    

## Description
Les champs non mappés bloquent l'enregistrement sur Airtable

## Changements apportés
* Suppression des champs `partnerId` et `signalementId`
* Suppression du html des précisions

## Pré-requis
* Mise à jour du keepass
* Récupérer les identifiants Zapier 
* Activer Oilhi et récupérer autres variables d'environnements

```
FEATURE_OILHI_ENABLE=1 
ZAPIER_OILHI_TOKEN=
ZAPIER_OILHI_USER_ID=
ZAPIER_OILHI_CREATE_AIRTABLE_RECORD_ZAP_ID=
```
* make worker-start
 
## Tests
- [ ] Affecter le partenaire **Partenaire 62-01** sur un signalement [#2024-02](http://localhost:8080/bo/signalements/00000000-0000-0000-2024-000000000002)  
- [ ] Connecter vous sur zapier et se rendre dans l'historique https://zapier.com/app/history
![image](https://github.com/MTES-MCT/histologe/assets/5757116/f5d1af83-2df6-4c34-8492-c8bfb21a9b9a)
