### PR TITLE
[BO] Tagger les mails des comptes et partenaires archivés pour éviter les doublons

### DIFF
--- a/migrations/Version20240322123431.php
+++ b/migrations/Version20240322123431.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use App\Entity\User;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -17,10 +18,10 @@ final class Version20240322123431 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql(
-            "UPDATE partner SET email = CONCAT(email, '.archived@', DATE_FORMAT(NOW(), '%Y%m%d%H%i')) WHERE is_archive = 1"
+            "UPDATE partner SET email = CONCAT(email, '".User::SUFFIXE_ARCHIVED."', DATE_FORMAT(NOW(), '%Y%m%d%H%i')) WHERE is_archive = 1"
         );
         $this->addSql(
-            "UPDATE user SET email = CONCAT(email, '.archived@', DATE_FORMAT(NOW(), '%Y%m%d%H%i')) WHERE statut = 2"
+            "UPDATE user SET email = CONCAT(email, '".User::SUFFIXE_ARCHIVED."', DATE_FORMAT(NOW(), '%Y%m%d%H%i')) WHERE statut = 2"
         );
     }
 

--- a/migrations/Version20240322123431.php
+++ b/migrations/Version20240322123431.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240322123431 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add a tag to email or achived user or partner';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            "UPDATE partner SET email = CONCAT(email, '.archived@', DATE_FORMAT(NOW(), '%Y%m%d%H%i')) WHERE is_archive = 1"
+        );
+        $this->addSql(
+            "UPDATE user SET email = CONCAT(email, '.archived@', DATE_FORMAT(NOW(), '%Y%m%d%H%i')) WHERE statut = 2"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/BackArchivedAccountController.php
+++ b/src/Controller/Back/BackArchivedAccountController.php
@@ -102,15 +102,19 @@ class BackArchivedAccountController extends AbstractController
         ]);
         $form->handleRequest($request);
 
-        $untaggedEmail = explode('.archived@', $user->getEmail())[0];
+        $untaggedEmail = explode(User::SUFFIXE_ARCHIVED, $user->getEmail())[0];
         $userExist = $userRepository->findOneBy(['email' => $untaggedEmail]);
-        if ($userExist && !\in_array('ROLE_USAGER', $userExist->getRoles())) {
-            $this->addFlash('error', 'Un utilisateur existe déjà avec cette adresse e-mail.');
+        if ($userExist) {
+            $this->addFlash('error', 'Un utilisateur existe déjà avec cette adresse e-mail. '
+            .$userExist->getNomComplet().' ( id '.$userExist->getId().' ) avec le rôle '
+            .$userExist->getRoleLabel());
         }
 
         $partnerExist = $partnerRepository->findOneBy(['email' => $untaggedEmail]);
         if ($partnerExist) {
-            $this->addFlash('error', 'Un partenaire existe déjà avec cette adresse e-mail.');
+            $this->addFlash('error', 'Un partenaire existe déjà avec cette adresse e-mail. '
+            .$partnerExist->getNom().' ( id '.$partnerExist->getId().' ) dans le territoire '
+            .$partnerExist->getTerritory()->getName());
         }
 
         if (!$userExist && !$partnerExist && $form->isSubmitted() && $form->isValid()) {

--- a/src/Controller/Back/BackArchivedPartnerController.php
+++ b/src/Controller/Back/BackArchivedPartnerController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller\Back;
 
-use App\Entity\User;
+use App\Entity\Partner;
 use App\Repository\PartnerRepository;
 use App\Repository\TerritoryRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -56,7 +56,7 @@ class BackArchivedPartnerController extends AbstractController
             'partners' => $paginatedArchivedPartners,
             'total' => $totalArchivedPartners,
             'page' => $page,
-            'pages' => (int) ceil($totalArchivedPartners / User::MAX_LIST_PAGINATION),
+            'pages' => (int) ceil($totalArchivedPartners / Partner::MAX_LIST_PAGINATION),
         ]);
     }
 }

