### PR TITLE
[BO - Ajout photos situation] Ne pas uploader les photos aux formats non pris en charge

### DIFF
--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -86,7 +86,7 @@ function initializeUploadModal(
 
     function typeValidation(file) {
         let acceptedType = fileSelectorInput.getAttribute('accept');
-        if (acceptedType == '*') {
+        if (acceptedType == '*/*') {
             return true
         }
         let acceptedTypes = acceptedType.split(',').map((type) => type.trim())

--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -85,17 +85,17 @@ function initializeUploadModal(
     }
 
     function typeValidation(file) {
-        let splitType = file.type.split('/')[0]
-        let acceptedType = fileSelectorInput.getAttribute('accept').split('/')[0];
+        let acceptedType = fileSelectorInput.getAttribute('accept');
         if (acceptedType == '*') {
             return true
         }
-        if (acceptedType == splitType) {
+        let acceptedTypes = acceptedType.split(',').map((type) => type.trim())
+        if (acceptedTypes.includes(file.type)) {
             return true
         }
         let div = document.createElement('div')
         div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
-        div.innerHTML = `Le type du fichier ${file.name} n'est pas accepté (acceptés : ".jpg", ".png", ".gif")`;
+        div.innerHTML = `Impossible d'ajouter le fichier "${file.name}" car le format n'est pas pris en charge. Veuillez sélectionner une photo au format JPG, PNG ou GIF.`;
         listContainer.prepend(div)
         return false;
     }
@@ -331,7 +331,8 @@ function initializeUploadModal(
         if (fileType == 'photo') {
             modal.dataset.fileType = 'photo'
             modal.querySelector('.type-photo').classList.remove('fr-hidden')
-            fileSelectorInput.setAttribute('accept', 'image/*')
+            fileSelectorInput.setAttribute('accept', 'image/jpeg,image/png,image/gif')
+
         } else {
             modal.dataset.fileType = 'document'
             modal.querySelector('.type-document').classList.remove('fr-hidden')


### PR DESCRIPTION
## Ticket

#2435

## Description
Contrôle du format des photo envoyé via la modale d'upload de photos, pour restreindre uniquement au jpg, png et gif.

## Pré-requis
`make npm-build`

## Tests
- [ ] Tester l'envoie d'une photo webp via le glisser déposer dans la modale d'upload d'ajout de photo et vérifier qu'un message d'erreur est affiché.
