### PR TITLE
[BO - Fiche signalement] Ajouter info travailleur / travailleuse sociale

### DIFF
--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -47,6 +47,9 @@
                         <div class="fr-col-12 fr-col-md-6">
                             <strong>Lien :</strong>
                             {{ signalement.lienDeclarantOccupant|signalement_lien_declarant_occupant }}
+                            {% if signalement.situationFoyer and signalement.situationFoyer.travailleurSocialAccompagnementDeclarant %}
+                                (travailleur social accompagnant)
+                            {% endif %}
                         </div>
                     {% endif %}
 


### PR DESCRIPTION
## Ticket

#2428

## Description
Ajout du libellé "travailleur social accompagnant" dans le lien du tiers déclarant 
![Screenshot 2024-04-09 at 17-40-24 Histologe](https://github.com/MTES-MCT/histologe/assets/7130780/961dda91-b05b-4c3a-a79f-9c87336f6a46)

## Tests
- [ ] Déposer un signalement en tant que pro en cochant la case travailleur social accompagnant et vérifier l'affichage en BO
