### PR TITLE
[BO - listes] Rendre la pagination dynamique

### DIFF
--- a/templates/_partials/macros.html.twig
+++ b/templates/_partials/macros.html.twig
@@ -1,0 +1,82 @@
+
+{% macro customPagination(pages, currentPage, routeName, queryParams) %}
+<nav role="navigation" class="fr-pagination" aria-label="Pagination">
+    <ul class="fr-pagination__list">
+        <li>
+            <a class="fr-pagination__link fr-pagination__link--first"
+               {% if currentPage > 1 %}
+                       href="{{ path(routeName, queryParams | merge({page: 1})) }}"
+                {% else %}
+                   aria-disabled="true"
+               {% endif %}>
+                Première page
+            </a>
+        </li>
+        <li>
+            <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
+               {% if currentPage > 1 %}
+                       href="{{ path(routeName, queryParams | merge({page: currentPage - 1})) }}"
+               {% else %}
+                   aria-disabled="true"
+               {% endif %} role="link">
+                Page précédente
+            </a>
+        </li>
+
+        {% if currentPage > 3 %}
+            <li>
+                <a class="fr-pagination__link" href="{{ path(routeName, queryParams | merge({page: 1})) }}">1</a>
+            </li>
+        {% endif %}
+        {% if currentPage > 4 %}
+            <li>
+                <a class="fr-pagination__link" title="placeholder">...</a>
+            </li>
+        {% endif %}
+
+        {% for i in max(1, currentPage - 2)..min(pages, currentPage + 2) %}
+            <li>
+                <a class="fr-pagination__link" {{ currentPage == i ? 'aria-current="page"' : '' }}
+                   href="{{ path(routeName, queryParams | merge({page: i})) }}"
+                   title="Page {{ i }}"
+                   data-page="{{ i }}">
+                    {{ i }}
+                </a>
+            </li>
+        {% endfor %}
+
+        {% if currentPage < pages - 3 %}
+            <li>
+                <a class="fr-pagination__link" title="placeholder">...</a>
+            </li>
+        {% endif %}
+        {% if currentPage < pages - 2 %}
+            <li>
+                <a class="fr-pagination__link" href="{{ path(routeName, queryParams | merge({page: pages})) }}">{{ pages }}</a>
+            </li>
+        {% endif %}
+
+        <li>
+            <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
+               {% if currentPage < pages %}
+                   href="{{ path(routeName, queryParams | merge({page: currentPage + 1})) }}"
+               {% else %}
+                   aria-disabled="true"
+               {% endif %} role="link">
+                Page suivante
+            </a>
+        </li>
+        <li>
+            <a class="fr-pagination__link fr-pagination__link--last"
+               {% if currentPage < pages %}
+                   href="{{ path(routeName, queryParams | merge({page: pages})) }}"
+               {% else %}
+                   aria-disabled="true"
+               {% endif %}
+               data-page="{{ pages }}">
+                Dernière page
+            </a>
+        </li>
+    </ul>
+</nav>
+{% endmacro %}

--- a/templates/back/account/index.html.twig
+++ b/templates/back/account/index.html.twig
@@ -98,79 +98,8 @@
             </tbody>
         </table>
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
-            <nav role="navigation" class="fr-pagination" aria-label="Pagination">
-                <ul class="fr-pagination__list">
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--first"
-                                {% if pages > 1 %}
-                                    href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %}>
-                            Première page
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
-                                {% if pages > 1 and page != 1 %}
-                                    href="{{ path('back_account_index', {page : page - 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page précédente
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link" {{ page == 1 ? 'aria-current="page"' : '' }}
-                           title="Page 1"
-                           data-page="1"
-                                href="{{ path('back_account_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
-                        >
-                            1
-                        </a>
-                    </li>
-                    {% if pages > 1 %}
-                        {% for i in 2..pages %}
-                            <li class="{% if loop.index > 2 and loop.index < pages-3 %}fr-hidden{% endif %}">
-                                <a class="fr-pagination__link" {{ page == i ? 'aria-current="page"' : '' }}
-                                        href="{{ path('back_account_index', {page : i, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
-                                   title="Page {{ i }}"
-                                   data-page="{{ i }}">
-                                    {{ i }}
-                                </a>
-                            </li>
-                            {% if loop.index is same as(3) %}
-                                <li>
-                                    <a class="fr-pagination__link" title="placeholder">
-                                        ...
-                                    </a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
-                                {% if pages > 1  and page < pages %}
-                                    href="{{ path('back_account_index', {page : page + 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page suivante
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--last"
-                                {% if pages > 1 %}
-                                    href="{{ path('back_account_index', {page : pages, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %}
-                           data-page="{{ pages }}">
-                            Dernière page
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            {% import '_partials/macros.html.twig' as macros %}
+            {{ macros.customPagination(pages, page, 'back_account_index', {territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms}) }}
         </div>
     </section>
 

