### PR TITLE
[Technique] [Socle sécurité] Complexifier les mots de passe 

### DIFF
--- a/assets/controllers/activate_account/activate_account.js
+++ b/assets/controllers/activate_account/activate_account.js
@@ -38,7 +38,7 @@ function canSubmitFormReinitPassword() {
         canSubmit = false;
         pwdMatchError.classList.remove('fr-hidden')
     }
-    if (pass.length < 8) {
+    if (pass.length < 12) {
         messageLength.classList.remove('fr-message--info', 'fr-message--valid')
         messageLength.classList.add('fr-message--error')
         canSubmit = false;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -70,7 +70,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column(type: 'string', nullable: true)]
     #[Assert\NotBlank(groups: ['password'])]
-    #[Assert\Length(min: 8, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caratères.', groups: ['password'])]
+    #[Assert\Length(min: 12, max: 200, minMessage: 'Le mot de passe doit contenir au moins {{ limit }} caratères.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[A-Z]/', message: 'Le mot de passe doit contenir au moins une lettre majuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[a-z]/', message: 'Le mot de passe doit contenir au moins une lettre minuscule.', groups: ['password'])]
     #[Assert\Regex(pattern: '/[0-9]/', message: 'Le mot de passe doit contenir au moins un chiffre.', groups: ['password'])]

--- a/templates/front/cgu_agents.html.twig
+++ b/templates/front/cgu_agents.html.twig
@@ -146,7 +146,7 @@
                 <h3>7.2 – L’Utilisateur</h3>
                 <p>L'Utilisateur s'assure de garder son mot de passe secret.
                     Celui-ci respecte les recommandations de robustesses de la CNIL
-                    (au moins 8 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
+                    (au moins 12 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
                     Toute divulgation du mot de passe, quelle que soit sa forme, est interdite.
                     Il assume les risques liés à l'utilisation de son adresse e-mail et mot de passe.</p>
                 <p>Il s’engage à ne pas commercialiser les données reçues et à ne pas les communiquer à des tiers en
@@ -165,7 +165,7 @@
                 <h3>7.3 – L’Administrateur</h3>
                 <p>L'Administrateur s'assure de garder son mot de passe secret.
                     Celui-ci respecte les recommandations de robustesses de la CNIL
-                    (au moins 8 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
+                    (au moins 12 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
                     Toute divulgation du mot de passe, quelle que soit sa forme, est interdite.
                     Il assume les risques liés à l'utilisation de son adresse e-mail et mot de passe.</p>
                 <p>L’Administrateur s’engage à ne pas commercialiser les données reçues et à ne pas les communiquer à
@@ -180,7 +180,7 @@
                 <h3>7.4 – Le Responsable de territoire</h3>
                 <p>Le Responsable de territoire s'assure de garder son mot de passe secret.
                     Celui-ci respecte les recommandations de robustesses de la CNIL
-                    (au moins 8 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
+                    (au moins 12 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
                     Toute divulgation du mot de passe, quelle que soit sa forme, est interdite.
                     Il assume les risques liés à l'utilisation de son adresse e-mail et mot de passe.</p>
                 <p>Le Responsable de territoire s’engage à ne pas commercialiser les données reçues et à ne pas les
@@ -195,7 +195,7 @@
                 <h3>7.5 – Le Partenaire</h3>
                 <p>Le Partenaire s'assure de garder son mot de passe secret.
                     Celui-ci respecte les recommandations de robustesses de la CNIL
-                    (au moins 8 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
+                    (au moins 12 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre).
                     Toute divulgation du mot de passe, quelle que soit sa forme, est interdite.
                     Il assume les risques liés à l'utilisation de son adresse e-mail et mot de passe.</p>
                 <p>Le Partenaire s’engage à ne pas commercialiser les données reçues et à ne pas les communiquer à des

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -72,7 +72,7 @@
                     <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
                     <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
                         <p class="fr-message">Votre mot de passe doit contenir :</p>
-                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">8 caractères minimum</p>
+                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">12 caractères minimum</p>
                         <p class="message-password fr-message fr-message--info" id="password-input-message-info-maj">1 caractère majuscule minimum</p>
                         <p class="message-password fr-message fr-message--info" id="password-input-message-info-min">1 caractère minuscule minimum</p>
                         <p class="message-password fr-message fr-message--info" id="password-input-message-info-nb">1 chiffre minimum</p>

--- a/tests/Functional/Controller/UserAccountControllerTest.php
+++ b/tests/Functional/Controller/UserAccountControllerTest.php
@@ -92,7 +92,7 @@ class UserAccountControllerTest extends WebTestCase
     public function provideInvalidPassword(): \Generator
     {
         yield 'blank' => ['Cette valeur ne doit pas être vide', ''];
-        yield 'short' => ['Le mot de passe doit contenir au moins 8 caratères', 'short'];
+        yield 'short' => ['Le mot de passe doit contenir au moins 12 caratères', 'short'];
         yield 'no_uppercase' => ['Le mot de passe doit contenir au moins une lettre majuscule', 'nouppercase'];
         yield 'no_lowercase' => ['Le mot de passe doit contenir au moins une lettre minuscule', 'NOLOWERCASE'];
         yield 'no_digit' => ['Le mot de passe doit contenir au moins un chiffre', 'NoDigitNoDigit'];

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -72,7 +72,7 @@ class UserTest extends KernelTestCase
     public function provideInvalidPassword(): \Generator
     {
         yield 'blank' => ['Cette valeur ne doit pas être vide', ''];
-        yield 'short' => ['Le mot de passe doit contenir au moins 8 caratères', 'short'];
+        yield 'short' => ['Le mot de passe doit contenir au moins 12 caratères', 'short'];
         yield 'no_uppercase' => ['Le mot de passe doit contenir au moins une lettre majuscule', 'nouppercase'];
         yield 'no_lowercase' => ['Le mot de passe doit contenir au moins une lettre minuscule', 'NOLOWERCASE'];
         yield 'no_digit' => ['Le mot de passe doit contenir au moins un chiffre', 'NoDigitNoDigit'];


### PR DESCRIPTION
## Ticket

#2638

## Description
Passe la longueur minimum des mot de passe de 8 a 12 caractères

## Pré-requis
`make npm-build`

## Tests
- [ ] Essayer de valider un mot de passe de moins de 12 caractères
