### PR TITLE
[BO - Command] Fix de la commande d'archivage des utilisateurs

### DIFF
--- a/migrations/Version20240625095546.php
+++ b/migrations/Version20240625095546.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\User;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240625095546 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Desarchive all users archived by command notify-and-archive-inactive-accounts';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $suffixArchived = User::SUFFIXE_ARCHIVED;
+        $statusActive = User::STATUS_ACTIVE;
+        $statusInactive = User::STATUS_INACTIVE;
+        $statusArchive = User::STATUS_ARCHIVE;
+
+        $this->addSql("
+            UPDATE user
+            SET statut = $statusInactive
+            WHERE last_login_at IS NULL
+              AND statut = $statusArchive
+              AND email NOT LIKE '%$suffixArchived%'
+        ");
+
+        $this->addSql("
+            UPDATE user
+            SET statut = $statusActive
+            WHERE last_login_at IS NOT NULL
+              AND statut = $statusArchive
+              AND email NOT LIKE '%$suffixArchived%'
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Command/Cron/NotifyAndArchiveInactiveAccountCommand.php
+++ b/src/Command/Cron/NotifyAndArchiveInactiveAccountCommand.php
@@ -7,6 +7,7 @@ use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
+use App\Service\Sanitizer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -103,6 +104,7 @@ class NotifyAndArchiveInactiveAccountCommand extends AbstractCronCommand
         $users = $this->userRepository->findUsersToArchive();
 
         foreach ($users as $user) {
+            $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
             $user->setStatut(User::STATUS_ARCHIVE);
             $user->setArchivingScheduledAt(null);
         }


### PR DESCRIPTION
## Ticket

#2726
#2730   

## Description
A l'occasion du ticket #2726 on a découvert qu'il y avait en prod 1755 utilisateurs archivés n'ayant pas le suffixe ".archived@" dans leur adresse mail : https://histologe-metabase.osc-fr1.scalingo.io/question/1198-users-archives-sans-suffixe-archived
Cela vient de la commande `notify-and-archive-inactive-accounts` qui change le statut de l'utilisateur sans tagger le mail.
Outre la correction à apporter à la commande, cela offre un bon moyen d'accéder à la demande d'Arnaud de désarchiver tous les utilisateurs ayant été archivés par cette commande (#2730)

## Changements apportés
* Fix de la commande
* Création d'une migration pour désarchiver ces 1755 utilisateurs (on remet le statut à 0 si l'utilisateur ne s'est jamais logué, à 1 s'il s'est logué)

## Pré-requis
Passer plusieurs utilisateurs au statut 2 sans modifier le mail en bdd

## Tests
- [ ] Jouer la migration et vérifier en base le statut de ces utilisateurs
