### PR TITLE
[FO - home et contact] Afficher la sélection dans le champ adresse

### DIFF
--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -2,9 +2,7 @@ if(document.querySelector('[data-fr-adresse-autocomplete]')){
     attachAutocompleteClickOutsideEvent()
 }
 document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdresse) => {
-    if (inputAdresse.matches('input')) {
-        attacheAutocompleteAddressEvent(inputAdresse);
-    }
+    attacheAutocompleteAddressEvent(inputAdresse);
 })
 
 function attachAutocompleteClickOutsideEvent() {

--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -2,7 +2,9 @@ if(document.querySelector('[data-fr-adresse-autocomplete]')){
     attachAutocompleteClickOutsideEvent()
 }
 document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdresse) => {
-    attacheAutocompleteAddressEvent(inputAdresse)
+    if (inputAdresse.matches('input')) {
+        attacheAutocompleteAddressEvent(inputAdresse);
+    }
 })
 
 function attachAutocompleteClickOutsideEvent() {

--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -2,7 +2,7 @@ if(document.querySelector('[data-fr-adresse-autocomplete]')){
     attachAutocompleteClickOutsideEvent()
 }
 document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdresse) => {
-    attacheAutocompleteAddressEvent(inputAdresse);
+    attacheAutocompleteAddressEvent(inputAdresse)
 })
 
 function attachAutocompleteClickOutsideEvent() {

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -6,9 +6,9 @@
         {% set widget_attr = {attr: {'aria-describedby': id ~"_help"}} %}
     {% endif %}
     {% if 'choice' in block_prefixes %}
-        {% set row_attr = attr|merge({'class': (row_attr.class|default('') ~ ' fr-select-group')|trim}) %}
+        {% set row_attr = row_attr|merge({'class': (row_attr.class|default('') ~ ' fr-select-group')|trim}) %}
     {% else %} 
-        {% set row_attr = attr|merge({'class': (row_attr.class|default('') ~ ' fr-input-group')|trim}) %}
+        {% set row_attr = row_attr|merge({'class': (row_attr.class|default('') ~ ' fr-input-group')|trim}) %}
     {% endif %}
     {% if errors|length > 0 %}
         {% set row_attr = row_attr|merge({'class': (row_attr.class ~ ' fr-input-group--error')|trim}) %}


### PR DESCRIPTION
## Ticket

#2383    

## Description
Afficher la sélection dans le champ adresse sur les pages accueil et contact

## Changements apportés
* Correction du js pour ne pas attacher les fonctions d'autocomplete à la div parente de l'input qui a aussi l'attribut data-fr-adresse-autocomplet

## Pré-requis

## Tests
- [ ] Tester sur les deux pages le composant d'autocomplete, le champ input doit bien avoir la valeur de l'adresse choisie quand on clique sur une des propositions
