### PR TITLE
[FO] Ne pas récupérer de bailleur social si l'usager a coché non ou je ne sais pas sur logement social

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -409,13 +409,16 @@ class SignalementManager extends AbstractManager
         Signalement $signalement,
         CoordonneesBailleurRequest $coordonneesBailleurRequest
     ) {
-        $bailleur = $this->bailleurRepository->findOneBailleurBy(
-            $coordonneesBailleurRequest->getNom(),
-            ZipcodeProvider::getZipCode($signalement->getCpOccupant())
-        );
-        $signalement->setBailleur($bailleur);
+        $bailleur = null;
+        if ($signalement->getIsLogementSocial() && $coordonneesBailleurRequest->getNom()) {
+            $bailleur = $this->bailleurRepository->findOneBailleurBy(
+                $coordonneesBailleurRequest->getNom(),
+                ZipcodeProvider::getZipCode($signalement->getCpOccupant())
+            );
+        }
 
-        $signalement->setNomProprio($coordonneesBailleurRequest->getNom())
+        $signalement->setBailleur($bailleur)
+            ->setNomProprio($coordonneesBailleurRequest->getNom())
             ->setPrenomProprio($coordonneesBailleurRequest->getPrenom())
             ->setMailProprio($coordonneesBailleurRequest->getMail())
             ->setTelProprio($coordonneesBailleurRequest->getTelephone())


### PR DESCRIPTION
## Ticket

#2394   

## Description
Ne pas chercher à récupérer de bailleur si l'usager à  cocher non ou je ne sais pas

## Changements apportés
* Méthode privée afin de savoir si le logement est social
* Prise en compte des valeurs `ne-sais-pas` et `nsp` dans les méthode `evalBoolean`

## Pré-requis

## Tests

#### Création de signalement
*En tant que Service de secours*
- [ ] Je saisis **je ne sais pas** et je soumet mon signalement
- [ ] Je saisis **oui** sans saisir de bailleur social (car facultatif) et je soumet mon signalement
- [ ] Je saisis **oui** avec saisie de bailleur social et je soumet mon signalement
- [ ] Je saisis **non** et je soumet mon signalement

*En tant que Locataire*
- [ ] Je saisis **non** pour le logement social et je soumet mon signalement
- [ ] Je saisis **oui** pour le logement social avec un bailleur social et je soumet mon signalement

#### Edition modale bailleur
* Appliquer les mêmes tests