--- a/src/Controller/Back/BackArchivedPartnerController.php
+++ b/src/Controller/Back/BackArchivedPartnerController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\User;
+use App\Repository\PartnerRepository;
+use App\Repository\TerritoryRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/bo/partner-archives')]
+class BackArchivedPartnerController extends AbstractController
+{
+    #[Route('/', name: 'back_archived_partner_index', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function index(
+        Request $request,
+        TerritoryRepository $territoryRepository,
+        PartnerRepository $partnerRepository
+    ): Response {
+        $page = $request->get('page') ?? 1;
+
+        $isNoneTerritory = 'none' == $request->get('territory');
+        $currentTerritory = $isNoneTerritory ? null : $territoryRepository->find((int) $request->get('territory'));
+        $partnerTerms = $request->get('partnerTerms');
+
+        $paginatedArchivedPartners = $partnerRepository->findAllArchivedOrWithoutTerritory(
+            territory: $currentTerritory,
+            isNoneTerritory: $isNoneTerritory,
+            filterTerms: $partnerTerms,
+            page: (int) $page
+        );
+
+        if ($request->isMethod(Request::METHOD_POST)) {
+            $isNoneTerritory = 'none' == $request->request->get('territory');
+            $currentTerritory = $territoryRepository->find((int) $request->request->get('territory'));
+            $partnerTerms = $request->request->get('bo-filters-partnerterms');
+
+            return $this->redirect($this->generateUrl('back_archived_partner_index', [
+                'page' => 1,
+                'territory' => $isNoneTerritory ? 'none' : $currentTerritory?->getId(),
+                'partnerTerms' => $partnerTerms,
+            ]));
+        }
+
+        $totalArchivedPartners = \count($paginatedArchivedPartners);
+
+        return $this->render('back/partner_archived/index.html.twig', [
+            'isNoneTerritory' => $isNoneTerritory,
+            'currentTerritory' => $currentTerritory,
+            'partnerTerms' => $partnerTerms,
+            'territories' => $territoryRepository->findAllList(),
+            'partners' => $paginatedArchivedPartners,
+            'total' => $totalArchivedPartners,
+            'page' => $page,
+            'pages' => (int) ceil($totalArchivedPartners / User::MAX_LIST_PAGINATION),
+        ]);
+    }
+}

--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -51,6 +51,12 @@ partners:
     type: "ARS"
     competence: "VISITES"
   -
+    nom: "Partenaire 13-07"
+    email: "partenaire-13-07@histologe.fr"
+    is_archive: 1
+    territory: "Bouches-du-Rhône"
+    type: "AUTRE"
+  -
     nom: "Partenaire 01-01"
     email: "partenaire-01-01@histologe.fr"
     is_archive: 0

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -194,6 +194,14 @@ users:
     is_mailing_active: 1
     territory: "Bouches-du-Rhône"
   -
+    email: user-13-07@histologe.fr
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partner: "Partenaire 13-07"
+    statut: 2
+    is_generique: 0
+    is_mailing_active: 1
+    territory: "Bouches-du-Rhône"
+  -
     email: user-2A-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 2A-01"
@@ -255,6 +263,14 @@ users:
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-02"
     statut: 1
+    is_generique: 0
+    is_mailing_active: 0
+    territory: "Ain"
+  -
+    email: user-01-06@histologe.fr
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partner: "Partenaire 01-03-ARCHIVE"
+    statut: 2
     is_generique: 0
     is_mailing_active: 0
     territory: "Ain"

--- a/src/DataFixtures/Loader/LoadPartnerData.php
+++ b/src/DataFixtures/Loader/LoadPartnerData.php
@@ -6,6 +6,7 @@ use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\Qualification;
 use App\Entity\Partner;
 use App\Repository\TerritoryRepository;
