### PR TITLE
[Esabora - SI-SH] Arrondir le score avec 1 chiffre après la virgule

### DIFF
--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -136,7 +136,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ->setProprietaireAverti((int) $signalement->getIsProprioAverti())
             ->setProprietaireAvertiDate($signalement->getProprioAvertiAt()?->format($formatDate))
             ->setProprietaireAvertiMoyen($modeContactProprio)
-            ->setSignalementScore($signalement->getScore())
+            ->setSignalementScore(round($signalement->getScore(), 1))
             ->setSignalementOrigine(AbstractEsaboraService::SIGNALEMENT_ORIGINE)
             ->setSignalementNumero($signalement->getReference())
             ->setSignalementCommentaire($cleanedSuiviDescription)

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -74,6 +74,7 @@ trait FixturesHelper
             ->setInseeOccupant('62193')
             ->setProfileDeclarant(ProfileDeclarant::LOCATAIRE)
             ->setValidatedAt(new \DateTimeImmutable())
+            ->setScore(1.46265448)
             ->addSuivi($this->getSuiviPartner());
     }
 

--- a/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
@@ -59,7 +59,7 @@ class DossierMessageSISHFactoryTest extends TestCase
         $signalement->setInseeOccupant(null);
 
         $dossierMessage = $dossierMessageFactory->createInstance($affectation);
-
+        $this->assertEquals(1.5, $dossierMessage->getSignalementScore());
         $this->assertCount(2, $dossierMessage->getPiecesJointesDocuments());
         $this->assertEquals(PartnerType::ARS->value, $dossierMessage->getPartnerType());
         $this->assertStringContainsString('Etat', $dossierMessage->getSignalementProblemes());


### PR DESCRIPTION
## Ticket

#2744    

## Description
Ajouter une précision d'un chiffre après la virgule

## Changements apportés
* Ajout de la précision dans le dossier SISH

## Pré-requis
```sh
make worker-start
make mock-start
```
Chercher un signalement du 13 avec un score.

## Tests
- [ ] Affecter un dossier au partenaire Partenaire 13-06 ESABORA ARS et vérifier la table job_event sur l'action `push_dossier` que le score a bien un chiffre apres la virgule
 