### PR TITLE
[FO - Stats] Les intitulés des désordres les plus courants dans le logement ne sont pas clairs

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -308,10 +308,10 @@ class SignalementRepository extends ServiceEntityRepository
     public function countByDesordresCriteres(
         ?Territory $territory,
         ?int $year,
-        ?DesordreCritereZone $desordreCritereZone = null,
+        ?DesordreCritereZone $desordreCritereZone = null
     ): array {
         $qb = $this->createQueryBuilder('s');
-        $qb->select('COUNT(s.id) AS count, desordreCriteres.id, desordreCriteres.labelCritere')
+        $qb->select('COUNT(s.id) AS count, desordreCriteres.labelCritere')
             ->leftJoin('s.desordreCriteres', 'desordreCriteres')
             ->where('s.statut != :statutArchived')
             ->setParameter('statutArchived', Signalement::STATUS_ARCHIVED)
@@ -328,12 +328,12 @@ class SignalementRepository extends ServiceEntityRepository
 
         if ($desordreCritereZone) {
             $qb->andWhere('desordreCriteres.zoneCategorie = :desordreCritereZone')
-            ->setParameter('desordreCritereZone', $desordreCritereZone->value);
+                ->setParameter('desordreCritereZone', $desordreCritereZone->value);
         }
 
-        $qb->groupBy('desordreCriteres.id')
-        ->orderBy('count', 'DESC')
-        ->setMaxResults(5);
+        $qb->groupBy('desordreCriteres.labelCritere')
+            ->orderBy('count', 'DESC')
+            ->setMaxResults(5);
 
         return $qb->getQuery()
             ->getResult();


### PR DESCRIPTION
## Ticket

#2591    

## Description
Pour les stats front, on groupe les desordreCritere par label plutôt que par id, pour ne pas se retrouver avec les 3 désordres les plus courants ayant exactement le même label (cf en prod)

## Changements apportés
* Changement du SignalementRepository

## Pré-requis

## Tests
- [ ] Tester les stats front avec les données de prod, et vérifier qu'on n'a qu'une seule fois "Le logement est humide et a des traces de moisissures" mais avec un nombre énorme