+use App\Service\Sanitizer;
 use App\Service\Token\TokenGeneratorInterface;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -33,9 +34,14 @@ class LoadPartnerData extends Fixture implements OrderedFixtureInterface
     {
         $partner = (new Partner())
             ->setNom($row['nom'])
-            ->setEmail($row['email'] ?? null)
             ->setIsArchive($row['is_archive'])
             ->setIsEsaboraActive($row['is_esabora_active'] ?? false);
+
+        if ($row['is_archive'] && null !== $row['email']) {
+            $partner->setEmail(Sanitizer::tagArchivedEmail($row['email']));
+        } else {
+            $partner->setEmail($row['email'] ?? null);
+        }
 
         if (isset($row['insee'])) {
             $partner->setInsee(json_decode($row['insee'], true));

--- a/src/DataFixtures/Loader/LoadUserData.php
+++ b/src/DataFixtures/Loader/LoadUserData.php
@@ -7,6 +7,7 @@ use App\EventListener\UserCreatedListener;
 use App\Factory\UserFactory;
 use App\Repository\PartnerRepository;
 use App\Repository\TerritoryRepository;
+use App\Service\Sanitizer;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -55,9 +56,14 @@ class LoadUserData extends Fixture implements OrderedFixtureInterface
             ->setRoles(json_decode($row['roles'], true))
             ->setStatut($row['statut'])
             ->setIsMailingActive($row['is_mailing_active'])
-            ->setEmail($row['email'])
             ->setPrenom($faker->firstName())
             ->setNom($faker->lastName());
+
+        if (User::STATUS_ARCHIVE === $row['statut']) {
+            $user->setEmail(Sanitizer::tagArchivedEmail($row['email']));
+        } else {
+            $user->setEmail($row['email']);
+        }
 
         if (isset($row['territory'])) {
             $user->setTerritory($this->territoryRepository->findOneBy(['name' => $row['territory']]));

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -40,6 +40,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public const ROLE_ADMIN_TERRITORY = self::ROLES['Responsable Territoire'];
     public const ROLE_ADMIN = self::ROLES['Super Admin'];
 
+    public const SUFFIXE_ARCHIVED = '.archived@';
+
     public const ROLES = [
         'Usager' => 'ROLE_USAGER',
         'Utilisateur' => 'ROLE_USER_PARTNER',

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -55,6 +55,19 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->getResult();
     }
 
+    public function findArchivedUserByEmail(string $email): ?User
+    {
+        $queryBuilder = $this->createQueryBuilder('u');
+
+        return $queryBuilder
+            ->andWhere('u.email LIKE :email')
+            ->setParameter('email', '%'.$email.'%')
+            ->andWhere('u.statut LIKE :archived')
+            ->setParameter('archived', User::STATUS_ARCHIVE)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function findActiveTerritoryAdmins(?Territory $territory, ?string $inseeOccupant): ?array
     {
         if (empty($territory)) {

--- a/src/Service/Sanitizer.php
+++ b/src/Service/Sanitizer.php
@@ -2,6 +2,8 @@
 
 namespace App\Service;
 
+use App\Entity\User;
+
 class Sanitizer
 {
     public static function sanitize($text): string
@@ -13,6 +15,6 @@ class Sanitizer
 
     public static function tagArchivedEmail(string $email): string
     {
-        return $email.'.archived@'.(new \DateTimeImmutable())->format('YmdHi');
+        return $email.User::SUFFIXE_ARCHIVED.(new \DateTimeImmutable())->format('YmdHi');
     }
 }

--- a/src/Service/Sanitizer.php
+++ b/src/Service/Sanitizer.php
@@ -10,4 +10,9 @@ class Sanitizer
 
         return str_replace('</p>', '<br>', $textSanitized); // Replace the end
     }
+
+    public static function tagArchivedEmail(string $email): string
+    {
+        return $email.'.archived@'.(new \DateTimeImmutable())->format('YmdHi');
+    }
 }

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -78,8 +78,12 @@ class AppExtension extends AbstractExtension
         ];
     }
 
-    public function cleanTaggedText(string $taggedText, string $tag, string $direction): string
+    public function cleanTaggedText(?string $taggedText, string $tag, string $direction): string
     {
+        if (null === $taggedText) {
+            return '';
+        }
+
         $parts = explode($tag, $taggedText);
 
         switch ($direction) {

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -22,6 +22,7 @@ class AppExtension extends AbstractExtension
             new TwigFilter('signalement_lien_declarant_occupant', [$this, 'getLabelLienDeclarantOccupant']),
             new TwigFilter('image64', [ImageBase64Encoder::class, 'encode']),
             new TwigFilter('truncate_filename', [$this, 'getTruncatedFilename']),
+            new TwigFilter('clean_tagged_text', [$this, 'cleanTaggedText']),
         ];
     }
 
@@ -75,5 +76,19 @@ class AppExtension extends AbstractExtension
             new TwigFunction('can_edit_esabora_credentials', [EsaboraPartnerTypeSubscription::class, 'isSubscribed']),
             new TwigFunction('show_label_facultatif', [AttributeParser::class, 'showLabelAsFacultatif']),
         ];
+    }
+
+    public function cleanTaggedText(string $taggedText, string $tag, string $direction): string
+    {
+        $parts = explode($tag, $taggedText);
+
+        switch ($direction) {
+            case 'left':
+                return $parts[0];
+            case 'right':
+                return $parts[1];
+            default:
+                return $taggedText;
+        }
     }
 }

--- a/templates/back/account/_form.html.twig
+++ b/templates/back/account/_form.html.twig
@@ -1,13 +1,15 @@
 {{ form_start(form,{attr:{'class':'needs-validation','novalidate':true}}) }}
 <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-md-0">
     <legend class="fr-fieldset__legend fr-text--regular">
-        <span>Pour réactiver le compte {{ user.email }}, veuillez vérifier les champs ci-dessous et les modifier si besoin.</span></br>
+        <span>Pour réactiver le compte {{ user.email|clean_tagged_text('.archived@', 'left') }}, veuillez vérifier les champs ci-dessous et les modifier si besoin.</span></br>
         <span>Tous les champs sont obligatoires.</span>
     </legend>
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-lg-6">
             <label for="{{ form.email.vars.id }}" class="fr-label">Adresse email</label>
-            {{ form_widget(form.email) }}
+                <input id="user_email" class="fr-input" type="email" name="user[email]" 
+                disabled="disabled" required="required"
+                value="{{ user.email|clean_tagged_text('.archived@', 'left')  }}">                            
             </br>
             <span class="fr-hint-text">L'adresse email ne peut pas être modifiée</span>
         </div>

