### PR TITLE
[Esabora SCSH] envoyer les document en format "resize" quand il s'agit d'image

### DIFF
--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -284,9 +284,14 @@ class UploadHandlerService
 
     public function getTmpFilepath(string $filename): ?string
     {
-        $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
-        $bucketFilepath = $this->parameterBag->get('url_bucket').'/'.$filename;
         try {
+            $variantNames = ImageManipulationHandler::getVariantNames($filename);
+            $fileResize = $variantNames[ImageManipulationHandler::SUFFIX_RESIZE];
+            if ($this->fileStorage->fileExists($fileResize)) {
+                $filename = $fileResize;
+            }
+            $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
+            $bucketFilepath = $this->parameterBag->get('url_bucket').'/'.$filename;
             file_put_contents($tmpFilepath, file_get_contents($bucketFilepath));
 
             return $tmpFilepath;


### PR DESCRIPTION
## Ticket

#2771

## Description
Utilisation des images et document au format réduit lors de la synchronisation des dossier afin d'eviter des time out due à leurs poids

## Changements apportés
Modification de la fonction `getTmpFilepath` afin qu'elle retourne toujours la version "resize" d'un document (si cette version existe)
