### PR TITLE
[FO / BO] Modifier email en e-mail

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -363,7 +363,7 @@ class PartnerController extends AbstractController
             $user = $userManager->createUserFromData($partner, $data);
         }
 
-        $message = 'L\'utilisateur a bien été créé. Un email de confirmation a été envoyé à '.$user->getEmail();
+        $message = 'L\'utilisateur a bien été créé. Un e-mail de confirmation a été envoyé à '.$user->getEmail();
         $this->addFlash('success', $message);
 
         return $this->redirectToRoute('back_partner_view', ['id' => $partner->getId()], Response::HTTP_SEE_OTHER);

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -45,7 +45,7 @@ class SignalementFileController extends AbstractController
         $this->addFlash(
             'success',
             sprintf(
-                'L\'export pdf vous sera envoyé par email à l\'adresse suivante : %s. N\'oubliez pas de regarder vos courriers indésirables (spam) !',
+                'L\'export pdf vous sera envoyé par e-mail à l\'adresse suivante : %s. N\'oubliez pas de regarder vos courriers indésirables (spam) !',
                 $user->getEmail()
             )
         );

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -160,7 +160,7 @@ class Signalement
     private ?string $telDeclarantSecondaire;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    #[Assert\Email(message: 'L\'adresse email du déclarant n\'est pas valide.')]
+    #[Assert\Email(message: 'L\'adresse e-mail du déclarant n\'est pas valide.')]
     private $mailDeclarant;
 
     #[ORM\Column(type: 'string', length: 200, nullable: true)]
@@ -184,7 +184,7 @@ class Signalement
     private $telOccupant;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    #[Assert\Email(message: 'L\'adresse email de l\'occupant n\'est pas valide.')]
+    #[Assert\Email(message: 'L\'adresse e-mail de l\'occupant n\'est pas valide.')]
     private $mailOccupant;
 
     #[ORM\Column(type: 'string', length: 100, nullable: true)]