--- a/templates/back/account/_form.html.twig
+++ b/templates/back/account/_form.html.twig
@@ -1,15 +1,13 @@
 {{ form_start(form,{attr:{'class':'needs-validation','novalidate':true}}) }}
 <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-md-0">
     <legend class="fr-fieldset__legend fr-text--regular">
-        <span>Pour réactiver le compte {{ user.email|clean_tagged_text('.archived@', 'left') }}, veuillez vérifier les champs ci-dessous et les modifier si besoin.</span></br>
+        <span>Pour réactiver le compte {{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}, veuillez vérifier les champs ci-dessous et les modifier si besoin.</span></br>
         <span>Tous les champs sont obligatoires.</span>
     </legend>
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-lg-6">
             <label for="{{ form.email.vars.id }}" class="fr-label">Adresse email</label>
-                <input id="user_email" class="fr-input" type="email" name="user[email]" 
-                disabled="disabled" required="required"
-                value="{{ user.email|clean_tagged_text('.archived@', 'left')  }}">                            
+                {{ form_widget(form.email, {'value': user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}) }}
             </br>
             <span class="fr-hint-text">L'adresse email ne peut pas être modifiée</span>
         </div>

--- a/templates/back/account/edit.html.twig
+++ b/templates/back/account/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <section class="fr-col-12 fr-p-5v">
-        <h2 class="fr-h2 fr-mb-0">Réactivation du compte {{ user.email }}</h2>
+        <h2 class="fr-h2 fr-mb-0">Réactivation du compte {{ user.email|clean_tagged_text('.archived@', 'left')  }}</h2>
         <div class="fr-pt-5v">
             {{ include('back/account/_form.html.twig') }}
         </div>

--- a/templates/back/account/edit.html.twig
+++ b/templates/back/account/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <section class="fr-col-12 fr-p-5v">
-        <h2 class="fr-h2 fr-mb-0">Réactivation du compte {{ user.email|clean_tagged_text('.archived@', 'left')  }}</h2>
+        <h2 class="fr-h2 fr-mb-0">Réactivation du compte {{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')  }}</h2>
         <div class="fr-pt-5v">
             {{ include('back/account/_form.html.twig') }}
         </div>

--- a/templates/back/account/index.html.twig
+++ b/templates/back/account/index.html.twig
@@ -82,12 +82,12 @@
                     <td>{{ user.territory }}</td>
                     <td>{{ user.partner ? user.partner.nom : 'aucun' }}</td>
                     <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
-                    <td>{{ user.email|clean_tagged_text('.archived@', 'left') }}</ail td>
+                    <td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
                     <td>{{ user.nom}}</ail td>
                     <td>{{ user.prenom}}</ail td>
                     <td class="fr-text--right">
                         <a href="{{ path('back_account_reactiver', {'id': user.id}) }}"
-                           class="fr-btn fr-icon-flashlight-fill fr-btn--sm" title="Réactiver le compte {{user.email}}"></a>
+                           class="fr-btn fr-icon-flashlight-fill fr-btn--sm" title="Réactiver le compte {{user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}}"></a>
                     </td>
                 </tr>
             {% else %}

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -68,7 +68,7 @@
                     </ul>
                 </div>
                 {% if is_granted('ROLE_ADMIN_PARTNER') %}
-                    {% set routesAdmin = ['back_user_report_index', 'back_situation_', 'back_partner_', 'back_account_', 'back_inactive_account_', 'back_expired_account_'] %}
+                    {% set routesAdmin = ['back_user_report_index', 'back_situation_', 'back_partner_', 'back_account_', 'back_inactive_account_', 'back_expired_account_', 'back_archived_partner'] %}
                     <button class="fr-sidemenu__btn"
                             aria-expanded="{% if routesAdmin|filter(route => app.request.get('_route') starts with route)|length > 0  %}true{% else %}false{% endif %}"
                             aria-controls="fr-sidemenu-outils-admin">Outils Admin

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -106,6 +106,13 @@
                                         {% if 'back_expired_account_' in app.request.get('_route') %}aria-current="page"{% endif %}>Comptes expirés</a>
                                     </li>
                                 {% endif %}
+                                {% if is_granted('ROLE_ADMIN') %}
+                                    <li class="fr-sidemenu__item {% if 'back_archived_partner' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
+                                        <a class="fr-sidemenu__link" href="{{ path('back_archived_partner_index') }}"
+                                        target="_self"
+                                        {% if 'back_archived_partner' in app.request.get('_route') %}aria-current="page"{% endif %}>Partenaires archivés</a>
+                                    </li>
+                                {% endif %}
                             {% endif %}
                         </ul>
                     </div>

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -90,6 +90,11 @@
                                        {% if 'back_partner' in app.request.get('_route') %}aria-current="page"{% endif %}>Partenaires</a>
                                 </li>
                                 {% if is_granted('ROLE_ADMIN') %}
+                                    <li class="fr-sidemenu__item {% if 'back_archived_partner' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
+                                        <a class="fr-sidemenu__link" href="{{ path('back_archived_partner_index') }}"
+                                        target="_self"
+                                        {% if 'back_archived_partner' in app.request.get('_route') %}aria-current="page"{% endif %}>Partenaires archivés</a>
+                                    </li>
                                     <li class="fr-sidemenu__item {% if 'back_account_' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
                                         <a class="fr-sidemenu__link" href="{{ path('back_account_index') }}"
                                         target="_self"
@@ -104,13 +109,6 @@
                                         <a class="fr-sidemenu__link" href="{{ path('back_expired_account_index') }}"
                                         target="_self"
                                         {% if 'back_expired_account_' in app.request.get('_route') %}aria-current="page"{% endif %}>Comptes expirés</a>
-                                    </li>
-                                {% endif %}
-                                {% if is_granted('ROLE_ADMIN') %}
-                                    <li class="fr-sidemenu__item {% if 'back_archived_partner' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
-                                        <a class="fr-sidemenu__link" href="{{ path('back_archived_partner_index') }}"
-                                        target="_self"
-                                        {% if 'back_archived_partner' in app.request.get('_route') %}aria-current="page"{% endif %}>Partenaires archivés</a>
                                     </li>
                                 {% endif %}
                             {% endif %}

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -108,7 +108,7 @@
                 </tr>
             {% else %}
                 <tr>
-                    <td colspan="3">no records found</td>
+                    <td colspan="3">Aucun partenaire trouvé</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -177,7 +177,7 @@
                     </tr>
                 {% else %}
                     <tr>
-                        <td colspan="3">no records found</td>
+                        <td colspan="3">Aucun partenaire trouvé</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/templates/back/partner_archived/index.html.twig
+++ b/templates/back/partner_archived/index.html.twig
@@ -1,13 +1,13 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Comptes archivés ou sans territoires et/ou partenaires{% endblock %}
+{% block title %}Partenaires archivés ou sans territoires{% endblock %}
 
 {% block content %}
     <section class="fr-p-5v">
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-6 fr-text--left">
-                    <h1 class="fr-h1 fr-mb-0">Comptes archivés</h1>
+                    <h1 class="fr-h1 fr-mb-0">Partenaires archivés</h1>
                 </div>
             </div>
         </header>
@@ -19,10 +19,10 @@
               
             <div class="fr-col-4 fr-p-2v">
                 <div class="fr-search-bar fr-mt-2v" id="header-search">
-                    <input class="fr-input" placeholder="Utilisateur" type="search" id="header-search-input"
-                        name="bo-filters-usersterms" value="{{ userTerms ?? '' }}">
+                    <input class="fr-input" placeholder="Partenaire" type="search" id="header-search-input"
+                        name="bo-filters-partnerterms" value="{{ partnerTerms ?? '' }}">
                     <button class="fr-btn" title="Rechercher">
-                        {{userTerms is null ? 'Utilisateur' : userTerms}}
+                        {{partnerTerms is null ? 'Partenaire' : partnerTerms}}
                     </button>&nbsp;
                 </div>
             </div>
@@ -35,43 +35,32 @@
                     {% endfor %}
                 </select>
             </div>
-            <div class="fr-col-3 fr-p-2v">
-                <select id="bo-filters-partners" class="fr-select" onchange="this.form.submit()" name="partner">
-                    <option value="" {{ not isNonePartner and currentPartner is null ? 'selected' : '' }}>Tous les partenaires</option>
-                    <option value="none" {{ isNonePartner ? 'selected' : '' }}>Aucun</option>
-                    {% for partner in partners %}
-                        <option value="{{ partner.id }}" {{ currentPartner ? (partner.id == currentPartner.id ? 'selected' : '') : '' }}>{{ partner.nom|upper }}</option>
-                    {% endfor %}
-                </select>
-            </div>
             <div class="fr-col-2 fr-p-2v">
-                <a href="{{ path('back_account_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser</a>
+                <a href="{{ path('back_archived_partner_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser</a>
             </div>
         </form>
     </section>
     {% endif %}
     <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <h1 class="fr-h2 fr-mb-0" id="desc-table">{{total}} comptes archivés ou sans territoires et/ou partenaires trouvés</h1>
+        <h1 class="fr-h2 fr-mb-0" id="desc-table">{{total}} partenaires archivés ou sans territoires trouvés</h1>
     </section>
     <section class="fr-col-12 fr-table fr-table--bordered fr-pt-0">
-        <table class="fr-display-inline-table sortable" aria-label="Liste des comptes archivés ou sans territoires et/ou partenaires" aria-describedby="desc-table">
+        <table class="fr-display-inline-table sortable" aria-label="Liste des partenaires archivés ou sans territoires" aria-describedby="desc-table">
             <thead>
             <tr>
                 <th>Dpt.</th>
-                <th>Partenaire</th>
-                <th>Statut part.</th>
+                <th>Statut</th>
                 <th>Email</th>
                 <th>Nom</th>
-                <th>Prénom</th>
-                <th class="fr-text--right"></th>
+                <th>Type</th>
             </tr>
             </thead>
             <tbody>
-            {% for user in users %}
-                {% if user.partner is null %}
+            {% for partner in partners %}
+                {% if partner is null %}
                     {% set classe = 'fr-badge--info' %}
                     {% set statut = 'aucun' %}
-                {% elseif user.partner and user.partner.isArchive  %}
+                {% elseif partner and partner.isArchive  %}
                     {% set classe = 'fr-badge--error' %}
                     {% set statut = 'archivé' %}
                 {% else %}
@@ -79,20 +68,15 @@
                     {% set statut = 'actif' %}
                 {% endif %}
                 <tr class="user-row">
-                    <td>{{ user.territory }}</td>
-                    <td>{{ user.partner ? user.partner.nom : 'aucun' }}</td>
+                    <td>{{ partner.territory }}</td>
                     <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
-                    <td>{{ user.email|clean_tagged_text('.archived@', 'left') }}</ail td>
-                    <td>{{ user.nom}}</ail td>
-                    <td>{{ user.prenom}}</ail td>
-                    <td class="fr-text--right">
-                        <a href="{{ path('back_account_reactiver', {'id': user.id}) }}"
-                           class="fr-btn fr-icon-flashlight-fill fr-btn--sm" title="Réactiver le compte {{user.email}}"></a>
-                    </td>
+                    <td>{{ partner.email|clean_tagged_text('.archived@', 'left') }}</ail td>
+                    <td>{{ partner.nom}}</ail td>
+                    <td>{{ partner.type.label}}</ail td>
                 </tr>
             {% else %}
                 <tr>
-                    <td colspan="7">Aucun utilisateur trouvé</td>
+                    <td colspan="4">Aucun partenaire trouvé</td>
                 </tr>
             {% endfor %}
             </tbody>
@@ -103,7 +87,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--first"
                                 {% if pages > 1 %}
-                                    href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
+                                    href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %}>
@@ -113,7 +97,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
                                 {% if pages > 1 and page != 1 %}
-                                    href="{{ path('back_account_index', {page : page - 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
+                                    href="{{ path('back_account_index', {page : page - 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %} role="link">
@@ -124,7 +108,7 @@
                         <a class="fr-pagination__link" {{ page == 1 ? 'aria-current="page"' : '' }}
                            title="Page 1"
                            data-page="1"
-                                href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
+                                href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                         >
                             1
                         </a>
@@ -133,7 +117,7 @@
                         {% for i in 2..pages %}
                             <li class="{% if loop.index > 2 and loop.index < pages-3 %}fr-hidden{% endif %}">
                                 <a class="fr-pagination__link" {{ page == i ? 'aria-current="page"' : '' }}
-                                        href="{{ path('back_account_index', {page : i, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
+                                        href="{{ path('back_account_index', {page : i, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                    title="Page {{ i }}"
                                    data-page="{{ i }}">
                                     {{ i }}
@@ -151,7 +135,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
                                 {% if pages > 1  and page < pages %}
-                                    href="{{ path('back_account_index', {page : page + 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
+                                    href="{{ path('back_account_index', {page : page + 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %} role="link">
@@ -161,7 +145,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--last"
                                 {% if pages > 1 %}
-                                    href="{{ path('back_account_index', {page : pages, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
+                                    href="{{ path('back_account_index', {page : pages, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %}

--- a/templates/back/partner_archived/index.html.twig
+++ b/templates/back/partner_archived/index.html.twig
@@ -70,7 +70,7 @@
                 <tr class="user-row">
                     <td>{{ partner.territory }}</td>
                     <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
-                    <td>{{ partner.email|clean_tagged_text('.archived@', 'left') }}</ail td>
+                    <td>{{ partner.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
                     <td>{{ partner.nom}}</ail td>
                     <td>{{ partner.type.label}}</ail td>
                 </tr>
@@ -87,7 +87,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--first"
                                 {% if pages > 1 %}
-                                    href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), partnerTerms: partnerTerms }) }}"
+                                    href="{{ path('back_archived_partner_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %}>
@@ -97,7 +97,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
                                 {% if pages > 1 and page != 1 %}
