### PR TITLE
 [BO - Fiche signalement] Changer l'intitulé du bloc composition du logement #2484 

### DIFF
--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -176,7 +176,9 @@ class SignalementEditController extends AbstractController
                 $validationGroups[] = $signalement->getProfileDeclarant()->value;
             }
             $errorMessage = FormHelper::getErrorsFromRequest(
-                $validator, $coordonneesBailleurRequest, $validationGroups
+                $validator,
+                $coordonneesBailleurRequest,
+                $validationGroups
             );
 
             if (empty($errorMessage)) {
@@ -224,7 +226,9 @@ class SignalementEditController extends AbstractController
                 'EDIT_'.$signalement->getProfileDeclarant()->value;
 
             $errorMessage = FormHelper::getErrorsFromRequest(
-                $validator, $informationsLogementRequest, $validationGroups
+                $validator,
+                $informationsLogementRequest,
+                $validationGroups
             );
 
             if (empty($errorMessage)) {
@@ -272,12 +276,14 @@ class SignalementEditController extends AbstractController
                 'EDIT_'.$signalement->getProfileDeclarant()->value;
 
             $errorMessage = FormHelper::getErrorsFromRequest(
-                $validator, $compositionLogementRequest, $validationGroups
+                $validator,
+                $compositionLogementRequest,
+                $validationGroups
             );
             if (empty($errorMessage)) {
                 $signalementManager->updateFromCompositionLogementRequest($signalement, $compositionLogementRequest);
                 $response = ['code' => Response::HTTP_OK];
-                $this->addFlash('success', 'La composition du logement a bien été modifiée.');
+                $this->addFlash('success', 'La description du logement a bien été modifiée.');
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -620,7 +620,7 @@ class SignalementManager extends AbstractManager
         $this->save($signalement);
         $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
-            description: 'La composition du logement a été modifée par ',
+            description: 'La description du logement a été modifée par ',
         );
     }
 

--- a/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
@@ -9,7 +9,7 @@
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-edit-composition-logement" class="fr-modal__title">
-                                Modifier la composition du logement
+                                Modifier la description du logement
                             </h1>
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
                             <div class="fr-select-group">

--- a/templates/back/signalement/view/information.html.twig
+++ b/templates/back/signalement/view/information.html.twig
@@ -337,7 +337,7 @@
             <div class="fr-p-3v fr-background-alt--grey">
                 <div class="fr-grid-row">
                     <div class="fr-col-12 fr-col-md-9">
-                        <h4 class="fr-h6">Composition du logement</h4>
+                        <h4 class="fr-h6">Description du logement</h4>
                     </div>
                     <div class="fr-col-12 fr-col-md-3 fr-text--right">
                         {% if canEditSignalement %}


### PR DESCRIPTION
## Ticket

#2484   

## Description
Suite aux retours du 13, 06 et 62, il faudrait modifier l'intitulé du bloc "Composition du logement" dans le BO pour Description du logement

## Changements apportés
* Changement dans le twig et dans SignalementManager

## Pré-requis

## Tests
- [ ] Ouvrir un signalement, vérifier l'intitulé du bloc
- [ ] Editer la description, vérifier l'intitulé de la modale et le texte du suivi créé
