### PR TITLE
[FO - Signalement] Saisie des adresses hors-BAN

### DIFF
--- a/assets/vue/components/signalement-form/address_subscreen.json
+++ b/assets/vue/components/signalement-form/address_subscreen.json
@@ -10,13 +10,21 @@
             "type": "SignalementFormTextfield",
             "label": "Code postal",
             "slug": "detail_code_postal",
-            "tagWhenEdit": "detail_manual"
+            "tagWhenEdit": "detail_manual",
+            "searchWhenEdit": {
+                "values": ["detail_code_postal", "detail_commune"],
+                "result": "detail_insee"
+            }
         },
         {
             "type": "SignalementFormTextfield",
             "label": "Commune",
             "slug": "detail_commune",
-            "tagWhenEdit": "detail_manual"
+            "tagWhenEdit": "detail_manual",
+            "searchWhenEdit": {
+                "values": ["detail_code_postal", "detail_commune"],
+                "result": "detail_insee"
+            }
         }
     ]
 }

--- a/assets/vue/components/signalement-form/address_subscreen.json
+++ b/assets/vue/components/signalement-form/address_subscreen.json
@@ -3,20 +3,17 @@
         {
         "type": "SignalementFormTextfield",
         "label": "Numéro et voie",
-        "slug": "detail_numero",
-        "disabled": true
+        "slug": "detail_numero"
         },
         {
         "type": "SignalementFormTextfield",
         "label": "Code postal",
-        "slug": "detail_code_postal",
-        "disabled": true
+        "slug": "detail_code_postal"
         },
         {
         "type": "SignalementFormTextfield",
         "label": "Commune",
-        "slug": "detail_commune",
-        "disabled": true
+        "slug": "detail_commune"
         }
     ]
 }

--- a/assets/vue/components/signalement-form/address_subscreen.json
+++ b/assets/vue/components/signalement-form/address_subscreen.json
@@ -1,19 +1,22 @@
 {
     "body": [
         {
-        "type": "SignalementFormTextfield",
-        "label": "Numéro et voie",
-        "slug": "detail_numero"
+            "type": "SignalementFormTextfield",
+            "label": "Numéro et voie",
+            "slug": "detail_numero",
+            "tagWhenEdit": "detail_manual"
         },
         {
-        "type": "SignalementFormTextfield",
-        "label": "Code postal",
-        "slug": "detail_code_postal"
+            "type": "SignalementFormTextfield",
+            "label": "Code postal",
+            "slug": "detail_code_postal",
+            "tagWhenEdit": "detail_manual"
         },
         {
-        "type": "SignalementFormTextfield",
-        "label": "Commune",
-        "slug": "detail_commune"
+            "type": "SignalementFormTextfield",
+            "label": "Commune",
+            "slug": "detail_commune",
+            "tagWhenEdit": "detail_manual"
         }
     ]
 }

--- a/assets/vue/components/signalement-form/address_subscreen.json
+++ b/assets/vue/components/signalement-form/address_subscreen.json
@@ -10,21 +10,13 @@
             "type": "SignalementFormTextfield",
             "label": "Code postal",
             "slug": "detail_code_postal",
