### PR TITLE
[Back - Suppression utilisateur] Notifier avant de changer l'email 

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -495,9 +495,6 @@ class PartnerController extends AbstractController
         /** @var User $user */
         $user = $userManager->find($userId);
         $this->denyAccessUnlessGranted('USER_DELETE', $user);
-        $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
-        $user->setStatut(User::STATUS_ARCHIVE);
-        $userManager->save($user);
         $notificationMailerRegistry->send(
             new NotificationMail(
                 type: NotificationMailerType::TYPE_ACCOUNT_DELETE,
@@ -505,6 +502,9 @@ class PartnerController extends AbstractController
                 territory: $user->getTerritory()
             )
         );
+        $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
+        $user->setStatut(User::STATUS_ARCHIVE);
+        $userManager->save($user);
         $this->addFlash('success', 'L\'utilisateur a bien été supprimé.');
 
         return $this->redirectToRoute(

--- a/src/EventListener/UserUpdatedListener.php
+++ b/src/EventListener/UserUpdatedListener.php
@@ -31,7 +31,9 @@ class UserUpdatedListener
 
     private function sendNotification(User $user): void
     {
-        if (!\in_array('ROLE_USAGER', $user->getRoles())) {
+        if (!\in_array('ROLE_USAGER', $user->getRoles())
+            && User::STATUS_ARCHIVE !== $user->getStatut()
+        ) {
             $this->notificationMailerRegistry->send(
                 new NotificationMail(
                     type: NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_FROM_BO,
@@ -46,7 +48,8 @@ class UserUpdatedListener
     private function shouldChangePassword(array $changes): bool
     {
         if (\array_key_exists('email', $changes) // if email has changed
-            || (\array_key_exists('roles', $changes)
+            || (
+                \array_key_exists('roles', $changes)
                 && \in_array('ROLE_USAGER', $changes['roles'][0])
             ) // if usager becomes user
         ) {


### PR DESCRIPTION
## Ticket

#2414    

## Description
Correction sur la notification lors de suppression d'utilisateur

## Changements apportés
* Notifier l'utilisateur de la suppression de son compte avant de changer l'email avec le suffixe archived
* Faire en sorte de ne pas notifier l'utilisateur du changement d'adresse e-mail si l'utilisateur est archivé

## Pré-requis

## Tests
- [ ] Supprimer un utilisateur et vérifier qu'on reçoit bien le mail de suppression de compte, mais qu'il n'y a pas une tentative d'envoyer un mail de réactivation
