### PR TITLE
[Bug] Sujets des notifications

### DIFF
--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -174,6 +174,7 @@ affectations:
     answered_by: "admin-03@histologe.fr"
     affected_by: "admin-03@histologe.fr"
     territory: "Bouches-du-Rhône"
+    created_at: '-15 days'
   -
     signalement: 2024-01
     partner: "partenaire-62-01@histologe.fr"

--- a/src/Service/Mailer/Mail/Signalement/AssignementNewMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/AssignementNewMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class AssignementNewMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s] Un nouveau signalement vous attend.';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ASSIGNMENT_NEW;
-    protected ?string $mailerSubject = '[%s] Un nouveau signalement vous attend.';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'affectation_email';
     protected ?string $tagHeader = 'Pro Nouvelle affectation';
@@ -45,9 +45,8 @@ class AssignementNewMailer extends AbstractNotificationMailer
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
-            $notificationMail->getSignalement()->getCpOccupant(),
-            $this->parameterBag->get('platform_name'),
+            self::MAILER_SUBJECT,
+            $notificationMail->getSignalement()->getCpOccupant()
         );
     }
 }

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToAllPartnersMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToAllPartnersMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SignalementClosedToAllPartnersMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Clôture du signalement';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_PARTNERS;
-    protected ?string $mailerSubject = '[%s - %s] Clôture du signalement';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'closed_to_partners_signalement_email';
     protected ?string $tagHeader = 'Pro Cloture Signalement';
@@ -44,7 +44,7 @@ class SignalementClosedToAllPartnersMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToOnePartnerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToOnePartnerMailer.php
@@ -14,8 +14,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SignalementClosedToOnePartnerMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] %s a terminé son intervention';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_PARTNER;
-    protected ?string $mailerSubject = '[%s - %s] %s a terminé son intervention';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'closed_to_partner_signalement_email';
     protected ?string $tagHeader = 'Pro Cloture Partenaire';
@@ -49,7 +49,7 @@ class SignalementClosedToOnePartnerMailer extends AbstractNotificationMailer
         $user = $this->security->getUser();
         $signalement = $notificationMail->getSignalement();
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant(),
             $user?->getPartner()->getNom(),

--- a/src/Service/Mailer/Mail/Signalement/SignalementNewMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementNewMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SignalementNewMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s] Un nouveau signalement vous attend';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_NEW;
-    protected ?string $mailerSubject = '[%s] Un nouveau signalement vous attend';
     protected ?string $mailerButtonText = 'Voir le signalement';
     protected ?string $mailerTemplate = 'new_signalement_email';
     protected ?string $tagHeader = 'Pro Nouveau Signalement';
@@ -42,6 +42,6 @@ class SignalementNewMailer extends AbstractNotificationMailer
 
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
-        $this->mailerSubject = sprintf($this->mailerSubject, $notificationMail->getSignalement()->getCpOccupant());
+        $this->mailerSubject = sprintf(self::MAILER_SUBJECT, $notificationMail->getSignalement()->getCpOccupant());
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviNewCommentBackMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Nouveau suivi';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_NEW_COMMENT_BACK;
-    protected ?string $mailerSubject = '[%s - %s] Nouveau suivi';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_signalement_back_email';
     protected ?string $tagHeader = 'Pro Nouveau Suivi Signalement';
@@ -41,7 +41,7 @@ class SuiviNewCommentBackMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviVisiteAbortedToPartnerMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Visite non effectuée';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_ABORTED_TO_PARTNER;
-    protected ?string $mailerSubject = '[%s - %s] Visite non effectuée';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_aborted_email';
 
@@ -41,7 +41,8 @@ class SuiviVisiteAbortedToPartnerMailer extends AbstractNotificationMailer
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
         $signalement = $notificationMail->getSignalement();
