### PR TITLE
[FO - Suivi] Mail nouvelle MAJ en trop

### DIFF
--- a/src/Manager/SignalementDraftManager.php
+++ b/src/Manager/SignalementDraftManager.php
@@ -56,14 +56,6 @@ class SignalementDraftManager extends AbstractManager
         $this->save($signalementDraft);
 
         if (SignalementDraftStatus::EN_SIGNALEMENT === $signalementDraft->getStatus() && isset($signalement)) {
-            if (ProfileDeclarant::LOCATAIRE === $signalement->getProfileDeclarant()
-                || ProfileDeclarant::BAILLEUR_OCCUPANT === $signalementDraft->getProfileDeclarant()
-            ) {
-                $toRecipient = $signalement->getMailDeclarant();
-            } else {
-                $toRecipient = $signalement->getMailOccupant();
-            }
-
             return [
                 'uuid' => $signalementDraft->getUuid(),
                 'signalementReference' => $signalement->getReference(),
@@ -71,7 +63,7 @@ class SignalementDraftManager extends AbstractManager
                     'front_suivi_signalement',
                     [
                     'code' => $signalement->getCodeSuivi(),
-                    'from' => $toRecipient,
+                    'from' => $signalement->getMailDeclarant(),
                 ],
                     UrlGeneratorInterface::ABSOLUTE_URL
                 ),


### PR DESCRIPTION
## Ticket

#2433

## Description
- Correction du lien de suivi proposé en fin de dépôt d'un signalement pour qu'il contienne toujours l’e-mail déclarant.

## Tests
- [ ] Déposer un signalement en tant que tiers et vérifier que le lien de suivi en fin de parcours contient bien l'email déclarant.
- [ ] Cliquer sur le lien et déposer une photo : Vérifier que le suivi est bien enregistré déposé par le déclarant et que je le déclarant ne reçoit pas d'e-mail nouveau suivi
