### PR TITLE
[Qa] getPartner() on null / EntityValueResolve....

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -88,14 +88,14 @@ class AffectationController extends AbstractController
         $this->denyAccessUnlessGranted('ASSIGN_TOGGLE', $signalement);
         if ($this->isCsrfTokenValid('signalement_remove_partner_'.$signalement->getId(), $request->get('_token'))) {
             $idAffectation = $request->get('affectation');
-            if (!empty($idAffectation)) {
-                $affectation = $affectationRepository->findOneBy(['id' => $idAffectation]);
+            $affectation = $affectationRepository->findOneBy(['id' => $idAffectation]);
+            if ($affectation) {
                 $partnersIdToRemove = [];
                 $partnersIdToRemove[] = $affectation->getPartner()->getId();
                 $this->affectationManager->removeAffectationsFrom($signalement, [], $partnersIdToRemove);
+                $this->affectationManager->flush();
+                $this->addFlash('success', 'Le partenaire a été désaffecté.');
             }
-            $this->affectationManager->flush();
-            $this->addFlash('success', 'Le partenaire a été désaffecté.');
 
             return $this->json(['status' => 'success']);
         }

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -59,7 +59,11 @@ class SecurityController extends AbstractController
             $tmpFilepath = $this->getParameter('uploads_tmp_dir').$filename;
             $bucketFilepath = $this->getParameter('url_bucket').'/'.$filename;
 
-            file_put_contents($tmpFilepath, file_get_contents($bucketFilepath));
+            $content = file_get_contents($bucketFilepath);
+            if (false === $content) {
+                throw new \Exception('File "'.$bucketFilepath.'" not found');
+            }
+            file_put_contents($tmpFilepath, $content);
             $file = new File($tmpFilepath);
 
             return new BinaryFileResponse($file);

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -9,6 +9,7 @@ use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Token\ActivationTokenGenerator;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -103,6 +104,7 @@ class UserAccountController extends AbstractController
         ActivationTokenGenerator $activationTokenGenerator,
         ValidatorInterface $validator,
         Security $security,
+        #[MapEntity(mapping: ['uuid' => 'uuid'])]
         User $user,
         string $token
     ): RedirectResponse|Response {

--- a/src/Dto/DemandeLienSignalement.php
+++ b/src/Dto/DemandeLienSignalement.php
@@ -23,7 +23,7 @@ class DemandeLienSignalement
     #[Assert\Callback]
     public function validate(ExecutionContextInterface $context, $payload)
     {
-        if (empty(trim($this->adresse)) || empty(trim($this->codePostal)) || empty(trim($this->ville))) {
+        if (empty(trim((string) $this->adresse)) || empty(trim((string) $this->codePostal)) || empty(trim((string) $this->ville))) {
             $context->buildViolation('Vous devez sélectionner une adresse dans la liste des propositions')
                 ->atPath('adresseHelper')
                 ->addViolation();


### PR DESCRIPTION
## Ticket

#2420

## Description
1) Uncaught PHP Exception Error: "Call to a member function getPartner() on null" at AffectationController.php line 94
https://sentry.incubateur.net/organizations/betagouv/issues/90999/?project=61&query=is%3Aunresolved&referrer=issue-stream
Lorsqu'on tente de supprimer une affectation sur un signalement (via le bouton poubelle) on avait un crash si l'affectation a déjà été supprimé (possible si la page est ouverte depuis longtemps ou si on a ouvert deux fois la même page par exemple). Corrigé.

2) object not found by "Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver"." at EntityValueResolver.php line 76
https://sentry.incubateur.net/organizations/betagouv/issues/85062/?project=61&query=is%3Aunresolved&referrer=issue-stream
Sur la route `activate_account` la route provoquait une requête sur les deux paramètres user + token donc même avec un user valide on avait un not found plutôt qu'une redirection avec le message lien expiré. C'est corrigé.

3) Deprecated: trim(): Passing null to parameter of type string is deprecated
https://sentry.incubateur.net/organizations/betagouv/issues/95049/?project=61&query=is%3Aunresolved&referrer=issue-stream
Correction de la dépréciation

4) Warning: file_get_contents(...) Not Found
https://sentry.incubateur.net/organizations/betagouv/issues/86810/?project=61&query=is%3Aunresolved&referrer=issue-stream
En prod (contrairement au dev) les warning ne levant pas une erreur, une image introuvable ne renvoyait pas le fichier image404 mais un fichier vide. C'est corrigé.

