### PR TITLE
[FO - page de suivi] Changement du texte si on n'a pas de photo

### DIFF
--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -132,7 +132,7 @@
             {% else %}
                 <div class="fr-grid-row fr-grid-row--middle fr-background-contrast--red-marianne fr-rounded fr-p-5v">
                     <div class="fr-col-12">
-                        Aucune photo à afficher
+                        Aucune photo à afficher, si vous avez ajouté des photos dans votre signalement, rafraîchissez la page pour les voir apparaître.
                     </div>
                 </div>
             {% endfor %}


### PR DESCRIPTION
## Ticket

#2436    

## Description
Suite à un ticket de Mathilde, on s'est aperçus que l'ouverture de la page de suivi juste après le déôt du signalement pouvait ne pas montrer les photos ajoutées dans le signalement (traitement asynchrone du worker).
Pour ne pas laisser penser à un bug on change le texte.

## Changements apportés
* changement du twig

## Pré-requis

## Tests
- [ ] Couper le worker
- [ ] Faire un signalement avec des photos
- [ ] Ouvrir la page de suivi juste après la validation
- [ ] Vérifier le texte
- [ ] Redémamrrer le worker, puis rafraichir la page de suivi
- [ ] Les photos doivent apparaitre
