### PR TITLE
[Bug] Bloquer page front signalement si archivé

### DIFF
--- a/src/Controller/FrontSignalementController.php
+++ b/src/Controller/FrontSignalementController.php
@@ -566,6 +566,7 @@ class FrontSignalementController extends AbstractController
         EntityManagerInterface $entityManager,
         SuiviFactory $suiviFactory,
         SignalementFileProcessor $signalementFileProcessor,
+        UserManager $userManager
     ): RedirectResponse {
         $signalement = $signalementRepository->findOneByCodeForPublic($code);
         if (!$signalement) {
@@ -581,6 +582,11 @@ class FrontSignalementController extends AbstractController
         if (\in_array($signalement->getStatut(), [Signalement::STATUS_CLOSED, Signalement::STATUS_REFUSED])) {
             return $this->redirectToRoute('front_suivi_signalement', ['code' => $signalement->getCodeSuivi()]);
         }
+        /* @var User $userOccupant */
+        $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
+        /* @var User $userDeclarant */
+        $userManager->createUsagerFromSignalement($signalement, UserManager::DECLARANT);
+
         $email = $request->get('signalement_front_response')['email'];
         $user = $userRepository->findOneBy(['email' => $email]);
         $suivi = $suiviFactory->createInstanceFrom(

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -517,6 +517,8 @@ class SignalementRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('s')
             ->andWhere('s.codeSuivi = :code')
             ->setParameter('code', $code)
+            ->andWhere('s.statut != :status')
+            ->setParameter('status', Signalement::STATUS_ARCHIVED)
             ->leftJoin('s.suivis', 'suivis', Join::WITH, 'suivis.isPublic = 1')
             ->addSelect('suivis')
             ->getQuery()

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -24,35 +24,43 @@
                 </div>
             </header>
             <hr>
-            
-            {% if suiviAuto is defined and suiviAuto is not empty %}
-                <div class="fr-grid-row fr-grid-row--middle fr-rounded fr-p-5v">
-                    <div class="fr-col-12">
-                        <div class="fr-grid-row">
-                            <div class="fr-col-12">
-                            {% if suiviAuto is same as constant('App\\Entity\\Suivi::ARRET_PROCEDURE')  %}
-                                Vous souhaitez arrêter la procédure ?<br>
-                            {% endif %}
-                            {% if suiviAuto is same as constant('App\\Entity\\Suivi::POURSUIVRE_PROCEDURE')  %}
-                                Vous souhaitez poursuivre la procédure ?<br>
-                            {% endif %}
-                            Nous allons informer les services de votre réponse. <br>
-                            Attention votre choix pourra avoir un impact sur la poursuite de votre dossier. <br>
+            {% if signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') %}
+                <div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
+                    <p>Votre signalement a été refusé, vous ne pouvez plus envoyer de messages.</p>
+                </div>
+            {% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
+                <div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
+                    <p>Votre signalement a été clôturé, vous ne pouvez plus envoyer de messages.</p>
+                </div>
+            {% else %}
+                {% if suiviAuto is defined and suiviAuto is not empty %}
+                    <div class="fr-grid-row fr-grid-row--middle fr-rounded fr-p-5v">
+                        <div class="fr-col-12">
+                            <div class="fr-grid-row">
+                                <div class="fr-col-12">
+                                {% if suiviAuto is same as constant('App\\Entity\\Suivi::ARRET_PROCEDURE')  %}
+                                    Vous souhaitez arrêter la procédure ?<br>
+                                {% endif %}
+                                {% if suiviAuto is same as constant('App\\Entity\\Suivi::POURSUIVRE_PROCEDURE')  %}
+                                    Vous souhaitez poursuivre la procédure ?<br>
+                                {% endif %}
+                                Nous allons informer les services de votre réponse. <br>
+                                Attention votre choix pourra avoir un impact sur la poursuite de votre dossier. <br>
+                                </div>
                             </div>
-                        </div>
-                        <div class="fr-grid-row fr-p-5v">
-                            <div class="fr-col-6 fr-text--center">
-                                <a class="fr-btn fr-btn--secondary fr-fi-arrow-left-line fr-btn--icon-left"
-                                href="{{ path('front_suivi_signalement',{code:signalement.codeSuivi, from:email}) }}">Annuler</a>
-                            </div>
-                            <div class="fr-col-6 fr-text--center">
-                                <a class="fr-btn fr-icon-checkbox-circle-fill fr-btn--icon-right"
-                                href="{{ path('front_suivi_signalement',{code:signalement.codeSuivi, from:email, suiviAuto:suiviAuto}) }}">Confirmer</a>
+                            <div class="fr-grid-row fr-p-5v">
+                                <div class="fr-col-6 fr-text--center">
+                                    <a class="fr-btn fr-btn--secondary fr-fi-arrow-left-line fr-btn--icon-left"
+                                    href="{{ path('front_suivi_signalement',{code:signalement.codeSuivi, from:email}) }}">Annuler</a>
+                                </div>
+                                <div class="fr-col-6 fr-text--center">
+                                    <a class="fr-btn fr-icon-checkbox-circle-fill fr-btn--icon-right"
+                                    href="{{ path('front_suivi_procedure',{code:signalement.codeSuivi, from:email, suiviAuto:suiviAuto}) }}&_token={{csrf_token('suivi_procedure')}}">Confirmer</a>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            {% elseif signalement.statut != constant('App\\Entity\\Signalement::STATUS_CLOSED')  %}
+                {% endif %}
                 <div class="fr-grid-row fr-grid-row--middle fr-rounded fr-p-5v">
                     <div class="fr-col-12">
                         <form action="{{ path('front_suivi_signalement_user_response',{code:signalement.codeSuivi}) }}"

--- a/tests/Functional/Controller/FrontSignalementControllerTest.php
+++ b/tests/Functional/Controller/FrontSignalementControllerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Controller;
 
 use App\Entity\Signalement;
+use App\Entity\Suivi;
 use App\Manager\UserManager;
 use App\Tests\SessionHelper;
 use Doctrine\ORM\EntityManagerInterface;
@@ -94,34 +95,85 @@ class FrontSignalementControllerTest extends WebTestCase
         );
     }
 
-    public function testDisplaySuiviSignalement(): void
+    public function provideStatusSignalement(): \Generator
+    {
+        yield 'Actif' => [Signalement::STATUS_ACTIVE];
+        yield 'Clôturé' => [Signalement::STATUS_CLOSED];
+        yield 'Refusé' => [Signalement::STATUS_REFUSED];
+        yield 'Archivé' => [Signalement::STATUS_ARCHIVED];
+    }
+
+    /**
+     * @dataProvider provideStatusSignalement
+     */
+    public function testDisplaySuiviProcedure(int $status): void
     {
         $client = static::createClient();
+
         /** @var EntityManagerInterface $entityManager */
         $entityManager = self::getContainer()->get('doctrine');
         /** @var Signalement $signalement */
         $signalement = $entityManager->getRepository(Signalement::class)->findOneBy([
-            'codeSuivi' => '0123456789',
+            'statut' => $status,
+        ]);
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $urlSuiviSignalementUser = $router->generate('front_suivi_procedure', [
+            'code' => $signalement->getCodeSuivi(),
+        ]).'?from='.$signalement->getMailOccupant().'&suiviAuto='.Suivi::ARRET_PROCEDURE;
+
+        $crawler = $client->request('GET', $urlSuiviSignalementUser);
+        if (Signalement::STATUS_ARCHIVED === $status) {
+            $this->assertResponseRedirects('/');
+        } elseif (Signalement::STATUS_ACTIVE === $status) {
+            $this->assertEquals('Signalement #2022-1', $crawler->filter('h1')->text());
+        } else {
+            $this->assertResponseRedirects('/suivre-mon-signalement/'.$signalement->getCodeSuivi().'?from='.$signalement->getMailOccupant());
+        }
+    }
+
+    /**
+     * @dataProvider provideStatusSignalement
+     */
+    public function testDisplaySuiviSignalement(int $status): void
+    {
+        $client = static::createClient();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get('doctrine');
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy([
+            'statut' => $status,
         ]);
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
         $urlSuiviSignalementUser = $router->generate('front_suivi_signalement', [
             'code' => $signalement->getCodeSuivi(),
-        ]).'?from[]='.$signalement->getMailOccupant();
+        ]).'?from='.$signalement->getMailOccupant();
 
         $crawler = $client->request('GET', $urlSuiviSignalementUser);
-        $this->assertResponseIsSuccessful();
-        $this->assertEquals('Signalement #2023-18', $crawler->filter('h1')->text());
+        if (Signalement::STATUS_ARCHIVED === $status) {
+            $this->assertResponseRedirects('/');
+        } elseif (Signalement::STATUS_ACTIVE === $status) {
+            $this->assertEquals('Signalement #2022-1', $crawler->filter('h1')->text());
+        } elseif (Signalement::STATUS_CLOSED === $status) {
+            $this->assertEquals('Votre signalement a été clôturé, vous ne pouvez plus envoyer de messages.', $crawler->filter('.fr-alert--error p')->text());
+        } elseif (Signalement::STATUS_REFUSED === $status) {
+            $this->assertEquals('Votre signalement a été refusé, vous ne pouvez plus envoyer de messages.', $crawler->filter('.fr-alert--error p')->text());
+        }
     }
 
-    public function testPostUsagerResponse(): void
+    /**
+     * @dataProvider provideStatusSignalement
+     */
+    public function testPostUsagerResponse(int $status): void
     {
         $client = static::createClient();
         /** @var EntityManagerInterface $entityManager */
         $entityManager = self::getContainer()->get('doctrine');
         /** @var Signalement $signalement */
         $signalement = $entityManager->getRepository(Signalement::class)->findOneBy([
-            'codeSuivi' => '0123456789',
+            'statut' => $status,
         ]);
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
@@ -147,8 +199,13 @@ class FrontSignalementControllerTest extends WebTestCase
                 ],
             ],
         ]);
