### PR TITLE
[FO - Bailleur] Problème sur la recherche multi-terme quand l'option de nettoyage ([RADIE]) est activé

### DIFF
--- a/src/Controller/BailleurController.php
+++ b/src/Controller/BailleurController.php
@@ -36,9 +36,16 @@ class BailleurController extends AbstractController
     private function sanitizeBailleurs(array $bailleurs, string $name): ArrayCollection
     {
         return (new ArrayCollection($bailleurs))
-            ->filter(fn ($bailleurItem) => str_contains(
-                strtolower($this->sanitizeName($bailleurItem->getName())),
-                strtolower($name)))
+            /* @var Bailleur $bailleurItem */
+            ->filter(function ($bailleurItem) use ($name) {
+                if (str_starts_with($bailleurItem->getName(), Bailleur::BAILLEUR_RADIE)) {
+                    $terms = explode(' ', $name);
+
+                    return str_contains(strtolower($this->sanitizeName($bailleurItem->getName())), $terms[0]);
+                }
+
+                return true;
+            })
             ->map(fn ($bailleurItem) => $bailleurItem->setName($this->sanitizeName($bailleurItem->getName())));
     }
 

--- a/tests/Functional/Controller/BailleurControllerTest.php
+++ b/tests/Functional/Controller/BailleurControllerTest.php
@@ -52,7 +52,6 @@ class BailleurControllerTest extends WebTestCase
 
         $this->client->request('GET', $route);
         $response = json_decode($this->client->getResponse()->getContent(), true);
-
         foreach ($response as $item) {
             $this->assertStringContainsString('ra', strtolower($item['name']));
             $this->assertStringNotContainsString(Bailleur::BAILLEUR_RADIE, strtolower($item['name']));
@@ -69,5 +68,19 @@ class BailleurControllerTest extends WebTestCase
         foreach ($response as $item) {
             $this->assertStringContainsString(Bailleur::BAILLEUR_RADIE, $item['name']);
         }
+    }
+
+    public function testSearchTermsSanitized(): void
+    {
+        $routeFirst = $this->router->generate('app_bailleur', ['name' => 'habitat 13', 'postcode' => 13002, 'sanitize' => true]);
+
+        $this->client->request('GET', $routeFirst);
+        $responseFirst = json_decode($this->client->getResponse()->getContent(), true);
+
+        $routeSecond = $this->router->generate('app_bailleur', ['name' => '13 habitat', 'postcode' => 13002, 'sanitize' => true]);
+        $this->client->request('GET', $routeSecond);
+        $responseSecond = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertEquals($responseFirst, $responseSecond);
     }
 }


### PR DESCRIPTION
## Ticket

#2534   

## Description
La récupération des bailleurs (auto-complete) en front ne fonctionne pas comme prévu avec plusieurs termes. 
*Exemple:* 
Bien qu'en base de donnée le bailleur se nomme **13 Habitat**, la recherche sur `habitat 13` ou `13 habitat` doit retourner le même résultat


## Changements apportés
* Ajout d'une condition pour traitement uniquement sur le bailleur avec la mention radié et non sur tous les bailleur
* Dans la fonction de filtrage, travailler uniquement avec le premier terme


## Pré-requis
Pour ne pas se limiter au bailleur des fixtures
```
make console app="import-bailleur"
```
## Tests
- [ ] Depuis le formulaire en tant que déclarant avec logement social, rechercher un bailleur radié ou non avec plusieurs termes
