### PR TITLE
[BUG BO] affichage des suivis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/flex": "^2",
         "symfony/form": "6.4.*",
         "symfony/framework-bundle": "6.4.*",
+        "symfony/html-sanitizer": "6.4.*",
         "symfony/http-client": "6.4.*",
         "symfony/intl": "6.4.*",
         "symfony/lock": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3bd92411a2b067d0d71ed00cb5ea6e4",
+    "content-hash": "2aea8c9209f174807119a6cfe7836277",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3189,6 +3189,180 @@
             "time": "2024-01-28T23:22:08+00:00"
         },
         {
+            "name": "league/uri",
+            "version": "7.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "bedb6e55eff0c933668addaa7efa1e1f2c417cc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/bedb6e55eff0c933668addaa7efa1e1f2c417cc4",
+                "reference": "bedb6e55eff0c933668addaa7efa1e1f2c417cc4",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-interfaces": "^7.3",
+                "php": "^8.1"
+            },
+            "conflict": {
+                "league/uri-schemes": "^1.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
+                "league/uri-components": "Needed to easily manipulate URI objects components",
+                "php-64bit": "to improve IPV4 host parsing",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "uri-template",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri/tree/7.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T07:42:40+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "7.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "8d43ef5c841032c87e2de015972c06f3865ef718"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/8d43ef5c841032c87e2de015972c06f3865ef718",
+                "reference": "8d43ef5c841032c87e2de015972c06f3865ef718",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1",
+                "psr/http-factory": "^1",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "php-64bit": "to improve IPV4 host parsing",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common interfaces and classes for URI representation and interaction",
+            "homepage": "https://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "rfc6570",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T07:42:40+00:00"
+        },
+        {
             "name": "lorenzo/pinky",
             "version": "1.1.0",
             "source": {
@@ -3240,6 +3414,73 @@
                 "source": "https://github.com/lorenzo/pinky/tree/1.1.0"
             },
             "time": "2023-07-31T13:36:50+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
+                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
+            },
+            "time": "2024-03-31T07:05:07+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -6705,6 +6946,75 @@
                 }
             ],
             "time": "2024-03-23T16:06:09+00:00"
+        },
+        {
+            "name": "symfony/html-sanitizer",
+            "version": "v6.4.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/html-sanitizer.git",
+                "reference": "0ff5d77e3160c15db3dbc3515a4f0143e3e4a218"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/0ff5d77e3160c15db3dbc3515a4f0143e3e4a218",
+                "reference": "0ff5d77e3160c15db3dbc3515a4f0143e3e4a218",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "league/uri": "^6.5|^7.0",
+                "masterminds/html5": "^2.7.2",
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HtmlSanitizer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to sanitize untrusted HTML input for safe insertion into a document's DOM.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "Purifier",
+                "html",
+                "sanitizer"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/html-sanitizer/tree/v6.4.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:22:46+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -11474,73 +11784,6 @@
                 "source": "https://github.com/FakerPHP/Faker/tree/v1.23.1"
             },
             "time": "2024-01-02T13:46:09+00:00"
-        },
-        {
-            "name": "masterminds/html5",
-            "version": "2.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
-                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Masterminds\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Matt Butcher",
-                    "email": "technosophos@gmail.com"
-                },
-                {
-                    "name": "Matt Farina",
-                    "email": "matt@mattfarina.com"
-                },
-                {
-                    "name": "Asmir Mustafic",
-                    "email": "goetas@gmail.com"
-                }
-            ],
-            "description": "An HTML5 parser and serializer.",
-            "homepage": "http://masterminds.github.io/html5-php",
-            "keywords": [
-                "HTML5",
-                "dom",
-                "html",
-                "parser",
-                "querypath",
-                "serializer",
-                "xml"
-            ],
-            "support": {
-                "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
-            },
-            "time": "2024-03-31T07:05:07+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -20,3 +20,4 @@ framework:
                     th: ''
                     td: ''
                 drop_elements: ['img']
