### PR TITLE
[BO - Dashboard] Manque filtrage depuis la carte "Mes affectations

### DIFF
--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -198,7 +198,7 @@ class WidgetDataKpiBuilder
         $this
             ->addWidgetCard('cardNouveauxSignalements', $this->countSignalement->getNew())
             ->addWidgetCard('cardCloturesPartenaires', $this->countSignalement->getClosedByAtLeastOnePartner())
-            ->addWidgetCard('cardMesAffectations')
+            ->addWidgetCard('cardMesAffectations', null, ['partenaires' => $this->user?->getPartner()?->getId()])
             ->addWidgetCard('cardTousLesSignalements', $this->countSignalement->getTotal())
             ->addWidgetCard('cardCloturesGlobales', $this->countSignalement->getClosedAllPartnersRecently())
             ->addWidgetCard('cardNouvellesAffectations', $this->countSignalement->getNew())


### PR DESCRIPTION
## Ticket

#1190   

## Description
Je suis responsable de territoire
Mon partenaire est la DDTM 13
Sur mon tableau de bord, je clique sur la carte "Mes affectations"
J'arrive sur la liste de tous les signalements, sans filtrage
Comportement attendu : avoir le filtre partenaire actif avec le partenaire du user en cours

## Changements apportés
* Ajout d'un paramètre pour le lien avec l'id du partenaire (dans WidgetDataKpiBuilder)

## Pré-requis

## Tests
- [ ] Se connecter avec différents RT et vérifier qu'on a bien une liste de signalement filtrée par affectation quand on clique sur le widget "Mes affectations")
