### PR TITLE
[Esabora - SISH] Envoi de la civilité

### DIFF
--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -12,6 +12,7 @@ signalements:
     loyer: null
     date_entree: "2019-12-01"
     nom_proprio: "HabitatMarsien"
+    type_proprio: "ORGANISME_SOCIETE"
     is_logement_social: 0
     nom_occupant: "Mamère"
     prenom_occupant: "Noëlle"

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -8,6 +8,7 @@ use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\MotifRefus;
 use App\Entity\Enum\OccupantLink;
 use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Enum\ProprioType;
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\QualificationStatus;
 use App\Entity\File;
@@ -404,6 +405,11 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
         if (Signalement::STATUS_REFUSED === $row['statut']) {
             $signalement
                 ->setMotifRefus(MotifRefus::tryFrom($row['motif_refus']));
+        }
+
+        if (isset($row['type_proprio'])) {
+            $signalement
+                ->setTypeProprio(ProprioType::tryFrom($row['type_proprio']));
         }
 
         if (isset($row['desordre_categorie'])) {

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -4,14 +4,12 @@ namespace App\Factory\Interconnection\Esabora;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\PartnerType;
-use App\Entity\Enum\ProprioType;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Repository\SuiviRepository;
 use App\Service\Esabora\AbstractEsaboraService;
 use App\Service\Esabora\CiviliteMapper;
-use App\Service\Esabora\Enum\PersonneQualite;
 use App\Service\Esabora\Enum\PersonneType;
 use App\Service\Esabora\Model\DossierMessageSISHPersonne;
 use App\Service\HtmlCleaner;
@@ -187,7 +185,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             if (!empty($personneQualite)) {
                 $dossierMessageSISHPersonne->setQualite($personneQualite->value);
             }
-            
+
             return $dossierMessageSISHPersonne;
         }
 

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -159,7 +159,11 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             $tel = $signalement->getTelOccupantDecoded(true)
                 ? substr($signalement->getTelOccupantDecoded(true), 0, 20)
                 : null;
-            $qualite = 'mme' === $signalement->getCiviliteOccupant() ? PersonneQualite::MADAME->value : PersonneQualite::MONSIEUR->value;
+
+            $qualite = PersonneQualite::MADAME_MONSIEUR->value;
+            if (!empty($signalement->getCiviliteOccupant())) {
+                $qualite = 'mme' === $signalement->getCiviliteOccupant() ? PersonneQualite::MADAME->value : PersonneQualite::MONSIEUR->value;
+            }
 
             return (new DossierMessageSISHPersonne())
                 ->setType(PersonneType::OCCUPANT->value)

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -178,15 +178,24 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             $tel = $signalement->getTelProprioDecoded(true)
                 ? substr($signalement->getTelProprioDecoded(true), 0, 20)
                 : null;
-            $qualite = ProprioType::PARTICULIER === $signalement->getTypeProprio() ? PersonneQualite::MADAME_MONSIEUR->value : PersonneQualite::SOCIETE->value;
+            
+            $qualite = null;
+            if (ProprioType::ORGANISME_SOCIETE === $signalement->getTypeProprio()) {
+                $qualite = PersonneQualite::SOCIETE->value;
+            }
 
-            return (new DossierMessageSISHPersonne())
+            $dossierMessageSISHPersonne = new DossierMessageSISHPersonne();
+            $dossierMessageSISHPersonne
                 ->setType(PersonneType::PROPRIETAIRE->value)
-                ->setQualite($qualite)
                 ->setNom(substr($signalement->getNomProprio(), 0, 60))
                 ->setAdresse($signalement->getAdresseProprio())
                 ->setEmail($signalement->getMailProprio())
                 ->setTelephone($tel);
