### PR TITLE
[QA] Warning: Cannot modify header information - headers already sent by

### DIFF
--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -40,7 +40,7 @@ class ExportSignalementController extends AbstractController
                 $response->headers->set('Content-Disposition', $disposition);
                 restore_error_handler();
 
-                return $response->send();
+                return $response;
             } catch (\ErrorException $e) {
                 restore_error_handler();
                 throw new \Exception('Erreur lors de l\'export du fichier par l\'user "'.$user->getId().'" : '.$e->getMessage().' - '.print_r($filters, true));


### PR DESCRIPTION
## Ticket

#2253    

## Description
Le problème n'a pas été résolu, réouverture du ticket

## Changements apportés
* Suppression de l'appel de la méthode send(), retourner uniquement la réponse résoud le problème

## Pré-requis
ouvrir les logs
```
tail -f var/log/dev.log
```
## Tests
- [ ] Faite un export et vérifier qu'il n'y ai plus d'exception

```
tail -f var/log/dev.log | grep "CRITI"
```
```
[2024-05-10T10:30:51.846792+00:00] request.CRITICAL: Uncaught PHP Exception ErrorException: "Warning: Cannot modify header information - headers already sent by (output started at /app/src/Service/Signalement/Export/SignalementExportLoader.php:19)" at SessionUtils.php line 52 {"exception":"[object] (ErrorException(code: 0): Warning: Cannot modify header information - headers already sent by (output started at /app/src/Service/Signalement/Export/SignalementExportLoader.php:19) at /app/vendor/symfony/http-foundation/Session/SessionUtils.php:52)"} []
```