+                max_input_length: 20000000

--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -1,0 +1,16 @@
+framework:
+    html_sanitizer:
+        sanitizers:
+            app.message_sanitizer:
+                allow_relative_links: true
+                allow_elements:
+                    a: ['class', 'target', 'href', 'title', 'rel']
+                    ul: ''
+                    ol: ''
+                    li: ''
+                    strong: ''
+                    em: ''
+                    br: ''
+                    span: ''
+                    div: ''
+                block_elements: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']

--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -2,6 +2,7 @@ framework:
     html_sanitizer:
         sanitizers:
             app.message_sanitizer:
+                allow_safe_elements: true
                 allow_relative_links: true
                 allow_elements:
                     a: ['class', 'target', 'href', 'title', 'rel']
@@ -10,7 +11,12 @@ framework:
                     li: ''
                     strong: ''
                     em: ''
-                    br: ''
                     span: ''
                     div: ''
-                block_elements: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+                    table: ''
+                    thead: ''
+                    tbody: ''
+                    tr: ''
+                    th: ''
+                    td: ''
+                drop_elements: ['img']

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -557,7 +557,7 @@ class SignalementController extends AbstractController
         );
 
         $description = htmlspecialchars(
-            nl2br($request->get('signalement_front_response')['content']),
+            $request->get('signalement_front_response')['content'],
             \ENT_QUOTES,
             'UTF-8'
         );

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -556,11 +556,11 @@ class SignalementController extends AbstractController
             isPublic: true,
         );
 
-        $description = htmlspecialchars(
+        $description = nl2br(htmlspecialchars(
             $request->get('signalement_front_response')['content'],
             \ENT_QUOTES,
             'UTF-8'
-        );
+        ));
 
         $docs = $entityManager->getRepository(File::class)->findBy(['signalement' => $signalement, 'isTemp' => true, 'uploadedBy' => $user]);
         if (\count($docs)) {

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -109,9 +109,7 @@ class Suivi
             return $this->description;
         }
 
-        $transformed = str_replace('&lt;br /&gt;', '<br />', $this->description);
-
-        return $transformed;
+        return str_replace('&lt;br /&gt;', '<br />', $this->description);
     }
 
     public function setDescription(string $description): self

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -109,7 +109,9 @@ class Suivi
             return $this->description;
         }
 
-        return str_replace('&lt;br /&gt;', '<br>', nl2br($this->description));
+        $transformed = str_replace('&lt;br /&gt;', '<br />', $this->description);
+
+        return $transformed;
     }
 
     public function setDescription(string $description): self

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -99,13 +99,17 @@ class Suivi
         return $this;
     }
 
-    public function getDescription(): ?string
+    public function getDescription($transformHtml = true): ?string
     {
         if (null !== $this->deletedAt) {
             return self::DESCRIPTION_DELETED.' '.$this->deletedAt->format('d/m/Y');
         }
 
-        return $this->description;
+        if (!$transformHtml) {
+            return $this->description;
+        }
+
+        return str_replace('&lt;br /&gt;', '<br>', nl2br($this->description));
     }
 
     public function setDescription(string $description): self

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -51,7 +51,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
         $firstSuivi = $this->suiviRepository->findFirstSuiviBy($signalement, Suivi::TYPE_PARTNER);
 
         $cleanedSuiviDescription = null !== $firstSuivi && null !== $firstSuivi->getDescription()
-            ? HtmlCleaner::clean($firstSuivi->getDescription())
+            ? HtmlCleaner::clean($firstSuivi->getDescription(false))
             : null;
 
         $formatDate = AbstractEsaboraService::FORMAT_DATE;

--- a/templates/back/notifications/index.html.twig
+++ b/templates/back/notifications/index.html.twig
@@ -61,7 +61,7 @@
                         |replace({'&t=___TOKEN___':'/'~notification.signalement.uuid})
                         |replace({'?t=___TOKEN___':'/'~notification.signalement.uuid})
                         |replace({'?folder=_up':'/'~notification.signalement.uuid~'?variant=resize'})
