### PR TITLE
[QA] Correction export csv avec filtre visite activé

### DIFF
--- a/src/Service/SearchFilterService.php
+++ b/src/Service/SearchFilterService.php
@@ -374,25 +374,25 @@ class SearchFilterService
                 ->setParameter('cities', $filters['cities']);
         }
         if (!empty($filters['visites'])) {
-            $qb->leftJoin('s.interventions', 'i');
+            $qb->leftJoin('s.interventions', 'intervSearch');
             $queryVisites = '';
 
             foreach ($filters['visites'] as $visiteFilter) {
                 $queryVisites .= ('' !== $queryVisites) ? ' OR ' : '';
                 switch ($visiteFilter) {
                     case VisiteStatus::NON_PLANIFIEE->value:
-                        $queryVisites .= '(i.id IS NULL)';
+                        $queryVisites .= '(intervSearch.id IS NULL)';
                         break;
                     case VisiteStatus::PLANIFIEE->value:
                         $todayDatetime = new \DateTime();
-                        $queryVisites .= '(i.status = \''.Intervention::STATUS_PLANNED.'\' AND i.scheduledAt > '.$todayDatetime->format('Y-m-d').')';
+                        $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_PLANNED.'\' AND intervSearch.scheduledAt > '.$todayDatetime->format('Y-m-d').')';
                         break;
                     case VisiteStatus::CONCLUSION_A_RENSEIGNER->value:
                         $todayDatetime = new \DateTime();
-                        $queryVisites .= '(i.status = \''.Intervention::STATUS_PLANNED.'\' AND i.scheduledAt <= '.$todayDatetime->format('Y-m-d').')';
+                        $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_PLANNED.'\' AND intervSearch.scheduledAt <= '.$todayDatetime->format('Y-m-d').')';
                         break;
                     case VisiteStatus::TERMINEE->value:
-                        $queryVisites .= '(i.status = \''.Intervention::STATUS_DONE.'\')';
+                        $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_DONE.'\')';
                         break;
                 }
             }


### PR DESCRIPTION
## Ticket

#2292   

## Description
Si on souhaitait exporter une liste de signalements avec le filtre de visite activé, on avait un doublon d'identifiant `i` de jointure sur `interventions`.

## Tests
- [ ] Activer un filtre sur l'état des visites et exporter en csv
