### PR TITLE
[BUG] photo en attente de suivi pouvant rester en attente plusieurs jours

### DIFF
--- a/migrations/Version20240626180734.php
+++ b/migrations/Version20240626180734.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240626180734 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set is_waiting_suivi flag to true on File created since more than 1 hour';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE file SET is_waiting_suivi = 0 WHERE created_at < DATE_SUB(NOW(), INTERVAL '1' HOUR)");
+    }
+}

--- a/migrations/Version20240626180734.php
+++ b/migrations/Version20240626180734.php
@@ -11,7 +11,7 @@ final class Version20240626180734 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Set is_waiting_suivi flag to true on File created since more than 1 hour';
+        return 'Set is_waiting_suivi flag to false on File created since more than 1 hour';
     }
 
     public function up(Schema $schema): void

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -556,7 +556,8 @@ class SignalementController extends AbstractController
         Request $request,
         EntityManagerInterface $entityManager,
         SuiviFactory $suiviFactory,
-        SignalementFileProcessor $signalementFileProcessor
+        SignalementFileProcessor $signalementFileProcessor,
+        UploadHandlerService $uploadHandlerService,
     ): RedirectResponse {
         $signalement = $signalementRepository->findOneByCodeForPublic($code);
         if (!$this->isGranted('SIGN_USAGER_EDIT', $signalement)) {
@@ -586,6 +587,9 @@ class SignalementController extends AbstractController
         if (\count($docs)) {
             $descriptionList = [];
             foreach ($docs as $doc) {
+                if ($uploadHandlerService->deleteIfExpiredFile($doc)) {
+                    continue;
+                }
                 $doc->setIsTemp(false);
                 $descriptionList[] = $signalementFileProcessor->generateListItemDescription($doc->getFilename(), $doc->getTitle(), true);
             }

--- a/src/Controller/SignalementFileController.php
+++ b/src/Controller/SignalementFileController.php
@@ -91,7 +91,7 @@ class SignalementFileController extends AbstractController
         if (!$file) {
             return $this->json(['success' => false], Response::HTTP_BAD_REQUEST);
         }
-        if (!$uploadHandlerService->deleteSignalementFile($file, $fileRepository)) {
+        if (!$uploadHandlerService->deleteFile($file)) {
             return $this->json(['success' => false], Response::HTTP_BAD_REQUEST);
         }
         $entityManager->remove($file);

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -1989,7 +1989,11 @@ class Signalement
     public function getFiles(): Collection
     {
         return $this->files->filter(function (File $file) {
-            return !$file->isTemp();
+            if ($file->isTemp() || $file->isIsWaitingSuivi()) {
+                return false;
+            }
+
+            return true;
         });
     }
 

--- a/tests/Functional/Service/UploadHandlerServiceTest.php
+++ b/tests/Functional/Service/UploadHandlerServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Service;
 
+use App\Repository\FileRepository;
 use App\Service\Files\FilenameGenerator;
 use App\Service\Files\HeicToJpegConverter;
 use App\Service\UploadHandlerService;
@@ -21,6 +22,7 @@ class UploadHandlerServiceTest extends KernelTestCase
     private MockObject|LoggerInterface $logger;
     private MockObject|HeicToJpegConverter $heicToJpegConverter;
     private MockObject|FilenameGenerator $filenameGenerator;
+    private MockObject|FileRepository $fileRepository;
 
     private string $projectDir = '';
     private string $fixturesPath = '/src/DataFixtures/Images/';
@@ -44,6 +46,7 @@ class UploadHandlerServiceTest extends KernelTestCase
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->heicToJpegConverter = $this->createMock(HeicToJpegConverter::class);
         $this->filenameGenerator = $this->createMock(FilenameGenerator::class);
+        $this->fileRepository = $this->createMock(FileRepository::class);
     }
 
     public function testTemporaryFileUploaded(): void
@@ -73,6 +76,7 @@ class UploadHandlerServiceTest extends KernelTestCase
             $this->logger,
             $this->heicToJpegConverter,
             $this->filenameGenerator,
+            $this->fileRepository
         );
 
         $uploadHandler = $uploadHandlerService->toTempFolder($uploadFile);
@@ -96,6 +100,7 @@ class UploadHandlerServiceTest extends KernelTestCase
             $this->createMock(LoggerInterface::class),
             $this->createMock(HeicToJpegConverter::class),
             $this->createMock(FilenameGenerator::class),
+            $this->fileRepository
         );
 
         $uploadedFileMock = $this->createMock(UploadedFile::class);
@@ -120,6 +125,7 @@ class UploadHandlerServiceTest extends KernelTestCase
             $this->createMock(LoggerInterface::class),
             $this->createMock(HeicToJpegConverter::class),
             $this->createMock(FilenameGenerator::class),
+            $this->fileRepository
         );
 
         $uploadedFileMock = $this->createMock(UploadedFile::class);
@@ -154,6 +160,7 @@ class UploadHandlerServiceTest extends KernelTestCase
             $this->logger,
             $this->heicToJpegConverter,
             $this->filenameGenerator,
+            $this->fileRepository
         );
 
         $uploadHandler = $uploadHandlerService->toTempFolder($uploadFile);


### PR DESCRIPTION
## Ticket

#2734

## Description
Correction de l'utilisation du flag is_waiting_suivi sur les documents envoyé depuis la popup d'upload : 
- Les docs ayant ce flag ne sont à présent jamais affichés sur le signalement (auparavant ils l'étaient même sans validation du popup)
- Une migration passe le flag a false pour ceux existant afin que des doc ne disparaissent pas sur de signalement ou ils étaient affichés
- Lors de la validation de la popup un suivi contenant les doc ayant ce flag est généré : ajout du contrôle de l'utilisateur ayant uploadé le fichiers + suppression du fichier si il date de plus d'une heure.

Le principe d'un flag temporaire existant aussi coté fiche signalement usager, pour éviter tout problème lors de la validation si le fichier temporaire à été uploadé il y'a plus d'une heure on le supprime.

J'en ai profité pour renomer/améliorer la fonction `deleteSignalementFile` du `UploadHandlerService`

## Tests
- [ ] Vérifier que le popup d'upload FO et BO fonctionne toujours correctement
- [ ] Ajouter des doc via le popup BO quitter la page sans valider et vérifier qu'il n'apparaisse pas
- [ ] Modifier leur date de création en base pour qu'il date de plus d'une heure, ajouter d'autre doc via popup BO et valider, confirmer que le suivi contient que les nouveau doc et que les ancien sont supprimé (si upload fait par le même user)
- [ ] passer le flag is_waiting_suivi  d'un fichier existant depuis plus d'une heure a true, faire `make execute-migration name=Version20240626180734 direction=up` et vérifier que le flag passe bien à false