### PR TITLE
[BO - Visite] Modification du suivi créé lorsqu'une visite doit être effectuée

### DIFF
--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -110,8 +110,8 @@ class NotifyVisitsCommand extends AbstractCronCommand
             $listAffectations = $this->affectationRepository->findAcceptedAffectationsFromVisitesPartner();
             foreach ($listAffectations as $affectation) {
                 if (0 == \count($affectation->getSignalement()->getInterventions())) {
-                    $description = 'Aucune information de visite n\'a été renseignée pour le logement.';
-                    $description .= ' Merci de programmer une visite dès que possible !';
+                    $description = 'La réalisation d\'une visite est nécessaire pour caractériser les désordres signalés.';
+                    $description .= ' Merci de renseigner la date ou les conclusions de la visite afin de poursuivre la prise en charge de ce signalement.';
                     $suivi = $this->suiviManager->createSuivi(
                         user: null,
                         signalement: $affectation->getSignalement(),


### PR DESCRIPTION
## Ticket

#2598    

## Description
Lorsqu'une affectation par un partenaire avec la compétence VISITE est passée depuis 15 jours et qu'aucune visite n'est prévue, le partenaire reçoit un mail et un suivi est créé.
On modifie le texte du suivi.

## Tests
- [ ] Vérifier le fonctionnement et le texte