-
-        $this->assertResponseRedirects('/suivre-mon-signalement/'.$codeSuivi.'?from='.$emailOccupant);
+        if (Signalement::STATUS_ARCHIVED === $status) {
+            $this->assertResponseRedirects('/');
+        } elseif (Signalement::STATUS_ACTIVE === $status) {
+            $this->assertResponseRedirects('/suivre-mon-signalement/'.$codeSuivi.'?from='.$emailOccupant);
+        } else {
+            $this->assertResponseRedirects('/suivre-mon-signalement/'.$codeSuivi);
+        }
     }
 
     public function provideAdressSignalementWithTerritoryActive(): array


### PR DESCRIPTION
## Ticket

#2378

## Description
- Route `front_suivi_signalement`, `front_suivi_procedure` et `front_suivi_signalement_user_response` non accessible pour des signalements archivé
- On bloque la possibilité d'envoyer des message sur les signalement clôturé/refusé (avec message informatif)
- Refacto (regroupement de ce qui concerne le suivi de procédure sans la route correspondante)
- Ajout et adaptation des tests sur cette partie

## Tests
- [ ] Vérifier qu'on ne peux pas accéder à la page de suivi d'un signalement archivé
- [ ] Vérifier qu'on ne peux pas envoyer de messages sur des signalement Refusé/Cloturé
- [ ] Vérifier qu'on peux accéder à la page suivi pour les autre statuts (et déposé commentaire)
