### PR TITLE
Anonymisation des comptes agents expiré 

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -19,6 +19,9 @@
       "command": "0 4 * * * php bin/console app:notify-and-archive-inactive-accounts"
     },
     {
+      "command": "30 4 * * php bin/console app:anonymize-expired-account"
+    },
+    {
       "command": "0 1 * * * sh /app/scripts/sync-db.sh"
     }
   ]

--- a/migrations/Version20240524151828.php
+++ b/migrations/Version20240524151828.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240524151828 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add anonymized_at column to user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD anonymized_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP anonymized_at');
+    }
+}

--- a/src/Command/Cron/AnonymizeExpiredAccountCommand.php
+++ b/src/Command/Cron/AnonymizeExpiredAccountCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Command\Cron;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use App\Service\Mailer\NotificationMail;
+use App\Service\Mailer\NotificationMailerRegistry;
+use App\Service\Mailer\NotificationMailerType;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(
+    name: 'app:anonymize-expired-account',
+    description: 'Sends notifications to inactive accounts and archives them after 30 days'
+)]
+class AnonymizeExpiredAccountCommand extends AbstractCronCommand
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
+        private readonly NotificationMailerRegistry $notificationMailerRegistry,
+        private readonly ParameterBagInterface $parameterBag
+    ) {
+        parent::__construct($this->parameterBag);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io = new SymfonyStyle($input, $output);
+        $nbAgents = $this->anonymizeExpiredUsers();
+
+        $this->entityManager->flush();
+
+        $message = $nbAgents.' comptes agents expirés anonymisés.';
+
+        if ($nbAgents > 0) {
+            $this->notificationMailerRegistry->send(
+                new NotificationMail(
+                    type: NotificationMailerType::TYPE_CRON,
+                    to: $this->parameterBag->get('admin_email'),
+                    message: $message,
+                    cronLabel: 'Anonymisation de comptes expirés',
+                )
+            );
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function anonymizeExpiredUsers(): int
+    {
+        $expiredUsers = $this->userRepository->findExpiredUsers(true);
+
+        /** @var User $user */
+        foreach ($expiredUsers as $user) {
+            $user->anonymize();
+        }
+
+        $this->io->success(\count($expiredUsers).' expired users anonymized.');
+
+        return \count($expiredUsers);
+    }
+}

--- a/src/Controller/Back/BackArchivedAccountController.php
+++ b/src/Controller/Back/BackArchivedAccountController.php
@@ -93,7 +93,9 @@ class BackArchivedAccountController extends AbstractController
     ): Response {
         $isUserUnlinked = (!$user->getTerritory() || !$user->getPartner());
 
-        if (User::STATUS_ARCHIVE !== $user->getStatut() && !$isUserUnlinked) {
+        if ((User::STATUS_ARCHIVE !== $user->getStatut() && !$isUserUnlinked) || $user->getAnonymizedAt()) {
+            $this->addFlash('error', 'Ce compte ne peut pas être réactivé.');
+
             return $this->redirect($this->generateUrl('back_account_index'));
         }
 
@@ -103,7 +105,7 @@ class BackArchivedAccountController extends AbstractController
         $form->handleRequest($request);
 
         $untaggedEmail = explode(User::SUFFIXE_ARCHIVED, $user->getEmail())[0];
-        $userExist = $userRepository->findOneBy(['email' => $untaggedEmail]);
+        $userExist = $userRepository->findOneByEmailExcepted($untaggedEmail, $user);
         if ($userExist) {
             $this->addFlash('error', 'Un utilisateur existe déjà avec cette adresse e-mail. '
             .$userExist->getNomComplet().' ( id '.$userExist->getId().' ) avec le rôle '

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -502,9 +502,7 @@ class PartnerController extends AbstractController
                 territory: $user->getTerritory()
             )
         );
-        if ($user->getAnonymizedAt()) {
-            $this->addFlash('error', 'Cet utilisateur est anonymisé.');
-        } elseif (User::STATUS_ARCHIVE === $user->getStatut()) {
+        if (User::STATUS_ARCHIVE === $user->getStatut()) {
             $this->addFlash('error', 'Cet utilisateur est déjà supprimé.');
         } else {
             $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -502,10 +502,16 @@ class PartnerController extends AbstractController
                 territory: $user->getTerritory()
             )
         );
-        $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
-        $user->setStatut(User::STATUS_ARCHIVE);
-        $userManager->save($user);
-        $this->addFlash('success', 'L\'utilisateur a bien été supprimé.');
+        if ($user->getAnonymizedAt()) {
+            $this->addFlash('error', 'Cet utilisateur est anonymisé.');
+        } elseif (User::STATUS_ARCHIVE === $user->getStatut()) {
+            $this->addFlash('error', 'Cet utilisateur est déjà supprimé.');
+        } else {
+            $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
+            $user->setStatut(User::STATUS_ARCHIVE);
+            $userManager->save($user);
+            $this->addFlash('success', 'L\'utilisateur a bien été supprimé.');
+        }
 
         return $this->redirectToRoute(
             'back_partner_view',

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -202,6 +202,24 @@ users:
     is_mailing_active: 1
     territory: "Bouches-du-Rhône"
   -
+    email: user-13-08@histologe.fr
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partner: "Partenaire 13-01"
+    statut: 2
+    is_generique: 0
+    is_mailing_active: 1
+    territory: "Bouches-du-Rhône"
+    anonymized: true
+  -
+    email: user-13-09@histologe.fr
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partner: "Partenaire 13-01"
+    statut: 2
+    is_generique: 0
+    is_mailing_active: 1
+    territory: "Bouches-du-Rhône"
+    last_login_at: '-2 year'
+  -
     email: user-2A-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 2A-01"

--- a/src/DataFixtures/Loader/LoadUserData.php
+++ b/src/DataFixtures/Loader/LoadUserData.php
@@ -78,6 +78,10 @@ class LoadUserData extends Fixture implements OrderedFixtureInterface
             $user->setLastLoginAt($lastLoginAt);
         }
 
+        if (isset($row['anonymized']) && $row['anonymized']) {
+            $user->anonymize();
+        }
+
         if (isset($row['token'])) {
             $user
                 ->setToken($row['token'])

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use App\Entity\Behaviour\TimestampableTrait;
 use App\Repository\UserRepository;
-use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -135,6 +134,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
     private ?\DateTimeInterface $archivingScheduledAt = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $anonymizedAt = null;
 
     public function __construct()
     {
@@ -321,7 +323,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return self::STATUS_LABELS[$this->statut];
     }
 
-    public function getLastLoginAt(): ?DateTimeImmutable
+    public function getLastLoginAt(): ?\DateTimeImmutable
     {
         return $this->lastLoginAt;
     }
@@ -335,7 +337,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return '';
     }
 
-    public function setLastLoginAt(?DateTimeImmutable $lastLoginAt): self
+    public function setLastLoginAt(?\DateTimeImmutable $lastLoginAt): self
     {
         $this->lastLoginAt = $lastLoginAt;
         $this->archivingScheduledAt = null;
@@ -456,12 +458,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function getTokenExpiredAt(): ?DateTimeImmutable
+    public function getTokenExpiredAt(): ?\DateTimeImmutable
     {
         return $this->tokenExpiredAt;
     }
 
-    public function setTokenExpiredAt(?DateTimeImmutable $tokenExpiredAt): self
+    public function setTokenExpiredAt(?\DateTimeImmutable $tokenExpiredAt): self
     {
         $this->tokenExpiredAt = $tokenExpiredAt;
 
@@ -545,6 +547,23 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setArchivingScheduledAt(?\DateTimeInterface $archivingScheduledAt): self
     {
         $this->archivingScheduledAt = $archivingScheduledAt;
+
+        return $this;
+    }
+
+    public function getAnonymizedAt(): ?\DateTimeImmutable
+    {
+        return $this->anonymizedAt;
+    }
+
+    public function anonymize(): static
+    {
+        if (self::STATUS_ARCHIVE === $this->getStatut() && null === $this->anonymizedAt) {
+            $this->setEmail('anonyme@'.date('YmdHis').'.'.uniqid());
+            $this->setPrenom('Utilisateur');
+            $this->setNom('Anonymisé');
+            $this->anonymizedAt = new \DateTimeImmutable();
+        }
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -40,6 +40,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public const ROLE_ADMIN = self::ROLES['Super Admin'];
 
     public const SUFFIXE_ARCHIVED = '.archived@';
+    public const ANONYMIZED_MAIL = 'anonyme@';
+    public const ANONYMIZED_PRENOM = 'Utilisateur';
+    public const ANONYMIZED_NOM = 'Anonymisé';
 
     public const ROLES = [
         'Usager' => 'ROLE_USAGER',
@@ -559,9 +562,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function anonymize(): static
     {
         if (self::STATUS_ARCHIVE === $this->getStatut() && null === $this->anonymizedAt) {
-            $this->setEmail('anonyme@'.date('YmdHis').'.'.uniqid());
-            $this->setPrenom('Utilisateur');
-            $this->setNom('Anonymisé');
+            $this->setEmail(self::ANONYMIZED_MAIL.date('YmdHis').'.'.uniqid());
+            $this->setPrenom(self::ANONYMIZED_PRENOM);
+            $this->setNom(self::ANONYMIZED_NOM);
             $this->anonymizedAt = new \DateTimeImmutable();
         }
 

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -38,6 +38,9 @@ class UserVoter extends Voter
         if (!$user instanceof UserInterface) {
             return false;
         }
+        if ($subject->getAnonymizedAt()) {
+            return false;
+        }
         if ($this->security->isGranted('ROLE_ADMIN')) {
             return true;
         }

--- a/tests/Functional/Command/Cron/AnonymizeExpiredAccountCommandTest.php
+++ b/tests/Functional/Command/Cron/AnonymizeExpiredAccountCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Tests\Functional\Command\Cron;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AnonymizeExpiredAccountCommandTest extends KernelTestCase
+{
+    public function testDisplayMessageSuccessfully(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:anonymize-expired-account');
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('1 expired users anonymized.', $output);
+        $this->assertEmailCount(1);
+    }
+}

--- a/tests/Functional/Controller/BackExpiredAccountControllerTest.php
+++ b/tests/Functional/Controller/BackExpiredAccountControllerTest.php
@@ -24,6 +24,6 @@ class BackExpiredAccountControllerTest extends WebTestCase
         $crawler = $client->request('GET', $route);
 
         $this->assertEquals(1, $crawler->filter('h2:contains("1 comptes usagers expirés")')->count());
-        $this->assertEquals(1, $crawler->filter('h2:contains("1 comptes agents expirés")')->count());
+        $this->assertEquals(1, $crawler->filter('h2:contains("2 comptes agents expirés")')->count());
     }
 }

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -60,7 +60,7 @@ class UserTest extends KernelTestCase
         $user->setStatut(User::STATUS_ARCHIVE);
         $user->anonymize();
         $this->assertNotNull($user->getAnonymizedAt());
-        $this->assertEquals(user::ANONYMIZED_PRENOM, $user->getPrenom());
+        $this->assertEquals(User::ANONYMIZED_PRENOM, $user->getPrenom());
         $this->assertEquals(User::ANONYMIZED_NOM, $user->getNom());
         $this->assertStringStartsWith(User::ANONYMIZED_MAIL, $user->getEmail());
 

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -60,9 +60,9 @@ class UserTest extends KernelTestCase
         $user->setStatut(User::STATUS_ARCHIVE);
         $user->anonymize();
         $this->assertNotNull($user->getAnonymizedAt());
-        $this->assertEquals('Utilisateur', $user->getPrenom());
-        $this->assertEquals('Anonymisé', $user->getNom());
-        $this->assertStringStartsWith('anonyme@', $user->getEmail());
+        $this->assertEquals(user::ANONYMIZED_PRENOM, $user->getPrenom());
+        $this->assertEquals(User::ANONYMIZED_NOM, $user->getNom());
+        $this->assertStringStartsWith(User::ANONYMIZED_MAIL, $user->getEmail());
 
         $tmp = $user->getAnonymizedAt();
         $user->anonymize();

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -51,6 +51,24 @@ class UserTest extends KernelTestCase
         $this->assertCount(0, $errors);
     }
 
+    public function testUserAnonymization()
+    {
+        $user = $this->getUser([User::ROLE_ADMIN_TERRITORY]);
+        $user->anonymize();
+        $this->assertNull($user->getAnonymizedAt());
+
+        $user->setStatut(User::STATUS_ARCHIVE);
+        $user->anonymize();
+        $this->assertNotNull($user->getAnonymizedAt());
+        $this->assertEquals('Utilisateur', $user->getPrenom());
+        $this->assertEquals('Anonymisé', $user->getNom());
+        $this->assertStringStartsWith('anonyme@', $user->getEmail());
+
+        $tmp = $user->getAnonymizedAt();
+        $user->anonymize();
+        $this->assertEquals($tmp, $user->getAnonymizedAt());
+    }
+
     public function provideInvalidPassword(): \Generator
     {
         yield 'blank' => ['Cette valeur ne doit pas être vide', ''];


### PR DESCRIPTION
## Ticket

#2429
#2554

## Description
- Ajout de la commande `app:anonymize-expired-account` qui anonymize les comptes agent sans activité depuis plus de deux ans à condition qu'il soit archivé (ce qui est fait automatiquement sans réponse de leur part via la commande `app:notify-and-archive-inactive-accounts`
- Correction du process de désarchivation d'un compte afin que l'utilisateur en cours de désarchivage ne soit pas bloqué par son propre e-mail (cas de soumission du formulaire sur un utilisateur sans partenaire/territoire non archivé)

## Pré-requis
`make load-migrations`

## Tests
- [ ] Tester la commande `app:anonymize-expired-account` et verifier que les comptes anonymisés ne sont affiché et pris en compte nulle part (comptes archivés, inactifs, expirés)
- [ ] S'assurer que l'on anonymise uniquement les agent inactif depuis plus de deux ans qui sont déja archivé
- [ ] S'assurer que le système de désarchivage fonctionne correctement et qu'il es impossible de désarchiver un user anonymisé
