### PR TITLE
[BO - Listes des signalements] Problème d'affichage des procédures suspectées sur la carte

### DIFF
--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -18,14 +18,15 @@
               <div class="fr-col-xl-10 fr-col-12">
                 <p class="fr-my-1w" v-if="item.conclusionsProcedure === null"><span class="fr-icon-lightbulb-line" aria-hidden="true"></span>
                   Procédure(s) suspectée(s) :
-                  <span v-if="item.qualificationsStatusesLabels.length === 0" class="fr-text--sm">Aucune</span>
+                  <span v-if="item.qualificationsStatusesLabels.length === 0 && item.nDE === false" class="fr-text--sm">Aucune</span>
                   <span
                       v-else
                       v-for="(procedure, index) in item.qualificationsStatusesLabels"
                       :key="index"
                       class="fr-badge fr-badge--sm fr-badge--no-icon fr-mx-1v"
                       :class="getBadgeClassNameQualification(procedure)"
-                      >{{ getBadgeLabelQualification(procedure) }}</span>
+                      >{{ getBadgeLabelQualification(procedure) }} </span>
+                  <span v-if="item.nDE" class="fr-badge fr-badge--sm fr-badge--no-icon fr-mx-1v fr-badge--info">NON DÉCENCE ÉNERGÉTIQUE</span>
                 </p>
                 <p v-else class="fr-my-1w"><span class="fr-icon-lightbulb-line" aria-hidden="true"></span>
                   Procédure(s) constatée(s) :
@@ -172,6 +173,7 @@ export default defineComponent({
       return className
     },
     getBadgeLabelQualification (label: string) {
+      console.log(label)
       let labelText = label
       labelText = labelText.replace('Suspicion ', '')
       labelText = labelText.replace(' à vérifier', '')

--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -173,7 +173,6 @@ export default defineComponent({
       return className
     },
     getBadgeLabelQualification (label: string) {
-      console.log(label)
       let labelText = label
       labelText = labelText.replace('Suspicion ', '')
       labelText = labelText.replace(' à vérifier', '')

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -569,7 +569,20 @@ class SearchFilter
     private function addFilterProcedure(QueryBuilder $qb, string $procedure): QueryBuilder
     {
         $qualification = Qualification::tryFrom($procedure);
-        $qb->andWhere('sq.qualification = :qualification')->setParameter('qualification', $qualification);
+        if (Qualification::NON_DECENCE_ENERGETIQUE === $qualification) {
+            $subqueryResults = $this->signalementQualificationRepository->findSignalementsByQualification(
+                $qualification,
+                [QualificationStatus::NDE_AVEREE, QualificationStatus::NDE_CHECK]
+            );
+        } else {
+            $subqueryResults = $this->signalementQualificationRepository->findSignalementsByQualification(
+                $qualification
+            );
+        }
+
+        $qb
+            ->andWhere('s.id IN (:subqueryResults)')
+            ->setParameter('subqueryResults', $subqueryResults);
 
         return $qb;
     }


### PR DESCRIPTION
## Ticket

#2723    
#2718 (régression + correction compteur)

## Description
Le badge NDE ne s'affiche pas. 
La PR #2718 applique une régression qui limite l'affichage des badges uniquement au badge du signalement filtré. 

## Changements apportés
* Ajout d'une condition pour afficher le badge NDE
* Correction de la sous-requête du filtre procédure
* Ignorer les signalements pour le filtre NDE lorsque celui ci est archivé (corrige le compteur)

## Pré-requis
```
make load-data
```
## Tests
- [ ] Filtrer sur la procédure NDE et vérifier que le badge non décence énergique s'affiche
- [ ] Sur les cartes avec les procédures suspectées, vérifier qu'elle s'affichent bien sur la fiche
- [ ] [NDE] Vérifier que le compteur du widget est égale au compteur de la liste filtré sur NDE