### PR TITLE
[Sécurité] Cloisonnement des rôles (+ divers)

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -86,16 +86,17 @@ class AffectationController extends AbstractController
         AffectationRepository $affectationRepository,
     ): RedirectResponse|JsonResponse {
         $this->denyAccessUnlessGranted('ASSIGN_TOGGLE', $signalement);
+        $idAffectation = $request->get('affectation');
+        $affectation = $affectationRepository->findOneBy(['id' => $idAffectation]);
+        if (!$affectation || $affectation->getSignalement()->getId() !== $signalement->getId()) {
+            return $this->json(['status' => 'denied'], 403);
+        }
         if ($this->isCsrfTokenValid('signalement_remove_partner_'.$signalement->getId(), $request->get('_token'))) {
-            $idAffectation = $request->get('affectation');
-            $affectation = $affectationRepository->findOneBy(['id' => $idAffectation]);
-            if ($affectation) {
-                $partnersIdToRemove = [];
-                $partnersIdToRemove[] = $affectation->getPartner()->getId();
-                $this->affectationManager->removeAffectationsFrom($signalement, [], $partnersIdToRemove);
-                $this->affectationManager->flush();
-                $this->addFlash('success', 'Le partenaire a été désaffecté.');
-            }
+            $partnersIdToRemove = [];
+            $partnersIdToRemove[] = $affectation->getPartner()->getId();
+            $this->affectationManager->removeAffectationsFrom($signalement, [], $partnersIdToRemove);
+            $this->affectationManager->flush();
+            $this->addFlash('success', 'Le partenaire a été désaffecté.');
 
             return $this->json(['status' => 'success']);
         }

--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -48,41 +48,37 @@ class BackStatistiquesController extends AbstractController
     #[Route('/filter', name: 'back_statistiques_filter')]
     public function filter(Request $request, TerritoryRepository $territoryRepository): Response
     {
-        if ($this->getUser()) {
-            $this->result = [];
+        $this->result = [];
 
-            $territory = $this->getSelectedTerritory($request, $territoryRepository);
-            $partner = $this->getSelectedPartner();
+        $territory = $this->getSelectedTerritory($request, $territoryRepository);
+        $partner = $this->getSelectedPartner();
 
-            $this->buildFilterLists($territory);
+        $this->buildFilterLists($territory);
 
-            $globalStatistics = $this->globalBackAnalyticsProvider->getData($territory, $partner);
-            $this->result['count_signalement'] = $globalStatistics['count_signalement'];
-            $this->result['average_criticite'] = $globalStatistics['average_criticite'];
-            $this->result['average_days_validation'] = $globalStatistics['average_days_validation'];
-            $this->result['average_days_closure'] = $globalStatistics['average_days_closure'];
-            $this->result['count_signalement_refuses'] = $globalStatistics['count_signalement_refuses'];
-            $this->result['count_signalement_archives'] = $globalStatistics['count_signalement_archives'];
+        $globalStatistics = $this->globalBackAnalyticsProvider->getData($territory, $partner);
+        $this->result['count_signalement'] = $globalStatistics['count_signalement'];
+        $this->result['average_criticite'] = $globalStatistics['average_criticite'];
+        $this->result['average_days_validation'] = $globalStatistics['average_days_validation'];
+        $this->result['average_days_closure'] = $globalStatistics['average_days_closure'];
+        $this->result['count_signalement_refuses'] = $globalStatistics['count_signalement_refuses'];
+        $this->result['count_signalement_archives'] = $globalStatistics['count_signalement_archives'];
 
-            $statisticsFilters = $this->createFilters($request, $territory, $partner);
-            $filteredStatistics = $this->filteredBackAnalyticsProvider->getData($statisticsFilters);
-            $this->result['count_signalement_filtered'] = $filteredStatistics['count_signalement_filtered'];
-            $this->result['average_criticite_filtered'] = $filteredStatistics['average_criticite_filtered'];
-            $this->result['countSignalementPerMonth'] = $filteredStatistics['count_signalement_per_month'];
-            $this->result['countSignalementPerPartenaire'] = $filteredStatistics['count_signalement_per_partenaire'];
-            $this->result['countSignalementPerSituation'] = $filteredStatistics['count_signalement_per_situation'];
-            $this->result['countSignalementPerCriticite'] = $filteredStatistics['count_signalement_per_criticite'];
-            $this->result['countSignalementPerStatut'] = $filteredStatistics['count_signalement_per_statut'];
-            $this->result['countSignalementPerCriticitePercent'] = $filteredStatistics['count_signalement_per_criticite_percent'];
-            $this->result['countSignalementPerVisite'] = $filteredStatistics['count_signalement_per_visite'];
-            $this->result['countSignalementPerMotifCloture'] = $filteredStatistics['count_signalement_per_motif_cloture'];
+        $statisticsFilters = $this->createFilters($request, $territory, $partner);
+        $filteredStatistics = $this->filteredBackAnalyticsProvider->getData($statisticsFilters);
+        $this->result['count_signalement_filtered'] = $filteredStatistics['count_signalement_filtered'];
+        $this->result['average_criticite_filtered'] = $filteredStatistics['average_criticite_filtered'];
+        $this->result['countSignalementPerMonth'] = $filteredStatistics['count_signalement_per_month'];
+        $this->result['countSignalementPerPartenaire'] = $filteredStatistics['count_signalement_per_partenaire'];
+        $this->result['countSignalementPerSituation'] = $filteredStatistics['count_signalement_per_situation'];
+        $this->result['countSignalementPerCriticite'] = $filteredStatistics['count_signalement_per_criticite'];
+        $this->result['countSignalementPerStatut'] = $filteredStatistics['count_signalement_per_statut'];
+        $this->result['countSignalementPerCriticitePercent'] = $filteredStatistics['count_signalement_per_criticite_percent'];
+        $this->result['countSignalementPerVisite'] = $filteredStatistics['count_signalement_per_visite'];
+        $this->result['countSignalementPerMotifCloture'] = $filteredStatistics['count_signalement_per_motif_cloture'];
 
-            $this->result['response'] = 'success';
+        $this->result['response'] = 'success';
 
-            return $this->json($this->result);
-        }
-
-        return $this->json(['response' => 'error'], 400);
+        return $this->json($this->result);
     }
 
     private function createFilters(Request $request, ?Territory $territory, ?Partner $partner): StatisticsFilters

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -123,9 +123,6 @@ class SignalementController extends AbstractController
                 || $this->isGranted('ROLE_ADMIN_TERRITORY')
                 || $isAccepted;
         }
