### PR TITLE
[BO - Affichage mode album] Theme Dark sur Album photo

### DIFF
--- a/assets/controllers/view_signalement.js
+++ b/assets/controllers/view_signalement.js
@@ -44,6 +44,9 @@ document?.querySelectorAll('.photos-album-swipe')?.forEach(btn => {
     })
 })
 const displayPhotoAlbum = (photoId) => {
+    if (document?.documentElement.getAttribute('data-fr-theme') == 'light') {
+        document?.documentElement.setAttribute('data-fr-theme', 'dark')
+    }
     document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
         element.classList?.remove('loop-current')
         element.classList?.add('fr-hidden')


### PR DESCRIPTION
## Ticket

#2439    

## Description
En local, le switch au thme dark quand on ouvre l'album-photo fonctionne très bien. Mais sur la staging, le switch ne fonctionne pas à la première ouverture de l'album photo, il fonctionne par contre à la deuxième ouverture : la première fois que j'ouvre l'album photo, le theme ne change pas (il est `null` d'après la console), puis je ferme l'album photo il devient `light`. Je reouvre une 2è fois l'album photo il devient bien `dark`. 
J'ai donc tenté une première correction à l'aveugle.
Si ça ne fonctionne pas, il faudra peut-être passer par des callbacks...

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis

## Tests
- [ ] Ouvrir l'album photo en local et vérifier que ça fonctionne, puis le même test à faire sur la staging
