### PR TITLE
[BO - Signalement] Liste Partenaire Affectation

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -194,20 +194,18 @@ class SignalementManager extends AbstractManager
         }
     }
 
-    public function findAllPartners(Signalement $signalement, bool $addCompetences = false): array
+    public function findAllPartners(Signalement $signalement): array
     {
         /** @var PartnerRepository $partnerRepository */
         $partnerRepository = $this->managerRegistry->getRepository(Partner::class);
         $partners['affected'] = $partnerRepository->findByLocalization(
             signalement: $signalement,
-            affected: true,
-            addCompetences: $addCompetences
+            affected: true
         );
 
         $partners['not_affected'] = $partnerRepository->findByLocalization(
             signalement: $signalement,
-            affected: false,
-            addCompetences: $addCompetences
+            affected: false
         );
 
         return $partners;

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -119,7 +119,7 @@ class PartnerRepository extends ServiceEntityRepository
     /**
      * @throws Exception
      */
-    public function findByLocalization(Signalement $signalement, bool $affected = true, bool $addCompetences = false): array
+    public function findByLocalization(Signalement $signalement, bool $affected = true): array
     {
         $operator = $affected ? 'IN' : 'NOT IN';
 
@@ -148,10 +148,7 @@ class PartnerRepository extends ServiceEntityRepository
             $queryBuilder->andWhere('p.id '.$operator.' (:subquery)')
             ->setParameter('subquery', $affectedPartners);
         }
-        if ($addCompetences) {
-            $queryBuilder->addSelect('p.competence');
-            $queryBuilder->orderBy('p.competence', 'DESC');
-        }
+        $queryBuilder->orderBy('p.nom', 'ASC');
 
         return $queryBuilder->getQuery()->getArrayResult();
     }

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -115,21 +115,6 @@ class SignalementManagerTest extends WebTestCase
         $this->assertCount(5, $partners['not_affected'], 'Five partners should not be affected');
     }
 
-    public function testFindAllPartnersWithCompetences()
-    {
-        $signalement = $this->signalementManager->findOneBy(['reference' => '2023-8']);
-
-        $partners = $this->signalementManager->findAllPartners($signalement, true);
-
-        $this->assertArrayHasKey('affected', $partners);
-        $this->assertArrayHasKey('not_affected', $partners);
-
-        $this->assertCount(0, $partners['affected'], '0 partner should be affected');
-        $this->assertCount(19, $partners['not_affected'], '19 partners should not be affected');
-        $firstPartner = $partners['not_affected'][0];
-        $this->assertArrayHasKey('competence', $firstPartner);
-    }
-
     public function testCloseSignalementForAllPartners()
     {
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -50,20 +50,6 @@ class PartnerRepositoryTest extends KernelTestCase
         $this->assertCount(5, $partners);
     }
 
-    public function testFindPartnersWithCompetences(): void
-    {
-        /** @var SignalementRepository $signalementRepository */
-        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-
-        /** @var Signalement $signalement */
-        $signalement = $signalementRepository->findOneBy(['reference' => '2023-8']);
-
-        $partners = $this->partnerRepository->findByLocalization($signalement, false, true);
-        $this->assertCount(19, $partners);
-        $firstPartner = $partners[0];
-        $this->assertArrayHasKey('competence', $firstPartner);
-    }
-
     public function testFindPossiblePartnersForCOR69(): void
     {
         /** @var SignalementRepository $signalementRepository */


### PR DESCRIPTION
## Ticket

#2345

## Description
- Dans la modale partenaires à affecter : affichage des partenaires par ordre alphabétique
- Suppression du paramètre addCompetences inutilisé

## Changements apportés


## Tests
- [ ] Vérifier l'ordre d'affichage des partenaire dans la modale "partenaires à affecter"
