### PR TITLE
[Sécurité - Login] Ne pas activer par défaut les user avec ROLE_USAGER

### DIFF
--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -152,7 +152,6 @@ class UserManager extends AbstractManager
                 );
 
                 $user->setIsMailingActive(true);
-                $user->setStatut(User::STATUS_ACTIVE);
                 $this->save($user);
             }
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -106,6 +106,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
                 FROM user u
                 LEFT JOIN affectation a  on a.partner_id = u.partner_id and a.statut = 0
                 WHERE u.statut = 0 AND DATE(u.created_at) <= (DATE(NOW()) - INTERVAL 10 DAY)
+                AND u.roles NOT LIKE "%ROLE_USAGER%"
                 GROUP BY u.email, u.created_at
                 ORDER BY nb_signalements desc';
 

--- a/src/Security/BackOfficeAuthenticator.php
+++ b/src/Security/BackOfficeAuthenticator.php
@@ -48,7 +48,7 @@ class BackOfficeAuthenticator extends AbstractLoginFormAuthenticator
 
         return new Passport(
             new UserBadge($email, function (string $email) {
-                return $this->userRepository->findOneBy(['email' => $email, 'statut' => [User::STATUS_ACTIVE, User::STATUS_INACTIVE]]);
+                return $this->userRepository->findOneBy(['email' => $email, 'statut' => User::STATUS_ACTIVE]);
             }),
             new PasswordCredentials($request->request->get('password', '')),
             [

--- a/tests/Functional/Command/Cron/RemindInactiveUserCommandTest.php
+++ b/tests/Functional/Command/Cron/RemindInactiveUserCommandTest.php
@@ -22,7 +22,7 @@ class RemindInactiveUserCommandTest extends KernelTestCase
         $commandTester->assertCommandIsSuccessful();
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('9 users has been notified', $output);
-        $this->assertEmailCount(10);
+        $this->assertStringContainsString('8 users has been notified', $output);
+        $this->assertEmailCount(9);
     }
 }

--- a/tests/Functional/Repository/UserRepositoryTest.php
+++ b/tests/Functional/Repository/UserRepositoryTest.php
@@ -29,7 +29,7 @@ class UserRepositoryTest extends KernelTestCase
         $users = $userRepository->findInactiveWithNbAffectationPending();
 
         $this->assertIsArray($users);
-        $this->assertCount(9, $users);
+        $this->assertCount(8, $users);
         foreach ($users as $user) {
             $this->assertArrayHasKey('email', $user);
             if (!empty($user['signalements'])) {


### PR DESCRIPTION
## Ticket

#2032

## Description
- Les utilisateur USAGER restent au `STATUS_INACTIVE` à la création
- La commande `app:remind-inactive-user` exclus les utilisateur de `ROLE_USAGER`
- Le système de login, permet le login des user au `STATUS_ACTIVE` uniquement

## Tests
- [ ] Vérifier que le fait de laisser les usager au `STATUS_INACTIVE` n'a pas d'impact sur le fonctionnement général
