### PR TITLE
[FO - Signalement]Vérifier la liaison avec la table bailleur dans le parc public

### DIFF
--- a/src/Controller/BailleurController.php
+++ b/src/Controller/BailleurController.php
@@ -26,6 +26,7 @@ class BailleurController extends AbstractController
 
         if ($sanitize) {
             $bailleurCollection = $this->sanitizeBailleurs($bailleurs, $name);
+            dump($bailleurCollection);
 
             return $this->json(array_values($bailleurCollection->toArray()));
         }
@@ -39,9 +40,10 @@ class BailleurController extends AbstractController
             /* @var Bailleur $bailleurItem */
             ->filter(function ($bailleurItem) use ($name) {
                 if (str_starts_with($bailleurItem->getName(), Bailleur::BAILLEUR_RADIE)) {
-                    $terms = explode(' ', $name);
+                    $name = strtolower($name);
+                    $name = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $name);
 
-                    return str_contains(strtolower($this->sanitizeName($bailleurItem->getName())), $terms[0]);
+                    return str_contains(strtolower($this->sanitizeName($bailleurItem->getName())), $name);
                 }
 
                 return true;

--- a/src/Controller/BailleurController.php
+++ b/src/Controller/BailleurController.php
@@ -26,7 +26,6 @@ class BailleurController extends AbstractController
 
         if ($sanitize) {
             $bailleurCollection = $this->sanitizeBailleurs($bailleurs, $name);
-            dump($bailleurCollection);
 
             return $this->json(array_values($bailleurCollection->toArray()));
         }

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -43,15 +43,20 @@ class BailleurRepository extends ServiceEntityRepository
 
     public function findOneBailleurBy(string $name, string $zip, bool $bailleurSanitized = false): ?Bailleur
     {
-        $name = $bailleurSanitized ? Bailleur::BAILLEUR_RADIE.' '.$name : $name;
         $queryBuilder = $this
             ->createQueryBuilder('b')
             ->innerJoin('b.bailleurTerritories', 'bt')
             ->innerJoin('bt.territory', 't')
             ->where('t.zip = :zip')
-            ->setParameter('zip', $zip)
-            ->andWhere('b.name LIKE :name')
+            ->setParameter('zip', $zip);
+        if ($bailleurSanitized) {
+            $queryBuilder->andWhere('b.name = :name OR b.name = :sanitizedName')
+            ->setParameter('name', $name)
+            ->setParameter('sanitizedName', Bailleur::BAILLEUR_RADIE.' '.$name);
+        } else {
+            $queryBuilder->andWhere('b.name = :name')
             ->setParameter('name', $name);
+        }
 
         return $queryBuilder->getQuery()->getOneOrNullResult();
     }

--- a/tests/Functional/Controller/BailleurControllerTest.php
+++ b/tests/Functional/Controller/BailleurControllerTest.php
@@ -48,12 +48,12 @@ class BailleurControllerTest extends WebTestCase
 
     public function testSearchBailleursSanitized(): void
     {
-        $route = $this->router->generate('app_bailleur', ['name' => 'ra', 'postcode' => 13002, 'sanitize' => true]);
+        $route = $this->router->generate('app_bailleur', ['name' => 'IÉ', 'postcode' => 30100, 'sanitize' => true]);
 
         $this->client->request('GET', $route);
         $response = json_decode($this->client->getResponse()->getContent(), true);
         foreach ($response as $item) {
-            $this->assertStringContainsString('ra', strtolower($item['name']));
+            $this->assertStringContainsString('ie', strtolower($item['name']));
             $this->assertStringNotContainsString(Bailleur::BAILLEUR_RADIE, strtolower($item['name']));
         }
     }

--- a/tests/Functional/Repository/BailleurRepositoryTest.php
+++ b/tests/Functional/Repository/BailleurRepositoryTest.php
@@ -7,6 +7,20 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class BailleurRepositoryTest extends KernelTestCase
 {
+    public function testFindOneBailleur(): void
+    {
+        /** @var BailleurRepository $bailleurRepository */
+        $bailleurRepository = static::getContainer()->get(BailleurRepository::class);
+
+        $bailleur = $bailleurRepository->findOneBailleurBy(
+            name: '13 HABITAT',
+            zip: '13',
+            bailleurSanitized: true
+        );
+
+        $this->assertEquals('13 HABITAT', $bailleur?->getName());
+    }
+
     public function testFindOneBailleurRadie(): void
     {
         /** @var BailleurRepository $bailleurRepository */

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -156,7 +156,7 @@ class SignalementBuilderTest extends KernelTestCase
         $this->assertArrayHasKey('lat', $signalement->getGeoloc());
         $this->assertArrayHasKey('lng', $signalement->getGeoloc());
 
-        $this->assertEquals('13 Habitat', $signalement->getNomProprio());
+        $this->assertEquals('13 HABITAT', $signalement->getNomProprio());
         $this->assertEquals('Sandrine', $signalement->getPrenomProprio());
         $this->assertEquals('sandrine@histologe.fr', $signalement->getMailProprio());
         $this->assertEquals('10 rue du 14 juillet', $signalement->getAdresseProprio());


### PR DESCRIPTION
## Ticket

#2700

## Description
- Correction du `BailleurRepository` afin que la recherche du bailleur utilisé à la création d'un draft en signalement fonctionne que le bailleur soit radié ou pas (pour rappel le nom du bailleur est toujours retourné sans la partie "[Radié(e)]" coté front mais pas coté BO)
- Correction d'un filtre dans la fonction `sanitizeBailleurs` afin que l'on retrouve les bailleur radié malgré des différences de case/accentuation

## Tests
- [ ] Tester l'ajout d'un signalement sur logement social avec un bailleur non radié ex "13 HABITAT" dans le 13, vérifier une fois soumis que l'id est bien enregistré en base et que la modification BO fonctionne
- [ ] Tester l'ajout d'un signalement sur logement social avec un bailleur radié ex "S.A. REGIONALE DE L'HABITAT" dans le 13, vérifier une fois soumis que l'id est bien enregistré en base et que la modification BO fonctionne
- [ ] Vérifier que la recherche d'un bailleur via le formulaire FO de signalement fonctionne pour les bailleurs radiés sans prise en compte de la case et de l'accentuation (ex : "S.A. REGIONALE DE L'HABITAT", "s.a. régionale de l'habitat")