@@ -435,13 +435,13 @@ class Signalement
     {
         // check mails
         if (!$this->mailDeclarant && !$this->mailOccupant) {
-            $context->buildViolation('Vous devez renseigner au moins une adresse email pour le déclarant ou l\'occupant.')
+            $context->buildViolation('Vous devez renseigner au moins une adresse e-mail pour le déclarant ou l\'occupant.')
                 ->atPath('mailDeclarant')
                 ->atPath('mailOccupant')
                 ->addViolation();
         }
         if ($this->mailDeclarant && $this->mailOccupant && $this->mailDeclarant === $this->mailOccupant) {
-            $context->buildViolation('les adresses emails du déclarant et de l\'occupant sont identiques (laisser l\'adresse vide si l\'occupant n\'en dispose pas).')
+            $context->buildViolation('les adresses e-mails du déclarant et de l\'occupant sont identiques (laisser l\'adresse vide si l\'occupant n\'en dispose pas).')
                 ->atPath('mailDeclarant')
                 ->atPath('mailOccupant')
                 ->addViolation();

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Email;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
-#[UniqueEntity('email', message: '{{ value }} existe déja, merci de saisir un nouvel email')]
+#[UniqueEntity('email', message: '{{ value }} existe déja, merci de saisir un nouvel e-mail')]
 #[ORM\HasLifecycleCallbacks()]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
@@ -74,7 +74,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[Assert\Regex(pattern: '/[0-9]/', message: 'Le mot de passe doit contenir au moins un chiffre.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[^a-zA-Z0-9]/', message: 'Le mot de passe doit contenir au moins un caractère spécial.', groups: ['password'])]
     #[Assert\NotCompromisedPassword(message: 'Ce mot de passe est compromis, veuillez en choisir un autre.', groups: ['password'])]
-    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas être votre email.', groups: ['password'])]
+    #[Assert\NotEqualTo(propertyPath: 'email', message: 'Le mot de passe ne doit pas être votre e-mail.', groups: ['password'])]
     private $password;
 
     #[ORM\Column(length: 255, nullable: true)]

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -270,8 +270,8 @@ class PartnerType extends AbstractType
             });
 
             if (!$canBeNotified) {
-                $context->addViolation('Email générique manquante: Il faut donc obligatoirement qu\'au moins
-                1 compte utilisateur accepte de recevoir les emails.');
+                $context->addViolation('E-mail générique manquante: Il faut donc obligatoirement qu\'au moins
+                1 compte utilisateur accepte de recevoir les e-mails.');
             }
         }
     }

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -38,7 +38,7 @@ class UserType extends AbstractType
                     'class' => 'fr-input-group fr-col-6',
                 ], 'attr' => [
                     'class' => 'fr-input',
-                ], 'label' => 'Adresse email',
+                ], 'label' => 'Adresse e-mail',
                 'required' => true,
             ])
             ->add('nom', TextType::class, [

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -73,7 +73,8 @@ class GridAffectationLoader
                 if (!empty($emailPartner)) {
                     $violations = $this->validator->validate($emailPartner, $emailConstraint);
                     if (\count($violations) > 0) {
-                        $errors[] = sprintf('line %d : Email incorrect pour un partenaire : %s',
+                        $errors[] = sprintf(
+                            'line %d : E-mail incorrect pour un partenaire : %s',
                             $numLine,
                             $emailPartner
                         );
@@ -103,7 +104,7 @@ class GridAffectationLoader
                 $emailUser = trim($item[GridAffectationHeader::USER_EMAIL]);
                 if (empty($emailUser) && !empty($item[GridAffectationHeader::USER_ROLE])) {
                     $errors[] = sprintf(
-                        'line %d : Email manquant pour %s %s, partenaire %s',
+                        'line %d : E-mail manquant pour %s %s, partenaire %s',
                         $numLine,
                         $item[GridAffectationHeader::USER_FIRSTNAME],
                         $item[GridAffectationHeader::USER_LASTNAME],
@@ -113,7 +114,7 @@ class GridAffectationLoader
                     // email must be valid and not used by another user of another partner
                     $violations = $this->validator->validate($emailUser, $emailConstraint);
                     if (\count($violations) > 0) {
-                        $errors[] = sprintf('line %d : Email incorrect pour un utilisateur : %s', $numLine, $emailUser);
+                        $errors[] = sprintf('line %d : E-mail incorrect pour un utilisateur : %s', $numLine, $emailUser);
                     }
 
                     /** @var User $userToCreate */
@@ -151,20 +152,20 @@ class GridAffectationLoader
         // check if there are no duplicate email between partners
         $duplicatesMailPartners = $this->checkIfDuplicates($mailPartners);
         if (\count($duplicatesMailPartners) > 0) {
-            $errors[] = 'Certains partenaires ont un mail en commun '.implode(',', array_keys($duplicatesMailPartners));
+            $errors[] = 'Certains partenaires ont un e-mail en commun '.implode(',', array_keys($duplicatesMailPartners));
         }
 
         // check if there are no duplicate email between users
         $duplicatesMailUsers = $this->checkIfDuplicates($mailUsers);
         if (\count($duplicatesMailUsers) > 0) {
-            $errors[] = 'Certains utilisateurs ont un mail en commun '.implode(',', array_keys($duplicatesMailUsers));
+            $errors[] = 'Certains utilisateurs ont un e-mail en commun '.implode(',', array_keys($duplicatesMailUsers));
         }
 
         // check if there are no duplicate email between partners and users
         $mails = array_merge($mailPartners, $mailUsers);
         $duplicatesMails = $this->checkIfDuplicates($mails);
         if (\count($duplicatesMails) > 0) {
-            $errors[] = 'Certains utilisateurs ont un mail en commun avec un partenaire '
+            $errors[] = 'Certains utilisateurs ont un e-mail en commun avec un partenaire '
                 .implode(',', array_keys($duplicatesMails));
         }
 

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -33,7 +33,7 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
     public function send(NotificationMail $notificationMail): bool
     {
         if (!$this->parameterBag->get('mail_enable')) {
-            $this->logger->info('Email has been disable, please enable MAIL_ENABLE=1');
+            $this->logger->info('E-mail has been disable, please enable MAIL_ENABLE=1');
 
             return true;
         }

--- a/src/Service/Signalement/Export/SignalementExportHeader.php
+++ b/src/Service/Signalement/Export/SignalementExportHeader.php
@@ -18,7 +18,7 @@ class SignalementExportHeader
             'Prénom',
             'Téléphone',
             'Téléphone sec.',
-            'Email',
+            'E-mail',
             'Adresse',
             'Code postal',
             'Commune',

--- a/src/Service/Signalement/Export/SignalementExportHeader.php
+++ b/src/Service/Signalement/Export/SignalementExportHeader.php
@@ -18,7 +18,7 @@ class SignalementExportHeader
             'Prénom',
             'Téléphone',
             'Téléphone sec.',
-            'E-mail',
+            'Email',
             'Adresse',
             'Code postal',
             'Commune',

--- a/templates/_partials/_modal_user_create.html.twig
+++ b/templates/_partials/_modal_user_create.html.twig
@@ -61,7 +61,7 @@
                                         <input type="email" id="user_create_email" name="user_create[email]"
                                             required="required" class="fr-input" onchange="checkUserMail(this)" oninput="checkUserMail(this)"
                                             data-token="{{ csrf_token('partner_checkmail') }}">
-                                        <span class="fr-hint-text">Un email d'activation du compte sera envoyé à cette adresse email.</span>
+                                        <span class="fr-hint-text">Un e-mail d'activation du compte sera envoyé à cette adresse e-mail.</span>
                                         <p class="fr-error-text fr-hidden">
                                             Courriel invalide
                                         </p>
@@ -70,7 +70,7 @@
                                 <div class="fr-grid-row fr-grid-row--gutters">
                                     <fieldset class="fr-fieldset fr-fieldset--inline fr-input-group fr-col-12 fr-col-md-6">
                                         <legend class="fr-fieldset__legend fr-text--regular">
-                                            <label class="fr-label">Recevoir les emails ?</label>
+                                            <label class="fr-label">Recevoir les e-mails ?</label>
                                         </legend>
                                         <div class="fr-fieldset__content">
                                             <div class="fr-fieldset__element fr-fieldset__element--inline">
@@ -90,7 +90,7 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <span class="fr-hint-text fr-mt-inf-3v">Si vous cochez oui, des emails concernant les signalements seront envoyés à cette adresse.</span>
+                                        <span class="fr-hint-text fr-mt-inf-3v">Si vous cochez oui, des e-mails concernant les signalements seront envoyés à cette adresse.</span>
                                     </fieldset>
                                 </div>
                             </div>

--- a/templates/_partials/_modal_user_delete.html.twig
+++ b/templates/_partials/_modal_user_delete.html.twig
@@ -18,7 +18,7 @@
                                 <ul class="fr-list">
                                     <li><span class="fr-modal-user-delete_username"></span> ne pourra plus se connecter à la plateforme {{ platform.name }} pour traiter des signalements.</li>
                                     <li>S'il s'agit du dernier compte utilisateur du partenaire, les signalements affectés ne pourrons plus être pris en charge par le partenaire.</li>
-                                    <li>Vous ne pourrez plus re-créer un compte avec cette adresse email : <span class="fr-modal-user-delete_useremail"></span>.</li>
+                                    <li>Vous ne pourrez plus re-créer un compte avec cette adresse e-mail : <span class="fr-modal-user-delete_useremail"></span>.</li>
                                 </ul>
                             </div>
                             <div class="fr-alert fr-alert--info">

--- a/templates/_partials/_modal_user_edit.html.twig
+++ b/templates/_partials/_modal_user_edit.html.twig
@@ -60,7 +60,7 @@
                                         <input type="email" id="user_edit_email" name="user_edit[email]"
                                             required="required" class="fr-input" onchange="checkUserMail(this)" oninput="checkUserMail(this)"
                                             data-token="{{ csrf_token('partner_checkmail') }}">
-                                        <span class="fr-hint-text">Un email d'activation du compte sera envoyé à cette adresse email.</span>
+                                        <span class="fr-hint-text">Un e-mail d'activation du compte sera envoyé à cette adresse e-mail.</span>
                                         <p class="fr-error-text fr-hidden">
                                             Courriel invalide
                                         </p>
@@ -69,7 +69,7 @@
                                 <div class="fr-grid-row fr-grid-row--gutters">
                                     <fieldset class="fr-fieldset fr-fieldset--inline fr-input-group fr-col-12 fr-col-md-6">
                                         <legend class="fr-fieldset__legend fr-text--regular">
-                                            <label class="fr-label">Recevoir les emails ?</label>
+                                            <label class="fr-label">Recevoir les e-mails ?</label>
                                         </legend>
                                         <div class="fr-fieldset__content">
                                             <div class="fr-fieldset__element fr-fieldset__element--inline">
@@ -89,7 +89,7 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <span class="fr-hint-text fr-mt-inf-3v">Si vous cochez oui, des emails concernant les signalements seront envoyés à cette adresse.</span>
+                                        <span class="fr-hint-text fr-mt-inf-3v">Si vous cochez oui, des e-mails concernant les signalements seront envoyés à cette adresse.</span>
                                     </fieldset>
                                 </div>
                             </div>

--- a/templates/back/account/_form.html.twig
+++ b/templates/back/account/_form.html.twig
@@ -6,10 +6,10 @@
     </legend>
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-lg-6">
-            <label for="{{ form.email.vars.id }}" class="fr-label">Adresse email</label>
+            <label for="{{ form.email.vars.id }}" class="fr-label">Adresse e-mail</label>
                 {{ form_widget(form.email, {'value': user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}) }}
             </br>
-            <span class="fr-hint-text">L'adresse email ne peut pas être modifiée</span>
+            <span class="fr-hint-text">L'adresse e-mail ne peut pas être modifiée</span>
         </div>
         
         {% if 'ROLE_USAGER' not in user.roles %}

--- a/templates/back/account/index.html.twig
+++ b/templates/back/account/index.html.twig
@@ -60,7 +60,7 @@
                 <th>Dpt.</th>
                 <th>Partenaire</th>
                 <th>Statut part.</th>
-                <th>Email</th>
+                <th>E-mail</th>
                 <th>Nom</th>
                 <th>Prénom</th>
                 <th class="fr-text--right"></th>

--- a/templates/back/cgu_bo.html.twig
+++ b/templates/back/cgu_bo.html.twig
@@ -86,11 +86,11 @@
         Les agents créent les comptes partenaires sur le Back-Office à partir des informations suivantes :
         <ul>
             <li>Nom et prénom du partenaire</li>
-            <li>Adresse email professionnelle</li>
+            <li>Adresse e-mail professionnelle</li>
             <li>Organisme de rattachement</li>
         </ul>
 
-        Le partenaire reçoit un email l’informant de la création de son compte et l'invitant à finaliser
+        Le partenaire reçoit un e-mail l’informant de la création de son compte et l'invitant à finaliser
         son inscription. La finalisation du compte partenaire est soumise à activation du compte par
         le partenaire et acceptation des présentes CGU.
         <br>
@@ -135,7 +135,7 @@
         L’agent détermine la criticité du signalement en fonction des informations fournies par l'utilisateur.
         <br>
         Une fois la criticité déterminée, l’agent détermine le ou les partenaires ou services compétents.
-        Il transfère sur la plateforme et par mail au partenaire :
+        Il transfère sur la plateforme et par e-mail au partenaire :
         <ul>
             <li>l’ensemble du signalement réalisé par l’Utilisateur,</li>
             <li>l’évaluation de la criticité du signalement.</li>
@@ -159,7 +159,7 @@
         <br>
         Les clôtures sont visibles par les partenaires concernés et les agents dans le Back-Office.
         <br>
-        Les partenaires concernés sont prévenus par email et / ou par notification dans le Back-Office.
+        Les partenaires concernés sont prévenus par e-mail et / ou par notification dans le Back-Office.
         <br>
         L’utilisateur est prévenu par courriel de la clôture de son signalement.
     </p>
@@ -264,7 +264,7 @@
     <p>
         La présente plateforme traite les données personnelles des utilisateurs et partenaires suivantes :
         <ul>
-            <li>Données relatives au signalement du problème d’habitat (nom, prénom, adresse-email, adresse du logement,
+            <li>Données relatives au signalement du problème d’habitat (nom, prénom, adresse e-mail, adresse du logement,
             taille du logement, désordres signalés, documents)</li>
             <li>Données de création de compte et relatives au suivi du signalement du problème d’habitat (nom, prénom,
             adresse e-mail, suivi du problème d’habitat)</li>
@@ -391,7 +391,7 @@
         Vous pouvez exercer ces droits en écrivant :
         <br>
         <ul>
-            <li>par mail à dpd.daj.sg@developpement-durable.gouv.fr</li>
+            <li>par e-mail à dpd.daj.sg@developpement-durable.gouv.fr</li>
             <li>
                 par voie postale :<br>
                 Ministère de la Transition écologique et solidaire<br>

--- a/templates/back/inactive-account/index.html.twig
+++ b/templates/back/inactive-account/index.html.twig
@@ -20,7 +20,7 @@
 		<div class="fr-text--sm fr-text--light">
 			Les comptes inactifs sont les comptes des agents qui n'ont pas eu de connexion depuis plus de 11 mois et qui ne sont pas archivés. 
 			<br>
-			Un mail leur est envoyé 30 jours et 7 jours avant la suppression des comptes, puis ils sont archivés s'il n'y a toujours pas de connexion 30 jours après la première notification.
+			Un e-mail leur est envoyé 30 jours et 7 jours avant la suppression des comptes, puis ils sont archivés s'il n'y a toujours pas de connexion 30 jours après la première notification.
 		</div>
 	</h2>
     {% if inactiveUsers|length %}

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -21,9 +21,9 @@
                     </p>
                 </div>
                 <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                    <label for="{{ form.insee.vars.id }}" class="fr-label">Email générique (facultatif)</label>
+                    <label for="{{ form.insee.vars.id }}" class="fr-label">E-mail générique (facultatif)</label>
                     {{ form_widget(form.email) }}
-                    <span class="fr-hint-text">Des emails concernant les signalements du partenaire seront envoyés à cette adresse.</span>
+                    <span class="fr-hint-text">Des e-mails concernant les signalements du partenaire seront envoyés à cette adresse.</span>
                 </div>
             </div>
         </div>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -36,7 +36,7 @@
         </div>
         <div class="fr-col-12 fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-6">
-                <div><b>Email générique :</b> {{ partner.email }}</div>
+                <div><b>E-mail générique :</b> {{ partner.email }}</div>
             </div>
             <div class="fr-col-6">
                 <div><b>Type :</b> {{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'Partenaire') }}</div>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -115,7 +115,7 @@
                 <th>Nom</th>
                 <th>Prénom</th>
                 <th>Courriel</th>
-                <th>Notif. emails</th>
+                <th>Notif. e-mails</th>
                 <th>Statut</th>
                 <th>Rôle</th>
                 <th class="fr-text--right">Actions</th>

--- a/templates/back/partner_archived/index.html.twig
+++ b/templates/back/partner_archived/index.html.twig
@@ -50,7 +50,7 @@
             <tr>
                 <th>Dpt.</th>
                 <th>Statut</th>
-                <th>Email</th>
+                <th>E-mail</th>
                 <th>Nom</th>
                 <th>Type</th>
             </tr>

--- a/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
@@ -14,7 +14,7 @@
                             <div class="fr-alert fr-alert--warning">
                                 <p>
                                     Si vous choisissez une <strong>date à venir</strong>,
-                                    un email sera automatiquement envoyé à l'usager.
+                                    un e-mail sera automatiquement envoyé à l'usager.
                                 </p>
                             </div>
 

--- a/templates/emails/accuse_reception_email.html.twig
+++ b/templates/emails/accuse_reception_email.html.twig
@@ -4,7 +4,7 @@
     <p>Bonjour,</p>
     <p>Nous avons bien reçu votre signalement concernant le logement situé <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>
-        <br>Vous recevrez par email les mises à jour concernant votre signalement.</p>
+        <br>Vous recevrez par e-mail les mises à jour concernant votre signalement.</p>
     {% if not signalement.isProprioAverti %}
         <p>
             Vous avez mentionné ne pas encore avoir alerté votre propriétaire. Il est nécessaire de l'informer de la

--- a/templates/emails/base_email.html.twig
+++ b/templates/emails/base_email.html.twig
@@ -379,7 +379,7 @@
             <td class="container">
                 <div class="content">
                     <div class="warning">
-                        <span><i>⚠ Cet email est généré automatiquement. Merci de ne pas y répondre.</i></span></br>
+                        <span><i>⚠ Cet e-mail est généré automatiquement. Merci de ne pas y répondre.</i></span></br>
                     </div>
                     <table role="presentation" class="main">
                         <!-- START MAIN CONTENT AREA -->

--- a/templates/emails/demande_feedback_usager_third_email.html.twig
+++ b/templates/emails/demande_feedback_usager_third_email.html.twig
@@ -11,7 +11,7 @@
     <p>
         Vous avez signalé un problème dans le logement au <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>. <br>
         Les services sont pleinement investis sur votre dossier. <br>
-        Cependant nous vous avons contacté par mail à 2 reprises afin de faire le point sur votre situation mais nos messages sont restés sans réponse de votre part. <br>
+        Cependant nous vous avons contacté par e-mail à 2 reprises afin de faire le point sur votre situation mais nos messages sont restés sans réponse de votre part. <br>
         Votre situation a-t-elle évolué ? Merci d'indiquer si vous souhaitez poursuivre ou arrêter la procédure en cliquant sur les boutons ci-dessous. <br>
     </p>
     

--- a/templates/emails/migration_pass_email.html.twig
+++ b/templates/emails/migration_pass_email.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>Dans le cadre de l'amélioration du service {{ platform.name }}, votre plateforme {{ platform.name }} a été migrée vers une plateforme unique !</p>
-    <p>Afin d'assurer la sécurité de votre compte, nous vous invitons à définir un nouveau mot de passe. Pour cela, cliquez sur le bouton ci-dessous et renseignez votre adresse mail</p>
+    <p>Afin d'assurer la sécurité de votre compte, nous vous invitons à définir un nouveau mot de passe. Pour cela, cliquez sur le bouton ci-dessous et renseignez votre adresse e-mail</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">
         <tbody>

--- a/templates/front/cgu_agents.html.twig
+++ b/templates/front/cgu_agents.html.twig
@@ -114,7 +114,7 @@
                 <ul>
                     <li>Le territoire ;</li>
                     <li>Le nom du partenaire ;</li>
-                    <li>L’email générique (facultatif) ;</li>
+                    <li>L’e-mail générique (facultatif) ;</li>
                     <li>Le type de partenaire ;</li>
                     <li>Les compétences du partenaire (facultatif) ;</li>
                     <li>Le ou les codes INSEE.</li>
@@ -126,7 +126,7 @@
                 <h2>Article 6 – Fonctionnalités spécifiques du Responsable de territoire et du Partenaire</h2>
                 <p>Le Responsable de territoire et le Partenaire sont habilités pour gérer les visites. Ils peuvent
                     ajouter une visite, modifier la date de la visite et confirmer la visite. </p>
-                <p>Ils reçoivent un mail de la Plateforme après chaque visite pour mettre à jour les informations de la
+                <p>Ils reçoivent un e-mail de la Plateforme après chaque visite pour mettre à jour les informations de la
                     visite et y ajouter les conclusions dans la partie « Visites ».
                 </p>
                 <p>Le Responsable de territoire est habilité pour affecter les signalements aux agents compétents.

--- a/templates/front/cgu_usagers.html.twig
+++ b/templates/front/cgu_usagers.html.twig
@@ -54,7 +54,7 @@
                             ;
                         </li>
                         <li>L’Usager valide le signalement en prenant connaissance que des services compétents peuvent
-                            programmer une visite du logement (un rappel par mail est envoyé à l’Usager 48 heures avant
+                            programmer une visite du logement (un rappel par e-mail est envoyé à l’Usager 48 heures avant
                             la visite) et que les informations déclarées vont être transmises à des Partenaires.
                         </li>
                     </ul>

--- a/templates/front/politique_de_confidentialite.html.twig
+++ b/templates/front/politique_de_confidentialite.html.twig
@@ -111,7 +111,7 @@
                 </ul>
                 <p>Pour les exercer, contactez-nous :</p>
                 <address>
-                    Email : <a href="mailto:dpd.daj.sg@developpement-durable.gouv.fr">dpd.daj.sg@developpement-durable.gouv.fr</a><br><br>
+                    E-mail : <a href="mailto:dpd.daj.sg@developpement-durable.gouv.fr">dpd.daj.sg@developpement-durable.gouv.fr</a><br><br>
                     Ou par voie postale :<br><br>
                     Ministère de la Transition écologique et solidaire<br>
                     Direction Générale de l’Aménagement, du Logement et de la Nature<br>

--- a/tests/Functional/Controller/SignalementFileControllerTest.php
+++ b/tests/Functional/Controller/SignalementFileControllerTest.php
@@ -125,7 +125,7 @@ class SignalementFileControllerTest extends WebTestCase
         $crawler = $this->client->request('GET', $redirectUrl);
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
         $this->assertStringContainsString(
-            'L\'export pdf vous sera envoyé par email',
+            'L\'export pdf vous sera envoyé par e-mail',
             $crawler->filter('.fr-alert')->text()
         );
     }

--- a/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
+++ b/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
@@ -118,25 +118,25 @@ class GridAffectationLoaderTest extends KernelTestCase
         $this->assertCount(
             2,
             $metaData['errors'],
-            'user-13-06@histologe.fr already exists and Partner emails exists partenaire-13-01@histologe.fr'
+            'user-13-06@histologe.fr already exists and Partner e-mails exists partenaire-13-01@histologe.fr'
         );
     }
 
     public function testValidateWithErrors(): void
     {
         $errors = [
-            'line 3 : Email incorrect pour un partenaire : arshistologe.fr',
+            'line 3 : E-mail incorrect pour un partenaire : arshistologe.fr',
             'line 5 : Type incorrect pour Random Type --> Random Type',
             'line 5 : Rôle incorrect pour jon.conor@histologe.fr --> Fake role',
             'line 6 : Type incorrect pour Random Type --> Random Type',
-            'line 6 : Email incorrect pour un utilisateur : john.doe@',
+            'line 6 : E-mail incorrect pour un utilisateur : john.doe@',
             'line 7 : Partenaire déjà existant avec (partenaire-13-01@histologe.fr) dans Bouches-du-Rhône, nom : Partenaire 13-01',
-            'line 8 : Email manquant pour Margaretta Borer, partenaire ADIL',
+            'line 8 : E-mail manquant pour Margaretta Borer, partenaire ADIL',
             'line 9 : Nom de partenaire manquant',
             'line 10 : Utilisateur déjà existant avec (user-13-06@histologe.fr) dans Bouches-du-Rhône, partenaire : Partenaire 13-06 ESABORA ARS, rôle : Utilisateur',
-            'Certains partenaires ont un mail en commun ddt-m@histologe.fr',
-            'Certains utilisateurs ont un mail en commun user-ddt@histologe.fr',
-            'Certains utilisateurs ont un mail en commun avec un partenaire ddt-m@histologe.fr,user-ddt@histologe.fr',
+            'Certains partenaires ont un e-mail en commun ddt-m@histologe.fr',
+            'Certains utilisateurs ont un e-mail en commun user-ddt@histologe.fr',
+            'Certains utilisateurs ont un e-mail en commun avec un partenaire ddt-m@histologe.fr,user-ddt@histologe.fr',
         ];
 
         $this->assertEquals(

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur.json
@@ -32,7 +32,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email",
+          "label": "Adresse e-mail",
           "slug": "vos_coordonnees_tiers_email"
         },
         {
@@ -84,7 +84,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_bailleur_occupant.json
@@ -50,7 +50,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email",
+          "label": "Adresse e-mail",
           "slug": "vos_coordonnees_occupant_email"
         },
         {

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_locataire.json
@@ -39,7 +39,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email",
+          "label": "Adresse e-mail",
           "slug": "vos_coordonnees_occupant_email"
         },
         {
@@ -117,7 +117,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_bailleur_email",
           "validate": {
             "required": false
@@ -1109,7 +1109,7 @@
         },
         {
           "type": "SignalementFormInfo",
-          "label": "Avant de déposer un signalement, il est recommandé de prévenir votre bailleur. Vous pourrez le faire grâce au modèle de courrier que nous vous enverrons par email dès la fin de votre signalement.",
+          "label": "Avant de déposer un signalement, il est recommandé de prévenir votre bailleur. Vous pourrez le faire grâce au modèle de courrier que nous vous enverrons par e-mail dès la fin de votre signalement.",
           "slug": "info_procedure_bailleur_prevenu_info",
           "conditional": {
             "show": "formStore.data.info_procedure_bailleur_prevenu ===  'non'"

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_service_secours.json
@@ -32,7 +32,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email",
+          "label": "Adresse e-mail",
           "slug": "vos_coordonnees_tiers_email"
         },
         {
@@ -86,7 +86,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false,
@@ -168,7 +168,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_bailleur_email",
           "validate": {
             "required": false,

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_particulier.json
@@ -46,7 +46,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email",
+          "label": "Adresse e-mail",
           "slug": "vos_coordonnees_tiers_email"
         },
         {
@@ -98,7 +98,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false
@@ -177,7 +177,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_bailleur_email",
           "validate": {
             "required": false

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tiers_pro.json
@@ -29,7 +29,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email",
+          "label": "Adresse e-mail",
           "slug": "vos_coordonnees_tiers_email"
         },
         {
@@ -81,7 +81,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false
@@ -160,7 +160,7 @@
         },
         {
           "type": "SignalementFormEmailfield",
-          "label": "Adresse email (facultatif)",
+          "label": "Adresse e-mail (facultatif)",
           "slug": "coordonnees_bailleur_email",
           "validate": {
             "required": false

--- a/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
+++ b/tools/wiremock/src/Resources/Signalement/questions_profile_tous.json
@@ -346,7 +346,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "",
-    "description": "<p>Un email a été envoyé à votre adresse. <br>Cliquez sur le lien dans l'email pour reprendre votre signalement.</p>",
+    "description": "<p>Un e-mail a été envoyé à votre adresse. <br>Cliquez sur le lien dans l'e-mail pour reprendre votre signalement.</p>",
     "slug": "draft_mail",
     "screenCategory": "Adresse et coordonnées",
     "components": {
@@ -373,7 +373,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre lien de suivi a bien été envoyé",
-    "description": "<p>Le lien vers votre page de suivi vous a été envoyé par email. Consultez votre boîte mail et n'oubliez de regarder dans les emails indésirables (spam).</p>",
+    "description": "<p>Le lien vers votre page de suivi vous a été envoyé par e-mail. Consultez votre boîte mail et n'oubliez de regarder dans les e-mails indésirables (spam).</p>",
     "slug": "lien_suivi_mail",
     "screenCategory": "Adresse et coordonnées",
     "components": {


### PR DESCRIPTION
## Ticket

#2505   

## Description
Le ticket était juste pour le texte `Le lien vers votre page de suivi vous a été envoyé par e-mail. Consultez votre boîte mail et n'oubliez de regarder dans les e-mails indésirables (spam).` quand on veut récupérer son lien de suivi à la création d'un signalement et détection de doublon, mais j'ai préféré le faire partout
Modifier `email` en `e-mail` partout

## Changements apportés
* Modification de textes un peu partout

## Pré-requis

## Tests
- [ ] Vérifier attentivement les fichiers
- [ ] Tester quelques cas
