### PR TITLE
[Sécurité] [FO] Masquer l'uuid des SignalementDraft en doublon trouvés

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -188,7 +188,7 @@ export default defineComponent({
           formStore.alreadyExists.signalements = requestResponse.signalements
           formStore.alreadyExists.createdAt = requestResponse.created_at
           formStore.alreadyExists.updatedAt = requestResponse.updated_at
-          formStore.alreadyExists.uuidDraft = requestResponse.uuid_draft
+          formStore.alreadyExists.draftExists = requestResponse.draft_exists
           if (link) {
             formStore.lastButtonClicked = ''
             link.click()

--- a/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -172,8 +172,8 @@ export default defineComponent({
       }
     },
     makeNewSignalement () {
-      if (formStore.alreadyExists.uuidDraft !== null && (formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement')) {
-        requests.archiveDraft(formStore.alreadyExists.uuidDraft, this.saveAndContinue)
+      if (formStore.alreadyExists.draftExists && (formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement')) {
+        requests.archiveDraft(this.saveAndContinue)
       } else if (formStore.alreadyExists.type === 'signalement') {
         this.saveAndContinue()
       }

--- a/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -77,12 +77,21 @@
             <div class="fr-modal__footer" v-if="formStore.alreadyExists.type==='signalement'">
               <ul class="fr-btns-group fr-btns-group--center fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                 <li>
-                  <button class="fr-btn" @click="getLienSuivi">
+                  <button
+                    :class="[ 'fr-btn', isButtonClicked ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
+                    @click="getLienSuivi"
+                    :disabled="isButtonClicked"
+                    >
                     Recevoir mon lien de suivi
                   </button>
                 </li>
                 <li>
-                  <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-already-exists" @click="makeNewSignalement">
+                  <button
+                    :class="[ 'fr-btn fr-btn--secondary', isButtonClicked ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
+                    aria-controls="fr-modal-already-exists"
+                    @click="makeNewSignalement"
+                    :disabled="isButtonClicked"
+                    >
                     Créer un nouveau signalement
                   </button>
                 </li>
@@ -91,12 +100,22 @@
             <div class="fr-modal__footer" v-else>
               <ul class="fr-btns-group fr-btns-group--center fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                 <li>
-                  <button class="fr-btn" aria-controls="fr-modal-already-exists" @click="continueFromDraft">
+                  <button
+                    :class="[ 'fr-btn', isButtonClicked ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
+                    aria-controls="fr-modal-already-exists"
+                    @click="continueFromDraft"
+                    :disabled="isButtonClicked"
+                    >
                     Oui, reprendre le signalement
                   </button>
                 </li>
                 <li>
-                  <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-already-exists" @click="makeNewSignalement">
+                  <button
+                    :class="[ 'fr-btn fr-btn--secondary', isButtonClicked ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
+                    aria-controls="fr-modal-already-exists"
+                    @click="makeNewSignalement"
+                    :disabled="isButtonClicked"
+                    >
                     Non, faire un nouveau signalement
                   </button>
                 </li>
@@ -129,14 +148,25 @@ export default defineComponent({
     return {
       formStore,
       errorMessage: '',
+      isButtonClicked: false,
       selectedSignalementUuid: null as string | null
     }
   },
   methods: {
+    desactiveNextbutton () {
+      if (formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire') {
+        formStore.lastButtonClicked = 'vos_coordonnees_occupant_next'
+      } else {
+        formStore.lastButtonClicked = 'vos_coordonnees_tiers_next'
+      }
+      this.isButtonClicked = true
+    },
     continueFromDraft () {
+      this.desactiveNextbutton()
       requests.sendMailContinueFromDraft(this.gotoValidationScreen)
     },
     getLienSuivi () {
+      this.desactiveNextbutton()
       this.errorMessage = ''
       if (this.selectedSignalementUuid === null) {
         if (this.formStore.alreadyExists.signalements && formStore.alreadyExists.signalements?.length === 1) {
@@ -172,6 +202,7 @@ export default defineComponent({
       }
     },
     makeNewSignalement () {
+      this.desactiveNextbutton()
       if (formStore.alreadyExists.draftExists && (formStore.alreadyExists.type === 'draft' || formStore.alreadyExists.type === 'signalement')) {
         requests.archiveDraft(this.saveAndContinue)
       } else if (formStore.alreadyExists.type === 'signalement') {
@@ -232,5 +263,19 @@ export default defineComponent({
     .signalement-form-modal-already-exists .fr-fieldset__element.item-divided {
       flex-basis: content;
     }
+  }
+  .fr-btn.fr-btn--loading {
+    opacity: 0.5;
+  }
+  .fr-btn.fr-btn--loading:disabled {
+    background-color: var(--background-action-high-blue-france);
+    color: var(--text-inverted-blue-france);
+  }
+  .fr-btn.fr-btn--secondary.fr-btn--loading:disabled {
+    background-color: transparent;
+    --hover: inherit;
+    --active: inherit;
+    color: var(--text-action-high-blue-france);
+    box-shadow: inset 0 0 0 1px var(--border-action-high-blue-france);
   }
 </style>

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -249,7 +249,7 @@ export default defineComponent({
       } else if (type === 'toggle') {
         this.toggleComponentBySlug(param, param2)
       } else if (type === 'archive') {
-        requests.archiveDraft(formStore.data.uuidSignalementDraft, this.gotoHomepage)
+        requests.archiveDraft(this.gotoHomepage)
       } else if (type.includes('goto')) {
         await this.showScreenBySlug(param, param2, type.includes('save'), type.includes('checkloc'))
       } else if (type.includes('resolve')) {

--- a/assets/vue/components/signalement-form/requests.ts
+++ b/assets/vue/components/signalement-form/requests.ts
@@ -113,8 +113,8 @@ export const requests = {
   },
 
   sendMailContinueFromDraft (functionReturn: Function) {
-    const url = formStore.props.ajaxurlSendMailContinueFromDraft.replace('uuid', formStore.alreadyExists.uuidDraft)
-    requests.doRequestPost(url, '', functionReturn, undefined)
+    const url = formStore.props.ajaxurlSendMailContinueFromDraft
+    requests.doRequestPost(url, formStore.data, functionReturn, undefined)
   },
 
   sendMailGetLienSuivi (uuid: any, functionReturn: Function) {
@@ -122,9 +122,9 @@ export const requests = {
     requests.doRequestPost(url, '', functionReturn, undefined)
   },
 
-  archiveDraft (uuidDraft: string, functionReturn: Function) {
-    const url = formStore.props.ajaxurlArchiveDraft.replace('uuid', uuidDraft)
-    requests.doRequestPost(url, '', functionReturn, undefined)
+  archiveDraft (functionReturn: Function) {
+    const url = formStore.props.ajaxurlArchiveDraft
+    requests.doRequestPost(url, formStore.data, functionReturn, undefined)
   },
 
   validateAddress (valueAdress: string, functionReturn: Function) {

--- a/assets/vue/components/signalement-form/store.ts
+++ b/assets/vue/components/signalement-form/store.ts
@@ -51,7 +51,7 @@ interface FormStore {
     type: string | null
     uuid: string | null
     signalements: any[] | null
-    uuidDraft: string | null
+    draftExists: boolean | null
     createdAt: string | null
     updatedAt: string | null
   }
@@ -93,7 +93,7 @@ const formStore: FormStore = reactive({
     uuid: null,
     type: null,
     signalements: null,
-    uuidDraft: null,
+    draftExists: null,
     createdAt: null,
     updatedAt: null
   },

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -122,18 +122,10 @@ class SignalementController extends AbstractController
                 $isTiersDeclarant
             );
 
-            $dataToHash = SignalementDraftHelper::getEmailDeclarant($signalementDraftRequest);
-            $dataToHash .= $signalementDraftRequest->getAdresseLogementAdresse();
-            $hash = hash('sha256', $dataToHash);
-
-            $existingSignalementDraft = $signalementDraftRepository->findOneBy(
-                [
-                    'checksum' => $hash,
-                    'status' => SignalementDraftStatus::EN_COURS,
-                ],
-                [
-                    'id' => 'DESC',
-                ]
+            $existingSignalementDraft = $this->findSignalementDraft(
+                $signalementDraftRequest,
+                $signalementDraftRepository,
+                $signalementRepository
             );
 
             if (!empty($existingSignalements)) {
@@ -151,7 +143,7 @@ class SignalementController extends AbstractController
                     'already_exists' => true,
                     'type' => 'signalement',
                     'signalements' => $signalements,
-                    'uuid_draft' => $existingSignalementDraft?->getUuid() ?? null,
+                    'draft_exists' => $existingSignalementDraft ? true : false,
                 ]);
             }
 
@@ -159,7 +151,7 @@ class SignalementController extends AbstractController
                 return $this->json([
                     'already_exists' => true,
                     'type' => 'draft',
-                    'uuid_draft' => $existingSignalementDraft->getUuid(),
+                    'draft_exists' => true,
                     'created_at' => $existingSignalementDraft->getCreatedAt(),
                     'updated_at' => $existingSignalementDraft->getUpdatedAt(),
                 ]);
@@ -223,16 +215,29 @@ class SignalementController extends AbstractController
         ]);
     }
 
-    #[Route('/signalement-draft/{uuid}/send_mail', name: 'send_mail_continue_from_draft')]
+    #[Route('/signalement-draft/send_mail', name: 'send_mail_continue_from_draft', methods: 'POST')]
     public function sendMailContinueFromDraft(
         NotificationMailerRegistry $notificationMailerRegistry,
-        SignalementDraft $signalementDraft,
-        Request $request
+        SignalementDraftRequestSerializer $serializer,
+        Request $request,
+        SignalementDraftRepository $signalementDraftRepository,
+        SignalementRepository $signalementRepository
     ): JsonResponse {
+        /** @var SignalementDraftRequest $signalementDraftRequest */
+        $signalementDraftRequest = $serializer->deserialize(
+            $payload = $request->getContent(),
+            SignalementDraftRequest::class,
+            'json'
+        );
+
+        $signalementDraft = $this->findSignalementDraft(
+            $signalementDraftRequest,
+            $signalementDraftRepository,
+            $signalementRepository
+        );
+
         if (
-            $request->isMethod('POST')
-            && $signalementDraft
-            && SignalementDraftStatus::EN_COURS === $signalementDraft->getStatus()
+            $signalementDraft
         ) {
             $success = $notificationMailerRegistry->send(
                 new NotificationMail(
@@ -297,16 +302,29 @@ class SignalementController extends AbstractController
         return $this->json(['response' => 'error'], Response::HTTP_BAD_REQUEST);
     }
 
-    #[Route('/signalement-draft/{uuid}/archive', name: 'archive_draft')]
+    #[Route('/signalement-draft/archive', name: 'archive_draft', methods: 'POST')]
     public function archiveDraft(
-        SignalementDraft $signalementDraft,
         Request $request,
-        SignalementDraftManager $signalementDraftManager
+        SignalementDraftRequestSerializer $serializer,
+        SignalementDraftManager $signalementDraftManager,
+        SignalementDraftRepository $signalementDraftRepository,
+        SignalementRepository $signalementRepository
     ): JsonResponse {
+        /** @var SignalementDraftRequest $signalementDraftRequest */
+        $signalementDraftRequest = $serializer->deserialize(
+            $payload = $request->getContent(),
+            SignalementDraftRequest::class,
+            'json'
+        );
+
+        $signalementDraft = $this->findSignalementDraft(
+            $signalementDraftRequest,
+            $signalementDraftRepository,
+            $signalementRepository
+        );
+
         if (
-            $request->isMethod('POST')
-            && $signalementDraft
-            && SignalementDraftStatus::EN_COURS === $signalementDraft->getStatus()
+            $signalementDraft
         ) {
             $signalementDraft->setStatus(SignalementDraftStatus::ARCHIVE);
             $signalementDraftManager->save($signalementDraft);
@@ -315,6 +333,35 @@ class SignalementController extends AbstractController
         }
 
         return $this->json(['response' => 'error'], Response::HTTP_BAD_REQUEST);
+    }
+
+    private function findSignalementDraft(
+        SignalementDraftRequest $signalementDraftRequest,
+        SignalementDraftRepository $signalementDraftRepository,
+        SignalementRepository $signalementRepository
+    ): ?SignalementDraft {
+        $isTiersDeclarant = SignalementDraftHelper::isTiersDeclarant($signalementDraftRequest);
+        $existingSignalements = $signalementRepository->findAllForEmailAndAddress(
+            SignalementDraftHelper::getEmailDeclarant($signalementDraftRequest),
+            $signalementDraftRequest->getAdresseLogementAdresseDetailNumero(),
+            $signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal(),
+            $signalementDraftRequest->getAdresseLogementAdresseDetailCommune(),
+            $isTiersDeclarant
+        );
+
+        $dataToHash = SignalementDraftHelper::getEmailDeclarant($signalementDraftRequest);
+        $dataToHash .= $signalementDraftRequest->getAdresseLogementAdresse();
+        $hash = hash('sha256', $dataToHash);
+
+        return $signalementDraftRepository->findOneBy(
+            [
+                'checksum' => $hash,
+                'status' => SignalementDraftStatus::EN_COURS,
+            ],
+            [
+                'id' => 'DESC',
+            ]
+        );
     }
 
     #[Route('/checkterritory', name: 'front_signalement_check_territory', methods: ['GET'])]

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -24,9 +24,9 @@
         data-platform-name="{{ platform.name }}"
         data-ajaxurl-check-territory="{{ path('front_signalement_check_territory') }}"
         data-ajaxurl-check-signalement-or-draft-already-exists="{{ path('check_signalement_or_draft_already_exists') }}"
-        data-ajaxurl-send-mail-continue-from-draft="{{ path('send_mail_continue_from_draft', {uuid: 'uuid'}) }}"
+        data-ajaxurl-send-mail-continue-from-draft="{{ path('send_mail_continue_from_draft') }}"
         data-ajaxurl-send-mail-get-lien-suivi="{{ path('send_mail_get_lien_suivi', {uuid: 'uuid'}) }}"
-        data-ajaxurl-archive-draft="{{ path('archive_draft', {uuid: 'uuid'}) }}"
+        data-ajaxurl-archive-draft="{{ path('archive_draft') }}"
         >
     </div>
   </main>

--- a/tests/Functional/Manager/SignalementDraftManagerTest.php
+++ b/tests/Functional/Manager/SignalementDraftManagerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Tests\Functional\Manager;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\User;
+use App\Factory\SignalementDraftFactory;
+use App\Manager\SignalementDraftManager;
+use App\Repository\SignalementDraftRepository;
+use App\Serializer\SignalementDraftRequestSerializer;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class SignalementDraftManagerTest extends WebTestCase
+{
+    public const TERRITORY_13 = 13;
+
+    private EntityManagerInterface $entityManager;
+    private ManagerRegistry $managerRegistry;
+    private SignalementDraftFactory $signalementDraftFactory;
+    private EventDispatcherInterface $eventDispatcher;
+    private SignalementDraftManager $signalementDraftManager;
+    private UrlGeneratorInterface $urlGenerator;
+    private SignalementDraftRequestSerializer $signalementDraftRequestSerializer;
+    private SignalementDraftRepository $signalementDraftRepository;
+
+    protected function setUp(): void
+    {
+        $client = static::createClient();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
+        $this->signalementDraftFactory = static::getContainer()->get(SignalementDraftFactory::class);
+        $this->eventDispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $this->urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
+        $this->signalementDraftRequestSerializer = static::getContainer()->get(SignalementDraftRequestSerializer::class);
+        $this->signalementDraftRepository = static::getContainer()->get(SignalementDraftRepository::class);
+
+        $this->signalementDraftManager = new SignalementDraftManager(
+            $this->signalementDraftFactory,
+            $this->eventDispatcher,
+            $this->managerRegistry,
+            $this->urlGenerator,
+            $this->signalementDraftRequestSerializer,
+            $this->signalementDraftRepository,
+        );
+
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+    }
+
+    public function testFindSignalementDraftByAddressAndMail()
+    {
+        $signalementDraftRequest = new SignalementDraftRequest();
+        $signalementDraftRequest->setAdresseLogementAdresse('33 Rue des phoceens 13002 Marseille');
+        $signalementDraftRequest->setProfil(ProfileDeclarant::LOCATAIRE->name);
+        $signalementDraftRequest->setVosCoordonneesOccupantEmail('locataire-01@histologe.fr');
+        $signalementDraft = $this->signalementDraftManager->findSignalementDraftByAddressAndMail($signalementDraftRequest);
+
+        $this->assertEquals('00000000-0000-0000-2023-locataire001', $signalementDraft->getUuid());
+    }
+}


### PR DESCRIPTION
## Ticket

#2677   

## Description
Ne pas renvoyer l'uuid du signalement draft dans la route `check_signalement_or_draft_already_exists`

## Changements apportés
* Dans l'app Vue, on remplace formStore.alreadyExists.uuidDraft par formStore.alreadyExists.draftExists et on ne met plus l'uuid dans les routes appelées (par contre on envoie formStore.data)
* Dans le controller, création d'une fonction findSignalementDraft qui renvoie un SignalementDraft à partir d'un SignalementDraftRequest, et on utilise cette fonction dans les 3 routes pour retrouver l'uuid du draft concerné

## Pré-requis

## Tests
- [ ] Commencer un signalement avec une adresse et un mail déjà existant en BDD, la modale s'ouvre, vérifier dans la console qu'on ne reçoit pas l'uuid du draft (route '`/signalement-draft/check`')
- [ ] Choisir de faire un nouveau signalement, vérifier dans la console, et en base que l'ancien draft est bien archivé et que l'uuid du draft n'a pas transité (route '`/signalement-draft/archive`')
- [ ] Recommencer, et choisir cette fois-ci de reprendre le brouillon existant, vérifier dans la console que l'uuid ne transite pas, puis qu'on reçoit bien le mail dans mailcatcher.  (route '`/signalement-draft/send_mail`') Vérifier en base qu'un nouveau draft n'est pas créé.
