### PR TITLE
[Esabora] Commande - Correction requête sur un envoi de dossier unique

### DIFF
--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -119,8 +119,7 @@ class AffectationRepository extends ServiceEntityRepository
         }
 
         if (null !== $uuidSignalement) {
-            $qb->innerJoin('a.signalement', 's')
-                ->andWhere('s.uuid LIKE :uuid_signalement')
+            $qb->andWhere('s.uuid LIKE :uuid_signalement')
                 ->setParameter('uuid_signalement', $uuidSignalement);
         }
 

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -33,5 +33,13 @@ class AffectationRepositoryTest extends KernelTestCase
         foreach ($affectationsSubscribedToEsabora as $affectationSubscribedToEsabora) {
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }
+
+        $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(
+            PartnerType::ARS,
+            true,
+            '00000000-0000-0000-2023-000000000012'
+        );
+
+        $this->assertCount(1, $affectationsSubscribedToEsabora);
     }
 }


### PR DESCRIPTION
## Ticket

#2331    

## Description
Régression  v2.0.2
[PR2272](https://github.com/MTES-MCT/histologe/pull/2272/files#diff-8e559732bcddf447751ccb9dbbd2f43782d7cb489e236dfea1452d76a2e2f7d7)

Possibilité d'avoir une même jointure en double qui provoque une erreur sur la requête d'exécution
## Changements apportés
* Suppression de la jointure en double
* Ajout d'un test 

## Pré-requis
`make worker-start`
`make mock`

## Tests
- [ ] Exécuter la commande ` make console app="push-esabora-dossier sish --uuid=00000000-0000-0000-2023-000000000012`, aucune erreur d’exécution ne doit être provoqué
