### PR TITLE
[BUG] corriger envoie de requêtes nouveau formulaire

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -179,12 +179,13 @@ export default defineComponent({
       }
 
       if (isUpdateAddress) {
+        formStore.data[this.id] = formStore.data[this.id + '_detail_numero'] + ' ' + formStore.data[this.id + '_detail_code_postal'] + ' ' + formStore.data[this.id + '_detail_commune']
         this.isTyping = true
         clearTimeout(this.idFetchTimeout)
         this.idFetchTimeout = setTimeout(() => {
           this.isTyping = false
           requests.validateAddress(search, this.handleUpdateInsee)
-        }, 300)
+        }, 2000)
       }
     },
     handleUpdateInsee (requestResponse: any) {

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -185,7 +185,7 @@ export default defineComponent({
         this.idFetchTimeout = setTimeout(() => {
           this.isTyping = false
           requests.validateAddress(search, this.handleUpdateInsee)
-        }, 2000)
+        }, 700)
       }
     },
     handleUpdateInsee (requestResponse: any) {

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -95,24 +95,17 @@ export const requests = {
       // TODO : il y a sûrement plus élégant à faire pour construire l'url (cf controlleur et twig)
       const url = formStore.props.ajaxurlPutSignalementDraft.replace('uuid', formStore.data.uuidSignalementDraft)
       requests.doRequestPut(url, formStore.data, functionReturn)
-    } else if (formStore.data.adresse_logement_adresse !== undefined &&
-          (formStore.data.vos_coordonnees_occupant_email !== undefined ||
-            formStore.data.vos_coordonnees_tiers_email !== undefined)
-    ) { // TODO : vérifier la condition (notamment en fonction des profils)
+    } else if (formStore.currentScreen && formStore.currentScreen.slug !== 'adresse_logement' && formStore.currentScreen.slug !== 'signalement_concerne') {
       const url = formStore.props.ajaxurlPostSignalementDraft
       requests.doRequestPost(url, formStore.data, functionReturn, undefined)
     } else {
-      // TODO : que renvoyer ?
       functionReturn(undefined)
     }
   },
 
   checkIfAlreadyExists (functionReturn: Function) {
     const url = formStore.props.ajaxurlCheckSignalementOrDraftAlreadyExists
-    if (formStore.data.adresse_logement_adresse !== undefined &&
-      (formStore.data.vos_coordonnees_occupant_email !== undefined ||
-        formStore.data.vos_coordonnees_tiers_email !== undefined)
-    ) {
+    if (formStore.currentScreen && formStore.currentScreen.slug !== 'adresse_logement' && formStore.currentScreen.slug !== 'signalement_concerne') {
       requests.doRequestPost(url, formStore.data, functionReturn, undefined)
     } else {
       functionReturn(undefined)


### PR DESCRIPTION
## Ticket

#2595

## Description
- Correction : Lorsque que l'on saisie une adresse totalement manuellement, le champ "adresse_logement_adresse" est envoyé vide.
- Modification : Utilisation de l'étape pour déterminer si on envoie la requête de soumission des données du formulaire
- Modification : augmentation de la latence avant appel du checkterritory pour éviter popup intempestive en cas d'erreur de frappe ou frappe lente

## Tests
- [ ] Soumettre un formulaire en renseignant une adresse complètement libre (ne rien taper dans le champs BAN) et verifier que le parcours fonctionne jusqu'à la soumission finale
