### PR TITLE
[BO - Modale ajout documents] Amélioration de la modale (UX et contenu)

### DIFF
--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -55,12 +55,12 @@ enum DocumentType: String
     public static function getSituationList(): array
     {
         return [
-            self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
-            self::AUTRE->name => self::AUTRE->label(),
             self::SITUATION_FOYER_BAIL->name => self::SITUATION_FOYER_BAIL->label(),
             self::SITUATION_FOYER_DPE->name => self::SITUATION_FOYER_DPE->label(),
             self::SITUATION_FOYER_ETAT_DES_LIEUX->name => self::SITUATION_FOYER_ETAT_DES_LIEUX->label(),
             self::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE->name => self::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE->label(),
+            self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
+            self::AUTRE->name => self::AUTRE->label(),
         ];
     }
 

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -44,7 +44,7 @@ enum DocumentType: String
         ];
     }
 
-    public static function getPhotosList(): array
+    public static function getOrderedPhotosList(): array
     {
         return [
             self::PHOTO_SITUATION->name => self::PHOTO_SITUATION->label(),
@@ -52,7 +52,7 @@ enum DocumentType: String
         ];
     }
 
-    public static function getSituationList(): array
+    public static function getOrderedSituationList(): array
     {
         return [
             self::SITUATION_FOYER_BAIL->name => self::SITUATION_FOYER_BAIL->label(),
@@ -64,7 +64,7 @@ enum DocumentType: String
         ];
     }
 
