### PR TITLE
[BO - Signalement - Ajout doc partenaire] Changer le focus après ajout

### DIFF
--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -296,6 +296,7 @@ function initializeUploadModal(
         if (modal.dataset.validated == "true" && modal.dataset.hasChanges == "true") {
             fetch(waitingSuiviRoute).then((response) => {
                 window.location.reload()
+                window.scrollTo(0, 0)
             })
             return true;
         }


### PR DESCRIPTION
## Ticket

#2446   

## Description
Scroll en haut de page pour voir le message flash après ajout de document

## Changements apportés
* scrollTo dans la fonction js

## Pré-requis

## Tests
- [ ] Sur un signalement, ajouter un document partenaire et vérifier qu'on est à nouveau en haut de la page
