### PR TITLE
[Sécurité] Correction du chargement de matomo.js

### DIFF
--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,14 +1,17 @@
 add_header X-Frame-Options "deny";
-add_header X-Content-Type-Options nosniff;
+add_header X-Content-Type-Options "nosniff";
 add_header X-XSS-Protection "1; mode=block";
 add_header Permissions-Policy "geolocation=(), camera=(), microphone=(), payment=(), accelerometer=(), ambient-light-sensor=(), gyroscope=(), magnetometer=(), usb=(), vibrate=()";
 add_header X-Permitted-Cross-Domain-Policies "none";
 add_header Referrer-Policy "no-referrer";
-add_header Cross-Origin-Embedder-Policy "require-corp";
+add_header Cross-Origin-Embedder-Policy "unsafe-none";  # Temporarily disable COEP for matomo.js
 add_header Cross-Origin-Opener-Policy "same-origin";
 add_header Cross-Origin-Resource-Policy "cross-origin";
 add_header Upgrade-Insecure-Requests "1";
 add_header X-Powered-By "none";
+add_header Access-Control-Allow-Origin "*";
+add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+add_header Access-Control-Allow-Headers "Content-Type, Authorization";
 
 
 location ~* ^/bo/signalements/.*\/delete$ {


### PR DESCRIPTION
## Ticket

#2754   

## Description
L'ajout du header `Cross-Origin-Embedder-Policy "require-corp";` empêchait le chargement du script de matomo.js car celui-ci ne contient pas les en-têtes `Cross-Origin-Resource-Policy` ou `Cross-Origin-Embedder-Policy`.

## Changements apportés
* Transformation de l'en-tête `Cross-Origin-Embedder-Policy "require-corp";`  en `Cross-Origin-Embedder-Policy "unsafe-none";`

## Pré-requis

## Tests
- [ ] Les différentes étapes des tests à faire
