### PR TITLE
[QA] Conversion en nombre entier pour le nombre de personnes

### DIFF
--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -17,6 +17,7 @@ class SignalementDraftRequest
     public const PATTERN_PHONE_KEY = '/.*(_tel|_tel_secondaire)$/';
 
     public const PATTERN_FILE_UPLOAD = '/\w+_upload/';
+    public const PATTERN_NOMBRE = '/_nb_|_nombre_/';
     public const FILE_UPLOAD_KEY = 'files';
 
     private ?string $profil = null;

--- a/src/Serializer/SignalementDraftRequestNormalizer.php
+++ b/src/Serializer/SignalementDraftRequestNormalizer.php
@@ -4,6 +4,7 @@ namespace App\Serializer;
 
 use App\Dto\Request\Signalement\RequestInterface;
 use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Model\InformationComplementaire;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\SignalementDraft;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -46,6 +47,8 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
                 }
 
                 $transformedData[SignalementDraftRequest::FILE_UPLOAD_KEY][$keyUpdated] = $data[$key];
+            } elseif (preg_match(SignalementDraftRequest::PATTERN_NOMBRE, $key, $matches) && is_numeric($value)) {
+                $transformedData[$key] = ceil($value);
             } else {
                 if ('isProprioAverti' === $key) {
                     $transformedData[$key] = $value;
@@ -92,6 +95,7 @@ class SignalementDraftRequestNormalizer implements DenormalizerInterface, Normal
         return [
             SignalementDraftRequest::class => true,
             TypeCompositionLogement::class => true,
+            InformationComplementaire::class => true,
             RequestInterface::class => true,
         ];
     }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -101,17 +101,11 @@ class SignalementBuilder
 
     public function withTypeCompositionLogement(): self
     {
-        // Some people write unexpected float values, round to superior
-        $compositionLogementNombrePersonnes = $this->signalementDraftRequest->getCompositionLogementNombrePersonnes();
-        if (!empty($compositionLogementNombrePersonnes) && is_numeric($compositionLogementNombrePersonnes)) {
-            $compositionLogementNombrePersonnes = ceil($compositionLogementNombrePersonnes);
-        }
-
         $this->signalement
             ->setTypeCompositionLogement(
                 $this->typeCompositionLogementFactory->createFromSignalementDraftPayload($this->payload)
             )
-            ->setNbOccupantsLogement($compositionLogementNombrePersonnes)
+            ->setNbOccupantsLogement($this->signalementDraftRequest->getCompositionLogementNombrePersonnes())
             ->setNatureLogement($this->signalementDraftRequest->getTypeLogementNature())
             ->setTypeLogement($this->signalementDraftRequest->getTypeLogementNature())
             ->setSuperficie($this->signalementDraftRequest->getCompositionLogementSuperficie())

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -101,11 +101,17 @@ class SignalementBuilder
 
     public function withTypeCompositionLogement(): self
     {
+        // Some people write unexpected float values, round to superior
+        $compositionLogementNombrePersonnes = $this->signalementDraftRequest->getCompositionLogementNombrePersonnes();
+        if (!empty($compositionLogementNombrePersonnes) && is_numeric($compositionLogementNombrePersonnes)) {
+            $compositionLogementNombrePersonnes = ceil($compositionLogementNombrePersonnes);
+        }
+
         $this->signalement
             ->setTypeCompositionLogement(
                 $this->typeCompositionLogementFactory->createFromSignalementDraftPayload($this->payload)
             )
-            ->setNbOccupantsLogement($this->signalementDraftRequest->getCompositionLogementNombrePersonnes())
+            ->setNbOccupantsLogement($compositionLogementNombrePersonnes)
             ->setNatureLogement($this->signalementDraftRequest->getTypeLogementNature())
             ->setTypeLogement($this->signalementDraftRequest->getTypeLogementNature())
             ->setSuperficie($this->signalementDraftRequest->getCompositionLogementSuperficie())


### PR DESCRIPTION
## Ticket

#2251   

## Description
Certaines personnes saisissent un nombre float pour le nombre de personnes (Ex : 3.5). On l'arrondit à l'entier supérieur.
Le ticket signale une autre conversion, mais elle a été corrigée par ailleurs.

## Tests
- [ ] Entrer un nombre de personnes avec décimale et vérifier l'arrondi à l'unité supérieure
**EDIT**
- [ ] Entrer un nombre de pièce avec décimale et vérifier l'arrondi à l'unité supérieure
- [ ] Entrer un nombre d'étage dans information complémentaire et vérifier l'arrondi à l'unité supérieure
