### PR TITLE
[FO - contact] Inverser l'alerte et le bouton envoyer un mail sur la page contact

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -760,9 +760,6 @@ p + ul {
 ul + p {
     margin-top: 1.5rem;
 }
-h2, h3 {
-    margin-top: 2rem;
-}
 
 .faq-redirection {
     position: fixed;

--- a/templates/front/aides_travaux.html.twig
+++ b/templates/front/aides_travaux.html.twig
@@ -84,7 +84,7 @@
             </div>
         </div>
 
-        <h2>Quelles aides pour mon profil ?</h2>
+        <h2 class="fr-mt-4w">Quelles aides pour mon profil ?</h2>
 
         <p>Les aides varient selon que vous êtes locataire, propriétaire occupant ou propriétaire bailleur :</p>
         <ul>
@@ -183,9 +183,9 @@
                 >Accéder au simulateur</a>
         </div>
 
-        <h2 id="aides">Les aides</h2>
+        <h2 id="aides" class="fr-mt-4w">Les aides</h2>
 
-        <h3>Les certificats d’économie d’énergie (CEE) “Standard”</h3>
+        <h3 class="fr-mt-4w">Les certificats d’économie d’énergie (CEE) “Standard”</h3>
 
         <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
@@ -210,7 +210,7 @@
                 >le site du service public</a>.
         </p>
 
-        <h3>MaPrimeRénov'</h3>
+        <h3 class="fr-mt-4w">MaPrimeRénov'</h3>
 
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
         <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
@@ -247,7 +247,7 @@
             </p>
         </div>
 
-        <h3>Ma Prime Logement Décent</h3>
+        <h3 class="fr-mt-4w">Ma Prime Logement Décent</h3>
 
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
         <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
@@ -273,7 +273,7 @@
                 >le site France Rénov'</a>.
         </p>
 
-        <h3>MaPrimeAdapt'</h3>
+        <h3 class="fr-mt-4w">MaPrimeAdapt'</h3>
 
         <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
@@ -297,7 +297,7 @@
                 >le site du service public</a>.
         </p>
 
-        <h3>La prime coup de pouce Chauffage</h3>
+        <h3 class="fr-mt-4w">La prime coup de pouce Chauffage</h3>
 
         <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
@@ -320,7 +320,7 @@
                 >le site du service public</a>.
         </p>
 
-        <h3>La prime « Coup de pouce Pilotage connecté du chauffage pièce par pièce »</h3>
+        <h3 class="fr-mt-4w">La prime « Coup de pouce Pilotage connecté du chauffage pièce par pièce »</h3>
 
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
@@ -336,7 +336,7 @@
                 >le site du service public</a>.
         </p>
 
-        <h3>La prime « Coup de pouce Rénovation performante d’une maison individuelle »</h3>
+        <h3 class="fr-mt-4w">La prime « Coup de pouce Rénovation performante d’une maison individuelle »</h3>
 
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
         <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
@@ -373,7 +373,7 @@
             </p>
         </div>
 
-        <h3>Aide à l'insonorisation de votre logement proche d'un aéroport</h3>
+        <h3 class="fr-mt-4w">Aide à l'insonorisation de votre logement proche d'un aéroport</h3>
 
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
 
@@ -394,7 +394,7 @@
                 >le site du service public</a>.
         </p>
 
-        <h3>Subvention de l’Agence nationale de l’habitat (Anah)</h3>
+        <h3 class="fr-mt-4w">Subvention de l’Agence nationale de l’habitat (Anah)</h3>
 
         <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 
@@ -422,9 +422,9 @@
                 >le site du service public</a>.
         </p>
 
-        <h2 id="prets">Les prêts</h2>
+        <h2 id="prets" class="fr-mt-4w">Les prêts</h2>
 
-        <h3>Éco-prêt à taux zéro (Éco-PTZ)</h3>
+        <h3 class="fr-mt-4w">Éco-prêt à taux zéro (Éco-PTZ)</h3>
 
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
         <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
@@ -456,7 +456,7 @@
             </div>
         </div>
 
-        <h3>Le prêt de votre caisse d'allocations familiales (CAF)</h3>
+        <h3 class="fr-mt-4w">Le prêt de votre caisse d'allocations familiales (CAF)</h3>
 
         <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
@@ -478,9 +478,9 @@
                 >le site du service public</a>.
         </p>
 
-        <h2 id="avantages-fiscaux">Les avantages fiscaux</h2>
+        <h2 id="avantages-fiscaux" class="fr-mt-4w">Les avantages fiscaux</h2>
 
-        <h3>Le crédit d’impôt pour des dépenses d'équipement conçu pour les personnes âgées ou handicapées</h3>
+        <h3 class="fr-mt-4w">Le crédit d’impôt pour des dépenses d'équipement conçu pour les personnes âgées ou handicapées</h3>
 
         <p class="fr-badge fr-badge--success fr-badge--no-icon fr-my-1v">Locataire</p>
         <p class="fr-badge fr-badge--error fr-badge--no-icon fr-my-1v">Propriétaire occupant</p>
@@ -506,7 +506,7 @@
                 >le site du service public</a>.
         </p>
 
-        <h3>Loc’Avantages</h3>
+        <h3 class="fr-mt-4w">Loc’Avantages</h3>
 
         <p class="fr-badge fr-badge--new fr-badge--no-icon fr-my-1v">Propriétaire bailleur</p>
 

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -34,14 +34,14 @@
 		<section class="fr-container">
 			<h2 class="fr-mt-5w">Vous avez une autre question ?</h2>
 			<p>Vous ne trouvez pas la réponse à votre question ? Vous souhaitez signaler un problème technique ? Contactez l'équipe Histologe.</p>
-			<a href="mailto:{{ contactEmail }}" class="fr-btn fr-btn--icon-left fr-mail-line">Envoyer un message</a>
-			<div class="fr-alert fr-alert--warning fr-mt-3w">
+			<div class="fr-alert fr-alert--warning fr-my-3w">
 				<h3 class="fr-alert__title">N'envoyez pas votre signalement par e-mail !</h3>
 				<p>
 					Les signalements ne peuvent être pas déposés par e-mail. 
 					Pour déposer un signalement, cliquez sur le bouton "Je dépose mon signalement" sur cette page ou sur l'élément "Signalement" dans le menu principal.
 				</p>
 			</div>
+			<a href="mailto:{{ contactEmail }}" class="fr-btn fr-btn--icon-left fr-mail-line">Envoyer un message</a>
 		</section>
 		<section class="fr-py-5w fr-mt-5w fr-background-contrast--blue-france">
 			<div class="fr-container">

--- a/templates/front/obligations_entretien.html.twig
+++ b/templates/front/obligations_entretien.html.twig
@@ -44,7 +44,7 @@
             </p>
         </div>
 
-        <h2>Propriétaire, locataire : qui répare quoi ?</h2>
+        <h2 class="fr-mt-4w">Propriétaire, locataire : qui répare quoi ?</h2>
 
         <p>
             Découvrez qui prend en charge quelles réparations pour chaque zone du logement.
@@ -153,7 +153,7 @@
             </div>
         </div>
 
-        <h3 id="entree">L'entrée</h3>
+        <h3 id="entree" class="fr-mt-4w">L'entrée</h3>
 
         <p>
             Dans l’entrée, le <strong>locataire</strong> doit s’occuper de :
@@ -177,7 +177,7 @@
             <li>Les radiateurs : remplacement</li>
         </ul>
 
-        <h3 id="salon-chambres">Le salon et les chambres</h3>
+        <h3 id="salon-chambres" class="fr-mt-4w">Le salon et les chambres</h3>
 
         <p>
             Dans les pièces à vivre (salon et chambres), le <strong>locataire</strong> s’occupe de :
@@ -202,7 +202,7 @@
             <li>Les radiateurs : remplacement</li>
         </ul>
 
-        <h3 id="cuisine">La cuisine</h3>
+        <h3 id="cuisine" class="fr-mt-4w">La cuisine</h3>
 
         <p>
             Dans la cuisine, le <strong>locataire</strong> doit s’occuper de :
@@ -239,7 +239,7 @@
             </p>
         </div>
 
-        <h3 id="wc-sdb">Les WC et la salle de bain</h3>
+        <h3 id="wc-sdb" class="fr-mt-4w">Les WC et la salle de bain</h3>
 
         <p>
             Dans les sanitaires (WC et salle de bain), le <strong>locataire</strong> s’occupe de :
@@ -265,7 +265,7 @@
             <li>Le conduit d’alimentation d’eau : remplacement</li>
         </ul>
 
-        <h3 id="autres-equipements">Les autres équipements</h3>
+        <h3 id="autres-equipements" class="fr-mt-4w">Les autres équipements</h3>
 
         <p>
             Le <strong>locataire</strong> prend en charge l’entretien des équipements suivants :
@@ -295,7 +295,7 @@
             </p>
         </div>
 
-        <h3 id="exterieur">L'extérieur du logement</h3>
+        <h3 id="exterieur" class="fr-mt-4w">L'extérieur du logement</h3>
 
         <h4>Dans un immeuble collectif</h4>
 


### PR DESCRIPTION
## Ticket

#2606

## Description
Inverser l'alerte et le bouton envoyer un mail sur la page contact
J'ai aussi virer un style css dans `histologe.scss` car il ajoutait de l'espacement autour de tous les `h2` et `h3` et cassait la mise en page, par exemple dans cette alerte : 
![image](https://github.com/MTES-MCT/histologe/assets/33071753/78d4f5c9-23d7-41b2-9269-b7f59d986322)

Comme ce style avait été ajouté dans ce commit https://github.com/MTES-MCT/histologe/commit/dd1d4b48ed5306c6249da6054b7fcbd82b2e43ea pour la mise en page des pages aides-travau et obligations-entretien, j'ai plutôt ajouté un `fr-mt-4w` sur les titres concernés de ces pages


## Changements apportés
* Modification des twig
* Modification de `histologe.scss`

## Pré-requis

## Tests
- [ ] Vérifier la mise en page de la page [contact](http://localhost:8080/contact)
- [ ] vérifier la mise en page des pages http://localhost:8080/entretien-logement-obligations-proprietaire-locataire et http://localhost:8080/aides-travaux-logement