-                                    href="{{ path('back_account_index', {page : page - 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
+                                    href="{{ path('back_archived_partner_index', {page : page - 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %} role="link">
@@ -108,7 +108,7 @@
                         <a class="fr-pagination__link" {{ page == 1 ? 'aria-current="page"' : '' }}
                            title="Page 1"
                            data-page="1"
-                                href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
+                                href="{{ path('back_archived_partner_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                         >
                             1
                         </a>
@@ -117,7 +117,7 @@
                         {% for i in 2..pages %}
                             <li class="{% if loop.index > 2 and loop.index < pages-3 %}fr-hidden{% endif %}">
                                 <a class="fr-pagination__link" {{ page == i ? 'aria-current="page"' : '' }}
-                                        href="{{ path('back_account_index', {page : i, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
+                                        href="{{ path('back_archived_partner_index', {page : i, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                    title="Page {{ i }}"
                                    data-page="{{ i }}">
                                     {{ i }}
@@ -135,7 +135,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
                                 {% if pages > 1  and page < pages %}
-                                    href="{{ path('back_account_index', {page : page + 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
+                                    href="{{ path('back_archived_partner_index', {page : page + 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %} role="link">
@@ -145,7 +145,7 @@
                     <li>
                         <a class="fr-pagination__link fr-pagination__link--last"
                                 {% if pages > 1 %}
