### PR TITLE
[QA - Sécurité] Alerte github historique

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -773,6 +773,10 @@ h2, h3 {
     }
 }
 
+#tags_active_container, #tags_inactive_container{
+    .fr-badge{cursor: pointer;}
+}
+
 
 @media (min-width: 992px) {
     .text-align-right--lg {

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -195,36 +195,19 @@ class SignalementActionController extends AbstractController
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_switch_value_'.$signalement->getUuid(), $request->get('_token'))) {
             $return = 0;
-            $item = $request->get('item');
-            $getMethod = 'get'.$item;
-            $setMethod = 'set'.$item;
             $value = $request->get('value');
-            if ('Tag' === $item) {
-                $tag = $entityManager->getRepository(Tag::class)->find((int) $value);
-                if ($signalement->getTags()->contains($tag)) {
-                    $signalement->removeTag($tag);
-                } else {
-                    $signalement->addTag($tag);
-                }
-            } else {
-                if (!$value) {
-                    $value = !(int) $signalement->$getMethod() ?? 1;
-                    $return = 1;
-                }
 
-                $signalement->$setMethod($value);
+            $tag = $entityManager->getRepository(Tag::class)->find((int) $value);
+            if ($signalement->getTags()->contains($tag)) {
+                $signalement->removeTag($tag);
+            } else {
+                $signalement->addTag($tag);
             }
+
             $entityManager->persist($signalement);
             $entityManager->flush();
-            if ('CodeProcedure' === $item) {
-                $item = 'Le type de procédure';
-            }
-            if (\is_bool($value) || 'Tag' === $item) {
-                return $this->json(['response' => 'success', 'return' => $return]);
-            }
-            $this->addFlash('success', $item.' a bien été enregistré !');
 
-            return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+            return $this->json(['response' => 'success', 'return' => $return]);
         }
 
         return $this->json(['response' => 'error'], 400);

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -194,7 +194,6 @@ class SignalementActionController extends AbstractController
     {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
         if ($this->isCsrfTokenValid('signalement_switch_value_'.$signalement->getUuid(), $request->get('_token'))) {
-            $return = 0;
             $value = $request->get('value');
 
             $tag = $entityManager->getRepository(Tag::class)->find((int) $value);
@@ -207,7 +206,7 @@ class SignalementActionController extends AbstractController
             $entityManager->persist($signalement);
             $entityManager->flush();
 
-            return $this->json(['response' => 'success', 'return' => $return]);
+            return $this->json(['response' => 'success']);
         }
 
         return $this->json(['response' => 'error'], 400);

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -1,13 +1,7 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% set picto_yes = '<p class="fr-badge fr-badge--success" data-action="click" data-item="%s" data-url="'~path('back_signalement_switch_value',{uuid:signalement.uuid})~'" data-token="'~csrf_token('signalement_switch_value_'~signalement.uuid)~'">Oui</p>' %}
-{% set picto_no = '<p class="fr-badge fr-badge--error" data-action="click" data-item="%s" data-url="'~path('back_signalement_switch_value',{uuid:signalement.uuid})~'" data-token="'~csrf_token('signalement_switch_value_'~signalement.uuid)~'">Non</p>' %}
-{% set picto_nsp = '<p class="fr-badge fr-badge--warning" data-action="click" data-item="%s" data-url="'~path('back_signalement_switch_value',{uuid:signalement.uuid})~'" data-token="'~csrf_token('signalement_switch_value_'~signalement.uuid)~'">NSP</p>' %}
 {% set static_picto_yes = '<p class="fr-badge fr-badge--success">Oui</p>' %}
 {% set static_picto_no = '<p class="fr-badge fr-badge--error">Non</p>' %}
-{% set static_picto_nsp = '<p class="fr-badge fr-badge--warning">NSP</p>' %}
-{% set procedures = ["RSD" , "Mise en sécurité","Incurie","Insalubrité", "Décence", "ADIL"] %}
-
 
 {% block content %}
     {% include '_partials/_modal_affectation.html.twig' %}


### PR DESCRIPTION
## Ticket

#2531

## Description
- Suppression d'une partie du code qui semble inutilisé et qui contenait la faille de sécurité

## Tests
- [ ] Vérifier que la route `back_signalement_switch_value` n'avait pas d'autre utilité que l'ajout/retrait de tag
