### PR TITLE
[FO - Form - nouvelle étape] Renvoyer les signalements "vides" vers une nouvelle page

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1388,5 +1388,39 @@
         }
       ]
     }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Votre signalement est incomplet",
+    "description": "<p>D'après les informations saisies, nous ne sommes pas en mesure de valider votre signalement : aucun désordre n'a été renseigné pour ce signalement.<br>Les signalements sans désordre ne peuvent pas être pris en charge par notre service.</p><p>Nous vous invitons à vérifier votre signalement et compléter les informations dans les parties :<ul><li>Type et composition du logement</li><li>Désordres</li></ul></p><p>Cliquez sur le bouton ci-dessous pour compléter votre signalement en renseignant au moins un désordre.</p>",
+    "slug": "signalement_incomplet",
+    "screenCategory": "Récapitulatif",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "signalement_incomplet_buttons",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Compléter mon signalement",
+                "slug": "signalement_incomplet_complete",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Abandonner mon signalement",
+                "slug": "signalement_incomplet_archive",
+                "action": "archive:",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -1230,5 +1230,39 @@
         }
       ]
     }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Votre signalement est incomplet",
+    "description": "<p>D'après les informations saisies, nous ne sommes pas en mesure de valider votre signalement : aucun désordre n'a été renseigné pour ce signalement.<br>Les signalements sans désordre ne peuvent pas être pris en charge par notre service.</p><p>Nous vous invitons à vérifier votre signalement et compléter les informations dans les parties :<ul><li>Type et composition du logement</li><li>Désordres</li></ul></p><p>Cliquez sur le bouton ci-dessous pour compléter votre signalement en renseignant au moins un désordre.</p>",
+    "slug": "signalement_incomplet",
+    "screenCategory": "Récapitulatif",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "signalement_incomplet_buttons",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Compléter mon signalement",
+                "slug": "signalement_incomplet_complete",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Abandonner mon signalement",
+                "slug": "signalement_incomplet_archive",
+                "action": "archive:",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1439,5 +1439,39 @@
         }
       ]
     }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Votre signalement est incomplet",
+    "description": "<p>D'après les informations saisies, nous ne sommes pas en mesure de valider votre signalement : aucun désordre n'a été renseigné pour ce signalement.<br>Les signalements sans désordre ne peuvent pas être pris en charge par notre service.</p><p>Nous vous invitons à vérifier votre signalement et compléter les informations dans les parties :<ul><li>Type et composition du logement</li><li>Désordres</li></ul></p><p>Cliquez sur le bouton ci-dessous pour compléter votre signalement en renseignant au moins un désordre.</p>",
+    "slug": "signalement_incomplet",
+    "screenCategory": "Récapitulatif",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "signalement_incomplet_buttons",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Compléter mon signalement",
+                "slug": "signalement_incomplet_complete",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Abandonner mon signalement",
+                "slug": "signalement_incomplet_archive",
+                "action": "archive:",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -859,5 +859,39 @@
         }
       ]
     }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Votre signalement est incomplet",
+    "description": "<p>D'après les informations saisies, nous ne sommes pas en mesure de valider votre signalement : aucun désordre n'a été renseigné pour ce signalement.<br>Les signalements sans désordre ne peuvent pas être pris en charge par notre service.</p><p>Nous vous invitons à vérifier votre signalement et compléter les informations dans les parties :<ul><li>Type et composition du logement</li><li>Désordres</li></ul></p><p>Cliquez sur le bouton ci-dessous pour compléter votre signalement en renseignant au moins un désordre.</p>",
+    "slug": "signalement_incomplet",
+    "screenCategory": "Récapitulatif",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "signalement_incomplet_buttons",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Compléter mon signalement",
+                "slug": "signalement_incomplet_complete",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Abandonner mon signalement",
+                "slug": "signalement_incomplet_archive",
+                "action": "archive:",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1256,5 +1256,39 @@
         }
       ]
     }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Votre signalement est incomplet",
