### PR TITLE
[BO - Signalement] Reprise de données Pas de Calais

### DIFF
--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -157,7 +157,7 @@ class SignalementImportLoader
     {
         $affectationCollection = new ArrayCollection();
         if (isset($dataMapped['partners']) && !empty($dataMapped['partners'])) {
-            if (str_contains($dataMapped['partners'], ',')) {
+            if (str_contains($dataMapped['partners'], ',') && '62' !== $territory->getZip()) {
                 $partnersName = explode(',', $dataMapped['partners']);
             } elseif (str_contains($dataMapped['partners'], '|')) {
                 $partnersName = explode('|', $dataMapped['partners']);


### PR DESCRIPTION
## Ticket

#2481

## Description
Certains partenaire du Pas de calais (62) contenant des virgule "," : ajout d'une condition pour éviter d'utiliser les virgule comme séparateur de partenaire sur ce territoire. 
