### PR TITLE
[QA] App\Manager\AffectationManager::createAffectationFrom(): Argument #3 ($user) must be of type ?App\Entity\User

### DIFF
--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -181,7 +181,7 @@ class SignalementImportLoader
                 $affectation = $this->affectationManager->createAffectationFrom(
                     $signalement,
                     $partner,
-                    $partner?->getUsers()?->first()
+                    $partner->getUsers()->isEmpty() ? null : $partner->getUsers()->first(),
                 );
                 if ($affectation instanceof Affectation) {
                     $affectation


### PR DESCRIPTION
## Ticket

#2539

## Description
- Fix de la commande `app:import-signalement` en cas d’affectation sur un partenaire sans utilisateurs (voir erreur https://sentry.incubateur.net/organizations/betagouv/issues/99549/?environment=prod&project=61&query=is%3Aunresolved&referrer=issue-stream)