+    "description": "<p>D'après les informations saisies, nous ne sommes pas en mesure de valider votre signalement : aucun désordre n'a été renseigné pour ce signalement.<br>Les signalements sans désordre ne peuvent pas être pris en charge par notre service.</p><p>Nous vous invitons à vérifier votre signalement et compléter les informations dans les parties :<ul><li>Type et composition du logement</li><li>Désordres</li></ul></p><p>Cliquez sur le bouton ci-dessous pour compléter votre signalement en renseignant au moins un désordre.</p>",
+    "slug": "signalement_incomplet",
+    "screenCategory": "Récapitulatif",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "signalement_incomplet_buttons",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Compléter mon signalement",
+                "slug": "signalement_incomplet_complete",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Abandonner mon signalement",
+                "slug": "signalement_incomplet_archive",
+                "action": "archive:",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1221,5 +1221,39 @@
         }
       ]
     }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Votre signalement est incomplet",
+    "description": "<p>D'après les informations saisies, nous ne sommes pas en mesure de valider votre signalement : aucun désordre n'a été renseigné pour ce signalement.<br>Les signalements sans désordre ne peuvent pas être pris en charge par notre service.</p><p>Nous vous invitons à vérifier votre signalement et compléter les informations dans les parties :<ul><li>Type et composition du logement</li><li>Désordres</li></ul></p><p>Cliquez sur le bouton ci-dessous pour compléter votre signalement en renseignant au moins un désordre.</p>",
+    "slug": "signalement_incomplet",
+    "screenCategory": "Récapitulatif",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "signalement_incomplet_buttons",
+          "customCss": "button-group-full-size",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Compléter mon signalement",
+                "slug": "signalement_incomplet_complete",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-mb-3v"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Abandonner mon signalement",
+                "slug": "signalement_incomplet_archive",
+                "action": "archive:",
+                "customCss": "fr-btn--secondary fr-mb-3v"
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -217,6 +217,9 @@ export default defineComponent({
 
       if (formStore.screenData) {
         this.removeNextScreensIfProfileUpdated()
+        if (this.nextSlug === 'confirmation_signalement' && formStore.data.signalementReference === '') {
+          this.nextSlug = 'signalement_incomplet'
+        }
         const nextScreen = formStore.screenData.find((screen: any) => screen.slug === this.nextSlug)
         if (nextScreen !== undefined) {
           formStore.currentScreen = nextScreen

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -217,6 +217,8 @@ export default defineComponent({
 
       if (formStore.screenData) {
         this.removeNextScreensIfProfileUpdated()
+        // si le signalement n'a pas pu être créé (par exemple pas de désordres) la route ne renvoie pas de référence de signalement
+        // du coup on ne va pas sur la page de confirmation, mais sur une page spéciale
         if (this.nextSlug === 'confirmation_signalement' && formStore.data.signalementReference === '') {
           this.nextSlug = 'signalement_incomplet'
         }

--- a/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -172,7 +172,11 @@ export default defineComponent({
       }
     },
     makeNewSignalement () {
-      requests.archiveDraft(this.saveAndContinue)
+      if (formStore.alreadyExists.uuidDraft !== null && (
+        formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement'
+      )) {
+        requests.archiveDraft(formStore.alreadyExists.uuidDraft, this.saveAndContinue)
+      }
     },
     saveAndContinue () {
       if (this.newClickEvent !== undefined) {

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -85,6 +85,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import formStore from './../store'
+import { requests } from '../requests'
 import SignalementFormAddress from './SignalementFormAddress.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormCheckbox from './SignalementFormCheckbox.vue'
@@ -158,6 +159,7 @@ export default defineComponent({
   data () {
     return {
       formStore,
+      requests,
       variablesReplacer,
       componentValidator,
       currentDisorderIndex: {
@@ -212,12 +214,12 @@ export default defineComponent({
     async handleClickComponent (type:string, param:string, param2:string) {
       if (type === 'link') {
         window.location.href = param
-      } else if (type === 'cancel') {
-        alert('on fait quoi quand on annule ?')
       } else if (type === 'show') {
         this.showComponentBySlug(param, param2)
       } else if (type === 'toggle') {
         this.toggleComponentBySlug(param, param2)
+      } else if (type === 'archive') {
+        requests.archiveDraft(formStore.data.uuidSignalementDraft, this.gotoHomepage)
       } else if (type.includes('goto')) {
         await this.showScreenBySlug(param, param2, type.includes('save'))
       } else if (type.includes('resolve')) {
@@ -276,6 +278,9 @@ export default defineComponent({
 
         this.currentDisorderIndex[currentCategory] = decrementIndex < 0 ? 0 : decrementIndex
       }
+    },
+    gotoHomepage () {
+      window.location.href = '/'
     }
   }
 })

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -129,15 +129,9 @@ export const requests = {
     requests.doRequestPost(url, '', functionReturn, undefined)
   },
 
-  archiveDraft (functionReturn: Function) {
-    if (formStore.alreadyExists.uuidDraft !== null && (
-      formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement'
-    )) {
-      const url = formStore.props.ajaxurlArchiveDraft.replace('uuid', formStore.alreadyExists.uuidDraft)
-      requests.doRequestPost(url, '', functionReturn, undefined)
-    } else {
-      functionReturn(undefined)
-    }
+  archiveDraft (uuidDraft: string, functionReturn: Function) {
+    const url = formStore.props.ajaxurlArchiveDraft.replace('uuid', uuidDraft)
+    requests.doRequestPost(url, '', functionReturn, undefined)
   },
 
   validateAddress (valueAdress: string, functionReturn: Function) {

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -49,10 +49,12 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
             ->withDesordres()
             ->build();
 
-        $this->signalementManager->save($signalement);
-        $this->sendNotifications($signalement);
-        $this->processFiles($signalementDraft, $signalement);
-        $this->autoAssigner->assign($signalement);
+        if (null !== $signalement) {
+            $this->signalementManager->save($signalement);
+            $this->sendNotifications($signalement);
+            $this->processFiles($signalementDraft, $signalement);
+            $this->autoAssigner->assign($signalement);
+        }
     }
 
     private function sendNotifications(Signalement $signalement): void

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -309,8 +309,12 @@ class SignalementBuilder
         return $this;
     }
 
-    public function build(): Signalement
+    public function build(): ?Signalement
     {
+        if ($this->signalement->getDesordrePrecisions()->isEmpty() && 0.0 === $this->signalement->getScore()) {
+            return null;
+        }
+
         return $this->signalement;
     }
 


### PR DESCRIPTION
## Ticket

#2363    

## Description
Au dépôt d'un signalement, si le signalement n'a aucun désordre, renvoyer l'usager vers une page l'invitant à compléter son signalement ou l'abandonner.

## Changements apportés
* Ajout d'une nouvelle page `signalement_incomplet` dans les json
* Dans l'app, vérifier qu'on a bien la référence su signalement créé lorsqu'on navigue vers la page "`confirmation_signalement`" sinon on redirige vers la nouvelle page 
* Création 'une action `archive` pour les boutons du formulaire et remaniement de la fonction `archiveDraft` (pour ne pas la limiter à la détection de doublon)
* Dans le `signalementBuilder` on vérifie que le signalement créé a des désordres et un score supérieur à 0 pour le builder, sinon on renvoie null et on n'enregistre pas le signalement en base (et on ne change pas le statut du draft)

## Pré-requis
`npm run watch
`
## Tests
- [ ] Faire un signalement sans sélectionner aucun désordres
- [ ] A la validation, vérifier qu'on arrive sur une page "Votre signalement est incomplet" (et qu'aucun signalement n'a été créé en base, et que le draft est toujours "EN_COURS"
- [ ] Si on clique sur "compléter mon signalement", vérifier qu'on revient à la partie type et composition
- [ ] Si on clique sur "abandonner" vérifier qu'on revient sur la page d'accueil, qu'aucun signalement n'est créé en base et que le draft est archivé
- [ ] Essayer avec différent profils
- [ ] Faire une TNR sur la détection de doublon de draft et l'archivage
