### PR TITLE
[FO - Form étape désordres] Changer les boutons du footer sur le récap désordres

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -2544,16 +2544,42 @@
               {
                 "type": "SignalementFormButton",
                 "label": "Je passe à la suite",
-                "slug": "desordres_renseignes_next",
+                "slug": "desordres_renseignes_next_no_disorder",
                 "action": "goto:ecran_intermediaire_procedure",
-                "customCss": "fr-mb-3v"
+                "customCss": "fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.hasDesordre('desordres_') === false"
+                }
               },
               {
                 "type": "SignalementFormButton",
                 "label": "Je renseigne les désordres",
+                "slug": "desordres_renseignes_previous_no_disorder",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.hasDesordre('desordres_') === false"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_renseignes_next",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.hasDesordre('desordres_') === true"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
                 "slug": "desordres_renseignes_previous",
                 "action": "resolve:findPreviousScreen",
-                "customCss": "fr-btn--secondary fr-mb-3v"
+                "customCss": "fr-btn--secondary fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.hasDesordre('desordres_') === true"
+                }
               }
             ]
           }

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -2560,29 +2560,62 @@
               {
                 "type": "SignalementFormButton",
                 "label": "Je passe à la suite",
-                "slug": "desordres_renseignes_next_autre",
+                "slug": "desordres_renseignes_next_autre_no_disorder",
                 "action": "goto:ecran_intermediaire_procedure",
                 "customCss": "fr-mb-3v",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+                  "show": "(formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur') && formStore.hasDesordre('desordres_') === false"
                 }
               },
               {
                 "type": "SignalementFormButton",
                 "label": "Je passe à la suite",
-                "slug": "desordres_renseignes_next_secours",
+                "slug": "desordres_renseignes_next_secours_no_disorder",
                 "action": "goto:utilisation_service",
                 "customCss": "fr-mb-3v",
                 "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
+                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours' && formStore.hasDesordre('desordres_') === false"
                 }
               },
               {
                 "type": "SignalementFormButton",
                 "label": "Je renseigne les désordres",
+                "slug": "desordres_renseignes_previous_no_disorder",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.hasDesordre('desordres_') === false"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_renseignes_next_autre",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-mb-3v",
+                "conditional": {
+                  "show": "(formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur') && formStore.hasDesordre('desordres_') === true"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_renseignes_next_secours",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours' && formStore.hasDesordre('desordres_') === true"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
                 "slug": "desordres_renseignes_previous",
                 "action": "resolve:findPreviousScreen",
-                "customCss": "fr-btn--secondary fr-mb-3v"
+                "customCss": "fr-btn--secondary fr-mb-3v",
+                "conditional": {
+                  "show": "formStore.hasDesordre('desordres_') === true"
+                }
               }
             ]
           }


### PR DESCRIPTION
## Ticket

#2362   

## Description
    Je suis locataire
    Je saisis un signalement sans désordre
    J'accède à la page "signalement incomplet"
    Je retourne sur le formulaire et j'ajoute des désordres"
    Lorsque j'arrive sur la page de récap des désordres, j'ai toujours les boutons "Je renseigne des désordres" et "Je passe à la suite", ce qui crée de la confusion

--> Il faudrait que, quand j'ai renseigné des désordres, j'ai les boutons "suivant" et "précédent"

## Changements apportés
* Changement des json de désordres

## Pré-requis
`npm run watch` (pour copier les json )

## Tests
- [ ] En tant qu'occupant, commencer un formulaire, ne pas renseigner de désordre
- [ ] Sur le récap, on a bien des boutons "je passe à la suite" et "je renseigne des désordres"
- [ ] Revenir en arrière pour renseigner un désordre
- [ ] Vérifier qu'on a maintenant des boutons "suivant" et "précédent"
- [ ] Idem avec un profil tiers