-                        |raw }}
+                        |sanitize_html('app.message_sanitizer') }}
                     </td>
                     <td>{{ notification.suivi.createdBy ? notification.suivi.createdBy.nomComplet : notification.signalement.nomOccupant|upper~' '~notification.signalement.prenomOccupant|capitalize }}</td>
                     <td class="fr-text--right">

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -63,6 +63,12 @@
         {% else %}
             <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
         {% endif %}
+            {#{{ dump(suivi.description
+                |replace({'&t=___TOKEN___':'/'~signalement.uuid})
+                |replace({'?t=___TOKEN___':'/'~signalement.uuid})
+                |replace({'?folder=_up':'/'~signalement.uuid~'?variant=resize'})
+                |sanitize_html('app.message_sanitizer'))
+            }}#}
             {{ suivi.description
                 |replace({'&t=___TOKEN___':'/'~signalement.uuid})
                 |replace({'?t=___TOKEN___':'/'~signalement.uuid})

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -67,7 +67,7 @@
                 |replace({'&t=___TOKEN___':'/'~signalement.uuid})
                 |replace({'?t=___TOKEN___':'/'~signalement.uuid})
                 |replace({'?folder=_up':'/'~signalement.uuid~'?variant=resize'})
-                |raw
+                |sanitize_html('app.message_sanitizer')
             }}
         </div>
         <div class="fr-col-2">

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -68,7 +68,7 @@
             {% if signalement.interventions is empty or intervention.details is empty %}
                 Non renseigné
             {% else %}
-                {{ intervention.details|raw|nl2br|sanitize_html('app.message_sanitizer') }}
+                {{ intervention.details|sanitize_html('app.message_sanitizer') }}
             {% endif %}
             </p>
         </div>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -68,7 +68,7 @@
             {% if signalement.interventions is empty or intervention.details is empty %}
                 Non renseigné
             {% else %}
-                {{ intervention.details|raw }}
+                {{ intervention.details|raw|nl2br|sanitize_html('app.message_sanitizer') }}
             {% endif %}
             </p>
         </div>

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -14,7 +14,7 @@
 				</strong>
 			</div>
 			<div class="message-box-message">
-				{{ suivi.description|replace({'___TOKEN___':csrf_token('suivi_signalement_ext_file_view')})|raw }}
+				{{ suivi.description|replace({'___TOKEN___':csrf_token('suivi_signalement_ext_file_view')})|sanitize_html('app.message_sanitizer') }}
 			</div>
 		</div>
 	{% endfor %}

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -270,7 +270,7 @@
                                 {% endif %}
                                 <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
                             </td>
-                            <td style="padding:.5rem;width:85%">  {{ suivi.description|raw }}</td>
+                            <td style="padding:.5rem;width:85%">  {{ suivi.description|sanitize_html('app.message_sanitizer') }}</td>
                         </tr>
                     {% endfor %}
                 </table>


### PR DESCRIPTION
## Ticket

#2499

## Description
Correction de l'affichage des suivis qui pouvant contenir de L’HTML peuvent casser l'affichage

## Changements apportés
* Ajout du composant Symfony [HTML Sanitizer](https://symfony.com/doc/current/html_sanitizer.html)
* Configuration du composant afin qu'il autorise uniquement les balise et attribut HTML attendu lors de l'affichage des suivi / rapport de visite
* Ne plus convertir les saut de ligne en en entité mais en html simple lors du dépot suivi usager (+ conversion avant affichage des ancien `br` enregistré en entité html pour un affichage correct)

## Pré-requis
`make composer`

## Tests
- [ ] Copier coller du HTML dans un suivi agent / un rapport de visite et vérifier que l'affichage reste correct.
- [ ] Déposer un suivi contenant des saut de ligne en tant qu'usager et vérifier qu'il s'affiche correctement


## Notes
- Une fois validé, penser à intégrer dans la PR #2514 pour la nouvelle version de la page de suivi
