### PR TITLE
[QA] Pb sur FileVoter

### DIFF
--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -91,8 +91,12 @@ class FileVoter extends Voter
         return null !== $file->getUploadedBy() && $file->getUploadedBy() === $user;
     }
 
-    private function isAdminOrRTonHisTerritory(File|Signalement $subject, User $user): bool
+    private function isAdminOrRTonHisTerritory(File|Signalement $subject, ?User $user = null): bool
     {
+        if (null === $user) {
+            return false;
+        }
+
         return $user->isSuperAdmin() ||
         ($user->isTerritoryAdmin() && $this->isOnUserTerritory($subject, $user));
     }


### PR DESCRIPTION
## Ticket

#2668    

## Description
Fix de l'erreur `Uncaught PHP Exception TypeError: "App\Security\Voter\FileVoter::isAdminOrRTonHisTerritory(): Argument #2 ($user) must be of type App\Entity\User, null given, called in /app/src/Security/Voter/FileVoter.php on line 39" at FileVoter.php line 94` (ouverture d'un fichier non visible à l'usager en dehors d'une connexion à la plateforme)

## Changements apportés
* Changement du voter

## Pré-requis

## Tests
- [ ] Ouvrir un fichier depuis la fiche BO, vérifier que c'est ok
- [ ] Idem depuis la fiche de suivi usager
