### PR TITLE
[BO - Signalement] Un admin partenaire ne peut plus ajouter des suivis sur un signalement sans avoir accepté l'affectation

### DIFF
--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -31,7 +31,7 @@ class Signalement
 {
     public const STATUS_NEED_VALIDATION = 1;
     public const STATUS_ACTIVE = 2;
-    public const STATUS_NEED_PARTNER_RESPONSE = 3;
+    public const STATUS_NEED_PARTNER_RESPONSE = 3; // statut pas utilisé, aucun signalement n'a ce statut
     public const STATUS_CLOSED = 6;
     public const STATUS_ARCHIVED = 7;
     public const STATUS_REFUSED = 8;

--- a/src/Security/Voter/SuiviVoter.php
+++ b/src/Security/Voter/SuiviVoter.php
@@ -13,11 +13,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class SuiviVoter extends Voter
 {
     public const CREATE = 'COMMENT_CREATE';
-    public const VIEW = 'COMMENT_VIEW';
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::CREATE, self::VIEW])
+        return \in_array($attribute, [self::CREATE])
             && ($subject instanceof Suivi || $subject instanceof Signalement);
     }
 
@@ -35,7 +34,6 @@ class SuiviVoter extends Voter
 
         return match ($attribute) {
             self::CREATE => $this->canCreate($subject, $user),
-            self::VIEW => $this->canView($subject, $user),
             default => false,
         };
     }
@@ -49,18 +47,5 @@ class SuiviVoter extends Voter
 
         return Signalement::STATUS_ACTIVE === $signalement->getStatut()
             && ($isUserInAcceptedAffectation || $user->isTerritoryAdmin() || $user->isSuperAdmin());
-    }
-
-    private function canView(mixed $comment, User $user): bool
-    {
-        if ($user->isSuperAdmin()) {
-            return true;
-        }
-
-        if ($this->canCreate($comment->getSignalement(), $user)) {
-            return true;
-        }
-
-        return true;
     }
 }

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -6,16 +6,14 @@
     </div>
     <div class="fr-col-3 fr-col-md-6 fr-text--right">
         {% if 
-                (is_granted('ROLE_ADMIN_PARTNER') or (isAffected and isAccepted))
-                and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION')
-                and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
-                and not isClosedForMe
-                %}
-        <button class="fr-btn fr-btn--icon-left fr-icon-quote-line" data-fr-opened="false"
-                aria-controls="fr-modal-add-suivi">
-            Ajouter un suivi
-        </button>
-        {% include '_partials/signalement/add_suivi.html.twig' %}
+            is_granted('COMMENT_CREATE', signalement)
+            and not isClosedForMe
+            %}
+            <button class="fr-btn fr-btn--icon-left fr-icon-quote-line" data-fr-opened="false"
+                    aria-controls="fr-modal-add-suivi">
+                Ajouter un suivi
+            </button>
+            {% include '_partials/signalement/add_suivi.html.twig' %}
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
## Ticket

#2729   

## Description
Un admin partenaire pouvait ajouter des suivi sur un signalement qu'il n'avait pas accepté. Correction de ce bug

## Changements apportés
* Durcissement du SuiviVoter
* Utilisation du voter COMMENT_CREATE dans le twig

## Pré-requis

## Tests
- [ ] Tester en SA : on ne peut créer un suivi que sur un signalement au statut en cours
- [ ] Tester en RT : idem, même si on est auto-affecté sur le signalement
- [ ] Tester en admin partenaire : on ne peut créer un suivi que sur un signalement au statut en cours et dont on a accepté l'affectation
- [ ] Tester en agent : idem admin partenaire
