### PR TITLE
[FO - Formulaire] Ajout de questions de bail et de procédure pour les tiers

### DIFF
--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -2594,17 +2594,7 @@
                 "action": "goto:ecran_intermediaire_procedure",
                 "customCss": "fr-mb-3v",
                 "conditional": {
-                  "show": "(formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur') && formStore.hasDesordre('desordres_') === true"
-                }
-              },
-              {
-                "type": "SignalementFormButton",
-                "label": "Suivant",
-                "slug": "desordres_renseignes_next_secours",
-                "action": "goto:utilisation_service",
-                "customCss": "fr-mb-3v",
-                "conditional": {
-                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours' && formStore.hasDesordre('desordres_') === true"
+                  "show": "formStore.hasDesordre('desordres_') === true"
                 }
               },
               {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -172,7 +172,7 @@
             "maxLength": 255
           },
           "conditional": {
-            "show": "formStore.data.signalement_concerne_logement_social_service_secours === 'non'"
+            "show": "formStore.data.signalement_concerne_logement_social_service_secours === 'non' || formStore.data.signalement_concerne_logement_social_service_secours === 'nsp'"
           },
           "accessibility": {
             "name": "lastName",
@@ -815,7 +815,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }
@@ -823,7 +823,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_bail_upload",
-          "label": "Ajoutez le bail en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter le bail (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'oui'"
           },
@@ -861,7 +861,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_etat_des_lieux_upload",
-          "label": "Ajoutez l'état des lieux en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter l'état des lieux (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
           },
@@ -899,7 +899,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_dpe_upload",
-          "label": "Ajoutez le DPE en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter le DPE (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_dpe === 'oui'"
           },
@@ -920,6 +920,131 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "bail_dpe_next",
+          "action": "goto.save:ecran_intermediaire_les_desordres",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "La procédure",
+    "description": "<p>Vous avez presque terminé ! <br>Répondez aux dernières questions puis envoyez votre signalement.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "slug": "ecran_intermediaire_procedure",
+    "screenCategory": "Procédure",
+    "icon": {
+      "src": "/img/form/screens/procedure.svg",
+      "alt": ""
+    },
+    "components": {
+      "body": [
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "ecran_intermediaire_procedure_previous",
+          "action": "goto:desordres_renseignes",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "J'y suis presque !",
+          "slug": "ecran_intermediaire_procedure_next",
+          "action": "goto:info_procedure"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "",
+    "slug": "info_procedure",
+    "screenCategory": "Procédure",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Le bailleur (propriétaire) du logement a-t-il été informé de la situation ?",
+          "slug": "info_procedure_bailleur_prevenu",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Le foyer a-t-il pris contact avec son assurance logement ?",
+          "slug": "info_procedure_assurance_contactee",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Le foyer n'a pas d'assurance logement",
+              "value": "pas_assurance_logement"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormTextarea",
+          "label": "Quelle a été la réponse de l'assurance ?",
+          "slug": "info_procedure_reponse_assurance",
+          "conditional": {
+            "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Si des travaux sont faits, le foyer souhaite-t-il rester dans le logement ?",
+          "slug": "info_procedure_depart_apres_travaux",
+          "values": [
+            {
+              "label": "Oui, le foyer souhaite rester dans le logement",
+              "value": "oui"
+            },
+            {
+              "label": "Non, le foyer veut déménager",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "info_procedure_utilisation_service_previous",
+          "action": "goto:ecran_intermediaire_procedure",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "info_procedure_utilisation_service_next",
           "action": "goto.save:utilisation_service",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
@@ -964,7 +1089,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "utilisation_service_previous",
-          "action": "goto:desordres_renseignes",
+          "action": "goto:info_procedure",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -780,7 +780,147 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "composition_logement_personnes_next",
-          "action": "goto.save:ecran_intermediaire_les_desordres",
+          "action": "goto.save:bail_dpe",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "",
+    "slug": "bail_dpe",
+    "screenCategory": "Type et composition",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Est-ce que le foyer a reçu un bail ?",
+          "slug": "bail_dpe_bail",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormInfo",
+          "slug": "bail_dpe_bail_info",
+          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_bail_upload",
+          "label": "Ajoutez le bail en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_bail === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "bail_dpe_etat_des_lieux",
+          "label": "Est-ce qu'un état des lieux a été réalisé à l'entrée du foyer dans le logement ?",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormWarning",
+          "slug": "bail_dpe_etat_des_lieux_warning",
+          "label": "D'après la loi, un état des lieux du logement doit être réalisé le jour de la remise des clés. Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/F31270' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'non' || formStore.data.bail_dpe_etat_des_lieux === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_etat_des_lieux_upload",
+          "label": "Ajoutez l'état des lieux en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "bail_dpe_dpe",
+          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergie)",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormWarning",
+          "slug": "bail_dpe_dpe_warning",
+          "label": "Le DPE fait partie des documents que le bailleur (propriétaire) doit obligatoirement fournir. Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/F16096' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'non' || formStore.data.bail_dpe_dpe === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_dpe_upload",
+          "label": "Ajoutez le DPE en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "bail_dpe_previous",
+          "action": "goto:composition_logement_personnes",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "bail_dpe_next",
+          "action": "goto.save:utilisation_service",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -834,7 +834,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }
@@ -842,7 +842,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_bail_upload",
-          "label": "Ajoutez le bail en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter le bail (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'oui'"
           },
@@ -880,7 +880,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_etat_des_lieux_upload",
-          "label": "Ajoutez l'état des lieux en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter l'état des lieux (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
           },
@@ -918,7 +918,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_dpe_upload",
-          "label": "Ajoutez le DPE en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter le DPE (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_dpe === 'oui'"
           },
