### PR TITLE
[FO - Formulaire - Accessibilité - 11.13] Faciliter remplissage automatique des champs

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -12,6 +12,10 @@
           "slug": "vos_coordonnees_tiers_nom_organisme",
           "conditional": {
             "show": "formStore.data.signalement_concerne_profil_detail_bailleur_bailleur === 'organisme_societe'"
+          },
+          "accessibility": {
+            "name": "organizationName",
+            "autocomplete": "organization"
           }
         },
         {
@@ -20,6 +24,10 @@
           "slug": "vos_coordonnees_tiers_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -28,17 +36,29 @@
           "slug": "vos_coordonnees_tiers_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
           "type": "SignalementFormEmailfield",
           "label": "Adresse e-mail",
-          "slug": "vos_coordonnees_tiers_email"
+          "slug": "vos_coordonnees_tiers_email",
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
+          }
         },
         {
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
-          "slug": "vos_coordonnees_tiers_tel"
+          "slug": "vos_coordonnees_tiers_tel",
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
+          }
         }
       ],
       "footer": [
@@ -72,6 +92,10 @@
           "slug": "coordonnees_occupant_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -80,6 +104,10 @@
           "slug": "coordonnees_occupant_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -88,6 +116,10 @@
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -96,6 +128,10 @@
           "slug": "coordonnees_occupant_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         }
       ],

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -30,6 +30,10 @@
           "slug": "vos_coordonnees_occupant_nom_organisme",
           "conditional": {
             "show": "formStore.data.signalement_concerne_profil_detail_bailleur_proprietaire === 'organisme_societe'"
+          },
+          "accessibility": {
+            "name": "organizationName",
+            "autocomplete": "organization"
           }
         },
         {
@@ -38,6 +42,10 @@
           "slug": "vos_coordonnees_occupant_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -46,17 +54,29 @@
           "slug": "vos_coordonnees_occupant_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
           "type": "SignalementFormEmailfield",
           "label": "Adresse e-mail",
-          "slug": "vos_coordonnees_occupant_email"
+          "slug": "vos_coordonnees_occupant_email",
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
+          }
         },
         {
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
-          "slug": "vos_coordonnees_occupant_tel"
+          "slug": "vos_coordonnees_occupant_tel",
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -27,6 +27,10 @@
           "slug": "vos_coordonnees_occupant_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -35,6 +39,10 @@
           "slug": "vos_coordonnees_occupant_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -48,12 +48,20 @@
         {
           "type": "SignalementFormEmailfield",
           "label": "Adresse e-mail",
-          "slug": "vos_coordonnees_occupant_email"
+          "slug": "vos_coordonnees_occupant_email",
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
+          }
         },
         {
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
-          "slug": "vos_coordonnees_occupant_tel"
+          "slug": "vos_coordonnees_occupant_tel",
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
+          }
         }
       ],
       "footer": [
@@ -95,6 +103,10 @@
           },
           "conditional": {
             "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -121,6 +133,10 @@
           "validate": {
             "required": false,
             "maxLength": 255
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -129,6 +145,10 @@
           "slug": "coordonnees_bailleur_email",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -137,6 +157,10 @@
           "slug": "coordonnees_bailleur_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -12,6 +12,10 @@
           "slug": "vos_coordonnees_tiers_nom_organisme",
           "conditional": {
             "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
+          },
+          "accessibility": {
+            "name": "organizationName",
+            "autocomplete": "organization"
           }
         },
         {
@@ -20,6 +24,10 @@
           "slug": "vos_coordonnees_tiers_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -28,17 +36,29 @@
           "slug": "vos_coordonnees_tiers_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
           "type": "SignalementFormEmailfield",
           "label": "Adresse e-mail",
-          "slug": "vos_coordonnees_tiers_email"
+          "slug": "vos_coordonnees_tiers_email",
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
+          }
         },
         {
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
-          "slug": "vos_coordonnees_tiers_tel"
+          "slug": "vos_coordonnees_tiers_tel",
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
+          }
         }
       ],
       "footer": [
@@ -73,6 +93,10 @@
           "validate": {
             "required": false,
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -82,6 +106,10 @@
           "validate": {
             "required": false,
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -91,6 +119,10 @@
           "validate": {
             "required": false,
             "maxLength": 255
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -99,6 +131,10 @@
           "slug": "coordonnees_occupant_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         }
       ],
@@ -137,6 +173,10 @@
           },
           "conditional": {
             "show": "formStore.data.signalement_concerne_logement_social_service_secours === 'non'"
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -164,6 +204,10 @@
           "validate": {
             "required": false,
             "maxLength": 255
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -173,6 +217,10 @@
           "validate": {
             "required": false,
             "maxLength": 255
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -181,6 +229,10 @@
           "slug": "coordonnees_bailleur_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -34,6 +34,10 @@
           "slug": "vos_coordonnees_tiers_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -42,17 +46,29 @@
           "slug": "vos_coordonnees_tiers_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
           "type": "SignalementFormEmailfield",
           "label": "Adresse e-mail",
-          "slug": "vos_coordonnees_tiers_email"
+          "slug": "vos_coordonnees_tiers_email",
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
+          }
         },
         {
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
-          "slug": "vos_coordonnees_tiers_tel"
+          "slug": "vos_coordonnees_tiers_tel",
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
+          }
         }
       ],
       "footer": [
@@ -86,6 +102,10 @@
           "slug": "coordonnees_occupant_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -94,6 +114,10 @@
           "slug": "coordonnees_occupant_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -102,6 +126,10 @@
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -110,6 +138,10 @@
           "slug": "coordonnees_occupant_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         }
       ],
@@ -147,6 +179,10 @@
           },
           "conditional": {
             "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -173,6 +209,10 @@
           "validate": {
             "required": false,
             "maxLength": 255
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -181,6 +221,10 @@
           "slug": "coordonnees_bailleur_email",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -189,6 +233,10 @@
           "slug": "coordonnees_bailleur_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -9,7 +9,11 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Structure",
-          "slug": "vos_coordonnees_tiers_nom_organisme"
+          "slug": "vos_coordonnees_tiers_nom_organisme",
+          "accessibility": {
+            "name": "organizationName",
+            "autocomplete": "organization"
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -17,6 +21,10 @@
           "slug": "vos_coordonnees_tiers_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -25,17 +33,29 @@
           "slug": "vos_coordonnees_tiers_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
           "type": "SignalementFormEmailfield",
           "label": "Adresse e-mail",
-          "slug": "vos_coordonnees_tiers_email"
+          "slug": "vos_coordonnees_tiers_email",
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
+          }
         },
         {
           "type": "SignalementFormPhonefield",
           "label": "Téléphone",
-          "slug": "vos_coordonnees_tiers_tel"
+          "slug": "vos_coordonnees_tiers_tel",
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
+          }
         }
       ],
       "footer": [
@@ -69,6 +89,10 @@
           "slug": "coordonnees_occupant_nom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -77,6 +101,10 @@
           "slug": "coordonnees_occupant_prenom",
           "validate": {
             "maxLength": 50
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -85,6 +113,10 @@
           "slug": "coordonnees_occupant_email",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -93,6 +125,10 @@
           "slug": "coordonnees_occupant_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         }
       ],
@@ -130,6 +166,10 @@
           },
           "conditional": {
             "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'non'"
+          },
+          "accessibility": {
+            "name": "lastName",
+            "autocomplete": "family-name"
           }
         },
         {
@@ -156,6 +196,10 @@
           "validate": {
             "required": false,
             "maxLength": 255
+          },
+          "accessibility": {
+            "name": "firstName",
+            "autocomplete": "given-name"
           }
         },
         {
@@ -164,6 +208,10 @@
           "slug": "coordonnees_bailleur_email",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "mail",
+            "autocomplete": "email"
           }
         },
         {
@@ -172,6 +220,10 @@
           "slug": "coordonnees_bailleur_tel",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "name": "telephone",
+            "autocomplete": "tel-national"
           }
         },
         {

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -37,7 +37,7 @@
                 />
           </div>
           <div class="fr-col-12 fr-col-md-8">
-            <form @submit.prevent="handleSubmit">
+            <form @submit.prevent="handleSubmit" autocomplete="on">
               <SignalementFormScreen
                 :label="formStore.currentScreen.label"
                 :description="formStore.currentScreen.description"

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -37,14 +37,17 @@
                 />
           </div>
           <div class="fr-col-12 fr-col-md-8">
-            <SignalementFormScreen
-              :label="formStore.currentScreen.label"
-              :description="formStore.currentScreen.description"
-              :icon="formStore.currentScreen.icon"
-              :components="formStore.currentScreen.components"
-              :customCss="formStore.currentScreen.customCss"
-              :changeEvent="saveAndChangeScreenBySlug"
-              />
+            <form @submit.prevent="handleSubmit">
+              <SignalementFormScreen
+                :label="formStore.currentScreen.label"
+                :description="formStore.currentScreen.description"
+                :icon="formStore.currentScreen.icon"
+                :components="formStore.currentScreen.components"
+                :customCss="formStore.currentScreen.customCss"
+                :changeEvent="saveAndChangeScreenBySlug"
+                />
+              <button type="submit" class="hidden-submit">Submit</button>
+            </form>
           </div>
         </div>
         <SignalementFormModalAlreadyExists
@@ -248,6 +251,10 @@ export default defineComponent({
       setTimeout(() => {
         window.scrollTo(0, 0)
       }, 50)
+    },
+    handleSubmit () {
+      // Vous pouvez gérer la soumission du formulaire ici
+      console.log('Form submitted!')
     }
   }
 })
