### PR TITLE
[QA] Corrections concernant les calculs de la NDE

### DIFF
--- a/src/Dto/Request/Signalement/QualificationNDERequest.php
+++ b/src/Dto/Request/Signalement/QualificationNDERequest.php
@@ -11,7 +11,7 @@ class QualificationNDERequest
         private ?string $dateEntree = null,
         private ?string $dateDernierBail = null,
         private ?string $dateDernierDPE = null,
-        private ?int $superficie = null,
+        private ?float $superficie = null,
         private ?int $consommationEnergie = null,
         private ?bool $dpe = null,
     ) {
@@ -22,7 +22,7 @@ class QualificationNDERequest
         return $this->dateEntree;
     }
 
-    public function getSuperficie(): ?int
+    public function getSuperficie(): ?float
     {
         return $this->superficie;
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -274,7 +274,7 @@ class SignalementManager extends AbstractManager
             ) {
                 $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_AFTER_2023));
             }
-    
+
             if (QualificationNDERequest::RADIO_VALUE_BEFORE_2023 === $qualificationNDERequest->getDateEntree()
                 && ($signalement->getDateEntree()->format('Y') >= '2023' || null === $signalement->getDateEntree())
             ) {

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -267,17 +267,19 @@ class SignalementManager extends AbstractManager
         QualificationNDERequest $qualificationNDERequest
     ) {
         $signalement = $signalementQualification->getSignalement();
-        // // mise à jour du signalement
-        if (QualificationNDERequest::RADIO_VALUE_AFTER_2023 === $qualificationNDERequest->getDateEntree()
-            && ($signalement->getDateEntree()->format('Y') < '2023' || null === $signalement->getDateEntree())
-        ) {
-            $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_AFTER_2023));
-        }
-
-        if (QualificationNDERequest::RADIO_VALUE_BEFORE_2023 === $qualificationNDERequest->getDateEntree()
-            && ($signalement->getDateEntree()->format('Y') >= '2023' || null === $signalement->getDateEntree())
-        ) {
-            $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_BEFORE_2023));
+        // mise à jour du signalement
+        if ($qualificationNDERequest->getDateEntree()) {
+            if (QualificationNDERequest::RADIO_VALUE_AFTER_2023 === $qualificationNDERequest->getDateEntree()
+                && ($signalement->getDateEntree()->format('Y') < '2023' || null === $signalement->getDateEntree())
+            ) {
+                $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_AFTER_2023));
+            }
+    
+            if (QualificationNDERequest::RADIO_VALUE_BEFORE_2023 === $qualificationNDERequest->getDateEntree()
+                && ($signalement->getDateEntree()->format('Y') >= '2023' || null === $signalement->getDateEntree())
+            ) {
+                $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_BEFORE_2023));
+            }
         }
 
         if (null !== $qualificationNDERequest->getSuperficie()
@@ -287,26 +289,28 @@ class SignalementManager extends AbstractManager
         }
         $this->save($signalement);
 
-        // // mise à jour du signalementqualification
-        if (QualificationNDERequest::RADIO_VALUE_AFTER_2023 === $qualificationNDERequest->getDateDernierBail()
-            && (
-                null === $signalementQualification->getDernierBailAt()
-                || $signalementQualification->getDernierBailAt()?->format('Y') < '2023'
-            )
-        ) {
-            $signalementQualification->setDernierBailAt(new \DateTimeImmutable(
-                QualificationNDERequest::RADIO_VALUE_AFTER_2023
-            ));
-        }
-        if (QualificationNDERequest::RADIO_VALUE_BEFORE_2023 === $qualificationNDERequest->getDateDernierBail()
-            && (
-                null === $signalementQualification->getDernierBailAt()
-                || $signalementQualification->getDernierBailAt()?->format('Y') >= '2023'
-            )
-        ) {
-            $signalementQualification->setDernierBailAt(
-                new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_BEFORE_2023)
-            );
+        // mise à jour du signalementqualification
+        if ($qualificationNDERequest->getDateDernierBail()) {
+            if (QualificationNDERequest::RADIO_VALUE_AFTER_2023 === $qualificationNDERequest->getDateDernierBail()
+                && (
+                    null === $signalementQualification->getDernierBailAt()
+                    || $signalementQualification->getDernierBailAt()?->format('Y') < '2023'
+                )
+            ) {
+                $signalementQualification->setDernierBailAt(new \DateTimeImmutable(
+                    QualificationNDERequest::RADIO_VALUE_AFTER_2023
+                ));
+            }
+            if (QualificationNDERequest::RADIO_VALUE_BEFORE_2023 === $qualificationNDERequest->getDateDernierBail()
+                && (
+                    null === $signalementQualification->getDernierBailAt()
+                    || $signalementQualification->getDernierBailAt()?->format('Y') >= '2023'
+                )
+            ) {
+                $signalementQualification->setDernierBailAt(
+                    new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_BEFORE_2023)
+                );
+            }
         }
 
         $signalementQualification->setDetails($qualificationNDERequest->getDetails());

--- a/src/Service/Signalement/Qualification/SignalementQualificationUpdater.php
+++ b/src/Service/Signalement/Qualification/SignalementQualificationUpdater.php
@@ -385,9 +385,12 @@ class SignalementQualificationUpdater
         Signalement $signalement,
         array $linkedDesordrePrecisions,
     ): ?SignalementQualification {
-        $dataDateBail = new \DateTimeImmutable(
-            $signalement->getTypeCompositionLogement()->getBailDpeDateEmmenagement()
-        );
+        $dataDateBail = null;
+        if ($signalement->getTypeCompositionLogement()->getBailDpeDateEmmenagement()) {
+            $dataDateBail = new \DateTimeImmutable(
+                $signalement->getTypeCompositionLogement()->getBailDpeDateEmmenagement()
+            );
+        }
         $dataHasDPE = null;
         if ('oui' === $signalement->getTypeCompositionLogement()->getBailDpeDpe()) {
             $dataHasDPE = true;


### PR DESCRIPTION
## Ticket

#2252
#2291
#2293 

## Description
Corrections lorsqu'il y a des éléments manquants dans le calcul de la NDE

## Tests
[Signalement avec NDE pré-existant](http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000008)
- [ ] Modifier la superficie dans la zone NDE avec une valeur float
- [ ] Passer la date du dernier bail ou la date d'entrée à `NULL` en bdd et tenter d'enregistrer la zone NDE
- [ ] Passer `$signalement->getTypeCompositionLogement()->getBailDpeDateEmmenagement()` à `NULL` en bdd et tenter d'enregistrer la zone NDE
