### PR TITLE
[FO - Signalement] Pour les tiers, la réponse de l'assurance est un champ facultatif

### DIFF
--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1007,10 +1007,13 @@
         },
         {
           "type": "SignalementFormTextarea",
-          "label": "Quelle a été la réponse de l'assurance ?",
+          "label": "Quelle a été la réponse de l'assurance ? (facultatif)",
           "slug": "info_procedure_reponse_assurance",
           "conditional": {
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
+          },
+          "validate": {
+            "required": false
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1236,10 +1236,13 @@
         },
         {
           "type": "SignalementFormTextarea",
-          "label": "Quelle a été la réponse de l'assurance ?",
+          "label": "Quelle a été la réponse de l'assurance ? (facultatif)",
           "slug": "info_procedure_reponse_assurance",
           "conditional": {
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
+          },
+          "validate": {
+            "required": false
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1234,10 +1234,13 @@
         },
         {
           "type": "SignalementFormTextarea",
-          "label": "Quelle a été la réponse de l'assurance ?",
+          "label": "Quelle a été la réponse de l'assurance ? (facultatif)",
           "slug": "info_procedure_reponse_assurance",
           "conditional": {
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
+          },
+          "validate": {
+            "required": false
           }
         },
         {

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -133,7 +133,7 @@
       </div>
 
       <!-- LA PROCEDURE  -->
-      <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.data.profil === 'bailleur'">
+      <div>
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
           <div class="fr-col-8">
             <h4 class="fr-h6">La procédure</h4>


### PR DESCRIPTION
## Ticket

#2275   

## Description
Dans le formulaire de signalement, la réponse de l'assurance est un champ facultatif pour les tiers.

## Pré-requis

`npm run watch`

## Tests
- [ ] Vérifier pour les tiers pro, les tiers particulier et les services de secours que le champ "réponse de l'assurance" est facultatif