@@ -264,5 +271,8 @@ export default defineComponent({
   }
   .signalement-form {
     background-color: white;
+  }
+  .hidden-submit {
+    display: none;
   }
 </style>

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -253,8 +253,7 @@ export default defineComponent({
       }, 50)
     },
     handleSubmit () {
-      // Vous pouvez gérer la soumission du formulaire ici
-      console.log('Form submitted!')
+      // il ne se passe rien, ce bouton ne sert que pour gérer l'accessibilité et l'autocomplete
     }
   }
 })

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -10,6 +10,8 @@
       v-model="formStore.data[idAddress]"
       :hasError="hasError"
       :error="error"
+      access_name="address"
+      access_autocomplete="address-line1"
     />
 
     <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">

--- a/assets/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -8,13 +8,13 @@
       <input
           type="email"
           :id="id + '_input'"
-          name="mail"
+          :name="access_name"
+          :autocomplete="access_autocomplete"
           :value="internalValue"
           :class="[ customCss, 'fr-input' ]"
           @input="updateValue($event)"
           aria-describedby="text-input-error-desc-error"
           :disabled="disabled"
-          autocomplete="email"
       >
     </div>
     <div
@@ -41,7 +41,9 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
-    error: { type: String, default: '' }
+    error: { type: String, default: '' },
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   computed: {
     internalValue: {

--- a/assets/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -8,12 +8,13 @@
       <input
           type="email"
           :id="id + '_input'"
-          :name="id"
+          name="mail"
           :value="internalValue"
           :class="[ customCss, 'fr-input' ]"
           @input="updateValue($event)"
           aria-describedby="text-input-error-desc-error"
           :disabled="disabled"
+          autocomplete="email"
       >
     </div>
     <div

--- a/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -26,10 +26,11 @@
             <input
               type="text"
               :id="id"
-              :name="id"
+              name="telephone"
               v-model="formStore.data[id]"
               class="fr-input"
               :aria-describedby="'text-input-error-desc-error-'+id"
+              autocomplete="tel-national"
               >
           </div>
         </div>

--- a/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -26,11 +26,11 @@
             <input
               type="text"
               :id="id"
-              name="telephone"
+              :name="access_name"
+              :autocomplete="access_autocomplete"
               v-model="formStore.data[id]"
               class="fr-input"
               :aria-describedby="'text-input-error-desc-error-'+id"
-              autocomplete="tel-national"
               >
           </div>
         </div>
@@ -85,6 +85,7 @@
               v-model="formStore.data[idSecond]"
               class="fr-input"
               :aria-describedby="'text-input-error-desc-error-'+idSecond"
+              :autocomplete="access_autocomplete"
               >
           </div>
         </div>
@@ -121,6 +122,8 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' },
     clickEvent: Function
   },
   data () {

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -43,6 +43,8 @@
         :autocomplete="component.autocomplete"
         :clickEvent="handleClickComponent"
         :handleClickComponent="handleClickComponent"
+        :access_name="component.accessibility?.name"
+        :access_autocomplete="component.accessibility?.autocomplete"
       />
     </div>
   </div>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -43,8 +43,8 @@
         :autocomplete="component.autocomplete"
         :clickEvent="handleClickComponent"
         :handleClickComponent="handleClickComponent"
-        :access_name="component.accessibility?.name"
-        :access_autocomplete="component.accessibility?.autocomplete"
+        :access_name="component.accessibility?.name ?? component.slug"
+        :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
       />
     </div>
   </div>

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -10,6 +10,8 @@
         :is="component.type"
         v-bind:key="component.slug"
         :id="component.slug"
+        :access_name="component.accessibility?.name ?? component.slug"
+        :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
         :label="component.label"
         :hint="component.hint"
         :labelInfo="component.labelInfo"

--- a/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -8,7 +8,7 @@
       <input
         type="text"
         :id="id + '_input'"
-        :name="id"
+        :name="access_name"
         :value="internalValue"
         :placeholder="placeholder"
         :class="[ customCss, 'fr-input' ]"
@@ -16,6 +16,7 @@
         aria-describedby="text-input-error-desc-error"
         :disabled="disabled"
         :maxlength="validate?.maxLength"
+        :autocomplete="access_autocomplete"
         >
     </div>
     <div
@@ -46,7 +47,9 @@ export default defineComponent({
     hasError: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
     error: { type: String, default: '' },
-    tagWhenEdit: { type: String, default: '' }
+    tagWhenEdit: { type: String, default: '' },
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -9,6 +9,7 @@
         type="text"
         :id="id + '_input'"
         :name="access_name"
+        :autocomplete="access_autocomplete"
         :value="internalValue"
         :placeholder="placeholder"
         :class="[ customCss, 'fr-input' ]"
@@ -16,7 +17,6 @@
         aria-describedby="text-input-error-desc-error"
         :disabled="disabled"
         :maxlength="validate?.maxLength"
-        :autocomplete="access_autocomplete"
         >
     </div>
     <div


### PR DESCRIPTION
## Ticket

#2236    

## Description
[Critère 11.13](https://accessibilite.public.lu/fr/rgaa4.1/criteres.html#crit-11-13) [AA] : La finalité d'un champ de saisie peut-elle être déduite pour faciliter le remplissage automatique des champs avec les données de l'utilisateur ?

## Changements apportés
* Ajout de données d'autocomplete dans les json du formulaire
* Prise en charge de ces attributs d'autocomplete pour les composants SignalementFormTextfield, SignalementFormPhonefield, SignalementFormAdress et SignalementFormEmailfield
* Ajout d'une balise form et d'un bouton submit caché dans l'app pour faire marcher l'autocomplete

## Pré-requis

## Tests
- [ ] Faire des tests avec différents profils et tester l'autocompletion sur les adresses, les mails, les téléphones, les noms et prénoms et noms d'organisation (plus facile sous chromium que sous firefox car on peut pré-enregistrer des adresses et noms d'organisation chrome://settings/addresses)
- [ ] Vérifier que les autres champs textes sans données d'autocomplétion sont valides et que le formulaire fonctionne bien
