### PR TITLE
[BO - Document] Mise à jour des types de documents

### DIFF
--- a/migrations/Version20240503102522.php
+++ b/migrations/Version20240503102522.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Enum\DocumentType;
+use App\Entity\Signalement;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240503102522 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update document type based on title)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $clauseisAutre = "AND f.document_type = '".DocumentType::AUTRE->name."'";
+        $clauseIsAutreProcedure = "AND f.document_type = '".DocumentType::AUTRE_PROCEDURE->name."'";
+        $clauseisAutreOrIsAutreProcedure = "AND (f.document_type = '".DocumentType::AUTRE->name."' OR f.document_type = '".DocumentType::AUTRE_PROCEDURE->name."')";
+
+        $autreTitle = ['photo'];
+        $this->addSql($this->generateUpdateSQL(DocumentType::AUTRE->name, $autreTitle, $clauseIsAutreProcedure));
+
+        $procedureRapportDeVisite = ['visite'];
+        $this->addSql($this->generateUpdateSQL(DocumentType::PROCEDURE_RAPPORT_DE_VISITE->name, $procedureRapportDeVisite, $clauseisAutreOrIsAutreProcedure));
+
+        $situationFoyerBail = ['bail_', 'bail-', 'bail '];
+        $this->addSql($this->generateUpdateSQL(DocumentType::SITUATION_FOYER_BAIL->name, $situationFoyerBail, $clauseisAutreOrIsAutreProcedure));
+
+        $situationFoyerEtatDesLieux = ['lieux'];
+        $this->addSql($this->generateUpdateSQL(DocumentType::SITUATION_FOYER_ETAT_DES_LIEUX->name, $situationFoyerEtatDesLieux, $clauseisAutreOrIsAutreProcedure));
+
+        $situationFoyerDPE = ['DPE'];
+        $this->addSql($this->generateUpdateSQL(DocumentType::SITUATION_FOYER_DPE->name, $situationFoyerDPE, $clauseisAutreOrIsAutreProcedure));
+
+        $autreProcedure = [
+            'rapport', 'courrier', 'demeure', 'facture', 'devis', 'travaux', 'arrete', 'urgence',
+            'peril', 'securite', 'bailleur',
+            'LMD', 'mairie', 'lettre', 'proprio', 'proprietaire',
+        ];
+        $this->addSql($this->generateUpdateSQL(DocumentType::AUTRE_PROCEDURE->name, $autreProcedure, $clauseisAutre));
+    }
+
+    public function generateUpdateSQL($type, $terms, $clauseSup)
+    {
+        $likeClauses = [];
+        foreach ($terms as $term) {
+            $likeClauses[] = "f.title LIKE '%".$term."%'";
+        }
+        $likeClause = 'AND ('.implode(' OR ', $likeClauses).') ';
+
+        $sql = "
+        UPDATE file f
+        INNER JOIN signalement s ON f.signalement_id = s.id
+        SET f.document_type = '".$type."'
+        WHERE f.file_type = 'document'
+        AND (s.statut = '".Signalement::STATUS_NEED_VALIDATION."' OR s.statut = '".Signalement::STATUS_ACTIVE."') "
+        .$likeClause.$clauseSup;
+
+        return $sql;
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#2526

## Description
Migration du `documentType` des fichiers : 
- de `fileType` = "document" et `documentType` = "AUTRE" ou "AUTRE_PROCEDURE"
- Concernant des signalement actif
Suivant cet algo : 
![image](https://github.com/MTES-MCT/histologe/assets/7130780/7f539a90-47a5-4352-9b7c-fd021d7999b2)
Certains document pouvant répondre à plusieurs critères la priorité va sur le type "AUTRE_PROCEDURE"

## Pré-requis
`make execute-migration name=Version20240503102522 direction=up`

## Tests
- [ ] Vérifier que les type de document correspondent a ceux définis par l'algo
Ex la requete suivante ne devrait pas retourner de résultat : 
```
SELECT * FROM `file` f INNER JOIN signalement s ON s.id = f.signalement_id 
WHERE (s.statut = 1 OR s.statut = 2) 
and f.title like '%courrier%' 
and f.file_type = 'document' 
and (f.document_type = 'AUTRE');
```
