### PR TITLE
[BO - Admin] Avoir accès à la liste des signalements qu'on peut désarchiver

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -50,3 +50,4 @@ import './controllers/back_signalement_delete_file/back_signalement_delete_file'
 import './controllers/front_demande_lien_signalement/front_demande_lien_signalement';
 import './controllers/front_suivi_signalement/front_suivi_signalement';
 import './controllers/search_filter_form'
+import './controllers/back_archived_signalements/back_archived_signalements_reactiver'

--- a/assets/controllers/back_archived_signalements/back_archived_signalements_reactiver.js
+++ b/assets/controllers/back_archived_signalements/back_archived_signalements_reactiver.js
@@ -1,0 +1,20 @@
+document?.querySelectorAll('[data-reactive]')?.forEach(actionBtn => {
+    actionBtn.addEventListeners('click touchdown', event => {
+        event.preventDefault();
+        let className;
+        if (event.target.classList.contains('signalement-row-reactive'))
+            className = '.signalement-row';
+        if (confirm('Voulez-vous vraiment réactiver ce signalement ?')) {
+            let formData = new FormData;
+            formData.append('_token', actionBtn.getAttribute('data-token'))
+            fetch(actionBtn.getAttribute('data-reactive'), {
+                method: 'POST',
+                body: formData,
+            }).then(r => {
+                if (r.ok) {
+                    window.location = r.url
+                }
+            })
+        }
+    })
+});