-                                    href="{{ path('back_account_index', {page : pages, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
+                                    href="{{ path('back_archived_partner_index', {page : pages, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
                                 {% else %}
                                     aria-disabled="true"
                                 {% endif %}

--- a/tests/Functional/Controller/Back/BackArchivedPartnerControllerTest.php
+++ b/tests/Functional/Controller/Back/BackArchivedPartnerControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Repository\TerritoryRepository;
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+class BackArchivedPartnerControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    public function testAccountList(): void
+    {
+        $client = static::createClient();
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('back_archived_partner_index');
+        $client->request('GET', $route);
+        $this->assertLessThan(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $client->getResponse()->getStatusCode(),
+            sprintf('Result value: %d', $client->getResponse()->getStatusCode())
+        );
+    }
+
+    public function testAccountListWithTerritory(): void
+    {
+        $client = static::createClient();
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        /** @var TerritoryRepository $territoryRepository */
+        $territoryRepository = static::getContainer()->get(TerritoryRepository::class);
+        $territory = $territoryRepository->findOneBy(['zip' => '01']);
+
+        $route = $router->generate('back_archived_partner_index', [
+            'territory' => $territory->getId(),
+        ]);
+        $client->request('GET', $route);
+        $this->assertLessThan(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $client->getResponse()->getStatusCode(),
+            sprintf('Result value: %d', $client->getResponse()->getStatusCode())
+        );
+    }
+}

