### PR TITLE
[BO - signalement] Possibilité d'ajouter des photos et rapport à une visite, et affichage de ces photos, mise à jour des suivis, catégorisation des types de documents

### DIFF
--- a/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -60,8 +60,16 @@ document.querySelectorAll('.btn-signalement-file-edit').forEach(swbtn => {
     + ' par '+ target.getAttribute('data-partner-name')+target.getAttribute('data-user-name')
     document.querySelector('#file-edit-fileid').value = target.getAttribute('data-file-id')
 
+    const selectedDocumentType = target.getAttribute('data-documentType'); 
+    if (target.getAttribute('data-description') || selectedDocumentType === 'PHOTO_VISITE') {
+      document.querySelector('#fileDescription').value = target.getAttribute('data-description')
+      document.querySelector('#fr-modal-edit-file-description').classList.remove('fr-hidden')
+    }else {
+      document.querySelector('#fileDescription').value = ''
+      document.querySelector('#fr-modal-edit-file-description').classList.add('fr-hidden')
+    }
+
     const documentTypes = JSON.parse(target.getAttribute('data-documentType-list'));
-    const selectedDocumentType = target.getAttribute('data-documentType');
     let typeSelectBox = document.querySelector('#document-type-select');
     typeSelectBox.innerHTML = '';
     let option = new Option('Sélectionnez un type', '');

--- a/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -61,13 +61,8 @@ document.querySelectorAll('.btn-signalement-file-edit').forEach(swbtn => {
     document.querySelector('#file-edit-fileid').value = target.getAttribute('data-file-id')
 
     const selectedDocumentType = target.getAttribute('data-documentType'); 
-    // if (target.getAttribute('data-description') || selectedDocumentType === 'PHOTO_VISITE') {
-      document.querySelector('#fileDescription').value = target.getAttribute('data-description')
-      document.querySelector('#fr-modal-edit-file-description').classList.remove('fr-hidden')
-    // }else {
-    //   document.querySelector('#fileDescription').value = ''
-    //   document.querySelector('#fr-modal-edit-file-description').classList.remove('fr-hidden')
-    // }
+    document.querySelector('#fileDescription').value = target.getAttribute('data-description')
+    document.querySelector('#fr-modal-edit-file-description').classList.remove('fr-hidden')
 
     const documentTypes = JSON.parse(target.getAttribute('data-documentType-list'));
     let typeSelectBox = document.querySelector('#document-type-select');

--- a/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -61,13 +61,13 @@ document.querySelectorAll('.btn-signalement-file-edit').forEach(swbtn => {
     document.querySelector('#file-edit-fileid').value = target.getAttribute('data-file-id')
 
     const selectedDocumentType = target.getAttribute('data-documentType'); 
-    if (target.getAttribute('data-description') || selectedDocumentType === 'PHOTO_VISITE') {
+    // if (target.getAttribute('data-description') || selectedDocumentType === 'PHOTO_VISITE') {
       document.querySelector('#fileDescription').value = target.getAttribute('data-description')
       document.querySelector('#fr-modal-edit-file-description').classList.remove('fr-hidden')
-    }else {
-      document.querySelector('#fileDescription').value = ''
-      document.querySelector('#fr-modal-edit-file-description').classList.add('fr-hidden')
-    }
+    // }else {
+    //   document.querySelector('#fileDescription').value = ''
+    //   document.querySelector('#fr-modal-edit-file-description').classList.remove('fr-hidden')
+    // }
 
     const documentTypes = JSON.parse(target.getAttribute('data-documentType-list'));
     let typeSelectBox = document.querySelector('#document-type-select');

--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -131,9 +131,6 @@ function initializeUploadModal(
                             clone = selectDesordreToClone.cloneNode(true)
                             clone.id = 'select-desordre-' + response.response
                         }else{
-                            console.log(modal.dataset.fileFilter)
-                            console.log(selectTypeSituationToClone)
-                            console.log(selectTypeProcedureToClone)
                             if ('situation' === modal.dataset.fileFilter ){
                                 clone = selectTypeSituationToClone.cloneNode(true)
                             } else {
@@ -142,7 +139,6 @@ function initializeUploadModal(
                             clone.id = 'select-type-' + response.response
                         }
                         clone.dataset.fileId = response.response
-                        console.log(clone)
                         if (clone.querySelectorAll('option').length == 1) {
                             clone.remove()
                         } else {
@@ -313,7 +309,7 @@ function initializeUploadModal(
     document.querySelectorAll('.open-modal-upload-files-btn').forEach((button) => {
         button.addEventListener('click', (e) => {
             fileType = e.target.dataset.fileType
-            fileFilter = e.target.dataset.fileFilter
+            fileFilter = e.target.dataset.fileFilter ?? null
             documentType = e.target.dataset.documentType ?? null
             interventionId = e.target.dataset.interventionId ?? null
         })

--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -1,58 +1,44 @@
 initializeUploadModal(
     '#fr-modal-upload-files',
-    '.modal-upload-drop-section',
-    '.modal-upload-list',
-    '.modal-upload-files-selector',
-    '.modal-upload-files-selector-input',
-    '#select-type-to-clone',
+    '#select-type-situation-to-clone',
+    '#select-type-procedure-to-clone',
     '#select-desordre-to-clone',
-    '#btn-validate-modal-upload-files',
-    '#modal-upload-file-dynamic-content'
 );
 
 document?.querySelectorAll('.fr-modal-visites-upload-files')?.forEach(modalVisiteUpload => {
     initializeUploadModal(
         '#'+modalVisiteUpload.id,
-        '.modal-upload-drop-section',
-        '.modal-upload-list',
-        '.modal-upload-files-selector',
-        '.modal-upload-files-selector-input',
         null,
         null,
-        '#btn-validate-modal-upload-files',
-        '#modal-upload-file-dynamic-content'
+        null,
     )
 })
 
 
 function initializeUploadModal(
     modalSelector, 
-    fileDropAreaSelector, 
-    fileListContainerSelector, 
-    fileTypeSelector, 
-    fileInputSelector,
-    selectTypeToCloneSelector, 
+    selectTypeSituationToCloneSelector, 
+    selectTypeProcedureToCloneSelector, 
     selectDesordreToCloneSelector, 
-    btnValidateSelector,
-    ancreSelector
 ) {
     const modal = document?.querySelector(modalSelector);
     if (!modal) return;
 
-    const dropArea = modal.querySelector(fileDropAreaSelector);
-    const listContainer = modal.querySelector(fileListContainerSelector);
-    const fileSelector = modal.querySelector(fileTypeSelector)
-    const fileSelectorInput = modal.querySelector(fileInputSelector)
+    const dropArea = modal.querySelector('.modal-upload-drop-section');
+    const listContainer = modal.querySelector('.modal-upload-list');
+    const fileSelector = modal.querySelector('.modal-upload-files-selector')
+    const fileSelectorInput = modal.querySelector('.modal-upload-files-selector-input')
     const addFileRoute = modal.dataset.addFileRoute;
     const addFileToken = modal.dataset.addFileToken;
     const waitingSuiviRoute = modal.dataset.waitingSuiviRoute;
     const deleteTmpFileRoute = modal.dataset.deleteTmpFileRoute;
-    const selectTypeToClone = selectTypeToCloneSelector ? modal.querySelector(selectTypeToCloneSelector) : null;
+    const selectTypeSituationToClone = selectTypeSituationToCloneSelector ? modal.querySelector(selectTypeSituationToCloneSelector) : null;
+    const selectTypeProcedureToClone = selectTypeProcedureToCloneSelector ? modal.querySelector(selectTypeProcedureToCloneSelector) : null;
     const selectDesordreToClone = selectDesordreToCloneSelector ? modal.querySelector(selectDesordreToCloneSelector) : null;    
     const editFileRoute = modal.dataset.editFileRoute;
     const editFileToken = modal.dataset.editFileToken;
-    const btnValidate = modal.querySelector(btnValidateSelector);
-    const ancre = modal.querySelector(ancreSelector);
+    const btnValidate = modal.querySelector('#btn-validate-modal-upload-files');
+    const ancre = modal.querySelector('#modal-upload-file-dynamic-content');
 
 
     fileSelector.onclick = () => fileSelectorInput.click()
@@ -139,13 +125,16 @@ function initializeUploadModal(
                 addEventListenerDeleteTmpFile(btnDeleteTmpFile)
                 if (this.status == 200) {
                     modal.dataset.hasChanges = true
-                    if (null !== selectDesordreToClone || null !== selectTypeToClone){
+                    if (null !== selectDesordreToClone || null !== selectTypeSituationToClone || null !== selectTypeProcedureToClone){
                         let clone
                         if (modal.dataset.fileType == 'photo') {
                             clone = selectDesordreToClone.cloneNode(true)
                             clone.id = 'select-desordre-' + response.response
-                        } else {
-                            clone = selectTypeToClone.cloneNode(true)
+                            if ('situation' === modal.dataset.fileFilter ){
+                                clone = selectTypeSituationToClone.cloneNode(true)
+                            } else {
+                                clone = selectTypeProcedureToClone.cloneNode(true)
+                            }
                             clone.id = 'select-type-' + response.response
                         }
                         clone.dataset.fileId = response.response
@@ -314,10 +303,11 @@ function initializeUploadModal(
         modal.dataset.hasChanges = false
     })
 
-    let fileType, documentType, interventionId
+    let fileType, fileFilter, documentType, interventionId
     document.querySelectorAll('.open-modal-upload-files-btn').forEach((button) => {
         button.addEventListener('click', (e) => {
             fileType = e.target.dataset.fileType
+            fileFilter = e.target.dataset.fileFilter
             documentType = e.target.dataset.documentType ?? null
             interventionId = e.target.dataset.interventionId ?? null
         })
@@ -330,7 +320,11 @@ function initializeUploadModal(
         modal.querySelectorAll('.type-conditional').forEach((type) => {
             type.classList.add('fr-hidden')
         })
+        modal.querySelectorAll('.filter-conditional').forEach((type) => {
+            type.classList.add('fr-hidden')
+        })
         modal.dataset.documentType = documentType
+        modal.dataset.fileFilter = fileFilter
         modal.dataset.interventionId = interventionId        
         if (fileType == 'photo') {
             modal.dataset.fileType = 'photo'
@@ -340,8 +334,12 @@ function initializeUploadModal(
             modal.dataset.fileType = 'document'
             modal.querySelector('.type-document').classList.remove('fr-hidden')
             fileSelectorInput.setAttribute('accept', '*/*')
+        }   
+        if (fileFilter == 'procedure') {
+            modal.querySelector('.filter-procedure').classList.remove('fr-hidden')
+        } else if (fileFilter == 'situation')  {
+            modal.querySelector('.filter-situation').classList.remove('fr-hidden')
         }
-
     })
 
     btnValidate.addEventListener('click', (e) => {

--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -130,6 +130,10 @@ function initializeUploadModal(
                         if (modal.dataset.fileType == 'photo') {
                             clone = selectDesordreToClone.cloneNode(true)
                             clone.id = 'select-desordre-' + response.response
+                        }else{
+                            console.log(modal.dataset.fileFilter)
+                            console.log(selectTypeSituationToClone)
+                            console.log(selectTypeProcedureToClone)
                             if ('situation' === modal.dataset.fileFilter ){
                                 clone = selectTypeSituationToClone.cloneNode(true)
                             } else {
@@ -138,6 +142,7 @@ function initializeUploadModal(
                             clone.id = 'select-type-' + response.response
                         }
                         clone.dataset.fileId = response.response
+                        console.log(clone)
                         if (clone.querySelectorAll('option').length == 1) {
                             clone.remove()
                         } else {
@@ -200,7 +205,8 @@ function initializeUploadModal(
             `
         } else{
             innerHTML += `<div class="fr-col-3 select-container">           
-            </div>`
+            </div>
+            <input type="hidden" id="file-id" name="file[id]">`
         }
         innerHTML += `<div class="fr-col-1">
             <a href="${deleteTmpFileRoute}" title="Supprimer" class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line fr-hidden delete-tmp-file delete-html"></a>         

--- a/migrations/Version20240329143924.php
+++ b/migrations/Version20240329143924.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\File;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240329143924 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set file_type document for document_type SITUATION_FOYER_BAIL, SITUATION_FOYER_ETAT_DES_LIEUX or SITUATION_FOYER_DPE ';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE file SET file_type = \''.File::FILE_TYPE_DOCUMENT
+            .'\' WHERE document_type = \'SITUATION_FOYER_BAIL\' AND file_type = \''.File::FILE_TYPE_PHOTO.'\'');
+        $this->addSql('UPDATE file SET file_type = \''.File::FILE_TYPE_DOCUMENT
+            .'\' WHERE document_type = \'SITUATION_FOYER_ETAT_DES_LIEUX\' AND file_type = \''.File::FILE_TYPE_PHOTO.'\'');
+        $this->addSql('UPDATE file SET file_type = \''.File::FILE_TYPE_DOCUMENT
+            .'\' WHERE document_type = \'SITUATION_FOYER_DPE\' AND file_type = \''.File::FILE_TYPE_PHOTO.'\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -178,6 +178,8 @@ class SignalementController extends AbstractController
 
         $partnerVisite = $affectationRepository->findAffectationWithQualification(Qualification::VISITES, $signalement);
 
+        $allPhotosOrdered = $signalementManager->getAllPhotosOrdered($signalement);
+
         return $this->render('back/signalement/view.html.twig', [
             'title' => 'Signalement',
             'createdFromDraft' => $signalement->getCreatedFrom(),
@@ -206,6 +208,7 @@ class SignalementController extends AbstractController
             'partnersCanVisite' => $partnerVisite,
             'pendingVisites' => $interventionRepository->getPendingVisitesForSignalement($signalement),
             'isDocumentsEnabled' => $parameterBag->get('feature_documents_enable'),
+            'allPhotosOrdered' => $allPhotosOrdered,
         ]);
     }
 

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -21,6 +21,7 @@ use App\Repository\InterventionRepository;
 use App\Repository\SignalementQualificationRepository;
 use App\Repository\TagRepository;
 use App\Security\Voter\UserVoter;
+use App\Service\Signalement\PhotoHelper;
 use App\Service\Signalement\SignalementDesordresProcessor;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -178,7 +179,7 @@ class SignalementController extends AbstractController
 
         $partnerVisite = $affectationRepository->findAffectationWithQualification(Qualification::VISITES, $signalement);
 
-        $allPhotosOrdered = $signalementManager->getAllPhotosOrdered($signalement);
+        $allPhotosOrdered = PhotoHelper::getSortedPhotos($signalement);
 
         return $this->render('back/signalement/view.html.twig', [
             'title' => 'Signalement',

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -12,6 +12,7 @@ use App\Manager\FileManager;
 use App\Manager\SuiviManager;
 use App\Messenger\Message\PdfExportMessage;
 use App\Repository\FileRepository;
+use App\Repository\InterventionRepository;
 use App\Service\Signalement\SignalementFileProcessor;
 use App\Service\UploadHandlerService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -214,6 +215,7 @@ class SignalementFileController extends AbstractController
         Request $request,
         FileRepository $fileRepository,
         EntityManagerInterface $entityManager,
+        InterventionRepository $interventionRepository,
     ): Response {
         if (!$this->isCsrfTokenValid('signalement_edit_file_'.$signalement->getId(), $request->get('_token'))) {
             if ($request->isXmlHttpRequest()) {
@@ -250,6 +252,13 @@ class SignalementFileController extends AbstractController
         $file->setDocumentType($documentType);
         $desordreSlug = $request->get('desordreSlug');
         $file->setDesordreSlug($desordreSlug);
+        $interventionId = $request->get('interventionId');
+        if (null !== $interventionId) {
+            $intervention = $interventionRepository->findOneBy(['id' => $interventionId]);
+            if ($intervention->getSignalement() === $file->getSignalement()) {
+                $file->setIntervention($intervention);
+            }
+        }
         $entityManager->persist($file);
         $entityManager->flush();
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -255,8 +255,8 @@ class SignalementFileController extends AbstractController
         $file->setDesordreSlug($desordreSlug);
         $interventionId = $request->get('interventionId');
         if (null !== $interventionId) {
-            $intervention = $interventionRepository->findOneBy(['id' => $interventionId]);
-            if ($intervention->getSignalement() === $file->getSignalement()) {
+            $intervention = $interventionRepository->find($interventionId);
+            if ($intervention?->getSignalement() === $file->getSignalement()) {
                 $file->setIntervention($intervention);
             }
         }

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -259,6 +259,10 @@ class SignalementFileController extends AbstractController
                 $file->setIntervention($intervention);
             }
         }
+        $description = $request->get('description');
+        if (null !== $description) {
+            $file->setDescription($description);
+        }
         $entityManager->persist($file);
         $entityManager->flush();
         if ($request->isXmlHttpRequest()) {

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -167,12 +167,13 @@ class SignalementFileController extends AbstractController
                 $suivi = $suiviFactory->createInstanceFrom($this->getUser(), $signalement);
                 /** @var User $user */
                 $user = $this->getUser();
-                $description = $user->getNomComplet().' a supprimé le document suivant :';
+                $description = $user->getNomComplet().' a supprimé ';
+                $description .= File::FILE_TYPE_DOCUMENT === $type ? 'le document suivant :' : 'la photo suivante :';
                 $suivi->setDescription(
                     $description
-                    .'<ul>'
+                    .'<ul><li>'
                     .$filename
-                    .'</ul>'
+                    .'</li></ul>'
                 );
                 $suivi->setType(SUIVI::TYPE_AUTO);
 

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -84,13 +84,18 @@ signalements:
       - "desordres_logement_securite_sol_dangereux_pieces_piece_a_vivre"
       - "desordres_logement_securite_balcons_pieces_salle_de_bain"
       - "desordres_logement_securite_plomb_pieces_salle_de_bain_diagnostique_oui"
-    desordre_photos:
+    files:
       - file: "Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png"
         titre: "Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png"
         slug: "desordres_batiment_proprete_interieur"
+        document_type: "PHOTO_SITUATION"
+      - file: "Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png"
+        titre: "Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png"
+        document_type: "AUTRE"
       - file: "Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png"
         titre: "Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png"
         slug: "desordres_logement_chauffage_details_fenetres_permeables"
+        document_type: "PHOTO_SITUATION"
   -
     territory: "Pas-de-Calais"
     uuid: "00000000-0000-0000-2024-000000000002"

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -434,16 +434,16 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 $signalement->addSignalementQualification($signalementQualification);
             }
         }
-        if (isset($row['desordre_photos'])) {
-            foreach ($row['desordre_photos'] as $document) {
+        if (isset($row['files'])) {
+            foreach ($row['files'] as $document) {
                 $file = $this->fileFactory->createInstanceFrom(
                     filename: $document['file'],
                     title: $document['titre'],
-                    type: File::FILE_TYPE_PHOTO,
+                    type: $document['file_type'] ?? File::FILE_TYPE_PHOTO,
                     signalement: $signalement,
                     // user: $user,
-                    documentType: DocumentType::PHOTO_SITUATION,
-                    desordreSlug: $document['slug']
+                    documentType: DocumentType::tryFrom($document['document_type']) ?? DocumentType::PHOTO_SITUATION,
+                    desordreSlug: $document['slug'] ?? null
                 );
                 $manager->persist($file);
             }

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -47,7 +47,6 @@ enum DocumentType: String
     {
         return [
             self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
-            self::PHOTO_VISITE->name => self::PHOTO_VISITE->label(), // TODO, garder ?
             self::AUTRE->name => self::AUTRE->label(),
         ];
     }

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -3,6 +3,7 @@
 namespace App\Entity\Enum;
 
 use App\Entity\Behaviour\EnumTrait;
+use App\Entity\File;
 
 enum DocumentType: String
 {
@@ -74,5 +75,19 @@ enum DocumentType: String
             self::BAILLEUR_DEVIS_POUR_TRAVAUX->name => self::BAILLEUR_DEVIS_POUR_TRAVAUX->label(),
             self::BAILLEUR_REPONSE_BAILLEUR->name => self::BAILLEUR_REPONSE_BAILLEUR->label(),
         ];
+    }
+
+    public function mapFileType(): ?string
+    {
+        return match ($this) {
+            self::SITUATION_FOYER_BAIL, self::SITUATION_FOYER_DPE,
+            self::SITUATION_FOYER_ETAT_DES_LIEUX, self::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE,
+            self::PROCEDURE_MISE_EN_DEMEURE, self::PROCEDURE_RAPPORT_DE_VISITE,
+            self::PROCEDURE_ARRETE_MUNICIPAL, self::PROCEDURE_ARRETE_PREFECTORAL,
+            self::PROCEDURE_SAISINE, self::BAILLEUR_DEVIS_POUR_TRAVAUX,
+            self::BAILLEUR_REPONSE_BAILLEUR, => File::FILE_TYPE_DOCUMENT,
+            self::PHOTO_SITUATION,self::PHOTO_VISITE => File::FILE_TYPE_PHOTO,
+            self::AUTRE => null,
+        };
     }
 }

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -47,18 +47,26 @@ enum DocumentType: String
     {
         return [
             self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
-            self::PHOTO_VISITE->name => self::PHOTO_VISITE->label(),
+            self::PHOTO_VISITE->name => self::PHOTO_VISITE->label(), // TODO, garder ?
             self::AUTRE->name => self::AUTRE->label(),
         ];
     }
 
-    public static function getDocumentsList(): array
+    public static function getSituationList(): array
     {
         return [
+            self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
+            self::AUTRE->name => self::AUTRE->label(),
             self::SITUATION_FOYER_BAIL->name => self::SITUATION_FOYER_BAIL->label(),
             self::SITUATION_FOYER_DPE->name => self::SITUATION_FOYER_DPE->label(),
             self::SITUATION_FOYER_ETAT_DES_LIEUX->name => self::SITUATION_FOYER_ETAT_DES_LIEUX->label(),
             self::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE->name => self::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE->label(),
+        ];
+    }
+
+    public static function getProcedureList(): array
+    {
+        return [
             self::PROCEDURE_MISE_EN_DEMEURE->name => self::PROCEDURE_MISE_EN_DEMEURE->label(),
             self::PROCEDURE_RAPPORT_DE_VISITE->name => self::PROCEDURE_RAPPORT_DE_VISITE->label(),
             self::PROCEDURE_ARRETE_MUNICIPAL->name => self::PROCEDURE_ARRETE_MUNICIPAL->label(),
@@ -66,9 +74,6 @@ enum DocumentType: String
             self::PROCEDURE_SAISINE->name => self::PROCEDURE_SAISINE->label(),
             self::BAILLEUR_DEVIS_POUR_TRAVAUX->name => self::BAILLEUR_DEVIS_POUR_TRAVAUX->label(),
             self::BAILLEUR_REPONSE_BAILLEUR->name => self::BAILLEUR_REPONSE_BAILLEUR->label(),
-            self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
-            self::PHOTO_VISITE->name => self::PHOTO_VISITE->label(),
-            self::AUTRE->name => self::AUTRE->label(),
         ];
     }
 }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -260,4 +260,11 @@ class File
 
         return $this;
     }
+
+    public function isSituationPhoto(): bool
+    {
+        return $this->fileType === $this::FILE_TYPE_PHOTO
+        && \array_key_exists($this->documentType->value, DocumentType::getSituationList())
+        && null === $this->intervention;
+    }
 }

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Behaviour\TimestampableTrait;
+use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\ProcedureType;
 use App\Repository\InterventionRepository;
@@ -315,5 +316,15 @@ class Intervention
         }
 
         return $this;
+    }
+
+    /**
+     * @return Collection<int, File>
+     */
+    public function getRapportDeVisite(): Collection
+    {
+        return $this->files->filter(function (File $file) {
+            return DocumentType::PROCEDURE_RAPPORT_DE_VISITE === $file->getDocumentType();
+        });
     }
 }

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -78,19 +78,20 @@ class FileFactory
         return $this->createInstanceFrom(
             filename: $file['file'],
             title: $file['titre'],
-            type: $this->getFileType($file),
+            type: $this->getFileType($file, $documentType),
             signalement: $signalement,
             user: $user,
             intervention: $intervention,
-            documentType: SignalementDocumentTypeMapper::map($file['slug']),
+            documentType: $documentType,
             desordreSlug: $desordreSlug,
             description: $fileDescription,
         );
     }
 
-    private function getFileType(array $file)
+    private function getFileType(array $file, DocumentType $documentType)
     {
         if ('photos' === $file['key']
+            && File::FILE_TYPE_PHOTO === $documentType->mapFileType()
             && \in_array(
                 strtolower(pathinfo($file['file'], \PATHINFO_EXTENSION)),
                 ImageManipulationHandler::IMAGE_EXTENSION

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -13,7 +13,6 @@ use App\Entity\Signalement;
 use App\Entity\User;
 use App\Factory\FileFactory;
 use App\Repository\InterventionRepository;
-use App\Service\ImageManipulationHandler;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use Doctrine\Persistence\ManagerRegistry;
 use League\Flysystem\FilesystemOperator;
@@ -207,24 +206,22 @@ class InterventionManager extends AbstractManager
         return $intervention;
     }
 
-    private function createFile(Intervention $intervention, string $document): File
-    {
+    private function createFile(
+        Intervention $intervention,
+        string $document,
+        string $fileType = File::FILE_TYPE_DOCUMENT,
+        DocumentType $documentType = DocumentType::PROCEDURE_RAPPORT_DE_VISITE
+    ): File {
         /** @var User $user */
         $user = $this->security->getUser();
 
-        $fileType = File::FILE_TYPE_DOCUMENT;
-        if (\in_array($this->fileStorage->mimeType($document), ImageManipulationHandler::IMAGE_MIME_TYPES)) {
-            $fileType = File::FILE_TYPE_PHOTO;
-        }
-
-        // TODO : quand la modale sera fait, le documentType pourra être différent
         return $this->fileFactory->createInstanceFrom(
             filename: $document,
             title: $document,
             type: $fileType,
             signalement: $intervention->getSignalement(),
             user: $user,
-            documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE
+            documentType: $documentType
         );
     }
 }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -13,11 +13,9 @@ use App\Dto\Request\Signalement\QualificationNDERequest;
 use App\Dto\Request\Signalement\SituationFoyerRequest;
 use App\Dto\SignalementAffectationListView;
 use App\Entity\Affectation;
-use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\ProprioType;
-use App\Entity\File;
 use App\Entity\Model\InformationComplementaire;
 use App\Entity\Model\InformationProcedure;
 use App\Entity\Model\SituationFoyer;
@@ -802,62 +800,6 @@ class SignalementManager extends AbstractManager
                 $row
             );
         }
-    }
-
-    public function getPhotosBySlug(Signalement $signalement, string $desordrePrecisionSlug): ?array
-    {
-        $photos = $signalement->getPhotos()->filter(function (File $file) use ($desordrePrecisionSlug) {
-            return DocumentType::PHOTO_SITUATION === $file->getDocumentType()
-            && $file->getDesordreSlug() === $desordrePrecisionSlug;
-        });
-
-        return $photos->toArray();
-    }
-
-    public function getAllPhotosOrdered(Signalement $signalement): ?array
-    {
-        $photoList = $signalement->getPhotos()->toArray();
-        $photoListByType = [
-            DocumentType::PHOTO_SITUATION->value => [],
-            DocumentType::PHOTO_VISITE->value => [],
-            DocumentType::AUTRE->value => [],
-        ];
-
-        foreach ($photoList as $photoItem) {
-            $type = $photoItem->getDocumentType();
-            $photoListByType[$type->value][] = $photoItem;
-        }
-
-        foreach ($photoListByType as &$photoArray) {
-            usort($photoArray, function (File $fileA, File $fileB) {
-                if (DocumentType::PHOTO_SITUATION === $fileA->getDocumentType()) {
-                    return $fileA->getId() <=> $fileB->getId();
-                }
-                if (DocumentType::PHOTO_VISITE === $fileA->getDocumentType()) {
-                    $interventionA = $fileA->getIntervention();
-                    $interventionB = $fileB->getIntervention();
-                    if (null === $interventionA && null === $interventionB) {
-                        return 0;
-                    }
-                    if (null === $interventionA) {
-                        return 1;
-                    }
-                    if (null === $interventionB) {
-                        return -1;
-                    }
-
-                    return $interventionA->getId() <=> $interventionB->getId();
-                }
-
-                return $fileA->getId() <=> $fileB->getId();
-            });
-        }
-
-        return array_merge(
-            $photoListByType[DocumentType::PHOTO_SITUATION->value],
-            $photoListByType[DocumentType::AUTRE->value],
-            $photoListByType[DocumentType::PHOTO_VISITE->value]
-        );
     }
 
     /**

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -816,27 +816,26 @@ class SignalementManager extends AbstractManager
 
     public function getAllPhotosOrdered(Signalement $signalement): ?array
     {
-        $photos = $signalement->getPhotos();
-        $photosArray = $photos->toArray();
-        $photoArraysByType = [
+        $photoList = $signalement->getPhotos()->toArray();
+        $photoListByType = [
             DocumentType::PHOTO_SITUATION->value => [],
             DocumentType::PHOTO_VISITE->value => [],
             DocumentType::AUTRE->value => [],
         ];
 
-        foreach ($photosArray as $photo) {
-            $type = $photo->getDocumentType();
-            $photoArraysByType[$type->value][] = $photo;
+        foreach ($photoList as $photoItem) {
+            $type = $photoItem->getDocumentType();
+            $photoListByType[$type->value][] = $photoItem;
         }
 
-        foreach ($photoArraysByType as &$photoArray) {
-            usort($photoArray, function (File $a, File $b) {
-                if (DocumentType::PHOTO_SITUATION === $a->getDocumentType()) {
-                    return $a->getId() <=> $b->getId();
+        foreach ($photoListByType as &$photoArray) {
+            usort($photoArray, function (File $fileA, File $fileB) {
+                if (DocumentType::PHOTO_SITUATION === $fileA->getDocumentType()) {
+                    return $fileA->getId() <=> $fileB->getId();
                 }
-                if (DocumentType::PHOTO_VISITE === $a->getDocumentType()) {
-                    $interventionA = $a->getIntervention();
-                    $interventionB = $b->getIntervention();
+                if (DocumentType::PHOTO_VISITE === $fileA->getDocumentType()) {
+                    $interventionA = $fileA->getIntervention();
+                    $interventionB = $fileB->getIntervention();
                     if (null === $interventionA && null === $interventionB) {
                         return 0;
                     }
@@ -850,17 +849,15 @@ class SignalementManager extends AbstractManager
                     return $interventionA->getId() <=> $interventionB->getId();
                 }
 
-                return $a->getId() <=> $b->getId();
+                return $fileA->getId() <=> $fileB->getId();
             });
         }
 
-        $sortedPhotos = array_merge(
-            $photoArraysByType[DocumentType::PHOTO_SITUATION->value],
-            $photoArraysByType[DocumentType::AUTRE->value],
-            $photoArraysByType[DocumentType::PHOTO_VISITE->value]
+        return array_merge(
+            $photoListByType[DocumentType::PHOTO_SITUATION->value],
+            $photoListByType[DocumentType::AUTRE->value],
+            $photoListByType[DocumentType::PHOTO_VISITE->value]
         );
-
-        return $sortedPhotos;
     }
 
     /**

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -149,8 +149,8 @@ class SuiviManager extends Manager
                 $description .= sprintf(
                     '%s a ajouté %s %s de la visite du %s :',
                     $user->getPartner()->getNom(),
-                    $nbDocs,
-                    $nbDocs > 1 ? ' photos' : ' photo',
+                    $nbPhotos,
+                    $nbPhotos > 1 ? ' photos' : ' photo',
                     $intervention->getScheduledAt()->format('d/m/Y')
                 );
             }
@@ -160,8 +160,10 @@ class SuiviManager extends Manager
         foreach ($files as $file) {
             $fileUrl = $this->urlGenerator->generate(
                 'show_uploaded_file',
-                ['folder' => '_up', 'filename' => $file->getFilename()]
-            );
+                ['filename' => $file->getFilename()],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            ).'?t=___TOKEN___';
+
             $linkFile = '<li><a class="fr-link" target="_blank" href="'.$fileUrl.'">'.$file->getTitle().'</a>';
             if (DocumentType::PHOTO_SITUATION === $file->getDocumentType() && null !== $file->getDesordreSlug()) {
                 $desordreCritere = $this->desordreCritereRepository->findOneBy(

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -133,20 +133,26 @@ class SuiviManager extends Manager
         if (DocumentType::PROCEDURE_RAPPORT_DE_VISITE === $documentType && null !== $intervention) {
             $isVisibleUsager = true;
             if ($nbDocs > 0) {
-                $description .= $user->getPartner()->getNom().' a ajouté ';
-                $description .= $nbDocs;
-                $description .= $nbDocs > 1 ? ' rapports de visite' : ' rapport de visite';
-                $description .= ' de la visite du '.$intervention->getScheduledAt()->format('d/m/Y').' :';
+                $description .= sprintf(
+                    '%s a ajouté %s %s de la visite du %s :',
+                    $user->getPartner()->getNom(),
+                    $nbDocs,
+                    $nbDocs > 1 ? ' rapports de visite' : ' rapport de visite',
+                    $intervention->getScheduledAt()->format('d/m/Y')
+                );
             }
         }
 
         if (DocumentType::PHOTO_VISITE === $documentType) {
             $isVisibleUsager = true;
             if ($nbPhotos > 0) {
-                $description .= $user->getPartner()->getNom().' a ajouté ';
-                $description .= $nbPhotos;
-                $description .= $nbPhotos > 1 ? ' photos' : ' photo';
-                $description .= ' de la visite du '.$intervention->getScheduledAt()->format('d/m/Y').' :';
+                $description .= sprintf(
+                    '%s a ajouté %s %s de la visite du %s :',
+                    $user->getPartner()->getNom(),
+                    $nbDocs,
+                    $nbDocs > 1 ? ' photos' : ' photo',
+                    $intervention->getScheduledAt()->format('d/m/Y')
+                );
             }
         }
 

--- a/src/Security/Voter/InterventionVoter.php
+++ b/src/Security/Voter/InterventionVoter.php
@@ -39,7 +39,10 @@ class InterventionVoter extends Voter
     public function canEditVisite(Intervention $intervention, User $user): bool
     {
         $signalement = $intervention->getSignalement();
-        if (Signalement::STATUS_ACTIVE !== $signalement->getStatut() && Signalement::STATUS_NEED_PARTNER_RESPONSE !== $signalement->getStatut()) {
+        if (
+            Signalement::STATUS_ACTIVE !== $signalement->getStatut() &&
+            Signalement::STATUS_NEED_PARTNER_RESPONSE !== $signalement->getStatut()
+        ) {
             return false;
         }
 

--- a/src/Service/Signalement/PhotoHelper.php
+++ b/src/Service/Signalement/PhotoHelper.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Service\Signalement;
+
+use App\Entity\Enum\DocumentType;
+use App\Entity\File;
+use App\Entity\Signalement;
+
+class PhotoHelper
+{
+    public static function getPhotosBySlug(Signalement $signalement, string $desordrePrecisionSlug): ?array
+    {
+        $photos = $signalement->getPhotos()->filter(function (File $file) use ($desordrePrecisionSlug) {
+            return DocumentType::PHOTO_SITUATION === $file->getDocumentType()
+            && $file->getDesordreSlug() === $desordrePrecisionSlug;
+        });
+
+        return $photos->toArray();
+    }
+
+    public static function getSortedPhotos(Signalement $signalement): ?array
+    {
+        $photoList = $signalement->getPhotos()->toArray();
+        $photoListByType = [
+            DocumentType::PHOTO_SITUATION->value => [],
+            DocumentType::PHOTO_VISITE->value => [],
+            DocumentType::AUTRE->value => [],
+        ];
+
+        foreach ($photoList as $photoItem) {
+            $type = $photoItem->getDocumentType();
+            $photoListByType[$type->value][] = $photoItem;
+        }
+
+        foreach ($photoListByType as &$photoArray) {
+            usort($photoArray, function (File $fileA, File $fileB) {
+                if (DocumentType::PHOTO_SITUATION === $fileA->getDocumentType()) {
+                    return $fileA->getId() <=> $fileB->getId();
+                }
+                if (DocumentType::PHOTO_VISITE === $fileA->getDocumentType()) {
+                    $interventionA = $fileA->getIntervention();
+                    $interventionB = $fileB->getIntervention();
+                    if (null === $interventionA && null === $interventionB) {
+                        return 0;
+                    }
+                    if (null === $interventionA) {
+                        return 1;
+                    }
+                    if (null === $interventionB) {
+                        return -1;
+                    }
+
+                    return $interventionA->getId() <=> $interventionB->getId();
+                }
+
+                return $fileA->getId() <=> $fileB->getId();
+            });
+        }
+
+        return array_merge(
+            $photoListByType[DocumentType::PHOTO_SITUATION->value],
+            $photoListByType[DocumentType::AUTRE->value],
+            $photoListByType[DocumentType::PHOTO_VISITE->value]
+        );
+    }
+}

--- a/src/Service/Signalement/SignalementDesordresProcessor.php
+++ b/src/Service/Signalement/SignalementDesordresProcessor.php
@@ -67,7 +67,7 @@ class SignalementDesordresProcessor
         }
 
         $photos[$key] = array_unique(
-            array_merge($photos[$key], $this->signalementManager->getPhotosBySlug($signalement, $slug)),
+            array_merge($photos[$key], PhotoHelper::getPhotosBySlug($signalement, $slug)),
             \SORT_REGULAR
         );
     }

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -22,17 +22,28 @@
                     </div>
                     <div class="fr-modal__content">
                         <div class="type-conditional type-document">
-                            <h1 class="fr-modal__title">
-                                Ajouter des documents partenaires
-                            </h1>
-                            <div>
-                                Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
+                            <div class="filter-conditional filter-procedure">
+                                <h1 class="fr-modal__title">
+                                    Ajouter des documents liés à la procédure
+                                </h1>
+                                <div>
+                                    Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
+                                </div>
+                                <div class="fr-alert fr-alert--info fr-alert--sm">
+                                    <p>Pour ajouter des documents de type Bail, DPE, Diagnostic et Etat des lieux, rendez-vous dans la partie "Déclaration usager".</p>
+                                </div>
                             </div>
-                            {#
-                            <div class="fr-alert fr-alert--info fr-alert--sm">
-                                <p>Pour ajouter des documents de type Bail, DPE, Diagnostic et Etat des lieux, rendez-vous dans la partie "Déclaration usager".</p>
+                            <div class="filter-conditional filter-situation">
+                                <h1 class="fr-modal__title">
+                                    Ajouter des documents liés à la situation
+                                </h1>
+                                <div>
+                                    Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
+                                </div>
+                                <div class="fr-alert fr-alert--warning fr-alert--sm">
+                                    <p>Ces photos seront partagées à l'usager.</p>
+                                </div>
                             </div>
-                            #}
                         </div>
                         <div class="type-conditional type-photo">
                             <h1 class="fr-modal__title">
@@ -61,9 +72,15 @@
                         </div>
                         <div style="display:none">
                             {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
-                            <select class="fr-select select-type" data-file-id="" id="select-type-to-clone">
+                            <select class="fr-select select-type" data-file-id="" id="select-type-situation-to-clone">
                                 <option value="">Sélectionner un type</option>
-                                {% for key, value in DocumentType.getDocumentsList() %}
+                                {% for key, value in DocumentType.getSituationList() %}
+                                    <option value="{{ key }}">{{ value }}</option>
+                                {% endfor %}
+                            </select>
+                            <select class="fr-select select-type" data-file-id="" id="select-type-procedure-to-clone">
+                                <option value="">Sélectionner un type</option>
+                                {% for key, value in DocumentType.getProcedureList() %}
                                     <option value="{{ key }}">{{ value }}</option>
                                 {% endfor %}
                             </select>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -41,36 +41,25 @@
         
         {% include 'back/signalement/view/user-declaration.html.twig' %}
 
-        {% if createdFromDraft %}
-            {% include 'back/signalement/view/photos-documents.html.twig' with {
-                'zonetitle': "Photos et documents de la situation",
-                'importedBy': "user"
-            } %}
-        {% endif %}
+        {% include 'back/signalement/view/photos-documents.html.twig' with {
+            'zonetitle': "Photos et documents de la situation",
+            'filesFilter': 'situation' 
+        } %}
     
         {% include 'back/signalement/view/information.html.twig' %}
         
         {% include 'back/signalement/view/nde.html.twig' %}
-
-        {% if not createdFromDraft %}
-            {% include 'back/signalement/view/photos-documents.html.twig' with {
-                'zonetitle': "Photos et documents",
-                'importedBy': "all"
-            } %}
-        {% endif %}
-        
+ 
         {% include 'back/signalement/view/partners.html.twig' %}
         
         {% include 'back/signalement/view/suivis.html.twig' %}
 
         {% include 'back/signalement/view/visites/visites-list.html.twig' %}
 
-        {% if createdFromDraft %}
-            {% include 'back/signalement/view/photos-documents.html.twig' with {
-                'zonetitle': "Photos et documents liés à la procédure",
-                'importedBy': "partner"
-            } %}
-        {% endif %}
+        {% include 'back/signalement/view/photos-documents.html.twig' with {
+            'zonetitle': "Documents liés à la procédure",
+            'filesFilter': 'procedure' 
+        } %}
     </section>
 {% endblock %}
 {% block javascripts %}

--- a/templates/back/signalement/view/edit-modals/edit-file.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-file.html.twig
@@ -18,8 +18,13 @@
                                     <b><span class="fr-modal-file-edit-filename"></span></b>
                                     <br>
                                     <span class="fr-modal-file-edit-infos"></span>             
-                                </div>               
+                                </div>          
                             </div>
+
+                            <div id="fr-modal-edit-file-description" class="fr-input-group fr-hidden fr-col-12  fr-mb-2w">
+                                <label class="fr-label" for="fileDescription">Description : </label>
+                                    <input class="fr-input" type="text" id="fileDescription" name="description">
+                            </div>     
 
                             <div class="fr-select-group">
                                  <select class="fr-select" name="documentType" id="document-type-select">

--- a/templates/back/signalement/view/edit-modals/edit-file.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-file.html.twig
@@ -19,12 +19,7 @@
                                     <br>
                                     <span class="fr-modal-file-edit-infos"></span>             
                                 </div>          
-                            </div>
-
-                            <div id="fr-modal-edit-file-description" class="fr-input-group fr-hidden fr-col-12  fr-mb-2w">
-                                <label class="fr-label" for="fileDescription">Description : </label>
-                                    <input class="fr-input" type="text" id="fileDescription" name="description">
-                            </div>     
+                            </div> 
 
                             <div class="fr-select-group">
                                  <select class="fr-select" name="documentType" id="document-type-select">
@@ -35,6 +30,11 @@
                                  <select class="fr-select fr-hidden" name="desordreSlug" id="desordre-slug-select">
                                 </select>
                             </div>
+
+                            <div id="fr-modal-edit-file-description" class="fr-input-group fr-hidden fr-col-12  fr-mb-2w">
+                                <label class="fr-label" for="fileDescription">Description : </label>
+                                    <input class="fr-input" type="text" id="fileDescription" name="description">
+                            </div>    
                         </div>
                         
                         <div class="fr-modal__footer">

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -3,16 +3,19 @@
         <button class="photos-album-btn-close fr-btn">Fermer</button>
     </div>
 
-    {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null )|length %}
+    {# {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null )|length %} #}
+    {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' )|length %}
     <div class="photos-album-navigation-container">
         <div>
             <button class="fr-btn photos-album-swipe" data-direction="-1">&lt;</button>
         </div>
         <div>
-            {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %}
+            {# {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %} #}
+            {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' ) %}
             <div class="photos-album-image-item {{ loop.index > 1 ? 'fr-hidden' : 'loop-current' }}" data-id="{{ photo.id }}">
                 <div>
-                    Photo de la situation - {{ loop.index }} / {{ loopLength }}
+                    {# Photo de la situation - {{ loop.index }} / {{ loopLength }} #}
+                    {{ photo.documentType.label}} - {{ loop.index }} / {{ loopLength }}
                 </div>
                 <div>
                     <img
@@ -31,6 +34,10 @@
                         {% endif %}
                         <br>
                     {% endif %}
+                    {% if photo.description is not same as null %}
+                        {{ photo.description }}
+                    {% endif %}
+                    <br>
                     Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
                 </div>
             </div>
@@ -42,7 +49,8 @@
     </div>
     <script type="text/javascript">
         const histoPhotoIds = []
-        {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %}
+        {# {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %} #}
+        {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' ) %}
             histoPhotoIds.push({{photo.id}})
         {% endfor %}
     </script>

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -2,19 +2,15 @@
     <div class="photos-album-close-button-container">
         <button class="photos-album-btn-close fr-btn">Fermer</button>
     </div>
-
-    {# {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null )|length %} #}
-    {% set loopLength = signalement.files|filter( photo => photo.fileType == 'photo' )|length %}
+    {% set loopLength = allPhotosOrdered|length %}
     <div class="photos-album-navigation-container">
         <div>
             <button class="fr-btn photos-album-swipe" data-direction="-1">&lt;</button>
         </div>
         <div>
-            {# {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %} #}
-            {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' ) %}
+            {% for index, photo in allPhotosOrdered %}
             <div class="photos-album-image-item {{ loop.index > 1 ? 'fr-hidden' : 'loop-current' }}" data-id="{{ photo.id }}">
                 <div>
-                    {# Photo de la situation - {{ loop.index }} / {{ loopLength }} #}
                     {{ photo.documentType.label}} - {{ loop.index }} / {{ loopLength }}
                 </div>
                 <div>
@@ -29,6 +25,8 @@
                         {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION
                                 and photo.desordreSlug is not same as null %}
                             {{ signalement.getDesordreLabel(photo.desordreSlug) }}
+                        {% elseif photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_VISITE %}
+                            {{ photo.documentType.label() }} du {{ photo.intervention.scheduledAt|date('d/m/Y') }} par {{ photo.intervention.partner.nom}}
                         {% else %}
                             {{ photo.documentType.label() }}
                         {% endif %}
@@ -49,9 +47,8 @@
     </div>
     <script type="text/javascript">
         const histoPhotoIds = []
-        {# {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' and photo.intervention is null ) %} #}
-        {% for index, photo in signalement.files|filter( photo => photo.fileType == 'photo' ) %}
-            histoPhotoIds.push({{photo.id}})
+        {% for index, photo in allPhotosOrdered %}
+            histoPhotoIds.push({{ photo.id }})
         {% endfor %}
     </script>
 </div>

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -70,10 +70,8 @@
 {% if filesFilter is same as 'situation' %}
     <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
         {% for index, photo in signalement.files|filter(
-            photo => photo.fileType == 'photo'
-                    and photo.intervention is null
+            photo => photo.isSituationPhoto
                     and filesFilter is same as 'situation' 
-                    and photo.documentType.label() in  DocumentType.getSituationList
             ) %}
             <div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
                 <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -139,7 +139,7 @@
                     {% if doc.intervention is null %}
                     <i>{{ doc.title|truncate_filename(45) }}</i>
                     {% else %}
-                    <i>Rapport de visite du {{ doc.intervention.scheduledAt|date('d/m/Y') }}</i>
+                    <i>Rapport de la visite du {{ doc.intervention.scheduledAt|date('d/m/Y') }} par {{ doc.intervention.partner.nom}}</i>
                     {% endif %}
                 </div>
             </div>

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -93,6 +93,7 @@
                         data-type="photo" 
                         data-file-id="{{ photo.id}}" 
                         data-signalement-uuid="{{ signalement.uuid}}" 
+                        data-description="{{ photo.description }}" 
                         data-documentType="{{ photo.documentType.name }}" 
                         data-documentType-list="{{ DocumentType.getPhotosList() | json_encode }}"
                         data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -1,35 +1,41 @@
-{% if importedBy is not same as 'user' %}
-    <hr class="fr-mt-3w">
+<hr class="fr-mt-3w">
 
-    <div class="fr-grid-row">
-        <div class="fr-col-9 fr-col-md-6">
-            <h3 class="fr-h5">{{ zonetitle }}</h3>
-        </div>
-        <div class="fr-col-3 fr-col-md-6 fr-text--right">
-            {% if (is_granted('FILE_CREATE', signalement)) %}
-                {% if isDocumentsEnabled %}
-                    <button 
-                    class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left open-modal-upload-files-btn" 
-                    data-fr-opened="false" 
-                    aria-controls="fr-modal-upload-files" 
-                    data-file-type="document">
-                        Ajouter des documents
-                    </button>
+<div class="fr-grid-row">
+    <div class="fr-col-9 fr-col-md-6">
+        <h3 class="fr-h5">{{ zonetitle }}</h3>
+    </div>
+    <div class="fr-col-3 fr-col-md-6 fr-text--right">
+        {% if (is_granted('FILE_CREATE', signalement)) %}
+            {% if isDocumentsEnabled %}
+                <button 
+                class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left open-modal-upload-files-btn" 
+                data-fr-opened="false" 
+                aria-controls="fr-modal-upload-files" 
+                data-file-type="document"
+                data-file-filter={{filesFilter}}
+                >
+                    Ajouter des documents
+                </button>
+                {% if filesFilter is same as 'situation' %}
                     <button 
                     class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-camera-fill open-modal-upload-files-btn" 
                     data-fr-opened="false" 
                     aria-controls="fr-modal-upload-files" 
-                    data-file-type="photo">
+                    data-file-type="photo"
+                    data-file-filter={{filesFilter}}
+                    >
                         Ajouter des photos
                     </button>
-                {% else %}
-                    <form method="POST" enctype="multipart/form-data" class="inline-form" action="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}">
-                        <label class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left"> Ajouter des documents
-                            <input type="file" accept="application/*" name="signalement-add-file[documents][]" class="fr-hidden fr-input--file-signalement" multiple>
-                        </label>
-                        <input type="hidden" name="_token" value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
-                        <input type="hidden" name="document_type" value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
-                    </form>
+                {% endif %}
+            {% else %}
+                <form method="POST" enctype="multipart/form-data" class="inline-form" action="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}">
+                    <label class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left"> Ajouter des documents
+                        <input type="file" accept="application/*" name="signalement-add-file[documents][]" class="fr-hidden fr-input--file-signalement" multiple>
+                    </label>
+                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_add_file_'~signalement.id) }}">
+                    <input type="hidden" name="document_type" value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
+                </form>
+                {% if filesFilter is same as 'situation' %}
                     <form method="POST" enctype="multipart/form-data" class="inline-form" action="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}">
                         <label class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-camera-fill"> Ajouter des photos
                             <input type="file" accept="image/*" name="signalement-add-file[photos][]" class="fr-hidden fr-input--file-signalement" multiple>
@@ -38,20 +44,19 @@
                         <input type="hidden" name="document_type" value="{{ enum('App\\Entity\\Enum\\DocumentType').AUTRE.name }}">
                     </form>
                 {% endif %}
-                
-
             {% endif %}
-        </div>
-    </div>
+            
 
+        {% endif %}
+    </div>
+</div>
+
+{% if filesFilter is same as 'situation' %}
     <div class="fr-alert fr-alert--info fr-alert--sm fr-mb-3v">
         <p>
             Pour ajouter plusieurs photos ou documents à la fois, sélectionnez vos fichiers en maintenant la touche CTRL enfoncée.
         </p>
     </div>
-
-{% else %}
-    <h3 class="fr-h6">{{ zonetitle }}</h3>
 {% endif %}
 
 {% if signalement.files|length == 0 %}
@@ -60,69 +65,71 @@
     </p>
 {% endif %}
 
-<div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
-    {% for index, photo in signalement.files|filter(
-        photo => photo.fileType == 'photo'
-                and photo.intervention is null
-                and (
-                    (importedBy is same as 'user' and (photo.uploadedBy is null or photo.isUsagerFile ))
-                    or (importedBy is same as 'partner' and (photo.uploadedBy is not null and photo.isPartnerFile))
-                    or importedBy is same as 'all'
-                )
-        ) %}
-        <div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
-            <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
-                 data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
-                 data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
-                 style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
-                <button 
-                    class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" 
-                    data-id={{ photo.id }} 
-                    title="Voir la photo {{ photo.filename }}"
-                ></button>
-                {% if is_granted('FILE_EDIT', photo) %}
-                    {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
-                    {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
+
+{% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
+{% if filesFilter is same as 'situation' %}
+    <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
+        {% for index, photo in signalement.files|filter(
+            photo => photo.fileType == 'photo'
+                    and photo.intervention is null
+                    and filesFilter is same as 'situation' 
+                    and photo.documentType.label() in  DocumentType.getSituationList
+            ) %}
+            <div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
+                <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
+                    data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
+                    data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
+                    style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
                     <button 
-                        class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-edit-line btn-signalement-file-edit"
-                        id="file_edit_{{ photo.id }}" 
-                        title="Editer la photo {{ photo.filename }}"
-                        aria-controls="fr-modal-edit-file"
-                        data-fr-opened="false" 
-                        data-filename="{{ photo.filename }}" 
-                        data-type="photo" 
-                        data-file-id="{{ photo.id}}" 
-                        data-signalement-uuid="{{ signalement.uuid}}" 
-                        data-description="{{ photo.description }}" 
-                        data-documentType="{{ photo.documentType.name }}" 
-                        data-documentType-list="{{ DocumentType.getPhotosList() | json_encode }}"
-                        data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
-                        data-partner-name="{{ photo.uploadedBy and photo.uploadedBy.partner ? photo.uploadedBy.partner.nom ~ ' - ' : '' }}"
-                        data-user-name="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
-                        data-desordreSlug="{{ photo.desordreSlug }}"
-                        data-signalement-desordres="{{ criteres | json_encode }}"
+                        class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" 
+                        data-id={{ photo.id }} 
+                        title="Voir la photo {{ photo.filename }}"
                     ></button>
-                {% endif %}
-                {% if is_granted('FILE_DELETE', photo) %}
-                    <button 
-                        title="Supprimer la photo {{ photo.filename }}"
-                        data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'photos',filename:photo.filename}) }}"
-                        data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"
-                        class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line signalement-file-delete"
-                    ></button>
-                {% endif %}
+                    {% if is_granted('FILE_EDIT', photo) %}
+                        {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
+                        <button 
+                            class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-edit-line btn-signalement-file-edit"
+                            id="file_edit_{{ photo.id }}" 
+                            title="Editer la photo {{ photo.filename }}"
+                            aria-controls="fr-modal-edit-file"
+                            data-fr-opened="false" 
+                            data-filename="{{ photo.filename }}" 
+                            data-type="photo" 
+                            data-file-id="{{ photo.id}}" 
+                            data-signalement-uuid="{{ signalement.uuid}}" 
+                            data-description="{{ photo.description }}" 
+                            data-documentType="{{ photo.documentType.name }}" 
+                            data-documentType-list="{{ DocumentType.getPhotosList() | json_encode }}"
+                            data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
+                            data-partner-name="{{ photo.uploadedBy and photo.uploadedBy.partner ? photo.uploadedBy.partner.nom ~ ' - ' : '' }}"
+                            data-user-name="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
+                            data-desordreSlug="{{ photo.desordreSlug }}"
+                            data-signalement-desordres="{{ criteres | json_encode }}"
+                        ></button>
+                    {% endif %}
+                    {% if is_granted('FILE_DELETE', photo) %}
+                        <button 
+                            title="Supprimer la photo {{ photo.filename }}"
+                            data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'photos',filename:photo.filename}) }}"
+                            data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"
+                            class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line signalement-file-delete"
+                        ></button>
+                    {% endif %}
+                </div>
             </div>
-        </div>
-    {% endfor %}
-</div>
+        {% endfor %}
+    </div>
+{% endif %}
 
 {% for index, doc in signalement.files|filter(
     doc => doc.fileType == 'document'
-            and (
-                (importedBy is same as 'user' and (doc.uploadedBy is null or doc.isUsagerFile ))
-                or (importedBy is same as 'partner' and (doc.uploadedBy is not null and doc.isPartnerFile))
-                or importedBy is same as 'all'
-            )
+        and (
+            (filesFilter is same as 'situation' 
+            and doc.documentType.label() in  DocumentType.getSituationList)
+            or 
+            (filesFilter is same as 'procedure' 
+            and doc.documentType.label() in  DocumentType.getProcedureList)
+        )
     ) %}
     <div class="fr-grid-row fr-grid-row--middle fr-background-alt--grey fr-rounded fr-p-3v signalement-file-item">
         <div class="fr-col-9">
@@ -161,7 +168,7 @@
                     data-type="document" 
                     data-file-id="{{ doc.id}}" 
                     data-documentType="{{ doc.documentType.name }}" 
-                    data-documentType-list="{{ DocumentType.getDocumentsList() | json_encode }}"
+                    data-documentType-list="{{ filesFilter is same as 'situation' ? DocumentType.getSituationList() | json_encode : DocumentType.getProcedureList() | json_encode }}"
                     data-createdAt="{{ doc.createdAt is defined ? doc.createdAt|date('d.m.Y') : 'N/R' }}"
                     data-partner-name="{{ doc.uploadedBy and doc.uploadedBy.partner ? doc.uploadedBy.partner.nom ~ ' - ' : '' }}"
                     data-user-name="{{ doc.uploadedBy.nomComplet ?? 'N/R' }}"

--- a/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
@@ -22,14 +22,6 @@
                         <button class="fr-btn--close fr-btn" aria-controls="visites-upload-files-{{intervention.id}}">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
-                        <div class="type-conditional type-document">
-                            <h1 class="fr-modal__title" id="fr-modal-visites-upload-files-{{intervention.id}}">
-                                Ajout du rapport de visite
-                            </h1>
-                            <div class="fr-alert fr-alert--warning fr-alert--sm">
-                                <p>Le rapport de visite sera partagé à l'usager.</p>
-                            </div>                         
-                        </div>
                         <div class="type-conditional type-photo">
                             <h1 class="fr-modal__title">
                                 Ajout des photos de la visite

--- a/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
@@ -1,0 +1,73 @@
+<dialog 
+    aria-labelledby="fr-modal-visites-upload-files-{{intervention.id}}" 
+    id="visites-upload-files-{{intervention.id}}" 
+    class="fr-modal fr-modal-visites-upload-files" 
+    role="dialog" 
+    data-file-type="document"
+    data-intervention-id="{{intervention.id}}"
+    data-has-changes="false"
+    data-validated="false"
+    data-add-file-route="{{ path('back_signalement_add_file',{uuid:signalement.uuid}) }}"
+    data-add-file-token="{{ csrf_token('signalement_add_file_'~signalement.id) }}"
+    data-edit-file-route="{{ path('back_signalement_edit_file',{uuid:signalement.uuid}) }}"
+    data-edit-file-token="{{ csrf_token('signalement_edit_file_'~signalement.id) }}"
+    data-delete-tmp-file-route="{{ path('back_signalement_delete_tmpfile',{id:'REPLACE'}) }}"
+    data-waiting-suivi-route="{{ path('back_signalement_file_waiting_suivi',{uuid:signalement.uuid}) }}"
+    >
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" aria-controls="visites-upload-files-{{intervention.id}}">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <div class="type-conditional type-document">
+                            <h1 class="fr-modal__title" id="fr-modal-visites-upload-files-{{intervention.id}}">
+                                Ajout du rapport de visite
+                            </h1>
+                            <div class="fr-alert fr-alert--warning fr-alert--sm">
+                                <p>Le rapport de visite sera partagé à l'usager.</p>
+                            </div>                         
+                        </div>
+                        <div class="type-conditional type-photo">
+                            <h1 class="fr-modal__title">
+                                Ajout des photos de la visite
+                            </h1>
+                            <div>
+                                Ajouter une ou plusieurs photos au signalement. 
+                            </div>
+                            <div class="fr-alert fr-alert--warning fr-alert--sm">
+                                <p>Les photos seront partagées à l'usager.</p>
+                            </div>
+                        </div>
+                        <div class="modal-upload-upload-container fr-mb-4w">
+                            <div class="modal-upload-drop-section">
+                                <span class="fr-icon-upload-2-line fr-icon--lg fr-text-label--blue-france"></span>
+                                <div class="modal-upload-drop-section-label fr-mt-1w">
+                                    Faites glisser vos documents ici
+                                </div>
+                            </div>
+                            <p class="fr-mb-1w">ou</p>
+                            <button class="modal-upload-files-selector fr-btn fr-icon-search-line fr-btn--icon-left fr-btn--secondary">Parcourir les fichiers de l'appareil</button>
+                            <input type="file" class="modal-upload-files-selector-input" multiple accept="application/*">
+                        </div>
+                        <div class="modal-upload-list-section" id="modal-upload-file-dynamic-content">
+                            <div class="modal-upload-list"></div>
+                        </div>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="visites-upload-files-{{intervention.id}}">
+                                Annuler
+                            </button>
+                            <button class="fr-btn fr-icon-check-line" aria-controls="visites-upload-files-{{intervention.id}}" id="btn-validate-modal-upload-files">
+                                Valider
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/back/signalement/view/visites/modals/visites-modals.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modals.html.twig
@@ -9,5 +9,8 @@
         {% include 'back/signalement/view/visites/modals/visites-modal-reschedule.html.twig' %}
     {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
         {% include 'back/signalement/view/visites/modals/visites-modal-edit.html.twig' %}
+        {% if (is_granted('FILE_CREATE', signalement) and  isDocumentsEnabled) %}
+            {% include 'back/signalement/view/visites/modals/visites-modal-upload-files.html.twig' %}
+        {% endif %}
     {% endif %}
 {% endif %}

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -60,20 +60,6 @@
                 {% endif %}
             {% endif %}
         </div>
-        <div class="fr-mb-3v fr-display-inline-flex">
-            <strong>Rapport : </strong>
-            {% if signalement.interventions is empty or intervention.files is empty %}
-                <span class="fr-badge fr-badge--no-icon" title="Non disponible">Non disponible</span> 
-            {% else %}
-                <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
-                    class="fr-btn fr-btn--sm"
-                    title="Afficher le document"
-                    rel="noopener"
-                    target="_blank">
-                    <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
-                </a>
-            {% endif %}
-        </div>
     </div>
     <div class="fr-col-12">
         <strong>Commentaire du partenaire :</strong>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -74,3 +74,54 @@
         </div>
     </div>
 </div>
+
+<div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
+    {% for index, photo in signalement.files|filter(
+        photo => photo.fileType == 'photo'
+                and photo.intervention is not null
+                and photo.intervention.id is same as intervention.id
+        ) %}
+        <div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
+            <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
+                 data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
+                 data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
+                 style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
+                <button 
+                    class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" 
+                    data-id={{ photo.id }} 
+                    title="Voir la photo {{ photo.filename }}"
+                ></button>
+                {% if is_granted('FILE_EDIT', photo) %}
+                    {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
+                    {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
+                    <button 
+                        class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-edit-line btn-signalement-file-edit"
+                        id="file_edit_{{ photo.id }}" 
+                        title="Editer la photo {{ photo.filename }}"
+                        aria-controls="fr-modal-edit-file"
+                        data-fr-opened="false" 
+                        data-filename="{{ photo.filename }}" 
+                        data-type="photo" 
+                        data-file-id="{{ photo.id}}" 
+                        data-signalement-uuid="{{ signalement.uuid}}" 
+                        data-documentType="{{ photo.documentType.name }}" 
+                        data-documentType-list="{{ DocumentType.getPhotosList() | json_encode }}"
+                        data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
+                        data-partner-name="{{ photo.uploadedBy and photo.uploadedBy.partner ? photo.uploadedBy.partner.nom ~ ' - ' : '' }}"
+                        data-user-name="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
+                        data-desordreSlug="{{ photo.desordreSlug }}"
+                        data-signalement-desordres="{{ criteres | json_encode }}"
+                    ></button>
+                {% endif %}
+                {# {% if is_granted('FILE_DELETE', photo) %}
+                    <button 
+                        title="Supprimer la photo {{ photo.filename }}"
+                        data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'photos',filename:photo.filename}) }}"
+                        data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"
+                        class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line signalement-file-delete"
+                    ></button>
+                {% endif %} #}
+            </div>
+        </div>
+    {% endfor %}
+</div>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -114,14 +114,6 @@
                         data-signalement-desordres="{{ criteres | json_encode }}"
                     ></button>
                 {% endif %}
-                {# {% if is_granted('FILE_DELETE', photo) %}
-                    <button 
-                        title="Supprimer la photo {{ photo.filename }}"
-                        data-delete="{{ path('back_signalement_delete_file',{uuid:signalement.uuid,type:'photos',filename:photo.filename}) }}"
-                        data-token="{{ csrf_token('signalement_delete_file_'~signalement.id) }}"
-                        class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line signalement-file-delete"
-                    ></button>
-                {% endif %} #}
             </div>
         </div>
     {% endfor %}

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -104,6 +104,7 @@
                         data-type="photo" 
                         data-file-id="{{ photo.id}}" 
                         data-signalement-uuid="{{ signalement.uuid}}" 
+                        data-description="{{ photo.description }}" 
                         data-documentType="{{ photo.documentType.name }}" 
                         data-documentType-list="{{ DocumentType.getPhotosList() | json_encode }}"
                         data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -20,7 +20,8 @@
             {% endif %}
         {% endif %}
     {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
-        {% if signalement.interventions is empty or intervention.files is empty %}
+        {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty%}
+        {# TODO les photos de visite sont considétées dans ce cas commme un rapport de visite #}
             {% if isDocumentsEnabled and is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
                 <button 
                     class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left open-modal-upload-files-btn" 
@@ -41,7 +42,7 @@
                     Editer le rapport
                 </button>
             {% endif %}
-            <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
+            <a href="{{ asset('_up/'~intervention.getRapportDeVisite[0].filename)~'/' ~ signalement.uuid }}"
                 class="fr-btn fr-btn--sm"
                 title="Afficher le document"
                 rel="noopener"

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -41,7 +41,7 @@
                     Editer le rapport
                 </button>
             {% endif %}
-            <a href="{{ asset('_up/'~intervention.getRapportDeVisite[0].filename)~'/' ~ signalement.uuid }}"
+            <a href="{{ asset('_up/'~intervention.getRapportDeVisite.first.filename)~'/' ~ signalement.uuid }}"
                 class="fr-btn"
                 title="Afficher le document"
                 rel="noopener"

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -1,26 +1,65 @@
 <div class="signalement-visites-buttons fr-text--right">
-    {% if signalement.interventions is empty %}
+    {% if signalement.interventions is empty %} 
         <button class="fr-btn fr-btn--sm fr-fi-calendar-line fr-btn--icon-left" aria-controls="add-visite-modal" data-fr-opened="false">
             Ajouter une visite
         </button>
-    {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}
-        {% if workflow_can(intervention, 'cancel') %}
-            <button class="fr-btn fr-btn--sm fr-btn--danger fr-fi-close-line fr-btn--icon-left" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
-                Annuler la visite
+    {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}    
+        {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
+            {% if workflow_can(intervention, 'cancel') %}
+                <button class="fr-btn fr-btn--sm fr-btn--danger fr-fi-close-line fr-btn--icon-left" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                    Annuler la visite
+                </button>
+            {% endif %}
+            <button class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" aria-controls="reschedule-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                Modifier la date
             </button>
-        {% endif %}
-        <button class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" aria-controls="reschedule-visite-modal-{{intervention.id}}" data-fr-opened="false">
-            Modifier la date
-        </button>
-        {% if workflow_can(intervention, 'confirm') %}
-            <button class="fr-btn fr-btn--sm fr-fi-check-line fr-btn--icon-left" aria-controls="confirm-visite-modal-{{intervention.id}}" data-fr-opened="false">
-                Confirmer la visite
-            </button>
+            {% if workflow_can(intervention, 'confirm') %}
+                <button class="fr-btn fr-btn--sm fr-fi-check-line fr-btn--icon-left" aria-controls="confirm-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                    Confirmer la visite
+                </button>
+            {% endif %}
         {% endif %}
     {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
-        <button class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" aria-controls="edit-visite-modal-{{intervention.id}}" data-fr-opened="false">
-            Editer le rapport
-        </button>
+        {% if signalement.interventions is empty or intervention.files is empty %}
+            {% if isDocumentsEnabled and is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
+                <button 
+                    class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left open-modal-upload-files-btn" 
+                    data-fr-opened="false" 
+                    aria-controls="visites-upload-files-{{intervention.id}}"
+                    data-file-type="document"
+                    data-document-type="PROCEDURE_RAPPORT_DE_VISITE"
+                    data-intervention-id="{{intervention.id}}">
+                    Ajouter un rapport de visite
+                </button>
+            {% endif %}
+        {% else %}
+            {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
+                <button 
+                    class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" 
+                    aria-controls="edit-visite-modal-{{intervention.id}}" 
+                    data-fr-opened="false">
+                    Editer le rapport
+                </button>
+            {% endif %}
+            <a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ signalement.uuid }}"
+                class="fr-btn fr-btn--sm"
+                title="Afficher le document"
+                rel="noopener"
+                target="_blank">
+                <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
+            </a>
+        {% endif %}
+        {% if isDocumentsEnabled and is_granted('INTERVENTION_EDIT_VISITE', intervention)%}
+            <button 
+                class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-camera-fill open-modal-upload-files-btn" 
+                data-fr-opened="false" 
+                aria-controls="visites-upload-files-{{intervention.id}}"
+                data-file-type="photo"
+                data-document-type="PHOTO_VISITE"
+                data-intervention-id="{{intervention.id}}">
+                Ajouter les photos de la visite
+            </button>
+        {% endif %}
     {% else %}
         &nbsp;
     {% endif %}

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -23,12 +23,10 @@
         {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty%}
             {% if isDocumentsEnabled and is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
                 <button 
-                    class="fr-btn fr-fi-file-fill open-modal-upload-files-btn" 
-                    data-fr-opened="false" 
-                    aria-controls="visites-upload-files-{{intervention.id}}"
-                    data-file-type="document"
-                    data-document-type="PROCEDURE_RAPPORT_DE_VISITE"
-                    data-intervention-id="{{intervention.id}}">
+                    class="fr-btn fr-fi-file-fill"
+                    aria-controls="edit-visite-modal-{{intervention.id}}"  
+                    data-fr-opened="false"
+                    >
                     Ajouter un rapport de visite
                 </button>
             {% endif %}

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -1,30 +1,29 @@
-<div class="signalement-visites-buttons fr-text--right">
+<div class="signalement-visites-buttons fr-text--right fr-btns-group fr-btns-group--inline fr-btns-group--sm fr-btns-group--right fr-btns-group--icon-left">
     {% if signalement.interventions is empty %} 
-        <button class="fr-btn fr-btn--sm fr-fi-calendar-line fr-btn--icon-left" aria-controls="add-visite-modal" data-fr-opened="false">
+        <button class="fr-btn fr-fi-calendar-line" aria-controls="add-visite-modal" data-fr-opened="false">
             Ajouter une visite
         </button>
     {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}    
         {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
             {% if workflow_can(intervention, 'cancel') %}
-                <button class="fr-btn fr-btn--sm fr-btn--danger fr-fi-close-line fr-btn--icon-left" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                <button class="fr-btn fr-btn--danger fr-fi-close-line" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
                     Annuler la visite
                 </button>
             {% endif %}
-            <button class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" aria-controls="reschedule-visite-modal-{{intervention.id}}" data-fr-opened="false">
+            <button class="fr-btn fr-btn--secondary fr-fi-edit-line" aria-controls="reschedule-visite-modal-{{intervention.id}}" data-fr-opened="false">
                 Modifier la date
             </button>
             {% if workflow_can(intervention, 'confirm') %}
-                <button class="fr-btn fr-btn--sm fr-fi-check-line fr-btn--icon-left" aria-controls="confirm-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                <button class="fr-btn fr-fi-check-line" aria-controls="confirm-visite-modal-{{intervention.id}}" data-fr-opened="false">
                     Confirmer la visite
                 </button>
             {% endif %}
         {% endif %}
     {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
         {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty%}
-        {# TODO les photos de visite sont considétées dans ce cas commme un rapport de visite #}
             {% if isDocumentsEnabled and is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
                 <button 
-                    class="fr-btn fr-btn--sm fr-fi-file-fill fr-btn--icon-left open-modal-upload-files-btn" 
+                    class="fr-btn fr-fi-file-fill open-modal-upload-files-btn" 
                     data-fr-opened="false" 
                     aria-controls="visites-upload-files-{{intervention.id}}"
                     data-file-type="document"
@@ -36,14 +35,14 @@
         {% else %}
             {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
                 <button 
-                    class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-edit-line fr-btn--icon-left" 
+                    class="fr-btn fr-btn--secondary fr-fi-edit-line" 
                     aria-controls="edit-visite-modal-{{intervention.id}}" 
                     data-fr-opened="false">
                     Editer le rapport
                 </button>
             {% endif %}
             <a href="{{ asset('_up/'~intervention.getRapportDeVisite[0].filename)~'/' ~ signalement.uuid }}"
-                class="fr-btn fr-btn--sm"
+                class="fr-btn"
                 title="Afficher le document"
                 rel="noopener"
                 target="_blank">
@@ -52,7 +51,7 @@
         {% endif %}
         {% if isDocumentsEnabled and is_granted('INTERVENTION_EDIT_VISITE', intervention)%}
             <button 
-                class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-camera-fill open-modal-upload-files-btn" 
+                class="fr-btn fr-btn--secondary fr-icon-camera-fill open-modal-upload-files-btn" 
                 data-fr-opened="false" 
                 aria-controls="visites-upload-files-{{intervention.id}}"
                 data-file-type="photo"

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -24,8 +24,8 @@
             <div class="fr-col-12 fr-col-md-6">
                 {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
                     {% include 'back/signalement/view/visites/modals/visites-modals.html.twig' %}
-                    {% include 'back/signalement/view/visites/visites-buttons.html.twig' %}
                 {% endif %}
+                {% include 'back/signalement/view/visites/visites-buttons.html.twig' %}
             </div>
         </div>
         {% include 'back/signalement/view/visites/visite-item.html.twig' %}

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -5,7 +5,6 @@ namespace App\Tests\Functional\Manager;
 use App\Dto\Request\Signalement\CompositionLogementRequest;
 use App\Dto\Request\Signalement\QualificationNDERequest;
 use App\Entity\Affectation;
-use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Signalement;
 use App\Entity\SignalementQualification;
@@ -264,22 +263,6 @@ class SignalementManagerTest extends WebTestCase
         /** @var ConstraintViolationList $errors */
         $errorsAsString = (string) $errors;
         $this->assertStringContainsString('Merci de définir le nombre de pièces à vivre', $errorsAsString);
-    }
-
-    public function testGetPhotosBySlug(): void
-    {
-        $signalement = $this->signalementManager->findOneBy(['reference' => '2023-27']);
-
-        $desordrePrecisionSlug = 'desordres_batiment_proprete_interieur';
-        $photos = $this->signalementManager->getPhotosBySlug($signalement, $desordrePrecisionSlug);
-        $this->assertCount(1, $photos);
-        $firstKey = array_keys($photos)[0];
-        $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[$firstKey]->getDocumentType());
-        $this->assertEquals('Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png', $photos[$firstKey]->getTitle());
-
-        $desordrePrecisionSlug = 'desordres_batiment_isolation_murs';
-        $photos = $this->signalementManager->getPhotosBySlug($signalement, $desordrePrecisionSlug);
-        $this->assertCount(0, $photos);
     }
 
     public function testUpdateFromSignalementQualificationWithNdeRequest(): void

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\EventListener\SignalementUpdatedListener;
 use App\Factory\SuiviFactory;
 use App\Manager\SuiviManager;
+use App\Repository\DesordreCritereRepository;
 use App\Repository\SuiviRepository;
 use App\Repository\UserRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -24,6 +25,7 @@ class SuiviManagerTest extends KernelTestCase
     private UrlGeneratorInterface $urlGenerator;
     private SignalementUpdatedListener $signalementUpdatedListener;
     private Security $security;
+    private DesordreCritereRepository $desordreCritereRepository;
 
     protected function setUp(): void
     {
@@ -33,6 +35,7 @@ class SuiviManagerTest extends KernelTestCase
         $this->urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
         $this->signalementUpdatedListener = static::getContainer()->get(SignalementUpdatedListener::class);
         $this->security = static::getContainer()->get(Security::class);
+        $this->desordreCritereRepository = static::getContainer()->get(DesordreCritereRepository::class);
     }
 
     public function testCreateSuivi(): void
@@ -43,6 +46,7 @@ class SuiviManagerTest extends KernelTestCase
             $this->urlGenerator,
             $this->signalementUpdatedListener,
             $this->security,
+            $this->desordreCritereRepository,
             Suivi::class,
         );
 
@@ -78,6 +82,7 @@ class SuiviManagerTest extends KernelTestCase
             $this->urlGenerator,
             $this->signalementUpdatedListener,
             $this->security,
+            $this->desordreCritereRepository,
             Suivi::class,
         );
 

--- a/tests/Functional/Service/Signalement/PhotoHelperTest.php
+++ b/tests/Functional/Service/Signalement/PhotoHelperTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Tests\Functional\Service\Signalement;
+
+use App\Entity\Enum\DocumentType;
+use App\Factory\SignalementAffectationListViewFactory;
+use App\Factory\SignalementExportFactory;
+use App\Factory\SignalementFactory;
+use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
+use App\Repository\BailleurRepository;
+use App\Repository\DesordreCritereRepository;
+use App\Repository\DesordrePrecisionRepository;
+use App\Service\Signalement\CriticiteCalculator;
+use App\Service\Signalement\DesordreTraitement\DesordreCompositionLogementLoader;
+use App\Service\Signalement\PhotoHelper;
+use App\Service\Signalement\Qualification\QualificationStatusService;
+use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
+use App\Specification\Signalement\SuroccupationSpecification;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class PhotoHelperTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private Security $security;
+    private ManagerRegistry $managerRegistry;
+    private SignalementFactory $signalementFactory;
+    private EventDispatcherInterface $eventDispatcher;
+    private QualificationStatusService $qualificationStatusService;
+    private SignalementAffectationListViewFactory $signalementAffectationListViewFactory;
+    private SignalementExportFactory $signalementExportFactory;
+    private ParameterBagInterface $parameterBag;
+    private SignalementManager $signalementManager;
+    private CsrfTokenManagerInterface $csrfTokenManager;
+    private SuroccupationSpecification $suroccupationSpecification;
+    private CriticiteCalculator $criticiteCalculator;
+    private SignalementQualificationUpdater $signalementQualificationUpdater;
+    private DesordrePrecisionRepository $desordrePrecisionRepository;
+    private DesordreCritereRepository $desordreCritereRepository;
+    private DesordreCompositionLogementLoader $desordreCompositionLogementLoader;
+    private SuiviManager $suiviManager;
+    private BailleurRepository $bailleurRepository;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
+        $this->security = static::getContainer()->get('security.helper');
+        $this->signalementFactory = static::getContainer()->get(SignalementFactory::class);
+        $this->eventDispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        /* @var QualificationStatusService $qualificationStatusService */
+        $this->qualificationStatusService = static::getContainer()->get(QualificationStatusService::class);
+        $this->signalementAffectationListViewFactory = static::getContainer()->get(
+            SignalementAffectationListViewFactory::class
+        );
+        $this->signalementExportFactory = static::getContainer()->get(SignalementExportFactory::class);
+        $this->parameterBag = static::getContainer()->get(ParameterBagInterface::class);
+        $this->csrfTokenManager = static::getContainer()->get(CsrfTokenManagerInterface::class);
+        $this->suroccupationSpecification = static::getContainer()->get(SuroccupationSpecification::class);
+        $this->criticiteCalculator = static::getContainer()->get(CriticiteCalculator::class);
+        $this->signalementQualificationUpdater = static::getContainer()->get(SignalementQualificationUpdater::class);
+        $this->desordrePrecisionRepository = static::getContainer()->get(DesordrePrecisionRepository::class);
+        $this->desordreCritereRepository = static::getContainer()->get(DesordreCritereRepository::class);
+        $this->desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
+        $this->suiviManager = static::getContainer()->get(SuiviManager::class);
+        $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
+
+        $this->signalementManager = new SignalementManager(
+            $this->managerRegistry,
+            $this->security,
+            $this->signalementFactory,
+            $this->eventDispatcher,
+            $this->qualificationStatusService,
+            $this->signalementAffectationListViewFactory,
+            $this->signalementExportFactory,
+            $this->parameterBag,
+            $this->csrfTokenManager,
+            $this->suroccupationSpecification,
+            $this->criticiteCalculator,
+            $this->signalementQualificationUpdater,
+            $this->desordrePrecisionRepository,
+            $this->desordreCritereRepository,
+            $this->desordreCompositionLogementLoader,
+            $this->suiviManager,
+            $this->bailleurRepository,
+        );
+    }
+
+    public function testGetPhotosBySlug(): void
+    {
+        $signalement = $this->signalementManager->findOneBy(['reference' => '2023-27']);
+
+        $desordrePrecisionSlug = 'desordres_batiment_proprete_interieur';
+        $photos = PhotoHelper::getPhotosBySlug($signalement, $desordrePrecisionSlug);
+        $this->assertCount(1, $photos);
+        $firstKey = array_keys($photos)[0];
+        $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[$firstKey]->getDocumentType());
+        $this->assertEquals('Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png', $photos[$firstKey]->getTitle());
+
+        $desordrePrecisionSlug = 'desordres_batiment_isolation_murs';
+        $photos = PhotoHelper::getPhotosBySlug($signalement, $desordrePrecisionSlug);
+        $this->assertCount(0, $photos);
+    }
+
+    public function testGetSortedPhotos(): void
+    {
+        $signalement = $this->signalementManager->findOneBy(['reference' => '2023-27']);
+
+        $photos = PhotoHelper::getSortedPhotos($signalement);
+        $this->assertCount(3, $photos);
+        $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[0]->getDocumentType());
+        $this->assertEquals('Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png', $photos[0]->getTitle());
+        $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[1]->getDocumentType());
+        $this->assertEquals(DocumentType::AUTRE, $photos[2]->getDocumentType());
+    }
+}

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -76,7 +76,7 @@ class FileFactoryTest extends TestCase
                 'slug' => 'bail_dpe_dpe_upload',
             ],
             'dummy-filename-dpe.PNG',
-            File::FILE_TYPE_PHOTO,
+            File::FILE_TYPE_DOCUMENT,
             DocumentType::SITUATION_FOYER_DPE,
         ];
 
@@ -112,7 +112,7 @@ class FileFactoryTest extends TestCase
                 'slug' => 'bail_dpe_bail_upload',
             ],
             'dummy-filename-bail.png',
-            File::FILE_TYPE_PHOTO,
+            File::FILE_TYPE_DOCUMENT,
             DocumentType::SITUATION_FOYER_BAIL,
         ];
 
@@ -137,6 +137,18 @@ class FileFactoryTest extends TestCase
             ],
             'dummy-filename-desordre.pdf',
             File::FILE_TYPE_DOCUMENT,
+            DocumentType::PHOTO_SITUATION,
+        ];
+
+        yield 'Désordre photos ' => [
+            [
+                'key' => 'photos',
+                'file' => 'dummy-filename-desordre.png',
+                'titre' => 'dummy-filename-desordre-titre.png',
+                'slug' => 'desordres_batiment_isolation_photos_upload',
+            ],
+            'dummy-filename-desordre.png',
+            File::FILE_TYPE_PHOTO,
             DocumentType::PHOTO_SITUATION,
         ];
     }


### PR DESCRIPTION
## Ticket

#2198    
#2199

## Description
Possibilité d'ajouter des photos de visite et un rapport de visite.
Affichage des photos de visite en mode album.
Séparation des documents, en fonction de leur type, entre les documents sur la situation (en faut de page) et les documents sur les procédures (en bas de page)
Ajustement des textes et de la visibilité des suivis d'ajout et de suppression de fichier

## Changements apportés
* Création d'un nouveau twig pour la modale d'upload de rapport et photos de visites
* Mise à jour des twigs liés aux visites et liés aux photos
* Mise à jour du form_upload_documents.js pour l'utiliser pour la momdale d'upload de rapport et de photos de visites
* Dans l'enum DocumentType, création de nouvelles listes pour séparer les types de documents en fonction de situation ou procédure
* Création d'une fonction getAllPhotosOrdered dans le signalementManager (pour l'affichage dans l'album photo)
* Dans SignalementFileController, on met à jour l'intervention et la description d'un fichier si elles existent
* Dans l'entité Intervention, création d'une fonction getRapportDeVisite (car avant seuls les rapports de visite avaient l'id d'une intervention, ce qui conditionnait l'affichage des boutons et du rapport dans la partie Visite. Or maintenant, les photos de visites ont également l'id de l'intervention)
* Mise à jour de la création de suivis dans le SuiviManager
* Mise à jour des suivis de suppression dans le SignalementFileController

## Pré-requis

## Tests
Faire les tests suivants sur un signalement fait avec le nouveau formulaire et un signalement fait avec l'ancien. 
:warning: attention de faire sur des signalements dans un territoire avec des partenaires de visite et d'affecter ces partenaires pour les tests sur les visites ! 
- [ ] Ajouter des photos de la situation. Si nouveau formulaire vérifier qu'on peut choisir le désordre. Si ancien, non. Vérifier le texte du suivi créé et l'affichage des photos dans le haut de la page
- [ ] Ajouter des documents de la situation. Vérifier que le choix des types est bien limité suivant les specs. Vérifier que les fichiers s'affichent en haut de la page, que le texte du suivi est bon et qu'il est partagé à l'usager.
- [ ] En bas de page, ajouter des documents partenaires. Vérifier que le choix des types est bien limité suivant les specs. Vérifier que les fichiers s'affichent en bas de la page, que le texte du suivi est bon, et que ce suivi n'est pas partagé à l'usager.
- [ ] Créer une visite effectuée dans le passé, sans ajouter un rapport de visite. Vérifier qu'on peut ajouter un rapport de visite a posteriori, et qu'on peut ajouter des photos de visite. Ajouter un rapport de visite, vérifier qu'il n'y a pas besoin de choisir le type, qu'il est affecté d'office. Vérifier que le suivi est partagé à l'usager et que le texte est bon. Vérifier qu'on a ensuite un bouton "Voir le rapport de visite" qui ouvre le bon document.
- [ ] Ajouter des photos de la visite, vérifier qu'on peut ajouter une description. Vérifier que les photos s'affichent bien en miniature sous la visite. Vérifier que le suivi est partagé à l'usager et que le texte est bon.
- [ ] Vérifier qu'on peut ouvrir les photos de visite en mode album. L'album ouvre toutes les photos liées au signalement, mais elles sont bien classées en fonction de leur type indépendamment de leur id. S'il y a plusieurs visites, elles sont bien classées par visite. Vérifier que dans l'album photo on a la description ajoutée à la photo de visite
- [ ] Editer les types ou les descriptions des photos et des documents, vérifier que ça fonctionne bien.
