### PR TITLE
 [Sécurité][BO] Cohérence des controles sur route back_signalement_qualification_editer

### DIFF
--- a/src/Controller/Back/BackSignalementQualificationController.php
+++ b/src/Controller/Back/BackSignalementQualificationController.php
@@ -6,7 +6,7 @@ use App\Dto\Request\Signalement\QualificationNDERequest;
 use App\Entity\Signalement;
 use App\Entity\SignalementQualification;
 use App\Manager\SignalementManager;
-use App\Security\Voter\UserVoter;
+use App\Security\Voter\SignalementVoter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -29,7 +29,7 @@ class BackSignalementQualificationController extends AbstractController
         SignalementManager $signalementManager,
         SerializerInterface $serializer
     ): RedirectResponse|JsonResponse {
-        $this->denyAccessUnlessGranted(UserVoter::SEE_NDE, $this->getUser());
+        $this->denyAccessUnlessGranted(SignalementVoter::EDIT_NDE, $signalement);
         $decodedRequest = json_decode($request->getContent());
         if ($this->isCsrfTokenValid('signalement_edit_nde_'.$signalement->getId(), $decodedRequest->_token)) {
             $qualificationNDERequest = $serializer->deserialize(


### PR DESCRIPTION
## Ticket

#2678   

## Description
La route back_signalement_qualification_editer est trop permissive, elle ne contient pas tous les contrôles présent sur back_signalement_view (voir $canEditNDE) pour savoir si le bloc est éditable sur le signalement

## Changements apportés
* Ajout d'une option de Voter à SignalementVoter
* utilisation de ce voter dans `back_signalement_qualification_editer` et `back_signalement_view`

## Pré-requis
`make console app="update-partners-communes-nde"` --> pour avoir des partenaires avec la compétence NDE dans le 63 et le 89
## Tests
- [ ] Tester l'ouverture d'une fiche signalement et la modification de ces infos de NDE avec un SA, le RT du territoire, un partenaire avec la compétence NDE et un partenaire sans le compétence NDE.
- [ ] Vérifier qu'il n'y a pas de régression (le partenaire sans la compétence ne doit pas voir la partie NDE ni pouvoir la modifier)
