### PR TITLE
[FO - Page suivi] Correction du fonctionnement de l'ancre de dernier suivi pour Chrome

### DIFF
--- a/assets/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -288,3 +288,10 @@ if (modalUploadFiles) {
         modalUploadFiles.dataset.validated = true
     })
 }
+
+document.addEventListener("DOMContentLoaded", function() {
+    if(window.location.hash) {
+        elmnt = document.getElementById(window.location.hash.substring(1))
+        elmnt.scrollIntoView({behavior:'instant'})
+    }
+})


### PR DESCRIPTION
## Ticket

#2631    

## Description
Sur Chrome, les ancres ne fonctionnent pas à cause du mouvement "smooth". Une correction javascript permet de le faire fonctionner indirectement.

## Tests
- [ ] Aller sur une page de suivi, vérifier que tout fonctionne bien, qu'il n'y a pas d'erreur js
- [ ] Créer un suivi public et suivre le lien : vérifier que la redirection est ok sur différents navigateurs