+            if (!empty($qualite)) {
+                $dossierMessageSISHPersonne->setQualite($qualite);
+            }
+            
+            return $dossierMessageSISHPersonne;
         }
 
         if (PersonneType::DECLARANT === $personneType && !empty($signalement->getLienDeclarantOccupant())) {
@@ -203,7 +212,6 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
 
             return (new DossierMessageSISHPersonne())
                 ->setType(PersonneType::DECLARANT->value)
-                ->setQualite(PersonneQualite::MADAME_MONSIEUR->value)
                 ->setNom($signalement->getNomDeclarant())
                 ->setPrenom($prenom)
                 ->setEmail($signalement->getMailDeclarant())

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -4,11 +4,13 @@ namespace App\Factory\Interconnection\Esabora;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\ProprioType;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Messenger\Message\Esabora\DossierMessageSISH;
 use App\Repository\SuiviRepository;
 use App\Service\Esabora\AbstractEsaboraService;
+use App\Service\Esabora\Enum\PersonneQualite;
 use App\Service\Esabora\Enum\PersonneType;
 use App\Service\Esabora\Model\DossierMessageSISHPersonne;
 use App\Service\HtmlCleaner;
@@ -157,9 +159,11 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             $tel = $signalement->getTelOccupantDecoded(true)
                 ? substr($signalement->getTelOccupantDecoded(true), 0, 20)
                 : null;
+            $qualite = 'mme' === $signalement->getCiviliteOccupant() ? PersonneQualite::MADAME->value : PersonneQualite::MONSIEUR->value;
 
             return (new DossierMessageSISHPersonne())
                 ->setType(PersonneType::OCCUPANT->value)
+                ->setQualite($qualite)
                 ->setNom($signalement->getNomOccupant())
                 ->setPrenom($prenom)
                 ->setEmail($signalement->getMailOccupant())
@@ -170,9 +174,11 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             $tel = $signalement->getTelProprioDecoded(true)
                 ? substr($signalement->getTelProprioDecoded(true), 0, 20)
                 : null;
+            $qualite = ProprioType::PARTICULIER === $signalement->getTypeProprio() ? PersonneQualite::MADAME_MONSIEUR->value : PersonneQualite::SOCIETE->value;
 
             return (new DossierMessageSISHPersonne())
                 ->setType(PersonneType::PROPRIETAIRE->value)
+                ->setQualite($qualite)
                 ->setNom(substr($signalement->getNomProprio(), 0, 60))
                 ->setAdresse($signalement->getAdresseProprio())
                 ->setEmail($signalement->getMailProprio())
@@ -193,6 +199,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
 
             return (new DossierMessageSISHPersonne())
                 ->setType(PersonneType::DECLARANT->value)
+                ->setQualite(PersonneQualite::MADAME_MONSIEUR->value)
                 ->setNom($signalement->getNomDeclarant())
                 ->setPrenom($prenom)
                 ->setEmail($signalement->getMailDeclarant())

--- a/src/Service/Esabora/CiviliteMapper.php
+++ b/src/Service/Esabora/CiviliteMapper.php
@@ -14,7 +14,6 @@ class CiviliteMapper
             return 'mme' === $signalement->getCiviliteOccupant() ? PersonneQualite::MADAME : PersonneQualite::MONSIEUR;
         }
 
-
         return PersonneQualite::MADAME_MONSIEUR;
     }
 

--- a/src/Service/Esabora/CiviliteMapper.php
+++ b/src/Service/Esabora/CiviliteMapper.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Service\Esabora;
+
+use App\Entity\Enum\ProprioType;
+use App\Entity\Signalement;
+use App\Service\Esabora\Enum\PersonneQualite;
+
+class CiviliteMapper
+{
+    public static function mapOccupant(Signalement $signalement): ?PersonneQualite
+    {
+        if (!empty($signalement->getCiviliteOccupant())) {
+            return 'mme' === $signalement->getCiviliteOccupant() ? PersonneQualite::MADAME : PersonneQualite::MONSIEUR;
+        }
+
+
+        return PersonneQualite::MADAME_MONSIEUR;
+    }
+
+    public static function mapProprio(Signalement $signalement): ?PersonneQualite
+    {
+        if (ProprioType::ORGANISME_SOCIETE === $signalement->getTypeProprio()) {
+            return PersonneQualite::SOCIETE;
+        }
+
+        return null;
+    }
+
+    public static function mapDeclarant(Signalement $signalement): ?PersonneQualite
+    {
+        // For now, we don't know the declarant civilité
+        return null;
+    }
+}

--- a/src/Service/Esabora/Enum/PersonneQualite.php
+++ b/src/Service/Esabora/Enum/PersonneQualite.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Service\Esabora\Enum;
+
+enum PersonneQualite: string
+{
+    case MONSIEUR = '1';
+    case MADAME = '2';
+    case MAITRE = '4';
+    case SOCIETE = '5';
+    case MADAME_MONSIEUR = '6';
+    case MONSIEUR_ET_MADAME = '7';
+}

--- a/src/Service/Esabora/EsaboraSISHService.php
+++ b/src/Service/Esabora/EsaboraSISHService.php
@@ -443,6 +443,10 @@ class EsaboraSISHService extends AbstractEsaboraService
                 'fieldValue' => $dossierMessageSISHPersonne->getType(),
             ],
             [
+                'fieldName' => 'Personne_Qualite',
+                'fieldValue' => $dossierMessageSISHPersonne->getQualite(),
+            ],
+            [
                 'fieldName' => 'Personne_Nom',
                 'fieldValue' => $dossierMessageSISHPersonne->getNom(),
             ],

