### PR TITLE
[BO - Liste signalements] Remettre "Aucun" dans la colonne dernier suivi quand pas de suivi

### DIFF
--- a/templates/back/table_result.html.twig
+++ b/templates/back/table_result.html.twig
@@ -47,9 +47,15 @@
                 {% if 'OCCUPANT' == signalement.lastSuiviBy or 'DECLARANT' == signalement.lastSuiviBy %}
                     {% set classe = 'fr-badge fr-badge--warning' %}
                 {% endif %}
-                <small class="{{ classe }}">{{ signalement.lastSuiviBy }}</small> <br>
+                <small class="{{ classe }}">                
+                    {% if signalement.lastSuiviBy is same as 'Aucun' %}   
+                        Occupant ou déclarant         
+                    {% else %}
+                        {{ signalement.lastSuiviBy }}
+                    {% endif %}
+                </small> <br>
             {% else %}
-                Occupant ou déclarant
+                Aucun
             {% endif %}
         </td>
         <td>


### PR DESCRIPTION
## Ticket

#2373   

## Description
Remettre "Aucun" dans la colonne dernier suivi quand pas de suivi

## Changements apportés
* Changement du twig

## Pré-requis

## Tests
- [ ] Faire un signalement usager sur un signalement en enlevant fromEmail dans la barre d'adresse
- [ ] Vérifier si sur la liste de signaments que c'est écrit "Aucun" quand il n'y a pas de suivi, et que c'est écrit "Occupant ou déclarant" pour le suivi créé précédemment
