### PR TITLE
[BO - Signalement] Réinitialisation de la géolocalisation quand édition de l'adresse

### DIFF
--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -129,11 +129,14 @@ function addressResetGeoloc(input, isResetInsee) {
                     .then(json => {
                         json.features.forEach((feature) => {
                             if (feature.properties.citycode) {
+                                document.querySelector('#' + idForm + ' [data-autocomplete-ville]').value = feature.properties.city
                                 document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
+                                document.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]').value = feature.geometry.coordinates[0]
+                                document.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]').value = feature.geometry.coordinates[1]
                             }
                         })
                     })
             }
         }
-    }, 200)
+    }, 1000)
 }

--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -5,9 +5,12 @@ document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdress
     attacheAutocompleteAddressEvent(inputAdresse)
 })
 
-document.querySelector('#form-edit-address-adresse')?.addEventListener('input', (event) => addressResetGeoloc(event.target, false));
-document.querySelector('#form-edit-address-codepostal')?.addEventListener('input', (event) => addressResetGeoloc(event.target, true));
-document.querySelector('#form-edit-address-ville')?.addEventListener('input', (event) => addressResetGeoloc(event.target, true));
+document.querySelector('#form-edit-address-adresse')?.addEventListener('input', (event) => {
+    let idForm = event.target.closest('form').id
+    document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 1
+});
+document.querySelector('#form-edit-address-codepostal')?.addEventListener('input', (event) => addressResetGeoloc(event.target));
+document.querySelector('#form-edit-address-ville')?.addEventListener('input', (event) => addressResetGeoloc(event.target));
 
 function attachAutocompleteClickOutsideEvent() {
     document.addEventListener('click', function (event) {
@@ -92,6 +95,9 @@ function attachAddressSuggestionEvent(inputAdresse, suggestion, feature) {
         if (document?.querySelector('#' + idForm + ' [data-autocomplete-ville]')) {
             document.querySelector('#' + idForm + ' [data-autocomplete-ville]').value = feature.properties.city
         }
+        if (document?.querySelector('#' + idForm + ' [data-autocomplete-manual]')) {
+            document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 0
+        }
         if (document?.querySelector('#' + idForm + ' [data-autocomplete-insee]')) {
             document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
         }
@@ -107,36 +113,28 @@ function attachAddressSuggestionEvent(inputAdresse, suggestion, feature) {
 }
 
 var idTimeout
-function addressResetGeoloc(input, isResetInsee) {
-    clearTimeout(idTimeout);
+function addressResetGeoloc(input) {
+    clearTimeout(idTimeout)
     idTimeout = setTimeout(() => {
+        const apiAdresse = 'https://api-adresse.data.gouv.fr/search/?q='
+        let newCodePostal = document.querySelector('#form-edit-address-codepostal')?.value
+        let newVille = document.querySelector('#form-edit-address-ville')?.value
         let idForm = input.closest('form').id
-        if (document?.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]')) {
-            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]').value = ''
-        }
-        if (document?.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]')) {
-            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]').value = ''
-        }
-    
-        if (isResetInsee) {
-            const apiAdresse = 'https://api-adresse.data.gouv.fr/search/?q='
-            let newCodePostal = document.querySelector('#form-edit-address-codepostal')?.value;
-            let newVille = document.querySelector('#form-edit-address-ville')?.value;
-            if (newCodePostal !== '' && newVille !== '') {
-                let query = apiAdresse + newCodePostal + ' ' + newVille
-                fetch(query)
-                    .then(response => response.json())
-                    .then(json => {
-                        json.features.forEach((feature) => {
-                            if (feature.properties.citycode) {
-                                document.querySelector('#' + idForm + ' [data-autocomplete-ville]').value = feature.properties.city
-                                document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
-                                document.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]').value = feature.geometry.coordinates[0]
-                                document.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]').value = feature.geometry.coordinates[1]
-                            }
-                        })
+        if (newCodePostal !== '' && newVille !== '') {
+            let query = apiAdresse + newCodePostal + ' ' + newVille
+            fetch(query)
+                .then(response => response.json())
+                .then(json => {
+                    json.features.forEach((feature) => {
+                        if (feature.properties.citycode) {
+                            document.querySelector('#' + idForm + ' [data-autocomplete-ville]').value = feature.properties.city
+                            document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 1
+                            document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
+                            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]').value = feature.geometry.coordinates[0]
+                            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]').value = feature.geometry.coordinates[1]
+                        }
                     })
-            }
+                })
         }
     }, 1000)
 }

--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -5,6 +5,10 @@ document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdress
     attacheAutocompleteAddressEvent(inputAdresse)
 })
 
+document.querySelector('#form-edit-address-adresse')?.addEventListener('input', (event) => addressResetGeoloc(event.target, false));
+document.querySelector('#form-edit-address-codepostal')?.addEventListener('input', (event) => addressResetGeoloc(event.target, true));
+document.querySelector('#form-edit-address-ville')?.addEventListener('input', (event) => addressResetGeoloc(event.target, true));
+
 function attachAutocompleteClickOutsideEvent() {
     document.addEventListener('click', function (event) {
         document?.querySelectorAll('.fr-address-group, .fr-address-group-bo').forEach((addressGroup) => {
@@ -100,4 +104,36 @@ function attachAddressSuggestionEvent(inputAdresse, suggestion, feature) {
         const addressGroup = document?.querySelector(inputAdresse.dataset.autocompleteQuerySelector)
         addressGroup.innerHTML = ''
     })
+}
+
+var idTimeout
+function addressResetGeoloc(input, isResetInsee) {
+    clearTimeout(idTimeout);
+    idTimeout = setTimeout(() => {
+        let idForm = input.closest('form').id
+        if (document?.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]')) {
+            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]').value = ''
+        }
+        if (document?.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]')) {
+            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]').value = ''
+        }
+    
+        if (isResetInsee) {
+            const apiAdresse = 'https://api-adresse.data.gouv.fr/search/?q='
+            let newCodePostal = document.querySelector('#form-edit-address-codepostal')?.value;
+            let newVille = document.querySelector('#form-edit-address-ville')?.value;
+            if (newCodePostal !== '' && newVille !== '') {
+                let query = apiAdresse + newCodePostal + ' ' + newVille
+                fetch(query)
+                    .then(response => response.json())
+                    .then(json => {
+                        json.features.forEach((feature) => {
+                            if (feature.properties.citycode) {
+                                document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
+                            }
+                        })
+                    })
+            }
+        }
+    }, 200)
 }

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -84,7 +84,7 @@
           "type": "SignalementFormAddress",
           "label": "Adresse du logement",
           "slug": "adresse_logement_adresse",
