### PR TITLE
 [BO] POssibilité de supprimer les suivis pour les SA 

### DIFF
--- a/migrations/Version20240410075332.php
+++ b/migrations/Version20240410075332.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240410075332 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add deleted_at and deleted_by_id on suivi';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE suivi ADD deleted_by_id INT DEFAULT NULL, ADD deleted_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE suivi ADD CONSTRAINT FK_2EBCCA8FC76F1F52 FOREIGN KEY (deleted_by_id) REFERENCES user (id)');
+        $this->addSql('CREATE INDEX IDX_2EBCCA8FC76F1F52 ON suivi (deleted_by_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE suivi DROP FOREIGN KEY FK_2EBCCA8FC76F1F52');
+        $this->addSql('DROP INDEX IDX_2EBCCA8FC76F1F52 ON suivi');
+        $this->addSql('ALTER TABLE suivi DROP deleted_by_id, DROP deleted_at');
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -336,8 +336,11 @@ document?.querySelectorAll('[data-delete]')?.forEach(actionBtn => {
                 body: formData,
             }).then(r => {
                 if (r.ok) {
-                    actionBtn.closest(className).remove()
-                    if (event.target.classList.contains('partner-row-delete')) {
+                    if (className && className !== undefined && className !== null){
+                        actionBtn?.closest(className).remove()
+                    }
+                    if (event.target.classList.contains('partner-row-delete')
+                        || event.target.classList.contains('suivi-row-delete')) {
                         window.location.reload(true)
                     }
                 }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -22,6 +22,7 @@ class Suivi
     public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';
     public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été cloturé pour';
     public const DESCRIPTION_SIGNALEMENT_VALIDE = 'Signalement validé';
+    public const DESCRIPTION_DELETED = 'Ce suivi a été supprimé par un administrateur le ';
 
     public const ARRET_PROCEDURE = 'arret-procedure';
     public const POURSUIVRE_PROCEDURE = 'poursuivre-procedure';
@@ -55,6 +56,13 @@ class Suivi
     private ?string $context = null;
 
     private bool $sendMail = true;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private $deletedAt;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private $deletedBy;
 
     public function __construct()
     {
@@ -93,6 +101,10 @@ class Suivi
 
     public function getDescription(): ?string
     {
+        if (null !== $this->deletedAt) {
+            return self::DESCRIPTION_DELETED.' '.$this->deletedAt->format('d/m/Y');
+        }
+
         return $this->description;
     }
 
@@ -159,6 +171,30 @@ class Suivi
     public function setSendMail(bool $sendMail): self
     {
         $this->sendMail = $sendMail;
+
+        return $this;
+    }
+
+    public function getDeletedAt(): ?DateTimeImmutable
+    {
+        return $this->deletedAt;
+    }
+
+    public function setDeletedAt(DateTimeImmutable $deletedAt): self
+    {
+        $this->deletedAt = $deletedAt;
+
+        return $this;
+    }
+
+    public function getDeletedBy(): ?User
+    {
+        return $this->deletedBy;
+    }
+
+    public function setDeletedBy(?User $deletedBy): self
+    {
+        $this->deletedBy = $deletedBy;
 
         return $this;
     }

--- a/src/Security/Voter/SuiviVoter.php
+++ b/src/Security/Voter/SuiviVoter.php
@@ -14,11 +14,10 @@ class SuiviVoter extends Voter
 {
     public const CREATE = 'COMMENT_CREATE';
     public const VIEW = 'COMMENT_VIEW';
-    public const DELETE = 'COMMENT_DELETE';
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::CREATE, self::VIEW, self::DELETE])
+        return \in_array($attribute, [self::CREATE, self::VIEW])
             && ($subject instanceof Suivi || $subject instanceof Signalement);
     }
 
@@ -40,7 +39,6 @@ class SuiviVoter extends Voter
         return match ($attribute) {
             self::CREATE => $this->canCreate($subject, $user),
             self::VIEW => $this->canView($subject, $user),
-            self::DELETE => $this->canDelete($subject, $user),
             default => false,
         };
     }
@@ -60,14 +58,5 @@ class SuiviVoter extends Voter
         }
 
         return true;
