### PR TITLE
Ajouter un DocumentType "AUTRE_PROCEDURE"

### DIFF
--- a/assets/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/controllers/back_signalement_view/form_upload_documents.js
@@ -110,6 +110,9 @@ function initializeUploadModal(
         if (modal.dataset.fileType == 'photo') {
             data.append('signalement-add-file[photos][]', file)
         } else {
+            if (modal.dataset.fileFilter == 'procedure') {
+                data.append('documentType', 'AUTRE_PROCEDURE')
+            }
             data.append('signalement-add-file[documents][]', file)
         }
         data.append('_token', addFileToken)

--- a/migrations/Version20240430120311.php
+++ b/migrations/Version20240430120311.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240430120311 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update file document_type from AUTRE to AUTRE_PROCEDURE for documents uploaded by users that are not USAGER';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE file f SET f.document_type = "AUTRE_PROCEDURE" WHERE f.file_type = "document" AND f.document_type = "AUTRE" AND f.uploaded_by_id IS NOT NULL AND f.uploaded_by_id NOT IN (SELECT id FROM user WHERE roles LIKE "%ROLE_USAGER%")');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -76,6 +76,9 @@ class SignalementFileController extends AbstractController
             ? File::INPUT_NAME_DOCUMENTS
             : File::INPUT_NAME_PHOTOS;
         $documentType = DocumentType::AUTRE;
+        if ($request->get('documentType') && $request->get('documentType') === DocumentType::AUTRE_PROCEDURE->name) {
+            $documentType = DocumentType::AUTRE_PROCEDURE;
+        }
         list($fileList) = $signalementFileProcessor->process($files, $inputName, $documentType);
 
         if (!$signalementFileProcessor->isValid()) {

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -21,6 +21,7 @@ enum DocumentType: String
     case BAILLEUR_DEVIS_POUR_TRAVAUX = 'BAILLEUR_DEVIS_POUR_TRAVAUX';
     case BAILLEUR_REPONSE_BAILLEUR = 'BAILLEUR_REPONSE_BAILLEUR';
     case AUTRE = 'AUTRE';
+    case AUTRE_PROCEDURE = 'AUTRE_PROCEDURE';
     case PHOTO_SITUATION = 'PHOTO_SITUATION';
     case PHOTO_VISITE = 'PHOTO_VISITE';
 
@@ -39,6 +40,7 @@ enum DocumentType: String
             self::BAILLEUR_DEVIS_POUR_TRAVAUX->name => 'Devis pour travaux',
             self::BAILLEUR_REPONSE_BAILLEUR->name => 'Réponse bailleur',
             self::AUTRE->name => 'Autre',
+            self::AUTRE_PROCEDURE->name => 'Autre procédure',
             self::PHOTO_SITUATION->name => 'Photo de désordre',
             self::PHOTO_VISITE->name => 'Photo de visite',
         ];
@@ -74,6 +76,7 @@ enum DocumentType: String
             self::PROCEDURE_SAISINE->name => self::PROCEDURE_SAISINE->label(),
             self::BAILLEUR_DEVIS_POUR_TRAVAUX->name => self::BAILLEUR_DEVIS_POUR_TRAVAUX->label(),
             self::BAILLEUR_REPONSE_BAILLEUR->name => self::BAILLEUR_REPONSE_BAILLEUR->label(),
+            self::AUTRE_PROCEDURE->name => self::AUTRE_PROCEDURE->label(),
         ];
     }
 


### PR DESCRIPTION
## Ticket

#2553

## Description
- Ajout du type de document "AUTRE_PROCEDURE"
- Ajout de ce type par défaut lors de l'ajout d'un document via la partie procédure
- Ajout de ce type dans la liste ds choix disponible pour les document procédure
- Migration injectant le type AUTRE_PROCEDURE sur tous les document de type AUTRE ajoutés par un agent.

## Pré-requis
`make npm-build`

## Tests
- [ ] Ouvrir http://localhost:8080/bo/signalements/00000000-0000-0000-2022-000000000004 et voir que tous les document se trouve dans la partie "Situation"
- [ ] Lancer `make execute-migration name=Version20240430120311 direction=up` et vérifier que les document sont passé dans procédure
- [ ] Ajouter un document depuis le bloc situation sans précisé le type et voir qu'il apparaît bien dans la partie situation
- [ ] Ajouter un document depuis le bloc procédure sans précisé le type et voir qu'il apparaît bien dans la partie procédure