-          "description": "Tapez l'adresse puis sélectionnez-la dans la liste",
+          "description": "Tapez l'adresse puis sélectionnez-la dans la liste. Si elle n'apparait pas, cliquez sur Saisir une adresse manuellement.",
           "isTerritoryToCheck": true
         },
         {

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -195,7 +195,10 @@ export default defineComponent({
       if (requestResponse.features !== undefined) {
         const suggestions = requestResponse.features
         if (suggestions[0] !== undefined) {
+          formStore.data[this.id + '_detail_commune'] = suggestions[0].properties.city
           formStore.data[this.id + '_detail_insee'] = suggestions[0].properties.citycode
+          formStore.data[this.id + '_detail_geoloc_lng'] = suggestions[0].geometry.coordinates[0]
+          formStore.data[this.id + '_detail_geoloc_lat'] = suggestions[0].geometry.coordinates[1]
           this.checkTerritory(
             formStore.data[this.id + '_detail_code_postal'],
             formStore.data[this.id + '_detail_insee']

--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -24,6 +24,7 @@ class AdresseOccupantRequest implements RequestInterface
         private readonly ?string $geolocLng = null,
         private readonly ?string $geolocLat = null,
         private readonly ?string $insee = null,
+        private readonly ?string $manual = null,
     ) {
     }
 
@@ -75,5 +76,10 @@ class AdresseOccupantRequest implements RequestInterface
     public function getInsee(): ?string
     {
         return $this->insee;
+    }
+
+    public function getManual(): ?string
+    {
+        return $this->manual;
     }
 }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -359,6 +359,12 @@ class SignalementManager extends AbstractManager
             ->setNumAppartOccupant($adresseOccupantRequest->getNumAppart())
             ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre());
 
+        if (empty($adresseOccupantRequest->getGeolocLat())) {
+            $signalement->setManualAddressOccupant(true);
+        } else {
+            $signalement->setManualAddressOccupant(false);
+        }
+
         $this->save($signalement);
 
         $this->suiviManager->addSuiviIfNeeded(

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -357,13 +357,8 @@ class SignalementManager extends AbstractManager
             ->setEtageOccupant($adresseOccupantRequest->getEtage())
             ->setEscalierOccupant($adresseOccupantRequest->getEscalier())
             ->setNumAppartOccupant($adresseOccupantRequest->getNumAppart())
-            ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre());
-
-        if (empty($adresseOccupantRequest->getGeolocLat())) {
-            $signalement->setManualAddressOccupant(true);
-        } else {
-            $signalement->setManualAddressOccupant(false);
-        }
+            ->setAdresseAutreOccupant($adresseOccupantRequest->getAutre())
+            ->setManualAddressOccupant('1' === $adresseOccupantRequest->getManual());
 
         $this->save($signalement);
 

--- a/templates/back/signalement/view/address-qualifications.html.twig
+++ b/templates/back/signalement/view/address-qualifications.html.twig
@@ -28,7 +28,7 @@
         {% endif %}
         {% if signalement.manualAddressOccupant %}
             <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-3v">
-                Cette adresse a été éditée manuellement lors de la déclaration.
+                Cette adresse a été éditée manuellement.
             </div>
         {% endif %}
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -47,6 +47,7 @@
                                         <input class="fr-input" id="form-edit-address-ville" type="text" name="ville" value="{{ signalement.villeOccupant }}" data-autocomplete-ville="true">
                                     </div>
 
+                                    <input type="hidden" name="manual" value="{{ signalement.manualAddressOccupant }}" data-autocomplete-manual="true">
                                     <input type="hidden" name="insee" value="{{ signalement.inseeOccupant }}" data-autocomplete-insee="true">
                                     <input type="hidden" name="geolocLat" value="{% if signalement.geoloc.lat is defined %}{{ signalement.geoloc.lat }}{% endif %}" data-autocomplete-geoloclat="true">
                                     <input type="hidden" name="geolocLng" value="{% if signalement.geoloc.lng is defined %}{{ signalement.geoloc.lng }}{% endif %}" data-autocomplete-geoloclng="true">


### PR DESCRIPTION
## Ticket

#2342    

## Description
Suite aux retours d'Arnaud, quelques modifications nécessaires pour les adresses hors BAN.

## Changements apportés
Dans le BO, 
- quand on édite une adresse à la main, il faut l'alerte pour les autres agents
- mise à jour du code Insee, de la géolocalisation et du nom de la ville, en cas de modification du couple code postal / ville

Dans le FO, 
- modification mineure sur l'indication de la saisie d'adresse
- mise à jour de la géolocalisation et du nom de la ville, en cas de modification du couple code postal / ville

## Tests
- [ ] Vérifier la description du champ sur le FO
- [ ] Vérifier les différents comportements en éditant une adresse via le BO (choisir dans la liste, modifier un ou plusieurs champs, etc.)