-    }
-
-    private function canDelete(mixed $comment, User $user): bool
-    {
-        if ($user->isSuperAdmin()) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -59,7 +59,7 @@
             {% endif %}
         </div>
 
-        {% if is_granted('ROLE_ADMIN') and suivi.deletedAt is null %}
+        {% if is_granted('ROLE_ADMIN') %}
             <div class="fr-col-6 bloc-suivi-content-row fr-pl-3v">
         {% else %}
             <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
@@ -78,12 +78,14 @@
                 <span class="fr-badge fr-badge--no-icon" title="Suivi interne">Suivi interne</span>
             {% endif %}
         </div>
-        {% if is_granted('ROLE_ADMIN') and suivi.deletedAt is null %}
+        {% if is_granted('ROLE_ADMIN') %}
             <div class="fr-col-1 fr-text--right">
+                {% if suivi.deletedAt is null %}
                 <button title="Supprimer le suivi"
                     data-delete="{{ path('back_signalement_delete_suivi',{uuid:signalement.uuid,suivi:suivi.id}) }}"
                     data-token="{{ csrf_token('signalement_delete_suivi_'~signalement.id) }}"
                     class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line suivi-row-delete"></button>
+                {% endif %}
             </div>            
         {% endif %}
     </div>

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -59,7 +59,7 @@
             {% endif %}
         </div>
 
-        {% if is_granted('ROLE_ADMIN') %}
+        {% if is_granted('ROLE_ADMIN') and suivi.deletedAt is null %}
             <div class="fr-col-6 bloc-suivi-content-row fr-pl-3v">
         {% else %}
             <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -78,7 +78,7 @@
                 <span class="fr-badge fr-badge--no-icon" title="Suivi interne">Suivi interne</span>
             {% endif %}
         </div>
-        {% if is_granted('ROLE_ADMIN') %}
+        {% if is_granted('ROLE_ADMIN') and suivi.deletedAt is null %}
             <div class="fr-col-1 fr-text--right">
                 <button title="Supprimer le suivi"
                     data-delete="{{ path('back_signalement_delete_suivi',{uuid:signalement.uuid,suivi:suivi.id}) }}"

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -59,7 +59,11 @@
             {% endif %}
         </div>
 
-        <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
+        {% if is_granted('ROLE_ADMIN') %}
+            <div class="fr-col-6 bloc-suivi-content-row fr-pl-3v">
+        {% else %}
+            <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
+        {% endif %}
             {{ suivi.description
                 |replace({'&t=___TOKEN___':'/'~signalement.uuid})
                 |replace({'?t=___TOKEN___':'/'~signalement.uuid})
@@ -74,6 +78,14 @@
                 <span class="fr-badge fr-badge--no-icon" title="Suivi interne">Suivi interne</span>
             {% endif %}
         </div>
+        {% if is_granted('ROLE_ADMIN') %}
+            <div class="fr-col-1 fr-text--right">
+                <button title="Supprimer le suivi"
+                    data-delete="{{ path('back_signalement_delete_suivi',{uuid:signalement.uuid,suivi:suivi.id}) }}"
+                    data-token="{{ csrf_token('signalement_delete_suivi_'~signalement.id) }}"
+                    class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line suivi-row-delete"></button>
+            </div>            
+        {% endif %}
     </div>
 {% endfor %}
 

--- a/tests/Functional/Controller/Back/SignalementActionControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementActionControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Back;
+
+use App\Entity\Suivi;
+use App\Repository\SignalementRepository;
+use App\Repository\SuiviRepository;
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class SignalementActionControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    private ?KernelBrowser $client = null;
+    private UserRepository $userRepository;
+    private SignalementRepository $signalementRepository;
+    private SuiviRepository $suiviRepository;
+    private RouterInterface $router;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->router = self::getContainer()->get(RouterInterface::class);
+        $this->userRepository = static::getContainer()->get(UserRepository::class);
+        $this->suiviRepository = static::getContainer()->get(SuiviRepository::class);
+        $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
+
+        $user = $this->userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $this->client->loginUser($user);
+    }
+
+    public function testDeleteSuivi(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000006']);
+
+        $route = $this->router->generate('back_signalement_delete_suivi', ['uuid' => $signalement->getUuid()]);
+        $this->client->request('GET', $route);
+
+        $description = 'Un petit message de rappel afin d\'y revenir plus tard';
+        $suivi = $this->suiviRepository->findOneBy(['description' => $description]);
+
+        $this->client->request(
+            'POST',
+            $route,
+            [
+                'suivi' => $suivi->getId(),
+                '_token' => $this->generateCsrfToken($this->client, 'signalement_delete_suivi_'.$signalement->getId()),
+            ]
+        );
+
+        $suivi = $this->suiviRepository->findOneBy(['description' => $description]);
+        $this->assertNotNull($suivi->getDeletedAt());
+        $this->assertNotNull($suivi->getDeletedBy());
+        $this->assertNotEquals($description, $suivi->getDescription());
+        $this->assertStringContainsString(Suivi::DESCRIPTION_DELETED, $suivi->getDescription());
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid().'#suivis');
+    }
+}


### PR DESCRIPTION
## Ticket

#2326    

## Description
Les SA peuvent "supprimer' un suivi, ce qui consiste à changer son texte par un texte générique

## Changements apportés
* Changement twi pour ajouter un bouton
* Création d'une route

## Pré-requis

## Tests
- [ ] En tant que SA, supprimer un suivi et vérifier que le comportement est le bon
- [ ] En tant qu'autre utilisateur on ne peut pas supprimemr de suivi