--- a/templates/back/notifications/index.html.twig
+++ b/templates/back/notifications/index.html.twig
@@ -78,79 +78,9 @@
             {% endfor %}
             </tbody>
         </table>
-        <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
-            <nav role="navigation" class="fr-pagination" aria-label="Pagination">
-                <ul class="fr-pagination__list">
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--first"
-                                {% if pages > 1 %}
-                            href="{{ path('back_notifications_list', {page : 1 }) }}"
-                        {% else %}
-                            aria-disabled="true"
-                                {% endif %}>
-                            Première page
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
-                                {% if pages > 1 and page != 1 %}
-                                    href="{{ path('back_notifications_list', {page : page - 1 }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page précédente
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link" {{ page == 1 ? 'aria-current="page"' : '' }}
-                           title="Page 1"
-                           data-page="1"
-                           href="{{ path('back_notifications_list', {page : 1 }) }}">
-                            1
-                        </a>
-                    </li>
-                    {% if pages > 1 %}
-                        {% for i in 2..pages %}
-                            <li class="{% if loop.index > 2 and loop.index < pages-3 %}fr-hidden{% endif %}">
-                                <a class="fr-pagination__link" {{ page == i ? 'aria-current="page"' : '' }}
-                                   href="{{ path('back_notifications_list', {page : i }) }}"
-                                   title="Page {{ i }}"
-                                   data-page="{{ i }}">
-                                    {{ i }}
-                                </a>
-                            </li>
-                            {% if loop.index is same as(3) %}
-                                <li>
-                                    <a class="fr-pagination__link" title="placeholder">
-                                        ...
-                                    </a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
-                                {% if pages > 1  and page < pages %}
-                                    href="{{ path('back_notifications_list', {page : page + 1 }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page suivante
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--last"
-                                {% if pages > 1 %}
-                                    href="{{ path('back_notifications_list', {page : pages }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %}
-                           data-page="{{ pages }}">
-                            Dernière page
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+        <div class="fr-grid-row fr-mt-2v fr-grid-row--center">    
+            {% import '_partials/macros.html.twig' as macros %}
+            {{ macros.customPagination(pages, page, 'back_notifications_list', {}) }}
         </div>
     </section>
 {% endblock %}

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -114,79 +114,8 @@
             </tbody>
         </table>
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
-            <nav role="navigation" class="fr-pagination" aria-label="Pagination">
-                <ul class="fr-pagination__list">
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--first"
-                                {% if pages > 1 %}
-                                    href="{{ path('back_partner_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : null ), type: (currentType ? currentType : null), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %}>
-                            Première page
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
-                                {% if pages > 1 and page != 1 %}
-                                    href="{{ path('back_partner_index', {page : page - 1, territory: (currentTerritory ? currentTerritory.id : null ), type: (currentType ? currentType : null), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page précédente
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link" {{ page == 1 ? 'aria-current="page"' : '' }}
-                           title="Page 1"
-                           data-page="1"
-                                href="{{ path('back_partner_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : null ), type: (currentType ? currentType : null), userTerms: userTerms }) }}"
-                        >
-                            1
-                        </a>
-                    </li>
-                    {% if pages > 1 %}
-                        {% for i in 2..pages %}
-                            <li class="{% if loop.index > 2 and loop.index < pages-3 %}fr-hidden{% endif %}">
-                                <a class="fr-pagination__link" {{ page == i ? 'aria-current="page"' : '' }}
-                                    href="{{ path('back_partner_index', {page : i, territory: (currentTerritory ? currentTerritory.id : null ), type: (currentType ? currentType : null), userTerms: userTerms }) }}"
-                                   title="Page {{ i }}"
-                                   data-page="{{ i }}">
-                                    {{ i }}
-                                </a>
-                            </li>
-                            {% if loop.index is same as(3) %}
-                                <li>
-                                    <a class="fr-pagination__link" title="placeholder">
-                                        ...
-                                    </a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
-                                {% if pages > 1  and page < pages %}
-                                    href="{{ path('back_partner_index', {page : page + 1, territory: (currentTerritory ? currentTerritory.id : null ), type: (currentType ? currentType : null), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page suivante
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--last"
-                                {% if pages > 1 %}
-                                    href="{{ path('back_partner_index', {page : pages, territory: (currentTerritory ? currentTerritory.id : null ), type: (currentType ? currentType : null), userTerms: userTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %}
-                           data-page="{{ pages }}">
-                            Dernière page
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+            {% import '_partials/macros.html.twig' as macros %}
+            {{ macros.customPagination(pages, page, 'back_partner_index', {territory: (currentTerritory ? currentTerritory.id : null), type: (currentType ? currentType : null), userTerms: userTerms}) }}
         </div>
     </section>
 

