### PR TITLE
[BO - Suivi] Les courriers ajoutés dans le message de suivi ne sont plus accessible

### DIFF
--- a/migrations/Version20240424073643.php
+++ b/migrations/Version20240424073643.php
@@ -30,7 +30,7 @@ final class Version20240424073643 extends AbstractMigration
             UPDATE suivi
             SET description = REPLACE(description, '$file?t=___TOKEN___', '$file')
             WHERE description LIKE '%$file?t=___TOKEN___%';
-        SQL);
+            SQL);
         }
     }
 

--- a/migrations/Version20240424073643.php
+++ b/migrations/Version20240424073643.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240424073643 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update link document message de suivi';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $filesToUpdate = [
+            '1_Demande_de_transmission_d_une_copie_d_un_DPE.docx',
+            '2_Information_au_bailleur_Mise_en_conformite.docx',
+            '3_Mise_en_demeure.docx',
+            '4_Invitation_a_contacter_l_ADIL.docx',
+            '5_Engagement_du_bailleur_a_realiser_des_travaux.docx',
+            '6_Saisine_de_la_Commission_departementale_de_conciliation.docx',
+        ];
+
+        foreach ($filesToUpdate as $file) {
+            $this->addSql(<<<SQL
+            UPDATE suivi
+            SET description = REPLACE(description, '$file?t=___TOKEN___', '$file')
+            WHERE description LIKE '%$file?t=___TOKEN___%';
+        SQL);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -186,7 +186,7 @@
                                     type: 'menuitem',
                                     text: "{{ doc.title|raw }}",
                                     onAction: function () {
-                                        editor.insertContent('&nbsp;<a href="{{ asset(files.path~doc.file) }}?t=___TOKEN___" class="fr-link" title="Afficher le document" target="_blank">Consulter "{{ doc.title }}"</a></br>');
+                                        editor.insertContent('&nbsp;<a href="{{ asset(files.path~doc.file) }}" class="fr-link" title="Afficher le document" target="_blank">Consulter "{{ doc.title }}"</a></br>');
                                     }
                                 })     
                             {% endif %}   


### PR DESCRIPTION
## Ticket

#2500    

## Description
Les courriers DPE qui sont déclarés comme des assets devraient être accessible publiquement

## Changements apportés
* Supprimer le placeholder token sur les liens de courriers
* Ajout d'une migration pour supprimer le placeholder `__TOKEN__` sur les courriers

## Pré-requis (Avant de changer de branche)
*  Ajouter un suivi avec tous les courriers sur un signalement qui a la situation NDE, les liens devraient renvoyées une 404 

![image](https://github.com/MTES-MCT/histologe/assets/5757116/97f1bed2-c61f-4ea2-a959-911fbe6aa5f9)

## Tests
- [ ] Créer un nouveau suivi avec tous les courriers et vérifier que chaque courrier se télécharge
- [ ] Exécuter la migration ` make execute-migration name=Version20240424073643 direction=up`
- [ ] Vérifier sur le suivi précédemment créer que les liens se télécharge. 
