### PR TITLE
 [FO - Reprise de brouillon] UI modale et comportement clic hors modale

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -161,6 +161,7 @@ export default defineComponent({
           formStore.existingDraft.createdAt = requestResponse.created_at
           formStore.existingDraft.updatedAt = requestResponse.updated_at
           if (link) {
+            formStore.lastButtonClicked = ''
             link.click()
           } else {
             Sentry.captureException(new Error('L\'élément lien n\'a pas été trouvé'))

--- a/assets/vue/components/signalement-form/components/SignalementFormModalContinueFromDraft.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalContinueFromDraft.vue
@@ -13,6 +13,7 @@
                 Il semblerait que vous ayez commencé à remplir un signalement pour le logement situé <strong>{{ formStore.data.adresse_logement_adresse }}</strong>,
                 le <strong>{{ formatDate(formStore.existingDraft.createdAt) }}</strong>.
                 <br>
+                <br>
                 Vous pouvez récupérer les infos de ce signalement et reprendre où vous en étiez.
                 <br>
                 Souhaitez-vous reprendre le signalement ?
@@ -25,7 +26,7 @@
               </SignalementFormWarning>
             </div>
             <div class="fr-modal__footer">
-              <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+              <ul class="fr-btns-group fr-btns-group--center fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                 <li>
                   <button class="fr-btn" aria-controls="fr-modal-continue-draft" @click="continueFromDraft">
                     Oui, reprendre le signalement


### PR DESCRIPTION
## Ticket

#2371 
#2372 

## Description
Ajustements sur l'UI de la modale, et réactivation des boutons du footer quand on clique hors de la modale

## Changements apportés
* LModification de 2 composants du formulaire

## Pré-requis

## Tests
- [ ] Commencer un signalement avec l'adresse et le mail d'un brouillon de signalement non validé
- [ ] Vérifier l'aspect de la modale (boutons centrés et saut de ligne)
- [ ] Cliquer hors de la modale et vérifier qu'on peut revenir en arrière puis refaire apparaitre la modale en cliquant sur suivant
