### PR TITLE
[BO - Maintenance] Bloquer les crons et la page de contact

### DIFF
--- a/src/Command/Cron/AbstractCronCommand.php
+++ b/src/Command/Cron/AbstractCronCommand.php
@@ -21,6 +21,12 @@ class AbstractCronCommand extends Command
 
     public function run(InputInterface $input, OutputInterface $output): int
     {
+        if ($this->parameterBag->get('maintenance_enable')) {
+            $output->writeln('Le mode maintenance est activé, merci de le désactiver une fois l\'opération terminée.');
+
+            return Command::FAILURE;
+        }
+
         if (!$this->parameterBag->get('cron_enable')) {
             $output->writeln('Merci d\'activer CRON_ENABLE=1 pour executer la commande');
 

--- a/src/EventListener/MaintenanceListener.php
+++ b/src/EventListener/MaintenanceListener.php
@@ -46,6 +46,7 @@ class MaintenanceListener
         return (str_starts_with($uri, '/signalement')
                 || str_starts_with($uri, '/suivre-mon-signalement')
                 || str_starts_with($uri, '/mot-de-pass-perdu')
+                || str_starts_with($uri, '/contact')
                 || str_starts_with($uri, '/activation'))
             && !$this->authorizationChecker->isGranted(User::ROLE_ADMIN);
     }

--- a/tests/Functional/EventListener/MaintenanceListenerTest.php
+++ b/tests/Functional/EventListener/MaintenanceListenerTest.php
@@ -28,6 +28,7 @@ class MaintenanceListenerTest extends WebTestCase
 
     public function provideRoutes(): \Generator
     {
+        yield 'Contact' => ['front_contact'];
         yield 'Lock dépot signalement' => ['front_signalement'];
         yield 'Lock demande activation' => ['login_activation'];
         yield 'Lock Mot de passe perdu' => ['login_mdp_perdu'];


### PR DESCRIPTION
## Ticket

#2350   

## Description
Les crons ainsi que la page de contact doivent être bloqué pour éviter toute interaction avec la base de données, notamment le cron SCHS à 18H UTC

## Changements apportés
* Ajout condition dans `AbstractCronCommand`
* Inclure la page de contact dans les pages inaccessibles

## Pré-requis

## Tests
- [ ] Activer le mode maintenance `MAINTENANCE_ENABLE=1`
- [ ] Vérifier que la page contact est inaccessible
- [ ] Vérifier qu'aucune commande de cron (les commandes situé dans `App\Command\Cron` ) puisse être lancé, en voici quelques une
     * `make console app="remind-inactive-user"`
     * `make console app="sync-esabora-sish"`
     * `make console app="sync-esabora-schs"`