@@ -1180,7 +1180,102 @@
           "type": "SignalementFormButton",
           "label": "J'y suis presque !",
           "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:utilisation_service"
+          "action": "goto:info_procedure"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "",
+    "slug": "info_procedure",
+    "screenCategory": "Procédure",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Le bailleur (propriétaire) du logement a-t-il été informé de la situation ?",
+          "slug": "info_procedure_bailleur_prevenu",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Le foyer a-t-il pris contact avec son assurance logement ?",
+          "slug": "info_procedure_assurance_contactee",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Le foyer n'a pas d'assurance logement",
+              "value": "pas_assurance_logement"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormTextarea",
+          "label": "Quelle a été la réponse de l'assurance ?",
+          "slug": "info_procedure_reponse_assurance",
+          "conditional": {
+            "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Si des travaux sont faits, le foyer souhaite-t-il rester dans le logement ?",
+          "slug": "info_procedure_depart_apres_travaux",
+          "values": [
+            {
+              "label": "Oui, le foyer souhaite rester dans le logement",
+              "value": "oui"
+            },
+            {
+              "label": "Non, le foyer veut déménager",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "info_procedure_utilisation_service_previous",
+          "action": "goto:ecran_intermediaire_procedure",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "info_procedure_utilisation_service_next",
+          "action": "goto.save:utilisation_service",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
     }
@@ -1219,7 +1314,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
+          "action": "goto:info_procedure",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -799,6 +799,146 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "composition_logement_personnes_next",
+          "action": "goto.save:bail_dpe",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "",
+    "slug": "bail_dpe",
+    "screenCategory": "Type et composition",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Est-ce que le foyer a reçu un bail ?",
+          "slug": "bail_dpe_bail",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormInfo",
+          "slug": "bail_dpe_bail_info",
+          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_bail_upload",
+          "label": "Ajoutez le bail en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_bail === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "bail_dpe_etat_des_lieux",
+          "label": "Est-ce qu'un état des lieux a été réalisé à l'entrée du foyer dans le logement ?",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormWarning",
+          "slug": "bail_dpe_etat_des_lieux_warning",
+          "label": "D'après la loi, un état des lieux du logement doit être réalisé le jour de la remise des clés. Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/F31270' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'non' || formStore.data.bail_dpe_etat_des_lieux === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_etat_des_lieux_upload",
+          "label": "Ajoutez l'état des lieux en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "bail_dpe_dpe",
+          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergie)",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormWarning",
+          "slug": "bail_dpe_dpe_warning",
+          "label": "Le DPE fait partie des documents que le bailleur (propriétaire) doit obligatoirement fournir. Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/F16096' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'non' || formStore.data.bail_dpe_dpe === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_dpe_upload",
+          "label": "Ajoutez le DPE en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "bail_dpe_previous",
+          "action": "goto:composition_logement_personnes",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "bail_dpe_next",
           "action": "goto.save:ecran_intermediaire_situation_occupant",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -786,6 +786,146 @@
           "type": "SignalementFormButton",
           "label": "Suivant",
           "slug": "composition_logement_personnes_next",
+          "action": "goto.save:bail_dpe",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "",
+    "slug": "bail_dpe",
+    "screenCategory": "Type et composition",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Est-ce que le foyer a reçu un bail ?",
+          "slug": "bail_dpe_bail",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormInfo",
+          "slug": "bail_dpe_bail_info",
+          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_bail_upload",
+          "label": "Ajoutez le bail en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_bail === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "bail_dpe_etat_des_lieux",
+          "label": "Est-ce qu'un état des lieux a été réalisé à l'entrée du foyer dans le logement ?",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormWarning",
+          "slug": "bail_dpe_etat_des_lieux_warning",
+          "label": "D'après la loi, un état des lieux du logement doit être réalisé le jour de la remise des clés. Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/F31270' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'non' || formStore.data.bail_dpe_etat_des_lieux === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_etat_des_lieux_upload",
+          "label": "Ajoutez l'état des lieux en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "slug": "bail_dpe_dpe",
+          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergie)",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormWarning",
+          "slug": "bail_dpe_dpe_warning",
+          "label": "Le DPE fait partie des documents que le bailleur (propriétaire) doit obligatoirement fournir. Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/F16096' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'non' || formStore.data.bail_dpe_dpe === 'nsp'"
+          }
+        },
+        {
+          "type": "SignalementFormUpload",
+          "slug": "bail_dpe_dpe_upload",
+          "label": "Ajoutez le DPE en cliquant sur le bouton ci-dessous (facultatif)",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "required": false
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "bail_dpe_previous",
+          "action": "goto:composition_logement_personnes",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "bail_dpe_next",
           "action": "goto.save:ecran_intermediaire_situation_occupant",
           "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -821,7 +821,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }
@@ -829,7 +829,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_bail_upload",
-          "label": "Ajoutez le bail en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter le bail (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'oui'"
           },
