### PR TITLE
[FO - form] Ajout de la question type_logement_commodites_piece_a_vivre_9m pour les tiers pro

### DIFF
--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -553,6 +553,35 @@
       "body": [
         {
           "type": "SignalementFormIcon",
+          "slug": "type_logement_commodites_piece_a_vivre_icon",
+          "icons": [
+            {
+              "src": "/img/form/PIECES/Picto-salon.svg",
+              "alt": ""
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Est-ce qu'au moins une des pièces à vivre (salon, chambre) fait 9m² ou plus ?",
+          "slug": "type_logement_commodites_piece_a_vivre_9m",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormIcon",
           "slug": "type_logement_commodites_cuisine_icon",
           "icons": [
             {


### PR DESCRIPTION
## Ticket

#2593   

## Description
Ajout de la question type_logement_commodites_piece_a_vivre_9m pour les tiers pro

## Changements apportés
* Modification du json

## Pré-requis
`npm run watch`
## Tests
- [ ] Faire un signalement en tant que tiers-pro
- [ ] Vérifier l'apparition de cette question (`Est-ce qu'au moins une des pièces à vivre (salon, chambre) fait 9m² ou plus ?`) au début des questions sur les cuisine, wc etc.
- [ ] Faire le formulaire jusqu'au bout et soumettre le signalement
- [ ] Vérifier dans le BO que la réponse à la question `Est-ce qu'au moins une des pièces à vivre (salon, chambre) fait 9m² ou plus ?` est bien prise en compte dans la fiche signalement
