### PR TITLE
[FO - Signalement] Autocomplétion Bailleur social

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -44,4 +44,4 @@ import './controllers/back_signalement_view/form_edit_modal';
 import './controllers/back_signalement_edit_file/back_signalement_edit_file';
 import './controllers/back_signalement_view/form_upload_documents';
 import './controllers/front_demande_lien_signalement/front_demande_lien_signalement';
-
+import './controllers/back_signalement_view/input_autocomplete_bailleur';

--- a/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
+++ b/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
@@ -6,9 +6,7 @@ let isAutocompleteOpen = false;
 
 document.addEventListener('click', function(event) {
     if (!event.target.closest('.fr-autocomplete-list') && isAutocompleteOpen) {
-        document.querySelector('.fr-autocomplete-list').innerHTML = '';
-        isAutocompleteOpen = false;
-        selectedSuggestionIndex = -1;
+        closeSuggestions();
     }
 });
 
@@ -21,6 +19,8 @@ if (inputElement) {
             selectedSuggestionIndex = -1
             const url = `${inputElement.dataset.autocompleteBailleurUrl}&name=${name}`;
             fetchBailleur(url);
+        } else if (name.length <= 1) {
+            closeSuggestions();
         }
     });
 
@@ -102,8 +102,12 @@ function handleEnter() {
     const suggestions = document.querySelectorAll('.fr-autocomplete-suggestion');
     if (selectedSuggestionIndex !== -1) {
         inputElement.value = suggestions[selectedSuggestionIndex].textContent;
-        document.querySelector('.fr-autocomplete-list').innerHTML = '';
-        selectedSuggestionIndex = -1;
-        isAutocompleteOpen = false;
+        closeSuggestions();
     }
+}
+
+function closeSuggestions() {
+    document.querySelector('.fr-autocomplete-list').innerHTML = '';
+    selectedSuggestionIndex = -1;
+    isAutocompleteOpen = false;
 }

