### PR TITLE
[Front / BO] Champ accompagnement par travailleur social : impossible de sélectionner "Non"

### DIFF
--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -43,6 +43,7 @@ class SituationFoyerRequest implements RequestInterface
             message: 'Veuillez préciser si l\'occupant est accompagné par un travailleur social.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
         )]
+        private readonly ?string $travailleurSocialAccompagnement = null,
         private readonly ?string $travailleurSocialAccompagnementDeclarant = null,
         private readonly ?string $beneficiaireRsa = null,
         private readonly ?string $beneficiaireFsl = null,
@@ -88,6 +89,11 @@ class SituationFoyerRequest implements RequestInterface
     public function getTravailleurSocialPreavisDepart(): ?string
     {
         return $this->travailleurSocialPreavisDepart;
+    }
+
+    public function getTravailleurSocialAccompagnement(): ?string
+    {
+        return $this->travailleurSocialAccompagnement;
     }
 
     public function getTravailleurSocialAccompagnementDeclarant(): ?string

--- a/src/Entity/Model/SituationFoyer.php
+++ b/src/Entity/Model/SituationFoyer.php
@@ -92,7 +92,9 @@ class SituationFoyer
 
     public function getTravailleurSocialQuitteLogement(bool $raw = true): ?string
     {
-        return (!$raw && 'nsp' === $this->travailleurSocialQuitteLogement) ? 'Ne sait pas' : $this->travailleurSocialQuitteLogement;
+        return (!$raw && 'nsp' === $this->travailleurSocialQuitteLogement)
+            ? 'Ne sait pas'
+            : $this->travailleurSocialQuitteLogement;
     }
 
     public function setTravailleurSocialQuitteLogement(?string $travailleurSocialQuitteLogement): self
@@ -104,7 +106,9 @@ class SituationFoyer
 
     public function getTravailleurSocialPreavisDepart(bool $raw = true): ?string
     {
-        return (!$raw && 'nsp' === $this->travailleurSocialPreavisDepart) ? 'Ne sait pas' : $this->travailleurSocialPreavisDepart;
+        return (!$raw && 'nsp' === $this->travailleurSocialPreavisDepart)
+            ? 'Ne sait pas'
+            : $this->travailleurSocialPreavisDepart;
     }
 
     public function setTravailleurSocialPreavisDepart(?string $travailleurSocialPreavisDepart): self
@@ -114,9 +118,11 @@ class SituationFoyer
         return $this;
     }
 
-    public function getTravailleurSocialAccompagnement(): ?string
+    public function getTravailleurSocialAccompagnement(bool $raw = true): ?string
     {
-        return $this->travailleurSocialAccompagnement;
+        return (!$raw && 'nsp' === $this->travailleurSocialAccompagnement)
+            ? 'Ne sait pas'
+            : $this->travailleurSocialAccompagnement;
     }
 
     public function setTravailleurSocialAccompagnement(?string $travailleurSocialAccompagnement): self
@@ -128,7 +134,9 @@ class SituationFoyer
 
     public function getTravailleurSocialAccompagnementDeclarant(bool $raw = true): ?string
     {
-        return (!$raw && 'nsp' === $this->travailleurSocialAccompagnementDeclarant) ? 'Ne sait pas' : $this->travailleurSocialAccompagnementDeclarant;
+        return (!$raw && 'nsp' === $this->travailleurSocialAccompagnementDeclarant)
+            ? 'Ne sait pas'
+            : $this->travailleurSocialAccompagnementDeclarant;
     }
 
     public function setTravailleurSocialAccompagnementDeclarant(?string $travailleurSocialAccompagnementDeclarant): self

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -643,8 +643,8 @@ class SignalementManager extends AbstractManager
             ->setLogementSocialMontantAllocation($situationFoyerRequest->getLogementSocialMontantAllocation())
             ->setTravailleurSocialQuitteLogement($situationFoyerRequest->getTravailleurSocialQuitteLogement())
             ->setTravailleurSocialPreavisDepart($situationFoyerRequest->getTravailleurSocialPreavisDepart())
