### PR TITLE
[Esabora - SISH] Intégration du numéro de dossier aux messages de suivi de statut

### DIFF
--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -83,7 +83,7 @@ class EsaboraManager
             case EsaboraStatus::ESABORA_WAIT->value:
                 if (Affectation::STATUS_WAIT !== $currentStatus) {
                     $this->affectationManager->updateAffectation($affectation, $user, Affectation::STATUS_WAIT);
-                    $description = 'remis en attente via '.$dossierResponse->getNameSI().' (Dossier '.$dossierResponse->getDossNum().')';
+                    $description = 'remis en attente via '.$dossierResponse->getNameSI();
                 }
                 break;
             case EsaboraStatus::ESABORA_ACCEPTED->value:

--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -83,7 +83,7 @@ class EsaboraManager
             case EsaboraStatus::ESABORA_WAIT->value:
                 if (Affectation::STATUS_WAIT !== $currentStatus) {
                     $this->affectationManager->updateAffectation($affectation, $user, Affectation::STATUS_WAIT);
-                    $description = 'remis en attente via '.$dossierResponse->getNameSI();
+                    $description = 'remis en attente via '.$dossierResponse->getNameSI().' (Dossier '.$dossierResponse->getDossNum().')';
                 }
                 break;
             case EsaboraStatus::ESABORA_ACCEPTED->value:
@@ -112,6 +112,10 @@ class EsaboraManager
                     );
                 }
                 break;
+        }
+
+        if (!empty($dossierResponse->getDossNum())) {
+            $description .= ' (Dossier '.$dossierResponse->getDossNum().')';
         }
 
         return $description;

--- a/src/Service/Esabora/Response/DossierPushSISHResponse.php
+++ b/src/Service/Esabora/Response/DossierPushSISHResponse.php
@@ -46,6 +46,11 @@ class DossierPushSISHResponse implements DossierResponseInterface
         return null;
     }
 
+    public function getDossNum(): ?string
+    {
+        return null;
+    }
+
     public function getEtat(): ?string
     {
         return null;

--- a/src/Service/Esabora/Response/DossierPushSISHResponse.php
+++ b/src/Service/Esabora/Response/DossierPushSISHResponse.php
@@ -53,6 +53,6 @@ class DossierPushSISHResponse implements DossierResponseInterface
 
     public function getNameSI(): ?string
     {
-        return 'SI-SH';
+        return 'SI-Santé Habitat (SI-SH)';
     }
 }

--- a/src/Service/Esabora/Response/DossierResponseInterface.php
+++ b/src/Service/Esabora/Response/DossierResponseInterface.php
@@ -12,6 +12,8 @@ interface DossierResponseInterface
 
     public function getSasCauseRefus(): ?string;
 
+    public function getDossNum(): ?string;
+
     public function getEtat(): ?string;
 
     public function getNameSI(): ?string;

--- a/src/Service/Esabora/Response/DossierStateSCHSResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSCHSResponse.php
@@ -90,6 +90,11 @@ class DossierStateSCHSResponse implements DossierResponseInterface
         return null;
     }
 
+    public function getDossNum(): ?string
+    {
+        return null;
+    }
+
     public function getNameSI(): ?string
     {
         return 'Esabora';

--- a/src/Service/Esabora/Response/DossierStateSISHResponse.php
+++ b/src/Service/Esabora/Response/DossierStateSISHResponse.php
@@ -127,6 +127,6 @@ class DossierStateSISHResponse implements DossierResponseInterface
 
     public function getNameSI(): ?string
     {
-        return 'SI-SH';
+        return 'SI-Santé Habitat (SI-SH)';
     }
 }

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -69,7 +69,7 @@ class EsaboraManagerTest extends KernelTestCase
 
         $basePath = __DIR__.'/../../../../tools/wiremock/src/Resources/Esabora/schs/ws_etat_dossier_sas/';
         $responseEsabora = file_get_contents($basePath.$filename);
-        $dossierResponse = str_contains($filename, 'etat_rejete')
+        $dossierResponse = str_contains($filename, 'sish')
                 ? new DossierStateSISHResponse(json_decode($responseEsabora, true), 200)
                 : new DossierStateSCHSResponse(json_decode($responseEsabora, true), 200);
 
@@ -141,11 +141,20 @@ class EsaboraManagerTest extends KernelTestCase
             false, // suivi mail not sent cause signalement closed
         ];
 
-        yield EsaboraStatus::ESABORA_REJECTED->value => [
+        yield EsaboraStatus::ESABORA_REJECTED->value.' SISH' => [
             '2022-2',
             '../../sish/ws_etat_dossier_sas/etat_rejete.json',
             'refusé via SI-Santé Habitat (SI-SH) pour motif suivant:',
             Affectation::STATUS_REFUSED,
+            Suivi::TYPE_AUTO,
+            false, // suivi mail not sent cause signalement closed
+        ];
+
+        yield EsaboraStatus::ESABORA_ACCEPTED->value.' SISH' => [
+            '2022-2',
+            '../../sish/ws_etat_dossier_sas/etat_importe.json',
+            'accepté via SI-Santé Habitat (SI-SH) (Dossier 2023/SISH/0010)',
+            Affectation::STATUS_ACCEPTED,
             Suivi::TYPE_AUTO,
             false, // suivi mail not sent cause signalement closed
         ];

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -144,7 +144,7 @@ class EsaboraManagerTest extends KernelTestCase
         yield EsaboraStatus::ESABORA_REJECTED->value => [
             '2022-2',
             '../../sish/ws_etat_dossier_sas/etat_rejete.json',
-            'refusé via SI-SH pour motif suivant:',
+            'refusé via SI-Santé Habitat (SI-SH) pour motif suivant:',
             Affectation::STATUS_REFUSED,
             Suivi::TYPE_AUTO,
             false, // suivi mail not sent cause signalement closed


### PR DESCRIPTION
## Ticket

#2705   

## Description
Modification du message de suivi lors de la mise à jour d'un dossier sur SISH :
- ajout du numéro de dossier Esabora
- remplacement de `SI-SH` par `SI-Santé Habitat (SI-SH)`

## Tests
- [ ] Envoyer un dossier sur SI-SH
- [ ] L'accepter ou le refuser dans le sas
- [ ] Vérifier le suivi créé
- [ ] Faire le même test sur SCHS pour vérifier qu'il n'y a pas d'effet de bord
