### PR TITLE
[QA] Formats de fichiers non détectés

### DIFF
--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Event\InterventionCreatedEvent;
 use App\Event\InterventionEditedEvent;
 use App\Event\InterventionRescheduledEvent;
+use App\Exception\File\EmptyFileException;
 use App\Exception\File\MaxUploadSizeExceededException;
 use App\Exception\File\UnsupportedFileFormatException;
 use App\Manager\InterventionManager;
@@ -62,7 +63,7 @@ class SignalementVisitesController extends AbstractController
         $newFilename = $filenameGenerator->generate($file);
         try {
             return $uploadHandler->uploadFromFile($file, $newFilename);
-        } catch (MaxUploadSizeExceededException|UnsupportedFileFormatException $exception) {
+        } catch (MaxUploadSizeExceededException|UnsupportedFileFormatException|EmptyFileException $exception) {
             $this->addFlash('error', $exception->getMessage());
 
             return null;

--- a/src/Exception/File/EmptyFileException.php
+++ b/src/Exception/File/EmptyFileException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exception\File;
+
+class EmptyFileException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Le fichier est vide où il y a eu un problème de téléchargement. Veuillez réessayer un fichier non vide.');
+    }
+}

--- a/src/Exception/File/EmptyFileException.php
+++ b/src/Exception/File/EmptyFileException.php
@@ -6,6 +6,6 @@ class EmptyFileException extends \Exception
 {
     public function __construct()
     {
-        parent::__construct('Le fichier est vide où il y a eu un problème de téléchargement. Veuillez réessayer un fichier non vide.');
+        parent::__construct('Le fichier est vide ou il y a eu un problème de téléchargement. Merci de réessayer ou d\'envoyer un autre fichier.');
     }
 }

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -49,7 +49,8 @@ class SignalementFileProcessor
                 Les fichiers de format {$fileExtension} ne sont pas pris en charge,
                 merci de choisir un fichier au format {$acceptedExtensions}.
                 ERROR;
-                $this->logger->error($message);
+                $fileInfo = '( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
+                $this->logger->error($message.$fileInfo);
                 $this->errors[] = $message;
             } elseif (
                 $file instanceof UploadedFile
@@ -61,7 +62,8 @@ class SignalementFileProcessor
                 Les fichiers de format {$fileExtension} ne sont pas pris en charge,
                 merci de choisir un fichier au format {$acceptedExtensions}.
                 ERROR;
-                $this->logger->error($message);
+                $fileInfo = '( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
+                $this->logger->error($message.$fileInfo);
                 $this->errors[] = $message;
             } else {
                 $inputTypeDetection = $inputName;

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\File;
+use App\Exception\File\EmptyFileException;
 use App\Exception\File\MaxUploadSizeExceededException;
 use App\Exception\File\UnsupportedFileFormatException;
 use App\Repository\FileRepository;
@@ -32,6 +33,7 @@ class UploadHandlerService
 
     /**
      * @throws MaxUploadSizeExceededException
+     * @throws EmptyFileException
      * @throws FilesystemException
      * @throws UnsupportedFileFormatException
      */
@@ -45,6 +47,10 @@ class UploadHandlerService
         }
         $newFilename = $this->filenameGenerator->generate($file);
         $titre = $this->filenameGenerator->getTitle();
+
+        if (0 === $file->getSize() || 'application/x-empty' === $file->getMimeType()) {
+            throw new EmptyFileException();
+        }
         if ($file->getSize() > self::MAX_FILESIZE) {
             throw new MaxUploadSizeExceededException(self::MAX_FILESIZE);
         }
@@ -208,6 +214,7 @@ class UploadHandlerService
     }
 
     /**
+     * @throws EmptyFileException
      * @throws MaxUploadSizeExceededException
      * @throws UnsupportedFileFormatException
      */
@@ -216,6 +223,9 @@ class UploadHandlerService
         string $newFilename,
         ?string $fileType = File::INPUT_NAME_DOCUMENTS
     ): ?string {
+        if (0 === $file->getSize() || 'application/x-empty' === $file->getMimeType()) {
+            throw new EmptyFileException();
+        }
         if ($file->getSize() > self::MAX_FILESIZE) {
             throw new MaxUploadSizeExceededException(self::MAX_FILESIZE);
         }

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -48,7 +48,7 @@ class UploadHandlerService
         $newFilename = $this->filenameGenerator->generate($file);
         $titre = $this->filenameGenerator->getTitle();
 
-        if (0 === $file->getSize() || 'application/x-empty' === $file->getMimeType()) {
+        if ($this->isFileEmpty($file)) {
             throw new EmptyFileException();
         }
         if ($file->getSize() > self::MAX_FILESIZE) {
@@ -223,7 +223,7 @@ class UploadHandlerService
         string $newFilename,
         ?string $fileType = File::INPUT_NAME_DOCUMENTS
     ): ?string {
-        if (0 === $file->getSize() || 'application/x-empty' === $file->getMimeType()) {
+        if ($this->isFileEmpty($file)) {
             throw new EmptyFileException();
         }
         if ($file->getSize() > self::MAX_FILESIZE) {
@@ -327,5 +327,14 @@ class UploadHandlerService
     public function getFile(): array
     {
         return $this->file;
+    }
+
+    private function isFileEmpty(UploadedFile $file): bool
+    {
+        if (0 === $file->getSize() || 'application/x-empty' === $file->getMimeType()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Functional/Service/UploadHandlerServiceTest.php
+++ b/tests/Functional/Service/UploadHandlerServiceTest.php
@@ -100,7 +100,7 @@ class UploadHandlerServiceTest extends KernelTestCase
 
         $uploadedFileMock = $this->createMock(UploadedFile::class);
         $uploadedFileMock
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getSize')
             ->willReturn(20 * 1024 * 1024);
 


### PR DESCRIPTION
## Ticket

#2669   

## Description
Ajout d'une nouvelle exception pour les fichiers vides (sera plus clair que `Le format application/x-empty n'est pas supporté`)
Ajout d'unfo sur le fichier dans l'erreur loguée dans Sentry (pour vérifier s'il faut ajouter des formats, extensions, autoriser l'absence d'extension etc.)

## Changements apportés
* Ajout d'une exception
* Modification de SignalementFileProcessor

## Pré-requis

## Tests
- [ ] CI ok
