### PR TITLE
  [FO - Suivi usager] Mauvais affichage de l'auteur des rappels de visites sur la page de suivi usager 

### DIFF
--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -5,10 +5,17 @@
 </div>
 <div class="fr-mt-4v">
 	{% for suivi in signalement.suivis %}
-		<div class="message-box {% if suivi.createdBy and suivi.createdBy.partner %}message-box--partner{% else %}message-box--usager{% endif %}">
+		<div class="message-box {% if (suivi.createdBy and suivi.createdBy.partner) or suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}message-box--partner{% else %}message-box--usager{% endif %}">
 			<div>
 				<strong>
-					{{ suivi.createdBy ? (suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')): (suivi.createdAt|date('Y') >= 2024) ? 'Occupant ou déclarant' : 'Vous' }}
+				
+					{% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
+						Suivi automatique
+					{% elseif suivi.createdBy is not null %}
+						{{ suivi.createdBy.partner ? suivi.createdBy.partner.nom : (suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')}}					
+            		{% else %}
+						{{(suivi.createdAt|date('Y') >= 2024) ? 'Occupant ou déclarant' : 'Vous' }}					
+                	{% endif %}
 					-
 					{{ suivi.createdAt|date('d/m/Y') }}
 				</strong>


### PR DESCRIPTION
## Ticket

#2552   

## Description
L'auteur des suivis automatiques visibles aux usagers étaient faux sur la page de suivi usager (mais correct dans le BO)

## Changements apportés
* Modification du twig

## Pré-requis

## Tests
- [ ] Ouvrir un signalement avec un partenaire visite affecté 
- [ ] Planifier une visite dans 2 jours
- [ ] Déclencher la commande `make console app="notify-visits"`
- [ ] Ouvrir la fiche usager correspondante au signalement, et vérifier que le message `Rappel de visite` est bien attribué à "Suivi automatique" et a le style partenaire
- [ ] Faire différents suivis publics sur le signalement (occupant, déclarant, depuis la page usager mais sans champ from dans la barre d'adresse, en tant que partenaire, que RT, que SA)
- [ ] Vérifier l'affichage de l'auteur de ces suivis sur la page de suivi usager et dans le BO