-        $this->mailerSubject = sprintf($this->mailerSubject,
+        $this->mailerSubject = sprintf(
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToPartnerMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviVisiteConfirmedToPartnerMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Conclusion de visite disponible';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CONFIRMED_TO_PARTNER;
-    protected ?string $mailerSubject = '[%s - %s] Conclusion de visite disponible';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_confirmed_to_partner_email';
     protected ?string $tagHeader = 'Pro Conclusion Visite Disponible';
@@ -42,7 +42,8 @@ class SuiviVisiteConfirmedToPartnerMailer extends AbstractNotificationMailer
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
         $signalement = $notificationMail->getSignalement();
-        $this->mailerSubject = sprintf($this->mailerSubject,
+        $this->mailerSubject = sprintf(
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToPartnerMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviVisiteCreatedToPartnerMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Visite programmée';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CREATED_TO_PARTNER;
-    protected ?string $mailerSubject = '[%s - %s] Visite programmée';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_created_to_partner_email';
     protected ?string $tagHeader = 'Pro Date Visite Prevue';
@@ -42,7 +42,8 @@ class SuiviVisiteCreatedToPartnerMailer extends AbstractNotificationMailer
     public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
     {
         $signalement = $notificationMail->getSignalement();
-        $this->mailerSubject = sprintf($this->mailerSubject,
+        $this->mailerSubject = sprintf(
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviVisiteFutureReminderToPartnerMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Rappel : visite programmée';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_FUTURE_REMINDER_TO_PARTNER;
-    protected ?string $mailerSubject = '[%s - %s] Rappel : visite programmée';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_future_reminder_to_partner_email';
     protected ?string $tagHeader = 'Pro Visite Prevue Rappel';
@@ -43,7 +43,7 @@ class SuiviVisiteFutureReminderToPartnerMailer extends AbstractNotificationMaile
     {
         $signalement = $notificationMail->getSignalement();
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteNeededMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteNeededMailer.php
@@ -12,9 +12,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviVisiteNeededMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Date de visite à renseigner';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_NEEDED;
-    protected ?string $mailerSubject = '[%s - %s] Date de visite à renseigner';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_needed_email';
     protected ?string $tagHeader = 'Pro Date Visite Manquante';
 
@@ -33,10 +33,7 @@ class SuiviVisiteNeededMailer extends AbstractNotificationMailer
 
         return [
             'signalement' => $signalement,
-            'lien_suivi' => $this->generateLink(
-                'front_suivi_signalement',
-                ['code' => $signalement->getCodeSuivi(), 'from' => $notificationMail->getTo()],
-            ),
+            'lien_suivi' => $this->generateLinkSignalementView($signalement->getUuid()),
         ];
     }
 
@@ -44,7 +41,7 @@ class SuiviVisiteNeededMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
@@ -12,8 +12,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviVisitePastReminderToPartnerMailer extends AbstractNotificationMailer
 {
+    public const MAILER_SUBJECT = '[%s - %s] Conclusion de visite à renseigner';
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER;
-    protected ?string $mailerSubject = '[%s - %s] Conclusion de visite à renseigner';
     protected ?string $mailerButtonText = 'Accéder au signalement';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_past_reminder_to_partner_email';
     protected ?string $tagHeader = 'Pro Conclusion Visite A Remplir';
@@ -43,7 +43,7 @@ class SuiviVisitePastReminderToPartnerMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $this->mailerSubject = sprintf(
-            $this->mailerSubject,
+            self::MAILER_SUBJECT,
             $signalement->getReference(),
             $signalement->getNomOccupantOrDeclarant()
         );

--- a/tests/Functional/Command/NotifyVisitsCommandTest.php
+++ b/tests/Functional/Command/NotifyVisitsCommandTest.php
@@ -21,8 +21,10 @@ class NotifyVisitsCommandTest extends KernelTestCase
 
         $commandTester->assertCommandIsSuccessful();
 
-        $this->assertEmailCount(7);
+        $this->assertEmailCount(9);
         $this->assertEmailSubjectContains($this->getMailerMessages()[1], '2024-02');
         $this->assertEmailSubjectContains($this->getMailerMessages()[3], '2022-6');
+        $this->assertEmailSubjectContains($this->getMailerMessages()[5], '2023-26');
+        $this->assertEmailSubjectContains($this->getMailerMessages()[7], '2023-20');
     }
 }


### PR DESCRIPTION
## Ticket

#2360

## Description
- Modification du lien dans le mail "Date de visite à renseigner" qui pointe maintenant vers la fiche du signalement en BO au lieu de FO
- Modification des mail utilisant des sujets dynamique pour que le sujet change bien lors d'envoi multiple d'email de même type sur des signalements différents
- Ajout d'une fixture et d'un test permettant de vérifier le second point

## Tests
- [ ] Ouvrir mailcatcher, lancer `make console app="notify-visits"` et vérifier qu'il y'a bien deux sujet différents sur les 4 notification de type "Date de visite à renseigner"
