### PR TITLE
 [QA] Erreur annulation de visite

### DIFF
--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -144,6 +144,12 @@ class SignalementVisitesController extends AbstractController
         }
         $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
 
+        if ($intervention->hasScheduledDatePassed()) {
+            $this->addFlash('error', 'Cette visite est déja passée et ne peut pas être annulée.');
+
+            return $this->redirectToRoute('back_index');
+        }
+
         $errorRedirect = $this->getSecurityRedirect(
             $signalement,
             $request,

--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -145,7 +145,7 @@ class SignalementVisitesController extends AbstractController
         $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
 
         if ($intervention->hasScheduledDatePassed()) {
-            $this->addFlash('error', 'Cette visite est déja passée et ne peut pas être annulée.');
+            $this->addFlash('error', 'Cette visite est déja passée et ne peut pas être annulée, merci de la noter comme non-effectuée.');
 
             return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
         }

--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -147,7 +147,7 @@ class SignalementVisitesController extends AbstractController
         if ($intervention->hasScheduledDatePassed()) {
             $this->addFlash('error', 'Cette visite est déja passée et ne peut pas être annulée.');
 
-            return $this->redirectToRoute('back_index');
+            return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
         }
 
         $errorRedirect = $this->getSecurityRedirect(


### PR DESCRIPTION
## Ticket

#2670   

## Description
Ajout d'une vérification supplémentaire dans le SignalementVisitesController pour éviter une erreur sentry et afficher un message clair

## Changements apportés
* Changement du controlleur, on vérifie que la visite est bien dans le futur avant d'annuler la visite

## Pré-requis
Vérifier l'heure de php/symfony en local

## Tests
- [ ] Planifier une visite pour dans 2 minutes (en fonction de l'heure de php/symfony)
- [ ] Ouvrir la modale d'annulation de visite
- [ ] Attendre 3 minutes, puis valider l'annulation
- [ ] Vérifier qu'on a bien un message d'erreur explicite et que la visite n'est pas annulée
