### PR TITLE
[Esabora] Correction de la création de suivi automatique lors des appels à Esabora

### DIFF
--- a/migrations/Version20240701083800.php
+++ b/migrations/Version20240701083800.php
@@ -17,6 +17,16 @@ final class Version20240701083800 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql("
+            DELETE FROM notification
+            WHERE suivi_id IN (
+                SELECT id FROM suivi
+                WHERE description LIKE 'Signalement <b> (Dossier %'
+                AND created_at > '2024-06-29 00:00:00'
+                AND type = 1
+                AND is_public = 0
+            )
+        ");
+        $this->addSql("
             DELETE FROM suivi
             WHERE description LIKE 'Signalement <b> (Dossier %'
             AND created_at > '2024-06-29 00:00:00'

--- a/migrations/Version20240701083800.php
+++ b/migrations/Version20240701083800.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240701083800 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Delete esabora-sish useless suivis ';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            DELETE FROM suivi
+            WHERE description LIKE 'Signalement <b> (Dossier %'
+            AND created_at > '2024-06-29 00:00:00'
+            AND type = 1
+            AND is_public = 0
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Service/Esabora/EsaboraManager.php
+++ b/src/Service/Esabora/EsaboraManager.php
@@ -114,7 +114,7 @@ class EsaboraManager
                 break;
         }
 
-        if (!empty($dossierResponse->getDossNum())) {
+        if (!empty($dossierResponse->getDossNum()) && !empty($description)) {
             $description .= ' (Dossier '.$dossierResponse->getDossNum().')';
         }
 


### PR DESCRIPTION
## Ticket

#2756    

## Description
Tous les appels à Esabora SISH créaient un suivi même s'il n'y avait aucun changement, car on ajoutait dans tous les cas le numéro de dossier dès qu'on l'avait

## Changements apportés
* Changement dans EsaboraManager->updateStatusFor() pour n'ajouter le numéro de dossier reçu que s'il y a un changement à indiquer dans un suivi
* Ajout d'un test fonctionnel pour vérifier que si on joue 2 fois de suite la fonction, seulement un suivi est créé
* Ajout d'une migration pour supprimer les suivis inutiles créés depuis la mise en prod du vendredi 28 juin 2024

## Pré-requis
AVANT de charger la branche

```
make mock-start
make console app="sync-esabora-sish"
make console app="sync-esabora-sish"
```

Deux suivis doivent être créés dans le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012 dont le 2ème ne sert à rien

Puis se mettre sur la branche


## Tests
- [ ] Jouer la migration (`make load-migrations`) et vérifier que le dernier suivi a bien été supprimé
- [ ] Rejouer la commande (`make console app="sync-esabora-sish"`) et vérifier qu'il n'y a plus de suivi inutile de créé