--- a/assets/controllers/back_archived_signalements/back_archived_signalements_reactiver.js
+++ b/assets/controllers/back_archived_signalements/back_archived_signalements_reactiver.js
@@ -1,9 +1,6 @@
 document?.querySelectorAll('[data-reactive]')?.forEach(actionBtn => {
     actionBtn.addEventListeners('click touchdown', event => {
         event.preventDefault();
-        let className;
-        if (event.target.classList.contains('signalement-row-reactive'))
-            className = '.signalement-row';
         if (confirm('Voulez-vous vraiment réactiver ce signalement ?')) {
             let formData = new FormData;
             formData.append('_token', actionBtn.getAttribute('data-token'))

--- a/src/Controller/Back/ArchivedSignalementController.php
+++ b/src/Controller/Back/ArchivedSignalementController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\Partner;
+use App\Entity\Signalement;
+use App\Repository\SignalementRepository;
+use App\Repository\TerritoryRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/bo/signalements-archives')]
+class ArchivedSignalementController extends AbstractController
+{
+    #[Route('/', name: 'back_archived_signalements_index', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function index(
+        Request $request,
+        TerritoryRepository $territoryRepository,
+        SignalementRepository $signalementRepository
+    ): Response {
+        $page = $request->get('page') ?? 1;
+
+        $currentTerritory = $territoryRepository->find((int) $request->get('territory'));
+        $referenceTerms = $request->get('referenceTerms');
+
+        $paginatedArchivedSignalements = $signalementRepository->findAllArchived(
+            territory: $currentTerritory,
+            referenceTerms: $referenceTerms,
+            page: (int) $page
+        );
+
+        if ($request->isMethod(Request::METHOD_POST)) {
+            $currentTerritory = $territoryRepository->find((int) $request->request->get('territory'));
+            $referenceTerms = $request->request->get('bo-filters-referenceTerms');
+
+            return $this->redirect($this->generateUrl('back_archived_signalements_index', [
+                'page' => 1,
+                'territory' => $currentTerritory?->getId(),
+                'referenceTerms' => $referenceTerms,
+            ]));
+        }
+
+        $totalArchivedSignalements = \count($paginatedArchivedSignalements);
+
+        return $this->render('back/signalement_archived/index.html.twig', [
+            'currentTerritory' => $currentTerritory,
+            'referenceTerms' => $referenceTerms,
+            'territories' => $territoryRepository->findAllList(),
+            'signalements' => $paginatedArchivedSignalements,
+            'total' => $totalArchivedSignalements,
+            'page' => $page,
+            'pages' => (int) ceil($totalArchivedSignalements / Partner::MAX_LIST_PAGINATION),
+        ]);
+    }
+
+    #[Route('/{uuid}/reactiver', name: 'back_archived_signalements_reactiver', methods: 'POST')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function reactiveSignalement(
+        Signalement $signalement,
+        Request $request,
+        ManagerRegistry $doctrine
+    ): RedirectResponse {
+        if ($this->isCsrfTokenValid('signalement_reactive_'.$signalement->getId(), $request->get('_token'))) {
+            $signalement->setStatut(Signalement::STATUS_ACTIVE);
+            $doctrine->getManager()->persist($signalement);
+            $doctrine->getManager()->flush();
+
+            return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+        }
+
+        return $this->redirectToRoute('back_archived_signalements_index');
+    }
+}

--- a/src/Controller/Back/ArchivedSignalementController.php
+++ b/src/Controller/Back/ArchivedSignalementController.php
@@ -66,7 +66,8 @@ class ArchivedSignalementController extends AbstractController
         Request $request,
         ManagerRegistry $doctrine
     ): RedirectResponse {
-        if ($this->isCsrfTokenValid('signalement_reactive_'.$signalement->getId(), $request->get('_token'))) {
+        if ($this->isCsrfTokenValid('signalement_reactive_'.$signalement->getId(), $request->get('_token'))
+        && Signalement::STATUS_ARCHIVED === $signalement->getStatut()) {
             $signalement->setStatut(Signalement::STATUS_ACTIVE);
             $doctrine->getManager()->persist($signalement);
             $doctrine->getManager()->flush();

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1254,4 +1254,34 @@ class SignalementRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function findAllArchived(
+        Territory|null $territory,
+        ?string $referenceTerms,
+        $page
+    ): Paginator {
+        $maxResult = Partner::MAX_LIST_PAGINATION;
+        $firstResult = ($page - 1) * $maxResult;
+        $queryBuilder = $this->createQueryBuilder('s');
+
+        $queryBuilder->where('s.statut = :archived')
+        ->setParameter('archived', Signalement::STATUS_ARCHIVED);
+
+        if (!empty($territory)) {
+            $queryBuilder
+                ->andWhere('s.territory = :territory')
+                ->setParameter('territory', $territory);
+        }
+
+        if (!empty($referenceTerms)) {
+            $queryBuilder
+                ->andWhere('s.reference LIKE :referenceTerms');
+            $queryBuilder
+                ->setParameter('referenceTerms', $referenceTerms);
+        }
+
+        $queryBuilder->setFirstResult($firstResult)->setMaxResults($maxResult);
+
+        return new Paginator($queryBuilder->getQuery(), false);
+    }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1264,8 +1264,9 @@ class SignalementRepository extends ServiceEntityRepository
         $firstResult = ($page - 1) * $maxResult;
         $queryBuilder = $this->createQueryBuilder('s');
 
-        $queryBuilder->where('s.statut = :archived')
-        ->setParameter('archived', Signalement::STATUS_ARCHIVED);
+        $queryBuilder
+            ->where('s.statut = :archived')
+            ->setParameter('archived', Signalement::STATUS_ARCHIVED);
 
         if (!empty($territory)) {
             $queryBuilder
@@ -1275,8 +1276,7 @@ class SignalementRepository extends ServiceEntityRepository
 
         if (!empty($referenceTerms)) {
             $queryBuilder
-                ->andWhere('s.reference LIKE :referenceTerms');
-            $queryBuilder
+                ->andWhere('s.reference LIKE :referenceTerms')
                 ->setParameter('referenceTerms', $referenceTerms);
         }
 

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -79,7 +79,7 @@
                     </ul>
                 </div>
                 {% if is_granted('ROLE_ADMIN_PARTNER') %}
-                    {% set routesAdmin = ['back_user_report_index', 'back_situation_', 'back_partner_', 'back_account_', 'back_inactive_account_', 'back_expired_account_', 'back_archived_partner'] %}
+                    {% set routesAdmin = ['back_user_report_index', 'back_situation_', 'back_partner_', 'back_account_', 'back_inactive_account_', 'back_expired_account_', 'back_archived_partner', 'back_archived_signalements_index'] %}
                     <button class="fr-sidemenu__btn"
                             aria-expanded="{% if routesAdmin|filter(route => app.request.get('_route') starts with route)|length > 0  %}true{% else %}false{% endif %}"
                             aria-controls="fr-sidemenu-outils-admin">Outils Admin
@@ -120,6 +120,11 @@
                                         <a class="fr-sidemenu__link" href="{{ path('back_expired_account_index') }}"
                                         target="_self"
                                         {% if 'back_expired_account_' in app.request.get('_route') %}aria-current="page"{% endif %}>Comptes expirés</a>
+                                    </li>
+                                    <li class="fr-sidemenu__item {% if 'back_inactive_account_' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
+                                        <a class="fr-sidemenu__link" href="{{ path('back_archived_signalements_index') }}"
+                                        target="_self"
+                                        {% if 'back_archived_signalements' in app.request.get('_route') %}aria-current="page"{% endif %}>Signalements archivés</a>
                                     </li>
                                 {% endif %}
                             {% endif %}

--- a/templates/back/signalement_archived/index.html.twig
+++ b/templates/back/signalement_archived/index.html.twig
@@ -34,7 +34,7 @@
                 </select>
             </div>
             <div class="fr-col-2 fr-p-2v">
-                <a href="{{ path('back_account_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser</a>
+                <a href="{{ path('back_archived_signalements_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser</a>
             </div>
         </form>
     </section>
@@ -116,7 +116,7 @@
         </table>
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
-            {{ macros.customPagination(pages, page, 'back_account_index', {territory: (currentTerritory ? currentTerritory.id :  null), referenceTerms: referenceTerms}) }}
+            {{ macros.customPagination(pages, page, 'back_archived_signalements_index', {territory: (currentTerritory ? currentTerritory.id :  null), referenceTerms: referenceTerms}) }}
         </div>
     </section>
 {% endblock %}

--- a/templates/back/signalement_archived/index.html.twig
+++ b/templates/back/signalement_archived/index.html.twig
@@ -1,0 +1,122 @@
+{% extends 'back/base_bo.html.twig' %}
+
+{% block title %}Signalements archivés{% endblock %}
+
+{% block content %}
+    <section class="fr-p-5v">
+        <header>
+            <div class="fr-grid-row">
+                <div class="fr-col-6 fr-text--left">
+                    <h1 class="fr-h1 fr-mb-0">Signalements archivés</h1>
+                </div>
+            </div>
+        </header>
+    </section>
+    <section class="fr-container--fluid">
+        <form action="#" name="bo-filters-form" id="bo_filters_form" method="POST"
+              class="fr-background--grey fr-p-2v fr-grid-row fr-grid-row--bottom">
+              
+            <div class="fr-col-4 fr-p-2v">
+                <div class="fr-search-bar fr-mt-2v" id="header-search">
+                    <input class="fr-input" placeholder="Référence" type="search" id="header-search-input"
+                        name="bo-filters-referenceTerms" value="{{ referenceTerms ?? '' }}">
+                    <button class="fr-btn" title="Rechercher">
+                        {{referenceTerms is null ? 'Référence' : referenceTerms}}
+                    </button>&nbsp;
+                </div>
+            </div>
+            <div class="fr-col-3 fr-p-2v">
+                <select id="bo-filters-territories" class="fr-select fr-select-submit" name="territory">
+                    <option value="" {{ currentTerritory is null ? 'selected' : '' }}>Tous les territoires</option>
+                    {% for territory in territories %}
+                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.name|upper }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="fr-col-2 fr-p-2v">
+                <a href="{{ path('back_account_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser</a>
+            </div>
+        </form>
+    </section>
+    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
+        <h2 class="fr-h2 fr-mb-0" id="desc-table">{{total}} signalements archivés</h2>
+    </section>
+    <section class="fr-col-12 fr-table fr-table--bordered fr-pt-0">
+        <table class="fr-display-inline-table sortable" aria-label="Liste des signalements archivés" aria-describedby="desc-table">
+            <thead>
+            <tr>
+                <th>#Ref.</th>
+                <th>Territoire</th>
+                <th>Date</th>
+                <th>Occupant</th>
+                <th>Adresse</th>
+                <th>Affectation</th>
+                <th>Dernier suivi</th>
+                <th class="fr-text--right ">Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+                {% for index,signalement in signalements %}
+                    <tr class="{% if signalement.statut is same as(1) or signalement.statut is same as(3) %}fr-background-contrast--orange-terre-battue{% endif %} signalement-row"
+                        data-score="{{ signalement.score }}">
+                        <td>
+                            <a href="{{ path('back_signalement_view',{uuid:signalement.uuid}) }}"
+                            class="fr-ws-nowrap">{{ signalement.reference }}</a>
+                        </td>
+                        <td>{{ signalement.territory.name}} ({{ signalement.territory.zip}}) </td>
+                        <td>{{ signalement.createdAt|date('d/m/Y') }}</td>
+                        <td>
+                            {{ signalement.nomOccupant|upper }}<br>{{ signalement.prenomOccupant|capitalize }}
+                        </td>
+                        <td>{{ signalement.villeOccupant|upper }} <br><small>[{{ signalement.adresseOccupant }}]</small></td>
+                        <td>
+                            {% for affectation in signalement.affectations %}
+                                {% set classe = '' %}
+                                {% if affectation.statut is same as (0) %}
+                                    {% set classe = 'fr-badge fr-badge--info' %}
+                                {% elseif affectation.statut is same as (1) %}
+                                    {% set classe = 'fr-badge fr-badge--success' %}
+                                {% elseif affectation.statut is same as (2) %}
+                                    {% set classe = 'fr-badge fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line' %}
+                                {% elseif affectation.statut is same as (3) %}
+                                    {% set classe = 'fr-badge fr-fi-close-circle-fill' %}
+                                {% endif %}
+                                <small class="{{ classe }} fr-ws-nowrap fr-badge--sm fr-my-1v fr-text--bold fr-display-block fr-limit-chars"><span
+                                    > {{ affectation.partner.nom }}</span></small>
+                            {% else %}
+                                Aucune
+                            {% endfor %}
+                        </td>
+                        <td>
+                            {% if signalement.lastSuiviBy is not null %}
+                                <strong>{{ signalement.lastSuiviAt|date('d.m.Y') }}</strong> <br>{% set classe = '' %}
+                                {% if 'OCCUPANT' == signalement.lastSuiviBy or 'DECLARANT' == signalement.lastSuiviBy %}
+                                    {% set classe = 'fr-badge fr-badge--warning' %}
+                                {% endif %}
+                                <small class="{{ classe }}">                
+                                    {% if signalement.lastSuiviBy is same as 'Aucun' %}   
+                                        Occupant ou déclarant         
+                                    {% else %}
+                                        {{ signalement.lastSuiviBy }}
+                                    {% endif %}
+                                </small> <br>
+                            {% else %}
+                                Aucun
+                            {% endif %}
+                        </td>
+                        <td class="fr-text--right fr-ws-nowrap">
+                            <button data-reactive="{{ path('back_archived_signalements_reactiver',{uuid:signalement.uuid}) }}"
+                                data-token="{{ csrf_token('signalement_reactive_'~signalement.id) }}"
+                                class="fr-btn fr-icon-flashlight-fill fr-btn--sm signalement-row-reactive">
+                            </button>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
+            {% import '_partials/macros.html.twig' as macros %}
+            {{ macros.customPagination(pages, page, 'back_account_index', {territory: (currentTerritory ? currentTerritory.id :  null), referenceTerms: referenceTerms}) }}
+        </div>
+    </section>
+{% endblock %}

--- a/tests/Functional/Controller/ArchivedSignalementControllerTest.php
+++ b/tests/Functional/Controller/ArchivedSignalementControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Signalement;
+use App\Repository\SignalementRepository;
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class ArchivedSignalementControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    private ?KernelBrowser $client = null;
+    private UserRepository $userRepository;
+    private RouterInterface $router;
+    private SignalementRepository $signalementRepository;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->userRepository = static::getContainer()->get(UserRepository::class);
+        $this->router = self::getContainer()->get(RouterInterface::class);
+        $this->signalementRepository = self::getContainer()->get(SignalementRepository::class);
+
+        $user = $this->userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $this->client->loginUser($user);
+    }
+
+    public function testArchivedSignalementIndex(): void
+    {
+        $route = $this->router->generate('back_archived_signalements_index');
+        $this->client->request('GET', $route);
+        $this->assertResponseIsSuccessful();
+
+        $this->assertSelectorTextContains('h2', '2 signalements archivés');
+    }
+
+    public function testReactiveSignalement()
+    {
+        /** @var Signalement $signalement */
+        $signalement = $this->signalementRepository->findOneBy([
+            'statut' => Signalement::STATUS_ARCHIVED,
+        ]);
+
+        $route = $this->router->generate('back_archived_signalements_reactiver', [
+            'uuid' => $signalement->getUuid(),
+        ]);
+
+        $this->client->request(
+            'POST',
+            $route,
+            [
+                '_token' => $this->generateCsrfToken($this->client, 'signalement_reactive_'.$signalement->getId()),
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+        $this->assertEquals(Signalement::STATUS_ACTIVE, $signalement->getStatut());
+    }
+}

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -131,4 +131,34 @@ class SignalementRepositoryTest extends KernelTestCase
         $this->assertArrayHasKey('count', $desordreCriteres[0]);
         $this->assertArrayHasKey('labelCritere', $desordreCriteres[0]);
     }
+
+    public function testFindAllArchived(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $signalementsArchived = $signalementRepository->findAllArchived(null, null, null);
+        $this->assertEquals(2, \count($signalementsArchived));
+    }
+
+    public function testFindAllArchivedTerritory(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        /** @var TerritoryRepository $territoryRepository */
+        $territoryRepository = $this->entityManager->getRepository(Territory::class);
+        $territory = $territoryRepository->findOneBy(['zip' => '13']);
+        $signalementsArchived = $signalementRepository->findAllArchived($territory, null, null);
+        $this->assertEquals(1, \count($signalementsArchived));
+    }
+
+    public function testFindAllArchivedReference(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        /** @var TerritoryRepository $territoryRepository */
+        $territoryRepository = $this->entityManager->getRepository(Territory::class);
+        $territory = $territoryRepository->findOneBy(['zip' => '13']);
+        $signalementsArchived = $signalementRepository->findAllArchived(null, '2024-04', null);
+        $this->assertEquals(1, \count($signalementsArchived));
+    }
 }


### PR DESCRIPTION
## Ticket

#2659   

## Description
Avoir une page avec la liste des signalements archivés, filtrable par territoire et par référence, et un bouton pour les désarchiver. 

## Changements apportés
* Création du controlleur et de la route
* Création du template twig et du controlleur js associé
* Création des tests

## Pré-requis

## Tests
- [ ] Aller sur cette nouvelle page, et vérifier la liste des signalements archivés (en comparant avec BDD)
- [ ] Tester le filtre par référence et par territoire
- [ ] Si base de prod, vérifier la pagination, et la pagination avec filtre
