### PR TITLE
[FO - Formulaire] Envoi événement à Matomo lorsqu'un signalement est en doublon 

### DIFF
--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -191,6 +191,9 @@ export default defineComponent({
           formStore.alreadyExists.createdAt = requestResponse.created_at
           formStore.alreadyExists.updatedAt = requestResponse.updated_at
           formStore.alreadyExists.draftExists = requestResponse.draft_exists
+          if (formStore.alreadyExists.type === 'signalement') {
+            Object(window).HistologeMatomoSendData('Modale - Doublon signalement')
+          }
           if (link) {
             formStore.lastButtonClicked = ''
             link.click()

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -192,7 +192,7 @@ export default defineComponent({
           formStore.alreadyExists.updatedAt = requestResponse.updated_at
           formStore.alreadyExists.draftExists = requestResponse.draft_exists
           if (formStore.alreadyExists.type === 'signalement') {
-            Object(window).HistologeMatomoSendData('Modale - Doublon signalement')
+            matomo.pushEvent('showModal', 'Signalement existant')
           }
           if (link) {
             formStore.lastButtonClicked = ''


### PR DESCRIPTION
## Ticket

#2607    

## Description
Envoi à Matomo de l'affichage de la modale qui indique qu'un signalement existe déjà.
Mais pas si un brouillon a déjà commencé.

![image](https://github.com/MTES-MCT/histologe/assets/5381875/6807c987-71f9-4802-8884-aeb476a8ccfc)


## Pré-requis
`make tools-run`
`make matomo-disable-ssl`

## Tests
- [ ] Commencer à créer un signalement avec des infos existantes, avoir la modale de doublon, et vérifier dans Matomo que l'événement s'affiche
