### PR TITLE
[Signalement] Modification des événements qui mettent à jour le code Insee de l'adresse des occupants

### DIFF
--- a/assets/controllers/component_search_address.js
+++ b/assets/controllers/component_search_address.js
@@ -5,12 +5,9 @@ document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdress
     attacheAutocompleteAddressEvent(inputAdresse)
 })
 
-document.querySelector('#form-edit-address-adresse')?.addEventListener('input', (event) => {
-    let idForm = event.target.closest('form').id
-    document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 1
-});
-document.querySelector('#form-edit-address-codepostal')?.addEventListener('input', (event) => addressResetGeoloc(event.target));
-document.querySelector('#form-edit-address-ville')?.addEventListener('input', (event) => addressResetGeoloc(event.target));
+document.querySelector('#form-edit-address-adresse')?.addEventListener('input', (event) => setManualEdit(event.target, false));
+document.querySelector('#form-edit-address-codepostal')?.addEventListener('input', (event) => setManualEdit(event.target, true));
+document.querySelector('#form-edit-address-ville')?.addEventListener('input', (event) => setManualEdit(event.target, true));
 
 function attachAutocompleteClickOutsideEvent() {
     document.addEventListener('click', function (event) {
@@ -98,6 +95,9 @@ function attachAddressSuggestionEvent(inputAdresse, suggestion, feature) {
         if (document?.querySelector('#' + idForm + ' [data-autocomplete-manual]')) {
             document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 0
         }
+        if (document?.querySelector('#' + idForm + ' [data-autocomplete-need-reset-insee]')) {
+            document.querySelector('#' + idForm + ' [data-autocomplete-need-reset-insee]').value = 0
+        }
         if (document?.querySelector('#' + idForm + ' [data-autocomplete-insee]')) {
             document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
         }
@@ -112,29 +112,10 @@ function attachAddressSuggestionEvent(inputAdresse, suggestion, feature) {
     })
 }
 
-var idTimeout
-function addressResetGeoloc(input) {
-    clearTimeout(idTimeout)
-    idTimeout = setTimeout(() => {
-        const apiAdresse = 'https://api-adresse.data.gouv.fr/search/?q='
-        let newCodePostal = document.querySelector('#form-edit-address-codepostal')?.value
-        let newVille = document.querySelector('#form-edit-address-ville')?.value
-        let idForm = input.closest('form').id
-        if (newCodePostal !== '' && newVille !== '') {
-            let query = apiAdresse + newCodePostal + ' ' + newVille
-            fetch(query)
-                .then(response => response.json())
-                .then(json => {
-                    json.features.forEach((feature) => {
-                        if (feature.properties.citycode) {
-                            document.querySelector('#' + idForm + ' [data-autocomplete-ville]').value = feature.properties.city
-                            document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 1
-                            document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
-                            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclng]').value = feature.geometry.coordinates[0]
-                            document.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]').value = feature.geometry.coordinates[1]
-                        }
-                    })
-                })
-        }
-    }, 1000)
+function setManualEdit(input, needResetInsee) {
+    let idForm = input.closest('form').id
+    document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 1
+    if (needResetInsee) {
+        document.querySelector('#' + idForm + ' [data-autocomplete-need-reset-insee]').value = 1
+    }
 }

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -84,8 +84,7 @@
           "type": "SignalementFormAddress",
           "label": "Adresse du logement",
           "slug": "adresse_logement_adresse",
-          "description": "Tapez l'adresse puis sélectionnez-la dans la liste. Si elle n'apparait pas, cliquez sur Saisir une adresse manuellement.",
-          "isTerritoryToCheck": true
+          "description": "Tapez l'adresse puis sélectionnez-la dans la liste. Si elle n'apparait pas, cliquez sur Saisir une adresse manuellement."
         },
         {
           "type": "SignalementFormSubscreen",
@@ -151,7 +150,7 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "adresse_logement_next",
-          "action": "goto.save:signalement_concerne",
+          "action": "goto.checkloc:signalement_concerne",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -223,6 +223,8 @@ export default defineComponent({
           formStore.data.adresse_logement_adresse_detail_insee = suggestions[0].properties.citycode
           formStore.data.adresse_logement_adresse_detail_geoloc_lng = suggestions[0].geometry.coordinates[0]
           formStore.data.adresse_logement_adresse_detail_geoloc_lat = suggestions[0].geometry.coordinates[1]
+          formStore.data.adresse_logement_adresse = formStore.data.adresse_logement_adresse_detail_numero + ' ' + formStore.data.adresse_logement_adresse_detail_code_postal + ' ' + formStore.data.adresse_logement_adresse_detail_commune
+          formStore.data.adresse_logement_adresse_suggestion = formStore.data.adresse_logement_adresse_detail_numero + ' ' + formStore.data.adresse_logement_adresse_detail_code_postal + ' ' + formStore.data.adresse_logement_adresse_detail_commune
 
           this.checkTerritory(
             formStore.data.adresse_logement_adresse_detail_code_postal,

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -36,7 +36,6 @@
         :multiple="component.multiple"
         :ariaControls="component.ariaControls"
         :tagWhenEdit="component.tagWhenEdit"
-        :isTerritoryToCheck="component.isTerritoryToCheck"
         v-model="formStore.data[component.slug]"
         :hasError="formStore.validationErrors[component.slug]  !== undefined"
         :error="formStore.validationErrors[component.slug]"
@@ -252,7 +251,7 @@ export default defineComponent({
       } else if (type === 'archive') {
         requests.archiveDraft(formStore.data.uuidSignalementDraft, this.gotoHomepage)
       } else if (type.includes('goto')) {
-        await this.showScreenBySlug(param, param2, type.includes('save'))
+        await this.showScreenBySlug(param, param2, type.includes('save'), type.includes('checkloc'))
       } else if (type.includes('resolve')) {
         this.navigateToDisorderScreen(param, param2, type.includes('save'))
       }
@@ -273,10 +272,10 @@ export default defineComponent({
         (componentToToggle as HTMLButtonElement).disabled = (isVisible !== '1')
       }
     },
-    async showScreenBySlug (slug: string, slugButton:string, isSaveAndCheck:boolean) {
+    async showScreenBySlug (slug: string, slugButton:string, isSaveAndCheck:boolean, isCheckLocation:boolean) {
       formStore.validationErrors = {}
 
-      if (isSaveAndCheck) {
+      if (isSaveAndCheck || isCheckLocation) {
         if (this.components && this.components.body) {
           this.validateComponents(this.components.body)
           if (Object.keys(formStore.validationErrors).length > 0) {
@@ -289,14 +288,14 @@ export default defineComponent({
       // Si pas d'erreur de validation, ou screen précédent (donc pas de validation), on change d'écran
       if (this.changeEvent !== undefined) {
         formStore.lastButtonClicked = slugButton
-        await this.changeEvent(slug, isSaveAndCheck)
+        await this.changeEvent(slug, isSaveAndCheck, isCheckLocation)
       }
     },
     async navigateToDisorderScreen (action: string, slugButton:string, isSaveAndCheck:boolean) {
       if (action === 'findNextScreen') {
         const index = formStore.data.currentStep.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
         const { currentCategory, incrementIndex, nextScreenSlug } = findNextScreen(formStore, index, slugButton)
-        await this.showScreenBySlug(nextScreenSlug, slugButton, isSaveAndCheck)
+        await this.showScreenBySlug(nextScreenSlug, slugButton, isSaveAndCheck, false)
         if (Object.keys(formStore.validationErrors).length === 0) {
           this.currentDisorderIndex[currentCategory] = incrementIndex
         }
@@ -305,7 +304,7 @@ export default defineComponent({
       if (action === 'findPreviousScreen') {
         const index = formStore.data.currentStep.includes('batiment') ? this.currentDisorderIndex.batiment : this.currentDisorderIndex.logement
         const { currentCategory, decrementIndex, previousScreenSlug } = findPreviousScreen(formStore, index)
-        await this.showScreenBySlug(previousScreenSlug, slugButton, isSaveAndCheck)
+        await this.showScreenBySlug(previousScreenSlug, slugButton, isSaveAndCheck, false)
 
         this.currentDisorderIndex[currentCategory] = decrementIndex < 0 ? 0 : decrementIndex
       }

--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -25,6 +25,7 @@ class AdresseOccupantRequest implements RequestInterface
         private readonly ?string $geolocLat = null,
         private readonly ?string $insee = null,
         private readonly ?string $manual = null,
+        private readonly ?string $needResetInsee = null,
     ) {
     }
 
@@ -81,5 +82,10 @@ class AdresseOccupantRequest implements RequestInterface
     public function getManual(): ?string
     {
         return $this->manual;
+    }
+
+    public function getNeedResetInsee(): ?string
+    {
+        return $this->needResetInsee;
     }
 }

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -47,6 +47,7 @@
                                         <input class="fr-input" id="form-edit-address-ville" type="text" name="ville" value="{{ signalement.villeOccupant }}" data-autocomplete-ville="true">
                                     </div>
 
+                                    <input type="hidden" name="needResetInsee" value="0" data-autocomplete-need-reset-insee="true">
                                     <input type="hidden" name="manual" value="{{ signalement.manualAddressOccupant }}" data-autocomplete-manual="true">
                                     <input type="hidden" name="insee" value="{{ signalement.inseeOccupant }}" data-autocomplete-insee="true">
                                     <input type="hidden" name="geolocLat" value="{% if signalement.geoloc.lat is defined %}{{ signalement.geoloc.lat }}{% endif %}" data-autocomplete-geoloclat="true">

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -18,6 +18,7 @@ use App\Manager\SuiviManager;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordreCritereRepository;
 use App\Repository\DesordrePrecisionRepository;
+use App\Service\DataGouv\AddressService;
 use App\Service\Signalement\CriticiteCalculator;
 use App\Service\Signalement\DesordreTraitement\DesordreCompositionLogementLoader;
 use App\Service\Signalement\Qualification\QualificationStatusService;
@@ -57,6 +58,7 @@ class SignalementManagerTest extends WebTestCase
     private DesordreCompositionLogementLoader $desordreCompositionLogementLoader;
     private SuiviManager $suiviManager;
     private BailleurRepository $bailleurRepository;
+    private AddressService $addressService;
 
     protected function setUp(): void
     {
@@ -82,6 +84,7 @@ class SignalementManagerTest extends WebTestCase
         $this->desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
         $this->suiviManager = static::getContainer()->get(SuiviManager::class);
         $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
+        $this->addressService = static::getContainer()->get(AddressService::class);
 
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
@@ -101,6 +104,7 @@ class SignalementManagerTest extends WebTestCase
             $this->desordreCompositionLogementLoader,
             $this->suiviManager,
             $this->bailleurRepository,
+            $this->addressService,
         );
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
         $client->loginUser($user);

--- a/tests/Functional/Service/Signalement/PhotoHelperTest.php
+++ b/tests/Functional/Service/Signalement/PhotoHelperTest.php
@@ -11,13 +11,13 @@ use App\Manager\SuiviManager;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordreCritereRepository;
 use App\Repository\DesordrePrecisionRepository;
+use App\Service\DataGouv\AddressService;
 use App\Service\Signalement\CriticiteCalculator;
 use App\Service\Signalement\DesordreTraitement\DesordreCompositionLogementLoader;
 use App\Service\Signalement\PhotoHelper;
 use App\Service\Signalement\Qualification\QualificationStatusService;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use App\Specification\Signalement\SuroccupationSpecification;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -27,7 +27,6 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class PhotoHelperTest extends KernelTestCase
 {
-    private EntityManagerInterface $entityManager;
     private Security $security;
     private ManagerRegistry $managerRegistry;
     private SignalementFactory $signalementFactory;
@@ -46,10 +45,10 @@ class PhotoHelperTest extends KernelTestCase
     private DesordreCompositionLogementLoader $desordreCompositionLogementLoader;
     private SuiviManager $suiviManager;
     private BailleurRepository $bailleurRepository;
+    private AddressService $addressService;
 
     protected function setUp(): void
     {
-        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->security = static::getContainer()->get('security.helper');
         $this->signalementFactory = static::getContainer()->get(SignalementFactory::class);
@@ -70,6 +69,7 @@ class PhotoHelperTest extends KernelTestCase
         $this->desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
         $this->suiviManager = static::getContainer()->get(SuiviManager::class);
         $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
+        $this->addressService = static::getContainer()->get(AddressService::class);
 
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
@@ -89,6 +89,7 @@ class PhotoHelperTest extends KernelTestCase
             $this->desordreCompositionLogementLoader,
             $this->suiviManager,
             $this->bailleurRepository,
+            $this->addressService,
         );
     }
 


### PR DESCRIPTION
## Ticket

#2601   

## Description
Suite à la possibilité donnée aux usagers et agents de modifier à la main les adresse, l'UX n'était pas idéale pour vérifier et mettre à jour le code Insee en cas d'édition manuelle.

## Changements apportés
* Côté FO : la mise à jour de la géolocalisation et la vérification de l'ouverture du territoire se fait au clic sur le bouton Suivant
  * J'ai donc ajouté un nouveau type d'action dans le json `checkloc` qui vient remplacer `save` sur le premier écran
  * J'ai déplacé la modale de territoire fermé à la racine de l'app plutôt que dans le composant d'adresse : c'est l'app elle-même qui fait cette vérification
* Côté BO : cela se fait à la validation du formulaire, côté back
  * le js ne sert plus qu'à signaler qu'une modification manuelle a été faite ou non

## Pré-requis
Pour avoir des messages corrects : `make console app="update-communes"`

## Tests
- [ ] FO : utiliser le champ de recherche d'adresse, et vérifier le comportement avec un territoire ouvert ou non
- [ ] FO : modifier une adresse déjà pré-remplie et vérifier
- [ ] FO : démarrer et écrire directement une adresse à la main, et vérifier
- [ ] FO : vérifier le comportement avec une ville mal ortographiée
- [ ] BO : faire les mêmes tests
