### PR TITLE
[FO - Form étape désordres] Ajouter des messages warning sur les récap désordres 

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -1011,6 +1011,14 @@
           ]
         },
         {
+          "type": "SignalementFormWarning",
+          "slug": "desordres_renseignes_batiment_warning",
+          "label": "Vous n'avez renseigné aucun désordre dans la partie Bâtiment. Pour ajouter des désordres, cliquez sur le bouton \"Non, j'en ai encore à déclarer\" ci-dessous.",
+          "conditional": {
+            "show": "formStore.hasDesordre('desordres_batiment') === false"
+          }
+        },
+        {
           "type": "SignalementFormSubscreen",
           "label": "Avez-vous terminé avec les désordres sur le bâtiment ?",
           "slug": "desordres_renseignes_batiment_subscreen",
@@ -2518,22 +2526,38 @@
               "alt": ""
             }
           ]
-        }
-      ],
-      "footer": [
-        {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_renseignes_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_renseignes_next",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormWarning",
+          "slug": "desordres_renseignes_warning",
+          "label": "Vous n'avez renseigné aucun désordre. Pour vous assurer du bon traitement de votre signalement, veuillez sélectionner au moins un désordre. Nous vous invitons également à renseigner le champ \"Précisions sur les désordres\" ci-dessus pour décrire votre problème.",
+          "conditional": {
+            "show": "formStore.hasDesordre('desordres_') === false"
+          }
+        },
+        {
+          "type": "SignalementFormSubscreen",
+          "label": "",
+          "slug": "desordres_renseignes_subscreen",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Je passe à la suite",
+                "slug": "desordres_renseignes_next",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Je renseigne les désordres",
+                "slug": "desordres_renseignes_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
         }
       ]
     }

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -1024,6 +1024,14 @@
           ]
         },
         {
+          "type": "SignalementFormWarning",
+          "slug": "desordres_renseignes_batiment_warning",
+          "label": "Vous n'avez renseigné aucun désordre dans la partie Bâtiment. Pour ajouter des désordres, cliquez sur le bouton \"Non, j'en ai encore à déclarer\" ci-dessous.",
+          "conditional": {
+            "show": "formStore.hasDesordre('desordres_batiment') === false"
+          }
+        },
+        {
           "type": "SignalementFormSubscreen",
           "label": "Avez-vous terminé avec les désordres sur le bâtiment ?",
           "slug": "desordres_renseignes_batiment_subscreen",
@@ -2534,34 +2542,50 @@
               "alt": ""
             }
           ]
-        }
-      ],
-      "footer": [
-        {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_renseignes_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_renseignes_next_autre",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+          "type": "SignalementFormWarning",
+          "slug": "desordres_renseignes_warning",
+          "label": "Vous n'avez renseigné aucun désordre. Pour vous assurer du bon traitement de votre signalement, veuillez sélectionner au moins un désordre. Nous vous invitons également à renseigner le champ \"Précisions sur les désordres\" ci-dessus pour décrire votre problème.",
           "conditional": {
-            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+            "show": "formStore.hasDesordre('desordres_') === false"
           }
         },
         {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_renseignes_next_secours",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-          "conditional": {
-            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
+          "type": "SignalementFormSubscreen",
+          "label": "",
+          "slug": "desordres_renseignes_subscreen",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Je passe à la suite",
+                "slug": "desordres_renseignes_next_autre",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Je passe à la suite",
+                "slug": "desordres_renseignes_next_secours",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Je renseigne les désordres",
+                "slug": "desordres_renseignes_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
           }
         }
       ]

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -120,6 +120,11 @@
             <a href="#" class="btn-link fr-btn--icon-left fr-icon-edit-line" @click="handleEdit('ecran_intermediaire_les_desordres')">Editer</a>
           </div>
         </div>
+        <SignalementFormWarning
+          v-if="formStore.hasDesordre('desordres_') === false"
+          :id="idDisorderOverview+'_warning'"
+          label="Vous n'avez renseigné aucun désordre. Pour vous assurer du bon traitement de votre signalement, veuillez sélectionner au moins un désordre."
+        />
         <SignalementFormDisorderOverview
           :id="idDisorderOverview"
           :icons="disorderIcons"
@@ -184,12 +189,14 @@ import { defineComponent } from 'vue'
 import formStore from './../store'
 import dictionaryStore from './../dictionary-store'
 import SignalementFormDisorderOverview from './SignalementFormDisorderOverview.vue'
+import SignalementFormWarning from './SignalementFormWarning.vue'
 import { dictionaryManager } from './../services/dictionaryManager'
 
 export default defineComponent({
   name: 'SignalementFormOverview',
   components: {
-    SignalementFormDisorderOverview
+    SignalementFormDisorderOverview,
+    SignalementFormWarning
   },
   props: {
     id: { type: String, default: null },

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -61,6 +61,7 @@ interface FormStore {
   updateData: (key: string, value: any) => void
   shouldShowField: (conditional: string) => boolean
   preprocessScreen: (screenBodyComponents: any) => Component[]
+  hasDesordre: (categorieSlug: string) => boolean
 }
 
 const formStore: FormStore = reactive({
@@ -181,6 +182,17 @@ const formStore: FormStore = reactive({
         }
       }
     }
+  },
+  hasDesordre (categorieSlug: string) {
+    let hasDesordre = false
+    for (const dataname in formStore.data) {
+      if (dataname.includes(categorieSlug) && formStore.data[dataname] !== null) {
+        hasDesordre = true
+        break
+      }
+    }
+
+    return hasDesordre
   }
 })
 


### PR DESCRIPTION
## Ticket

#2362    

## Description
Ajout de warning sur les 3 récap du formulaires si aucun désordre n'a été sélectionné

## Changements apportés
* Ajout d'une fonction dans le store pour vérifier si des désordres ont été cochés
* ajout de warning dans les json
* ajout d'un warning dans le composant `SignalementFormOverview`

## Pré-requis

## Tests
- [ ] Faire un signalement en tant qu'occupant en choisissant "batiment" et "logement", sélectionnez des catégories, mais pas de désordres, aller jusqu'au bout du formulaire (sans valider) et vérifier l'affichage des warning sur les 3 récapitulatifs (récap batiment, récap désordres et récap global)
- [ ] une fois au bout, éditer les désordres, et choisir un désordre dans une catégorie batiment, vérifier que les 3 warnings ne s'affichent plus
- [ ] Faire la même chose en tant que tiers
