### PR TITLE
[BO - Signalement] Photos non rattachées aux désordres

### DIFF
--- a/migrations/Version20240411120500.php
+++ b/migrations/Version20240411120500.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240411120500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Met à jour le desordreSlug des file suite à un bug de la MEP du 4 avril';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $files = $this->connection->executeQuery('
+            SELECT f.id, f.signalement_id, f.filename
+            FROM file f
+            WHERE f.document_type = "PHOTO_SITUATION"
+            AND f.created_at > "2024-04-04 12:00:00"
+            AND f.desordre_slug IS NULL
+        ')->fetchAllAssociative();
+
+        foreach ($files as $file) {
+            $signalementDraftData = $this->connection->executeQuery('
+                SELECT sd.payload
+                FROM signalement_draft sd
+                JOIN signalement s ON s.created_from_id = sd.id
+                WHERE s.id = :signalementId
+            ', ['signalementId' => $file['signalement_id']])->fetchAssociative();
+
+            $desordreSlug = $this->extractDesordreSlugFromPayload($signalementDraftData['payload'], $file['filename']);
+
+            $this->connection->executeStatement('
+                UPDATE file
+                SET desordre_slug = :desordreSlug
+                WHERE id = :fileId
+            ', ['desordreSlug' => $desordreSlug, 'fileId' => $file['id']]);
+        }
+    }
+
+    private function extractDesordreSlugFromPayload(string $payload, string $filename): ?string
+    {
+        $jsonData = json_decode($payload, true);
+
+        foreach ($jsonData as $key => $value) {
+            if (\is_array($value) && isset($value[0]['file'])) {
+                foreach ($value as $photo) {
+                    if ($photo['file'] === $filename) {
+                        return str_replace('_details_photos_upload', '', $key);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20240411120500.php
+++ b/migrations/Version20240411120500.php
@@ -50,7 +50,10 @@ final class Version20240411120500 extends AbstractMigration
             if (\is_array($value) && isset($value[0]['file'])) {
                 foreach ($value as $photo) {
                     if ($photo['file'] === $filename) {
-                        return str_replace('_details_photos_upload', '', $key);
+                        $key = str_replace('_details_photos_upload', '', $key);
+                        $key = str_replace('_photos_upload', '', $key);
+
+                        return $key;
                     }
                 }
             }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -210,15 +210,22 @@ class File
 
     public function setDesordreSlug(?string $desordreSlug): self
     {
-        if (!$this->getSignalement() || !$this->getDocumentType() || DocumentType::PHOTO_SITUATION !== $this->getDocumentType()) {
+        if (
+            !$this->getSignalement()
+            || !$this->getDocumentType()
+            || DocumentType::PHOTO_SITUATION !== $this->getDocumentType()
+        ) {
             $this->desordreSlug = null;
 
             return $this;
         }
         if (!$desordreSlug) {
             $this->desordreSlug = null;
-        } elseif (\in_array($desordreSlug, $this->getSignalement()->getDesordreCritereSlugs())
-            || \in_array($desordreSlug, $this->getSignalement()->getDesordrePrecisionSlugs())) {
+        } elseif (
+            \in_array($desordreSlug, $this->getSignalement()->getDesordreCritereSlugs())
+            || \in_array($desordreSlug, $this->getSignalement()->getDesordrePrecisionSlugs())
+            || \in_array($desordreSlug, $this->getSignalement()->getDesordreCategorieSlugs())
+        ) {
             $this->desordreSlug = $desordreSlug;
         }
 

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2301,12 +2301,23 @@ class Signalement
 
     public function getDesordreCritereSlugs()
     {
-        return $this->getDesordreCriteres()->map(fn (DesordreCritere $desordreCritere) => $desordreCritere->getSlugCritere())->toArray();
+        return $this->getDesordreCriteres()->map(
+            fn (DesordreCritere $desordreCritere) => $desordreCritere->getSlugCritere()
+        )->toArray();
     }
 
     public function getDesordrePrecisionSlugs()
     {
-        return $this->getDesordrePrecisions()->map(fn (DesordrePrecision $desordrePrecision) => $desordrePrecision->getDesordrePrecisionSlug())->toArray();
+        return $this->getDesordrePrecisions()->map(
+            fn (DesordrePrecision $desordrePrecision) => $desordrePrecision->getDesordrePrecisionSlug()
+        )->toArray();
+    }
+
+    public function getDesordreCategorieSlugs()
+    {
+        return $this->getDesordreCriteres()->map(
+            fn (DesordreCritere $desordreCritere) => $desordreCritere->getSlugCategorie()
+        )->toArray();
     }
 
     public function getBailleur(): ?Bailleur

--- a/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
@@ -48,7 +48,7 @@ class SignalementDraftFileMessageHandler
             foreach ($files as $key => $fileList) {
                 foreach ($fileList as $fileItem) {
                     $fileItem['slug'] = $key;
-                    $file = $this->fileFactory->createFromFileArray(file: $fileItem);
+                    $file = $this->fileFactory->createFromFileArray(file: $fileItem, signalement: $signalement);
                     $this->uploadHandlerService->moveFromBucketTempFolder($file->getFilename());
                     $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
                     $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));

--- a/tests/Functional/Messenger/MessageHandler/SignalementDraftFileMessageHandlerTest.php
+++ b/tests/Functional/Messenger/MessageHandler/SignalementDraftFileMessageHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Messenger\MessageHandler;
 
+use App\Entity\Enum\DocumentType;
 use App\Messenger\Message\SignalementDraftFileMessage;
 use App\Messenger\MessageHandler\SignalementDraftFileMessageHandler;
 use App\Repository\SignalementDraftRepository;
@@ -43,6 +44,21 @@ class SignalementDraftFileMessageHandlerTest extends KernelTestCase
         $handler = $this->signalementDraftFileMessageHandler;
         $handler($message);
         $this->assertCount(7, $signalement->getFiles());
+        foreach ($signalement->getFiles() as $file) {
+            switch ($file->getFilename()) {
+                case 'Capture-d-ecran-1-desordre.png':
+                case 'Capture-d-ecran-é-desordre.png':
+                    $this->assertEquals(DocumentType::PHOTO_SITUATION, $file->getDocumentType());
+                    $this->assertEquals('desordres_batiment_proprete', $file->getDesordreSlug());
+                    break;
+                case 'Capture-d-ecran-bail-2.png':
+                    $this->assertEquals(DocumentType::SITUATION_FOYER_BAIL, $file->getDocumentType());
+                    $this->assertNull($file->getDesordreSlug());
+                    break;
+                default:
+                    $this->assertNotNull($file->getDocumentType());
+            }
+        }
     }
 
     public function testHandleMessageWithFailure(): void


### PR DESCRIPTION
## Ticket

#2437    

## Description
Suite aux modifications de File.setDesordreSlug() dans ce commit (https://github.com/MTES-MCT/histologe/commit/757f67028975867568c13180c0a0bc7e6a090efa#diff-efb705be4240485a34a0a7cca55154c6f3c2e2c8e0f7706b504b260ec3f5d9f6), les photos des signalements n'étaient plus rattachées à leur désordre depuis le 4 avril

## Changements apportés
* Correction de File.setDesordreSlug()  pour chercher aussi dans les slugs de catégorie (et création de Signalement.getDesordreCategorieSlugs())
* Passage du signalement à FileFactory->createFromFileArray() dans SignalementDraftFileMessageHandler.php
* Ajout d'assertions dans SignalementDraftFileMessageHandlerTest.php
* Création d'une migration pour corriger l'existant

## Pré-requis

## Tests
- [ ] Faire un signalement avec des photos dans des désordres, et vérifier qu'elles sont bien rattachées aux désordres dans le BO et dans la BDD aussi
- [ ] En base, mettre NULL pour certains desordreSlug de signalement créés après le 4 avril, jouer la migration et s'assurer qu'elle remplit bien le desordreSlug
- [ ] 