--- a/tests/Functional/Controller/CartographieControllerTest.php
+++ b/tests/Functional/Controller/CartographieControllerTest.php
@@ -47,7 +47,7 @@ class CartographieControllerTest extends WebTestCase
     {
         /** @var UserRepository $userRepository */
         $userRepository = static::getContainer()->get(UserRepository::class);
-        $users = $userRepository->findAll();
+        $users = $userRepository->findBy(['statut' => User::STATUS_ACTIVE]);
         /** @var User $user */
         foreach ($users as $user) {
             if ($user->getTerritory()) {

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -125,10 +125,10 @@ class PartnerControllerTest extends WebTestCase
 
         $this->assertResponseRedirects('/bo/partenaires/');
         $this->assertTrue($partner->getIsArchive());
-        $this->assertStringStartsWith($mailBeforArchive.'.archived@', $partner->getEmail());
+        $this->assertStringStartsWith($mailBeforArchive.User::SUFFIXE_ARCHIVED, $partner->getEmail());
         foreach ($partnerUsers as $user) {
             $this->assertEquals(User::STATUS_ARCHIVE, $user->getStatut());
-            $this->assertStringContainsString('.archived@', $user->getEmail());
+            $this->assertStringContainsString(User::SUFFIXE_ARCHIVED, $user->getEmail());
         }
     }
 
@@ -259,7 +259,7 @@ class PartnerControllerTest extends WebTestCase
         ]);
 
         $this->assertEquals(2, $user->getStatut());
-        $this->assertStringContainsString('.archived@', $user->getEmail());
+        $this->assertStringContainsString(User::SUFFIXE_ARCHIVED, $user->getEmail());
     }
 
     public function testDeleteUserAccountWithCsrfUnvalid(): void
@@ -273,7 +273,7 @@ class PartnerControllerTest extends WebTestCase
         ]);
 
         $this->assertNotEquals(2, $user->getStatut());