@@ -867,7 +867,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_etat_des_lieux_upload",
-          "label": "Ajoutez l'état des lieux en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter l'état des lieux (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_etat_des_lieux === 'oui'"
           },
@@ -905,7 +905,7 @@
         {
           "type": "SignalementFormUpload",
           "slug": "bail_dpe_dpe_upload",
-          "label": "Ajoutez le DPE en cliquant sur le bouton ci-dessous (facultatif)",
+          "label": "Ajouter le DPE (facultatif)",
           "conditional": {
             "show": "formStore.data.bail_dpe_dpe === 'oui'"
           },
@@ -1178,7 +1178,102 @@
           "type": "SignalementFormButton",
           "label": "J'y suis presque !",
           "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:utilisation_service"
+          "action": "goto:info_procedure"
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "",
+    "slug": "info_procedure",
+    "screenCategory": "Procédure",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Le bailleur (propriétaire) du logement a-t-il été informé de la situation ?",
+          "slug": "info_procedure_bailleur_prevenu",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Le foyer a-t-il pris contact avec son assurance logement ?",
+          "slug": "info_procedure_assurance_contactee",
+          "values": [
+            {
+              "label": "Oui",
+              "value": "oui"
+            },
+            {
+              "label": "Non",
+              "value": "non"
+            },
+            {
+              "label": "Le foyer n'a pas d'assurance logement",
+              "value": "pas_assurance_logement"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        },
+        {
+          "type": "SignalementFormTextarea",
+          "label": "Quelle a été la réponse de l'assurance ?",
+          "slug": "info_procedure_reponse_assurance",
+          "conditional": {
+            "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
+          }
+        },
+        {
+          "type": "SignalementFormOnlyChoice",
+          "label": "Si des travaux sont faits, le foyer souhaite-t-il rester dans le logement ?",
+          "slug": "info_procedure_depart_apres_travaux",
+          "values": [
+            {
+              "label": "Oui, le foyer souhaite rester dans le logement",
+              "value": "oui"
+            },
+            {
+              "label": "Non, le foyer veut déménager",
+              "value": "non"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ]
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormButton",
+          "label": "Précédent",
+          "slug": "info_procedure_utilisation_service_previous",
+          "action": "goto:ecran_intermediaire_procedure",
+          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+        },
+        {
+          "type": "SignalementFormButton",
+          "label": "Suivant",
+          "slug": "info_procedure_utilisation_service_next",
+          "action": "goto.save:utilisation_service",
+          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
     }
@@ -1217,7 +1312,7 @@
           "type": "SignalementFormButton",
           "label": "Précédent",
           "slug": "utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
+          "action": "goto:info_procedure",
           "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
         },
         {

--- a/src/Entity/Model/InformationProcedure.php
+++ b/src/Entity/Model/InformationProcedure.php
@@ -37,7 +37,7 @@ class InformationProcedure
                 return 'Ne sait pas';
             }
         }
-        
+
         return $this->infoProcedureAssuranceContactee;
     }
 

--- a/src/Entity/Model/InformationProcedure.php
+++ b/src/Entity/Model/InformationProcedure.php
@@ -30,7 +30,15 @@ class InformationProcedure
 
     public function getInfoProcedureAssuranceContactee(bool $raw = true): ?string
     {
-        return (!$raw && 'pas_assurance_logement' === $this->infoProcedureAssuranceContactee) ? 'Pas d\'assurance logement' : $this->infoProcedureAssuranceContactee;
+        if (!$raw) {
+            if ('pas_assurance_logement' === $this->infoProcedureAssuranceContactee) {
+                return 'Pas d\'assurance logement';
+            } elseif ('nsp' === $this->infoProcedureAssuranceContactee) {
+                return 'Ne sait pas';
+            }
+        }
+        
+        return $this->infoProcedureAssuranceContactee;
     }
 
     public function setInfoProcedureAssuranceContactee(?string $infoProcedureAssuranceContactee): self


### PR DESCRIPTION
## Ticket

#2275   

## Description
Les questions concernant le bail/dpe et la procédure n'étaient pas posées aux tiers jusque là.
Elles sont donc ajoutées aux parcours tiers particulier, tiers pro et service de secours.

## Tests
- [ ] Vérifier les 3 parcours, l'affichage des champs, l'upload de documents, et l'affichage des infos dans le BO
- [ ] Vérifier si il n'y a pas de régression sur les autres parcours