-            ->setTravailleurSocialAccompagnementDeclarant(
-                $situationFoyerRequest->getTravailleurSocialAccompagnementDeclarant()
+            ->setTravailleurSocialAccompagnement(
+                $situationFoyerRequest->getTravailleurSocialAccompagnement()
             )
             ->setLogementSocialAllocationCaisse($situationFoyerRequest->getIsAllocataire());
 

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -52,8 +52,8 @@
                                     <option value="" {{isAllocataire in [null, ''] ? 'selected' : '' }}></option>
                                     <option value="CAF" {{ isAllocataire is same as 'CAF' ? 'selected' : '' }}>CAF</option>
                                     <option value="MSA" {{ isAllocataire is same as 'MSA' ? 'selected' : '' }}>MSA</option>
-                                    <option value="oui" {{ isAllocataire in ['Oui', '1'] ? 'selected' : '' }}>Oui</option>
-                                    <option value="non" {{ isAllocataire in ['Non', '0'] ? 'selected' : '' }}>Non</option>
+                                    <option value="oui" {{ isAllocataire in ['oui', 'Oui', '1'] ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ isAllocataire in ['non', 'Non', '0'] ? 'selected' : '' }}>Non</option>
                                 </select>
                             </div>
 
@@ -113,21 +113,21 @@
                             </div>
 
                             <div class="fr-select-group">
-                                {% set travailleurSocialAccompagnementDeclarant = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementDeclarant : null %}
-                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementDeclarant">
+                                {% set travailleurSocialAccompagnement = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnement : null %}
+                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnement">
                                     Accompagnement par un ou une travailleuse sociale
                                     {{ show_label_facultatif(
                                         'App\\Dto\\Request\\Signalement\\SituationFoyerRequest',
-                                        'travailleurSocialAccompagnementDeclarant',
+                                        'travailleurSocialAccompagnement',
                                         signalement.profileDeclarant,
                                         null != signalement.createdFrom)
                                     }}
                                 </label>
-                                <select class="fr-select" id="situationFoyerTravailleurSocialAccompagnementDeclarant" name="travailleurSocialAccompagnementDeclarant">
-                                    <option value="" {{ travailleurSocialAccompagnementDeclarant not in ['1', '0', 'nsp'] ? 'selected' : '' }}></option>
-                                    <option value="1" {{ travailleurSocialAccompagnementDeclarant is same as '1' ? 'selected' : '' }}>Oui</option>
-                                    <option value="0" {{ travailleurSocialAccompagnementDeclarant is same as '0' ? 'selected' : '' }}>Non</option>
-                                    <option value="nsp" {{ travailleurSocialAccompagnementDeclarant is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                <select class="fr-select" id="situationFoyerTravailleurSocialAccompagnement" name="travailleurSocialAccompagnement">
+                                    <option value="" {{ travailleurSocialAccompagnement not in ['oui', 'non', 'nsp'] ? 'selected' : '' }}></option>
+                                    <option value="oui" {{ travailleurSocialAccompagnement is same as 'oui' ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ travailleurSocialAccompagnement is same as 'non' ? 'selected' : '' }}>Non</option>
+                                    <option value="nsp" {{ travailleurSocialAccompagnement is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
 

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -592,12 +592,12 @@
                     <div class="fr-col-12">
                         <strong>Accompagnement par un ou une travailleuse sociale :</strong>
                         {% if signalement.situationFoyer %}
-                            {% if signalement.situationFoyer.travailleurSocialAccompagnementDeclarant is same as '1' %}
+                            {% if signalement.situationFoyer.travailleurSocialAccompagnement is same as 'oui' %}
                                 {{ static_picto_yes|raw }}
-                            {% elseif signalement.situationFoyer.travailleurSocialAccompagnementDeclarant is same as '0' %}
+                            {% elseif signalement.situationFoyer.travailleurSocialAccompagnement is same as 'non' %}
                                 {{ static_picto_no|raw }}
                             {% else %}
-                                {{signalement.situationFoyer.travailleurSocialAccompagnementDeclarant(false)}}
+                                {{signalement.situationFoyer.travailleurSocialAccompagnement(false)}}
                             {% endif %}
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Ticket

#2403    

## Description
Après investigation on utilise pas la bonne valeur dans le BO
`travailleur_social_accompagnement_declarant` est la case à cocher du screenshoot, la question est posé uniquement aux tiers pro

![image](https://github.com/MTES-MCT/histologe/assets/5757116/fde3b15c-2321-4064-8428-abc2ad037007)


Il faudrait donc utiliser `travailleur_social_accompagnement` dans le BO 

Les pro du BO remplissait cette valeur en pensant répondre à `Accompagnement par un ou une travailleuse sociale`

Comme la valeur `travailleur_social_accompagnement_declarant` n'a jamais été affiché de manière intentionnelle, on peut laisser comme ça et poser la question à Mathilde avant d'envisager une action (la seule que je vois c'est de remettre ce toute les valeur à null en base) 

## Changements apportés
* Ajout du champ `$travailleurSocialAccompagnement` dans `SituationRequest`
* Affichage `$travailleurSocialAccompagnement` au  lieu de `$travailleurSocialAccompagnementDeclarant`

## Pré-requis

## Tests
- [ ] En tant que locataire remplissez le formulaire et répondez non à la question et vérifier que non est bien affiché sur le BO et dans la modale d'édition
- [ ] En tant que tiers pro remplissez le formulaire et répondez oui à la question et vérifier que oui est bien affiché sur le BO et dans la modale d'édition
- [ ] En tant que tiers pro remplissez le formulaire et répondez ne sais pas à la question et vérifier que ne sais pas est bien affiché sur le BO et dans la modale d'édition
- [ ] En tant qu'agent modifier la valeur de `Accompagnement par un ou une travailleuse sociale` du formulaire d'édition et vérifier que la bonne valeur s'affiche
