### PR TITLE
[Technique] [Sécurité] La demande de récup du mot de passe doit retourner une réponse unique

### DIFF
--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -37,18 +37,13 @@ class UserAccountController extends AbstractController
                         user: $user,
                     )
                 );
+            }
 
-                return $this->render('security/login_link_sent.html.twig', [
-                    'title' => 'Lien d\'activation envoyé !',
-                    'message' => 'Vous allez recevoir un courriel contenant un lien vous pemettant de créer votre mot de passe afin d\'activer votre compte.',
-                    'email' => $email,
-                ]);
-            }
-            if ($user && User::STATUS_ACTIVE === $user->getStatut()) {
-                $this->addFlash('error', 'Votre compte est déjà activé, vous pouvez vous connecter');
-            } else {
-                $this->addFlash('error', 'Cette adresse ne correspond à aucun compte, vérifiez votre saisie');
-            }
+            return $this->render('security/login_link_sent.html.twig', [
+                'title' => 'Lien d\'activation',
+                'message' => 'Si un compte inactif existe pour le courriel indiqué vous allez recevoir un courriel contenant un lien vous pemettant de créer votre mot de passe afin d\'activer votre compte.',
+                'email' => $email,
+            ]);
         }
 
         return $this->render('security/login_activation.html.twig');
@@ -72,23 +67,12 @@ class UserAccountController extends AbstractController
                         user: $user
                     )
                 );
-
-                return $this->render('security/login_link_sent.html.twig', [
-                    'title' => 'Lien de récupération envoyé !',
-                    'message' => 'Vous allez recevoir un courriel contenant un lien vous permettant de réinitialiser votre mot de passe.',
-                    'email' => $email,
-                ]);
             }
 
-            $typeError = 'DEFAULT';
-            if ($user && User::STATUS_ACTIVE !== $user->getStatut()) {
-                $typeError = 'STATUS';
-            }
-
-            return $this->render('security/reset_password.html.twig', [
-                'title' => $title,
+            return $this->render('security/login_link_sent.html.twig', [
+                'title' => 'Lien de récupération',
+                'message' => 'Si un compte actif existe pour le courriel indiqué vous allez recevoir un courriel contenant un lien vous permettant de réinitialiser votre mot de passe.',
                 'email' => $email,
-                'typeError' => $typeError,
             ]);
         }
 

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -41,7 +41,7 @@ class UserAccountController extends AbstractController
 
             return $this->render('security/login_link_sent.html.twig', [
                 'title' => 'Lien d\'activation',
-                'message' => 'Si un compte inactif existe pour le courriel indiqué vous allez recevoir un courriel contenant un lien vous pemettant de créer votre mot de passe afin d\'activer votre compte.',
+                'message' => 'Si un compte inactif existe pour le courriel indiqué, vous allez recevoir un courriel contenant un lien vous pemettant de créer votre mot de passe afin d\'activer votre compte.',
                 'email' => $email,
             ]);
         }
@@ -71,7 +71,7 @@ class UserAccountController extends AbstractController
 
             return $this->render('security/login_link_sent.html.twig', [
                 'title' => 'Lien de récupération',
-                'message' => 'Si un compte actif existe pour le courriel indiqué vous allez recevoir un courriel contenant un lien vous permettant de réinitialiser votre mot de passe.',
+                'message' => 'Si un compte actif existe pour le courriel indiqué, vous allez recevoir un courriel contenant un lien vous permettant de réinitialiser votre mot de passe.',
                 'email' => $email,
             ]);
         }

--- a/templates/security/login_link_sent.html.twig
+++ b/templates/security/login_link_sent.html.twig
@@ -10,8 +10,7 @@
                 <p class="fr-callout__text fr-mb-5v">
                     {{ message }}
                 </p>
-                <em class="fr-fi-information-line fr-text--light fr-text-label--blue-france">Ce courriel à été envoyé à
-                    l'adresse: {{ email }}</em>
+                <em class="fr-fi-information-line fr-text--light fr-text-label--blue-france">Vérifiez vos courriels sur {{ email }}</em>
             </header>
         </section>
     </main>

--- a/templates/security/login_link_sent.html.twig
+++ b/templates/security/login_link_sent.html.twig
@@ -10,7 +10,7 @@
                 <p class="fr-callout__text fr-mb-5v">
                     {{ message }}
                 </p>
-                <em class="fr-fi-information-line fr-text--light fr-text-label--blue-france">Vérifiez vos courriels sur {{ email }}</em>
+                <em class="fr-fi-information-line fr-text--light fr-text-label--blue-france">Vérifiez vos courriels à l'adresse {{ email }}</em>
             </header>
         </section>
     </main>

--- a/templates/security/reset_password.html.twig
+++ b/templates/security/reset_password.html.twig
@@ -14,27 +14,7 @@
                     Vous recevrez un courriel avec un lien vous permettant de réinitialiser votre mot de passe.
                 </em>
             </header>
-            <form action="{{ path('login_mdp_perdu') }}" class="needs-validation fr-mt-5v fr-col-md-6"
-                  name="login-activation-form" method="POST" novalidate="">
-                {% if typeError is defined %}
-                    {% if typeError == 'STATUS' %}
-                    <div role="alert" class="fr-alert fr-alert--error fr-alert--sm fr-mb-5w">
-                        <p class="fr-alert__title">Compte inactif</p>
-                        <p>
-                            Aucun compte actif ne correspond à l'adresse e-mail "{{email}}".
-                            <br>
-                            Vous pouvez essayer l'<a href="{{ path('login_activation') }}">activation de votre compte.</a>
-                        </p>
-                    </div>
-                    {% else %}
-                    <div role="alert" class="fr-alert fr-alert--error fr-alert--sm fr-mb-5w">
-                        <p class="fr-alert__title">Aucun compte correspondant</p>
-                        <p>
-                            Aucun utilisateur ne correspond à l'adresse e-mail "{{email}}".
-                        </p>
-                    </div>
-                    {% endif %}
-                {% endif %}
+            <form action="{{ path('login_mdp_perdu') }}" class="needs-validation fr-mt-5v fr-col-md-6" name="login-activation-form" method="POST" novalidate="">
                 <div class="fr-input-group">
                     <label class="fr-label" for="login-email">
                         Courriel


### PR DESCRIPTION
## Ticket

#2644

## Description
Le système d'activation du compte et de réinitialisation du mot de passe retourne toujours la même page sans préciser si le compte existe ou pas, ni son statut afin d'éviter de pouvoir lister les comptes existants

## Tests
- [ ] Vérifier que la page d'activation d'un compte fonctionne correctement
- [ ] Vérifier que la page de réinitialisation du mot de passe fonctionne correctement
