### PR TITLE
[BO - Signalement] Erreur suivi auto de suppression document situation et partenaire

### DIFF
--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -168,7 +168,7 @@ class SignalementFileController extends AbstractController
                 /** @var User $user */
                 $user = $this->getUser();
                 $description = $user->getNomComplet().' a supprimé ';
-                $description .= File::FILE_TYPE_DOCUMENT === $type ? 'le document suivant :' : 'la photo suivante :';
+                $description .= File::INPUT_NAME_DOCUMENTS === $type ? 'le document suivant :' : 'la photo suivante :';
                 $suivi->setDescription(
                     $description
                     .'<ul><li>'


### PR DESCRIPTION
## Ticket

#2447   

## Description
Correction du suivi automatique de suppression document. (document au lieu de photo)

## Changements apportés
* Modification du controller

## Pré-requis

## Tests
- [ ] Ajouter photos, documents usager et documents partenaire su un signalement
- [ ] Les supprimer et vérifier les suivis
