### PR TITLE
[Esabora - SI-SH] Envoi impossible de dossier lorsque la superficie n'est pas un entier

### DIFF
--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -118,7 +118,7 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             ->setSitLogementBailDateEntree($signalement->getDateEntree()?->format($formatDate))
             ->setSitLogementPreavisDepart((int) $signalement->getIsPreavisDepart())
             ->setSitLogementRelogement((int) $signalement->getIsRelogement())
-            ->setSitLogementSuperficie($signalement->getSuperficie())
+            ->setSitLogementSuperficie((int) $signalement->getSuperficie())
             ->setSitLogementMontantLoyer($signalement->getLoyer())
             ->setDeclarantNonOccupant($signalement->getIsNotOccupant())
             ->setLogementNature($signalement->getNatureLogement())

--- a/src/Messenger/Message/Esabora/DossierMessageSISH.php
+++ b/src/Messenger/Message/Esabora/DossierMessageSISH.php
@@ -43,7 +43,7 @@ final class DossierMessageSISH implements DossierMessageInterface
     private ?string $sitLogementBailDateEntree = null;
     private ?int $sitLogementPreavisDepart = null;
     private ?int $sitLogementRelogement = null;
-    private ?float $sitLogementSuperficie = null;
+    private ?int $sitLogementSuperficie = null;
     private ?float $sitLogementMontantLoyer = null;
     private ?int $declarantNonOccupant = null;
     private ?string $logementNature = null;
@@ -474,12 +474,12 @@ final class DossierMessageSISH implements DossierMessageInterface
         return $this;
     }
 
-    public function getSitLogementSuperficie(): ?float
+    public function getSitLogementSuperficie(): ?int
     {
         return $this->sitLogementSuperficie;
     }
 
-    public function setSitLogementSuperficie(?float $sitLogementSuperficie): self
+    public function setSitLogementSuperficie(?int $sitLogementSuperficie): self
     {
         $this->sitLogementSuperficie = $sitLogementSuperficie;
 

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -75,6 +75,7 @@ trait FixturesHelper
             ->setProfileDeclarant(ProfileDeclarant::LOCATAIRE)
             ->setValidatedAt(new \DateTimeImmutable())
             ->setScore(1.46265448)
+            ->setSuperficie('75.5')
             ->addSuivi($this->getSuiviPartner());
     }
 

--- a/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
@@ -69,6 +69,7 @@ class DossierMessageSISHFactoryTest extends TestCase
         $this->assertEquals(5, \strlen($dossierMessage->getLocalisationCodePostal()));
         $this->assertNotNull($dossierMessage->getLocalisationVille());
         $this->assertEquals('H', $dossierMessage->getSasLogicielProvenance());
+        $this->assertEquals(75, $dossierMessage->getSitLogementSuperficie());
         $this->assertEquals(
             AbstractEsaboraService::SIGNALEMENT_ORIGINE,
             $dossierMessage->getSignalementOrigine()


### PR DESCRIPTION
## Ticket

#2743    

## Description
*Requête*
```
"sitLogementSuperficie":66.19,
````

*Réponse*
```json
{
  "sasId": null,
  "statusCode": 400,
  "errorReason": "{\"code\":\"WS_ERR_SQL\",\"message\":\"22P02 - ERROR:  invalid input syntax for integer: \\\"66.19\\\"\"}",
  "sasEtat": null,
  "sasCauseRefus": null,
  "etat": null,
  "nameSI": "SI-SH"
}
```

## Pré-requis
```sh
make worker-start
make mock-start
```
En base de données, chercher un signalement du 13 et mettez un nombre décimal sur la superficie.

## Tests
- [ ] Affecter un dossier au partenaire Partenaire 13-06 ESABORA ARS et vérifier la table job_event sur l'action `push_dossier` que la superficie est bien un entier