### PR TITLE
[BO - Affichage mode album] Améliorations UI

### DIFF
--- a/assets/controllers/view_signalement.js
+++ b/assets/controllers/view_signalement.js
@@ -11,7 +11,7 @@ document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
     btn.addEventListeners('click touchdown', (event) => {
         document?.querySelectorAll('.photos-album')?.forEach(element => {
             element.classList?.remove('fr-hidden')
-
+            document.documentElement.setAttribute('data-fr-theme', 'dark')
             displayPhotoAlbum(swipeId)
         })
     })
@@ -19,6 +19,7 @@ document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
 document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
     btn.addEventListeners('click touchdown', (event) => {
         document?.querySelectorAll('.photos-album')?.forEach(element => {
+            document.documentElement.setAttribute('data-fr-theme', 'light')
             element.classList?.add('fr-hidden')
         })
     })

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -627,6 +627,29 @@ div.photos-album {
         text-align: right;
     }
 
+    .photos-album-swipe {
+        background-color: rgb(133, 133, 246);//blue-france-625
+        color: rgb(0, 0, 145);//blue-france-sun-113
+        
+        &:active {
+            background: rgb(177,177,249);//blue-france-625-active
+        }
+        &:hover {
+            background: rgb(198,198,251);//var(--blue-france-625-hover);
+        }
+    }
+    .photos-album-btn-close {
+        background-color: rgb(133, 133, 246);//blue-france-625
+        color: rgb(0, 0, 145);//blue-france-sun-113
+        
+        &:active {
+            background: rgb(177,177,249);//blue-france-625-active
+        }
+        &:hover {
+            background: rgb(198,198,251);//var(--blue-france-625-hover);
+        }
+    }
+
     .photos-album-navigation-container {
         display: flex;
         height: calc(100% - 4rem);

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -627,29 +627,6 @@ div.photos-album {
         text-align: right;
     }
 
-    .photos-album-swipe {
-        background-color: rgb(133, 133, 246);//blue-france-625
-        color: rgb(0, 0, 145);//blue-france-sun-113
-        
-        &:active {
-            background: rgb(177,177,249);//blue-france-625-active
-        }
-        &:hover {
-            background: rgb(198,198,251);//var(--blue-france-625-hover);
-        }
-    }
-    .photos-album-btn-close {
-        background-color: rgb(133, 133, 246);//blue-france-625
-        color: rgb(0, 0, 145);//blue-france-sun-113
-        
-        &:active {
-            background: rgb(177,177,249);//blue-france-625-active
-        }
-        &:hover {
-            background: rgb(198,198,251);//var(--blue-france-625-hover);
-        }
-    }
-
     .photos-album-navigation-container {
         display: flex;
         height: calc(100% - 4rem);

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -1,6 +1,6 @@
 <div class="photos-album fr-hidden">
     <div class="photos-album-close-button-container">
-        <button class="photos-album-btn-close fr-btn">Fermer</button>
+        <button class="photos-album-btn-close fr-btn fr-btn--icon-left fr-icon-close-line">Fermer</button>
     </div>
     {% set loopLength = allPhotosOrdered|length %}
     <div class="photos-album-navigation-container">
@@ -19,7 +19,7 @@
                         alt="Photo ajoutée par : {{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
                         >
                 </div>
-                <div>
+                <div class="fr-mt-1w">
                     {% if photo.documentType is not same as null
                         and photo.documentType is not same as enum('App\\Entity\\Enum\\DocumentType').AUTRE %}
                         {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION
@@ -35,7 +35,8 @@
                     {% if photo.description is not same as null %}
                         {{ photo.description }}
                     {% endif %}
-                    <br>
+                </div>
+                <div class="fr-mt-1w">
                     Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
                 </div>
             </div>


### PR DESCRIPTION
## Ticket

#2439    

## Description

- Ajouter une marge sous la photo, avant la description
- Augmenter l'espace entre la description et l'auteur de la photo
- Ajouter l'icône fr-icon-close-line dans le bouton "Fermer"
- Modifier la couleur des boutons (accessibilité) : il faut utiliser les boutons du thème "sombre" [dans le DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton) (je n'ai pas réussi à activier le passage en mode sombre en js, ni à utiliser les variables, mais en utilisant les codes rgb c'est ok, ouvert à amélioration)

## Changements apportés
* css et txig

## Pré-requis

## Tests
- [ ] Afficher l'album et vérifier l'UI
