### PR TITLE
[QA] Correction calcul suroccupation si le nombre de pièces n'est pas précisé

### DIFF
--- a/src/Specification/Signalement/SuroccupationSpecification.php
+++ b/src/Specification/Signalement/SuroccupationSpecification.php
@@ -29,7 +29,7 @@ class SuroccupationSpecification
     private function checkSuroccupation(
         ?string $isAllocataire,
         int $nbOccupants,
-        int $nbPieces,
+        ?int $nbPieces,
         ?float $superficie,
     ): bool {
         $suroccupation = false;
@@ -53,7 +53,7 @@ class SuroccupationSpecification
                 $this->slug = 'desordres_type_composition_logement_suroccupation_allocataire';
             }
         } else {
-            if ($nbPieces < $nbOccupants / $this::NON_ALLOCATAIRE_MIN_PIECES_PER_OCCUPANT) {
+            if (!empty($nbPieces) && $nbPieces < $nbOccupants / $this::NON_ALLOCATAIRE_MIN_PIECES_PER_OCCUPANT) {
                 $suroccupation = true;
                 $this->slug = 'desordres_type_composition_logement_suroccupation_non_allocataire';
             }

--- a/tests/Functional/Specification/Signalement/SuroccupationSpecificationTest.php
+++ b/tests/Functional/Specification/Signalement/SuroccupationSpecificationTest.php
@@ -152,6 +152,19 @@ class SuroccupationSpecificationTest extends KernelTestCase
         );
     }
 
+    public function testCheckSuroccupationAllocataireNull5PersonnesNbPiecesNull(): void
+    {
+        $this->situationFoyer->setLogementSocialAllocation(null);
+        $this->typeCompositionLogement->setCompositionLogementNombrePersonnes('5');
+        $this->typeCompositionLogement->setCompositionLogementNbPieces(null);
+        $isSuroccupation = $this->suroccupationSpecification->isSatisfiedBy(
+            $this->situationFoyer,
+            $this->typeCompositionLogement
+        );
+
+        $this->assertFalse($isSuroccupation);
+    }
+
     public function testCheckPasSuroccupationAllocataireNull5Personnes(): void
     {
         $this->situationFoyer->setLogementSocialAllocation(null);


### PR DESCRIPTION
## Ticket

#2290   

## Description
Sur les signalements où le nombre de pièces n'est pas précisé, le calcul de suroccupation si on n'est pas allocataire peut planter

## Tests
- [ ] Se mettre dans le contexte et modifier les informations du logement
