### PR TITLE
[BO - Clôture du signalement] Modifier les messages warning 

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -45,3 +45,4 @@ import './controllers/back_signalement_edit_file/back_signalement_edit_file';
 import './controllers/back_signalement_view/form_upload_documents';
 import './controllers/front_demande_lien_signalement/front_demande_lien_signalement';
 import './controllers/back_signalement_view/input_autocomplete_bailleur';
+import './controllers/back_signalement_view/form_cloture_modal';

--- a/assets/controllers/back_signalement_view/form_cloture_modal.js
+++ b/assets/controllers/back_signalement_view/form_cloture_modal.js
@@ -1,0 +1,16 @@
+const radioButtons = document.querySelectorAll('input[name="cloture[publicSuivi]"]');
+const cloturePublicOui = document.querySelector('#warning_cloture_public_oui');
+const cloturePublicNon = document.querySelector('#warning_cloture_public_non');
+radioButtons.forEach(radioButton => {
+    radioButton.addEventListener('change', function(event) {
+        const value = event.target.value;
+        if (value === '1') {
+            cloturePublicOui?.classList.remove('fr-hidden')
+            cloturePublicNon?.classList.add('fr-hidden')
+        } else if (value === '0') {
+            cloturePublicOui?.classList.add('fr-hidden')
+            cloturePublicNon?.classList.remove('fr-hidden')
+        }
+    });
+});
+

--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -53,9 +53,12 @@
                         {{ form_end(clotureForm) }}
                         
                         {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                            <div class="fr-alert fr-alert--warning">
+                            <div id="warning_cloture_public_oui" class="fr-alert fr-alert--warning">
                                 <h3 class="fr-alert__title">Attention</h3>
                                 <p>Le motif et les détails de clôture seront également envoyés à l'usager.</p>
+                            </div>
+                            <div id="warning_cloture_public_non" class="fr-alert fr-alert--info fr-hidden">
+                                <p>L'usager ne sera pas informé de la clôture de son signalement.</p>
                             </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Ticket

#2392    

## Description
Modifier le message dans la modale de cloture suivant qu'on choisisse de partager à l'usager ou non

## Changements apportés
* Ajout d'un fichier js
* Modification du twig

## Pré-requis
`npm run watch`

## Tests
- [ ] En tant que responsable de territoire, fermer un signalement et vérifier l'affichage des messages de warning/alerte en fonction du choix de partager ou non à l'usager
