### PR TITLE
[FO - Signalement] Multiple création de signalement

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -175,7 +175,7 @@ export default defineComponent({
       if (formStore.alreadyExists.uuidDraft !== null && (
         formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement'
       )) {
-        requests.archiveDraft(formStore.alreadyExists.uuidDraft, this.saveAndContinue)
+        this.saveAndContinue()
       }
     },
     saveAndContinue () {

--- a/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -175,7 +175,7 @@ export default defineComponent({
       if (formStore.alreadyExists.uuidDraft !== null && (
         formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement'
       )) {
-        this.saveAndContinue()
+        requests.archiveDraft(formStore.alreadyExists.uuidDraft, this.saveAndContinue)
       }
     },
     saveAndContinue () {

--- a/src/Manager/SignalementDraftManager.php
+++ b/src/Manager/SignalementDraftManager.php
@@ -54,7 +54,11 @@ class SignalementDraftManager extends AbstractManager
             ->setProfileDeclarant(ProfileDeclarant::from(strtoupper($signalementDraftRequest->getProfil())));
 
         if (self::LAST_STEP === $signalementDraftRequest->getCurrentStep()) {
-            $signalement = $this->dispatchSignalementDraftCompleted($signalementDraft);
+            if (SignalementDraftStatus::EN_SIGNALEMENT === $signalementDraft->getStatus()) {
+                $signalement = $signalementDraft->getSignalements()->first();
+            } else {
+                $signalement = $this->dispatchSignalementDraftCompleted($signalementDraft);
+            }
         }
         $this->save($signalementDraft);
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1214,6 +1214,7 @@ class SignalementRepository extends ServiceEntityRepository
             $qb->addOrderBy('s.createdAt', 'DESC');
         } else {
             $qb->addOrderBy('s.lastSuiviAt', 'DESC');
+            $qb->setMaxResults(1);
         }
 
         return $qb->getQuery()->getResult();

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -258,7 +258,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 				<div class="fr-col-10 fr-col-md-11 fr-h5 fr-disorder-overview-title">Le logement</div>
 			</div>
 			{% set zone = 'batiment' %}
-			{% for situation,criteres in infoDesordres['criticitesArranged'][enum('App\\Entity\\Enum\\DesordreCritereZone').LOGEMENT.name] %}
+			{% for situation,criteres in infoDesordres['criticitesArranged'][enum('App\\Entity\\Enum\\DesordreCritereZone').BATIMENT.name] %}
 				{% include 'front/_partials/_desordre-v2.html.twig' %}
 			{% endfor %}
 		{% endif %}


### PR DESCRIPTION
## Ticket

#2576

## Description
- Afin d’éviter qu'un draft de signalement génère plusieurs signalement, ajout d'un contrôle sur le statut du draft avant de lancer la transformation en signalement
- Modification de la requête récupérant les doublon de signalement afin qu'elle en retourne qu'un signalement (hors tiers déclarant) pour éviter que le titre de la popup soit incorrect "Ces signalements existent déjà" => "Ce signalement existe déjà"
- Fix d'une erreur dans l'affichage des désordre sur la nouvelle page de suivi usager

## Pré-requis
`make npm-build`

## Tests
- [ ] Forcer un bug à la soumission d'un signalement (ex : ajouter `return ['test' => 'test']` ligne 199 du `SignalementController` et vérifier qu'un seul signalement est généré après de multiple soumission
