### PR TITLE
[Front] Mettre à jour les stats publiques

### DIFF
--- a/assets/vue/components/common/HistoFranceMap.vue
+++ b/assets/vue/components/common/HistoFranceMap.vue
@@ -682,7 +682,7 @@ export default defineComponent({
       captionTerritoryCountPlural: '',
       minValue: 0,
       maxValue: 6000,
-      minColor: '#FFFFFF',
+      minColor: '#bfc4d5',
       maxColor: '#2F4077'
 
     }
@@ -796,7 +796,7 @@ export default defineComponent({
   .histo-france-map .legend-gradient {
     width: 266px;
     height: 24px;
-    background: linear-gradient(to right, #FFFFFF, #2F4077);
+    background: linear-gradient(to right, #bfc4d5, #2F4077);
   }
 
   .histo-france-map .legend-undeployed {

--- a/assets/vue/components/common/HistoFranceMap.vue
+++ b/assets/vue/components/common/HistoFranceMap.vue
@@ -1,25 +1,15 @@
 <template>
   <div class="histo-france-map">
-    <h3>Répartition par territoire</h3>
+    <h3>Répartition des signalements par département</h3>
 
     <div class="fr-container--fluid fr-my-10v">
       <div class="fr-grid-row fr-grid-row--gutters">
-        <div class="captions fr-col-12 fr-col-md-3">
-          <ul>
-            <li>Aucune donnée</li>
-            <li>1 - 50</li>
-            <li>51 - 250</li>
-            <li>251 - 1 000</li>
-            <li>1 001+</li>
-          </ul>
-        </div>
-
         <div v-if="displayTerritoryCaption" class="territory-caption" :style="{ left: territoryCaptionX+'px', top: territoryCaptionY+'px'}">
           {{ captionTerritoryName }} ({{ captionTerritoryZip }})<br>
           {{ captionTerritoryCount }} signalement{{ captionTerritoryCountPlural }}
         </div>
 
-        <div ref="francemap" class="map fr-col-12 fr-col-md-9">
+        <div ref="francemap" class="map fr-col-12 fr-col-md-12">
           <svg viewBox="0 0 588 550" preserveAspectRatio="xMinYMin meet" @mouseover="handleStateHover" @mouseout="handleStateOut">
             <path id="dpt2B" inkscape:label="Haute-Corse" class="st0" d="M562.1,441.7l-2.8,1.9l0.4,1.9l1.5,1.9l-1.7,1.3l0.8,1.5l-1.1,1.3v1.7l1.9,1.7
               v2.6l-1.1,2.5l-1.3,0.6l-1.5-2.1l-2.7,0.2l-0.6-0.4h-2.3l-2.1,1.9l-0.8,3.2l-4.9,0.9l-3.8,3.2l-0.8,2.1l-1.9-0.2l-1-1.1l-0.5,3.2
@@ -649,6 +639,21 @@
         </div>
 
       </div>
+      <div class="fr-grid-row fr-grid-row--gutters">
+        <div class="legend fr-col-12 fr-col-md-12">
+          <div class="legend-title">Légende</div>
+          <div class="legend-bar">
+            <div class="legend-gradient"></div>
+            <div class="legend-labels">
+              <span>{{ minValue }}</span>
+              <span>{{ maxValue }}+</span>
+            </div>
+            <div class="legend-labels">
+              <div class="legend-undeployed"></div> Département non déployé
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -674,7 +679,12 @@ export default defineComponent({
       captionTerritoryName: '',
       captionTerritoryZip: '',
       captionTerritoryCount: '',
-      captionTerritoryCountPlural: ''
+      captionTerritoryCountPlural: '',
+      minValue: 0,
+      maxValue: 6000,
+      minColor: '#FFFFFF',
+      maxColor: '#2F4077'
+
     }
   },
   mounted () {
@@ -682,19 +692,30 @@ export default defineComponent({
       const zipCode:string = territoryItem.zip
       const el = this.$el.querySelector('#dpt' + zipCode)
       if (el !== undefined) {
-        if (territoryItem.count > 1000) {
-          el.classList.add('color-1001')
-        } else if (territoryItem.count > 250) {
-          el.classList.add('color-251')
-        } else if (territoryItem.count > 50) {
-          el.classList.add('color-51')
-        } else if (territoryItem.count > 0) {
-          el.classList.add('color-1')
-        }
+        const color = this.getBackgroundColor(territoryItem.count)
+        el.style.fill = color
       }
     }
   },
   methods: {
+    getBackgroundColor (count:number) {
+      if (count > this.maxValue) {
+        return this.maxColor
+      } else {
+        const percent = count / this.maxValue
+        const color1 = this.hexToRgb(this.minColor)
+        const color2 = this.hexToRgb(this.maxColor)
+        const color = color1.map((channel: any, index: any) => Math.round(channel + (color2[index] - channel) * percent))
+        return `rgb(${color.join(',')})`
+      }
+    },
+    hexToRgb (hex: string) {
+      return [
+        parseInt(hex.slice(1, 3), 16),
+        parseInt(hex.slice(3, 5), 16),
+        parseInt(hex.slice(5, 7), 16)
+      ]
+    },
     handleStateHover (e:any) {
       if (e.target.tagName === 'path') {
         const territoryItem = this.getTerritoryItemByZip(e.target.id.substring(3))
@@ -759,48 +780,52 @@ export default defineComponent({
     left: 0;
   }
 
-  .histo-france-map .captions {
-    text-align: left;
-    margin-top: 40px;
-    padding-left: 20px;
+  .histo-france-map .legend {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
   }
-  .histo-france-map .captions > ul {
-    padding-left: 40px;
+
+  .histo-france-map .legend-bar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 266px;
   }
-  .histo-france-map .captions > ul li::marker {
-    font-size: 40px;
-    line-height: 35px;
+
+  .histo-france-map .legend-gradient {
+    width: 266px;
+    height: 24px;
+    background: linear-gradient(to right, #FFFFFF, #2F4077);
   }
-  .histo-france-map .captions > ul li:nth-child(1)::marker {
-    color: #CCCCCC;
+
+  .histo-france-map .legend-undeployed {
+    width: 14px;
+    height: 14px;
+    background: #E5E5E5;
   }
-  .histo-france-map .captions > ul li:nth-child(2)::marker {
-    color: #E3E3FD;
+
+  .histo-france-map .legend-labels {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
   }
-  .histo-france-map .captions > ul li:nth-child(3)::marker {
-    color: #CACAFB;
-  }
-  .histo-france-map .captions > ul li:nth-child(4)::marker {
-    color: #6A6AF4;
-  }
-  .histo-france-map .captions > ul li:nth-child(5)::marker {
-    color: #000091;
+
+  .histo-france-map .legend-title {
+    margin-top: 8px;
+    font-weight: bold;
   }
 
   .st0{
-    fill:#CCCCCC;
+    fill:#E5E5E5;
     stroke:#FFFFFF;
     stroke-width:0.5;
     stroke-miterlimit:3.9745;
   }
   .st1{
-    fill:#CCCCCC;
+    fill:#E5E5E5;
     fill-opacity:0;
   }
-  .color-1{fill:#E3E3FD}
-  .color-51{fill:#CACAFB}
-  .color-251{fill:#6A6AF4}
-  .color-1001{fill:#000091}
 
   .st0:hover {
     fill:#fcc0b0;

--- a/assets/vue/components/common/external/chartjs/HistoChartBar.vue
+++ b/assets/vue/components/common/external/chartjs/HistoChartBar.vue
@@ -15,13 +15,14 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue'
 import { Bar } from 'vue-chartjs'
 import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js'
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
 
-export default {
+export default defineComponent({
   name: 'HistoChartBar',
   components: { Bar },
   props: {
@@ -45,8 +46,8 @@ export default {
       default: 250
     },
     cssClasses: {
-      default: '',
-      type: String
+      type: String,
+      default: ''
     },
     indexAxis: {
       default: 'y',
@@ -102,7 +103,7 @@ export default {
           },
           tooltip: {
             callbacks: {
-              title: function (context) {
+              title: function (context: any) {
                 return context[0].label.split(' ,').join('\n')
               }
             }
@@ -111,7 +112,7 @@ export default {
       }
     }
   }
-}
+})
 </script>
 
 <style>

--- a/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
+++ b/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
@@ -67,6 +67,10 @@ export default defineComponent({
     plugins: {
       type: Array,
       default: () => []
+    },
+    labelCharMax: {
+      type: Number,
+      default: 50
     }
   },
   data () {
@@ -74,9 +78,11 @@ export default defineComponent({
     const inData = []
     const inColors = []
     for (const i in this.items) {
-      inLabels.push(this.items[i].label)
-      inData.push(this.items[i].count)
-      inColors.push(this.items[i].color)
+      const { label, count, color } = this.items[i]
+      const labelChunks = this.splitLabelIntoChunks(label, this.labelCharMax)
+      inLabels.push(labelChunks)
+      inData.push(count)
+      inColors.push(color)
     }
     return {
       chartData: {
@@ -97,10 +103,38 @@ export default defineComponent({
         plugins: {
           legend: {
             position: 'bottom',
-            align: 'start'
+            align: 'start',
+            labels: {
+              padding: 20
+            }
           }
         }
       }
+    }
+  },
+  methods: {
+    splitLabelIntoChunks (label, labelCharMax) {
+      const labelChunks = []
+      let currentChunk = ''
+      let currentLength = 0
+
+      const words = label.split(' ')
+      for (const word of words) {
+        if (currentLength + word.length + 1 <= labelCharMax) {
+          currentChunk += word + ' '
+          currentLength += word.length + 1
+        } else {
+          labelChunks.push(currentChunk.trim())
+          currentChunk = word + ' '
+          currentLength = word.length + 1
+        }
+      }
+
+      if (currentChunk.trim() !== '') {
+        labelChunks.push(currentChunk.trim())
+      }
+
+      return labelChunks
     }
   }
 })

--- a/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
+++ b/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
@@ -96,7 +96,8 @@ export default defineComponent({
         maintainAspectRatio: false,
         plugins: {
           legend: {
-            position: 'bottom'
+            position: 'bottom',
+            align: 'start'
           }
         }
       }

--- a/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
+++ b/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
@@ -105,7 +105,10 @@ export default defineComponent({
             position: 'bottom',
             align: 'start',
             labels: {
-              padding: 20
+              padding: 20,
+              font: {
+                lineHeight: 0.9
+              }
             }
           }
         }

--- a/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
+++ b/assets/vue/components/common/external/chartjs/HistoChartDoughnut.vue
@@ -15,7 +15,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from 'vue'
 import { Doughnut } from 'vue-chartjs'
 
@@ -57,8 +57,8 @@ export default defineComponent({
       default: 400
     },
     cssClasses: {
-      default: '',
-      type: String
+      type: String,
+      default: ''
     },
     styles: {
       type: Object,
@@ -113,7 +113,7 @@ export default defineComponent({
     }
   },
   methods: {
-    splitLabelIntoChunks (label, labelCharMax) {
+    splitLabelIntoChunks (label: string, labelCharMax: number) {
       const labelChunks = []
       let currentChunk = ''
       let currentLength = 0

--- a/assets/vue/components/common/external/chartjs/HistoChartLine.vue
+++ b/assets/vue/components/common/external/chartjs/HistoChartLine.vue
@@ -14,7 +14,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from 'vue'
 import { Line } from 'vue-chartjs'
 import { Chart as ChartJS, Title, Tooltip, Legend, LineElement, LinearScale, PointElement, CategoryScale, Filler } from 'chart.js'

--- a/assets/vue/components/common/external/chartjs/HistoChartPie.vue
+++ b/assets/vue/components/common/external/chartjs/HistoChartPie.vue
@@ -15,7 +15,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from 'vue'
 import { Pie } from 'vue-chartjs'
 

--- a/assets/vue/components/front-stats/TheHistoAppFrontStats.vue
+++ b/assets/vue/components/front-stats/TheHistoAppFrontStats.vue
@@ -97,11 +97,13 @@ export default defineComponent({
       this.sharedState.stats.countSignalementPerMonth = requestResponse.signalement_per_month
       this.sharedState.stats.countSignalementPerStatut = requestResponse.signalement_per_statut
       this.sharedState.stats.countSignalementPerMotifCloture = requestResponse.signalement_per_motif_cloture
+      this.sharedState.stats.countSignalementPerDesordresCategories = requestResponse.signalement_per_desordres_categories
       this.sharedState.stats.countSignalementPerLogementDesordres = requestResponse.signalement_per_logement_desordres
       this.sharedState.stats.countSignalementPerBatimentDesordres = requestResponse.signalement_per_batiment_desordres
       this.sharedState.stats.countSignalementPerMonthThisYear = requestResponse.signalement_per_month_this_year
       this.sharedState.stats.countSignalementPerStatutThisYear = requestResponse.signalement_per_statut_this_year
       this.sharedState.stats.countSignalementPerMotifClotureThisYear = requestResponse.signalement_per_motif_cloture_this_year
+      this.sharedState.stats.countSignalementPerDesordresCategoriesThisYear = requestResponse.signalement_per_desordres_categories_this_year
       this.sharedState.stats.countSignalementPerLogementDesordresThisYear = requestResponse.signalement_per_logement_desordres_this_year
       this.sharedState.stats.countSignalementPerBatimentDesordresThisYear = requestResponse.signalement_per_batiment_desordres_this_year
     }

--- a/assets/vue/components/front-stats/TheHistoAppFrontStats.vue
+++ b/assets/vue/components/front-stats/TheHistoAppFrontStats.vue
@@ -4,7 +4,9 @@
     class="histo-app-front-stats fr-pt-5w"
     :data-ajaxurl="sharedProps.ajaxurl"
     >
-    <h1>Histologe en quelques chiffres</h1>
+    <div class="fr-container">
+      <h1>Histologe en quelques chiffres</h1>
+    </div>
     <div v-if="loadingInit" class="loading fr-m-10w">
       Initialisation des statistiques...
     </div>
@@ -89,16 +91,19 @@ export default defineComponent({
       this.sharedState.stats.countTerritory = requestResponse.count_territory
       this.sharedState.stats.percentValidation = requestResponse.percent_validation
       this.sharedState.stats.percentCloture = requestResponse.percent_cloture
+      this.sharedState.stats.percentRefused = requestResponse.percent_refused
       this.sharedState.stats.countImported = requestResponse.count_imported
       this.sharedState.stats.countSignalementPerTerritory = requestResponse.signalement_per_territoire
       this.sharedState.stats.countSignalementPerMonth = requestResponse.signalement_per_month
       this.sharedState.stats.countSignalementPerStatut = requestResponse.signalement_per_statut
-      this.sharedState.stats.countSignalementPerSituation = requestResponse.signalement_per_situation
       this.sharedState.stats.countSignalementPerMotifCloture = requestResponse.signalement_per_motif_cloture
+      this.sharedState.stats.countSignalementPerLogementDesordres = requestResponse.signalement_per_logement_desordres
+      this.sharedState.stats.countSignalementPerBatimentDesordres = requestResponse.signalement_per_batiment_desordres
       this.sharedState.stats.countSignalementPerMonthThisYear = requestResponse.signalement_per_month_this_year
       this.sharedState.stats.countSignalementPerStatutThisYear = requestResponse.signalement_per_statut_this_year
-      this.sharedState.stats.countSignalementPerSituationThisYear = requestResponse.signalement_per_situation_this_year
       this.sharedState.stats.countSignalementPerMotifClotureThisYear = requestResponse.signalement_per_motif_cloture_this_year
+      this.sharedState.stats.countSignalementPerLogementDesordresThisYear = requestResponse.signalement_per_logement_desordres_this_year
+      this.sharedState.stats.countSignalementPerBatimentDesordresThisYear = requestResponse.signalement_per_batiment_desordres_this_year
     }
   }
 })
@@ -109,7 +114,7 @@ export default defineComponent({
     background-color: '#FFF';
   }
   .histo-app-front-stats h1 {
-    text-align: center;
+    text-align: left;
     color: var(--blue-france-sun-113-625);
   }
 

--- a/assets/vue/components/front-stats/TheHistoFrontStatsGlobal.vue
+++ b/assets/vue/components/front-stats/TheHistoFrontStatsGlobal.vue
@@ -18,6 +18,9 @@
           <TheHistoFrontStatsDetailsItem :data="strPercentClosed">
             <template #title>taux de clôture des signalements</template>
           </TheHistoFrontStatsDetailsItem>
+          <TheHistoFrontStatsDetailsItem :data="strPercentRefused">
+            <template #title>taux de signalements refusés</template>
+          </TheHistoFrontStatsDetailsItem>
         </div>
         <div class="fr-col-12 fr-col-lg-9">
           <HistoFranceMap :data=sharedState.stats.countSignalementPerTerritory />
@@ -73,6 +76,9 @@ export default defineComponent({
     },
     strPercentClosed () {
       return this.sharedState.stats.percentCloture.toString() + ' %'
+    },
+    strPercentRefused () {
+      return this.sharedState.stats.percentRefused.toString() + ' %'
     },
     strCountImported () {
       return this.sharedState.stats.countImported.toString()

--- a/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
+++ b/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="histo-front-stats-territory fr-px-5w fr-pt-5w">
     <div class="fr-container">
-      <h2>Evolution territoriale du logement</h2>
+      <h2>Evolution territoriale du mal-logement</h2>
       <label for="filter-territoires">Sélectionnez un territoire pour afficher ses statistiques</label>
       <HistoSelect
         id="filter-territoires"
@@ -14,30 +14,37 @@
       <div class="fr-container--fluid fr-my-10v">
         <div class="fr-grid-row fr-grid-row--gutters">
           <TheHistoFrontStatsTerritoryItem sizeClass="7" v-model="sharedState.filters.perMonthYearType" :onChange="handleChangePerMonth">
-            <template #title>Signalements déposés</template>
+            <template #title>Nombre de signalements déposés</template>
             <template #graph>
               <HistoChartLine v-if="!isLoadingPerMonth" :items=perMonthData />
             </template>
           </TheHistoFrontStatsTerritoryItem>
 
           <TheHistoFrontStatsTerritoryItem sizeClass="5" v-model="sharedState.filters.perStatutYearType" :onChange="handleChangePerStatut">
-            <template #title>Statut du signalement</template>
+            <template #title>Répartition des signalements par statut</template>
             <template #graph>
               <HistoChartPie v-if="!isLoadingPerStatut" :items=perStatutData />
             </template>
           </TheHistoFrontStatsTerritoryItem>
 
-          <TheHistoFrontStatsTerritoryItem sizeClass="7" v-model="sharedState.filters.perSituationYearType" :onChange="handleChangePerSituation">
-            <template #title>Répartition par famille de désordres</template>
+          <TheHistoFrontStatsTerritoryItem sizeClass="12" v-model="sharedState.filters.perMotifClotureYearType" :onChange="handleChangePerMotifCloture">
+            <template #title>Répartition des signalements clôturés par motif de clôture</template>
             <template #graph>
-              <HistoChartBar v-if="!isLoadingPerSituation" :items=perSituationData indexAxis="x" />
+              <HistoChartBar v-if="!isLoadingPerMotifCloture" :items=perMotifClotureData indexAxis="x"  />
             </template>
           </TheHistoFrontStatsTerritoryItem>
 
-          <TheHistoFrontStatsTerritoryItem sizeClass="5" v-model="sharedState.filters.perMotifClotureYearType" :onChange="handleChangePerMotifCloture">
-            <template #title>Motif de clôture</template>
+          <TheHistoFrontStatsTerritoryItem sizeClass="4" v-model="sharedState.filters.perLogementDesordresYearType" :onChange="handleChangePerLogementDesordres">
+            <template #title>Logement : désordres les plus courants*</template>
             <template #graph>
-              <HistoChartDoughnut v-if="!isLoadingPerMotifCloture" :items=perMotifClotureData />
+              <HistoChartDoughnut v-if="!isLoadingPerLogementDesordres" :items=perLogementDesordresData />
+            </template>
+          </TheHistoFrontStatsTerritoryItem>
+
+          <TheHistoFrontStatsTerritoryItem sizeClass="4" v-model="sharedState.filters.perBatimentDesordresYearType" :onChange="handleChangePerBatimentDesordres">
+            <template #title>Bâtiment : désordres les plus courants*</template>
+            <template #graph>
+              <HistoChartDoughnut v-if="!isLoadingPerBatimentDesordres" :items=perBatimentDesordresData />
             </template>
           </TheHistoFrontStatsTerritoryItem>
         </div>
@@ -75,8 +82,9 @@ export default defineComponent({
       sharedState: store.state,
       isLoadingPerMonth: false,
       isLoadingPerStatut: false,
-      isLoadingPerSituation: false,
-      isLoadingPerMotifCloture: false
+      isLoadingPerMotifCloture: false,
+      isLoadingPerLogementDesordres: false,
+      isLoadingPerBatimentDesordres: false
     }
   },
   methods: {
@@ -93,13 +101,17 @@ export default defineComponent({
       this.isLoadingPerStatut = true
       setTimeout(() => { this.isLoadingPerStatut = false }, 100)
     },
-    handleChangePerSituation () {
-      this.isLoadingPerSituation = true
-      setTimeout(() => { this.isLoadingPerSituation = false }, 100)
-    },
     handleChangePerMotifCloture () {
       this.isLoadingPerMotifCloture = true
       setTimeout(() => { this.isLoadingPerMotifCloture = false }, 100)
+    },
+    handleChangePerLogementDesordres () {
+      this.isLoadingPerLogementDesordres = true
+      setTimeout(() => { this.isLoadingPerLogementDesordres = false }, 100)
+    },
+    handleChangePerBatimentDesordres () {
+      this.isLoadingPerBatimentDesordres = true
+      setTimeout(() => { this.isLoadingPerBatimentDesordres = false }, 100)
     }
   },
   computed: {
@@ -115,17 +127,23 @@ export default defineComponent({
       }
       return this.sharedState.stats.countSignalementPerStatut
     },
-    perSituationData () {
-      if (this.sharedState.filters.perSituationYearType === 'year') {
-        return this.sharedState.stats.countSignalementPerSituationThisYear
-      }
-      return this.sharedState.stats.countSignalementPerSituation
-    },
     perMotifClotureData () {
       if (this.sharedState.filters.perMotifClotureYearType === 'year') {
         return this.sharedState.stats.countSignalementPerMotifClotureThisYear
       }
       return this.sharedState.stats.countSignalementPerMotifCloture
+    },
+    perLogementDesordresData () {
+      if (this.sharedState.filters.perLogementDesordresYearType === 'year') {
+        return this.sharedState.stats.countSignalementPerLogementDesordresThisYear
+      }
+      return this.sharedState.stats.countSignalementPerLogementDesordres
+    },
+    perBatimentDesordresData () {
+      if (this.sharedState.filters.perBatimentDesordresYearType === 'year') {
+        return this.sharedState.stats.countSignalementPerBatimentDesordresThisYear
+      }
+      return this.sharedState.stats.countSignalementPerBatimentDesordres
     }
   }
 })

--- a/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
+++ b/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
@@ -11,7 +11,7 @@
         :option-items=sharedState.filters.territoiresList
         />
 
-      <div class="fr-container--fluid fr-my-10v">
+      <div class="fr-container--fluid fr-py-5v">
         <div class="fr-grid-row fr-grid-row--gutters">
           <TheHistoFrontStatsTerritoryItem sizeClass="7" v-model="sharedState.filters.perMonthYearType" :onChange="handleChangePerMonth">
             <template #title>Nombre de signalements déposés</template>
@@ -41,7 +41,7 @@
           >
             <template #title>Désordres par catégorie</template>
             <template #graph>
-              <HistoChartDoughnut v-if="!isLoadingPerDesordresCategories" :items=perDesordresCategoriesData />
+              <HistoChartPie v-if="!isLoadingPerDesordresCategories" :items=perDesordresCategoriesData />
             </template>
           </TheHistoFrontStatsTerritoryItem>
 
@@ -69,6 +69,7 @@
             </template>
           </TheHistoFrontStatsTerritoryItem>
         </div>
+        <br>
         <i>* Les statistiques concernant les désordres les plus courants par catégorie sont disponibles depuis février 2024 uniquement.</i>
       </div>
     </div>

--- a/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
+++ b/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
@@ -34,20 +34,31 @@
             </template>
           </TheHistoFrontStatsTerritoryItem>
 
-          <TheHistoFrontStatsTerritoryItem sizeClass="4" v-model="sharedState.filters.perLogementDesordresYearType" :onChange="handleChangePerLogementDesordres">
+          <TheHistoFrontStatsTerritoryItem
+            sizeClass="4"
+            :isTotalActive="false"
+            v-model="sharedState.filters.perLogementDesordresYearType"
+            :onChange="handleChangePerLogementDesordres"
+          >
             <template #title>Logement : désordres les plus courants*</template>
             <template #graph>
               <HistoChartDoughnut v-if="!isLoadingPerLogementDesordres" :items=perLogementDesordresData />
             </template>
           </TheHistoFrontStatsTerritoryItem>
 
-          <TheHistoFrontStatsTerritoryItem sizeClass="4" v-model="sharedState.filters.perBatimentDesordresYearType" :onChange="handleChangePerBatimentDesordres">
+          <TheHistoFrontStatsTerritoryItem
+            sizeClass="4"
+            v-model="sharedState.filters.perBatimentDesordresYearType"
+            :onChange="handleChangePerBatimentDesordres"
+            :isTotalActive="false"
+          >
             <template #title>Bâtiment : désordres les plus courants*</template>
             <template #graph>
               <HistoChartDoughnut v-if="!isLoadingPerBatimentDesordres" :items=perBatimentDesordresData />
             </template>
           </TheHistoFrontStatsTerritoryItem>
         </div>
+        <i>* Les statistiques concernant les désordres les plus courants par catégorie sont disponibles depuis février 2024 uniquement.</i>
       </div>
     </div>
   </div>

--- a/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
+++ b/assets/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
@@ -36,6 +36,17 @@
 
           <TheHistoFrontStatsTerritoryItem
             sizeClass="4"
+            v-model="sharedState.filters.perDesordresCategoriesYearType"
+            :onChange="handleChangePerDesordresCategories"
+          >
+            <template #title>Désordres par catégorie</template>
+            <template #graph>
+              <HistoChartDoughnut v-if="!isLoadingPerDesordresCategories" :items=perDesordresCategoriesData />
+            </template>
+          </TheHistoFrontStatsTerritoryItem>
+
+          <TheHistoFrontStatsTerritoryItem
+            sizeClass="4"
             :isTotalActive="false"
             v-model="sharedState.filters.perLogementDesordresYearType"
             :onChange="handleChangePerLogementDesordres"
@@ -94,6 +105,7 @@ export default defineComponent({
       isLoadingPerMonth: false,
       isLoadingPerStatut: false,
       isLoadingPerMotifCloture: false,
+      isLoadingPerDesordresCategories: false,
       isLoadingPerLogementDesordres: false,
       isLoadingPerBatimentDesordres: false
     }
@@ -115,6 +127,10 @@ export default defineComponent({
     handleChangePerMotifCloture () {
       this.isLoadingPerMotifCloture = true
       setTimeout(() => { this.isLoadingPerMotifCloture = false }, 100)
+    },
+    handleChangePerDesordresCategories () {
+      this.isLoadingPerDesordresCategories = true
+      setTimeout(() => { this.isLoadingPerDesordresCategories = false }, 100)
     },
     handleChangePerLogementDesordres () {
       this.isLoadingPerLogementDesordres = true
@@ -143,6 +159,12 @@ export default defineComponent({
         return this.sharedState.stats.countSignalementPerMotifClotureThisYear
       }
       return this.sharedState.stats.countSignalementPerMotifCloture
+    },
+    perDesordresCategoriesData () {
+      if (this.sharedState.filters.perDesordresCategoriesYearType === 'year') {
+        return this.sharedState.stats.countSignalementPerDesordresCategoriesThisYear
+      }
+      return this.sharedState.stats.countSignalementPerDesordresCategories
     },
     perLogementDesordresData () {
       if (this.sharedState.filters.perLogementDesordresYearType === 'year') {

--- a/assets/vue/components/front-stats/TheHistoFrontStatsTerritoryItem.vue
+++ b/assets/vue/components/front-stats/TheHistoFrontStatsTerritoryItem.vue
@@ -2,7 +2,7 @@
   <div :class="[ 'histo-front-stats-territory-item fr-col-12 fr-mb-5w', 'fr-col-md-' + sizeClass ]">
     <div class="fr-p-2w">
       <div class="title"><slot name="title"></slot></div>
-      <TheHistoFrontStatsYearToggle v-model="yearType" :on-change="onYearTypeChange" />
+      <TheHistoFrontStatsYearToggle v-model="yearType" :on-change="onYearTypeChange" :isTotalActive="isTotalActive" />
       <div class="clear"></div>
       <div class="graph"><slot name="graph"></slot></div>
     </div>
@@ -19,6 +19,7 @@ export default defineComponent({
   props: {
     sizeClass: { type: String, default: '' },
     modelValue: { type: String, default: '' },
+    isTotalActive: { type: Boolean, default: true },
     onChange: { type: Function }
   },
   emits: ['update:modelValue'],

--- a/assets/vue/components/front-stats/TheHistoFrontStatsYearToggle.vue
+++ b/assets/vue/components/front-stats/TheHistoFrontStatsYearToggle.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="histo-front-stats-year-toggle">
     <div>
-      <button :class="classSelectedYear" @click="handleToggle('year')">{{ this.year }}</button>
-      <button :class="classSelectedAll" @click="handleToggle('all')">Total</button>
+      <button :class="classSelectedYear" @click="handleToggle('year')">{{ year }}</button>
+      <button v-if="isTotalActive" :class="classSelectedAll" @click="handleToggle('all')">Total</button>
     </div>
   </div>
 </template>
@@ -14,6 +14,7 @@ export default defineComponent({
   name: 'TheHistoFrontStatsYearToggle',
   props: {
     modelValue: { type: String, default: '' },
+    isTotalActive: { type: Boolean, default: true },
     onChange: { type: Function }
   },
   data () {

--- a/assets/vue/components/front-stats/store.ts
+++ b/assets/vue/components/front-stats/store.ts
@@ -5,8 +5,9 @@ export const store = {
     filters: {
       perMonthYearType: 'year',
       perStatutYearType: 'year',
-      perSituationYearType: 'year',
       perMotifClotureYearType: 'year',
+      perLogementDesordresYearType: 'year',
+      perBatimentDesordresYearType: 'year',
       territoire: 'all',
       territoiresList: new Array<HistoInterfaceSelectOption>()
     },
@@ -16,16 +17,19 @@ export const store = {
       countTerritory: 0,
       percentValidation: 0,
       percentCloture: 0,
+      percentRefused: 0,
       countImported: 0,
       countSignalementPerTerritory: Object,
       countSignalementPerMonth: Object,
       countSignalementPerStatut: Object,
-      countSignalementPerSituation: Object,
       countSignalementPerMotifCloture: Object,
+      countSignalementPerLogementDesordres: Object,
+      countSignalementPerBatimentDesordres: Object,
       countSignalementPerMonthThisYear: Object,
       countSignalementPerStatutThisYear: Object,
-      countSignalementPerSituationThisYear: Object,
-      countSignalementPerMotifClotureThisYear: Object
+      countSignalementPerMotifClotureThisYear: Object,
+      countSignalementPerLogementDesordresThisYear: Object,
+      countSignalementPerBatimentDesordresThisYear: Object
     }
   },
   props: {

--- a/assets/vue/components/front-stats/store.ts
+++ b/assets/vue/components/front-stats/store.ts
@@ -6,6 +6,7 @@ export const store = {
       perMonthYearType: 'year',
       perStatutYearType: 'year',
       perMotifClotureYearType: 'year',
+      perDesordresCategoriesYearType: 'year',
       perLogementDesordresYearType: 'year',
       perBatimentDesordresYearType: 'year',
       territoire: 'all',
@@ -23,11 +24,13 @@ export const store = {
       countSignalementPerMonth: Object,
       countSignalementPerStatut: Object,
       countSignalementPerMotifCloture: Object,
+      countSignalementPerDesordresCategories: Object,
       countSignalementPerLogementDesordres: Object,
       countSignalementPerBatimentDesordres: Object,
       countSignalementPerMonthThisYear: Object,
       countSignalementPerStatutThisYear: Object,
       countSignalementPerMotifClotureThisYear: Object,
+      countSignalementPerDesordresCategoriesThisYear: Object,
       countSignalementPerLogementDesordresThisYear: Object,
       countSignalementPerBatimentDesordresThisYear: Object
     }

--- a/src/Controller/FrontStatistiquesController.php
+++ b/src/Controller/FrontStatistiquesController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Repository\TerritoryRepository;
 use App\Service\Statistics\BatimentDesordresStatisticProvider;
+use App\Service\Statistics\DesordresCategoriesStatisticProvider;
 use App\Service\Statistics\GlobalAnalyticsProvider;
 use App\Service\Statistics\ListTerritoryStatisticProvider;
 use App\Service\Statistics\LogementDesordresStatisticProvider;
@@ -27,6 +28,7 @@ class FrontStatistiquesController extends AbstractController
         private TerritoryStatisticProvider $territoryStatisticProvider,
         private MonthStatisticProvider $monthStatisticProvider,
         private StatusStatisticProvider $statusStatisticProvider,
+        private DesordresCategoriesStatisticProvider $desordresCategoriesStatisticProvider,
         private LogementDesordresStatisticProvider $logementDesordresStatisticProvider,
         private BatimentDesordresStatisticProvider $batimentDesordresStatisticProvider,
         private MotifClotureStatisticProvider $motifClotureStatisticProvider
@@ -73,6 +75,9 @@ class FrontStatistiquesController extends AbstractController
 
         $this->ajaxResult['signalement_per_motif_cloture'] = $this->motifClotureStatisticProvider->getData($territory, null, 'bar');
         $this->ajaxResult['signalement_per_motif_cloture_this_year'] = $this->motifClotureStatisticProvider->getData($territory, $currentYear, 'bar');
+
+        $this->ajaxResult['signalement_per_desordres_categories'] = $this->desordresCategoriesStatisticProvider->getData($territory, null);
+        $this->ajaxResult['signalement_per_desordres_categories_this_year'] = $this->desordresCategoriesStatisticProvider->getData($territory, $currentYear);
 
         $this->ajaxResult['signalement_per_logement_desordres'] = $this->logementDesordresStatisticProvider->getData($territory, null);
         $this->ajaxResult['signalement_per_logement_desordres_this_year'] = $this->logementDesordresStatisticProvider->getData($territory, $currentYear);

--- a/src/Controller/FrontStatistiquesController.php
+++ b/src/Controller/FrontStatistiquesController.php
@@ -3,11 +3,12 @@
 namespace App\Controller;
 
 use App\Repository\TerritoryRepository;
+use App\Service\Statistics\BatimentDesordresStatisticProvider;
 use App\Service\Statistics\GlobalAnalyticsProvider;
 use App\Service\Statistics\ListTerritoryStatisticProvider;
+use App\Service\Statistics\LogementDesordresStatisticProvider;
 use App\Service\Statistics\MonthStatisticProvider;
 use App\Service\Statistics\MotifClotureStatisticProvider;
-use App\Service\Statistics\SituationStatisticProvider;
 use App\Service\Statistics\StatusStatisticProvider;
 use App\Service\Statistics\TerritoryStatisticProvider;
 use DateTime;
@@ -26,9 +27,10 @@ class FrontStatistiquesController extends AbstractController
         private TerritoryStatisticProvider $territoryStatisticProvider,
         private MonthStatisticProvider $monthStatisticProvider,
         private StatusStatisticProvider $statusStatisticProvider,
-        private SituationStatisticProvider $situationStatisticProvider,
+        private LogementDesordresStatisticProvider $logementDesordresStatisticProvider,
+        private BatimentDesordresStatisticProvider $batimentDesordresStatisticProvider,
         private MotifClotureStatisticProvider $motifClotureStatisticProvider
-        ) {
+    ) {
     }
 
     #[Route('/statistiques', name: 'front_statistiques')]
@@ -49,6 +51,7 @@ class FrontStatistiquesController extends AbstractController
         $this->ajaxResult['count_territory'] = $globalStatistics['count_territory'];
         $this->ajaxResult['percent_validation'] = $globalStatistics['percent_validation'];
         $this->ajaxResult['percent_cloture'] = $globalStatistics['percent_cloture'];
+        $this->ajaxResult['percent_refused'] = $globalStatistics['percent_refused'];
         $this->ajaxResult['count_imported'] = $globalStatistics['count_imported'];
 
         $this->ajaxResult['list_territoires'] = $this->listTerritoryStatisticProvider->getData();
@@ -68,11 +71,14 @@ class FrontStatistiquesController extends AbstractController
         $this->ajaxResult['signalement_per_statut'] = $this->statusStatisticProvider->getData($territory, null);
         $this->ajaxResult['signalement_per_statut_this_year'] = $this->statusStatisticProvider->getData($territory, $currentYear);
 
-        $this->ajaxResult['signalement_per_situation'] = $this->situationStatisticProvider->getData($territory, null);
-        $this->ajaxResult['signalement_per_situation_this_year'] = $this->situationStatisticProvider->getData($territory, $currentYear);
+        $this->ajaxResult['signalement_per_motif_cloture'] = $this->motifClotureStatisticProvider->getData($territory, null, 'bar');
+        $this->ajaxResult['signalement_per_motif_cloture_this_year'] = $this->motifClotureStatisticProvider->getData($territory, $currentYear, 'bar');
 
-        $this->ajaxResult['signalement_per_motif_cloture'] = $this->motifClotureStatisticProvider->getData($territory, null);
-        $this->ajaxResult['signalement_per_motif_cloture_this_year'] = $this->motifClotureStatisticProvider->getData($territory, $currentYear);
+        $this->ajaxResult['signalement_per_logement_desordres'] = $this->logementDesordresStatisticProvider->getData($territory, null);
+        $this->ajaxResult['signalement_per_logement_desordres_this_year'] = $this->logementDesordresStatisticProvider->getData($territory, $currentYear);
+
+        $this->ajaxResult['signalement_per_batiment_desordres'] = $this->batimentDesordresStatisticProvider->getData($territory, null);
+        $this->ajaxResult['signalement_per_batiment_desordres_this_year'] = $this->batimentDesordresStatisticProvider->getData($territory, $currentYear);
 
         return $this->json($this->ajaxResult);
     }

--- a/src/Service/Statistics/BatimentDesordresStatisticProvider.php
+++ b/src/Service/Statistics/BatimentDesordresStatisticProvider.php
@@ -29,7 +29,7 @@ class BatimentDesordresStatisticProvider
         $data = self::initBatimentDesordresPerValue();
         $i = 0;
         foreach ($countPerBatimentDesordres as $countPerBatimentDesordre) {
-            if ($data[$i]) {
+            if (isset($data[$i])) {
                 $data[$i]['count'] = $countPerBatimentDesordre['count'];
                 $data[$i]['label'] = $countPerBatimentDesordre['labelCritere'];
                 ++$i;

--- a/src/Service/Statistics/BatimentDesordresStatisticProvider.php
+++ b/src/Service/Statistics/BatimentDesordresStatisticProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Service\Statistics;
+
+use App\Entity\Enum\DesordreCritereZone;
+use App\Entity\Territory;
+use App\Repository\SignalementRepository;
+
+class BatimentDesordresStatisticProvider
+{
+    public function __construct(private SignalementRepository $signalementRepository)
+    {
+    }
+
+    public function getData(Territory|null $territory, int|null $year): array
+    {
+        $countPerBatimentDesordres = $this->signalementRepository->countByDesordresCriteres(
+            $territory,
+            $year,
+            true,
+            DesordreCritereZone::BATIMENT
+        );
+
+        return $this->createFullArray($countPerBatimentDesordres);
+    }
+
+    private function createFullArray($countPerBatimentDesordres): array
+    {
+        $data = self::initBatimentDesordresPerValue();
+        $i = 0;
+        foreach ($countPerBatimentDesordres as $countPerBatimentDesordre) {
+            if ($data[$i]) {
+                $data[$i]['count'] = $countPerBatimentDesordre['count'];
+                $data[$i]['label'] = $countPerBatimentDesordre['labelCritere'];
+                ++$i;
+            }
+        }
+
+        return $data;
+    }
+
+    private static function initBatimentDesordresPerValue(): array
+    {
+        return [
+            0 => [
+                'label' => '',
+                'color' => '#2F4077',
+                'count' => 0,
+            ],
+            1 => [
+                'label' => '',
+                'color' => '#447049',
+                'count' => 0,
+            ],
+            2 => [
+                'label' => '',
+                'color' => '#6E445A',
+                'count' => 0,
+            ],
+            3 => [
+                'label' => '',
+                'color' => '#716043',
+                'count' => 0,
+            ],
+            4 => [
+                'label' => '',
+                'color' => '#8D533E',
+                'count' => 0,
+            ],
+        ];
+    }
+}

--- a/src/Service/Statistics/BatimentDesordresStatisticProvider.php
+++ b/src/Service/Statistics/BatimentDesordresStatisticProvider.php
@@ -17,7 +17,6 @@ class BatimentDesordresStatisticProvider
         $countPerBatimentDesordres = $this->signalementRepository->countByDesordresCriteres(
             $territory,
             $year,
-            true,
             DesordreCritereZone::BATIMENT
         );
 

--- a/src/Service/Statistics/DesordresCategoriesStatisticProvider.php
+++ b/src/Service/Statistics/DesordresCategoriesStatisticProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Service\Statistics;
+
+use App\Entity\Territory;
+use App\Repository\SignalementRepository;
+
+class DesordresCategoriesStatisticProvider
+{
+    public function __construct(private SignalementRepository $signalementRepository)
+    {
+    }
+
+    public function getData(Territory|null $territory, int|null $year): array
+    {
+        $countPerDesordresCategories = $this->signalementRepository->countCritereByZone(
+            $territory,
+            $year,
+            true
+        );
+
+        return $this->createFullArray($countPerDesordresCategories);
+    }
+
+    private function createFullArray($countPerDesordresCategories): array
+    {
+        $data = self::initDesordresCategoriesPerValue();
+
+        $data[0]['count'] = $countPerDesordresCategories['critere_batiment_count'] + $countPerDesordresCategories['desordrecritere_batiment_count'];
+        $data[1]['count'] = $countPerDesordresCategories['critere_logement_count'] + $countPerDesordresCategories['desordrecritere_logement_count'];
+
+        return $data;
+    }
+
+    private static function initDesordresCategoriesPerValue(): array
+    {
+        return [
+            0 => [
+                'label' => 'Bâtiment',
+                'color' => '#2F4077',
+                'count' => 0,
+            ],
+            1 => [
+                'label' => 'Logement',
+                'color' => '#447049',
+                'count' => 0,
+            ],
+        ];
+    }
+}

--- a/src/Service/Statistics/DesordresCategoriesStatisticProvider.php
+++ b/src/Service/Statistics/DesordresCategoriesStatisticProvider.php
@@ -15,8 +15,7 @@ class DesordresCategoriesStatisticProvider
     {
         $countPerDesordresCategories = $this->signalementRepository->countCritereByZone(
             $territory,
-            $year,
-            true
+            $year
         );
 
         return $this->createFullArray($countPerDesordresCategories);

--- a/src/Service/Statistics/DesordresCategoriesStatisticProvider.php
+++ b/src/Service/Statistics/DesordresCategoriesStatisticProvider.php
@@ -22,12 +22,12 @@ class DesordresCategoriesStatisticProvider
         return $this->createFullArray($countPerDesordresCategories);
     }
 
-    private function createFullArray($countPerDesordresCategories): array
+    private function createFullArray(array $dataZone): array
     {
         $data = self::initDesordresCategoriesPerValue();
 
-        $data[0]['count'] = $countPerDesordresCategories['critere_batiment_count'] + $countPerDesordresCategories['desordrecritere_batiment_count'];
-        $data[1]['count'] = $countPerDesordresCategories['critere_logement_count'] + $countPerDesordresCategories['desordrecritere_logement_count'];
+        $data['BATIMENT']['count'] = $dataZone['critere_batiment_count'] + $dataZone['desordrecritere_batiment_count'];
+        $data['LOGEMENT']['count'] = $dataZone['critere_logement_count'] + $dataZone['desordrecritere_logement_count'];
 
         return $data;
     }
@@ -35,12 +35,12 @@ class DesordresCategoriesStatisticProvider
     private static function initDesordresCategoriesPerValue(): array
     {
         return [
-            0 => [
+            'BATIMENT' => [
                 'label' => 'Bâtiment',
                 'color' => '#2F4077',
                 'count' => 0,
             ],
-            1 => [
+            'LOGEMENT' => [
                 'label' => 'Logement',
                 'color' => '#447049',
                 'count' => 0,

--- a/src/Service/Statistics/GlobalAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalAnalyticsProvider.php
@@ -90,7 +90,7 @@ class GlobalAnalyticsProvider
     {
         $total = $this->getCountSignalementData();
         if ($total > 0) {
-            return round($this->signalementRepository->countRefused(true) / $total * 1000) / 10;
+            return round($this->signalementRepository->countRefused() / $total * 1000) / 10;
         }
 
         return '-';

--- a/src/Service/Statistics/GlobalAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalAnalyticsProvider.php
@@ -22,6 +22,7 @@ class GlobalAnalyticsProvider
         $data['count_territory'] = $this->getCountTerritoryData();
         $data['percent_validation'] = $this->getValidatedData();
         $data['percent_cloture'] = $this->getClotureData();
+        $data['percent_refused'] = $this->getRefusedData();
         $data['count_imported'] = $this->getImportedData();
 
         return $data;
@@ -80,6 +81,16 @@ class GlobalAnalyticsProvider
         $total = $this->getCountSignalementData();
         if ($total > 0) {
             return round($this->signalementRepository->countClosed(true) / $total * 1000) / 10;
+        }
+
+        return '-';
+    }
+
+    private function getRefusedData(): string|float
+    {
+        $total = $this->getCountSignalementData();
+        if ($total > 0) {
+            return round($this->signalementRepository->countRefused(true) / $total * 1000) / 10;
         }
 
         return '-';

--- a/src/Service/Statistics/LogementDesordresStatisticProvider.php
+++ b/src/Service/Statistics/LogementDesordresStatisticProvider.php
@@ -17,7 +17,6 @@ class LogementDesordresStatisticProvider
         $countPerLogementDesordres = $this->signalementRepository->countByDesordresCriteres(
             $territory,
             $year,
-            true,
             DesordreCritereZone::LOGEMENT
         );
 

--- a/src/Service/Statistics/LogementDesordresStatisticProvider.php
+++ b/src/Service/Statistics/LogementDesordresStatisticProvider.php
@@ -29,7 +29,7 @@ class LogementDesordresStatisticProvider
         $data = self::initLogementDesordresPerValue();
         $i = 0;
         foreach ($countPerLogementDesordres as $countPerLogementDesordre) {
-            if ($data[$i]) {
+            if (isset($data[$i])) {
                 $data[$i]['count'] = $countPerLogementDesordre['count'];
                 $data[$i]['label'] = $countPerLogementDesordre['labelCritere'];
                 ++$i;

--- a/src/Service/Statistics/LogementDesordresStatisticProvider.php
+++ b/src/Service/Statistics/LogementDesordresStatisticProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Service\Statistics;
+
+use App\Entity\Enum\DesordreCritereZone;
+use App\Entity\Territory;
+use App\Repository\SignalementRepository;
+
+class LogementDesordresStatisticProvider
+{
+    public function __construct(private SignalementRepository $signalementRepository)
+    {
+    }
+
+    public function getData(Territory|null $territory, int|null $year): array
+    {
+        $countPerLogementDesordres = $this->signalementRepository->countByDesordresCriteres(
+            $territory,
+            $year,
+            true,
+            DesordreCritereZone::LOGEMENT
+        );
+
+        return $this->createFullArray($countPerLogementDesordres);
+    }
+
+    private function createFullArray($countPerLogementDesordres): array
+    {
+        $data = self::initLogementDesordresPerValue();
+        $i = 0;
+        foreach ($countPerLogementDesordres as $countPerLogementDesordre) {
+            if ($data[$i]) {
+                $data[$i]['count'] = $countPerLogementDesordre['count'];
+                $data[$i]['label'] = $countPerLogementDesordre['labelCritere'];
+                ++$i;
+            }
+        }
+
+        return $data;
+    }
+
+    private static function initLogementDesordresPerValue(): array
+    {
+        return [
+            0 => [
+                'label' => '',
+                'color' => '#2F4077',
+                'count' => 0,
+            ],
+            1 => [
+                'label' => '',
+                'color' => '#447049',
+                'count' => 0,
+            ],
+            2 => [
+                'label' => '',
+                'color' => '#6E445A',
+                'count' => 0,
+            ],
+            3 => [
+                'label' => '',
+                'color' => '#716043',
+                'count' => 0,
+            ],
+            4 => [
+                'label' => '',
+                'color' => '#8D533E',
+                'count' => 0,
+            ],
+        ];
+    }
+}

--- a/src/Service/Statistics/MotifClotureStatisticProvider.php
+++ b/src/Service/Statistics/MotifClotureStatisticProvider.php
@@ -19,11 +19,28 @@ class MotifClotureStatisticProvider
         return $this->createFullArray($countPerMotifsCloture);
     }
 
-    public function getData(Territory|null $territory, int|null $year): array
-    {
+    public function getData(
+        Territory|null $territory,
+        int|null $year,
+        string $type = 'doughnut'
+    ): array {
         $countPerMotifsCloture = $this->signalementRepository->countByMotifCloture($territory, $year, true);
 
-        return $this->createFullArray($countPerMotifsCloture);
+        if ('doughnut' === $type) {
+            return $this->createFullArray($countPerMotifsCloture);
+        }
+
+        return $this->createArrayBar($countPerMotifsCloture);
+    }
+
+    private function createArrayBar($countPerMotifsCloture): array
+    {
+        $data = [];
+        foreach ($countPerMotifsCloture as $countPerMotifCloture) {
+            $data[$countPerMotifCloture['motifCloture']->label()] = $countPerMotifCloture['count'];
+        }
+
+        return $data;
     }
 
     private function createFullArray($countPerMotifsCloture): array

--- a/tests/Functional/Controller/FrontStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/FrontStatistiquesControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class FrontStatistiquesControllerTest extends WebTestCase
+{
+    public function testFrontStatistiques(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request(
+            'GET',
+            $router->generate(
+                'front_statistiques_filter'
+            )
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+
+        $expectedResponses = [
+            ['result' => 1, 'label' => 'count_signalement_resolus'],
+            ['result' => 38, 'label' => 'count_signalement'],
+        ];
+
+        foreach ($expectedResponses as $expectedResponse) {
+            $this->assertEquals($expectedResponse['result'], $response[$expectedResponse['label']]);
+        }
+        $this->assertEquals($response['count_territory'], \count($response['list_territoires']));
+        $this->assertEquals(2, \count($response['signalement_per_desordres_categories']));
+        $this->assertArrayHasKey('BATIMENT', $response['signalement_per_desordres_categories']);
+        $this->assertArrayHasKey('LOGEMENT', $response['signalement_per_desordres_categories']);
+        $this->assertEquals(5, \count($response['signalement_per_logement_desordres']));
+        $this->assertEquals(5, \count($response['signalement_per_batiment_desordres']));
+    }
+}

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -101,4 +101,34 @@ class SignalementRepositoryTest extends KernelTestCase
 
         $this->assertTrue($signalement->hasQualificaton(Qualification::RSD));
     }
+
+    public function testCountRefused(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $signalementsRefused = $signalementRepository->countRefused();
+        $this->assertEquals(1, $signalementsRefused);
+    }
+
+    public function testCountCritereByZone(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $zones = $signalementRepository->countCritereByZone(null, null);
+        $this->assertEquals(4, \count($zones));
+        $this->assertArrayHasKey('critere_batiment_count', $zones);
+        $this->assertArrayHasKey('critere_logement_count', $zones);
+        $this->assertArrayHasKey('desordrecritere_batiment_count', $zones);
+        $this->assertArrayHasKey('desordrecritere_logement_count', $zones);
+    }
+
+    public function testCountByDesordresCriteres(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $desordreCriteres = $signalementRepository->countByDesordresCriteres(null, null, null);
+        $this->assertEquals(5, \count($desordreCriteres));
+        $this->assertArrayHasKey('count', $desordreCriteres[0]);
+        $this->assertArrayHasKey('labelCritere', $desordreCriteres[0]);
+    }
 }

--- a/tests/Functional/Service/Statistics/BatimentDesordresStatisticProviderTest.php
+++ b/tests/Functional/Service/Statistics/BatimentDesordresStatisticProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Tests\Functional\Service\Statistics;
+
+use App\Repository\SignalementRepository;
+use App\Service\Statistics\BatimentDesordresStatisticProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class BatimentDesordresStatisticProviderTest extends KernelTestCase
+{
+    public function testGetData(): void
+    {
+        self::bootKernel();
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $data = (new BatimentDesordresStatisticProvider($signalementRepository))->getData(null, null);
+
+        $this->assertEquals(5, \count($data));
+        $this->assertArrayHasKey('label', $data[0]);
+        $this->assertArrayHasKey('count', $data[0]);
+        $this->assertArrayHasKey('color', $data[0]);
+        $this->assertEquals('#2F4077', $data[0]['color']);
+    }
+}

--- a/tests/Functional/Service/Statistics/DesordresCategoriesStatisticProviderTest.php
+++ b/tests/Functional/Service/Statistics/DesordresCategoriesStatisticProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tests\Functional\Service\Statistics;
+
+use App\Repository\SignalementRepository;
+use App\Service\Statistics\DesordresCategoriesStatisticProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DesordresCategoriesStatisticProviderTest extends KernelTestCase
+{
+    public function testGetData(): void
+    {
+        self::bootKernel();
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $data = (new DesordresCategoriesStatisticProvider($signalementRepository))->getData(null, null);
+
+        $this->assertEquals(2, \count($data));
+        $this->assertArrayHasKey('BATIMENT', $data);
+        $this->assertArrayHasKey('LOGEMENT', $data);
+        $this->assertArrayHasKey('color', $data['BATIMENT']);
+        $this->assertArrayHasKey('label', $data['BATIMENT']);
+        $this->assertArrayHasKey('count', $data['BATIMENT']);
+        $this->assertEquals('#2F4077', $data['BATIMENT']['color']);
+        $this->assertEquals('Bâtiment', $data['BATIMENT']['label']);
+        $this->assertEquals('#447049', $data['LOGEMENT']['color']);
+        $this->assertEquals('Logement', $data['LOGEMENT']['label']);
+    }
+}

--- a/tests/Functional/Service/Statistics/GlobalAnalyticsProviderTest.php
+++ b/tests/Functional/Service/Statistics/GlobalAnalyticsProviderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Tests\Functional\Service\Statistics;
+
+use App\Repository\SignalementRepository;
+use App\Repository\TerritoryRepository;
+use App\Service\Statistics\GlobalAnalyticsProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GlobalAnalyticsProviderTest extends KernelTestCase
+{
+    public function testGetData(): void
+    {
+        self::bootKernel();
+        /** @var TerritoryRepository $territoryRepository */
+        $territoryRepository = self::getContainer()->get(TerritoryRepository::class);
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $data = (new GlobalAnalyticsProvider($signalementRepository, $territoryRepository))->getData();
+
+        $this->assertEquals(7, \count($data));
+        $this->assertArrayHasKey('count_signalement_resolus', $data);
+        $this->assertArrayHasKey('count_signalement', $data);
+        $this->assertArrayHasKey('count_territory', $data);
+        $this->assertArrayHasKey('percent_validation', $data);
+        $this->assertArrayHasKey('percent_cloture', $data);
+        $this->assertArrayHasKey('percent_refused', $data);
+        $this->assertArrayHasKey('count_imported', $data);
+    }
+}

--- a/tests/Functional/Service/Statistics/LogementDesordresStatisticProviderTest.php
+++ b/tests/Functional/Service/Statistics/LogementDesordresStatisticProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Tests\Functional\Service\Statistics;
+
+use App\Repository\SignalementRepository;
+use App\Service\Statistics\LogementDesordresStatisticProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class LogementDesordresStatisticProviderTest extends KernelTestCase
+{
+    public function testGetData(): void
+    {
+        self::bootKernel();
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $data = (new LogementDesordresStatisticProvider($signalementRepository))->getData(null, null);
+
+        $this->assertEquals(5, \count($data));
+        $this->assertArrayHasKey('label', $data[0]);
+        $this->assertArrayHasKey('count', $data[0]);
+        $this->assertArrayHasKey('color', $data[0]);
+        $this->assertEquals('#2F4077', $data[0]['color']);
+    }
+}

--- a/tests/Functional/Service/Statistics/MotifClotureStatisticProviderTest.php
+++ b/tests/Functional/Service/Statistics/MotifClotureStatisticProviderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tests\Functional\Service\Statistics;
+
+use App\Repository\SignalementRepository;
+use App\Service\Statistics\MotifClotureStatisticProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class MotifClotureStatisticProviderTest extends KernelTestCase
+{
+    public function testGetDataDoughnut(): void
+    {
+        self::bootKernel();
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $data = (new MotifClotureStatisticProvider($signalementRepository))->getData(null, null);
+
+        $this->assertEquals(14, \count($data));
+        $this->assertArrayHasKey('TRAVAUX_FAITS_OU_EN_COURS', $data);
+        $this->assertArrayHasKey('color', $data['TRAVAUX_FAITS_OU_EN_COURS']);
+        $this->assertArrayHasKey('label', $data['TRAVAUX_FAITS_OU_EN_COURS']);
+        $this->assertArrayHasKey('count', $data['TRAVAUX_FAITS_OU_EN_COURS']);
+        $this->assertEquals('#18753C', $data['TRAVAUX_FAITS_OU_EN_COURS']['color']);
+        $this->assertEquals('Travaux faits ou en cours', $data['TRAVAUX_FAITS_OU_EN_COURS']['label']);
+    }
+
+    public function testGetDataBar(): void
+    {
+        self::bootKernel();
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $data = (new MotifClotureStatisticProvider($signalementRepository))->getData(null, null, 'bar');
+        $this->assertEquals(3, \count($data));
+        $this->assertArrayHasKey('Abandon de procédure / absence de réponse', $data);
+        $this->assertEquals(1, $data['Abandon de procédure / absence de réponse']);
+        $this->assertArrayHasKey('Non décence', $data);
+        $this->assertEquals(2, $data['Non décence']);
+        $this->assertArrayHasKey('Travaux faits ou en cours', $data);
+        $this->assertEquals(1, $data['Travaux faits ou en cours']);
+    }
+}


### PR DESCRIPTION
## Ticket

#1550    

## Description
Mise à jour des statistiques publiques http://localhost:8080/statistiques

- [ ] Dans la partie "Histologe en quelques chiffres", à la fin, ajouter une carte `Taux de signalements refusés` qui correspond au % de signalements refusés / nb signalements enregistrés (sans les archivés et importés) 
- [ ] Passer le donut "Motif de clôture" en barres verticales
- [ ] Supprimer le graph barres verticales "RÉPARTITION PAR FAMILLE DE DÉSORDRES"
- [ ] Ajouter un diagramme circulaire plein "DÉSORDRES PAR CATÉGORIE" qui reprend la proportion désordres par zone (logement ou bâtiment) -> voir le tableau pour la catégorisation des désordres de l'ancien formulaire
- [ ] Ajouter un diagramme circulaire creux (donut) "LOGEMENT : DÉSORDRES LES PLUS COURANTS*" : qui affiche les 5 désordres les plus renseignés pour le logement depuis la mise en ligne uniquement
- [ ] Ajouter un diagramme circulaire creux (donut) "BÂTIMENT : DÉSORDRES LES PLUS COURANTS*" : qui affiche les 5 désordres les plus renseignés pour le bâtiment depuis la mise en ligne uniquement
- [ ] Pour ces 2 derniers diagrammes, l'élément "Total" est inactif -> on affiche que les résultats depuis la mise en ligne et on met une astérisque en dessous

Le [prototype de la nouvelle page](https://xd.adobe.com/view/8959c3fa-ca2e-4042-9983-5db664d3009e-dc0a/screen/c61af72f-bd7c-4361-a079-db7b1cba595e/) dispo sur Adobe Xd.

## Changements apportés
* Mise à jour des composants Vue
* Création de nouveaux providers

## Pré-requis

## Tests
- [ ] Aller vérifier l'affichage de la nouvelle page stats front
- [ ] Vérifier la cohérence des données
