### PR TITLE
[E-mail inscription] Mise à jour du lien de démo

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -7,7 +7,7 @@ twig:
             logo145: 'logo_145.png'
             logosvg: 'logo-histologe.svg'
             url: '%host_url%'
-            demo: 'https://app.livestorm.co/incubateur-des-territoires/demonstration-histologe?type=detailed'
+            demo: 'https://app.livestorm.co/mte/demonstration-histologe'
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr


### PR DESCRIPTION
## Ticket

#1194   

## Description
Le lien de démo a changé depuis au moins un an. Il fallait le mettre à jour...

## Tests
- [ ] S'inscrire sur Histologe et vérifier le lien dans le mail d'inscription
