### PR TITLE
[Bug] cron Esabora

### DIFF
--- a/src/Service/Esabora/Handler/InterventionVisiteServiceHandler.php
+++ b/src/Service/Esabora/Handler/InterventionVisiteServiceHandler.php
@@ -25,9 +25,15 @@ class InterventionVisiteServiceHandler implements InterventionSISHHandlerInterfa
 
     public function handle(Affectation $affectation): void
     {
+        $hasDateError = false;
         $dossierVisiteSISHCollectionResponse = $this->esaboraSISHService->getVisiteDossier($affectation);
         if ($hasSuccess = AbstractEsaboraService::hasSuccess($dossierVisiteSISHCollectionResponse)) {
             foreach ($dossierVisiteSISHCollectionResponse->getCollection() as $dossierVisite) {
+                if (!$dossierVisite->getVisiteDate()) {
+                    $hasDateError = true;
+                    $hasSuccess = false;
+                    continue;
+                }
                 $this->esaboraManager->createOrUpdateVisite($affectation, $dossierVisite);
             }
             ++$this->countSuccess;
@@ -52,6 +58,9 @@ class InterventionVisiteServiceHandler implements InterventionSISHHandlerInterfa
             partnerId: $affectation->getPartner()->getId(),
             partnerType: $affectation->getPartner()->getType(),
         );
+        if ($hasDateError) {
+            throw new \Exception('Date de visite manquante');
+        }
     }
 
     public function getCountSuccess(): int

--- a/src/Service/Esabora/Handler/InterventionVisiteServiceHandler.php
+++ b/src/Service/Esabora/Handler/InterventionVisiteServiceHandler.php
@@ -23,6 +23,9 @@ class InterventionVisiteServiceHandler implements InterventionSISHHandlerInterfa
     ) {
     }
 
+    /**
+     * @throws \Exception
+     */
     public function handle(Affectation $affectation): void
     {
         $hasDateError = false;

--- a/templates/emails/cron_email.html.twig
+++ b/templates/emails/cron_email.html.twig
@@ -10,4 +10,12 @@
     {% if count_failed is defined and message_failed is defined %}
         <p><span>&#10060;</span> {{ count_failed }}  {{ message_failed }}</p>
     {% endif %}
+    {% if error_messages is defined and error_messages|length %}
+        <p>Erreurs:</p>
+        <ul>
+            {% for error in error_messages %}
+                <li>{{ error }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Ticket

#2374

## Description
- Gestion des erreur PHP et exception dans la `SynchronizeInterventionSISHCommand.php`
- Gestion spécifique du cas des visites sans dates retournés par Esabora (lève une exception)

## Tests
- [ ] Sur une copie de la base de prod exécuter `make console app="sync-esabora-sish-intervention 87446c3c-821c-4e16-8329-5edbd2496161"` et vérifier que le script ne crashe plus malgré l'erreur de date
- [ ] Provoquer une erreur PHP (ex ajout de la ligne `100/0;` dans le bloc `try `de `SynchronizeInterventionSISHCommand`) et vérifier que le script ne crashe pas
