### PR TITLE
[FO - stats] Changer l'url de la route stats

### DIFF
--- a/src/Controller/StatistiquesController.php
+++ b/src/Controller/StatistiquesController.php
@@ -35,7 +35,7 @@ class StatistiquesController extends AbstractController
     ) {
     }
 
-    #[Route('/statistiques', name: 'front_statistiques')]
+    #[Route('/stats', name: 'front_statistiques')]
     public function statistiques(): Response
     {
         return $this->render('front/statistiques.html.twig');

--- a/src/EventListener/SeoPageNotFoundRedirectListener.php
+++ b/src/EventListener/SeoPageNotFoundRedirectListener.php
@@ -11,10 +11,11 @@ class SeoPageNotFoundRedirectListener
 {
     public const SEO_URL_MAPPING = [
         '/Home' => 'home',
-        '/Aide' => 'front_about',
+        '/Aide' => 'front_aides_travaux',
         '/Territoires' => 'front_about',
         '/Contact' => 'front_contact',
         '/Statistiques' => 'front_statistiques',
+        '/statistiques' => 'front_statistiques',
         '/Chiffres' => 'front_statistiques',
         '/CGU' => 'front_cgu',
     ];


### PR DESCRIPTION
## Ticket

#2603    

## Description
passer la route de /statistiques à /stats pour être en cohérence avec les autres startups

## Changements apportés
* Changement de la route du controller

## Pré-requis

## Tests
- [ ] Aller sur la page de stats et vérifier l'url
- [ ] Essayer l'ancienne url `http://localhost:8080/statistiques` et vérifier que la redirection se fait
