### PR TITLE
[QA] Interdire (ou supprimer) les emojis dans les champs textes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ logs: ## Show container logs
 create-db: ## Create database
 	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:database:drop --force --no-interaction || true"
 	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:database:create --no-interaction"
+	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev messenger:setup-transports --no-interaction"
 	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:migrations:migrate --no-interaction"
 	@$(DOCKER_COMP) exec histologe_phpfpm sh -c "$(SYMFONY) --env=dev doctrine:fixtures:load --no-interaction"
 	@bash -l -c 'make execute-migration name=Version20231027135554 direction=up'

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -7,6 +7,10 @@ doctrine:
                 # IMPORTANT: You MUST configure your server version,
                 # either here or in the DATABASE_URL env var (see .env file)
                 server_version: '8.0'
+                charset: utf8mb4
+                default_table_options:
+                    charset: utf8mb4
+                    collate: utf8mb4_unicode_ci
         types:
             type_composition_logement: App\Entity\DoctrineType\Signalement\TypeCompositionLogementType
             situation_foyer: App\Entity\DoctrineType\Signalement\SituationFoyerType

--- a/migrations/Version20240402143605.php
+++ b/migrations/Version20240402143605.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+final class Version20240402143605 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getDescription(): string
+    {
+        return 'Convert messenger_messages table to utf8mb4';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ('test' === $this->container->getParameter('kernel.environment')) {
+            return;
+        }
+
+        $this->addSql('ALTER TABLE messenger_messages CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Service/Esabora/EsaboraSISHService.php
+++ b/src/Service/Esabora/EsaboraSISHService.php
@@ -12,6 +12,7 @@ use App\Service\Esabora\Response\DossierVisiteSISHCollectionResponse;
 use App\Service\UploadHandlerService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Intl\Transliterator\EmojiTransliterator;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class EsaboraSISHService extends AbstractEsaboraService
@@ -237,6 +238,8 @@ class EsaboraSISHService extends AbstractEsaboraService
             }, $dossierMessageSISH->getPiecesJointesDocuments());
         }
 
+        $transliterator = EmojiTransliterator::create('strip');
+
         return [
             [
                 'fieldName' => 'Sas_Adresse',
@@ -404,7 +407,7 @@ class EsaboraSISHService extends AbstractEsaboraService
             ],
             [
                 'fieldName' => 'Signalement_Details',
-                'fieldValue' => $dossierMessageSISH->getSignalementDetails(),
+                'fieldValue' => $transliterator->transliterate((string) $dossierMessageSISH->getSignalementDetails()),
             ],
             [
                 'fieldName' => 'Signalement_Problemes',


### PR DESCRIPTION
## Ticket

#2370

## Description
- Configuration doctrine du `charset` et `collate` par défaut pour qu'il soit en `utf8mb4` lors des migrations auto-générées des futures tables/colonnes
- Passage de la table `messenger_messages` en `utf8mb4`
- Suppression des émojis du champs détails des signalement avant envoi vers Esabora

## Pré-requis
`make execute-migration name=Version20240402143605 direction=up`

## Tests
Je n'ai pas réussi a appliquer les tests suivant en local (impossible d'enregistrer une emojis dans le champs détails d'un signalement et de l'afficher correctement sur la fiche signalement, alors que ca fonctionne sur Staging)
- [ ] Injecter un emoji dans le détail du signalement 2023-12 (ex "Suite à la tempête, j'ai un arbre qui est tombé sur la maison 🏠 qui engendre un logement non conforme.")
- [ ] Désactiver le worker, retirer le partenaire ESABORA ARS
- [ ] Ajouter le partenaire ESABORA ARS et vérifier que l’emoji est bien enregistré dans la table `messenger_messages`
- [ ] Activer le worker et vérifier que l'emoji est supprimé dans le message de la table `job_event`