--- a/templates/back/partner_archived/index.html.twig
+++ b/templates/back/partner_archived/index.html.twig
@@ -72,7 +72,7 @@
                     <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
                     <td>{{ partner.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
                     <td>{{ partner.nom}}</ail td>
-                    <td>{{ partner.type.label}}</ail td>
+                    <td>{{ partner.type is null ? 'N/R' : partner.type.label}}</ail td>
                 </tr>
             {% else %}
                 <tr>
@@ -81,80 +81,9 @@
             {% endfor %}
             </tbody>
         </table>
-        <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
-            <nav role="navigation" class="fr-pagination" aria-label="Pagination">
-                <ul class="fr-pagination__list">
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--first"
-                                {% if pages > 1 %}
-                                    href="{{ path('back_archived_partner_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %}>
-                            Première page
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
-                                {% if pages > 1 and page != 1 %}
-                                    href="{{ path('back_archived_partner_index', {page : page - 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page précédente
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link" {{ page == 1 ? 'aria-current="page"' : '' }}
-                           title="Page 1"
-                           data-page="1"
-                                href="{{ path('back_archived_partner_index', {page : 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
-                        >
-                            1
-                        </a>
-                    </li>
-                    {% if pages > 1 %}
-                        {% for i in 2..pages %}
-                            <li class="{% if loop.index > 2 and loop.index < pages-3 %}fr-hidden{% endif %}">
-                                <a class="fr-pagination__link" {{ page == i ? 'aria-current="page"' : '' }}
-                                        href="{{ path('back_archived_partner_index', {page : i, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
-                                   title="Page {{ i }}"
-                                   data-page="{{ i }}">
-                                    {{ i }}
-                                </a>
-                            </li>
-                            {% if loop.index is same as(3) %}
-                                <li>
-                                    <a class="fr-pagination__link" title="placeholder">
-                                        ...
-                                    </a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
-                                {% if pages > 1  and page < pages %}
-                                    href="{{ path('back_archived_partner_index', {page : page + 1, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %} role="link">
-                            Page suivante
-                        </a>
-                    </li>
-                    <li>
-                        <a class="fr-pagination__link fr-pagination__link--last"
-                                {% if pages > 1 %}
-                                    href="{{ path('back_archived_partner_index', {page : pages, territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms }) }}"
-                                {% else %}
-                                    aria-disabled="true"
-                                {% endif %}
-                           data-page="{{ pages }}">
-                            Dernière page
-                        </a>
-                    </li>
-                </ul>
-            </nav>
+        <div class="fr-grid-row fr-mt-2v fr-grid-row--center">    
+            {% import '_partials/macros.html.twig' as macros %}
+            {{ macros.customPagination(pages, page, 'back_archived_partner_index', {territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms}) }}
         </div>
     </section>
 


### PR DESCRIPTION
## Ticket

#2518   

## Description
Rendre la pagination dynamique sur les listes paginées (hors ancienne liste de signalements) à l'instar de ce qui est fait sur la nouvelle liste de signalements.
Exemple pour la page 8 sur 51, au lieu de 
`1 2 3 .... 49 50 51`
avoir
`1 ... 6 7 8 9 10 ... 51`

## Changements apportés
* Création d'une macro twig
* utilisation de la macro pour la liste des notifications, des partenaires, des partenaires archivés et des comptes archivés

## Pré-requis

## Tests
- [ ] Tester les 4 listes concernées (cf ci-dessus) en naviguant entre les pages, avec et sans critères de filtres 
