### PR TITLE
[Esabora] Pouvoir pousser en ligne de commande un dossier peu importe l'état de synchronisation

### DIFF
--- a/src/Command/PushEsaboraDossierCommand.php
+++ b/src/Command/PushEsaboraDossierCommand.php
@@ -58,6 +58,7 @@ class PushEsaboraDossierCommand extends Command
         if ($uuid) {
             $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
                 partnerType: 'sish' === $serviceType ? PartnerType::ARS : PartnerType::COMMUNE_SCHS,
+                isSynchronized: null,
                 uuidSignalement: $uuid
             );
         } elseif ($zip) {

--- a/tests/Unit/Command/PushEsaboraDossierCommandTest.php
+++ b/tests/Unit/Command/PushEsaboraDossierCommandTest.php
@@ -88,7 +88,7 @@ class PushEsaboraDossierCommandTest extends TestCase
             ->method('findAffectationSubscribedToEsabora')
             ->with(
                 $this->equalTo(PartnerType::ARS),
-                true,
+                null,
                 $this->equalTo('00000000-0000-0000-2023-000000000010')
             )
             ->willReturn([$affectation]);


### PR DESCRIPTION
## Ticket

#2426    

## Description
Dans la commande `app:push-esabora-dossier` qui permet de pousser un dossier sans passer par la fiche signalement

Lorsque qu'on pousse un dossier unique via l'uuid du signalement et que la synchronisation a un statut à 0 cad colonne `is_synchronized` de la table `Affectation`,  le dossier ne peut être pas poussé.

```sh
php bin/console app:push-esabora-dossier schs --uuid=e81e633a-a5ca-469d-a6f6-a3c460314efd
```

Pour plus de souplesse, on devait pouvoir pousser ou repousser un dossier en ligne de commande peu importe son statut de synchronisation (la gestion des doublons est géré coté esabora)

## Changements apportés
* Passer le paramètre status à null afin de lever le filtre sur le statut

## Pré-requis
```sh
make worker-start
make mock-start
```

## Tests
- [ ] Exécuter 2 fois `make console app="push-esabora schs --uuid=00000000-0000-0000-2023-000000000012"` et vérifier que l'appel est toujours executé
- [ ] Mettre à jour à 0 `is_synchronized` en executant la requête ```UPDATE `affectation` SET `is_synchronized` = '0' WHERE `affectation`.`id` = 18;```
- [ ] Exécuter 1 fois `make console app="push-esabora schs --uuid=00000000-0000-0000-2023-000000000012"` et vérifier que l'appel est toujours exécuté
- [ ] `is_synchronized` est toujours mis à jour à 1 après l'envoi du dossier 
