### PR TITLE
[BO - Fiche usager - modale ajout documents] Modifier le texte

### DIFF
--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -101,7 +101,7 @@ class SuiviManager extends Manager
         ) {
             if ($nbDocs > 0) {
                 $description .= $nbDocs;
-                $description .= $nbDocs > 1 ? ' documents partenaires ont été ajoutés' : ' document partenaire a été ajouté';
+                $description .= $nbDocs > 1 ? ' documents liés à la procédure ont été ajoutés' : ' document lié à la procédure a été ajouté';
                 $description .= ' au signalement.';
             }
         }

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -41,7 +41,7 @@
                                     Ajouter un ou plusieurs documents. Pour chaque document, veuillez renseigner son type.
                                 </div>
                                 <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-1w ">
-                                    <p>Pour ajouter des documents concernant la procédure ou le bailleur, rendez-vous dans la partie "Documents partenaires".</p>
+                                    <p>Pour ajouter des documents concernant la procédure ou le bailleur, rendez-vous dans la partie "Documents liés à la procédure".</p>
                                 </div>
                                 <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
                                     <p>Ces documents seront partagés à l'usager.</p>


### PR DESCRIPTION
## Ticket

#2504   

## Description
Suite à des retours, on a modifié l'intitulé de la partie Documents partenaires en Documents liés à la procédure.
Il faut le répercuter dans le message d'info de la modale -> mettre Documents liés à la procédure

## Changements apportés
* Modifier le titre de la modale et le suivi

## Pré-requis

## Tests
- [ ] Aller sur une fiche signalement et vérifier le texte dans la modale d'ajout de documents liés à la situation
- [ ] Ajouter des documents liés à  la procédure et vérifier le texte du suivi