--- a/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
+++ b/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
@@ -5,8 +5,8 @@ let selectedSuggestionIndex = -1;
 let isAutocompleteOpen = false;
 
 document.addEventListener('click', function(event) {
-    if (!event.target.closest('.search-bailleur-autocomplete-list') && isAutocompleteOpen) {
-        document.querySelector('.search-bailleur-autocomplete-list').innerHTML = '';
+    if (!event.target.closest('.fr-autocomplete-list') && isAutocompleteOpen) {
+        document.querySelector('.fr-autocomplete-list').innerHTML = '';
         isAutocompleteOpen = false;
         selectedSuggestionIndex = -1;
     }
@@ -43,7 +43,7 @@ async function fetchBailleur(url) {
         const response = await fetch(url);
         const resultList = await response.json();
         if (response.ok) {
-            const ulElement = document.querySelector('.search-bailleur-autocomplete-list');
+            const ulElement = document.querySelector('.fr-autocomplete-list');
             ulElement.innerHTML = '';
             resultList.forEach((resultItem, index) => {
                 let suggestion = document.createElement('li');
@@ -102,7 +102,7 @@ function handleEnter() {
     const suggestions = document.querySelectorAll('.fr-autocomplete-suggestion');
     if (selectedSuggestionIndex !== -1) {
         inputElement.value = suggestions[selectedSuggestionIndex].textContent;
-        document.querySelector('.search-bailleur-autocomplete-list').innerHTML = '';
+        document.querySelector('.fr-autocomplete-list').innerHTML = '';
         selectedSuggestionIndex = -1;
         isAutocompleteOpen = false;
     }

--- a/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
+++ b/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
@@ -16,8 +16,10 @@ if (inputElement) {
     inputElement.addEventListener('keyup', function (event) {
         event.preventDefault();
         const isNavigationKey = ['ArrowDown', 'ArrowUp', 'Enter', ' '].includes(event.key);
-        if (!isNavigationKey && event.target.value.length > 1) {
-            const url = `${inputElement.dataset.autocompleteBailleurUrl}&name=${event.target.value}`;
+        const name = event.target.value.trim();
+        if (!isNavigationKey && name.length > 1) {
+            selectedSuggestionIndex = -1
+            const url = `${inputElement.dataset.autocompleteBailleurUrl}&name=${name}`;
             fetchBailleur(url);
         }
     });

--- a/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
+++ b/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/browser'
+
+const inputElement = document.querySelector('[data-autocomplete-bailleur-url]');
+
+if (inputElement) {
+    inputElement.addEventListener('keyup', function (event) {
+        event.preventDefault();
+        if (event.target.value.length > 1) {
+            const url = `${inputElement.dataset.autocompleteBailleurUrl}&name=${event.target.value}`;
+            fetchBailleur(url);
+        }
+    });
+}
+
+async function fetchBailleur(url) {
+    try {
+        const response = await fetch(url);
+        const resultList = await response.json();
+        if (response.ok) {
+            const divElement = document.querySelector('.search-bailleur-autocomplete-list');
+            divElement.innerHTML = '';
+            resultList.forEach((resultItem) => {
+                let suggestion = document.createElement('div');
+                suggestion.classList.add(
+                    'fr-col-12',
+                    'fr-p-3v',
+                    'fr-text-label--blue-france',
+                    'fr-bailleur-suggestion'
+                );
+                suggestion.textContent = resultItem.name;
+                suggestion.addEventListener('click', (event) => {
+                    inputElement.value = event.target.textContent;
+                    divElement.innerHTML = '';
+                })
+                divElement.append(suggestion);
+            });
+        }
+    } catch (error) {
+        console.error(error);
+        Sentry.captureException(new Error(error));
+    }
+}

--- a/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
+++ b/assets/controllers/back_signalement_view/input_autocomplete_bailleur.js
@@ -1,13 +1,37 @@
 import * as Sentry from '@sentry/browser'
 
 const inputElement = document.querySelector('[data-autocomplete-bailleur-url]');
+let selectedSuggestionIndex = -1;
+let isAutocompleteOpen = false;
+
+document.addEventListener('click', function(event) {
+    if (!event.target.closest('.search-bailleur-autocomplete-list') && isAutocompleteOpen) {
+        document.querySelector('.search-bailleur-autocomplete-list').innerHTML = '';
+        isAutocompleteOpen = false;
+        selectedSuggestionIndex = -1;
+    }
+});
 
 if (inputElement) {
     inputElement.addEventListener('keyup', function (event) {
         event.preventDefault();
-        if (event.target.value.length > 1) {
+        const isNavigationKey = ['ArrowDown', 'ArrowUp', 'Enter', ' '].includes(event.key);
+        if (!isNavigationKey && event.target.value.length > 1) {
             const url = `${inputElement.dataset.autocompleteBailleurUrl}&name=${event.target.value}`;
             fetchBailleur(url);
+        }
+    });
+
+    inputElement.addEventListener('keydown', function (event) {
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            handleDown();
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            handleUp();
+        } else if (event.key === 'Enter') {
+            event.preventDefault();
+            handleEnter();
         }
     });
 }
@@ -17,26 +41,67 @@ async function fetchBailleur(url) {
         const response = await fetch(url);
         const resultList = await response.json();
         if (response.ok) {
-            const divElement = document.querySelector('.search-bailleur-autocomplete-list');
-            divElement.innerHTML = '';
-            resultList.forEach((resultItem) => {
-                let suggestion = document.createElement('div');
+            const ulElement = document.querySelector('.search-bailleur-autocomplete-list');
+            ulElement.innerHTML = '';
+            resultList.forEach((resultItem, index) => {
+                let suggestion = document.createElement('li');
                 suggestion.classList.add(
                     'fr-col-12',
                     'fr-p-3v',
                     'fr-text-label--blue-france',
-                    'fr-bailleur-suggestion'
+                    'fr-autocomplete-suggestion'
                 );
                 suggestion.textContent = resultItem.name;
                 suggestion.addEventListener('click', (event) => {
                     inputElement.value = event.target.textContent;
-                    divElement.innerHTML = '';
-                })
-                divElement.append(suggestion);
+                    ulElement.innerHTML = '';
+                });
+
+                if (index === selectedSuggestionIndex) {
+                    suggestion.classList.add('fr-autocomplete-suggestion-highlighted');
+                }
+                ulElement.append(suggestion);
             });
+            isAutocompleteOpen = true;
         }
     } catch (error) {
         console.error(error);
         Sentry.captureException(new Error(error));
+    }
+}
+
+function handleDown() {
+    const suggestions = document.querySelectorAll('.fr-autocomplete-suggestion');
+    if (selectedSuggestionIndex < suggestions.length - 1) {
+        selectedSuggestionIndex++;
+        updateSelectedSuggestion();
+    }
+}
+
+function handleUp() {
+    if (selectedSuggestionIndex > 0) {
+        selectedSuggestionIndex--;
+        updateSelectedSuggestion();
+    }
+}
+
+function updateSelectedSuggestion() {
+    const suggestions = document.querySelectorAll('.fr-autocomplete-suggestion');
+    suggestions.forEach((suggestion, index) => {
+        if (index === selectedSuggestionIndex) {
+            suggestion.classList.add('fr-autocomplete-suggestion-highlighted');
+        } else {
+            suggestion.classList.remove('fr-autocomplete-suggestion-highlighted');
+        }
+    });
+}
+
+function handleEnter() {
+    const suggestions = document.querySelectorAll('.fr-autocomplete-suggestion');
+    if (selectedSuggestionIndex !== -1) {
+        inputElement.value = suggestions[selectedSuggestionIndex].textContent;
+        document.querySelector('.search-bailleur-autocomplete-list').innerHTML = '';
+        selectedSuggestionIndex = -1;
+        isAutocompleteOpen = false;
     }
 }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -715,6 +715,8 @@ div.photos-album {
         justify-content: space-between;
     }
 }
+
+.fr-bailleur-suggestion:hover,
 .fr-adresse-suggestion:hover {
     background-color: var(--artwork-minor-blue-cumulus);
     color: white !important;

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -716,10 +716,15 @@ div.photos-album {
     }
 }
 
+ul.search-bailleur-autocomplete-list {
+  list-style-type: none;
+}
+
 .fr-bailleur-suggestion:hover,
 .fr-adresse-suggestion:hover {
     background-color: var(--artwork-minor-blue-cumulus);
     color: white !important;
+    cursor: pointer;
 }
 .fr-address-group, .fr-address-group-bo{
     cursor: pointer;
@@ -743,3 +748,7 @@ div.photos-album {
     }
 }
 
+.fr-autocomplete-suggestion-highlighted {
+  background-color: #417dc4;
+  color: white !important;
+}

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -716,17 +716,18 @@ div.photos-album {
     }
 }
 
-ul.search-bailleur-autocomplete-list {
+ul.fr-autocomplete-list {
   list-style-type: none;
 }
 
-.fr-bailleur-suggestion:hover,
+.fr-autocomplete-suggestion:hover,
 .fr-adresse-suggestion:hover {
     background-color: var(--artwork-minor-blue-cumulus);
     color: white !important;
-    cursor: pointer;
 }
-.fr-address-group, .fr-address-group-bo{
+.fr-address-group,
+.fr-address-group-bo,
+.fr-autocomplete-list {
     cursor: pointer;
 }
 .fr-address-group {

--- a/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[customCss, 'fr-mb-3w']" :id="id">
+  <div :class="[customCss, 'fr-mb-3w']" :id="id + '_textfield'">
     <SignalementFormTextfield
         :key="id"
         :id="id"
@@ -117,8 +117,9 @@ export default defineComponent({
         this.selectedSuggestionIndex = -1
       }
     },
-    closeAutocomplete (event) {
-      if (!event.target.closest('.fr-autocomplete-group')) {
+    closeAutocomplete (event: any) {
+      const target = event.target as HTMLElement
+      if (target && !event.target.closest('.fr-autocomplete-group')) {
         this.suggestions = []
         this.selectedSuggestionIndex = -1
       }

--- a/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -135,5 +135,6 @@ export default defineComponent({
 ul.fr-autocomplete-group {
   list-style-type: none;
   margin-top: -1.5rem;
+  cursor: pointer;
 }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -1,9 +1,9 @@
 <template>
-  <div :class="[customCss, 'fr-mb-3w']" :id="id + '_textfield'">
+  <div :class="[customCss, 'fr-mb-3w']" :id="id">
     <SignalementFormTextfield
-        :key="id"
-        :id="id"
-        v-model="formStore.data[id]"
+        :key="idAutocomplete"
+        :id="idAutocomplete"
+        v-model="formStore.data[idAutocomplete]"
         :label="label"
         :description="description"
         :placeholder="placeholder"
@@ -57,6 +57,7 @@ export default defineComponent({
   data () {
     return {
       idFetchTimeout: 0 as unknown as ReturnType<typeof setTimeout>,
+      idAutocomplete: this.id + '_textfield',
       suggestions: [] as any[],
       formStore,
       selectedSuggestion: '',
@@ -66,17 +67,21 @@ export default defineComponent({
   created () {
     document.addEventListener('click', this.closeAutocomplete)
     watch(
-      () => this.formStore.data[this.id],
+      () => this.formStore.data[this.idAutocomplete],
       (newValue: any) => {
         clearTimeout(this.idFetchTimeout)
         this.idFetchTimeout = setTimeout(() => {
           const name = newValue.trim()
+          this.updateValue(name)
           if (name.length > 1) {
             this.selectedSuggestionIndex = -1
             const url = this.autocomplete.isAbsoluteLink
               ? variablesReplacer.replace(this.autocomplete.route)
               : window.location.origin + variablesReplacer.replace(this.autocomplete.route)
             requests.getAutompleteSuggestions(url, this.handleSuggestions)
+          } else {
+            this.suggestions = []
+            this.selectedSuggestionIndex = -1
           }
         }, 200)
       }
@@ -89,17 +94,17 @@ export default defineComponent({
     handleClickSuggestion (index: number) {
       if (this.suggestions && this.suggestions[index]) {
         this.selectedSuggestionIndex = index
-        this.formStore.data[this.id] = this.suggestions[index].name
-        const idWithoutAutocomplete = this.id.replace('_autocomplete', '')
+        this.formStore.data[this.idAutocomplete] = this.suggestions[index].name
+        const idWithoutAutocomplete = this.idAutocomplete.replace('_autocomplete_textfield', '')
         this.formStore.data[idWithoutAutocomplete] = this.suggestions[index].name
         this.selectedSuggestion = this.suggestions[index].name
         this.suggestions.length = 0
       }
     },
     handleSuggestions (requestResponse: any) {
-      const idWithoutAutocomplete = this.id.replace('_autocomplete', '')
-      this.formStore.data[idWithoutAutocomplete] = this.formStore.data[this.id]
-      if (this.formStore.data[this.id] !== this.selectedSuggestion) {
+      const idWithoutAutocomplete = this.idAutocomplete.replace('_autocomplete_textfield', '')
+      this.formStore.data[idWithoutAutocomplete] = this.formStore.data[this.idAutocomplete]
+      if (this.formStore.data[this.idAutocomplete] !== this.selectedSuggestion) {
         this.suggestions = requestResponse
       }
     },

--- a/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -1,0 +1,113 @@
+<template>
+  <div :class="[customCss, 'fr-mb-3w']" :id="id">
+    <SignalementFormTextfield
+        :key="id"
+        :id="id"
+        v-model="formStore.data[id]"
+        :label="label"
+        :description="description"
+        :placeholder="placeholder"
+        :validate="validate"
+        :autocomplete="autocomplete"
+        :hasError="hasError"
+        :error="error"
+    />
+
+    <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-group">
+      <div class="fr-col-12 fr-p-3v fr-text-label--blue-france fr-autocomplete-suggestion"
+           v-for="(suggestion, index) in suggestions"
+           :key="index"
+           @click="handleClickSuggestion(index)">
+        {{ suggestion.name }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, watch } from 'vue'
+import { requests } from '../requests'
+import { variablesReplacer } from './../services/variableReplacer'
+import SignalementFormTextfield from './SignalementFormTextfield.vue'
+import formStore from '../store'
+
+export default defineComponent({
+  name: 'SignalementFormAutocomplete',
+  components: {
+    SignalementFormTextfield
+  },
+  props: {
+    id: { type: String, default: null },
+    label: { type: String, default: null },
+    description: { type: String, default: null },
+    placeholder: { type: String, default: null },
+    modelValue: { type: String, default: null },
+    customCss: { type: String, default: '' },
+    validate: { type: Object, default: null },
+    hasError: { type: Boolean, default: false },
+    error: { type: String, default: '' },
+    autocomplete: { type: Object, default: null },
+    disabled: { type: Boolean, default: false }
+  },
+  data () {
+    return {
+      idFetchTimeout: 0 as unknown as ReturnType<typeof setTimeout>,
+      suggestions: [] as any[],
+      formStore,
+      selectedSuggestion: ''
+    }
+  },
+  created () {
+    watch(
+      () => this.formStore.data[this.id],
+      (newValue: any) => {
+        clearTimeout(this.idFetchTimeout)
+        this.idFetchTimeout = setTimeout(() => {
+          if (newValue.length > 1) {
+            const url = this.autocomplete.isAbsoluteLink
+              ? variablesReplacer.replace(this.autocomplete.route)
+              : window.location.origin + variablesReplacer.replace(this.autocomplete.route)
+            requests.getAutompleteSuggestions(url, this.handleSuggestions)
+          }
+        }, 200)
+      }
+    )
+  },
+  methods: {
+    updateValue (value: any) {
+      this.$emit('update:modelValue', value)
+    },
+    handleClickSuggestion (index: number) {
+      if (this.suggestions) {
+        this.formStore.data[this.id] = this.suggestions[index].name
+        const idWithoutAutocomplete = this.id.replace('_autocomplete', '')
+        this.formStore.data[idWithoutAutocomplete] = this.suggestions[index].name
+        this.selectedSuggestion = this.suggestions[index].name
+        this.suggestions.length = 0
+      }
+    },
+    handleSuggestions (requestResponse: any) {
+      const idWithoutAutocomplete = this.id.replace('_autocomplete', '')
+      this.formStore.data[idWithoutAutocomplete] = this.formStore.data[this.id]
+      if (this.formStore.data[this.id] !== this.selectedSuggestion) {
+        this.suggestions = requestResponse
+      }
+    }
+  },
+  emits: ['update:modelValue']
+})
+</script>
+
+<style>
+.fr-autocomplete-suggestion:hover {
+  background-color: #417dc4;
+  color: white !important;
+}
+.fr-autocomplete-group {
+  margin-top: -1.5rem;
+}
+.signalement-form-autocomplete .signalement-form-button {
+  width: 100%;
+  text-align: center;
+}
+</style>

--- a/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -70,7 +70,9 @@ export default defineComponent({
       (newValue: any) => {
         clearTimeout(this.idFetchTimeout)
         this.idFetchTimeout = setTimeout(() => {
-          if (newValue.length > 1) {
+          const name = newValue.trim()
+          if (name.length > 1) {
+            this.selectedSuggestionIndex = -1
             const url = this.autocomplete.isAbsoluteLink
               ? variablesReplacer.replace(this.autocomplete.route)
               : window.location.origin + variablesReplacer.replace(this.autocomplete.route)

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -39,6 +39,7 @@
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"
         :class="{ 'fr-hidden': component.conditional && !formStore.shouldShowField(component.conditional.show) }"
+        :autocomplete="component.autocomplete"
         :clickEvent="handleClickComponent"
         :handleClickComponent="handleClickComponent"
       />
@@ -110,6 +111,7 @@ import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
 import SignalementFormWarning from './SignalementFormWarning.vue'
 import SignalementFormYear from './SignalementFormYear.vue'
 import SignalementFormModal from './SignalementFormModal.vue'
+import SignalementFormAutocomplete from './SignalementFormAutocomplete.vue'
 import { variablesReplacer } from './../services/variableReplacer'
 import { componentValidator } from './../services/componentValidator'
 import { findPreviousScreen, findNextScreen } from '../services/disorderScreenNavigator'
@@ -142,7 +144,8 @@ export default defineComponent({
     SignalementFormDisorderCategoryList,
     SignalementFormDisorderOverview,
     SignalementFormRoomList,
-    SignalementFormModal
+    SignalementFormModal,
+    SignalementFormAutocomplete
   },
   props: {
     label: String,

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -133,7 +133,9 @@ export const requests = {
     const url = (formStore.props.urlApiAdress as string) + valueAdress
     requests.doRequestGet(url, functionReturn)
   },
-
+  getAutompleteSuggestions (url: string, functionReturn: Function) {
+    requests.doRequestGet(url, functionReturn)
+  },
   checkTerritory (postcode: string, citycode: string, functionReturn: Function) {
     const url = (formStore.props.ajaxurlCheckTerritory as string) + '?cp=' + postcode + '&insee=' + citycode
     requests.doRequestGet(url, functionReturn)

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -96,6 +96,7 @@ const formStore: FormStore = reactive({
     'SignalementFormOnlyChoice',
     'SignalementFormRoomList',
     'SignalementFormAddress',
+    'SignalementFormAutocomplete',
     'SignalementFormCheckbox',
     'SignalementFormCounter',
     'SignalementFormDate',

--- a/migrations/Version20240308161921.php
+++ b/migrations/Version20240308161921.php
@@ -19,6 +19,7 @@ final class Version20240308161921 extends AbstractMigration
         $this->addSql('CREATE TABLE bailleur (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE TABLE bailleur_territory (id INT AUTO_INCREMENT NOT NULL, bailleur_id INT NOT NULL, territory_id INT NOT NULL, INDEX IDX_7A87051F57B5D0A2 (bailleur_id), INDEX IDX_7A87051F73F74AD4 (territory_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_7ABB27F35E237E06 ON bailleur (name)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_7A87051F57B5D0A273F74AD4 ON bailleur_territory (bailleur_id, territory_id)');
         $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F57B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id)');
         $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F73F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id)');
         $this->addSql('ALTER TABLE signalement ADD bailleur_id INT DEFAULT NULL');
@@ -31,6 +32,7 @@ final class Version20240308161921 extends AbstractMigration
     public function down(Schema $schema): void
     {
         $this->addSql('DROP INDEX UNIQ_7ABB27F35E237E06 ON bailleur');
+        $this->addSql('DROP INDEX UNIQ_7A87051F57B5D0A273F74AD4 ON bailleur_territory');
         $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511457B5D0A2');
         $this->addSql('ALTER TABLE bailleur_territory DROP FOREIGN KEY FK_7A87051F57B5D0A2');
         $this->addSql('ALTER TABLE bailleur_territory DROP FOREIGN KEY FK_7A87051F73F74AD4');

--- a/migrations/Version20240308161921.php
+++ b/migrations/Version20240308161921.php
@@ -24,6 +24,8 @@ final class Version20240308161921 extends AbstractMigration
         $this->addSql('ALTER TABLE signalement ADD bailleur_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B5511457B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id)');
         $this->addSql('CREATE INDEX IDX_F4B5511457B5D0A2 ON signalement (bailleur_id)');
+        $this->addSql('UPDATE territory SET name = "Seine-Saint-Denis" WHERE zip = "93"');
+        $this->addSql('UPDATE territory SET name = "Côtes-d\'Armor" WHERE zip = "22"');
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20240308161921.php
+++ b/migrations/Version20240308161921.php
@@ -11,32 +11,29 @@ final class Version20240308161921 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add bailleur table';
+        return 'Create bailleur tables';
     }
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE bailleur (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, is_social TINYINT(1) NOT NULL, active TINYINT(1) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE bailleur_territory (bailleur_id INT NOT NULL, territory_id INT NOT NULL, INDEX IDX_7A87051F57B5D0A2 (bailleur_id), INDEX IDX_7A87051F73F74AD4 (territory_id), PRIMARY KEY(bailleur_id, territory_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F57B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F73F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id) ON DELETE CASCADE');
-
-        $this->addSql('ALTER TABLE signalement ADD bailleur_id INT DEFAULT NULL, CHANGE is_usager_abandon_procedure is_usager_abandon_procedure TINYINT(1) DEFAULT NULL, CHANGE date_naissance_occupant date_naissance_occupant DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE score_logement score_logement DOUBLE PRECISION NOT NULL, CHANGE score_batiment score_batiment DOUBLE PRECISION NOT NULL');
+        $this->addSql('CREATE TABLE bailleur (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE bailleur_territory (id INT AUTO_INCREMENT NOT NULL, bailleur_id INT NOT NULL, territory_id INT NOT NULL, INDEX IDX_7A87051F57B5D0A2 (bailleur_id), INDEX IDX_7A87051F73F74AD4 (territory_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_7ABB27F35E237E06 ON bailleur (name)');
+        $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F57B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id)');
+        $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F73F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id)');
+        $this->addSql('ALTER TABLE signalement ADD bailleur_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B5511457B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id)');
         $this->addSql('CREATE INDEX IDX_F4B5511457B5D0A2 ON signalement (bailleur_id)');
-
-        $this->addSql('UPDATE territory SET name = "Seine-Saint-Denis" WHERE zip = "93"');
-        $this->addSql('UPDATE territory SET name = "Côtes-d\'Armor" WHERE zip = "22"');
     }
 
     public function down(Schema $schema): void
     {
+        $this->addSql('DROP INDEX UNIQ_7ABB27F35E237E06 ON bailleur');
+        $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511457B5D0A2');
         $this->addSql('ALTER TABLE bailleur_territory DROP FOREIGN KEY FK_7A87051F57B5D0A2');
         $this->addSql('ALTER TABLE bailleur_territory DROP FOREIGN KEY FK_7A87051F73F74AD4');
         $this->addSql('DROP TABLE bailleur');
         $this->addSql('DROP TABLE bailleur_territory');
-
-        $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511457B5D0A2');
         $this->addSql('DROP INDEX IDX_F4B5511457B5D0A2 ON signalement');
         $this->addSql('ALTER TABLE signalement DROP bailleur_id');
     }

--- a/migrations/Version20240308161921.php
+++ b/migrations/Version20240308161921.php
@@ -16,15 +16,28 @@ final class Version20240308161921 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE bailleur (id INT AUTO_INCREMENT NOT NULL, territory_id INT NOT NULL, name VARCHAR(255) NOT NULL, is_social TINYINT(1) NOT NULL, active TINYINT(1) NOT NULL, INDEX IDX_7ABB27F373F74AD4 (territory_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE bailleur ADD CONSTRAINT FK_7ABB27F373F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id)');
+        $this->addSql('CREATE TABLE bailleur (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, is_social TINYINT(1) NOT NULL, active TINYINT(1) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE bailleur_territory (bailleur_id INT NOT NULL, territory_id INT NOT NULL, INDEX IDX_7A87051F57B5D0A2 (bailleur_id), INDEX IDX_7A87051F73F74AD4 (territory_id), PRIMARY KEY(bailleur_id, territory_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F57B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE bailleur_territory ADD CONSTRAINT FK_7A87051F73F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id) ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE signalement ADD bailleur_id INT DEFAULT NULL, CHANGE is_usager_abandon_procedure is_usager_abandon_procedure TINYINT(1) DEFAULT NULL, CHANGE date_naissance_occupant date_naissance_occupant DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE score_logement score_logement DOUBLE PRECISION NOT NULL, CHANGE score_batiment score_batiment DOUBLE PRECISION NOT NULL');
+        $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B5511457B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id)');
+        $this->addSql('CREATE INDEX IDX_F4B5511457B5D0A2 ON signalement (bailleur_id)');
+
         $this->addSql('UPDATE territory SET name = "Seine-Saint-Denis" WHERE zip = "93"');
         $this->addSql('UPDATE territory SET name = "Côtes-d\'Armor" WHERE zip = "22"');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE bailleur DROP FOREIGN KEY FK_7ABB27F373F74AD4');
+        $this->addSql('ALTER TABLE bailleur_territory DROP FOREIGN KEY FK_7A87051F57B5D0A2');
+        $this->addSql('ALTER TABLE bailleur_territory DROP FOREIGN KEY FK_7A87051F73F74AD4');
         $this->addSql('DROP TABLE bailleur');
+        $this->addSql('DROP TABLE bailleur_territory');
+
+        $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511457B5D0A2');
+        $this->addSql('DROP INDEX IDX_F4B5511457B5D0A2 ON signalement');
+        $this->addSql('ALTER TABLE signalement DROP bailleur_id');
     }
 }

--- a/migrations/Version20240308161921.php
+++ b/migrations/Version20240308161921.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240308161921 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add bailleur table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE bailleur (id INT AUTO_INCREMENT NOT NULL, territory_id INT NOT NULL, name VARCHAR(255) NOT NULL, is_social TINYINT(1) NOT NULL, active TINYINT(1) NOT NULL, INDEX IDX_7ABB27F373F74AD4 (territory_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE bailleur ADD CONSTRAINT FK_7ABB27F373F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id)');
+        $this->addSql('UPDATE territory SET name = "Seine-Saint-Denis" WHERE zip = "93"');
+        $this->addSql('UPDATE territory SET name = "Côtes-d\'Armor" WHERE zip = "22"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bailleur DROP FOREIGN KEY FK_7ABB27F373F74AD4');
+        $this->addSql('DROP TABLE bailleur');
+    }
+}

--- a/scripts/upload-s3.sh
+++ b/scripts/upload-s3.sh
@@ -36,6 +36,11 @@ else
     exit 1
   fi
   case "$option" in
+    "bailleurs")
+        echo "Upload bailleurs.csv to cloud..."
+        aws s3 cp data/bailleurs.csv s3://${BUCKET_URL}/csv/ ${debug}
+        aws s3 ls s3://${BUCKET_URL}/csv/bailleurs.csv
+        ;;
     "desordres")
       echo "Upload desordres_tables.csv to cloud..."
       aws s3 cp data/desordres_tables.csv s3://${BUCKET_URL}/csv/ ${debug}

--- a/src/Command/ImportBailleurCommand.php
+++ b/src/Command/ImportBailleurCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[AsCommand(
     name: 'app:import-bailleur',
-    description: 'Add a short description for your command',
+    description: 'Import Bailleur from csv',
 )]
 class ImportBailleurCommand extends Command
 {
@@ -52,7 +52,7 @@ class ImportBailleurCommand extends Command
             $io->warning($error);
         }
 
-        $io->success(sprintf('%s bailleur(s) have been imported', $metadata['count_bailleurs']));
+        $io->success(sprintf('%s bailleur(s) have been imported.', $metadata['count_bailleurs']));
 
         return Command::SUCCESS;
     }

--- a/src/Command/ImportBailleurCommand.php
+++ b/src/Command/ImportBailleurCommand.php
@@ -48,7 +48,7 @@ class ImportBailleurCommand extends Command
         );
 
         $metadata = $this->bailleurLoader->getMetadata();
-        foreach ($metadata['errors'] as $key => $error) {
+        foreach ($metadata['errors'] as $error) {
             $io->warning($error);
         }
 

--- a/src/Command/ImportBailleurCommand.php
+++ b/src/Command/ImportBailleurCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\Import\Bailleur\BailleurLoader;
+use App\Service\Import\CsvParser;
+use App\Service\UploadHandlerService;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(
+    name: 'app:import-bailleur',
+    description: 'Add a short description for your command',
+)]
+class ImportBailleurCommand extends Command
+{
+    public function __construct(
+        private CsvParser $csvParser,
+        private BailleurLoader $bailleurLoader,
+        private UploadHandlerService $uploadHandlerService,
+        private FilesystemOperator $fileStorage,
+        private ParameterBagInterface $parameterBag,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $fromFile = 'csv/bailleurs.csv';
+        $toFile = $this->parameterBag->get('uploads_tmp_dir').'bailleurs.csv';
+        if (!$this->fileStorage->fileExists($fromFile)) {
+            $io->error('CSV File does not exists');
+
+            return Command::FAILURE;
+        }
+
+        $this->uploadHandlerService->createTmpFileFromBucket($fromFile, $toFile);
+
+        $this->bailleurLoader->load(
+            $this->csvParser->parseAsDict($toFile),
+            $output
+        );
+
+        $metadata = $this->bailleurLoader->getMetadata();
+        foreach ($metadata['errors'] as $key => $error) {
+            $io->warning($error);
+        }
+
+        $io->success(sprintf('%s bailleur(s) have been imported', $metadata['count_bailleurs']));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/BailleurController.php
+++ b/src/Controller/BailleurController.php
@@ -17,8 +17,9 @@ class BailleurController extends AbstractController
         #[MapQueryParameter] string $name,
         #[MapQueryParameter] string $postcode,
     ): JsonResponse {
+        $name = trim($name);
         $zip = ZipcodeProvider::getZipCode($postcode);
-        $bailleurs = $bailleurRepository->findActiveBy($name, $zip);
+        $bailleurs = !empty($name) ? $bailleurRepository->findBailleursBy($name, $zip) : [];
 
         return $this->json($bailleurs);
     }

--- a/src/Controller/BailleurController.php
+++ b/src/Controller/BailleurController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\BailleurRepository;
+use App\Service\Signalement\ZipcodeProvider;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\Routing\Annotation\Route;
+
+class BailleurController extends AbstractController
+{
+    #[Route('/bailleurs', name: 'app_bailleur')]
+    public function index(
+        BailleurRepository $bailleurRepository,
+        #[MapQueryParameter] string $name,
+        #[MapQueryParameter] string $postcode,
+    ): JsonResponse {
+        $zip = ZipcodeProvider::getZipCode($postcode);
+        $bailleurs = $bailleurRepository->findActiveBy($name, $zip);
+
+        return $this->json($bailleurs);
+    }
+}

--- a/src/DataFixtures/Files/Bailleur.yml
+++ b/src/DataFixtures/Files/Bailleur.yml
@@ -2,272 +2,204 @@ bailleurs:
   -
     territory: "Bouches-du-Rhône"
     name: "13 HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "3F SUD SA HLM"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "ADOMA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "ASSOCIATION DE GESTION VILOGIA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "BATIGERE SA D¿HLM"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "CDC HABITAT SOCIAL SA H.L.M."
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "GRAND DELTA HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "HABITAT MARSEILLE PROVENCE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "I.C.F. HABITAT SUD-EST MEDITERRANEE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "NEOLIA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "O.P.H. GIRONDE HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "O.P.H. PAYS D'AIX HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "O.P.H. VENDEE HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "OUEST PROVENCE HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "PARIS HABITAT OPH"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "POSTE HABITAT PROVENCE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] GRAND AVIGNON RESIDENCES O.P.H."
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. d'HLM LE NOUVEAU LOGIS AZUR"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. FIAC"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. HLM PHOCEENNE D'HABITATIONS"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. LOGEO MEDITERRANEE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. MAISON SAINE AIR LUMIERE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. NOUVEAU LOGIS PROVENCAL - NLP"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. NOUVELLE DE MARSEILLE - SNHM"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] S.A. REGIONALE DE L'HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "[Radié(e)] UNION ENTREPR SALARIES LOGEMENT - UESL"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "SA CO GI VA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. D'HLM LOGIS MEDITERRANEE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A.E.M. MARSEILLE HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. ERILIA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. ESPACIL HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. FAMILLE ET PROVENCE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. FDI HABITAT"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. FRANCAISE DES HABITATIONS ECONOMIQUES"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. GASCONNE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. LOGIREM"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. PROMOLOGIS S.A M.A.I HLM"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. TOIT ET JOIE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. UN TOIT POUR TOUS"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.A. VILOGIA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.E.M. CDC Habitat"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.E.M. DU PAYS D'ARLES - SEMPA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.E.M.I. DE MARTIGUES SEMIVIM"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "S.E.M.I. SALON-DE-PROVENCE"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "STE GESTION IMMOB VILLE MARSEILLE - SOGIMA"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "UNICIL SA D'HLM"
-    is_social: 1
   -
     territory: "Bouches-du-Rhône"
     name: "VALLIS HABITAT"
-    is_social: 1
   -
     territory: "Loire-Atlantique"
     name: "O.P.H. DE HAUTE LOIRE"
-    is_social: 1
   -
     territory: "Loire-Atlantique"
     name: "[Radié(e)] S.A. FOYER VELLAVE (ALLIADE HABITAT)"
-    is_social: 1
   -
     territory: "Loire-Atlantique"
     name: "S.A. AUVERGNE HABITAT"
-    is_social: 1
   -
     territory: "Loire-Atlantique"
     name: "S.A. BATIR ET LOGER"
-    is_social: 1
   -
     territory: "Loire-Atlantique"
     name: "SA HLM ALLIADE HABITAT"
-    is_social: 1
   -
     territory: "Loire-Atlantique"
     name: "S.C.I.C. LE TOIT FOREZIEN"
-    is_social: 1
   -
     territory: "Gard"
     name: "Douarnenez Habitat"
-    is_social: 1
   -
     territory: "Gard"
     name: "Finistère Habitat"
-    is_social: 1
   -
     territory: "Gard"
     name: "I.C.F. ATLANTIQUE"
-    is_social: 1
   -
     territory: "Gard"
     name: "LE LOGIS BRETON"
-    is_social: 1
   -
     territory: "Gard"
     name: "O.P.A.C. DE LA SAVOIE"
-    is_social: 1
   -
     territory: "Gard"
     name: "O.P.H. BOURG HABITAT"
-    is_social: 1
   -
     territory: "Gard"
     name: "O.P.H. BREST METROPOLE HABITAT"
-    is_social: 1
   -
     territory: "Gard"
     name: "O.P.H. DE QUIMPER ET CORNOUAILLE"
-    is_social: 1
   -
     territory: "Gard"
     name: "S.A. AIGUILLON-CONSTRUCTION"
-    is_social: 1
   -
     territory: "Gard"
     name: "S.A. ARMORIQUE HABITAT"
-    is_social: 1
   -
     territory: "Gard"
     name: "SA D'HLM LES FOYERS"
-    is_social: 1
   -
     territory: "Gard"
     name: "S.A. ESPACIL HABITAT"
-    is_social: 1
   -
     territory: "Gard"
     name: "S.A. LE FOYER D'ARMOR"
-    is_social: 1
   -
     territory: "Gard"
     name: "S.E.M. CDC Habitat"
-    is_social: 1
   -
     territory: "Gard"
     name: "SOCIETE IMMOBILIERE GRAND HAINAUT - SIGH"
-    is_social: 1

--- a/src/DataFixtures/Files/Bailleur.yml
+++ b/src/DataFixtures/Files/Bailleur.yml
@@ -1,0 +1,273 @@
+bailleurs:
+  -
+    territory: "Bouches-du-Rhône"
+    name: "13 HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "3F SUD SA HLM"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "ADOMA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "ASSOCIATION DE GESTION VILOGIA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "BATIGERE SA D¿HLM"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "CDC HABITAT SOCIAL SA H.L.M."
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "GRAND DELTA HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "HABITAT MARSEILLE PROVENCE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "I.C.F. HABITAT SUD-EST MEDITERRANEE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "NEOLIA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "O.P.H. GIRONDE HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "O.P.H. PAYS D'AIX HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "O.P.H. VENDEE HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "OUEST PROVENCE HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "PARIS HABITAT OPH"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "POSTE HABITAT PROVENCE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] GRAND AVIGNON RESIDENCES O.P.H."
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. d'HLM LE NOUVEAU LOGIS AZUR"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. FIAC"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. HLM PHOCEENNE D'HABITATIONS"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. LOGEO MEDITERRANEE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. MAISON SAINE AIR LUMIERE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. NOUVEAU LOGIS PROVENCAL - NLP"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. NOUVELLE DE MARSEILLE - SNHM"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] S.A. REGIONALE DE L'HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "[Radié(e)] UNION ENTREPR SALARIES LOGEMENT - UESL"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "SA CO GI VA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. D'HLM LOGIS MEDITERRANEE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A.E.M. MARSEILLE HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. ERILIA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. ESPACIL HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. FAMILLE ET PROVENCE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. FDI HABITAT"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. FRANCAISE DES HABITATIONS ECONOMIQUES"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. GASCONNE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. LOGIREM"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. PROMOLOGIS S.A M.A.I HLM"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. TOIT ET JOIE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. UN TOIT POUR TOUS"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.A. VILOGIA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.E.M. CDC Habitat"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.E.M. DU PAYS D'ARLES - SEMPA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.E.M.I. DE MARTIGUES SEMIVIM"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "S.E.M.I. SALON-DE-PROVENCE"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "STE GESTION IMMOB VILLE MARSEILLE - SOGIMA"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "UNICIL SA D'HLM"
+    is_social: 1
+  -
+    territory: "Bouches-du-Rhône"
+    name: "VALLIS HABITAT"
+    is_social: 1
+  -
+    territory: "Loire-Atlantique"
+    name: "O.P.H. DE HAUTE LOIRE"
+    is_social: 1
+  -
+    territory: "Loire-Atlantique"
+    name: "[Radié(e)] S.A. FOYER VELLAVE (ALLIADE HABITAT)"
+    is_social: 1
+  -
+    territory: "Loire-Atlantique"
+    name: "S.A. AUVERGNE HABITAT"
+    is_social: 1
+  -
+    territory: "Loire-Atlantique"
+    name: "S.A. BATIR ET LOGER"
+    is_social: 1
+  -
+    territory: "Loire-Atlantique"
+    name: "SA HLM ALLIADE HABITAT"
+    is_social: 1
+  -
+    territory: "Loire-Atlantique"
+    name: "S.C.I.C. LE TOIT FOREZIEN"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "Douarnenez Habitat"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "Finistère Habitat"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "I.C.F. ATLANTIQUE"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "LE LOGIS BRETON"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "O.P.A.C. DE LA SAVOIE"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "O.P.H. BOURG HABITAT"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "O.P.H. BREST METROPOLE HABITAT"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "O.P.H. DE QUIMPER ET CORNOUAILLE"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "S.A. AIGUILLON-CONSTRUCTION"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "S.A. ARMORIQUE HABITAT"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "SA D'HLM LES FOYERS"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "S.A. ESPACIL HABITAT"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "S.A. LE FOYER D'ARMOR"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "S.E.M. CDC Habitat"
+    is_social: 1
+  -
+    territory: "Gard"
+    name: "SOCIETE IMMOBILIERE GRAND HAINAUT - SIGH"
+    is_social: 1

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -1750,7 +1750,8 @@ signalements:
     uuid: "00000000-0000-0000-2024-000000000004"
     details: "Actuellement locataire, j'attire votre attention sur certaines conditions de non-décence et de confort qui affectent ma qualité de vie quotidienne."
     is_proprio_averti: 1
-    is_logement_social: 0
+    is_logement_social: 1
+    bailleur: "13 Habitat"
     nb_adultes: "2"
     nb_enfants_m6: "0"
     nb_enfants_p6: "2"

--- a/src/DataFixtures/Files/Territory.yml
+++ b/src/DataFixtures/Files/Territory.yml
@@ -112,7 +112,7 @@ territories:
     bbox: "{\"n\":\"48.031311\",\"e\":\"5.518767\",\"s\":\"46.899847\",\"w\":\"4.06519\"}"
   -
     zip: "22"
-    name: "Côtes d'Armor"
+    name: "Côtes-d'Armor"
     is_active: 0
     bbox: "{\"n\":\"48.900942\",\"e\":\"-1.909064\",\"s\":\"48.032568\",\"w\":\"-3.665906\"}"
   -
@@ -571,7 +571,7 @@ territories:
     bbox: "{\"n\":\"48.950962\",\"s\":\"48.729351\",\"e\":\"2.336941\",\"w\":\"2.145702\"}"
   -
     zip: "93"
-    name: "Seine-St-Denis"
+    name: "Seine-Saint-Denis"
     is_active: 0
     bbox: "{\"n\":\"49.012329\",\"s\":\"48.807248\",\"e\":\"2.603292\",\"w\":\"2.288311\"}"
   -
@@ -613,7 +613,7 @@ territories:
     name: "Mayotte"
     is_active: 0
     bbox: "[]"
-    
+
   -
     zip: "64"
     name: "Agglo de Pau"

--- a/src/DataFixtures/Loader/LoadBailleurData.php
+++ b/src/DataFixtures/Loader/LoadBailleurData.php
@@ -22,19 +22,24 @@ class LoadBailleurData extends Fixture implements OrderedFixtureInterface
         foreach ($bailleursRows['bailleurs'] as $row) {
             $this->loadBailleurs($manager, $row);
         }
-        $manager->flush();
     }
 
     public function loadBailleurs(ObjectManager $manager, array $row): void
     {
         /** @var Territory $territory */
         $territory = $this->territoryRepository->findOneBy(['name' => $row['territory']]);
-        $bailleur = (new Bailleur())
-            ->setName($row['name'])
-            ->setTerritory($territory)
-            ->setIsSocial($row['is_social']);
-
+        /** @var Bailleur $bailleur */
+        $bailleur = $manager->getRepository(Bailleur::class)->findOneBy(['name' => $row['name']]);
+        if (null === $bailleur) {
+            $bailleur = (new Bailleur())
+                ->setName($row['name'])
+                ->addTerritory($territory)
+                ->setIsSocial($row['is_social']);
+        } else {
+            $bailleur->addTerritory($territory);
+        }
         $manager->persist($bailleur);
+        $manager->flush();
     }
 
     public function getOrder(): int

--- a/src/DataFixtures/Loader/LoadBailleurData.php
+++ b/src/DataFixtures/Loader/LoadBailleurData.php
@@ -33,8 +33,7 @@ class LoadBailleurData extends Fixture implements OrderedFixtureInterface
         if (null === $bailleur) {
             $bailleur = (new Bailleur())
                 ->setName($row['name'])
-                ->addTerritory($territory)
-                ->setIsSocial($row['is_social']);
+                ->addTerritory($territory);
         } else {
             $bailleur->addTerritory($territory);
         }
@@ -44,6 +43,6 @@ class LoadBailleurData extends Fixture implements OrderedFixtureInterface
 
     public function getOrder(): int
     {
-        return 18;
+        return 11;
     }
 }

--- a/src/DataFixtures/Loader/LoadBailleurData.php
+++ b/src/DataFixtures/Loader/LoadBailleurData.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\DataFixtures\Loader;
+
+use App\Entity\Bailleur;
+use App\Entity\Territory;
+use App\Repository\TerritoryRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\Yaml\Yaml;
+
+class LoadBailleurData extends Fixture implements OrderedFixtureInterface
+{
+    public function __construct(private TerritoryRepository $territoryRepository)
+    {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $bailleursRows = Yaml::parseFile(__DIR__.'/../Files/Bailleur.yml');
+        foreach ($bailleursRows['bailleurs'] as $row) {
+            $this->loadBailleurs($manager, $row);
+        }
+        $manager->flush();
+    }
+
+    public function loadBailleurs(ObjectManager $manager, array $row): void
+    {
+        /** @var Territory $territory */
+        $territory = $this->territoryRepository->findOneBy(['name' => $row['territory']]);
+        $bailleur = (new Bailleur())
+            ->setName($row['name'])
+            ->setTerritory($territory)
+            ->setIsSocial($row['is_social']);
+
+        $manager->persist($bailleur);
+    }
+
+    public function getOrder(): int
+    {
+        return 18;
+    }
+}

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -20,6 +20,7 @@ use App\Factory\Signalement\InformationComplementaireFactory;
 use App\Factory\Signalement\InformationProcedureFactory;
 use App\Factory\Signalement\SituationFoyerFactory;
 use App\Factory\Signalement\TypeCompositionLogementFactory;
+use App\Repository\BailleurRepository;
 use App\Repository\CritereRepository;
 use App\Repository\CriticiteRepository;
 use App\Repository\DesordreCategorieRepository;
@@ -31,6 +32,7 @@ use App\Repository\TagRepository;
 use App\Repository\TerritoryRepository;
 use App\Repository\UserRepository;
 use App\Service\ImageManipulationHandler;
+use App\Service\Signalement\ZipcodeProvider;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -41,6 +43,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
 {
     public function __construct(
         private TerritoryRepository $territoryRepository,
+        private BailleurRepository $bailleurRepository,
         private SituationRepository $situationRepository,
         private CritereRepository $critereRepository,
         private CriticiteRepository $criticiteRepository,
@@ -191,6 +194,11 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             foreach ($row['criticites'] as $criticite) {
                 $signalement->addCriticite($this->criticiteRepository->findOneBy(['label' => $criticite]));
             }
+        }
+
+        if (isset($row['bailleur'])) {
+            $zip = ZipcodeProvider::getZipCode($row['cp_occupant']);
+            $signalement->setBailleur($this->bailleurRepository->findOneBailleurBy($row['bailleur'], $zip));
         }
 
         $manager->persist($signalement);

--- a/src/Entity/Bailleur.php
+++ b/src/Entity/Bailleur.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\BailleurRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+#[ORM\Entity(repositoryClass: BailleurRepository::class)]
+class Bailleur
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    #[Ignore]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\Column]
+    #[Ignore]
+    private ?bool $isSocial = null;
+
+    #[ORM\Column]
+    #[Ignore]
+    private ?bool $active = true;
+
+    #[ORM\ManyToOne(inversedBy: 'bailleurs')]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Ignore]
+    private ?Territory $territory = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function isIsSocial(): ?bool
+    {
+        return $this->isSocial;
+    }
+
+    public function setIsSocial(bool $isSocial): static
+    {
+        $this->isSocial = $isSocial;
+
+        return $this;
+    }
+
+    public function isActive(): ?bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): static
+    {
+        $this->active = $active;
+
+        return $this;
+    }
+
+    public function getTerritory(): ?Territory
+    {
+        return $this->territory;
+    }
+
+    public function setTerritory(?Territory $territory): static
+    {
+        $this->territory = $territory;
+
+        return $this;
+    }
+}

--- a/src/Entity/Bailleur.php
+++ b/src/Entity/Bailleur.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use App\Repository\BailleurRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Ignore;
 
@@ -26,10 +28,19 @@ class Bailleur
     #[Ignore]
     private ?bool $active = true;
 
-    #[ORM\ManyToOne(inversedBy: 'bailleurs')]
-    #[ORM\JoinColumn(nullable: false)]
+    #[ORM\ManyToMany(targetEntity: Territory::class, inversedBy: 'bailleurs')]
     #[Ignore]
-    private ?Territory $territory = null;
+    private Collection $territories;
+
+    #[ORM\OneToMany(mappedBy: 'bailleur', targetEntity: Signalement::class)]
+    #[Ignore]
+    private Collection $signalements;
+
+    public function __construct()
+    {
+        $this->territories = new ArrayCollection();
+        $this->signalements = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {
@@ -41,7 +52,7 @@ class Bailleur
         return $this->name;
     }
 
-    public function setName(string $name): static
+    public function setName(string $name): self
     {
         $this->name = $name;
 
@@ -53,7 +64,7 @@ class Bailleur
         return $this->isSocial;
     }
 
-    public function setIsSocial(bool $isSocial): static
+    public function setIsSocial(bool $isSocial): self
     {
         $this->isSocial = $isSocial;
 
@@ -65,21 +76,63 @@ class Bailleur
         return $this->active;
     }
 
-    public function setActive(bool $active): static
+    public function setActive(bool $active): self
     {
         $this->active = $active;
 
         return $this;
     }
 
-    public function getTerritory(): ?Territory
+    /**
+     * @return Collection<int, Territory>
+     */
+    public function getTerritories(): Collection
     {
-        return $this->territory;
+        return $this->territories;
     }
 
-    public function setTerritory(?Territory $territory): static
+    public function addTerritory(Territory $territory): self
     {
-        $this->territory = $territory;
+        if (!$this->territories->contains($territory)) {
+            $this->territories->add($territory);
+        }
+
+        return $this;
+    }
+
+    public function removeTerritory(Territory $territory): self
+    {
+        $this->territories->removeElement($territory);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Signalement>
+     */
+    public function getSignalements(): Collection
+    {
+        return $this->signalements;
+    }
+
+    public function addSignalement(Signalement $signalement): self
+    {
+        if (!$this->signalements->contains($signalement)) {
+            $this->signalements->add($signalement);
+            $signalement->setBailleur($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSignalement(Signalement $signalement): self
+    {
+        if ($this->signalements->removeElement($signalement)) {
+            // set the owning side to null (unless already changed)
+            if ($signalement->getBailleur() === $this) {
+                $signalement->setBailleur(null);
+            }
+        }
 
         return $this;
     }

--- a/src/Entity/Bailleur.php
+++ b/src/Entity/Bailleur.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Ignore;
 
 #[ORM\Entity(repositoryClass: BailleurRepository::class)]
+#[ORM\UniqueConstraint(columns: ['name'])]
 class Bailleur
 {
     #[ORM\Id]
@@ -20,26 +21,18 @@ class Bailleur
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
-    #[ORM\Column]
-    #[Ignore]
-    private ?bool $isSocial = null;
-
-    #[ORM\Column]
-    #[Ignore]
-    private ?bool $active = true;
-
-    #[ORM\ManyToMany(targetEntity: Territory::class, inversedBy: 'bailleurs')]
-    #[Ignore]
-    private Collection $territories;
-
     #[ORM\OneToMany(mappedBy: 'bailleur', targetEntity: Signalement::class)]
     #[Ignore]
     private Collection $signalements;
 
+    #[ORM\OneToMany(mappedBy: 'bailleur', targetEntity: BailleurTerritory::class, cascade: ['persist'])]
+    #[Ignore]
+    private Collection $bailleurTerritories;
+
     public function __construct()
     {
-        $this->territories = new ArrayCollection();
         $this->signalements = new ArrayCollection();
+        $this->bailleurTerritories = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -59,80 +52,40 @@ class Bailleur
         return $this;
     }
 
-    public function isIsSocial(): ?bool
-    {
-        return $this->isSocial;
-    }
-
-    public function setIsSocial(bool $isSocial): self
-    {
-        $this->isSocial = $isSocial;
-
-        return $this;
-    }
-
-    public function isActive(): ?bool
-    {
-        return $this->active;
-    }
-
-    public function setActive(bool $active): self
-    {
-        $this->active = $active;
-
-        return $this;
-    }
-
     /**
-     * @return Collection<int, Territory>
+     * @return Collection<int, BailleurTerritory>
      */
-    public function getTerritories(): Collection
+    public function getBailleurTerritories(): Collection
     {
-        return $this->territories;
+        return $this->bailleurTerritories;
+    }
+
+    public function addBailleurTerritory(BailleurTerritory $bailleurTerritory): self
+    {
+        if (!$this->bailleurTerritories->contains($bailleurTerritory)) {
+            $this->bailleurTerritories->add($bailleurTerritory);
+            $bailleurTerritory->setBailleur($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBailleurTerritory(BailleurTerritory $bailleurTerritory): self
+    {
+        if ($this->bailleurTerritories->removeElement($bailleurTerritory)) {
+            // set the owning side to null (unless already changed)
+            if ($bailleurTerritory->getBailleur() === $this) {
+                $bailleurTerritory->setBailleur(null);
+            }
+        }
+
+        return $this;
     }
 
     public function addTerritory(Territory $territory): self
     {
-        if (!$this->territories->contains($territory)) {
-            $this->territories->add($territory);
-        }
-
-        return $this;
-    }
-
-    public function removeTerritory(Territory $territory): self
-    {
-        $this->territories->removeElement($territory);
-
-        return $this;
-    }
-
-    /**
-     * @return Collection<int, Signalement>
-     */
-    public function getSignalements(): Collection
-    {
-        return $this->signalements;
-    }
-
-    public function addSignalement(Signalement $signalement): self
-    {
-        if (!$this->signalements->contains($signalement)) {
-            $this->signalements->add($signalement);
-            $signalement->setBailleur($this);
-        }
-
-        return $this;
-    }
-
-    public function removeSignalement(Signalement $signalement): self
-    {
-        if ($this->signalements->removeElement($signalement)) {
-            // set the owning side to null (unless already changed)
-            if ($signalement->getBailleur() === $this) {
-                $signalement->setBailleur(null);
-            }
-        }
+        $bailleurTerritory = (new BailleurTerritory())->setTerritory($territory);
+        $this->addBailleurTerritory($bailleurTerritory);
 
         return $this;
     }

--- a/src/Entity/BailleurTerritory.php
+++ b/src/Entity/BailleurTerritory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\BailleurTerritoryRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: BailleurTerritoryRepository::class)]
+class BailleurTerritory
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'bailleurTerritories')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Bailleur $bailleur = null;
+
+    #[ORM\ManyToOne(inversedBy: 'bailleurTerritories')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Territory $territory = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBailleur(): ?Bailleur
+    {
+        return $this->bailleur;
+    }
+
+    public function setBailleur(?Bailleur $bailleur): static
+    {
+        $this->bailleur = $bailleur;
+
+        return $this;
+    }
+
+    public function getTerritory(): ?Territory
+    {
+        return $this->territory;
+    }
+
+    public function setTerritory(?Territory $territory): static
+    {
+        $this->territory = $territory;
+
+        return $this;
+    }
+}

--- a/src/Entity/BailleurTerritory.php
+++ b/src/Entity/BailleurTerritory.php
@@ -6,6 +6,7 @@ use App\Repository\BailleurTerritoryRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: BailleurTerritoryRepository::class)]
+#[ORM\UniqueConstraint(columns: ['bailleur_id', 'territory_id'])]
 class BailleurTerritory
 {
     #[ORM\Id]
@@ -48,5 +49,10 @@ class BailleurTerritory
         $this->territory = $territory;
 
         return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->bailleur->getName().'-'.$this->getTerritory()->getName();
     }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -403,6 +403,9 @@ class Signalement
     #[ORM\ManyToMany(targetEntity: DesordrePrecision::class, mappedBy: 'signalement')]
     private Collection $desordrePrecisions;
 
+    #[ORM\ManyToOne(inversedBy: 'signalements')]
+    private ?Bailleur $bailleur = null;
+
     public function __construct()
     {
         $this->situations = new ArrayCollection();
@@ -2300,5 +2303,17 @@ class Signalement
     public function getDesordrePrecisionSlugs()
     {
         return $this->getDesordrePrecisions()->map(fn (DesordrePrecision $desordrePrecision) => $desordrePrecision->getDesordrePrecisionSlug())->toArray();
+    }
+
+    public function getBailleur(): ?Bailleur
+    {
+        return $this->bailleur;
+    }
+
+    public function setBailleur(?Bailleur $bailleur): self
+    {
+        $this->bailleur = $bailleur;
+
+        return $this;
     }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -736,6 +736,10 @@ class Signalement
 
     public function getNomProprio(): ?string
     {
+        if ($this->bailleur) {
+            return $this->bailleur->getName();
+        }
+
         return $this->nomProprio;
     }
 

--- a/src/Entity/Territory.php
+++ b/src/Entity/Territory.php
@@ -61,8 +61,7 @@ class Territory
     #[ORM\Column]
     private ?bool $isAutoAffectationEnabled = false;
 
-    #[ORM\OneToMany(mappedBy: 'territory', targetEntity: Bailleur::class)]
-    #[Ignore]
+    #[ORM\ManyToMany(targetEntity: Bailleur::class, mappedBy: 'territories')]
     private Collection $bailleurs;
 
     public function __construct()
@@ -323,23 +322,20 @@ class Territory
         return $this->bailleurs;
     }
 
-    public function addBailleur(Bailleur $bailleur): self
+    public function addBailleur(Bailleur $bailleur): static
     {
         if (!$this->bailleurs->contains($bailleur)) {
             $this->bailleurs->add($bailleur);
-            $bailleur->setTerritory($this);
+            $bailleur->addTerritory($this);
         }
 
         return $this;
     }
 
-    public function removeBailleur(Bailleur $bailleur): self
+    public function removeBailleur(Bailleur $bailleur): static
     {
         if ($this->bailleurs->removeElement($bailleur)) {
-            // set the owning side to null (unless already changed)
-            if ($bailleur->getTerritory() === $this) {
-                $bailleur->setTerritory(null);
-            }
+            $bailleur->removeTerritory($this);
         }
 
         return $this;

--- a/src/Entity/Territory.php
+++ b/src/Entity/Territory.php
@@ -61,6 +61,10 @@ class Territory
     #[ORM\Column]
     private ?bool $isAutoAffectationEnabled = false;
 
+    #[ORM\OneToMany(mappedBy: 'territory', targetEntity: Bailleur::class)]
+    #[Ignore]
+    private Collection $bailleurs;
+
     public function __construct()
     {
         $this->users = new ArrayCollection();
@@ -68,6 +72,7 @@ class Territory
         $this->signalements = new ArrayCollection();
         $this->affectations = new ArrayCollection();
         $this->tags = new ArrayCollection();
+        $this->bailleurs = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -306,6 +311,36 @@ class Territory
     public function setIsAutoAffectationEnabled(bool $isAutoAffectationEnabled): self
     {
         $this->isAutoAffectationEnabled = $isAutoAffectationEnabled;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Bailleur>
+     */
+    public function getBailleurs(): Collection
+    {
+        return $this->bailleurs;
+    }
+
+    public function addBailleur(Bailleur $bailleur): self
+    {
+        if (!$this->bailleurs->contains($bailleur)) {
+            $this->bailleurs->add($bailleur);
+            $bailleur->setTerritory($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBailleur(Bailleur $bailleur): self
+    {
+        if ($this->bailleurs->removeElement($bailleur)) {
+            // set the owning side to null (unless already changed)
+            if ($bailleur->getTerritory() === $this) {
+                $bailleur->setTerritory(null);
+            }
+        }
 
         return $this;
     }

--- a/src/Entity/Territory.php
+++ b/src/Entity/Territory.php
@@ -61,8 +61,9 @@ class Territory
     #[ORM\Column]
     private ?bool $isAutoAffectationEnabled = false;
 
-    #[ORM\ManyToMany(targetEntity: Bailleur::class, mappedBy: 'territories')]
-    private Collection $bailleurs;
+    #[ORM\OneToMany(mappedBy: 'territory', targetEntity: BailleurTerritory::class)]
+    #[Ignore]
+    private Collection $bailleurTerritories;
 
     public function __construct()
     {
@@ -71,7 +72,7 @@ class Territory
         $this->signalements = new ArrayCollection();
         $this->affectations = new ArrayCollection();
         $this->tags = new ArrayCollection();
-        $this->bailleurs = new ArrayCollection();
+        $this->bailleurTerritories = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -315,27 +316,30 @@ class Territory
     }
 
     /**
-     * @return Collection<int, Bailleur>
+     * @return Collection<int, BailleurTerritory>
      */
-    public function getBailleurs(): Collection
+    public function getBailleurTerritories(): Collection
     {
-        return $this->bailleurs;
+        return $this->bailleurTerritories;
     }
 
-    public function addBailleur(Bailleur $bailleur): static
+    public function addBailleurTerritory(BailleurTerritory $bailleurTerritory): static
     {
-        if (!$this->bailleurs->contains($bailleur)) {
-            $this->bailleurs->add($bailleur);
-            $bailleur->addTerritory($this);
+        if (!$this->bailleurTerritories->contains($bailleurTerritory)) {
+            $this->bailleurTerritories->add($bailleurTerritory);
+            $bailleurTerritory->setTerritory($this);
         }
 
         return $this;
     }
 
-    public function removeBailleur(Bailleur $bailleur): static
+    public function removeBailleurTerritory(BailleurTerritory $bailleurTerritory): static
     {
-        if ($this->bailleurs->removeElement($bailleur)) {
-            $bailleur->removeTerritory($this);
+        if ($this->bailleurTerritories->removeElement($bailleurTerritory)) {
+            // set the owning side to null (unless already changed)
+            if ($bailleurTerritory->getTerritory() === $this) {
+                $bailleurTerritory->setTerritory(null);
+            }
         }
 
         return $this;

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -411,13 +411,11 @@ class SignalementManager extends AbstractManager
         Signalement $signalement,
         CoordonneesBailleurRequest $coordonneesBailleurRequest
     ) {
-        $bailleur = $this->bailleurRepository->findOneActiveBy(
+        $bailleur = $this->bailleurRepository->findOneBailleurBy(
             $coordonneesBailleurRequest->getNom(),
             ZipcodeProvider::getZipCode($signalement->getCpOccupant())
         );
-        if (null !== $bailleur) {
-            $signalement->setBailleur($bailleur);
-        }
+        $signalement->setBailleur($bailleur);
 
         $signalement->setNomProprio($coordonneesBailleurRequest->getNom())
             ->setPrenomProprio($coordonneesBailleurRequest->getPrenom())

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Bailleur;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Bailleur>
+ *
+ * @method Bailleur|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Bailleur|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Bailleur[]    findAll()
+ * @method Bailleur[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class BailleurRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Bailleur::class);
+    }
+
+    public function findActiveBy(string $name, string $zip): array
+    {
+        $queryBuilder = $this
+            ->createQueryBuilder('b')
+            ->innerJoin('b.territory', 't')
+            ->where('t.zip = :zip')
+            ->setParameter('zip', $zip)
+            ->andWhere('b.name LIKE :name')
+            ->setParameter('name', '%'.$name.'%');
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+}

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -21,15 +21,15 @@ class BailleurRepository extends ServiceEntityRepository
         parent::__construct($registry, Bailleur::class);
     }
 
-    public function findActiveBy(string $name, string $zip): array
+    public function findBailleursBy(string $name, string $zip): array
     {
         $terms = explode(' ', trim($name));
         $queryBuilder = $this
             ->createQueryBuilder('b')
-            ->innerJoin('b.territories', 't')
+            ->innerJoin('b.bailleurTerritories', 'bt')
+            ->innerJoin('bt.territory', 't')
             ->where('t.zip = :zip')
-            ->setParameter('zip', $zip)
-            ->andWhere('b.active = true');
+            ->setParameter('zip', $zip);
 
         foreach ($terms as $index => $term) {
             $placeholder = 'term_'.$index;
@@ -41,16 +41,16 @@ class BailleurRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery()->getResult();
     }
 
-    public function findOneActiveBy(string $name, string $zip): ?Bailleur
+    public function findOneBailleurBy(string $name, string $zip): ?Bailleur
     {
         $queryBuilder = $this
             ->createQueryBuilder('b')
-            ->innerJoin('b.territories', 't')
+            ->innerJoin('b.bailleurTerritories', 'bt')
+            ->innerJoin('bt.territory', 't')
             ->where('t.zip = :zip')
             ->setParameter('zip', $zip)
             ->andWhere('b.name LIKE :name')
-            ->setParameter('name', $name)
-            ->andWhere('b.active = true');
+            ->setParameter('name', $name);
 
         return $queryBuilder->getQuery()->getOneOrNullResult();
     }

--- a/src/Repository/BailleurTerritoryRepository.php
+++ b/src/Repository/BailleurTerritoryRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\BailleurTerritory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BailleurTerritory>
+ *
+ * @method BailleurTerritory|null find($id, $lockMode = null, $lockVersion = null)
+ * @method BailleurTerritory|null findOneBy(array $criteria, array $orderBy = null)
+ * @method BailleurTerritory[]    findAll()
+ * @method BailleurTerritory[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class BailleurTerritoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BailleurTerritory::class);
+    }
+}

--- a/src/Service/Import/Bailleur/BailleurHeader.php
+++ b/src/Service/Import/Bailleur/BailleurHeader.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Service\Import\Bailleur;
+
+class BailleurHeader
+{
+    public const DEPARTEMENT = 'Département du logement attribué';
+    public const ORGANISME_NOM = 'Organisme de l\'attribution';
+}

--- a/src/Service/Import/Bailleur/BailleurLoader.php
+++ b/src/Service/Import/Bailleur/BailleurLoader.php
@@ -37,7 +37,7 @@ class BailleurLoader
             if (\count($item) > 1) {
                 if (null !== $territoryName = $item[BailleurHeader::DEPARTEMENT]) {
                     $territory = $this->territoryRepository->findOneBy(['name' => $territoryName]);
-                    if ($this->hasErrors($territoryName, $item, $key, $territory)) {
+                    if ($this->hasErrors($territoryName, $key, $territory)) {
                         continue;
                     }
 
@@ -84,7 +84,7 @@ class BailleurLoader
         return $bailleur;
     }
 
-    private function hasErrors(string $territoryName, array $item, int $key, ?Territory $territory = null): bool
+    private function hasErrors(string $territoryName, int $key, ?Territory $territory = null): bool
     {
         if (null === $territory) {
             $this->metadata['errors'][] = sprintf(

--- a/src/Service/Import/Bailleur/BailleurLoader.php
+++ b/src/Service/Import/Bailleur/BailleurLoader.php
@@ -70,8 +70,7 @@ class BailleurLoader
         if (null === $bailleur) {
             $bailleur = (new Bailleur())
                 ->addTerritory($territory)
-                ->setName($bailleurName)
-                ->setIsSocial(true);
+                ->setName($bailleurName);
             ++$this->metadata['count_bailleurs'];
         } else {
             $bailleur->addTerritory($territory);

--- a/src/Service/Import/Bailleur/BailleurLoader.php
+++ b/src/Service/Import/Bailleur/BailleurLoader.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Service\Import\Bailleur;
+
+use App\Entity\Bailleur;
+use App\Repository\BailleurRepository;
+use App\Repository\TerritoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BailleurLoader
+{
+    private const FLUSH_COUNT = 500;
+
+    private array $metadata = [
+        'count_bailleurs' => 0,
+        'errors' => [],
+    ];
+
+    public function __construct(
+        private BailleurRepository $bailleurRepository,
+        private TerritoryRepository $territoryRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function load(array $data, ?OutputInterface $output = null): void
+    {
+        $progressBar = new ProgressBar($output, \count($data));
+        $progressBar->start();
+        foreach ($data as $key => $item) {
+            if (\count($item) > 1) {
+                if (null !== $territoryName = $item[BailleurHeader::DEPARTEMENT]) {
+                    $territory = $this->territoryRepository->findOneBy([
+                        'name' => $territoryName,
+                    ]);
+                    if (null !== $territory && !empty($item[BailleurHeader::ORGANISME_NOM])) {
+                        $bailleur = $this->bailleurRepository->findOneBy([
+                            'name' => $item[BailleurHeader::ORGANISME_NOM],
+                            'territory' => $territory->getId(),
+                        ]);
+                        if (null === $bailleur) {
+                            $bailleur = (new Bailleur())
+                                ->setTerritory($territory)
+                                ->setName($item[BailleurHeader::ORGANISME_NOM])
+                                ->setIsSocial(true);
+                            $this->entityManager->persist($bailleur);
+                            ++$this->metadata['count_bailleurs'];
+                        }
+                        if (0 === $this->metadata['count_bailleurs'] % self::FLUSH_COUNT) {
+                            $this->entityManager->flush();
+                        }
+                    } elseif (null === $territory) {
+                        $this->metadata['errors'][] = sprintf(
+                            '[%s] ligne %d - Le territoire n\'existe pas.',
+                            $territoryName,
+                            $key
+                        );
+                    } else {
+                        $this->metadata['errors'][] = sprintf(
+                            '[%s] ligne %d - Le nom de l\'organisme est manquant.',
+                            $territoryName,
+                            $key
+                        );
+                    }
+                    if (null !== $output) {
+                        $progressBar->advance();
+                    }
+                }
+            }
+        }
+        if (null !== $output) {
+            $progressBar->finish();
+            $progressBar->clear();
+        }
+        $this->entityManager->flush();
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Service/Import/Bailleur/BailleurLoader.php
+++ b/src/Service/Import/Bailleur/BailleurLoader.php
@@ -12,8 +12,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class BailleurLoader
 {
-    private const FLUSH_COUNT = 500;
-
     private array $metadata = [
         'count_bailleurs' => 0,
         'errors' => [],

--- a/src/Service/Signalement/PostalCodeHomeChecker.php
+++ b/src/Service/Signalement/PostalCodeHomeChecker.php
@@ -9,14 +9,13 @@ class PostalCodeHomeChecker
 {
     public function __construct(
         private readonly TerritoryRepository $territoryRepository,
-        private ZipcodeProvider $zipcodeProvider
     ) {
     }
 
     public function isActive(string $postalCode, ?string $inseeCode = null): bool
     {
         $territoryItem = $this->territoryRepository->findOneBy([
-            'zip' => $this->zipcodeProvider->getZipCode($postalCode),
+            'zip' => ZipcodeProvider::getZipCode($postalCode),
             'isActive' => 1,
         ]);
 

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -74,9 +74,9 @@ class SignalementBuilder
         );
 
         $territory = $this->territoryRepository->findOneBy([
-            'zip' => $this
-                ->zipcodeProvider
-                ->getZipCode($this->signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal()),
+            'zip' => ZipcodeProvider::getZipCode(
+                $this->signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal()
+            ),
         ]);
 
         $this->signalement = (new Signalement())

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -414,7 +414,7 @@ class SignalementBuilder
                 ->setTelProprio($this->signalementDraftRequest->getCoordonneesBailleurTel())
                 ->setTelProprioSecondaire($this->signalementDraftRequest->getCoordonneesBailleurTelSecondaire());
 
-            $bailleur = $this->bailleurRepository->findOneActiveBy($bailleurNom, $this->territory->getZip());
+            $bailleur = $this->bailleurRepository->findOneBailleurBy($bailleurNom, $this->territory->getZip());
             if (null !== $bailleur) {
                 $this->signalement->setBailleur($bailleur);
             }

--- a/src/Service/Signalement/ZipcodeProvider.php
+++ b/src/Service/Signalement/ZipcodeProvider.php
@@ -9,7 +9,7 @@ class ZipcodeProvider
     public const MARTINIQUE_CODE_DEPARTMENT_972 = '972';
     public const LA_REUNION_CODE_DEPARTMENT_974 = '974';
 
-    public function getZipCode(string $postalCode): string
+    public static function getZipCode(string $postalCode): string
     {
         $zipChunk = substr(trim($postalCode), 0, 3);
 

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -20,7 +20,18 @@
                                         signalement.profileDeclarant)
                                     }}
                                 </label>
-                                <input class="fr-input" type="text" id="coordonneesBailleurNom" name="nom" value="{{ signalement.nomProprio }}" maxlength="255">
+                                <input class="fr-input"
+                                       type="text"
+                                       id="coordonneesBailleurNom"
+                                       name="nom"
+                                       value="{{ signalement.nomProprio }}"
+                                       maxlength="255"
+                                        {% if signalement.isLogementSocial  %}
+                                            data-autocomplete-bailleur-url="{{ path('app_bailleur', {'postcode': signalement.cpOccupant}) }}"
+                                        {% endif %}
+                                >
+                                <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france search-bailleur-autocomplete-list">
+                                </div>
                             </div>
 
                             <div class="fr-input-group">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -26,12 +26,13 @@
                                        name="nom"
                                        value="{{ signalement.nomProprio }}"
                                        maxlength="255"
+                                       autocomplete="off"
                                         {% if signalement.isLogementSocial  %}
                                             data-autocomplete-bailleur-url="{{ path('app_bailleur', {'postcode': signalement.cpOccupant}) }}"
                                         {% endif %}
                                 >
-                                <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france search-bailleur-autocomplete-list">
-                                </div>
+                                <ul class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france search-bailleur-autocomplete-list">
+                                </ul>
                             </div>
 
                             <div class="fr-input-group">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -31,7 +31,7 @@
                                             data-autocomplete-bailleur-url="{{ path('app_bailleur', {'postcode': signalement.cpOccupant}) }}"
                                         {% endif %}
                                 >
-                                <ul class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france search-bailleur-autocomplete-list">
+                                <ul class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-list">
                                 </ul>
                             </div>
 

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -43,23 +43,7 @@ class SignalementEditControllerTest extends WebTestCase
             ['uuid' => $signalement->getUuid()]
         );
 
-        $payload = [
-            'nom' => '13 HABITAT',
-            'prenom' => '',
-            'mail' => 'contact@13habitat.fr',
-            'telephone' => '0611000000',
-            'ville' => 'Marseille',
-            'beneficiaireRsa' => '',
-            'beneficiaireFsl' => '',
-            'revenuFiscal' => '',
-            'dateNaissance' => '',
-        ];
-
-        $payload['_token'] = $this->generateCsrfToken(
-            $this->client,
-            'signalement_edit_coordonnees_bailleur_'.$signalement->getId()
-        );
-
+        $payload = $this->getPayload('13 habitat', $signalement->getId());
         $this->client->request('POST', $route, [], [], [], json_encode($payload));
 
         $this->assertResponseIsSuccessful();
@@ -76,8 +60,18 @@ class SignalementEditControllerTest extends WebTestCase
             ['uuid' => $signalement->getUuid()]
         );
 
+        $payload = $this->getPayload('Habitat Social Solidaire', $signalement->getId());
+        $this->client->request('POST', $route, [], [], [], json_encode($payload));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertNull($signalement->getBailleur());
+        $this->assertEquals('Habitat Social Solidaire', $signalement->getNomProprio());
+    }
+
+    public function getPayload(string $bailleurName, int $signalementId): array
+    {
         $payload = [
-            'nom' => 'Habitat Social Solidaire',
+            'nom' => $bailleurName,
             'prenom' => '',
             'mail' => 'contact@13habitat.fr',
             'telephone' => '0611000000',
@@ -90,13 +84,9 @@ class SignalementEditControllerTest extends WebTestCase
 
         $payload['_token'] = $this->generateCsrfToken(
             $this->client,
-            'signalement_edit_coordonnees_bailleur_'.$signalement->getId()
+            'signalement_edit_coordonnees_bailleur_'.$signalementId
         );
 
-        $this->client->request('POST', $route, [], [], [], json_encode($payload));
-
-        $this->assertResponseIsSuccessful();
-        $this->assertNull($signalement->getBailleur());
-        $this->assertEquals('Habitat Social Solidaire', $signalement->getNomProprio());
+        return $payload;
     }
 }

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Back;
+
+use App\Repository\SignalementRepository;
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class SignalementEditControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    public function testEditCoordonneesBailleur(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        /** @var RouterInterface $router */
+        $router = $client->getContainer()->get(RouterInterface::class);
+
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $signalement = $signalementRepository->findOneBy(['isLogementSocial' => true, 'villeOccupant' => 'Marseille']);
+        $client->loginUser($user);
+        $route = $router->generate('back_signalement_edit_coordonnees_bailleur', ['uuid' => $signalement->getUuid()]);
+
+        $payload = [
+            'nom' => '13 HABITAT',
+            'prenom' => '',
+            'mail' => 'contact@13habitat.fr',
+            'telephone' => '0611000000',
+            'ville' => 'Marseille',
+            'beneficiaireRsa' => '',
+            'beneficiaireFsl' => '',
+            'revenuFiscal' => '',
+            'dateNaissance' => '',
+        ];
+
+        $payload['_token'] = $this->generateCsrfToken(
+            $client,
+            'signalement_edit_coordonnees_bailleur_'.$signalement->getId()
+        );
+
+        $client->request('POST', $route, [], [], [], json_encode($payload));
+
+        $this->assertResponseIsSuccessful();
+
+        $this->assertEquals('13 HABITAT', $signalement->getBailleur()->getName());
+        $this->assertEquals('13 HABITAT', $signalement->getNomProprio());
+    }
+}

--- a/tests/Functional/Controller/BailleurControllerTest.php
+++ b/tests/Functional/Controller/BailleurControllerTest.php
@@ -22,4 +22,21 @@ class BailleurControllerTest extends WebTestCase
             $this->assertStringContainsString('habitat', strtolower($item['name']));
         }
     }
+
+    public function testSearchTerms(): void
+    {
+        $client = static::createClient();
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $routeFirst = $router->generate('app_bailleur', ['name' => 'habitat 13', 'postcode' => 13002]);
+
+        $client->request('GET', $routeFirst);
+        $responseFirst = json_decode($client->getResponse()->getContent(), true);
+
+        $routeSecond = $router->generate('app_bailleur', ['name' => '13 habitat', 'postcode' => 13002]);
+        $client->request('GET', $routeSecond);
+        $responseSecond = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertEquals($responseFirst, $responseSecond);
+    }
 }

--- a/tests/Functional/Controller/BailleurControllerTest.php
+++ b/tests/Functional/Controller/BailleurControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class BailleurControllerTest extends WebTestCase
+{
+    public function testSearchBailleurs(): void
+    {
+        $client = static::createClient();
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('app_bailleur', ['name' => 'habitat', 'postcode' => 13002]);
+
+        $client->request('GET', $route);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(19, $response);
+
+        foreach ($response as $item) {
+            $this->assertStringContainsString('habitat', strtolower($item['name']));
+        }
+    }
+}

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -16,6 +16,7 @@ use App\Factory\SignalementExportFactory;
 use App\Factory\SignalementFactory;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
+use App\Repository\BailleurRepository;
 use App\Repository\DesordreCritereRepository;
 use App\Repository\DesordrePrecisionRepository;
 use App\Service\Signalement\CriticiteCalculator;
@@ -56,6 +57,7 @@ class SignalementManagerTest extends WebTestCase
     private DesordreCritereRepository $desordreCritereRepository;
     private DesordreCompositionLogementLoader $desordreCompositionLogementLoader;
     private SuiviManager $suiviManager;
+    private BailleurRepository $bailleurRepository;
 
     protected function setUp(): void
     {
@@ -80,6 +82,7 @@ class SignalementManagerTest extends WebTestCase
         $this->desordreCritereRepository = static::getContainer()->get(DesordreCritereRepository::class);
         $this->desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
         $this->suiviManager = static::getContainer()->get(SuiviManager::class);
+        $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
 
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
@@ -98,6 +101,7 @@ class SignalementManagerTest extends WebTestCase
             $this->desordreCritereRepository,
             $this->desordreCompositionLogementLoader,
             $this->suiviManager,
+            $this->bailleurRepository,
         );
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
         $client->loginUser($user);

--- a/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
+++ b/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Tests\Functional\Service\Import\Bailleur;
+
+use App\Repository\BailleurRepository;
+use App\Repository\BailleurTerritoryRepository;
+use App\Repository\TerritoryRepository;
+use App\Service\Import\Bailleur\BailleurLoader;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class BailleurLoaderTest extends KernelTestCase
+{
+    public function testLoadValidBailleur(): void
+    {
+        $bailleurLoader = new BailleurLoader(
+            self::getContainer()->get(BailleurRepository::class),
+            self::getContainer()->get(BailleurTerritoryRepository::class),
+            self::getContainer()->get(TerritoryRepository::class),
+            self::getContainer()->get(EntityManagerInterface::class)
+        );
+
+        $bailleurLoader->load($this->getData());
+
+        $metadata = $bailleurLoader->getMetadata();
+        $this->assertEquals(5, $metadata['count_bailleurs']);
+        $this->assertStringContainsString('Le territoire n\'existe pas.', $metadata['errors'][0]);
+    }
+
+    private function getData(): array
+    {
+        return [
+            [
+                'Département du logement attribué' => 'Bouches-du-Rhône',
+                "Organisme de l'attribution" => 'MEDITERRANEE 1',
+            ],
+            [
+                'Département du logement attribué' => 'Bouches-du-Rhône',
+                "Organisme de l'attribution" => 'MEDITERRANEE 2',
+            ],
+            [
+                'Département du logement attribué' => 'Bouches-du-Rhône',
+                "Organisme de l'attribution" => 'MEDITERRANEE 3',
+            ],
+            [
+                'Département du logement attribué' => 'Bouches-du-Rhône',
+                "Organisme de l'attribution" => '',
+            ],
+            [
+                'Département du logement attribué' => 'Charente',
+                "Organisme de l'attribution" => 'DOMOFRANCE 1',
+            ],
+            [
+                'Département du logement attribué' => 'Charente',
+                "Organisme de l'attribution" => 'DOMOFRANCE 2',
+            ],
+            [
+                'Département du logement attribué' => 'Charente',
+                "Organisme de l'attribution" => 'MEDITERRANEE 3',
+            ],
+            [
+                'Département du logement attribué' => 'Charente',
+                "Organisme de l'attribution" => '',
+            ],
+            [
+                'Département du logement attribué' => 'Saint Martin',
+                "Organisme de l'attribution" => 'LOGEMENT HLS',
+            ],
+        ];
+    }
+}

--- a/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
+++ b/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional\Service\Import\Bailleur;
 use App\Repository\BailleurRepository;
 use App\Repository\BailleurTerritoryRepository;
 use App\Repository\TerritoryRepository;
+use App\Service\Import\Bailleur\BailleurHeader;
 use App\Service\Import\Bailleur\BailleurLoader;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -31,40 +32,40 @@ class BailleurLoaderTest extends KernelTestCase
     {
         return [
             [
-                'Département du logement attribué' => 'Bouches-du-Rhône',
-                "Organisme de l'attribution" => 'MEDITERRANEE 1',
+                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 1',
             ],
             [
-                'Département du logement attribué' => 'Bouches-du-Rhône',
-                "Organisme de l'attribution" => 'MEDITERRANEE 2',
+                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 2',
             ],
             [
-                'Département du logement attribué' => 'Bouches-du-Rhône',
-                "Organisme de l'attribution" => 'MEDITERRANEE 3',
+                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 3',
             ],
             [
-                'Département du logement attribué' => 'Bouches-du-Rhône',
-                "Organisme de l'attribution" => '',
+                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::ORGANISME_NOM => '',
             ],
             [
-                'Département du logement attribué' => 'Charente',
-                "Organisme de l'attribution" => 'DOMOFRANCE 1',
+                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::ORGANISME_NOM => 'DOMOFRANCE 1',
             ],
             [
-                'Département du logement attribué' => 'Charente',
-                "Organisme de l'attribution" => 'DOMOFRANCE 2',
+                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::ORGANISME_NOM => 'DOMOFRANCE 2',
             ],
             [
-                'Département du logement attribué' => 'Charente',
-                "Organisme de l'attribution" => 'MEDITERRANEE 3',
+                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 3',
             ],
             [
-                'Département du logement attribué' => 'Charente',
-                "Organisme de l'attribution" => '',
+                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::ORGANISME_NOM => '',
             ],
             [
-                'Département du logement attribué' => 'Saint Martin',
-                "Organisme de l'attribution" => 'LOGEMENT HLS',
+                BailleurHeader::DEPARTEMENT => 'Saint Martin',
+                BailleurHeader::ORGANISME_NOM => 'LOGEMENT HLS',
             ],
         ];
     }

--- a/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
+++ b/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
@@ -12,6 +12,9 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class BailleurLoaderTest extends KernelTestCase
 {
+    private const BOUCHE_DU_RHONE = 'Bouches-du-Rhône';
+    private const CHARENTE = 'Charente';
+
     public function testLoadValidBailleur(): void
     {
         $bailleurLoader = new BailleurLoader(
@@ -32,35 +35,35 @@ class BailleurLoaderTest extends KernelTestCase
     {
         return [
             [
-                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
                 BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 1',
             ],
             [
-                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
                 BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 2',
             ],
             [
-                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
                 BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 3',
             ],
             [
-                BailleurHeader::DEPARTEMENT => 'Bouches-du-Rhône',
+                BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
                 BailleurHeader::ORGANISME_NOM => '',
             ],
             [
-                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::DEPARTEMENT => self::CHARENTE,
                 BailleurHeader::ORGANISME_NOM => 'DOMOFRANCE 1',
             ],
             [
-                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::DEPARTEMENT => self::CHARENTE,
                 BailleurHeader::ORGANISME_NOM => 'DOMOFRANCE 2',
             ],
             [
-                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::DEPARTEMENT => self::CHARENTE,
                 BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 3',
             ],
             [
-                BailleurHeader::DEPARTEMENT => 'Charente',
+                BailleurHeader::DEPARTEMENT => self::CHARENTE,
                 BailleurHeader::ORGANISME_NOM => '',
             ],
             [

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -11,6 +11,7 @@ use App\Factory\Signalement\InformationProcedureFactory;
 use App\Factory\Signalement\SituationFoyerFactory;
 use App\Factory\Signalement\TypeCompositionLogementFactory;
 use App\Manager\DesordreCritereManager;
+use App\Repository\BailleurRepository;
 use App\Repository\DesordreCategorieRepository;
 use App\Repository\DesordreCritereRepository;
 use App\Repository\DesordrePrecisionRepository;
@@ -22,7 +23,6 @@ use App\Service\Signalement\DesordreTraitement\DesordreTraitementProcessor;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use App\Service\Signalement\ReferenceGenerator;
 use App\Service\Signalement\SignalementBuilder;
-use App\Service\Signalement\ZipcodeProvider;
 use App\Service\Token\TokenGeneratorInterface;
 use App\Service\UploadHandlerService;
 use App\Tests\FixturesHelper;
@@ -44,7 +44,7 @@ class SignalementBuilderTest extends KernelTestCase
         self::bootKernel();
 
         $territoryRepository = static::getContainer()->get(TerritoryRepository::class);
-        $zipcodeProvider = static::getContainer()->get(ZipcodeProvider::class);
+        $bailleurRepository = static::getContainer()->get(BailleurRepository::class);
         $referenceGenerator = static::getContainer()->get(ReferenceGenerator::class);
         $tokenGenerator = static::getContainer()->get(TokenGeneratorInterface::class);
         $signalementDraftRequestSerializer = static::getContainer()->get(SignalementDraftRequestSerializer::class);
@@ -66,7 +66,7 @@ class SignalementBuilderTest extends KernelTestCase
 
         $this->signalementBuilder = new SignalementBuilder(
             $territoryRepository,
-            $zipcodeProvider,
+            $bailleurRepository,
             $referenceGenerator,
             $tokenGenerator,
             $signalementDraftRequestSerializer,

--- a/tests/Functional/Service/Signalement/ZipCodeProviderTest.php
+++ b/tests/Functional/Service/Signalement/ZipCodeProviderTest.php
@@ -7,44 +7,35 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class ZipCodeProviderTest extends KernelTestCase
 {
-    private ZipcodeProvider $zipcodeProvider;
-
-    protected function setUp(): void
-    {
-        self::bootKernel();
-        $container = static::getContainer();
-        $this->zipcodeProvider = $container->get(ZipcodeProvider::class);
-    }
-
     public function testGetZipCodeTerritory(): void
     {
         $this->assertEquals(
             ZipcodeProvider::CORSE_DU_SUD_CODE_DEPARTMENT_2A,
-            $this->zipcodeProvider->getZipCode('20167'),
+            ZipcodeProvider::getZipCode('20167'),
         );
         $this->assertEquals(
             ZipcodeProvider::CORSE_DU_SUD_CODE_DEPARTMENT_2A,
-            $this->zipcodeProvider->getZipCode('20000'),
+            ZipcodeProvider::getZipCode('20000'),
         );
         $this->assertEquals(
             ZipcodeProvider::HAUTE_CORSE_CODE_DEPARTMENT_2B,
-            $this->zipcodeProvider->getZipCode('20200')
+            ZipcodeProvider::getZipCode('20200')
         );
         $this->assertEquals(
             ZipcodeProvider::HAUTE_CORSE_CODE_DEPARTMENT_2B,
-            $this->zipcodeProvider->getZipCode('20600')
+            ZipcodeProvider::getZipCode('20600')
         );
         $this->assertEquals(
             ZipcodeProvider::LA_REUNION_CODE_DEPARTMENT_974,
-            $this->zipcodeProvider->getZipCode('97400')
+            ZipcodeProvider::getZipCode('97400')
         );
         $this->assertEquals(
             ZipcodeProvider::MARTINIQUE_CODE_DEPARTMENT_972,
-            $this->zipcodeProvider->getZipCode('97200')
+            ZipcodeProvider::getZipCode('97200')
         );
         $this->assertEquals(
             '13',
-            $this->zipcodeProvider->getZipCode('13002')
+            ZipcodeProvider::getZipCode('13002')
         );
     }
 }

--- a/tests/Unit/Command/ImportBailleurCommandTest.php
+++ b/tests/Unit/Command/ImportBailleurCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\ImportBailleurCommand;
+use App\Service\Import\Bailleur\BailleurLoader;
+use App\Service\Import\CsvParser;
+use App\Service\UploadHandlerService;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ImportBailleurCommandTest extends KernelTestCase
+{
+    private MockObject|CsvParser $csvParser;
+    private MockObject|BailleurLoader $bailleurLoader;
+    private MockObject|UploadHandlerService $uploadHandlerServiceMock;
+    private MockObject|FilesystemOperator $fileStorage;
+    private MockObject|ParameterBagInterface $parameterBag;
+
+    protected function setUp(): void
+    {
+        $this->csvParser = $this->createMock(CsvParser::class);
+        $this->bailleurLoader = $this->createMock(BailleurLoader::class);
+        $this->uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
+        $this->fileStorage = $this->createMock(FilesystemOperator::class);
+        $this->parameterBag = static::getContainer()->get(ParameterBagInterface::class);
+    }
+
+    public function testDisplayWithFailureMessage(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->add(new ImportBailleurCommand(
+            $this->csvParser,
+            $this->bailleurLoader,
+            $this->uploadHandlerServiceMock,
+            $this->fileStorage,
+            $this->parameterBag
+        ));
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+        $this->assertStringContainsString('CSV File does not exists', $commandTester->getDisplay());
+        $this->assertEquals(1, $commandTester->getStatusCode());
+    }
+
+    public function testDisplayWithSucessMessage(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $this->fileStorage
+            ->expects($this->once())
+            ->method('fileExists')
+            ->with('csv/bailleurs.csv')
+            ->willReturn(true);
+
+        $this->uploadHandlerServiceMock
+            ->expects($this->once())
+            ->method('createTmpFileFromBucket');
+
+        $this->bailleurLoader
+            ->expects($this->once())
+            ->method('getMetadata')
+            ->willReturn([
+                'count_bailleurs' => 10,
+                'errors' => ['[Wallis-et-Futuna] ligne 2 - Le territoire n\'existe pas',
+                ], ]);
+
+        $command = $application->add(new ImportBailleurCommand(
+            $this->csvParser,
+            $this->bailleurLoader,
+            $this->uploadHandlerServiceMock,
+            $this->fileStorage,
+            $this->parameterBag
+        ));
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Le territoire n\'existe pas ', $output);
+        $this->assertStringContainsString('10 bailleur(s) have been imported', $output);
+        $commandTester->assertCommandIsSuccessful();
+    }
+}

--- a/tests/Unit/Command/ImportBailleurCommandTest.php
+++ b/tests/Unit/Command/ImportBailleurCommandTest.php
@@ -68,8 +68,8 @@ class ImportBailleurCommandTest extends KernelTestCase
             ->method('getMetadata')
             ->willReturn([
                 'count_bailleurs' => 10,
-                'errors' => ['[Wallis-et-Futuna] ligne 2 - Le territoire n\'existe pas',
-                ], ]);
+                'errors' => ['[Wallis-et-Futuna] ligne 2 - Le territoire n\'existe pas'],
+            ]);
 
         $command = $application->add(new ImportBailleurCommand(
             $this->csvParser,

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -84,6 +84,25 @@
           "slug": "coordonnees_bailleur_nom",
           "validate": {
             "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormAutocomplete",
+          "label": "Nom de l'organisme",
+          "slug": "coordonnees_bailleur_nom_autocomplete",
+          "placeholder": "Taper le nom de l'organisme ici",
+          "validate": {
+            "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+          },
+          "autocomplete": {
+            "isAbsoluteLink": false,
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -102,7 +102,7 @@
           },
           "autocomplete": {
             "isAbsoluteLink": false,
-            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete_textfield}}"
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -153,7 +153,7 @@
           },
           "autocomplete": {
             "isAbsoluteLink": false,
-            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete_textfield}}"
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -136,12 +136,12 @@
             "maxLength": 255
           },
           "conditional": {
-            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+            "show": "formStore.data.signalement_concerne_logement_social_service_secours === 'non'"
           }
         },
         {
           "type": "SignalementFormAutocomplete",
-          "label": "Nom de l'organisme",
+          "label": "Nom de l'organisme (facultatif)",
           "slug": "coordonnees_bailleur_nom_autocomplete",
           "placeholder": "Taper le nom de l'organisme ici",
           "validate": {
@@ -149,7 +149,7 @@
             "maxLength": 255
           },
           "conditional": {
-            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+            "show": "formStore.data.signalement_concerne_logement_social_service_secours === 'oui'"
           },
           "autocomplete": {
             "isAbsoluteLink": false,

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -134,6 +134,26 @@
           "validate": {
             "required": false,
             "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormAutocomplete",
+          "label": "Nom de l'organisme",
+          "slug": "coordonnees_bailleur_nom_autocomplete",
+          "placeholder": "Taper le nom de l'organisme ici",
+          "validate": {
+            "required": false,
+            "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+          },
+          "autocomplete": {
+            "isAbsoluteLink": false,
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -162,7 +162,7 @@
           },
           "autocomplete": {
             "isAbsoluteLink": false,
-            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete_textfield}}"
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -144,6 +144,25 @@
           "slug": "coordonnees_bailleur_nom",
           "validate": {
             "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormAutocomplete",
+          "label": "Nom de l'organisme",
+          "slug": "coordonnees_bailleur_nom_autocomplete",
+          "placeholder": "Taper le nom de l'organisme ici",
+          "validate": {
+            "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+          },
+          "autocomplete": {
+            "isAbsoluteLink": false,
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -127,6 +127,25 @@
           "slug": "coordonnees_bailleur_nom",
           "validate": {
             "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+          }
+        },
+        {
+          "type": "SignalementFormAutocomplete",
+          "label": "Nom de l'organisme",
+          "slug": "coordonnees_bailleur_nom_autocomplete",
+          "placeholder": "Taper le nom de l'organisme ici",
+          "validate": {
+            "maxLength": 255
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui'"
+          },
+          "autocomplete": {
+            "isAbsoluteLink": false,
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
           }
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -145,7 +145,7 @@
           },
           "autocomplete": {
             "isAbsoluteLink": false,
-            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete}}"
+            "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete_textfield}}"
           }
         },
         {


### PR DESCRIPTION
## Ticket

#2215   

## Description
Ajout d'une liste de bailleurs en auto-complétion si c'est un logement social.

## Changements apportés
* Ajout d'une nouvelle table "bailleur".
* Ajout d'une nouvelle commande sheel pour pousser le csv bailleur
* Ajout d'une commande pour importer la liste des bailleurs.
* Ajout d'une nouvelle route
* Ajout d'un nouveau composant d'autocomplétion pour le formulaire.
* Ajout du système d'auto-complétion côté BO si c'est un logement social.
* Correction de noms du territoire
* Passer le service ZipcodeProvider en statique

## Prérequis
```
make create-db
make npm-build
```
Le fichier est déjà sur le bucket
## Tests
- [ ] Exécuter la commande `make console app="import-bailleur"`
- [ ] [FO] En tant que locataire avec un logement social, la liste des bailleurs m'est proposée en autocomplétion.
- [ ] [FO] En tant que tiers professionnel avec un logement social, la liste des bailleurs m'est proposée en autocomplétion.
- [ ] [FO] En tant que tiers particulier avec un logement social, la liste des bailleurs m'est proposée en autocomplétion.
- [ ] [FO] En tant que service de secours avec un logement social, la liste des bailleurs m'est proposée en autocomplétion.
- [ ] [FO] En tant que déclarant sans avoir coché "logement social", la liste des bailleurs ne m'est pas proposée en autocomplétion.
- [ ] Aller au bout sur un des profil et vérifier que le bailleur est bien enregistré
- [ ] [BO] En tant qu'agent et sur une édition "Informations sur le bailleur" de la fiche signalement, la liste des bailleurs m'est proposée en autocomplétion.
- [ ] [FO][BO] La navigation au clavier doit est possible
- [ ] [FO][BO] On doit pouvoir quitter la liste de suggestion sur un clic extérieur à la zone de suggestion