### PR TITLE
[BO - Liste signalement] Trier les villes du filtre par ordre alphabétique

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -507,7 +507,9 @@ class SignalementRepository extends ServiceEntityRepository
                 ->setParameter('territory', $territory);
         }
 
-        return $qb->groupBy('s.villeOccupant')
+        return $qb
+            ->groupBy('s.villeOccupant')
+            ->orderBy('s.villeOccupant', 'ASC')
             ->getQuery()
             ->getResult();
     }


### PR DESCRIPTION
## Ticket

#2417    

## Description
Tri manquant sur le filtre ville

## Changements apportés
* Ajout d'un tri ascendant

## Pré-requis

## Tests
- [ ] En tant que super admin, les villes sont bien triés par ordre alphabétique sur le filtre ville
- [ ] En tant que RT, les villes sont bien triés par ordre alphabétique sur le filtre ville
- [ ] En tant qu'agent, les villes sont bien triés par ordre alphabétique sur le filtre ville 