### PR TITLE
[FO / BO - Signalement] Auteur document & photo non identifié quand ajout depuis formulaire 

### DIFF
--- a/migrations/Version20240424122241.php
+++ b/migrations/Version20240424122241.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240424122241 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add author on file uploaded from signalement';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE file f
+        JOIN signalement s ON f.signalement_id = s.id
+        JOIN user u ON u.email = s.mail_declarant
+        SET f.uploaded_by_id = u.id
+        WHERE f.uploaded_by_id IS NULL
+        AND f.document_type IN (\'PHOTO_SITUATION\', \'SITUATION_FOYER_BAIL\', \'SITUATION_FOYER_ETAT_DES_LIEUX\', \'SITUATION_FOYER_DPE\', \'SITUATION_DIAGNOSTIC_PLOMB_AMIANTE\')');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -175,7 +175,7 @@ class SignalementFileController extends AbstractController
                 /** @var User $user */
                 $user = $this->getUser();
                 $description = $user->getNomComplet().' a supprimé ';
-                $description .= File::INPUT_NAME_DOCUMENTS === $type ? 'le document suivant :' : 'la photo suivante :';
+                $description .= File::FILE_TYPE_DOCUMENT === $type ? 'le document suivant :' : 'la photo suivante :';
                 $suivi->setDescription(
                     $description
                     .'<ul><li>'
@@ -187,7 +187,7 @@ class SignalementFileController extends AbstractController
                 $entityManager->persist($suivi);
                 $entityManager->flush();
 
-                if ('document' === $type) {
+                if (File::FILE_TYPE_DOCUMENT === $type) {
                     $this->addFlash('success', 'Le document a bien été supprimé.');
                 } else {
                     $this->addFlash('success', 'La photo a bien été supprimée.');

--- a/src/EventSubscriber/SignalementCreatedSubscriber.php
+++ b/src/EventSubscriber/SignalementCreatedSubscriber.php
@@ -26,14 +26,7 @@ class SignalementCreatedSubscriber implements EventSubscriberInterface
     {
         $signalement = $event->getSignalement();
 
-        $userOccupant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::OCCUPANT);
-        $userDeclarant = $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::DECLARANT);
-
-        if ($signalement->getIsNotOccupant()) {
-            $user = $userDeclarant;
-        } else {
-            $user = $userOccupant;
-        }
-        $this->fileManager->updateSignalementFilesUser($signalement, $user);
+        $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::OCCUPANT);
+        $this->userManager->createUsagerFromSignalement($signalement, $this->userManager::DECLARANT);
     }
 }

--- a/src/Manager/FileManager.php
+++ b/src/Manager/FileManager.php
@@ -56,16 +56,4 @@ class FileManager extends AbstractManager
 
         return $file;
     }
-
-    public function updateSignalementFilesUser(
-        Signalement $signalement,
-        User $user,
-    ) {
-        foreach ($signalement->getFiles() as $file) {
-            if (null === $file->getUploadedBy()) {
-                $file->setUploadedBy($user);
-                $this->save($file);
-            }
-        }
-    }
 }

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -183,25 +183,6 @@ class UserManager extends AbstractManager
         return null;
     }
 