-        $this->assertStringNotContainsString('.archived@', $user->getEmail());
+        $this->assertStringNotContainsString(User::SUFFIXE_ARCHIVED, $user->getEmail());
         $this->assertResponseRedirects('/bo/partenaires/');
     }
 }

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -111,6 +111,7 @@ class PartnerControllerTest extends WebTestCase
         /** @var Partner $partner */
         $partner = $this->partnerRepository->findOneBy(['nom' => 'Partenaire 13-03']);
         $partnerUsers = $partner->getUsers();
+        $mailBeforArchive = $partner->getEmail();
 
         $route = $this->router->generate('back_partner_delete');
         $this->client->request(
@@ -124,8 +125,10 @@ class PartnerControllerTest extends WebTestCase
 
         $this->assertResponseRedirects('/bo/partenaires/');
         $this->assertTrue($partner->getIsArchive());
+        $this->assertStringStartsWith($mailBeforArchive.'.archived@', $partner->getEmail());
         foreach ($partnerUsers as $user) {
             $this->assertEquals(User::STATUS_ARCHIVE, $user->getStatut());
+            $this->assertStringContainsString('.archived@', $user->getEmail());
         }
     }
 
@@ -256,6 +259,7 @@ class PartnerControllerTest extends WebTestCase
         ]);
 
         $this->assertEquals(2, $user->getStatut());
+        $this->assertStringContainsString('.archived@', $user->getEmail());
     }
 
     public function testDeleteUserAccountWithCsrfUnvalid(): void
@@ -269,6 +273,7 @@ class PartnerControllerTest extends WebTestCase
         ]);
 
         $this->assertNotEquals(2, $user->getStatut());
+        $this->assertStringNotContainsString('.archived@', $user->getEmail());
         $this->assertResponseRedirects('/bo/partenaires/');
     }
 }

--- a/tests/Functional/Controller/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/SignalementListControllerTest.php
@@ -45,7 +45,7 @@ class SignalementListControllerTest extends WebTestCase
     {
         /** @var UserRepository $userRepository */
         $userRepository = static::getContainer()->get(UserRepository::class);
-        $users = $userRepository->findAll();
+        $users = $userRepository->findBy(['statut' => User::STATUS_ACTIVE]);
         /** @var User $user */
         foreach ($users as $user) {
             if ($user->getTerritory()) {

--- a/tests/Functional/Service/Token/ActivationTokenGeneratorTest.php
+++ b/tests/Functional/Service/Token/ActivationTokenGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Service\Token;
 
 use App\Entity\User;
+use App\Repository\UserRepository;
 use App\Service\Token\ActivationTokenGenerator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -47,8 +48,9 @@ class ActivationTokenGeneratorTest extends KernelTestCase
 
     public function testValidateTokenNok(): void
     {
+        /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
-        $user = $userRepository->findOneBy(['email' => 'user-01-07@histologe.fr']);
+        $user = $userRepository->findArchivedUserByEmail('user-01-07@histologe.fr');
 
         $container = static::getContainer();
         $activationTokenGenerator = $container->get(ActivationTokenGenerator::class);


### PR DESCRIPTION
## Ticket

#2035   

## Description
Lorsqu'on archive un user ou un partenaire, on tag le champ email pour qu'il n'y ait plus de doublon `.archived@yyyymmddhhmm`

## Changements apportés
- ajout d'une page des partenaires archivés
- à l'archivage d'un utilisateur et d'un partner on tag le mail avec `.archived@yyyymmddhhmm`
- au désarchivage, on vérifie que le mail n'est pas utilisé ailleurs, et on affiche une alerte si besoin (et on retire le tag si ok)
- à l'affichage on masque le tag
- on fait une commande pour taguer les mails de tous les utilisateurs et partenaires archivés

## Pré-requis

## Tests
- [ ] Lancer la migration et vérifier en base que les utilisateurs et partenaires archivés ont bien le tag
- [ ] Aller voir dans le BO que le tag n'apparait pas dans les page de comptes archivés et partenaires archivés
- [ ] Archiver un utilisateur, et vérifier qu'il apparait bien dans les comptes archivés
- [ ] Archiver un partenaire, et vérifier qu'il apparait bien dans les partenaires archivés, et que ses utilisateurs apparaissent dans les comptes archivés
- [ ] Désarchiver un utilisateur, vérifier qu'on ne voit pas le tag, et qu'il est bien désarchiver (vérifier le mail en base)
- [ ] Idem pour un partenaire
- [ ] Aller changer un utilisateur en base pour lui mettre l'e-mail d'un utilisateur archivé (sans le tag évidemment)
- [ ] Essayer d'aller désarchiver l'utilisateur qui a le même mail et vérifier qu'on a bien une alerte
