### PR TITLE
[BO - Filtre signalement] Correction tri 

### DIFF
--- a/assets/vue/components/common/AppSearch.vue
+++ b/assets/vue/components/common/AppSearch.vue
@@ -6,7 +6,6 @@
         :name="id"
         :value="modelValue"
         @input="onInputEvent"
-        @search="onSearchEvent"
         :placeholder="placeholder"
         type="search"
     />
@@ -21,7 +20,6 @@ export default defineComponent({
   props: {
     id: { type: String, default: '' },
     modelValue: { type: String, default: '' },
-    onInput: { type: Function },
     placeholder: { type: String, default: '' },
     minLengthSearch: { type: Number, default: 0 }
   },
@@ -30,17 +28,8 @@ export default defineComponent({
     onInputEvent (e: any) {
       if (e.target.value.length >= this.minLengthSearch) {
         this.$emit('update:modelValue', e.target.value)
-        if (this.onInput !== undefined) {
-          this.onInput(e.target.value)
-        }
-      }
-    },
-    onSearchEvent (e: any) {
-      if (e.target.value === '') {
-        this.$emit('update:modelValue', null)
-        if (this.onInput !== undefined) {
-          this.onInput(null)
-        }
+      } else if (e.target.value.length === 0) {
+        this.$emit('update:modelValue', '')
       }
     }
   }

--- a/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -172,9 +172,9 @@ export default defineComponent({
       }
     },
     makeNewSignalement () {
-      if (formStore.alreadyExists.uuidDraft !== null && (formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement')){
+      if (formStore.alreadyExists.uuidDraft !== null && (formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement')) {
         requests.archiveDraft(formStore.alreadyExists.uuidDraft, this.saveAndContinue)
-      } else if(formStore.alreadyExists.type === 'signalement'){
+      } else if (formStore.alreadyExists.type === 'signalement') {
         this.saveAndContinue()
       }
     },

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -95,7 +95,7 @@ export const requests = {
       // TODO : il y a sûrement plus élégant à faire pour construire l'url (cf controlleur et twig)
       const url = formStore.props.ajaxurlPutSignalementDraft.replace('uuid', formStore.data.uuidSignalementDraft)
       requests.doRequestPut(url, formStore.data, functionReturn)
-    } else if (formStore.currentScreen && formStore.currentScreen.slug !== 'adresse_logement' && formStore.currentScreen.slug !== 'signalement_concerne') {
+    } else if ((formStore.currentScreen != null) && formStore.currentScreen.slug !== 'adresse_logement' && formStore.currentScreen.slug !== 'signalement_concerne') {
       const url = formStore.props.ajaxurlPostSignalementDraft
       requests.doRequestPost(url, formStore.data, functionReturn, undefined)
     } else {
@@ -105,7 +105,7 @@ export const requests = {
 
   checkIfAlreadyExists (functionReturn: Function) {
     const url = formStore.props.ajaxurlCheckSignalementOrDraftAlreadyExists
-    if (formStore.currentScreen && formStore.currentScreen.slug !== 'adresse_logement' && formStore.currentScreen.slug !== 'signalement_concerne') {
+    if ((formStore.currentScreen != null) && formStore.currentScreen.slug !== 'adresse_logement' && formStore.currentScreen.slug !== 'signalement_concerne') {
       requests.doRequestPost(url, formStore.data, functionReturn, undefined)
     } else {
       functionReturn(undefined)

--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -124,6 +124,7 @@ export default defineComponent({
       this.sharedState.user.canSeeScore = isAdminOrAdminTerritoire
       this.sharedState.user.partnerId = requestResponse.partnerId
       this.sharedState.hasSignalementImported = requestResponse.hasSignalementImported
+      this.sharedState.input.order = 'reference-DESC'
 
       this.sharedState.territories = []
       for (const id in requestResponse.territories) {
@@ -193,6 +194,8 @@ export default defineComponent({
       this.clearScreen()
       const [field, direction] = this.sharedState.input.order.split('-')
       this.removeQueryParameter('page')
+      this.removeQueryParameter('sortBy')
+      this.removeQueryParameter('orderBy')
 
       const url = new URL(window.location.toString())
       url.searchParams.delete('page')
@@ -219,35 +222,25 @@ export default defineComponent({
       this.sharedState.input.queryParameters = []
 
       for (const [key, value] of Object.entries(this.sharedState.input.filters)) {
-        if (value && value !== null) {
+        if (value) {
           if (key === 'dateDepot' || key === 'dateDernierSuivi') {
             const [dateDebut, dateFin] = this.handleDateParameter(key, value)
             url.searchParams.set(`${key}Debut`, dateDebut)
             url.searchParams.set(`${key}Fin`, dateFin)
             url.searchParams.delete(key)
-          } else if (
-            key === 'territoires' ||
-              key === 'partenaires' ||
-              key === 'communes' ||
-              key === 'etiquettes' ||
-              key === 'epcis'
-          ) {
-            if (typeof value === 'object') {
-              if (key === 'epcis') {
-                value.forEach((valueItem: any) => {
-                  const code = valueItem.split('|').shift()
-                  this.addQueryParameter(`${key}[]`, code)
-                  url.searchParams.append(`${key}[]`, code)
-                })
-              } else {
-                value.forEach((valueItem: any) => {
-                  this.addQueryParameter(`${key}[]`, valueItem)
-                  url.searchParams.append(`${key}[]`, valueItem)
-                })
-              }
+          } else if (typeof value === 'object' &&
+              (key === 'partenaires' || key === 'communes' || key === 'etiquettes' || key === 'epcis')) {
+            if (key === 'epcis') {
+              value.forEach((valueItem: any) => {
+                const code = valueItem.split('|').shift()
+                this.addQueryParameter(`${key}[]`, code)
+                url.searchParams.append(`${key}[]`, code)
+              })
             } else {
-              this.addQueryParameter(`${key}[]`, value)
-              url.searchParams.set(`${key}[]`, value)
+              value.forEach((valueItem: any) => {
+                this.addQueryParameter(`${key}[]`, valueItem)
+                url.searchParams.append(`${key}[]`, valueItem)
+              })
             }
           } else if (typeof value === 'string') {
             this.addQueryParameter(key, value)
@@ -258,6 +251,13 @@ export default defineComponent({
           url.searchParams.delete(key)
         }
       }
+
+      const [field, direction] = this.sharedState.input.order.split('-')
+      url.searchParams.set('sortBy', field)
+      url.searchParams.set('direction', direction)
+      this.addQueryParameter('sortBy', field)
+      this.addQueryParameter('orderBy', direction)
+
       window.history.pushState({}, '', decodeURIComponent(url.toString()))
       this.buildUrl()
       requests.getSignalements(this.handleSignalements, { signal: this.abortRequest?.signal })

--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -175,11 +175,16 @@ export default defineComponent({
       this.init()
     },
     handleSignalements (requestResponse: any) {
-      this.sharedState.signalements.filters = requestResponse.filters
-      this.sharedState.signalements.list = requestResponse.list
-      this.sharedState.signalements.pagination = requestResponse.pagination
-      this.loadingList = false
-      window.scrollTo(0, 0)
+      if (typeof requestResponse === 'string' && requestResponse === 'error') {
+        this.hasErrorLoading = true
+      } else {
+        this.hasErrorLoading = false
+        this.sharedState.signalements.filters = requestResponse.filters
+        this.sharedState.signalements.list = requestResponse.list
+        this.sharedState.signalements.pagination = requestResponse.pagination
+        this.loadingList = false
+        window.scrollTo(0, 0)
+      }
     },
     handlePageChange (pageNumber: number) {
       this.clearScreen()
@@ -228,20 +233,17 @@ export default defineComponent({
             url.searchParams.set(`${key}Debut`, dateDebut)
             url.searchParams.set(`${key}Fin`, dateFin)
             url.searchParams.delete(key)
-          } else if (typeof value === 'object' &&
-              (key === 'partenaires' || key === 'communes' || key === 'etiquettes' || key === 'epcis')) {
-            if (key === 'epcis') {
-              value.forEach((valueItem: any) => {
-                const code = valueItem.split('|').shift()
-                this.addQueryParameter(`${key}[]`, code)
-                url.searchParams.append(`${key}[]`, code)
-              })
-            } else {
-              value.forEach((valueItem: any) => {
-                this.addQueryParameter(`${key}[]`, valueItem)
-                url.searchParams.append(`${key}[]`, valueItem)
-              })
-            }
+          } else if (typeof value === 'object' && (key === 'partenaires' || key === 'communes' || key === 'etiquettes')) {
+            value.forEach((valueItem: any) => {
+              this.addQueryParameter(`${key}[]`, valueItem)
+              url.searchParams.append(`${key}[]`, valueItem)
+            })
+          } else if (typeof value === 'object' && key === 'epcis') {
+            value.forEach((valueItem: any) => {
+              const code = valueItem.split('|').shift()
+              this.addQueryParameter(`${key}[]`, code)
+              url.searchParams.append(`${key}[]`, code)
+            })
           } else if (typeof value === 'string') {
             this.addQueryParameter(key, value)
             url.searchParams.set(key, value)

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -9,7 +9,7 @@
               <li v-if="sharedState.user.isResponsableTerritoire">
                 <button class="fr-tag"
                         ref="myAffectationButton"
-                        aria-pressed="sharedState.input.filters.showMyAffectationOnly === 'oui'"
+                        aria-pressed="{{ sharedState.input.filters.showMyAffectationOnly === 'oui' }}"
                         @click="toggleCurrentPartnerAffectation">
                   Afficher mes affectations uniquement
                 </button>
@@ -19,7 +19,7 @@
                     v-if="sharedState.hasSignalementImported"
                     ref="isImportedButton"
                     class="fr-tag"
-                    aria-pressed="sharedState.input.filters.isImported === 'oui'"
+                    aria-pressed="{{ sharedState.input.filters.isImported === 'oui' }}"
                     @click="toggleIsImported"
                 >Afficher les signalements importés
                 </button>
@@ -30,8 +30,8 @@
             <div v-if="sharedState.user.isAdmin" class="fr-col-12 fr-col-lg-6 fr-col-xl-2 grey-background">
               <HistoSelect
                   v-if="sharedState.territories.length > 0"
-                  id="filter-territoires"
-                  v-model="sharedState.input.filters.territoires"
+                  id="filter-territoire"
+                  v-model="sharedState.input.filters.territoire"
                   @update:modelValue="updateTerritory"
                   inner-label="Territoire"
                   title="Rechercher par territoire"
@@ -93,12 +93,11 @@
             </div>
             <div class="fr-col-12 fr-col-lg-6 fr-col-xl-7">
               <ul class="fr-tags-group">
-                <li>
+                <li v-for="(value, key) in filtersSanitized"  :key="key">
                   <button
+                      v-if="value.length > 0"
                       class="fr-tag fr-tag--sm fr-tag--dismiss"
-                      v-for="(value, key) in filtersSanitized"
                       :aria-label="`Retirer ${key}`"
-                      :key="key"
                       @click="removeFilter(key)"
                   >
                     {{ getBadgeFilterLabel(key, value) }}
@@ -382,7 +381,7 @@ export default defineComponent({
     },
     resetFilters () {
       this.sharedState.input.filters = {
-        territoires: [],
+        territoire: null,
         etiquettes: [],
         partenaires: [],
         communes: [],
@@ -449,9 +448,6 @@ export default defineComponent({
 <style>
   .grey-background {
     .histo-select select {
-      background-color: var(--background-contrast-grey);
-    }
-    .histo-multi-select .selector {
       background-color: var(--background-contrast-grey);
     }
     .histo-date-picker input {

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -9,7 +9,7 @@
               <li v-if="sharedState.user.isResponsableTerritoire">
                 <button class="fr-tag"
                         ref="myAffectationButton"
-                        aria-pressed="{{ sharedState.input.filters.showMyAffectationOnly === 'oui' }}"
+                        :aria-pressed="ariaPressed.showMyAffectationOnly.toString()"
                         @click="toggleCurrentPartnerAffectation">
                   Afficher mes affectations uniquement
                 </button>
@@ -19,7 +19,7 @@
                     v-if="sharedState.hasSignalementImported"
                     ref="isImportedButton"
                     class="fr-tag"
-                    aria-pressed="{{ sharedState.input.filters.isImported === 'oui' }}"
+                    :aria-pressed="ariaPressed.isImported.toString()"
                     @click="toggleIsImported"
                 >Afficher les signalements importés
                 </button>
@@ -431,6 +431,10 @@ export default defineComponent({
       showOptions: false,
       reset: false,
       sharedState: store.state,
+      ariaPressed: {
+        isImported: store.state.input.filters.isImported === 'oui',
+        showMyAffectationOnly: store.state.input.filters.showMyAffectationOnly === 'oui'
+      },
       statusSignalementList: store.state.statusSignalementList,
       statusAffectationList: store.state.statusAffectationList,
       statusVisiteList: store.state.statusVisiteList,

--- a/assets/vue/components/signalement-list/components/SignalementListHeader.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListHeader.vue
@@ -60,8 +60,8 @@ export default defineComponent({
         { Id: 'reference-ASC', Text: 'Ordre croissant' },
         { Id: 'nomOccupant-ASC', Text: 'Ordre alphabétique (A -> Z)' },
         { Id: 'nomOccupant-DESC', Text: 'Ordre alphabétique inversé (Z -> A)' },
-        { Id: 'createdAt-DESC', Text: 'Le plus récent' },
-        { Id: 'createdAt-ASC', Text: 'Le plus ancien' }
+        { Id: 'lastSuiviAt-DESC', Text: 'Suivi le plus récent' },
+        { Id: 'lastSuiviAt-ASC', Text: 'Suivi le plus ancien' }
       ]
     }
   }

--- a/assets/vue/components/signalement-list/services/badgeFilterLabelBuilder.ts
+++ b/assets/vue/components/signalement-list/services/badgeFilterLabelBuilder.ts
@@ -5,7 +5,7 @@ export function buildBadge (key: string, value: any): string | undefined {
     return undefined
   }
 
-  if (key === 'territoires') {
+  if (key === 'territoire') {
     return store.state.territories.find(territory => territory.Id.toString() === value)?.Text
   }
 
@@ -79,7 +79,7 @@ function buildRangeDateBadge (key: string, value: any): string | undefined {
   return `${label} ${startDate} - ${endDate}`
 }
 
-function buildStaticBadge (key: string, value: any): string | undefined {
+function buildStaticBadge (_key: string, value: any): string | undefined {
   const staticListsWithNoDuplicateId = [
     store.state.statusSignalementList,
     store.state.statusAffectationList,

--- a/assets/vue/components/signalement-list/services/badgeFilterLabelBuilder.ts
+++ b/assets/vue/components/signalement-list/services/badgeFilterLabelBuilder.ts
@@ -57,7 +57,7 @@ export function buildBadge (key: string, value: any): string | undefined {
     return buildRangeDateBadge(key, value)
   }
 
-  return buildStaticBadge(key, value)
+  return buildStaticBadge(value)
 }
 
 function buildRangeDateBadge (key: string, value: any): string | undefined {
@@ -79,7 +79,7 @@ function buildRangeDateBadge (key: string, value: any): string | undefined {
   return `${label} ${startDate} - ${endDate}`
 }
 
-function buildStaticBadge (_key: string, value: any): string | undefined {
+function buildStaticBadge (value: any): string | undefined {
   const staticListsWithNoDuplicateId = [
     store.state.statusSignalementList,
     store.state.statusAffectationList,

--- a/assets/vue/components/signalement-list/store.ts
+++ b/assets/vue/components/signalement-list/store.ts
@@ -12,7 +12,7 @@ export const store = {
       order: 'reference-DESC',
       queryParameters: [] as QueryParameter[],
       filters: {
-        territoires: new Array<string>(),
+        territoire: null,
         etiquettes: new Array<HistoInterfaceSelectOption>(),
         partenaires: new Array<HistoInterfaceSelectOption | string>(),
         communes: new Array<string>(),

--- a/src/Dto/Request/Signalement/SignalementSearchQuery.php
+++ b/src/Dto/Request/Signalement/SignalementSearchQuery.php
@@ -67,6 +67,7 @@ class SignalementSearchQuery
         private readonly ?string $isImported = null,
         #[Assert\Choice(['reference', 'nomOccupant', 'lastSuiviAt'])]
         private readonly string $sortBy = 'reference',
+        #[Assert\Choice(['ASC', 'DESC', 'asc', 'desc'])]
         private readonly string $orderBy = 'DESC',
     ) {
     }

--- a/src/Dto/Request/Signalement/SignalementSearchQuery.php
+++ b/src/Dto/Request/Signalement/SignalementSearchQuery.php
@@ -11,7 +11,7 @@ class SignalementSearchQuery
     public const MAX_LIST_PAGINATION = 25;
 
     public function __construct(
-        private readonly ?array $territoires = null,
+        private readonly ?string $territoire = null,
         private readonly ?string $searchTerms = null,
         #[Assert\Choice(['nouveau', 'en_cours', 'ferme', 'refuse'])]
         private readonly ?string $status = null,
@@ -65,15 +65,15 @@ class SignalementSearchQuery
         private readonly ?int $page = 1,
         #[Assert\Choice(['oui'])]
         private readonly ?string $isImported = null,
-        #[Assert\Choice(['reference', 'nomOccupant', 'createdAt'])]
+        #[Assert\Choice(['reference', 'nomOccupant', 'lastSuiviAt'])]
         private readonly string $sortBy = 'reference',
         private readonly string $orderBy = 'DESC',
     ) {
     }
 
-    public function getTerritoires(): ?array
+    public function getTerritoire(): ?string
     {
-        return $this->territoires;
+        return $this->territoire;
     }
 
     public function getSearchTerms(): ?string
@@ -210,7 +210,7 @@ class SignalementSearchQuery
     {
         $filters = [];
         $filters['searchterms'] = $this->getSearchTerms() ?? null;
-        $filters['territories'] = $this->getTerritoires() ?? null;
+        $filters['territories'] = null !== $this->getTerritoire() ? [$this->getTerritoire()] : null;
         $filters['statuses'] = null !== $this->getStatus()
             ? [SignalementStatus::mapFilterStatus($this->getStatus())]
             : null;
@@ -275,7 +275,7 @@ class SignalementSearchQuery
 
         $filters['page'] = $this->getPage() ?? 1;
         $filters['maxItemsPerPage'] = self::MAX_LIST_PAGINATION;
-        $filters['sortBy'] = $this->getSortBy() ?? 'createdAt';
+        $filters['sortBy'] = $this->getSortBy() ?? 'reference';
         $filters['orderBy'] = $this->getOrderBy() ?? 'DESC';
 
         return array_filter($filters);

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -233,8 +233,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search Terms with Firstname Occupant' => [['searchTerms' => 'Mapaire'], 1];
         yield 'Search Terms with Lastname Occupant' => [['searchTerms' => 'Nawell'], 2];
         yield 'Search Terms with Email Occupant' => [['searchTerms' => 'nawell.mapaire@yopmail.com'], 1];
-        yield 'Search by Territory 13' => [['territoires' => ['13']], 25];
-        yield 'Search by Territory 01 and 69' => [['territoires' => ['01', '70']], 9];
+        yield 'Search by Territory 13' => [['territoire' => '13'], 25];
         yield 'Search by Commune' => [['communes' => ['gex', 'marseille']], 30];
         yield 'Search by Commune code postal' => [['communes' => ['13002']], 1];
         yield 'Search by EPCIS' => [['epcis' => ['244400503']], 1];

--- a/tests/Unit/Dto/Request/Signalement/SignalementSearchQueryTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SignalementSearchQueryTest.php
@@ -11,7 +11,7 @@ class SignalementSearchQueryTest extends TestCase
     public function testGetFilters(): void
     {
         $query = new SignalementSearchQuery(
-            ['13'],
+            '13',
             'John',
             'nouveau',
             ['Marseille'],


### PR DESCRIPTION
## Ticket

#2597    

## Description
 Quand on commence par un tri alphabétique croissant, le tri alphabétique décroissant reste en croissant, et vice-versa, le tri n'est plus pris en compte quand on ajoute un filtre

 Changer le tri "plus récent"/"plus ancien" en utilisant la date de dernier suivi plutôt que la date de dépôt (qui est redondant avec la référence)

## Changements apportés
* Correction tri
* Remplacement tri de date de dépôt par tri date de dernier suivi
* Correction url filtre territoires (`territoires[]=13` par `territoire=13`)
* Composant AppSearch, écouter uniquement sur l'evenement onInput
* Correction comportement suppression de la saisie
* Mise à jour fixtures pour les suivi(s)

## Pré-requis

```
make npm-watch
```

Les données de liste déroulante provenant de la base de données sont en cache, si besoin
```sh
 make clear-pool pool="--all" make clear-pool pool="--all"
```

Pas de date de dernier suivi sur la carte, préparer la requête SQL suivante
```sql
select reference, last_suivi_at from signalement order by last_suivi_at DESC #ASC
```

Si besoin de toutes les EPCIs (il y'en as quelque uns dans les fixtures)
```sh
make console app="load-epci"
```

## Tests
- [ ] Afficher la liste de signalement, filtrer sur territoire et vérifier que l'url n'accepte plus de tableau de térritoires
- [ ] Faire plusieurs tri successif et vérifier que le tri se fait correctement 
- [ ] Faire plusieurs tri en ajoutant des filtres
- [ ] Faire une recherche dans la barre de recherche et supprimer votre recherche en utilisant le clavier, les badge doit disparaître au lieu d'être conservé avec les 3 premiers caractères

![image](https://github.com/MTES-MCT/histologe/assets/5757116/f59c528c-ce8b-47ac-abca-480f2dc619a6)

