### PR TITLE
[Back - Signalement] Il manque très souvent la ville du propriétaire

### DIFF
--- a/migrations/Version20240405080750.php
+++ b/migrations/Version20240405080750.php
@@ -11,14 +11,14 @@ final class Version20240405080750 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Update missing ville_proprio from signalement_draft';
     }
 
     public function up(Schema $schema): void
     {
         $this->addSql('UPDATE signalement s
         INNER JOIN signalement_draft d ON s.created_from_id = d.id
-        SET s.ville_proprio = d.payload->"$.coordonnees_bailleur_adresse_detail_commune"
+        SET s.ville_proprio =  JSON_UNQUOTE(d.payload->"$.coordonnees_bailleur_adresse_detail_commune")
         WHERE s.code_postal_proprio IS NOT NULL AND s.ville_proprio IS NULL');
     }
 

--- a/migrations/Version20240405080750.php
+++ b/migrations/Version20240405080750.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240405080750 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE signalement s
+        INNER JOIN signalement_draft d ON s.created_from_id = d.id
+        SET s.ville_proprio = d.payload->"$.coordonnees_bailleur_adresse_detail_commune"
+        WHERE s.code_postal_proprio IS NOT NULL AND s.ville_proprio IS NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -143,7 +143,7 @@ class SignalementDraftRequest
     private ?string $coordonneesBailleurAdresse = null;
     private ?string $coordonneesBailleurAdresseDetailNumero = null;
     private ?string $coordonneesBailleurAdresseDetailCodePostal = null;
-    private ?string $coordonneesBailleurAdresseCommune = null;
+    private ?string $coordonneesBailleurAdresseDetailCommune = null;
     private ?string $zoneConcerneeZone = null;
     private ?string $typeLogementNature = null;
     private ?string $typeLogementNatureAutrePrecision = null;
@@ -693,14 +693,14 @@ class SignalementDraftRequest
         return $this;
     }
 
-    public function getCoordonneesBailleurAdresseCommune(): ?string
+    public function getCoordonneesBailleurAdresseDetailCommune(): ?string
     {
-        return $this->coordonneesBailleurAdresseCommune;
+        return $this->coordonneesBailleurAdresseDetailCommune;
     }
 
-    public function setCoordonneesBailleurAdresseCommune(?string $coordonneesBailleurAdresseCommune): self
+    public function setCoordonneesBailleurAdresseDetailCommune(?string $coordonneesBailleurAdresseDetailCommune): self
     {
-        $this->coordonneesBailleurAdresseCommune = $coordonneesBailleurAdresseCommune;
+        $this->coordonneesBailleurAdresseDetailCommune = $coordonneesBailleurAdresseDetailCommune;
 
         return $this;
     }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -402,7 +402,7 @@ class SignalementBuilder
         } else {
             $this->signalement
                 ->setAdresseProprio($this->signalementDraftRequest->getCoordonneesBailleurAdresseDetailNumero())
-                ->setVilleProprio($this->signalementDraftRequest->getCoordonneesBailleurAdresseCommune())
+                ->setVilleProprio($this->signalementDraftRequest->getCoordonneesBailleurAdresseDetailCommune())
                 ->setCodePostalProprio($this->signalementDraftRequest->getCoordonneesBailleurAdresseDetailCodePostal())
                 ->setMailProprio($this->signalementDraftRequest->getCoordonneesBailleurEmail())
                 ->setNomProprio($bailleurNom = $this->signalementDraftRequest->getCoordonneesBailleurNom())

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -156,6 +156,13 @@ class SignalementBuilderTest extends KernelTestCase
         $this->assertArrayHasKey('lat', $signalement->getGeoloc());
         $this->assertArrayHasKey('lng', $signalement->getGeoloc());
 
+        $this->assertEquals('13 Habitat', $signalement->getNomProprio());
+        $this->assertEquals('Sandrine', $signalement->getPrenomProprio());
+        $this->assertEquals('sandrine@histologe.fr', $signalement->getMailProprio());
+        $this->assertEquals('10 rue du 14 juillet', $signalement->getAdresseProprio());
+        $this->assertEquals('64000', $signalement->getCodePostalProprio());
+        $this->assertEquals('Pau', $signalement->getVilleProprio());
+
         $this->assertTrue($signalement->getIsLogementSocial());
         $this->assertTrue($signalement->getIsBailEnCours());
         $this->assertTrue($signalement->getIsProprioAverti());


### PR DESCRIPTION
## Ticket

#2413

## Description
- Correction du nom de la propriété concernant la ville du proprio de `SignalementDraftRequest.php`
- Utilisation de cette propriété dans le  `SignalementBuilder.php`
- Ajout d'une migration permettant de récupérer les ville des propriétaire dans le draft (pour les signalement en provenance d'un draft ayant un code postal mais pas de ville d'enregistré pour le proprio)
- Ajout de tests sur les infos proprio

## Tests
- [ ] Ajouter un signalement pour un (ou plusieurs) de ces profil "TIERS_PRO"/"LOCATAIRE"/"TIERS_PARTICULIER"/"SERVICE_SECOURS" et vérifier que la ville propriétaire s'affiche bien en BO
- [ ] Mettre cette ville à NULL à la main en DB et jouer `make execute-migration name=Version20240405080750 direction=up` puis vérifier que la ville est revenu
