### PR TITLE
fix doublon nom suivi

### DIFF
--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -29,7 +29,6 @@
                 Suivi automatique
 
             {% elseif suivi.createdBy is not null %}
-                <strong>{{ suivi.createdBy.nomComplet|capitalize }}</strong>
                 <div class="part-infos-hover"
                      data-user="{{ suivi.createdBy.nomComplet }}"
                      data-mail="{{ suivi.createdBy.email }}">

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -35,9 +35,9 @@
                 {{
                     'ROLE_USAGER' in suivi.createdBy.roles
                         ? (suivi.createdBy.email is same as signalement.mailOccupant
-                            ? 'OCCUPANT'
-                            : 'DECLARANT'
-                        )
+                            ? 'OCCUPANT'~ '\n' ~ suivi.createdBy.nomComplet|capitalize
+                            : 'DECLARANT'~ '\n' ~ suivi.createdBy.nomComplet|capitalize
+                        )|nl2br
                         : (suivi.createdBy.partner
                             ? (suivi.createdBy.partner.isArchive or ('ROLE_ADMIN' not in suivi.createdBy.roles and suivi.createdBy.partner.territory is not same as(signalement.territory))
                                 ? 'Partenaire supprimé'


### PR DESCRIPTION
## Ticket

#2478

## Description
Retrait du nom prénom sur les suivi BO qui faisait doublon en cas de dépot par un partenaire

## Tests
- [ ] Vérifier l'affichage des suivis déposé par partenaires et usagers
