### PR TITLE
[FO - page aides] Corrections

### DIFF
--- a/templates/front/aides_travaux.html.twig
+++ b/templates/front/aides_travaux.html.twig
@@ -180,15 +180,15 @@
             </p>
             <a href="https://france-renov.gouv.fr/aides/simulation#/" target="_blank" class="fr-btn" rel="noopener external"
                 title="Accéder au simulateur - ouvre une nouvelle fenêtre"
-                >Accéder au simulateurs</a>
+                >Accéder au simulateur</a>
         </div>
 
         <h2 id="aides">Les aides</h2>
 
         <h3>Les certificats d’économie d’énergie (CEE) “Standard”</h3>
 
-        <p class="fr-badge fr-badge--success fr-badge--no-icon">Locataire</p>
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
         <p class="fr-mt-5v">
             Il s’agit d’une aide versée par les fournisseurs d’énergie pour les travaux d’économies d’énergie dans le logement.
@@ -212,8 +212,8 @@
 
         <h3>MaPrimeRénov'</h3>
 
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
-        <p class="fr-badge fr-badge--new fr-badge--no-icon">Propriétaire bailleur</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
         <p class="fr-mt-5v">
             MaPrimeRénov’ est une aide pour effectuer des travaux de rénovation énergétique dans votre logement.
@@ -249,8 +249,8 @@
 
         <h3>Ma Prime Logement Décent</h3>
 
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
-        <p class="fr-badge fr-badge--new fr-badge--no-icon">Propriétaire bailleur</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
         <p class="fr-mt-5v">
             Ma Prime Logement Décent permet de financer des travaux de rénovation de logements indignes ou d’habitats dégradés.
@@ -275,9 +275,9 @@
 
         <h3>MaPrimeAdapt'</h3>
 
-        <p class="fr-badge fr-badge--success fr-badge--no-icon">Locataire</p>
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
-        <p class="fr-badge fr-badge--new fr-badge--no-icon">Propriétaire bailleur</p>
+        <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
         <p class="fr-mt-5v">
             MaPrimeAdapt’ est une aide proposée par l’Agence nationale de l’habitat (Anah).
@@ -299,8 +299,8 @@
 
         <h3>La prime coup de pouce Chauffage</h3>
 
-        <p class="fr-badge fr-badge--success fr-badge--no-icon">Locataire</p>
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
         <p class="fr-mt-5v">
             Il s’agit d’une aide financière pour le remplacement d'une chaudière au charbon ou 
@@ -322,7 +322,7 @@
 
         <h3>La prime « Coup de pouce Pilotage connecté du chauffage pièce par pièce »</h3>
 
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
         <p class="fr-mt-5v">
             La prime « Coup de pouce Pilotage connecté du chauffage pièce par pièce » permet de financer 
@@ -338,8 +338,8 @@
 
         <h3>La prime « Coup de pouce Rénovation performante d’une maison individuelle »</h3>
 
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
-        <p class="fr-badge fr-badge--new fr-badge--no-icon">Propriétaire bailleur</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
         <p class="fr-mt-5v">
             Cette aide s’inscrit dans le cadre des certificats d’économie d’énergie (CEE). 
@@ -375,7 +375,7 @@
 
         <h3>Aide à l'insonorisation de votre logement proche d'un aéroport</h3>
 
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
         <p class="fr-mt-5v">
             Si vous vivez à côté d’un aéroport, vous pouvez bénéficier d’une aide pour insonoriser votre logement, sous certaines conditions.
@@ -396,7 +396,7 @@
 
         <h3>Subvention de l’Agence nationale de l’habitat (Anah)</h3>
 
-        <p class="fr-badge fr-badge--new fr-badge--no-icon">Propriétaire bailleur</p>
+        <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
         <p class="fr-mt-5v">
             L’Agence nationale de l’habitat (Anah) peut subventionner vos travaux.
@@ -426,8 +426,8 @@
 
         <h3>Éco-prêt à taux zéro (Éco-PTZ)</h3>
 
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
-        <p class="fr-badge fr-badge--new fr-badge--no-icon">Propriétaire bailleur</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
         <p class="fr-mt-5v">
             L’éco-prêt à taux zéro (Éco-PTZ) est un prêt sans intérêts délivrés par certaines banques, pour réaliser certains types de travaux :
@@ -458,8 +458,8 @@
 
         <h3>Le prêt de votre caisse d'allocations familiales (CAF)</h3>
 
-        <p class="fr-badge fr-badge--success fr-badge--no-icon">Locataire</p>
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
         <p class="fr-mt-5v">
             Votre caisse d’allocations familiales (CAF) peut vous accorder un prêt à l’amélioration de l’habitat, sous certaines conditions.
@@ -482,8 +482,8 @@
 
         <h3>Le crédit d’impôt pour des dépenses d'équipement conçu pour les personnes âgées ou handicapées</h3>
 
-        <p class="fr-badge fr-badge--success fr-badge--no-icon">Locataire</p>
-        <p class="fr-badge fr-badge--error fr-badge--no-icon">Propriétaire occupant</p>
+        <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
+        <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
         <p class="fr-mt-5v">
             Si vous réalisez des travaux pour adapter votre logement à la perte d’autonomie, 
@@ -508,7 +508,7 @@
 
         <h3>Loc’Avantages</h3>
 
-        <p class="fr-badge fr-badge--new fr-badge--no-icon">Propriétaire bailleur</p>
+        <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
         <p class="fr-mt-5v">
             Le dispositif Loc’Avantages permet aux propriétaires bailleurs de bénéficier 


### PR DESCRIPTION
## Ticket

#2405    

## Description
 faute dans le bouton. Il faut retirer le S à simulateur.
 Et il faudrait ajouter une marge sous les labels pour qu'en mobile ils soient pas collés l'un à l'autre :

## Changements apportés
* Changement du twig

## Pré-requis

## Tests
- [ ] Vérifier l'affichage de la page aide en version mobile
