### PR TITLE
[FO - Formulaire] Envoi des changements d'écran à Matomo sous forme d'événement

### DIFF
--- a/.scalingo/nginx/server.location
+++ b/.scalingo/nginx/server.location
@@ -1,14 +1,17 @@
 add_header X-Frame-Options "deny";
-add_header X-Content-Type-Options nosniff;
+add_header X-Content-Type-Options "nosniff";
 add_header X-XSS-Protection "1; mode=block";
 add_header Permissions-Policy "geolocation=(), camera=(), microphone=(), payment=(), accelerometer=(), ambient-light-sensor=(), gyroscope=(), magnetometer=(), usb=(), vibrate=()";
 add_header X-Permitted-Cross-Domain-Policies "none";
 add_header Referrer-Policy "no-referrer";
-add_header Cross-Origin-Embedder-Policy "require-corp";
+add_header Cross-Origin-Embedder-Policy "unsafe-none";
 add_header Cross-Origin-Opener-Policy "same-origin";
 add_header Cross-Origin-Resource-Policy "cross-origin";
 add_header Upgrade-Insecure-Requests "1";
 add_header X-Powered-By "none";
+add_header Access-Control-Allow-Origin "*";
+add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+add_header Access-Control-Allow-Headers "Content-Type, Authorization";
 
 
 location ~* ^/bo/signalements/.*\/delete$ {

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -291,6 +291,8 @@ export default defineComponent({
             // Prétraitement des composants avec repeat
             formStore.currentScreen.components.body = formStore.preprocessScreen(formStore.currentScreen.components.body)
           }
+          window.location.hash = formStore.data.currentStep
+          Object(window).HistologeMatomoInit()
         } else {
           if (this.slugCoordonnees.includes(this.nextSlug)) { // TODO à mettre à jour suivant le slug des différents profils
             // on fait un appel API pour charger la suite des questions avant de changer d'écran

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -292,7 +292,7 @@ export default defineComponent({
             formStore.currentScreen.components.body = formStore.preprocessScreen(formStore.currentScreen.components.body)
           }
           window.location.hash = formStore.data.currentStep
-          Object(window).HistologeMatomoInit()
+          Object(window).HistologeMatomoSendData()
         } else {
           if (this.slugCoordonnees.includes(this.nextSlug)) { // TODO à mettre à jour suivant le slug des différents profils
             // on fait un appel API pour charger la suite des questions avant de changer d'écran

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -69,6 +69,7 @@
 import { defineComponent } from 'vue'
 import formStore from './store'
 import dictionaryStore from './dictionary-store'
+import { matomo } from './matomo'
 import { requests } from './requests'
 import * as Sentry from '@sentry/browser'
 import { profileUpdater } from './services/profileUpdater'
@@ -95,6 +96,7 @@ export default defineComponent({
       isLoadingInit: true,
       formStore,
       dictionaryStore,
+      matomo,
       sharedProps: formStore.props,
       isTerritoryModalOpen: false,
       territoryModalLabel: '',
@@ -291,7 +293,7 @@ export default defineComponent({
             // Prétraitement des composants avec repeat
             formStore.currentScreen.components.body = formStore.preprocessScreen(formStore.currentScreen.components.body)
           }
-          Object(window).HistologeMatomoSendData(formStore.data.currentStep)
+          matomo.pushEvent('changeScreen', formStore.data.currentStep)
         } else {
           if (this.slugCoordonnees.includes(this.nextSlug)) { // TODO à mettre à jour suivant le slug des différents profils
             // on fait un appel API pour charger la suite des questions avant de changer d'écran

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -291,8 +291,7 @@ export default defineComponent({
             // Prétraitement des composants avec repeat
             formStore.currentScreen.components.body = formStore.preprocessScreen(formStore.currentScreen.components.body)
           }
-          window.location.hash = formStore.data.currentStep
-          Object(window).HistologeMatomoSendData()
+          Object(window).HistologeMatomoSendData(formStore.data.currentStep)
         } else {
           if (this.slugCoordonnees.includes(this.nextSlug)) { // TODO à mettre à jour suivant le slug des différents profils
             // on fait un appel API pour charger la suite des questions avant de changer d'écran

--- a/assets/vue/components/signalement-form/matomo.ts
+++ b/assets/vue/components/signalement-form/matomo.ts
@@ -1,0 +1,7 @@
+export const matomo = {
+  pushEvent (eventAction: string, eventName: string) {
+    const _paq = Object(window)._paq = Object(window)._paq || [];
+    const eventCategory = 'Signaler un problème de logement'
+    _paq.push(['trackEvent', eventCategory, eventAction, eventName])
+  }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -60,29 +60,29 @@
     {% if matomo is defined and matomo.enable == 1 %}
         <!-- Matomo -->
         <script nonce="{{ app.request.attributes.get('csp_script_nonce') }}">
-            window.HistologeMatomoSendData = function () {
-                var _paq = window._paq = window._paq || [];
-                {% if platform.url starts with 'https' %}
-                    _paq.push(['setSecureCookie', true]);
-                {% endif %}
-                /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-                {% if app.user is not null and 'ROLE_ADMIN' not in app.user.roles and 'ROLE_USAGER' not in app.user.roles %}
-                    _paq.push(['setCustomDimension', customDimensionId = 1, customDimensionValue = '{{ app.user.roles|first}}' ]);
-                    _paq.push(['setCustomDimension', customDimensionId = 2, customDimensionValue = '{{ app.user.territory.name }}' ]);
-                    _paq.push(['setCustomDimension', customDimensionId = 3, customDimensionValue = '{{ app.user.partner.nom }}' ]);
-                    _paq.push(['requireConsent']);
-                {% endif %}
-                _paq.push(['trackPageView']);
-                _paq.push(['enableLinkTracking']);
-                (function() {
-                    var u="{{ matomo.url }}";
-                    _paq.push(['setTrackerUrl', u+'matomo.php']);
-                    _paq.push(['setSiteId', '{{ matomo.site_id }}']);
-                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-                    g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
-                })();
-            }
-            window.HistologeMatomoSendData()
+            var _paq = window._paq = window._paq || [];
+            {% if platform.url starts with 'https' %}
+                _paq.push(['setSecureCookie', true]);
+            {% endif %}
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            {% if app.user is not null and 'ROLE_ADMIN' not in app.user.roles and 'ROLE_USAGER' not in app.user.roles %}
+                _paq.push(['setCustomDimension', customDimensionId = 1, customDimensionValue = '{{ app.user.roles|first}}' ]);
+                _paq.push(['setCustomDimension', customDimensionId = 2, customDimensionValue = '{{ app.user.territory.name }}' ]);
+                _paq.push(['setCustomDimension', customDimensionId = 3, customDimensionValue = '{{ app.user.partner.nom }}' ]);
+                _paq.push(['requireConsent']);
+            {% endif %}
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var u="{{ matomo.url }}";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', '{{ matomo.site_id }}']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
+            })();
+            /*window.HistologeMatomoSendData = function (slug) {
+                _paq.push(['trackEvent', 'Formulaire', slug])
+            }*/
         </script>
         <!-- End Matomo Code -->
     {% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -60,8 +60,7 @@
     {% if matomo is defined and matomo.enable == 1 %}
         <!-- Matomo -->
         <script nonce="{{ app.request.attributes.get('csp_script_nonce') }}">
-            window.HistologeMatomoInit = function () {
-                console.log('ici')
+            window.HistologeMatomoSendData = function () {
                 var _paq = window._paq = window._paq || [];
                 {% if platform.url starts with 'https' %}
                     _paq.push(['setSecureCookie', true]);
@@ -77,14 +76,13 @@
                 _paq.push(['enableLinkTracking']);
                 (function() {
                     var u="{{ matomo.url }}";
-                    console.log(u)
                     _paq.push(['setTrackerUrl', u+'matomo.php']);
                     _paq.push(['setSiteId', '{{ matomo.site_id }}']);
                     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
                     g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
                 })();
             }
-            window.HistologeMatomoInit()
+            window.HistologeMatomoSendData()
         </script>
         <!-- End Matomo Code -->
     {% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -60,26 +60,31 @@
     {% if matomo is defined and matomo.enable == 1 %}
         <!-- Matomo -->
         <script nonce="{{ app.request.attributes.get('csp_script_nonce') }}">
-            var _paq = window._paq = window._paq || [];
-            {% if platform.url starts with 'https' %}
-                _paq.push(['setSecureCookie', true]);
-            {% endif %}
-            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-            {% if app.user is not null and 'ROLE_ADMIN' not in app.user.roles and 'ROLE_USAGER' not in app.user.roles %}
-                _paq.push(['setCustomDimension', customDimensionId = 1, customDimensionValue = '{{ app.user.roles|first}}' ]);
-                _paq.push(['setCustomDimension', customDimensionId = 2, customDimensionValue = '{{ app.user.territory.name }}' ]);
-                _paq.push(['setCustomDimension', customDimensionId = 3, customDimensionValue = '{{ app.user.partner.nom }}' ]);
-                _paq.push(['requireConsent']);
-            {% endif %}
-            _paq.push(['trackPageView']);
-            _paq.push(['enableLinkTracking']);
-            (function() {
-                var u="{{ matomo.url }}";
-                _paq.push(['setTrackerUrl', u+'matomo.php']);
-                _paq.push(['setSiteId', '{{ matomo.site_id }}']);
-                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-                g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
-            })();
+            window.HistologeMatomoInit = function () {
+                console.log('ici')
+                var _paq = window._paq = window._paq || [];
+                {% if platform.url starts with 'https' %}
+                    _paq.push(['setSecureCookie', true]);
+                {% endif %}
+                /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+                {% if app.user is not null and 'ROLE_ADMIN' not in app.user.roles and 'ROLE_USAGER' not in app.user.roles %}
+                    _paq.push(['setCustomDimension', customDimensionId = 1, customDimensionValue = '{{ app.user.roles|first}}' ]);
+                    _paq.push(['setCustomDimension', customDimensionId = 2, customDimensionValue = '{{ app.user.territory.name }}' ]);
+                    _paq.push(['setCustomDimension', customDimensionId = 3, customDimensionValue = '{{ app.user.partner.nom }}' ]);
+                    _paq.push(['requireConsent']);
+                {% endif %}
+                _paq.push(['trackPageView']);
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="{{ matomo.url }}";
+                    console.log(u)
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '{{ matomo.site_id }}']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
+                })();
+            }
+            window.HistologeMatomoInit()
         </script>
         <!-- End Matomo Code -->
     {% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -81,7 +81,7 @@
                 g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
             })();
             window.HistologeMatomoSendData = function (slug) {
-                _paq.push(['trackEvent', 'Formulaire', slug])
+                _paq.push(['trackEvent', 'Signaler un problème de logement', slug])
             }
         </script>
         <!-- End Matomo Code -->

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -80,9 +80,9 @@
                 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
                 g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
             })();
-            /*window.HistologeMatomoSendData = function (slug) {
+            window.HistologeMatomoSendData = function (slug) {
                 _paq.push(['trackEvent', 'Formulaire', slug])
-            }*/
+            }
         </script>
         <!-- End Matomo Code -->
     {% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -80,9 +80,6 @@
                 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
                 g.async=true; g.src='{{ matomo.cdn }}'; s.parentNode.insertBefore(g,s);
             })();
-            window.HistologeMatomoSendData = function (slug) {
-                _paq.push(['trackEvent', 'Signaler un problème de logement', slug])
-            }
         </script>
         <!-- End Matomo Code -->
     {% endif %}


### PR DESCRIPTION
## Ticket

#2604    

## Description
Envoi à Matomo des changements d'écran dans le formulaire de signalement.
Dans un premier temps, j'avais imaginé modifier le hash au sein de l'url. Mais il s'avère que ce n'est pas nécessaire.
Matomo a une fonction pour cela : utiliser des événements qui peuvent être catégorisés.

![image](https://github.com/MTES-MCT/histologe/assets/5381875/5b04c30a-d174-4a56-bb77-1d5fcabd945f)

## Changements apportés
* Reprise des corrections sur les headers que Hélène a fait par ailleur pour l'utilisation de Matomo
* Ajout d'un push de type `trackEvent` à Matomo lors d'un changement d'écran, en précisant le slug de l'écran en cours

## Pré-requis
`make down`
`make run`
`make tools-run`
`make matomo-disable-ssl`

## Tests
- [ ] Naviguer sur le site et vérifier que les changements de page sont bien trackés
- [ ] Naviguer dans le formulaire et vérifier que les changements d'écran son bien trackés via des événements