-    public function getUserCreatorOfSignalement(Signalement $signalement): ?User
-    {
-        $mail = ($signalement->getIsNotOccupant())
-            ? $signalement->getMailDeclarant()
-            : $signalement->getMailOccupant();
-
-        if (null !== $mail) {
-            /** @var User $user */
-            $user = $this->findOneBy(['email' => $mail]);
-            if (null !== $user) {
-                return $user;
-            }
-
-            return $user;
-        }
-
-        return null;
-    }
-
     public function getUserTypeForSignalementAndUser(Signalement $signalement, ?User $user): ?string
     {
         if (!$user) {

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -183,6 +183,25 @@ class UserManager extends AbstractManager
         return null;
     }
 
+    public function getUserCreatorOfSignalement(Signalement $signalement): ?User
+    {
+        $mail = ($signalement->getIsNotOccupant())
+            ? $signalement->getMailDeclarant()
+            : $signalement->getMailOccupant();
+
+        if (null !== $mail) {
+            /** @var User $user */
+            $user = $this->findOneBy(['email' => $mail]);
+            if (null !== $user) {
+                return $user;
+            }
+
+            return $user;
+        }
+
+        return null;
+    }
+
     public function getUserTypeForSignalementAndUser(Signalement $signalement, ?User $user): ?string
     {
         if (!$user) {

--- a/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
@@ -4,6 +4,7 @@ namespace App\Messenger\MessageHandler;
 
 use App\Dto\Request\Signalement\SignalementDraftRequest;
 use App\Factory\FileFactory;
+use App\Manager\UserManager;
 use App\Messenger\Message\SignalementDraftFileMessage;
 use App\Repository\SignalementDraftRepository;
 use App\Repository\SignalementRepository;
@@ -22,6 +23,7 @@ class SignalementDraftFileMessageHandler
         private FileFactory $fileFactory,
         private UploadHandlerService $uploadHandlerService,
         private LoggerInterface $logger,
+        private UserManager $userManager,
     ) {
     }
 
@@ -43,7 +45,7 @@ class SignalementDraftFileMessageHandler
         );
 
         $signalement = $this->signalementRepository->find($signalementDraftFileMessage->getSignalementId());
-
+        $uploadUser = $this->userManager->getUserCreatorOfSignalement($signalement);
         if ($files = $signalementDraftRequest->getFiles()) {
             foreach ($files as $key => $fileList) {
                 foreach ($fileList as $fileItem) {
@@ -52,6 +54,9 @@ class SignalementDraftFileMessageHandler
                     $this->uploadHandlerService->moveFromBucketTempFolder($file->getFilename());
                     $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
                     $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
+                    if (null !== $uploadUser) {
+                        $file->setUploadedBy($uploadUser);
+                    }
                     $signalement->addFile($file);
                 }
             }

--- a/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
@@ -45,7 +45,7 @@ class SignalementDraftFileMessageHandler
         );
 
         $signalement = $this->signalementRepository->find($signalementDraftFileMessage->getSignalementId());
-        $uploadUser = $this->userManager->getUserCreatorOfSignalement($signalement);
+        $uploadUser = $this->userManager->findOneBy(['email' => $signalement->getMailDeclarant()]);
         if ($files = $signalementDraftRequest->getFiles()) {
             foreach ($files as $key => $fileList) {
                 foreach ($fileList as $fileItem) {

--- a/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/SignalementDraftFileMessageHandler.php
@@ -54,9 +54,7 @@ class SignalementDraftFileMessageHandler
                     $this->uploadHandlerService->moveFromBucketTempFolder($file->getFilename());
                     $file->setSize($this->uploadHandlerService->getFileSize($file->getFilename()));
                     $file->setIsVariantsGenerated($this->uploadHandlerService->hasVariants($file->getFilename()));
-                    if (null !== $uploadUser) {
-                        $file->setUploadedBy($uploadUser);
-                    }
+                    $file->setUploadedBy($uploadUser);
                     $signalement->addFile($file);
                 }
             }


### PR DESCRIPTION
## Ticket

#2450 : [FO / BO - Signalement] Auteur document & photo non identifié quand ajout depuis formulaire
#2447 : [BO - Signalement] Erreur suivi auto de suppression document situation et partenaire

## Description
Correction du suivi de suppression de documents
Ajout de l'utilisateur sur les fichiers ajoutés depuis le formulaire (mais honnêtement j'étais persuadée que ça fonctionnait )

## Changements apportés
* Correction du SignalementFileController.php
* Dans le SignalementDraftFileMessageHandler, on enregistre l'utilisateur à l'origine de la création du signalement sur les fichiers, mais je pensais que c'était fait avec l'appel à `$this->fileManager->updateSignalementFilesUser` dans le SignalementCreatedSubscriber donc je suis un peu dubitative

## Pré-requis

## Tests
- [ ] Créer un signalement en ajoutant des documents et des photos
- [ ] Vérifier dans le BO qu'on a bien l'auteur sur les photos et les documents
- [ ] Ajouter des documents en tant que partenaire
- [ ] Supprimer un document et une photo et vérifier l'intitulé des suivis