-    public static function getProcedureList(): array
+    public static function getOrderedProcedureList(): array
     {
         return [
             self::PROCEDURE_MISE_EN_DEMEURE->name => self::PROCEDURE_MISE_EN_DEMEURE->label(),

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -266,7 +266,7 @@ class File
     public function isSituationPhoto(): bool
     {
         return $this->fileType === $this::FILE_TYPE_PHOTO
-        && \array_key_exists($this->documentType->value, DocumentType::getSituationList())
+        && \array_key_exists($this->documentType->value, DocumentType::getOrderedSituationList())
         && null === $this->intervention;
     }
 }

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -95,7 +95,10 @@ class SuiviManager extends Manager
         $description = '';
         $isVisibleUsager = false;
 
-        if (\array_key_exists($documentType?->value, DocumentType::getProcedureList()) && null === $intervention) {
+        if (
+            \array_key_exists($documentType?->value, DocumentType::getOrderedProcedureList())
+            && null === $intervention
+        ) {
             if ($nbDocs > 0) {
                 $description .= $nbDocs;
                 $description .= $nbDocs > 1 ? ' documents partenaires ont été ajoutés' : ' document partenaire a été ajouté';
@@ -103,7 +106,7 @@ class SuiviManager extends Manager
             }
         }
 
-        if (\array_key_exists($documentType?->value, DocumentType::getSituationList())) {
+        if (\array_key_exists($documentType?->value, DocumentType::getOrderedSituationList())) {
             $isVisibleUsager = true;
             if ($nbDocs > 0) {
                 $description .= $nbDocs;

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -77,13 +77,13 @@
                             {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
                             <select class="fr-select select-type" data-file-id="" id="select-type-situation-to-clone">
                                 <option value="">Sélectionner un type</option>
-                                {% for key, value in DocumentType.getSituationList() %}
+                                {% for key, value in DocumentType.getOrderedSituationList() %}
                                     <option value="{{ key }}">{{ value }}</option>
                                 {% endfor %}
                             </select>
                             <select class="fr-select select-type" data-file-id="" id="select-type-procedure-to-clone">
                                 <option value="">Sélectionner un type</option>
-                                {% for key, value in DocumentType.getProcedureList() %}
+                                {% for key, value in DocumentType.getOrderedProcedureList() %}
                                     <option value="{{ key }}">{{ value }}</option>
                                 {% endfor %}
                             </select>

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -29,7 +29,7 @@
                                 <div>
                                     Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
                                 </div>
-                                <div class="fr-alert fr-alert--info fr-alert--sm">
+                                <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-1w ">
                                     <p>Pour ajouter des documents de type Bail, DPE, Diagnostic et Etat des lieux, rendez-vous dans la partie "Déclaration usager".</p>
                                 </div>
                             </div>
@@ -40,8 +40,11 @@
                                 <div>
                                     Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
                                 </div>
-                                <div class="fr-alert fr-alert--warning fr-alert--sm">
-                                    <p>Ces photos seront partagées à l'usager.</p>
+                                <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-1w ">
+                                    <p>Pour ajouter des documents concernant la procédure ou le bailleur, rendez-vous dans la partie "Documents partenaires".</p>
+                                </div>
+                                <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
+                                    <p>Ces documents seront partagés à l'usager.</p>
                                 </div>
                             </div>
                         </div>
@@ -52,7 +55,7 @@
                             <div>
                                 Ajouter une ou plusieurs photos au signalement. Pour chaque photo, veuillez sélectionner le désordre auquel elle est rattachée. 
                             </div>
-                            <div class="fr-alert fr-alert--warning fr-alert--sm">
+                            <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
                                 <p>Ces photos seront partagées à l'usager.</p>
                             </div>
                         </div>

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -97,7 +97,7 @@
                             data-signalement-uuid="{{ signalement.uuid}}" 
                             data-description="{{ photo.description }}" 
                             data-documentType="{{ photo.documentType.name }}" 
-                            data-documentType-list="{{ DocumentType.getPhotosList() | json_encode }}"
+                            data-documentType-list="{{ DocumentType.getOrderedPhotosList() | json_encode }}"
                             data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
                             data-partner-name="{{ photo.uploadedBy and photo.uploadedBy.partner ? photo.uploadedBy.partner.nom ~ ' - ' : '' }}"
                             data-user-name="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
@@ -123,10 +123,10 @@
     doc => doc.fileType == 'document'
         and (
             (filesFilter is same as 'situation' 
-            and doc.documentType.label() in  DocumentType.getSituationList)
+            and doc.documentType.label() in  DocumentType.getOrderedSituationList)
             or 
             (filesFilter is same as 'procedure' 
-            and doc.documentType.label() in  DocumentType.getProcedureList)
+            and doc.documentType.label() in  DocumentType.getOrderedProcedureList)
         )
     ) %}
     <div class="fr-grid-row fr-grid-row--middle fr-background-alt--grey fr-rounded fr-p-3v signalement-file-item">
@@ -166,7 +166,7 @@
                     data-type="document" 
                     data-file-id="{{ doc.id}}" 
                     data-documentType="{{ doc.documentType.name }}" 
-                    data-documentType-list="{{ filesFilter is same as 'situation' ? DocumentType.getSituationList() | json_encode : DocumentType.getProcedureList() | json_encode }}"
+                    data-documentType-list="{{ filesFilter is same as 'situation' ? DocumentType.getOrderedSituationList() | json_encode : DocumentType.getOrderedProcedureList() | json_encode }}"
                     data-createdAt="{{ doc.createdAt is defined ? doc.createdAt|date('d.m.Y') : 'N/R' }}"
                     data-partner-name="{{ doc.uploadedBy and doc.uploadedBy.partner ? doc.uploadedBy.partner.nom ~ ' - ' : '' }}"
                     data-user-name="{{ doc.uploadedBy.nomComplet ?? 'N/R' }}"

--- a/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
@@ -29,7 +29,7 @@
                             <div>
                                 Ajouter une ou plusieurs photos au signalement. 
                             </div>
-                            <div class="fr-alert fr-alert--warning fr-alert--sm">
+                            <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
                                 <p>Les photos seront partagées à l'usager.</p>
                             </div>
                         </div>
@@ -37,7 +37,7 @@
                             <div class="modal-upload-drop-section">
                                 <span class="fr-icon-upload-2-line fr-icon--lg fr-text-label--blue-france"></span>
                                 <div class="modal-upload-drop-section-label fr-mt-1w">
-                                    Faites glisser vos documents ici
+                                    Faites glisser vos photos ici
                                 </div>
                             </div>
                             <p class="fr-mb-1w">ou</p>


### PR DESCRIPTION
## Ticket

#2440    

## Description

- Ajouter une marge avant le message warning
- Ajouter le texte Pour ajouter des documents concernant la procédure ou le bailleur, rendez-vous dans la partie "Documents partenaires". (cf. [specs](https://github.com/MTES-MCT/histologe/wiki/Ajout-documents#ajouter-des-documents-sur-la-situation-usager))
- Modifier le message warning pour Ces documents seront partagés à l'usager.
- Modifier l'ordre des éléments dans la liste déroulante des types de documents pour que "Photo de désordre" soit en avant dernier et "Autre" en dernier"
- 

## Changements apportés
* Changement des twig et des document types

## Pré-requis

## Tests
- [ ] Ouvrir les modales d'upload de photos (situation et visite) et de documents (situation et partenaire) et vérifier la correction des points ci-dessus
