### PR TITLE
[FO - Page Suivi usager] Ajustement graphique et lien vers dernier suivi

### DIFF
--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
@@ -37,7 +37,7 @@ class SuiviNewCommentFrontMailer extends AbstractNotificationMailer
                 'front_suivi_signalement',
                 ['code' => $signalement->getCodeSuivi(), 'from' => $notificationMail->getTo()],
                 UrlGeneratorInterface::ABSOLUTE_URL
-            ) . '#suivi-last',
+            ).'#suivi-last',
         ];
     }
 }

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
@@ -37,7 +37,7 @@ class SuiviNewCommentFrontMailer extends AbstractNotificationMailer
                 'front_suivi_signalement',
                 ['code' => $signalement->getCodeSuivi(), 'from' => $notificationMail->getTo()],
                 UrlGeneratorInterface::ABSOLUTE_URL
-            ),
+            ) . '#suivi-last',
         ];
     }
 }

--- a/templates/_partials/_modal_send_lien_suivi.html.twig
+++ b/templates/_partials/_modal_send_lien_suivi.html.twig
@@ -53,7 +53,7 @@
                                     </div>
                                 </fieldset>
                             {% endif %}
-                            Voici le lien vers la page de suivi : {{ lienSuivi }}.<br>
+                            Voici le lien vers la page de suivi : {{ lienSuivi }}<br>
                             Pour envoyer le lien par mail, cliquez sur le bouton ci-dessous.
                             <input type="hidden" name="preferedResponse" value="redirection">
                         </div>

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -69,13 +69,15 @@ signalement.isProprioAverti is not same as true
 and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT
 and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR
 %}
-<h4 class="fr-mb-2v">Prévenez votre bailleur (propriétaire) !</h4>
-<div class="fr-mb-4v">
-	Il est recommandé d'informer le bailleur du logement des problèmes rencontrés dans le logement.
-	<br>
-	Nous vous mettons à disposition un modèle de courrier à remplir et envoyer à votre bailleur. 
-							Cliquez sur le bouton ci-dessous pour le télécharger.
-	<br>
+<div class="fr-callout fr-icon-information-line">
+    <h4 class="fr-mb-2v">Prévenez votre bailleur (propriétaire) !</h4>
+    <p class="fr-callout__text">
+		Il est recommandé d'informer le bailleur du logement des problèmes rencontrés dans le logement.
+		<br>
+		Nous vous mettons à disposition un modèle de courrier à remplir et envoyer à votre bailleur. 
+		Cliquez sur le bouton ci-dessous pour le télécharger.
+		<br>
+    </p>
 	<a class="fr-btn fr-btn--icon-left open-modal-upload-files-btn fr-icon-arrow-down-line fr-mt-2v" download href="{{ asset('build/files/Lettre-information-proprietaire-bailleur_A-COMPLETER.pdf') }}">
 		Télécharger le courrier
 	</a>

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -5,7 +5,7 @@
 </div>
 <div class="fr-mt-4v">
 	{% for suivi in signalement.suivis %}
-		<div class="message-box {% if (suivi.createdBy and suivi.createdBy.partner) or suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}message-box--partner{% else %}message-box--usager{% endif %}">
+		<div {% if loop.last %}id="suivi-last"{% endif %} class="message-box {% if (suivi.createdBy and suivi.createdBy.partner) or suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}message-box--partner{% else %}message-box--usager{% endif %}">
 			<div>
 				<strong>
 				


### PR DESCRIPTION
## Ticket

#2631 
#2632
#2634   

## Description
- Suppression d'un point dans la modale d'envoi de lien
- Lien direct vers le dernier suivi pour les usagers
- Mise en valeur de la partie qui conseille de prévenir son bailleur

## Tests
- [ ] BO : voir la modale d'envoi de lien à l'usager et vérifier absence du point après l'url
- [ ] BO : Créer un suivi public. Puis vérifier que le clic sur le mail reçu par l'usager redirige vers le dernier suivi
- [ ] FO : sur la page de suivi, avec un signalement pour lequel le bailleur n'a pas été prévenu, vérifier que le paragraphe qui encourage à prévenir est dans un callout
