### PR TITLE
[BO - Liste signalement] Améliorations UI sur les filtres 

### DIFF
--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -139,23 +139,27 @@ export default defineComponent({
       optionNoneItem.Id = 'AUCUN'
       optionNoneItem.Text = 'Aucun'
       this.sharedState.partenaires.push(optionNoneItem)
-      for (const id in requestResponse.partners) {
+      const partnersArray = Object.values(requestResponse.partners)
+      partnersArray.sort((a: any, b:any) => (a.nom > b.nom) ? 1 : ((b.nom > a.nom) ? -1 : 0))
+      partnersArray.forEach((partner: any) => {
         const optionItem = new HistoInterfaceSelectOption()
-        optionItem.Id = requestResponse.partners[id].id.toString()
-        optionItem.Text = requestResponse.partners[id].nom
+        optionItem.Id = partner.id.toString()
+        optionItem.Text = partner.nom
         this.sharedState.partenaires.push(optionItem)
-      }
+      })
 
       this.sharedState.etiquettes = []
       optionNoneItem.Id = ''
       optionNoneItem.Text = ''
       this.sharedState.etiquettes.push(optionNoneItem)
-      for (const id in requestResponse.tags) {
+      const tagsArray = Object.values(requestResponse.tags)
+      tagsArray.sort((a: any, b:any) => (a.label > b.label) ? 1 : ((b.label > a.label) ? -1 : 0))
+      tagsArray.forEach((tag: any) => {
         const optionItem = new HistoInterfaceSelectOption()
-        optionItem.Id = requestResponse.tags[id].id.toString()
-        optionItem.Text = requestResponse.tags[id].label
+        optionItem.Id = tag.id.toString()
+        optionItem.Text = tag.label
         this.sharedState.etiquettes.push(optionItem)
-      }
+      })
 
       this.sharedState.communes = []
       for (const id in requestResponse.communes) {
@@ -164,7 +168,7 @@ export default defineComponent({
 
       this.sharedState.epcis = []
       for (const id in requestResponse.epcis) {
-        this.sharedState.epcis.push(`${requestResponse.epcis[id].code} | ${requestResponse.epcis[id].nom}`)
+        this.sharedState.epcis.push(`${requestResponse.epcis[id].nom} (${requestResponse.epcis[id].code} )`)
       }
     },
     handleTerritoryChange (value: any) {

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -454,6 +454,9 @@ export default defineComponent({
     .histo-select select {
       background-color: var(--background-contrast-grey);
     }
+    .histo-multi-select .selector {
+      background-color: var(--background-contrast-grey);
+    }
     .histo-date-picker input {
       background-color: var(--background-contrast-grey);
       box-shadow: inset 0 -2px 0 0 var(--border-plain-grey);


### PR DESCRIPTION
## Ticket

#2684 
#2683 
#2695 
#2693

## Description
2684 : Dans les filtres, les 2 filtres avec sélection multiple doivent avoir un fond gris
2683 : Pour le filtre étiquette, afficher les étiquettes par ordre alphabétique
2693 : Pour le filtre partenaires, afficher les partenaires par ordre alphabétique
2695 : Dans le filtre EPCI, il faudrait déplacer le numéro insee derrière le nom de l'EPCI et (entre parenthèses)


## Changements apportés
* Changement de l'app Vue

## Pré-requis
```
npm run watch
make clear-pool pool="--all"
make console app="load-epci"
```

## Tests
- [ ] Afficher la nouvelle liste de signalements et vérifier les 4 points ci-dessus
- [ ] Faire des tests de non régression sur les filtres
