### PR TITLE
Fix email de notification usager "Une visite de votre logement est prévue"

### DIFF
--- a/src/EventSubscriber/InterventionCreatedSubscriber.php
+++ b/src/EventSubscriber/InterventionCreatedSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace App\EventSubscriber;
 
+use App\Entity\Enum\InterventionType;
 use App\Entity\Intervention;
 use App\Entity\Suivi;
 use App\Event\InterventionCreatedEvent;
@@ -38,10 +39,12 @@ class InterventionCreatedSubscriber implements EventSubscriberInterface
         );
         $this->suiviManager->save($suivi);
 
-        $this->visiteNotifier->notifyUsagers(
-            $intervention,
-            NotificationMailerType::TYPE_VISITE_CREATED_TO_USAGER
-        );
+        if (InterventionType::VISITE === $intervention->getType() && $intervention->getScheduledAt() >= new \DateTimeImmutable()) {
+            $this->visiteNotifier->notifyUsagers(
+                $intervention,
+                NotificationMailerType::TYPE_VISITE_CREATED_TO_USAGER
+            );
+        }
 
         $this->visiteNotifier->notifyAgents(
             intervention: $intervention,

--- a/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
@@ -62,4 +62,64 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $this->assertEmailCount(2);
         $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
     }
+
+    public function testInterventionVisitInPast(): void
+    {
+        $date = (new \DateTimeImmutable())->modify('-1 day');
+        $type = InterventionType::VISITE;
+        $this->testNbMailSent($date, $type);
+        $this->assertEmailCount(0);
+    }
+
+    public function testInterventionVisitInFuture(): void
+    {
+        $date = (new \DateTimeImmutable())->modify('+1 day');
+        $type = InterventionType::VISITE;
+        $this->testNbMailSent($date, $type);
+        $this->assertEmailCount(2);
+    }
+
+    public function testInterventionNoVisitInFuture(): void
+    {
+        $date = (new \DateTimeImmutable())->modify('+1 day');
+        $type = InterventionType::ARRETE_PREFECTORAL;
+        $this->testNbMailSent($date, $type);
+        $this->assertEmailCount(0);
+    }
+
+    public function testInterventionNoVisitInPast(): void
+    {
+        $date = (new \DateTimeImmutable())->modify('-1 day');
+        $type = InterventionType::ARRETE_PREFECTORAL;
+        $this->testNbMailSent($date, $type);
+        $this->assertEmailCount(0);
+    }
+
+    private function testNbMailSent(\DateTimeImmutable $date, $type): void
+    {
+        $eventDispatcher = new EventDispatcher();
+        $visiteNotifier = static::getContainer()->get(VisiteNotifier::class);
+        $suiviManager = static::getContainer()->get(SuiviManager::class);
+
+        /** @var InterventionRepository $interventionRepository */
+        $interventionRepository = $this->entityManager->getRepository(Intervention::class);
+        $intervention = $interventionRepository->findOneBy([
+            'status' => Intervention::STATUS_PLANNED,
+            'type' => InterventionType::VISITE,
+        ]);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
+        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager);
+        $eventDispatcher->addSubscriber($interventionCreatedSubscriber);
+
+        $intervention->setScheduledAt($date);
+        $intervention->setType($type);
+
+        $eventDispatcher->dispatch(
+            new InterventionCreatedEvent($intervention, $user),
+            InterventionCreatedEvent::NAME
+        );
+    }
 }


### PR DESCRIPTION
## Ticket

#2407 

## Description
L'email de notification usager "Une visite de votre logement est prévue" est envoyé uniquement si : 
- Le type de l'intervention est VISITE
- La date est dans le futur

## Changements apportés
- Ajout de test permettant de vérifier que les mails ne sont pas envoyés quand les conditions ne sont pas réunis
