### PR TITLE
[BO - Edition de photos] Ajouter limite de caractères pour la description

### DIFF
--- a/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -67,26 +67,34 @@ document.querySelectorAll('.btn-signalement-file-edit').forEach(swbtn => {
     const documentTypes = JSON.parse(target.getAttribute('data-documentType-list'));
     let typeSelectBox = document.querySelector('#document-type-select');
     typeSelectBox.innerHTML = '';
-    let option = new Option('Sélectionnez un type', '');
-    if ('' === selectedDocumentType) {
-        option.selected = true;
-    }
-    typeSelectBox.appendChild(option);
-    for (let key in documentTypes) {
-      if (documentTypes.hasOwnProperty(key)) {
-        let label = documentTypes[key];
-        let option = new Option(label, key);
-        if (key === selectedDocumentType) {
-            option.selected = true;
-        }
-        typeSelectBox.appendChild(option);
+    if (documentTypes !== null ) {
+      let option = new Option('Sélectionnez un type', '');
+      if ('' === selectedDocumentType) {
+          option.selected = true;
       }
-    }
-    histoUpdateDesordreSelect(target, selectedDocumentType)    
+      typeSelectBox.appendChild(option);
+      for (let key in documentTypes) {
+        if (documentTypes.hasOwnProperty(key)) {
+          let label = documentTypes[key];
+          let option = new Option(label, key);
+          if (key === selectedDocumentType) {
+              option.selected = true;
+          }
+          typeSelectBox.appendChild(option);
+        }
+      }
+      histoUpdateDesordreSelect(target, selectedDocumentType)    
+  
+      document.querySelector('#document-type-select').addEventListener('change', function () {
+        const selectedValue = this.value;
+        histoUpdateDesordreSelect(target, selectedValue)   
+      });
 
-    document.querySelector('#document-type-select').addEventListener('change', function () {
-      const selectedValue = this.value;
-      histoUpdateDesordreSelect(target, selectedValue)   
-    });
+    } else {
+      let option = new Option(selectedDocumentType, selectedDocumentType);
+      option.selected = true;
+      typeSelectBox.appendChild(option);
+      typeSelectBox.classList.add('fr-hidden')
+    }
   })
 })

--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -195,7 +195,7 @@ function initializeUploadModal(
             innerHTML += `
             <div class="fr-col-3">                
                 <input type="text" id="file-description" name="file[description]"
-                required="required" class="fr-input" placeholder="Description de l'image">
+                required="required" class="fr-input" placeholder="Description de l'image" maxlength=250>
                 <input type="hidden" id="file-id" name="file[id]">
             </div>           
             `

--- a/migrations/Version20240410151123.php
+++ b/migrations/Version20240410151123.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240410151123 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change description column formmat on file';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file CHANGE description description TINYTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file CHANGE description description LONGTEXT DEFAULT NULL');
+    }
+}

--- a/migrations/Version20240410151123.php
+++ b/migrations/Version20240410151123.php
@@ -11,7 +11,7 @@ final class Version20240410151123 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Change description column formmat on file';
+        return 'Change description column format on file';
     }
 
     public function up(Schema $schema): void

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -7,6 +7,7 @@ use App\Repository\FileRepository;
 use App\Service\ImageManipulationHandler;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: FileRepository::class)]
 class File
@@ -56,7 +57,8 @@ class File
     #[ORM\Column]
     private ?bool $isVariantsGenerated = null;
 
-    #[ORM\Column(type: 'text', nullable: true)]
+    #[ORM\Column(type: 'text', nullable: true, length: 250)]
+    #[Assert\Length(max: 250)]
     private ?string $description;
 
     #[ORM\Column]

--- a/templates/back/signalement/view/edit-modals/edit-file.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-file.html.twig
@@ -32,8 +32,10 @@
                             </div>
 
                             <div id="fr-modal-edit-file-description" class="fr-input-group fr-hidden fr-col-12  fr-mb-2w">
-                                <label class="fr-label" for="fileDescription">Description : </label>
-                                    <input class="fr-input" type="text" id="fileDescription" name="description">
+                                <label class="fr-label" for="fileDescription">Description (250 caractères maximum) : 
+                                </label>
+                                <textarea class="fr-input" type="text" id="fileDescription" name="description" maxlength=250>
+                                </textarea>
                             </div>    
                         </div>
                         

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -106,7 +106,6 @@
                         data-signalement-uuid="{{ signalement.uuid}}" 
                         data-description="{{ photo.description }}" 
                         data-documentType="{{ photo.documentType.name }}" 
-                        data-documentType-list="{{ DocumentType.getPhotosList() | json_encode }}"
                         data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
                         data-partner-name="{{ photo.uploadedBy and photo.uploadedBy.partner ? photo.uploadedBy.partner.nom ~ ' - ' : '' }}"
                         data-user-name="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"


### PR DESCRIPTION
## Ticket

#2438    

## Description
Limiter la taille du champ description pour les fichiers

## Changements apportés
* Migration + limitation dans l'entité
* Limitation dans les champs lors de l'ajout et de l'édition

## Pré-requis

## Tests
- [ ] Ajouter une photo de visite, vérifier qu'on ne peut pas mettre une description de plus de 250 caractères
- [ ] Editer une photo de visite et vérifier aussi la limitation