-            "tagWhenEdit": "detail_manual",
-            "searchWhenEdit": {
-                "values": ["detail_code_postal", "detail_commune"],
-                "result": "detail_insee"
-            }
+            "tagWhenEdit": "detail_manual"
         },
         {
             "type": "SignalementFormTextfield",
             "label": "Commune",
             "slug": "detail_commune",
-            "tagWhenEdit": "detail_manual",
-            "searchWhenEdit": {
-                "values": ["detail_code_postal", "detail_commune"],
-                "result": "detail_insee"
-            }
+            "tagWhenEdit": "detail_manual"
         }
     ]
 }

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -152,6 +152,7 @@ export default defineComponent({
         this.formStore.data[this.id + '_detail_insee'] = this.suggestions[index].properties.citycode
         this.formStore.data[this.id + '_detail_geoloc_lng'] = this.suggestions[index].geometry.coordinates[0]
         this.formStore.data[this.id + '_detail_geoloc_lat'] = this.suggestions[index].geometry.coordinates[1]
+        this.formStore.data[this.id + '_detail_manual'] = 0
         if (this.isTerritoryToCheck) {
           requests.checkTerritory(
             this.suggestions[index].properties.postcode,

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -26,8 +26,8 @@
     <SignalementFormButton
       :key="idShow"
       :id="idShow"
-      label="Afficher tous les champs"
-      :customCss="buttonCss + ' btn-link fr-btn--icon-left fr-icon-eye-line'"
+      label="Saisir une adresse manuellement"
+      :customCss="buttonCss + ' btn-link fr-btn--icon-left fr-icon-edit-line'"
       :validate="validate"
       :action="actionShow"
       :clickEvent="handleClickButton"

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -27,11 +27,8 @@
       :key="idShow"
       :id="idShow"
       label="Afficher tous les champs"
-      customCss="btn-link fr-btn--icon-left fr-icon-eye-line"
+      :customCss="buttonCss + ' btn-link fr-btn--icon-left fr-icon-eye-line'"
       :validate="validate"
-      v-model="formStore.data[idShow]"
-      :hasError="formStore.validationErrors[idShow] !== undefined"
-      :error="formStore.validationErrors[idShow]"
       :action="actionShow"
       :clickEvent="handleClickButton"
     />
@@ -40,7 +37,7 @@
       :key="idSubscreen"
       :id="idSubscreen"
       label=""
-      customCss="fr-hidden fr-mt-3v"
+      :customCss="subscreenCss + ' fr-mt-3v'"
       :components="screens"
       :validate="validate"
       v-model="formStore.data[idSubscreen]"
@@ -95,6 +92,7 @@ export default defineComponent({
     subscreenManager.addSubscreenData(this.id, updatedSubscreenData)
     return {
       idFetchTimeout: 0 as unknown as ReturnType<typeof setTimeout>,
+      isTyping: false,
       idAddress: this.id + '_suggestion',
       idShow: this.id + '_afficher_les_champs',
       idSubscreen: this.id + '_detail',
@@ -117,7 +115,9 @@ export default defineComponent({
           return
         }
         clearTimeout(this.idFetchTimeout)
+        this.isTyping = true
         this.idFetchTimeout = setTimeout(() => {
+          this.isTyping = false
           if (newValue.length > 10) {
             const codePostal = this.idAddress === 'adresse_logement_adresse_suggestion'
               ? ' ' + this.getCodePostalFromQueryParam()
@@ -127,12 +127,81 @@ export default defineComponent({
         }, 200)
       }
     )
+    watch(
+      () => this.formStore.data[this.id + '_detail_code_postal'],
+      async () => {
+        this.handleAddressFieldsEdited()
+      }
+    )
+    watch(
+      () => this.formStore.data[this.id + '_detail_commune'],
+      async () => {
+        this.handleAddressFieldsEdited()
+      }
+    )
+  },
+  computed: {
+    buttonCss () {
+      if (
+        this.formStore.data[this.idShow] ||
+          this.formStore.data[this.id + '_detail_numero'] ||
+          this.formStore.data[this.id + '_detail_code_postal'] ||
+          this.formStore.data[this.id + '_detail_commune']
+      ) {
+        return 'fr-hidden'
+      }
+      return ''
+    },
+    subscreenCss () {
+      if (this.buttonCss === '') {
+        return 'fr-hidden'
+      }
+      return ''
+    }
   },
   methods: {
     updateValue (value: any) {
       this.$emit('update:modelValue', value)
     },
+    handleAddressFieldsEdited () {
+      let isUpdateAddress = true
+      let search = ''
+      if (formStore.data[this.id + '_detail_code_postal'] === '' || formStore.data[this.id + '_detail_code_postal'] === undefined) {
+        isUpdateAddress = false
+      } else {
+        search = formStore.data[this.id + '_detail_code_postal'] + ' '
+      }
+
+      if (formStore.data[this.id + '_detail_commune'] === '' || formStore.data[this.id + '_detail_commune'] === undefined) {
+        isUpdateAddress = false
+      } else {
+        search += formStore.data[this.id + '_detail_commune']
+      }
+
+      if (isUpdateAddress) {
+        this.isTyping = true
+        clearTimeout(this.idFetchTimeout)
+        this.idFetchTimeout = setTimeout(() => {
+          this.isTyping = false
+          requests.validateAddress(search, this.handleUpdateInsee)
+        }, 300)
+      }
+    },
+    handleUpdateInsee (requestResponse: any) {
+      // Si le code postal / la commune ont été édités à la main, on valide l'ouverture du territoire
+      if (requestResponse.features !== undefined) {
+        const suggestions = requestResponse.features
+        if (suggestions[0] !== undefined) {
+          formStore.data[this.id + '_detail_insee'] = suggestions[0].properties.citycode
+          this.checkTerritory(
+            formStore.data[this.id + '_detail_code_postal'],
+            formStore.data[this.id + '_detail_insee']
+          )
+        }
+      }
+    },
     handleClickButton (type:string, param:string, slugButton:string) {
+      this.formStore.data[this.idShow] = 1
       if (this.clickEvent !== undefined) {
         this.clickEvent(type, param, slugButton)
       }
@@ -154,27 +223,22 @@ export default defineComponent({
         this.formStore.data[this.id + '_detail_geoloc_lat'] = this.suggestions[index].geometry.coordinates[1]
         this.formStore.data[this.id + '_detail_manual'] = 0
         if (this.isTerritoryToCheck) {
-          requests.checkTerritory(
+          this.checkTerritory(
             this.suggestions[index].properties.postcode,
-            this.suggestions[index].properties.citycode,
-            this.handleTerritoryChecked
+            this.suggestions[index].properties.citycode
           )
         }
         this.suggestions.length = 0
-      }
-      const subscreen = document.querySelector('#' + this.idSubscreen)
-      const buttonShow = document.querySelector('#' + this.idShow)
-      if (subscreen) {
-        subscreen.classList.remove('fr-hidden')
-      }
-      if (buttonShow) {
-        buttonShow.classList.add('fr-hidden')
       }
     },
     handleAddressFound (requestResponse: any) {
       this.suggestions = requestResponse.features
     },
     handleTerritoryChecked (requestResponse: any) {
+      // Si on a re-saisi du texte entre-temps, pas la peine de faire cette requête complémentaire
+      if (this.isTyping) {
+        return
+      }
       if (!requestResponse.success) {
         this.modalLabel = requestResponse.label
         this.modalDescription = requestResponse.message
@@ -183,6 +247,13 @@ export default defineComponent({
         this.formStore.data[this.id] = ''
       }
       this.isSearchSkipped = false
+    },
+    checkTerritory (postCode: any, cityCode: any) {
+      requests.checkTerritory(
+        postCode,
+        cityCode,
+        this.handleTerritoryChecked
+      )
     },
     getCodePostalFromQueryParam () {
       const queryString = window.location.search

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -35,7 +35,6 @@
         :multiple="component.multiple"
         :ariaControls="component.ariaControls"
         :tagWhenEdit="component.tagWhenEdit"
-        :searchWhenEdit="component.searchWhenEdit"
         :isTerritoryToCheck="component.isTerritoryToCheck"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
@@ -195,7 +194,11 @@ export default defineComponent({
       for (const component of components) {
         const value = formStore.data[component.slug]
         if (this.isRequired(component)) {
-          if (!value) {
+          // Cas particulier de validation de composant de type adresse SignalementFormAddress
+          if (component.type === 'SignalementFormAddress') {
+            this.validateComponentAddress(component.slug)
+          // Les autres composants requis doivent avoir une valeur correspondante dans le Store
+          } else if (!value) {
             formStore.validationErrors[component.slug] = 'Ce champ est requis'
           }
         }
@@ -205,6 +208,29 @@ export default defineComponent({
         // Vérifier si ce composant nécessite une validation de ses sous-composants
         if (this.needToValidateSubComponents(component)) {
           this.validateComponents(component.components.body)
+        }
+      }
+    },
+    validateComponentAddress (componentSlug: any) {
+      const validationError = 'Ce champ est requis'
+      // tous les champs sont vides, on affiche l'erreur sur le champs de recherche
+      if (!formStore.data[componentSlug] &&
+            !formStore.data[componentSlug + '_detail_numero'] &&
+            !formStore.data[componentSlug + '_detail_code_postal'] &&
+            !formStore.data[componentSlug + '_detail_commune']
+      ) {
+        formStore.validationErrors[componentSlug] = validationError
+
+      // il y a eu une édition manuelle : on vérifie tous les sous-champs
+      } else if (formStore.data[componentSlug + '_detail_manual'] !== 0) {
+        if (!formStore.data[componentSlug + '_detail_numero']) {
+          formStore.validationErrors[componentSlug + '_detail_numero'] = validationError
+        }
+        if (!formStore.data[componentSlug + '_detail_code_postal']) {
+          formStore.validationErrors[componentSlug + '_detail_code_postal'] = validationError
+        }
+        if (!formStore.data[componentSlug + '_detail_commune']) {
+          formStore.validationErrors[componentSlug + '_detail_commune'] = validationError
         }
       }
     },

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -35,6 +35,7 @@
         :multiple="component.multiple"
         :ariaControls="component.ariaControls"
         :tagWhenEdit="component.tagWhenEdit"
+        :searchWhenEdit="component.searchWhenEdit"
         :isTerritoryToCheck="component.isTerritoryToCheck"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -34,6 +34,7 @@
         :disabled="component.disabled"
         :multiple="component.multiple"
         :ariaControls="component.ariaControls"
+        :tagWhenEdit="component.tagWhenEdit"
         :isTerritoryToCheck="component.isTerritoryToCheck"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -27,6 +27,7 @@
         :multiple="component.multiple"
         :ariaControls="component.ariaControls"
         :tagWhenEdit="component.tagWhenEdit"
+        :searchWhenEdit="component.searchWhenEdit"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -27,7 +27,6 @@
         :multiple="component.multiple"
         :ariaControls="component.ariaControls"
         :tagWhenEdit="component.tagWhenEdit"
-        :searchWhenEdit="component.searchWhenEdit"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -25,6 +25,8 @@
         :validate="component.validate"
         :disabled="component.disabled"
         :multiple="component.multiple"
+        :ariaControls="component.ariaControls"
+        :tagWhenEdit="component.tagWhenEdit"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"

--- a/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -31,7 +31,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import formStore from './../store'
-import { requests } from './../requests'
 import { variablesReplacer } from './../services/variableReplacer'
 
 export default defineComponent({
@@ -47,8 +46,7 @@ export default defineComponent({
     hasError: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
     error: { type: String, default: '' },
-    tagWhenEdit: { type: String, default: '' },
-    searchWhenEdit: { type: Object, default: null }
+    tagWhenEdit: { type: String, default: '' }
   },
   data () {
     return {
@@ -72,31 +70,6 @@ export default defineComponent({
       this.$emit('update:modelValue', value)
       if (this.tagWhenEdit !== '') {
         formStore.data[this.tagWhenEdit] = 1
-      }
-
-      if (this.searchWhenEdit !== undefined && this.searchWhenEdit !== null) {
-        let isUpdateAddress = true
-        let search = ''
-        for (const index of this.searchWhenEdit.values) {
-          if (formStore.data[index] === '') {
-            isUpdateAddress = false
-          } else {
-            search += formStore.data[index] + ' '
-          }
-        }
-
-        if (isUpdateAddress) {
-          clearTimeout(this.idFetchTimeout)
-          this.idFetchTimeout = setTimeout(() => {
-            requests.validateAddress(search, this.handleUpdateInsee)
-          }, 200)
-        }
-      }
-    },
-    handleUpdateInsee (requestResponse: any) {
-      const suggestions = requestResponse.features
-      if (suggestions[0] !== undefined) {
-        formStore.data[this.searchWhenEdit.result] = suggestions[0].properties.citycode
       }
     }
   },

--- a/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -30,6 +30,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import formStore from './../store'
 import { variablesReplacer } from './../services/variableReplacer'
 
 export default defineComponent({
@@ -44,7 +45,8 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
-    error: { type: String, default: '' }
+    error: { type: String, default: '' },
+    tagWhenEdit: { type: String, default: '' }
   },
   data () {
     return {
@@ -65,6 +67,9 @@ export default defineComponent({
     updateValue (event: Event) {
       const value = (event.target as HTMLInputElement).value
       this.$emit('update:modelValue', value)
+      if (this.tagWhenEdit !== '') {
+        formStore.data[this.tagWhenEdit] = 1
+      }
     }
   },
   emits: ['update:modelValue']

--- a/assets/vue/components/signalement-form/services/subscreenManager.ts
+++ b/assets/vue/components/signalement-form/services/subscreenManager.ts
@@ -6,6 +6,7 @@ export const subscreenManager = {
       return {
         ...component,
         slug: id + '_' + (component.slug as string),
+        tagWhenEdit: id + '_' + (component.tagWhenEdit as string),
         validate: validateParent
       }
     })

--- a/assets/vue/components/signalement-form/services/subscreenManager.ts
+++ b/assets/vue/components/signalement-form/services/subscreenManager.ts
@@ -3,10 +3,23 @@ import formStore from '../store'
 export const subscreenManager = {
   generateSubscreenData (id: string, data: any[], validateParent: any) {
     return data.map((component) => {
+      let updatedSearchWhenEdit
+      if (component.searchWhenEdit !== undefined) {
+        const updatedValues = []
+        for (const index of component.searchWhenEdit.values) {
+          updatedValues.push(id + '_' + (index as string))
+        }
+        updatedSearchWhenEdit = {
+          values: updatedValues,
+          result: id + '_' + (component.searchWhenEdit.result as string)
+        }
+      }
+
       return {
         ...component,
         slug: id + '_' + (component.slug as string),
         tagWhenEdit: id + '_' + (component.tagWhenEdit as string),
+        searchWhenEdit: updatedSearchWhenEdit,
         validate: validateParent
       }
     })

--- a/assets/vue/components/signalement-form/services/subscreenManager.ts
+++ b/assets/vue/components/signalement-form/services/subscreenManager.ts
@@ -3,23 +3,10 @@ import formStore from '../store'
 export const subscreenManager = {
   generateSubscreenData (id: string, data: any[], validateParent: any) {
     return data.map((component) => {
-      let updatedSearchWhenEdit
-      if (component.searchWhenEdit !== undefined) {
-        const updatedValues = []
-        for (const index of component.searchWhenEdit.values) {
-          updatedValues.push(id + '_' + (index as string))
-        }
-        updatedSearchWhenEdit = {
-          values: updatedValues,
-          result: id + '_' + (component.searchWhenEdit.result as string)
-        }
-      }
-
       return {
         ...component,
         slug: id + '_' + (component.slug as string),
         tagWhenEdit: id + '_' + (component.tagWhenEdit as string),
-        searchWhenEdit: updatedSearchWhenEdit,
         validate: validateParent
       }
     })

--- a/migrations/Version20240507143556.php
+++ b/migrations/Version20240507143556.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240507143556 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add manual address flag to signalement table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement ADD manual_address_occupant TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP manual_address_occupan');
+    }
+}

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -33,6 +33,7 @@ class SignalementDraftRequest
     private ?string $adresseLogementAdresseDetailInsee = null;
     private ?float $adresseLogementAdresseDetailGeolocLat = null;
     private ?float $adresseLogementAdresseDetailGeolocLng = null;
+    private ?bool $adresseLogementAdresseDetailManual = null;
     #[Assert\Length(max: 3)]
     private ?string $adresseLogementComplementAdresseEscalier = null;
     #[Assert\Length(max: 5)]
@@ -334,6 +335,18 @@ class SignalementDraftRequest
     public function setAdresseLogementAdresseDetailGeolocLng(?float $adresseLogementAdresseDetailGeolocLng): self
     {
         $this->adresseLogementAdresseDetailGeolocLng = $adresseLogementAdresseDetailGeolocLng;
+
+        return $this;
+    }
+
+    public function getAdresseLogementAdresseDetailManual(): ?bool
+    {
+        return $this->adresseLogementAdresseDetailManual;
+    }
+
+    public function setAdresseLogementAdresseDetailManual(?bool $adresseLogementAdresseDetailManual): self
+    {
+        $this->adresseLogementAdresseDetailManual = $adresseLogementAdresseDetailManual;
 
         return $this;
     }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -255,6 +255,9 @@ class Signalement
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private $inseeOccupant;
 
+    #[ORM\Column(type: 'boolean', nullable: true)]
+    private $manualAddressOccupant;
+
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private $codeSuivi;
 
@@ -1312,6 +1315,18 @@ class Signalement
     public function setInseeOccupant(?string $inseeOccupant): self
     {
         $this->inseeOccupant = $inseeOccupant;
+
+        return $this;
+    }
+
+    public function getManualAddressOccupant(): ?bool
+    {
+        return $this->manualAddressOccupant;
+    }
+
+    public function setManualAddressOccupant(?bool $manualAddressOccupant): self
+    {
+        $this->manualAddressOccupant = $manualAddressOccupant;
 
         return $this;
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -339,8 +339,7 @@ class SignalementManager extends AbstractManager
             ->setEtageOccupant($adresseOccupantRequest->getEtage())
             ->setEscalierOccupant($adresseOccupantRequest->getEscalier())
             ->setNumAppartOccupant($adresseOccupantRequest->getNumAppart())
-            ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre())
-            ->setManualAddressOccupant(false);
+            ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre());
 
         $this->save($signalement);
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -339,7 +339,8 @@ class SignalementManager extends AbstractManager
             ->setEtageOccupant($adresseOccupantRequest->getEtage())
             ->setEscalierOccupant($adresseOccupantRequest->getEscalier())
             ->setNumAppartOccupant($adresseOccupantRequest->getNumAppart())
-            ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre());
+            ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre())
+            ->setManualAddressOccupant(false);
 
         $this->save($signalement);
 

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -331,7 +331,8 @@ class SignalementBuilder
             ->setNumAppartOccupant(
                 $this->signalementDraftRequest->getAdresseLogementComplementAdresseNumeroAppartement()
             )
-            ->setAdresseAutreOccupant($this->signalementDraftRequest->getAdresseLogementComplementAdresseAutre());
+            ->setAdresseAutreOccupant($this->signalementDraftRequest->getAdresseLogementComplementAdresseAutre())
+            ->setManualAddressOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailManual());
     }
 
     private function setOccupantDeclarantData(): void

--- a/templates/back/signalement/view/address-qualifications.html.twig
+++ b/templates/back/signalement/view/address-qualifications.html.twig
@@ -1,4 +1,4 @@
-<div class="fr-grid-row fr-mt-3w">
+<div class="fr-grid-row fr-grid-row--gutters fr-mt-3w">
     <div class="fr-col-12 fr-col-md-6" data-ajax-form>
         {% if canEditSignalement %}
             {% include 'back/signalement/view/edit-modals/edit-address.html.twig' %}
@@ -25,6 +25,11 @@
                 href="http://www.openstreetmap.org/?mlat={{ signalement.geoloc.lat }}&mlon={{ signalement.geoloc.lng }}#map=18/{{ signalement.geoloc.lat }}/{{ signalement.geoloc.lng }}">
                 Voir sur la carte
             </a>
+        {% endif %}
+        {% if signalement.manualAddressOccupant %}
+            <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-3v">
+                Cette adresse a été éditée manuellement lors de la déclaration.
+            </div>
         {% endif %}
     </div>
     

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -32,19 +32,19 @@
                                         </div>
                                     </div>
 
-                                    <div class="fr-input-group fr-input-group--disabled">
+                                    <div class="fr-input-group">
                                         <label class="fr-label" for="form-edit-address-adresse">Numéro et voie</label>
-                                        <input class="fr-input" id="form-edit-address-adresse" type="text" readonly name="adresse" value="{{ signalement.adresseOccupant }}" data-autocomplete-addresse="true">
+                                        <input class="fr-input" id="form-edit-address-adresse" type="text" name="adresse" value="{{ signalement.adresseOccupant }}" data-autocomplete-addresse="true">
                                     </div>
 
-                                    <div class="fr-input-group fr-input-group--disabled">
+                                    <div class="fr-input-group">
                                         <label class="fr-label" for="form-edit-address-codepostal">Code postal</label>
-                                        <input class="fr-input" id="form-edit-address-codepostal" type="text" readonly name="codePostal" value="{{ signalement.cpOccupant }}" data-autocomplete-codepostal="true">
+                                        <input class="fr-input" id="form-edit-address-codepostal" type="text" name="codePostal" value="{{ signalement.cpOccupant }}" data-autocomplete-codepostal="true">
                                     </div>
 
-                                    <div class="fr-input-group fr-input-group--disabled">
+                                    <div class="fr-input-group">
                                         <label class="fr-label" for="form-edit-address-ville">Commune</label>
-                                        <input class="fr-input" id="form-edit-address-ville" type="text" readonly name="ville" value="{{ signalement.villeOccupant }}" data-autocomplete-ville="true">
+                                        <input class="fr-input" id="form-edit-address-ville" type="text" name="ville" value="{{ signalement.villeOccupant }}" data-autocomplete-ville="true">
                                     </div>
 
                                     <input type="hidden" name="insee" value="{{ signalement.inseeOccupant }}" data-autocomplete-insee="true">

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -92,19 +92,19 @@
                                 </div>
                             </div>
 
-                            <div class="fr-input-group fr-input-group--disabled">
+                            <div class="fr-input-group">
                                 <label class="fr-label" for="form-edit-coordonnees-bailleur-adresse">Numéro et voie</label>
-                                <input class="fr-input" id="form-edit-coordonnees-bailleur-adresse" type="text" readonly name="adresse" value="{{ signalement.adresseProprio }}" data-autocomplete-addresse="true">
+                                <input class="fr-input" id="form-edit-coordonnees-bailleur-adresse" type="text" name="adresse" value="{{ signalement.adresseProprio }}" data-autocomplete-addresse="true">
                             </div>
 
-                            <div class="fr-input-group fr-input-group--disabled">
+                            <div class="fr-input-group">
                                 <label class="fr-label" for="form-edit-coordonnees-bailleur-codepostal">Code postal</label>
-                                <input class="fr-input" id="form-edit-coordonnees-bailleur-codepostal" type="text" readonly name="codePostal" value="{{ signalement.codePostalProprio }}" data-autocomplete-codepostal="true">
+                                <input class="fr-input" id="form-edit-coordonnees-bailleur-codepostal" type="text" name="codePostal" value="{{ signalement.codePostalProprio }}" data-autocomplete-codepostal="true">
                             </div>
 
-                            <div class="fr-input-group fr-input-group--disabled">
+                            <div class="fr-input-group">
                                 <label class="fr-label" for="form-edit-coordonnees-bailleur-ville">Commune</label>
-                                <input class="fr-input" id="form-edit-coordonnees-bailleur-ville" type="text" readonly name="ville" value="{{ signalement.villeProprio }}" data-autocomplete-ville="true">
+                                <input class="fr-input" id="form-edit-coordonnees-bailleur-ville" type="text" name="ville" value="{{ signalement.villeProprio }}" data-autocomplete-ville="true">
                             </div>
 
                             <div class="fr-select-group">


### PR DESCRIPTION
## Ticket

#2342    

## Description
Sur certains département, les adresses recherchées ne se trouvent pas dans la BAN.
On ouvre donc la possibilité aux gens de saisir directement leur adresse.
Inconvénient : le code INSEE et la géolocalisation seront faux pour ces adresses.

## Pré-requis
`make load-migrations`

`npm run watch`

## Tests
- [ ] Faire un signalement : vérifier qu'on a accès aux différents champs pour l'adresse occupant et l'adresse propriétaire
- [ ] BO : Vérifier qu'on retrouve bien les adresses modifiées
- [ ] BO : Vérifier qu'on peut éditer les champs séparément
- [ ] Si modification du code postal ou de la ville, vérifier qu'une mise à jour du code INSEE est faite
- [ ] BO : Si modification d'un des champs, vérifier qu'une alerte s'affiche
  - [ ] BO : Modifier l'adresse en tant qu'agent, et vérifier que l'alerte disparait
