### PR TITLE
[BO - Cartographie] Filtres "non zonés

### DIFF
--- a/src/Controller/Back/CartographieController.php
+++ b/src/Controller/Back/CartographieController.php
@@ -50,7 +50,7 @@ class CartographieController extends AbstractController
         }
 
         $userToFilterCities = $user;
-        if ($this->isGranted('ROLE_ADMIN') || $this->isGranted('ROLE_ADMIN_TERRITORY')) {
+        if ($this->isGranted('ROLE_ADMIN')) {
             $userToFilterCities = null;
         }
 


### PR DESCRIPTION
## Ticket

#2454    

## Description
Filtre les villes et les partenaires dans les filtres de la cartographie pour les RT 
Lors de ce commit https://github.com/MTES-MCT/histologe/commit/af0ad350b771e6ce218e13f246b470e25b89aea5 en septembre 2022, les filtres de la cartographie avaient été volontairement non filtrés en fonction du territoire (villes et partenaires) pour les SA (normal) et pour les RT
On supprime cette exception pour les RT

## Changements apportés
* Modification du controller pour les RT

## Pré-requis

## Tests
- [ ] Se connecter et vérifier les filtres de la carto avec les différents rôles
