### PR TITLE
[Notifications - Emails] Mise en place d'une adresse no-reply

### DIFF
--- a/.env
+++ b/.env
@@ -29,6 +29,7 @@ ADMIN_EMAIL=support@histologe.beta.gouv.fr
 NOTIFICATIONS_EMAIL=notifications@histologe.beta.gouv.fr
 CONTACT_EMAIL=contact@histologe.beta.gouv.fr
 USER_SYSTEM_EMAIL=admin@histologe.net
+REPLY_TO_EMAIL=ne-pas-repondre@histologe.beta.gouv.fr
 WIDGET_DATA_KPI_CACHE_EXPIRED_AFTER=3600 #second
 WIDGET_AFFECTATION_PARTNER_CACHE_EXPIRED_AFTER=30 #second
 WIDGET_SIGNALEMENT_ACCEPTED_NO_SUIVI_CACHE_EXPIRED_AFTER=30 #second

--- a/.env.sample
+++ b/.env.sample
@@ -57,6 +57,7 @@ ADMIN_EMAIL=support@histologe.beta.gouv.fr
 NOTIFICATIONS_EMAIL=notifications@histologe.beta.gouv.fr
 CONTACT_EMAIL=contact@histologe.beta.gouv.fr
 USER_SYSTEM_EMAIL=admin@histologe.net
+REPLY_TO_EMAIL=ne-pas-repondre@histologe.beta.gouv.fr
 WIDGET_DATA_KPI_CACHE_EXPIRED_AFTER=3600 #second
 WIDGET_AFFECTATION_PARTNER_CACHE_EXPIRED_AFTER=30 #second
 WIDGET_SIGNALEMENT_ACCEPTED_NO_SUIVI_CACHE_EXPIRED_AFTER=30 #second

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,6 +25,7 @@ parameters:
     notifications_email: '%env(resolve:NOTIFICATIONS_EMAIL)%'
     contact_email: '%env(resolve:CONTACT_EMAIL)%'
     user_system_email: '%env(resolve:USER_SYSTEM_EMAIL)%'
+    reply_to_email: '%env(resolve:REPLY_TO_EMAIL)%'
     host_url: '%env(resolve:HISTOLOGE_URL)%'
     token_lifetime: '1 day'
     cron_enable: '%env(bool:CRON_ENABLE)%'

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -22,6 +22,8 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
     protected ?string $tagHeader = null;
     protected array $mailerParams = [];
 
+    private const REPLY_TO_EMAIL = 'no-reply@histologe.fr';
+
     public function __construct(
         protected MailerInterface $mailer,
         protected ParameterBagInterface $parameterBag,
@@ -136,6 +138,7 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
 
         return $notification->htmlTemplate('emails/'.$this->mailerTemplate.'.html.twig')
             ->context(array_merge($params, $config))
+            ->replyTo(self::REPLY_TO_EMAIL)
             ->subject(
                 mb_strtoupper($this->parameterBag->get('platform_name'))
                 .' '

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -22,7 +22,7 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
     protected ?string $tagHeader = null;
     protected array $mailerParams = [];
 
-    private const REPLY_TO_EMAIL = 'no-reply@histologe.beta.gouv.fr';
+    private const REPLY_TO_EMAIL = 'ne-pas-repondre@histologe.beta.gouv.fr';
 
     public function __construct(
         protected MailerInterface $mailer,

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -22,7 +22,7 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
     protected ?string $tagHeader = null;
     protected array $mailerParams = [];
 
-    private const REPLY_TO_EMAIL = 'no-reply@histologe.fr';
+    private const REPLY_TO_EMAIL = 'no-reply@histologe.beta.gouv.fr';
 
     public function __construct(
         protected MailerInterface $mailer,

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -22,8 +22,6 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
     protected ?string $tagHeader = null;
     protected array $mailerParams = [];
 
-    private const REPLY_TO_EMAIL = 'ne-pas-repondre@histologe.beta.gouv.fr';
-
     public function __construct(
         protected MailerInterface $mailer,
         protected ParameterBagInterface $parameterBag,
@@ -138,7 +136,7 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
 
         return $notification->htmlTemplate('emails/'.$this->mailerTemplate.'.html.twig')
             ->context(array_merge($params, $config))
-            ->replyTo(self::REPLY_TO_EMAIL)
+            ->replyTo($this->parameterBag->get('reply_to_email'))
             ->subject(
                 mb_strtoupper($this->parameterBag->get('platform_name'))
                 .' '

--- a/templates/emails/base_email.html.twig
+++ b/templates/emails/base_email.html.twig
@@ -111,7 +111,7 @@
                 clear: both;
                 margin-top: 10px;
                 margin-bottom: 10px;
-                color: #666666;
+                color: #222222;
                 font-size: 12px;
                 text-align: center;
                 width: 100%;
@@ -379,7 +379,7 @@
             <td class="container">
                 <div class="content">
                     <div class="warning">
-                        <span><i>⚠ Cet e-mail est généré automatiquement. Merci de ne pas y répondre.</i></span></br>
+                        <strong>⚠ Cet e-mail est généré automatiquement. Merci de ne pas y répondre.</strong></br>
                     </div>
                     <table role="presentation" class="main">
                         <!-- START MAIN CONTENT AREA -->


### PR DESCRIPTION
## Ticket

#2605   

## Description
Mise en place d'une adresse `ne-pas-repondre@histologe.beta.gouv.fr` pour toutes les notifications par e-mail

## Tests
- [ ] Envoyer un e-mail via la plateforme et vérifier le header reply-to
- [ ] Vérifier la mise en forme de l'intro du mail (le texte qui dit de ne pas répondre)
- [ ] Envoyer un e-mail à `ne-pas-repondre@histologe.beta.gouv.fr` et vérifier le mail de réponse