### PR TITLE
[FO - Stats] Ajouter une marge sous la légende

### DIFF
--- a/assets/vue/components/common/HistoFranceMap.vue
+++ b/assets/vue/components/common/HistoFranceMap.vue
@@ -648,7 +648,7 @@
               <span>{{ minValue }}</span>
               <span>{{ maxValue }}+</span>
             </div>
-            <div class="legend-labels">
+            <div class="legend-labels fr-my-1w">
               <div class="legend-undeployed"></div> Département non déployé
             </div>
           </div>


### PR DESCRIPTION
## Ticket

#2533    

## Description
Sur la carte

    Ajouter un espace avant la ligne du rectangle gris -territoire non déployé
    Ajouter un espace à la fin de la légende (pour que le texte ne soit pas collé au bord)


## Changements apportés
* Ajout d'une classe css de margin

## Pré-requis

## Tests
- [ ] Vérifier l'affichage des stats FO
