### PR TITLE
[BO - Partenaire][Esabora] Restreindre l'édition des données d'authentification aux super admin

### DIFF
--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -34,6 +34,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 class PartnerType extends AbstractType
 {
     private $isAdmin = false;
+    private $isAdminTerritory = false;
 
     public function __construct(
         private readonly ParameterBagInterface $parameterBag,
@@ -44,6 +45,9 @@ class PartnerType extends AbstractType
     ) {
         if ($this->security->isGranted('ROLE_ADMIN')) {
             $this->isAdmin = true;
+        }
+        if ($this->security->isGranted('ROLE_ADMIN_TERRITORY')) {
+            $this->isAdminTerritory = true;
         }
     }
 
@@ -136,6 +140,7 @@ class PartnerType extends AbstractType
                     'class' => 'fr-toggle__input',
                 ],
                 'required' => false,
+                'disabled' => !$this->isAdminTerritory,
             ])
             ->add('esaboraUrl', UrlType::class, [
                 'attr' => [

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -13,6 +13,7 @@ use App\Repository\PartnerRepository;
 use App\Repository\TerritoryRepository;
 use App\Repository\UserRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -32,12 +33,18 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class PartnerType extends AbstractType
 {
+    private $isAdmin = false;
+
     public function __construct(
         private readonly ParameterBagInterface $parameterBag,
         private readonly CommuneManager $communeManager,
         private readonly UserRepository $userRepository,
         private readonly PartnerRepository $partnerRepository,
+        private readonly Security $security
     ) {
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            $this->isAdmin = true;
+        }
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -135,12 +142,14 @@ class PartnerType extends AbstractType
                     'class' => 'fr-input',
                 ],
                 'required' => false,
+                'disabled' => !$this->isAdmin,
             ])
             ->add('esaboraToken', TextType::class, [
                 'attr' => [
                     'class' => 'fr-input',
                 ],
                 'required' => false,
+                'disabled' => !$this->isAdmin,
             ])
             ->add('territory', EntityType::class, [
                 'class' => Territory::class,

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -85,19 +85,11 @@
                 </div>
                 <div class="fr-col-12 fr-col-md-6 fr-p-1v">
                     <label for="{{ form.esaboraUrl.vars.id }}" class="fr-label">URL Esabora (facultatif)</label>                        
-                    {% if is_granted('ROLE_ADMIN') %}
-                        {{ form_widget(form.esaboraUrl) }}
-                    {% else %}
-                        {{ form_widget(form.esaboraUrl, { 'attr': {'disabled': true}}) }}
-                    {% endif %}
+                    {{ form_widget(form.esaboraUrl) }}
                 </div>
                 <div class="fr-col-12 fr-col-md-6 fr-p-1v">
                     <label for="{{ form.esaboraToken.vars.id }}" class="fr-label">Token Esabora (facultatif)</label>                     
-                    {% if is_granted('ROLE_ADMIN') %}
-                        {{ form_widget(form.esaboraToken) }}
-                    {% else %}
-                        {{ form_widget(form.esaboraToken, { 'attr': {'disabled': true}}) }}
-                    {% endif %}
+                    {{ form_widget(form.esaboraToken) }}
                 </div>      
             </div>
         </div>

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -73,19 +73,32 @@
                 <div class="fr-col-12 fr-col-md-6 fr-p-1v">
                     <span class="fr-label">Synchronisation Esabora (facultatif)</span>
                     <div class="fr-toggle">
-                        {{ form_widget(form.isEsaboraActive) }}
+                        {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+                            {{ form_widget(form.isEsaboraActive) }}
+                        {% else %}
+                            {{ form_widget(form.isEsaboraActive, { 'attr': {'disabled': true}}) }}
+                        {% endif %}
                         <label class="fr-toggle__label" for="{{ form.isEsaboraActive.vars.id }}"
                             data-fr-checked-label="Activée" data-fr-unchecked-label="Désactivée">
                         </label>
-                    </div>
+                    </div>        
                 </div>
                 <div class="fr-col-12 fr-col-md-6 fr-p-1v">
-                    <label for="{{ form.esaboraUrl.vars.id }}" class="fr-label">URL Esabora (facultatif)</label>
-                    {{ form_widget(form.esaboraUrl) }}
+                    <label for="{{ form.esaboraUrl.vars.id }}" class="fr-label">URL Esabora (facultatif)</label>                        
+                    {% if is_granted('ROLE_ADMIN') %}
+                        {{ form_widget(form.esaboraUrl) }}
+                    {% else %}
+                        {{ form_widget(form.esaboraUrl, { 'attr': {'disabled': true}}) }}
+                    {% endif %}
                 </div>
                 <div class="fr-col-12 fr-col-md-6 fr-p-1v">
-                    <label for="{{ form.esaboraToken.vars.id }}" class="fr-label">Token Esabora (facultatif)</label>
-                    {{ form_widget(form.esaboraToken) }}</div>
+                    <label for="{{ form.esaboraToken.vars.id }}" class="fr-label">Token Esabora (facultatif)</label>                     
+                    {% if is_granted('ROLE_ADMIN') %}
+                        {{ form_widget(form.esaboraToken) }}
+                    {% else %}
+                        {{ form_widget(form.esaboraToken, { 'attr': {'disabled': true}}) }}
+                    {% endif %}
+                </div>      
             </div>
         </div>
     </div>

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -73,11 +73,7 @@
                 <div class="fr-col-12 fr-col-md-6 fr-p-1v">
                     <span class="fr-label">Synchronisation Esabora (facultatif)</span>
                     <div class="fr-toggle">
-                        {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                            {{ form_widget(form.isEsaboraActive) }}
-                        {% else %}
-                            {{ form_widget(form.isEsaboraActive, { 'attr': {'disabled': true}}) }}
-                        {% endif %}
+                        {{ form_widget(form.isEsaboraActive) }}
                         <label class="fr-toggle__label" for="{{ form.isEsaboraActive.vars.id }}"
                             data-fr-checked-label="Activée" data-fr-unchecked-label="Désactivée">
                         </label>


### PR DESCRIPTION
## Ticket

#2126   

## Description
Restreindre l'édition des données d'authentification aux super admin  en laissant aux RT la possibilité de désactiver l'interfaçage

## Changements apportés
* Passage de disable au form_widget() dans le twig

## Pré-requis

## Tests
- [ ] Se connecter en SA, RT et admin partenaire d'un partenaire avec interfaçage Esabora et vérifier la possibilité d'édition de l'interfaçage