-        $canExportSignalement = $this->isGranted('ROLE_ADMIN')
-            || $this->isGranted('ROLE_ADMIN_TERRITORY')
-            || $isAffected;
 
         $signalementQualificationNDE = $signalementQualificationRepository->findOneBy([
             'signalement' => $signalement,
@@ -184,7 +181,6 @@ class SignalementController extends AbstractController
             'criteres' => $infoDesordres['criteres'],
             'needValidation' => Signalement::STATUS_NEED_VALIDATION === $signalement->getStatut(),
             'canEditSignalement' => $canEditSignalement,
-            'canExportSignalement' => $canExportSignalement,
             'isAffected' => $isAffected,
             'isAccepted' => $isAccepted,
             'isClosed' => Signalement::STATUS_CLOSED === $signalement->getStatut(),

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -31,6 +31,12 @@ class SignalementFileController extends AbstractController
         Signalement $signalement,
         MessageBusInterface $messageBus
     ): Response {
+        $this->denyAccessUnlessGranted('SIGN_VIEW', $signalement);
+        if (Signalement::STATUS_ARCHIVED === $signalement->getStatut()) {
+            $this->addFlash('error', "Ce signalement a été archivé et n'est pas consultable.");
+
+            return $this->redirectToRoute('back_index');
+        }
         /** @var User $user */
         $user = $this->getUser();
 

--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -348,6 +348,7 @@ class SignalementVisitesController extends AbstractController
         EntityManagerInterface $entityManager,
         UploadHandlerService $uploadHandlerService,
     ): Response {
+        $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
         if (!$this->isCsrfTokenValid('delete_rapport', $request->get('_token')) || $intervention->getSignalement()->getId() !== $signalement->getId() || $intervention->getFiles()->isEmpty()) {
             return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
         }

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -10,12 +10,10 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController
@@ -44,8 +42,8 @@ class SecurityController extends AbstractController
     ): BinaryFileResponse|RedirectResponse {
         $request = Request::createFromGlobals();
 
-        if (!$this->isCsrfTokenValid('suivi_signalement_ext_file_view', $request->get('t') || !$this->isGranted('FILE_VIEW', $signalement))) {
-            $this->createAccessDeniedException();
+        if (!$this->isCsrfTokenValid('suivi_signalement_ext_file_view', $request->get('t')) && !$this->isGranted('FILE_VIEW', $signalement)) {
+            throw $this->createNotFoundException();
         }
         try {
             $variant = $request->query->get('variant');
@@ -79,13 +77,5 @@ class SecurityController extends AbstractController
     public function logout(): void
     {
         throw new LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
-    }
-
-    #[Route('/signalement/csrf-token', name: 'app_csrf_token', methods: ['GET'])]
-    public function generateFormSignalementCsrfToken(CsrfTokenManagerInterface $csrfTokenManager): JsonResponse
-    {
-        return $this->json([
-                'csrf_token' => $csrfTokenManager->getToken('new_signalement'),
-        ]);
     }
 }

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -52,7 +52,9 @@ class SignalementController extends AbstractController
         SignalementDraft $signalementDraft
     ): Response {
         if (SignalementDraftStatus::EN_COURS !== $signalementDraft->getStatus()) {
-            throw $this->createNotFoundException();
+            $this->addFlash('error', 'Le brouillon n\'est plus modifiable.');
+
+            return $this->redirectToRoute('front_signalement');
         }
 
         return $this->render('front/nouveau_formulaire.html.twig', [

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -51,6 +51,10 @@ class SignalementController extends AbstractController
     public function edit(
         SignalementDraft $signalementDraft
     ): Response {
+        if (SignalementDraftStatus::EN_COURS !== $signalementDraft->getStatus()) {
+            throw $this->createNotFoundException();
+        }
+
         return $this->render('front/nouveau_formulaire.html.twig', [
             'uuid_signalement' => $signalementDraft->getUuid(),
         ]);
@@ -179,6 +183,9 @@ class SignalementController extends AbstractController
         ValidatorInterface $validator,
         SignalementDraft $signalementDraft,
     ): JsonResponse {
+        if (SignalementDraftStatus::ARCHIVE === $signalementDraft->getStatus()) {
+            throw $this->createNotFoundException();
+        }
         /** @var SignalementDraftRequest $signalementDraftRequest */
         $signalementDraftRequest = $serializer->deserialize(
             $payload = $request->getContent(),

--- a/src/DataFixtures/Files/SignalementDraft.yml
+++ b/src/DataFixtures/Files/SignalementDraft.yml
@@ -28,6 +28,12 @@ signalements_draft:
     payload: 'locataire.json'
     status: 'EN_SIGNALEMENT'
   -
+    uuid: '00000000-0000-0000-2024-locataire003'
+    profile_declarant: 'LOCATAIRE'
+    email_declarant: 'locataire-03@histologe.fr'
+    payload: 'locataire.json'
+    status: 'ARCHIVE'
+  -
     uuid: '00000000-0000-0000-2023-locataire004'
     profile_declarant: 'LOCATAIRE'
     email_declarant: 'tous-les-desordres-locataire@histologe.fr'

--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -30,7 +30,7 @@ class FileVoter extends Voter
     {
         /** @var User $user */
         $user = $token->getUser();
-        if(!$user instanceof User) {
+        if (!$user instanceof User) {
             return false;
         }
 

--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -30,6 +30,9 @@ class FileVoter extends Voter
     {
         /** @var User $user */
         $user = $token->getUser();
+        if(!$user instanceof User) {
+            return false;
+        }
 
         if (!$subject instanceof Signalement && !$subject instanceof File) {
             return false;

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -74,7 +74,7 @@
                 </a>
             {% endif %}
 
-            {% if canExportSignalement %}
+            {% if is_granted('SIGN_VIEW', signalement) %}
                     <a href="{{ path('back_signalement_gen_pdf',{uuid:signalement.uuid}) }}"
                        class="fr-btn fr-btn--sm fr-btn--icon-left fr-fi-file-pdf-fill ignore-blank-style"
                        title="Exporter le PDF">Exporter le PDF

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -28,7 +28,7 @@
                 étiquettes</strong>
             <span class="fr-hint-text">Ci-dessous la liste des étiquettes existantes.</span>
         </div>
-        {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+        {% if is_granted('TAG_CREATE') %}
             <div class="fr-col-12">
                 <form action="{{ path('back_tag_create',{uuid:signalement.uuid}) }}" method="POST" name="new-tag-form">
                     <div class="fr-grid-row fr-grid-row--no-gutters">

--- a/tests/Functional/Controller/AffectationControllerTest.php
+++ b/tests/Functional/Controller/AffectationControllerTest.php
@@ -5,6 +5,8 @@ namespace App\Tests\Functional\Controller;
 use App\Entity\Enum\MotifRefus;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
+use App\Repository\AffectationRepository;
+use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Repository\SuiviRepository;
 use App\Repository\UserRepository;
@@ -19,13 +21,18 @@ class AffectationControllerTest extends WebTestCase
     use SessionHelper;
 
     public const USER_ADMIN_TERRITORY_13 = 'admin-territoire-13-01@histologe.fr';
+    public const USER_PARTNER_TERRITORY_13 = 'user-13-01@histologe.fr';
     public const SIGNALEMENT_REFERENCE = '2022-1';
+    public const SIGNALEMENT_ACTIVE_UUID = '00000000-0000-0000-2022-000000000001';
+    public const SIGNALEMENT_NEED_VALIDATION_UUID = '00000000-0000-0000-2023-000000000016';
 
     private ?KernelBrowser $client = null;
     private UserRepository $userRepository;
     private RouterInterface $router;
     private SignalementRepository $signalementRepository;
     private SuiviRepository $suiviRepository;
+    private AffectationRepository $affectationRepository;
+    private PartnerRepository $partnerRepository;
 
     protected function setUp(): void
     {
@@ -34,14 +41,14 @@ class AffectationControllerTest extends WebTestCase
         $this->signalementRepository = self::getContainer()->get(SignalementRepository::class);
         $this->suiviRepository = self::getContainer()->get(SuiviRepository::class);
         $this->userRepository = static::getContainer()->get(UserRepository::class);
-
-        $user = $this->userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
-        $this->client->loginUser($user);
+        $this->affectationRepository = static::getContainer()->get(AffectationRepository::class);
+        $this->partnerRepository = static::getContainer()->get(PartnerRepository::class);
     }
 
     public function testRejectAffectationSignalement(): void
     {
         $user = $this->userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $this->client->loginUser($user);
 
         /** @var Signalement $signalement */
         $signalement = $this->signalementRepository->findOneBy(['reference' => self::SIGNALEMENT_REFERENCE]);
@@ -81,6 +88,7 @@ class AffectationControllerTest extends WebTestCase
     public function testAcceptAffectationSignalement(): void
     {
         $user = $this->userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $this->client->loginUser($user);
 
         /** @var Signalement $signalement */
         $signalement = $this->signalementRepository->findOneBy(['reference' => self::SIGNALEMENT_REFERENCE]);
@@ -109,6 +117,9 @@ class AffectationControllerTest extends WebTestCase
 
     public function testCheckingNoDuplicatedMailSentWhenPartnerAffectationIsMultiple(): void
     {
+        $user = $this->userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $this->client->loginUser($user);
+
         /** @var Signalement $signalement */
         $signalement = $this->signalementRepository->findOneBy([
             'reference' => self::SIGNALEMENT_REFERENCE,
@@ -141,5 +152,81 @@ class AffectationControllerTest extends WebTestCase
             }
         }
         $this->assertEquals(\count($tos), \count(array_unique($tos)));
+    }
+
+    public function testToggleAffectationWithRoleUserPartner()
+    {
+        $user = $this->userRepository->findOneBy(['email' => self::USER_PARTNER_TERRITORY_13]);
+        $this->client->loginUser($user);
+
+        $routeAffectationResponse = $this->router->generate('back_signalement_toggle_affectation', [
+            'uuid' => self::SIGNALEMENT_ACTIVE_UUID,
+        ]);
+        $this->client->request('POST', $routeAffectationResponse, [
+            'signalement-affectation' => [
+                'partners' => [3, 4, 5],
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testToggleAffectationWithInactiveSignalement()
+    {
+        $user = $this->userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $this->client->loginUser($user);
+
+        $routeAffectationResponse = $this->router->generate('back_signalement_toggle_affectation', [
+            'uuid' => self::SIGNALEMENT_NEED_VALIDATION_UUID,
+        ]);
+        $this->client->request('POST', $routeAffectationResponse, [
+            'signalement-affectation' => [
+                'partners' => [3, 4, 5],
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testRemoveAffectation()
+    {
+        $user = $this->userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $this->client->loginUser($user);
+
+        /** @var Signalement $signalement */
+        $signalement = $this->signalementRepository->findOneBy([
+            'reference' => self::SIGNALEMENT_REFERENCE,
+        ]);
+
+        $routeAffectationResponse = $this->router->generate('back_signalement_remove_partner', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+        $this->client->request('POST', $routeAffectationResponse, [
+            'affectation' => $signalement->getAffectations()->first()->getId(),
+            '_token' => $this->generateCsrfToken($this->client, 'signalement_remove_partner_'.$signalement->getId()),
+        ]);
+        $this->assertSame('{"status":"success"}', $this->client->getResponse()->getContent());
+    }
+
+    public function testRemoveAffectationFromOtherSignalement()
+    {
+        $user = $this->userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $this->client->loginUser($user);
+
+        /** @var Signalement $signalement */
+        $signalement = $this->signalementRepository->findOneBy([
+            'reference' => self::SIGNALEMENT_REFERENCE,
+        ]);
+
+        $partner = $this->partnerRepository->findOneBy(['email' => 'partenaire-01-01@histologe.fr']);
+        $affectation = $this->affectationRepository->findOneBy(['partner' => $partner]);
+
+        $routeAffectationResponse = $this->router->generate('back_signalement_remove_partner', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+        $this->client->request('POST', $routeAffectationResponse, [
+            'affectation' => $affectation->getId(),
+            '_token' => $this->generateCsrfToken($this->client, 'signalement_remove_partner_'.$signalement->getId()),
+        ]);
+        $this->assertSame('{"status":"denied"}', $this->client->getResponse()->getContent());
+        $this->assertResponseStatusCodeSame(403);
     }
 }

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -233,7 +233,8 @@ class SignalementControllerTest extends WebTestCase
         $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => '00000000-0000-0000-2024-locataire003']);
         $client->request('GET', $urlSignalementEdit);
 
-        $this->assertEquals(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $this->assertEquals(Response::HTTP_FOUND, $client->getResponse()->getStatusCode());
+        $this->assertResponseRedirects('/signalement');
 
         $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => '00000000-0000-0000-2023-locataire001']);
         $client->request('GET', $urlSignalementEdit);

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -183,6 +183,25 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(1, $signalementDraft->getSignalements()->count());
     }
 
+    public function testUpdateSignalementDraftArchived(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = $client->getContainer()->get(RouterInterface::class);
+        $urlPutSignalement = $router->generate('mise_a_jour_nouveau_signalement_draft', [
+            'uuid' => '00000000-0000-0000-2024-locataire003',
+        ]);
+
+        $payloadLocataireSignalement = file_get_contents(
+            __DIR__.'../../../files/post_signalement_draft_payload.json'
+        );
+
+        $client->request('PUT', $urlPutSignalement, [], [], [], $payloadLocataireSignalement);
+
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+    }
+
     /**
      * @dataProvider provideSignalementDraftUuid
      */
@@ -198,6 +217,28 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals($step, $response['signalement']['payload']['currentStep']);
+    }
+
+    public function testSignalementEdit(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = static::getContainer()->get(RouterInterface::class);
+        $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => 'test']);
+        $client->request('GET', $urlSignalementEdit);
+
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+
+        $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => '00000000-0000-0000-2024-locataire003']);
+        $client->request('GET', $urlSignalementEdit);
+
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+
+        $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => '00000000-0000-0000-2023-locataire001']);
+        $client->request('GET', $urlSignalementEdit);
+
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
     public function provideSignalementRequestPayload(): \Generator


### PR DESCRIPTION
## Ticket

#2645

## Description
/SignalementController
- Mettre un Not Found sur reprise la de signalement en statuts : EN_SIGNALEMENT / ARCHIVE
- Bloquer la soumission d’un signalementDraft archivé

/Security/SecurityController
- Suppression de la route “app_csrf_token” plus utilisé
- Fix contrôles sur la route /_up et FileVoter (erreur amené suite à la nouvelle page suivi usager)

/Back/AffectationController
- Ajout de tests sur la route ‘back_signalement_toggle_affectation’
- Bloquer la possibilité de supprimer une affectation sur un signalement différent (+ tests)

/Back/BackTagController
- mise en cohérence du contrôle de la route ‘back_tag_create’ et du twig ‘tags.html.twig’

/Back/SignalementEditController
- Modification du voter sur ‘SIGN_EDIT’ afin que le contrôle vérifie les statuts du signalement

/Back/SignalementFileController
- Contrôle pour l’export PDF basé sur le voter ‘SIGN_VIEW’

Back/SignalementVisitesController
- Ajout du contrôle par voter ‘INTERVENTION_EDIT_VISITE’ sur la route ‘back_signalement_visite_deleterapport’

## D'autres points doivent être traités dans des tickets séparés
#2677
#2678 
#2679 
#2680