--- a/src/Service/Esabora/Model/DossierMessageSISHPersonne.php
+++ b/src/Service/Esabora/Model/DossierMessageSISHPersonne.php
@@ -5,6 +5,7 @@ namespace App\Service\Esabora\Model;
 class DossierMessageSISHPersonne
 {
     private ?string $type = null;
+    private ?string $qualite = null;
     private ?string $nom = null;
     private ?string $prenom = null;
     private ?string $telephone = null;
@@ -22,6 +23,18 @@ class DossierMessageSISHPersonne
     public function setType(?string $type): self
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function getQualite(): ?string
+    {
+        return $this->qualite;
+    }
+
+    public function setQualite(?string $qualite): self
+    {
+        $this->qualite = $qualite;
 
         return $this;
     }

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -60,6 +60,7 @@ trait FixturesHelper
             ->setVilleOccupant('Calais')
             ->setCpOccupant('62100')
             ->setNumAppartOccupant(2)
+            ->setCiviliteOccupant('mme')
             ->setNomOccupant($faker->lastName())
             ->setPrenomOccupant($faker->firstName())
             ->setTelOccupant($faker->phoneNumber())

--- a/tests/Functional/Service/Esabora/CiviliteMapperTest.php
+++ b/tests/Functional/Service/Esabora/CiviliteMapperTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Tests\Unit\Service\Esabora;
+
+use App\Entity\Signalement;
+use App\Repository\SignalementRepository;
+use App\Service\Esabora\CiviliteMapper;
+use App\Service\Esabora\Enum\PersonneQualite;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class CiviliteMapperTest extends WebTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private SignalementRepository $signalementRepository;
+
+    private const OLD_SIGNALEMENT_UUID = '00000000-0000-0000-2023-000000000008';
+    private const NEW_SIGNALEMENT_UUID = '00000000-0000-0000-2023-000000000027';
+    
+    protected function setUp(): void
+    {
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->signalementRepository = $this->entityManager->getRepository(Signalement::class);
+    }
+
+    public function testMapOccupant(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => self::NEW_SIGNALEMENT_UUID]);
+        $this->assertEquals(PersonneQualite::MADAME, CiviliteMapper::mapOccupant($signalement));
+
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => self::OLD_SIGNALEMENT_UUID]);
+        $this->assertEquals(PersonneQualite::MADAME_MONSIEUR, CiviliteMapper::mapOccupant($signalement));
+    }
+
+    public function testMapProprio(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => self::NEW_SIGNALEMENT_UUID]);
+        $this->assertEquals(PersonneQualite::SOCIETE, CiviliteMapper::mapProprio($signalement));
+
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => self::OLD_SIGNALEMENT_UUID]);
+        $this->assertNull(CiviliteMapper::mapProprio($signalement));
+    }
+
+    public function testMapDeclarant(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => self::NEW_SIGNALEMENT_UUID]);
+        $this->assertNull(CiviliteMapper::mapDeclarant($signalement));
+
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => self::OLD_SIGNALEMENT_UUID]);
+        $this->assertNull(CiviliteMapper::mapDeclarant($signalement));
+    }
+}

--- a/tests/Functional/Service/Esabora/CiviliteMapperTest.php
+++ b/tests/Functional/Service/Esabora/CiviliteMapperTest.php
@@ -7,7 +7,6 @@ use App\Repository\SignalementRepository;
 use App\Service\Esabora\CiviliteMapper;
 use App\Service\Esabora\Enum\PersonneQualite;
 use Doctrine\ORM\EntityManagerInterface;
-use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class CiviliteMapperTest extends WebTestCase
@@ -17,7 +16,7 @@ class CiviliteMapperTest extends WebTestCase
 
     private const OLD_SIGNALEMENT_UUID = '00000000-0000-0000-2023-000000000008';
     private const NEW_SIGNALEMENT_UUID = '00000000-0000-0000-2023-000000000027';
-    
+
     protected function setUp(): void
     {
         $this->entityManager = static::getContainer()->get('doctrine')->getManager();


### PR DESCRIPTION
## Ticket

#2704    

## Description
Il est possible de transmettre les données de civilité à SISH pour utilisation dans leur logiciel.

## Changements apportés
* Pour l'occupant : on a la civilité en option
  * Si vide : on envoie `MADAME_MONSIEUR`
  * Sinon, on envoie selon ce qu'on sait : `MADAME` ou `MONSIEUR`
* Pour le déclarant : on n'envoie rien
* Pour le proprio, on utilise typeProprio
  * Si le typeProprio est `ORGANISME_SOCIETE` : on envoie `SOCIETE`
  * Sinon, on n'envoie rien

## Tests
- [ ] Modifier un partenaire ARS avec le token d'env de test Esabora disponible dans keepass
- [ ] Créer un signalement avec un déclarant différent de l'occupant
- [ ] Affecter le partenaire
- [ ] Vérifier le statut dans la table `job_event`
- [ ] Vérifier dans le sas Esabora les données envoyées 
