### PR TITLE
[BO - Signalement] Contrôle des entrées des formulaires

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -55,7 +55,10 @@ class AffectationController extends AbstractController
                 $partnersIdToRemove = array_diff($alreadyAffectedPartner, $postedPartner);
 
                 foreach ($partnersIdToAdd as $partnerIdToAdd) {
-                    $partner = $this->partnerRepository->find($partnerIdToAdd);
+                    $partner = $this->partnerRepository->findOneBy(['id' => $partnerIdToAdd, 'territory' => $signalement->getTerritory(), 'isArchive' => false]);
+                    if (!$partner) {
+                        continue;
+                    }
                     $affectation = $this->affectationManager->createAffectationFrom(
                         $signalement,
                         $partner,

--- a/src/Controller/Back/BackTagController.php
+++ b/src/Controller/Back/BackTagController.php
@@ -18,6 +18,9 @@ class BackTagController extends AbstractController
     {
         $this->denyAccessUnlessGranted('TAG_CREATE', null);
         $label = $request->get('new-tag-label');
+        if (mb_strlen($label) < 2) {
+            return $this->json(['response' => 'error', 'message' => 'Le tag doit contenir au moins 2 caractères']);
+        }
         $tag = new Tag();
         $tag->setTerritory($signalement->getTerritory());
         $tag->setLabel($label);

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -57,6 +57,11 @@ class SignalementActionController extends AbstractController
             } else {
                 $statut = Signalement::STATUS_REFUSED;
                 $motifRefus = MotifRefus::tryFrom($response['motifRefus']);
+                if (!$motifRefus || mb_strlen($response['suivi']) < 10) {
+                    $this->addFlash('error', 'Champs incorrects ou manquants !');
+
+                    return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+                }
                 $signalement->setMotifRefus($motifRefus);
                 $description = 'cloturé car non-valide avec le motif suivant : '.$motifRefus->label().'<br>Plus précisément :<br>'.$response['suivi'];
 
@@ -104,6 +109,11 @@ class SignalementActionController extends AbstractController
             $content = $form['content'];
             $content = preg_replace('/<p[^>]*>/', '', $content); // Remove the start <p> or <p attr="">
             $content = str_replace('</p>', '<br />', $content); // Replace the end
+            if (mb_strlen($content) < 10) {
+                $this->addFlash('error', 'Le contenu du suivi doit faire au moins 10 caractères !');
+
+                return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+            }
             $suivi->setDescription($content);
             $suivi->setIsPublic(!empty($form['notifyUsager']));
             $suivi->setSignalement($signalement);

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -85,6 +85,11 @@ class SignalementController extends AbstractController
         if ($clotureForm->isSubmitted() && $clotureForm->isValid()) {
             $params['motif_cloture'] = $clotureForm->get('motif')->getData();
             $params['motif_suivi'] = $clotureForm->getExtraData()['suivi'];
+            if (mb_strlen($params['motif_suivi']) < 10) {
+                $this->addFlash('error', 'Le motif de suivi doit contenir au moins 10 caractères.');
+
+                return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
+            }
             $params['suivi_public'] = false;
             if ($this->isGranted('ROLE_ADMIN_TERRITORY') && isset($clotureForm->getExtraData()['publicSuivi'])) {
                 $params['suivi_public'] = $clotureForm->getExtraData()['publicSuivi'];
@@ -93,7 +98,7 @@ class SignalementController extends AbstractController
             $params['closed_for'] = $clotureForm->get('type')->getData();
 
             $entity = null;
-            if ('all' === $params['closed_for']) {
+            if ('all' === $params['closed_for'] && $this->isGranted('ROLE_ADMIN_TERRITORY')) {
                 $params['subject'] = 'tous les partenaires';
                 $entity = $signalement = $signalementManager->closeSignalementForAllPartners(
                     $signalement,

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -270,6 +270,14 @@ class SignalementFileController extends AbstractController
             }
         }
         $description = $request->get('description');
+        if (mb_strlen($description) > 255) {
+            if ($request->isXmlHttpRequest()) {
+                return $this->json(['response' => 'La description ne doit pas dépasser 255 caractères'], Response::HTTP_BAD_REQUEST);
+            }
+            $this->addFlash('error', 'La description ne doit pas dépasser 255 caractères');
+
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
+        }
         if (null !== $description) {
             $file->setDescription($description);
         }

--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -8,10 +8,13 @@ class AdresseOccupantRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de saisir une adresse.')]
+        #[Assert\Length(max: 100, maxMessage: 'L\'adresse ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $adresse = null,
         #[Assert\NotBlank(message: 'Merci de saisir un code postal.')]
+        #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
         private readonly ?string $codePostal = null,
         #[Assert\NotBlank(message: 'Merci de saisir une ville.')]
+        #[Assert\Length(max: 100, maxMessage: 'La ville ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $ville = null,
         #[Assert\Length(max: 5, maxMessage: 'L\'étage ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $etage = null,
@@ -21,10 +24,17 @@ class AdresseOccupantRequest implements RequestInterface
         private readonly ?string $numAppart = null,
         #[Assert\Length(max: 255, maxMessage: 'Le champ Autre ne peut pas dépasser {{ limit }} caractères.')]
         private readonly ?string $autre = null,
+        #[Assert\Length(max: 50, maxMessage: 'La longitude ne peut pas dépasser {{ limit }} caractères.')]
+        #[Assert\Regex(pattern: '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/', message: 'La longitude doit être un nombre décimal.')]
         private readonly ?string $geolocLng = null,
+        #[Assert\Length(max: 50, maxMessage: 'La latitude ne peut pas dépasser {{ limit }} caractères.')]
+        #[Assert\Regex(pattern: '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/', message: 'La latitude doit être un nombre décimal.')]
         private readonly ?string $geolocLat = null,
+        #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code insee doit être composé de 5 chiffres.')]
         private readonly ?string $insee = null,
+        #[Assert\Choice(choices: ['1'], message: 'Le champ "manual" est incorrect.')]
         private readonly ?string $manual = null,
+        #[Assert\Choice(choices: ['1'], message: 'Le champ "needResetInsee" est incorrect.')]
         private readonly ?string $needResetInsee = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -9,12 +9,20 @@ class CompositionLogementRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de définir le type de logement.')]
+        #[Assert\Choice(
+            choices: ['maison', 'appartement', 'autre'],
+            message: 'Le type de logement est incorrect.'
+        )]
         private readonly ?string $type = null,
         #[Assert\When(
             expression: 'this.getType() == "autre"',
             constraints: [
                 new Assert\NotBlank(message: 'Merci de préciser le type de logement autre.'),
             ],
+        )]
+        #[Assert\Length(
+            max: 100,
+            maxMessage: 'Le type de logement autre ne doit pas dépasser {{ limit }} caractères.',
         )]
         private readonly ?string $typeLogementNatureAutrePrecision = null,
         #[Assert\NotBlank(
@@ -29,20 +37,38 @@ class CompositionLogementRequest implements RequestInterface
             message: 'Merci de saisir la superficie du logement.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs de superficie.')]
+        #[Assert\Type(type: 'numeric', message: 'La superficie doit être un nombre.')]
+        #[Assert\Length(
+            max: 10,
+            maxMessage: 'La superficie ne doit pas dépasser {{ limit }} caractères.',
+        )]
         private readonly ?string $superficie = null,
         #[Assert\NotBlank(
             message: 'Merci de définir la hauteur du logement.',
             groups: [
                 'LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS', ]
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Hauteur > 2m" est incorrecte.'
+        )]
         private readonly ?string $compositionLogementHauteur = null,
         #[Assert\NotBlank(
             message: 'Merci de définir le nombre de pièces à vivre.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
         )]
-        #[Assert\Positive(
-            message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
+        #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
+        #[Assert\Type(type: 'numeric', message: 'Le nombre de pièces à vivre doit être un nombre.')]
+        #[Assert\Length(
+            max: 10,
+            maxMessage: 'Le nombre de pièces à vivre ne doit pas dépasser {{ limit }} caractères.',
+        )]
         private readonly ?string $compositionLogementNbPieces = null,
+        #[Assert\Type(type: 'numeric', message: 'Le nombre d\'étages doit être un nombre.')]
+        #[Assert\Length(
+            max: 10,
+            maxMessage: 'Le nombre d\'étages ne doit pas dépasser {{ limit }} caractères.',
+        )]
         private readonly ?string $nombreEtages = null,
         #[Assert\When(
             expression: 'this.getType() == "appartement"',
@@ -52,6 +78,10 @@ class CompositionLogementRequest implements RequestInterface
             constraints: [
                 new Assert\NotBlank(message: 'Merci de préciser si le logement est au rez-de-chaussée.'),
             ],
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Rez-de-chaussée" est incorrect.'
         )]
         private readonly ?string $typeLogementRdc = null,
         #[Assert\When(
@@ -63,12 +93,20 @@ class CompositionLogementRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de préciser si le logement est au dernier étage.'),
             ],
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Dernier étage" est incorrect.'
+        )]
         private readonly ?string $typeLogementDernierEtage = null,
         #[Assert\When(
             expression: 'this.getType() == "appartement" && this.getTypeLogementDernierEtage() == "oui"',
             constraints: [
                 new Assert\NotBlank(message: 'Merci de préciser si le logement est sous comble et sans fenêtre.'),
             ],
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Sous comble et sans fenêtre" est incorrect.'
         )]
         private readonly ?string $typeLogementSousCombleSansFenetre = null,
         #[Assert\When(
@@ -77,14 +115,26 @@ class CompositionLogementRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de préciser si le logement est au sous-sol et sans fenêtre.'),
             ],
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Sous-sol et sans fenêtre" est incorrect.'
+        )]
         private readonly ?string $typeLogementSousSolSansFenetre = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si une pièce fait plus de 9m².',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER'])]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Pièce à vivre > 9m²" est incorrect.'
+        )]
         private readonly ?string $typeLogementCommoditesPieceAVivre9m = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si il y a une cuisine.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Cuisine" est incorrect.'
         )]
         private readonly ?string $typeLogementCommoditesCuisine = null,
         #[Assert\When(
@@ -93,10 +143,18 @@ class CompositionLogementRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de préciser s\'il y a une cuisine collective.'),
             ],
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non'],
+            message: 'Le champ "Cuisine collective" est incorrect.'
+        )]
         private readonly ?string $typeLogementCommoditesCuisineCollective = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si il y a une salle de bain.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Salle de bain" est incorrect.'
         )]
         private readonly ?string $typeLogementCommoditesSalleDeBain = null,
         #[Assert\When(
@@ -105,10 +163,18 @@ class CompositionLogementRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de préciser s\'il y a une salle de bain collective.'),
             ],
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non'],
+            message: 'Le champ "Salle de bain collective" est incorrect.'
+        )]
         private readonly ?string $typeLogementCommoditesSalleDeBainCollective = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si il y a des WC.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "WC" est incorrect.'
         )]
         private readonly ?string $typeLogementCommoditesWc = null,
         #[Assert\When(
@@ -117,13 +183,20 @@ class CompositionLogementRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de préciser s\'il y a des wc collectifs.'),
             ],
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non'],
+            message: 'Le champ "WC collectifs" est incorrect.'
+        )]
         private readonly ?string $typeLogementCommoditesWcCollective = null,
-
         #[Assert\When(
             expression: 'this.getTypeLogementCommoditesWc() == "oui" && this.getTypeLogementCommoditesCuisine() == "oui"',
             constraints: [
                 new Assert\NotBlank(message: 'Merci de préciser s\'il y a des wc dans la cuisine.'),
             ],
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non'],
+            message: 'Le champ "WC dans la cuisine" est incorrect.'
         )]
         private readonly ?string $typeLogementCommoditesWcCuisine = null,
     ) {

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -19,6 +19,7 @@ class CoordonneesBailleurRequest implements RequestInterface
         private readonly ?string $prenom = null,
         #[Assert\NotBlank(message: 'Merci de saisir l\'email du bailleur.', groups: ['BAILLEUR_OCCUPANT', 'BAILLEUR'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
+        #[Assert\Length(max: 255, maxMessage: 'L\'email du bailleur ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $mail = null,
         #[Assert\NotBlank(
             message: 'Merci de saisir le numéro de téléphone du bailleur.',
@@ -28,13 +29,19 @@ class CoordonneesBailleurRequest implements RequestInterface
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephoneBis = null,
         #[Assert\NotBlank(message: 'Merci de saisir l\'adresse du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\Length(max: 255, maxMessage: 'L\'adresse du bailleur ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $adresse = null,
         #[Assert\NotBlank(message: 'Merci de saisir le code postal du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
         private readonly ?string $codePostal = null,
         #[Assert\NotBlank(message: 'Merci de saisir la ville du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\Length(max: 255, maxMessage: 'La ville du bailleur ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $ville = null,
+        #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "bénéficiaire RSA" est incorrect.')]
         private readonly ?string $beneficiaireRsa = null,
+        #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "bénéficiaire FSL" est incorrect.')]
         private readonly ?string $beneficiaireFsl = null,
+        #[Assert\Length(max: 50, maxMessage: 'Le revenu fiscal ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $revenuFiscal = null,
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $dateNaissance = null,

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Constraints\Email;
 class CoordonneesFoyerRequest implements RequestInterface
 {
     public function __construct(
+        #[Assert\Choice(choices: ['ORGANISME_SOCIETE', 'PARTICULIER'], message: 'Le type de propriétaire est incorrect.')]
         private readonly ?string $typeProprio = null,
         #[Assert\When(
             expression: 'this.getTypeProprio() == "ORGANISME_SOCIETE"',
@@ -18,6 +19,7 @@ class CoordonneesFoyerRequest implements RequestInterface
         )]
         private readonly ?string $nomStructure = null,
         #[Assert\NotBlank(message: 'Merci de sélectionner une civilité.', groups: ['LOCATAIRE'])]
+        #[Assert\Choice(choices: ['mme', 'mr'], message: 'La civilité est incorrecte.')]
         private readonly ?string $civilite = null,
         #[Assert\NotBlank(
             message: 'Merci de saisir un nom.',
@@ -31,6 +33,7 @@ class CoordonneesFoyerRequest implements RequestInterface
         private readonly ?string $prenom = null,
         #[Assert\NotBlank(message: 'Merci de saisir un email.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
+        #[Assert\Length(max: 255, maxMessage: 'L\'email ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $mail = null,
         #[Assert\NotBlank(
             message: 'Merci de saisir un numéro de téléphone.',

--- a/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Constraints\Email;
 class CoordonneesTiersRequest implements RequestInterface
 {
     public function __construct(
+        #[Assert\Choice(choices: ['ORGANISME_SOCIETE', 'PARTICULIER'], message: 'Le type de propriétaire est incorrect.')]
         private readonly ?string $typeProprio = null,
         #[Assert\NotBlank(message: 'Merci de saisir un nom.')]
         #[Assert\Length(max: 50, maxMessage: 'Le nom ne doit pas dépasser {{ limit }} caractères.')]
@@ -18,10 +19,12 @@ class CoordonneesTiersRequest implements RequestInterface
         private readonly ?string $prenom = null,
         #[Assert\NotBlank(message: 'Merci de saisir un courriel.')]
         #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
+        #[Assert\Length(max: 255, maxMessage: 'L\'email ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $mail = null,
         #[Assert\NotBlank(message: 'Merci de saisir un numéro de téléphone.')]
         #[AppAssert\TelephoneFormat]
         private readonly ?string $telephone = null,
+        #[Assert\Choice(choices: ['PROCHE', 'VOISIN', 'SECOURS', 'BAILLEUR', 'PRO', 'AUTRE'], message: 'Le lien avec l\'occupant est incorrect.')]
         private readonly ?string $lien = null,
         #[Assert\When(
             expression: 'this.getLien() == "PRO" || this.getLien() == "SECOURS"',
@@ -29,6 +32,7 @@ class CoordonneesTiersRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de saisir un nom de structure.'),
             ],
         )]
+        #[Assert\Length(max: 200, maxMessage: 'Le nom de la structure ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $structure = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -31,6 +31,7 @@ class InformationsLogementRequest implements RequestInterface
         #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "DPE" est incorrect.')]
         private readonly ?string $bailDpeDpe = null,
         #[Assert\Type(type: 'numeric', message: 'Le loyer doit être un nombre.')]
+        #[Assert\Length(max: 20, maxMessage: 'Le loyer ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $loyer = null,
         #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "Paiement loyers à jour" est incorrect.')]
         private readonly ?string $loyersPayes = null,

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -8,10 +8,13 @@ class InformationsLogementRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de définir le nombre de personnes.')]
+        #[Assert\Positive(message: 'Le nombre de personnes doit être un nombre positif.')]
+        #[Assert\Type(type: 'numeric', message: 'Le nombre de personnes doit être un nombre.')]
         private readonly ?string $nombrePersonnes = null,
         #[Assert\NotBlank(
             message: 'Merci de définir si il y a des enfants de moins de 6 ans',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO', 'BAILLEUR'])]
+        #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "Enfants -6 ans" est incorrect.')]
         private readonly ?string $compositionLogementEnfants = null,
         #[Assert\NotBlank(message: 'Merci de définir la date d\'arrivée.', groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
         #[Assert\DateTime('Y-m-d')]
@@ -19,13 +22,19 @@ class InformationsLogementRequest implements RequestInterface
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $bailleurDateEffetBail = null,
         #[Assert\NotBlank(message: 'Merci d\'indiquer si un bail existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR'])]
+        #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "bail" est incorrect.')]
         private readonly ?string $bailDpeBail = null,
         #[Assert\NotBlank(message: 'Merci d\'indiquer si un état des lieux existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR'])]
+        #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "état des lieux" est incorrect.')]
         private readonly ?string $bailDpeEtatDesLieux = null,
         #[Assert\NotBlank(message: 'Merci d\'indiquer si un DPE existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "DPE" est incorrect.')]
         private readonly ?string $bailDpeDpe = null,
+        #[Assert\Type(type: 'numeric', message: 'Le loyer doit être un nombre.')]
         private readonly ?string $loyer = null,
+        #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "Paiement loyers à jour" est incorrect.')]
         private readonly ?string $loyersPayes = null,
+        #[Assert\Regex(pattern: '/^[0-9]{4}$/', message: 'L\'année de construction doit être composée de 4 chiffres.')]
         private readonly ?string $anneeConstruction = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
+++ b/src/Dto/Request/Signalement/ProcedureDemarchesRequest.php
@@ -8,10 +8,18 @@ class ProcedureDemarchesRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci d\'indiquer si le bailleur a été averti.', groups : ['LOCATAIRE'])]
+        #[Assert\Choice(
+            choices: ['0', '1'],
+            message: 'Le champ "Propriétaire averti" est incorrect.',
+        )]
         private readonly ?string $isProprioAverti = null,
         #[Assert\NotBlank(
             message: 'Merci d\'indiquer si l\'assurance a été contactée.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR']
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'pas_assurance_logement'],
+            message: 'Le champ "Assurance contactée" est incorrect.',
         )]
         private readonly ?string $infoProcedureAssuranceContactee = null,
         #[Assert\When(
@@ -20,11 +28,20 @@ class ProcedureDemarchesRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de noter la réponse de l\'assurance.'),
             ],
         )]
+        #[Assert\Length(
+            max: 255,
+            maxMessage: 'La réponse de l\'assurance ne doit pas dépasser {{ limit }} caractères.',
+        )]
         private readonly ?string $infoProcedureReponseAssurance = null,
         #[Assert\NotBlank(
             message : 'Merci d\'indiquer si l\'occupant souhaite garder son logement après travaux.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT'])]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Souhaite garder le logement après travaux" est incorrect.',
+        )]
         private readonly ?string $infoProcedureDepartApresTravaux = null,
+        #[Assert\Length(max: 50)]
         private readonly ?string $preavisDepart = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -7,15 +7,27 @@ use Symfony\Component\Validator\Constraints as Assert;
 class SituationFoyerRequest implements RequestInterface
 {
     public function __construct(
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Logement social" est incorrect.',
+        )]
         private readonly ?string $isLogementSocial = null,
         #[Assert\NotBlank(
             message: 'Veuillez préciser si une demande de relogement a été faite.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non'],
+            message: 'Le champ "Relogement" est incorrect.',
+        )]
         private readonly ?string $isRelogement = null,
         #[Assert\NotBlank(
             message: 'Veuillez préciser si l\'occupant est allocataire.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'CAF', 'MSA'],
+            message: 'Le champ "Allocataire" est incorrect.',
         )]
         private readonly ?string $isAllocataire = null,
         #[Assert\DateTime('Y-m-d')]
@@ -26,10 +38,16 @@ class SituationFoyerRequest implements RequestInterface
             ],
         )]
         private readonly ?string $dateNaissanceOccupant = null,
+        #[Assert\Length(max: 50, maxMessage: 'Le numéro d\'allocataire ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $numAllocataire = null,
+        #[Assert\Length(max: 20, maxMessage: 'Le montant de l\'allocation ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $logementSocialMontantAllocation = null,
         #[Assert\NotBlank(message: 'Veuillez définir le champ souhaite quitter le logement.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
+        )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Souhaite quitter le logement" est incorrect.',
         )]
         private readonly ?string $travailleurSocialQuitteLogement = null,
         #[Assert\When(
@@ -38,15 +56,33 @@ class SituationFoyerRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de préciser s\'il y a un préavis de départ.'),
             ],
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Préavis de départ" est incorrect.',
+        )]
         private readonly ?string $travailleurSocialPreavisDepart = null,
         #[Assert\NotBlank(
             message: 'Veuillez préciser si l\'occupant est accompagné par un travailleur social.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
         )]
+        #[Assert\Choice(
+            choices: ['oui', 'non', 'nsp'],
+            message: 'Le champ "Accompagnement par un travailleur social" est incorrect.',
+        )]
         private readonly ?string $travailleurSocialAccompagnement = null,
+        #[Assert\Length(max: 50)]
         private readonly ?string $travailleurSocialAccompagnementDeclarant = null,
+        #[Assert\Choice(
+            choices: ['oui', 'non'],
+            message: 'Le champ "Bénéficiaire du RSA" est incorrect.',
+        )]
         private readonly ?string $beneficiaireRsa = null,
+        #[Assert\Choice(
+            choices: ['oui', 'non'],
+            message: 'Le champ "Bénéficiaire du FSL" est incorrect.',
+        )]
         private readonly ?string $beneficiaireFsl = null,
+        #[Assert\Length(max: 50)]
         private readonly ?string $revenuFiscal = null,
     ) {
     }

--- a/src/Dto/Request/Signalement/VisiteRequest.php
+++ b/src/Dto/Request/Signalement/VisiteRequest.php
@@ -10,6 +10,7 @@ class VisiteRequest
         private readonly ?int $idIntervention = null,
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $date = null,
+        #[Assert\DateTime('H:i')]
         private readonly ?string $time = null,
         private readonly ?int $idPartner = null,
         private readonly ?string $details = null,

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -34,17 +34,17 @@
 
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="form-edit-address-adresse">Numéro et voie</label>
-                                        <input class="fr-input" id="form-edit-address-adresse" type="text" name="adresse" value="{{ signalement.adresseOccupant }}" data-autocomplete-addresse="true">
+                                        <input class="fr-input" id="form-edit-address-adresse" type="text" name="adresse" value="{{ signalement.adresseOccupant }}" data-autocomplete-addresse="true" maxlength="100">
                                     </div>
 
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="form-edit-address-codepostal">Code postal</label>
-                                        <input class="fr-input" id="form-edit-address-codepostal" type="text" name="codePostal" value="{{ signalement.cpOccupant }}" data-autocomplete-codepostal="true">
+                                        <input class="fr-input" id="form-edit-address-codepostal" type="text" name="codePostal" value="{{ signalement.cpOccupant }}" data-autocomplete-codepostal="true" minlength="5" maxlength="5">
                                     </div>
 
                                     <div class="fr-input-group">
                                         <label class="fr-label" for="form-edit-address-ville">Commune</label>
-                                        <input class="fr-input" id="form-edit-address-ville" type="text" name="ville" value="{{ signalement.villeOccupant }}" data-autocomplete-ville="true">
+                                        <input class="fr-input" id="form-edit-address-ville" type="text" name="ville" value="{{ signalement.villeOccupant }}" data-autocomplete-ville="true" maxlength="100">
                                     </div>
 
                                     <input type="hidden" name="needResetInsee" value="0" data-autocomplete-need-reset-insee="true">

--- a/tests/Functional/Controller/Back/BackTagControllerTest.php
+++ b/tests/Functional/Controller/Back/BackTagControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Back;
+
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class BackTagControllerTest extends WebTestCase
+{
+    private ?KernelBrowser $client = null;
+    private UserRepository $userRepository;
+    private RouterInterface $router;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->userRepository = static::getContainer()->get(UserRepository::class);
+        $this->router = self::getContainer()->get(RouterInterface::class);
+
+        $user = $this->userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $this->client->loginUser($user);
+    }
+
+    public function testCreateTagSuccess(): void
+    {
+        $route = $this->router->generate('back_tag_create', ['uuid' => '00000000-0000-0000-2023-000000000006']);
+        $this->client->request('POST', $route, ['new-tag-label' => 'test']);
+
+        $this->assertJson($this->client->getResponse()->getContent());
+        $this->assertStringContainsString('success', $this->client->getResponse()->getContent());
+    }
+
+    public function testCreateTagError(): void
+    {
+        $route = $this->router->generate('back_tag_create', ['uuid' => '00000000-0000-0000-2023-000000000006']);
+        $this->client->request('POST', $route, ['new-tag-label' => 't']);
+
+        $this->assertJson($this->client->getResponse()->getContent());
+        $this->assertStringContainsString('Le tag doit contenir au moins 2 caract\u00e8res', $this->client->getResponse()->getContent());
+    }
+}

--- a/tests/Functional/Controller/Back/SignalementFileControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementFileControllerTest.php
@@ -2,15 +2,19 @@
 
 namespace App\Tests\Functional\Controller\Back;
 
+use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Routing\RouterInterface;
 
 class SignalementFileControllerTest extends WebTestCase
 {
+    use SessionHelper;
     private ?KernelBrowser $client = null;
     private UserRepository $userRepository;
+    private SignalementRepository $signalementRepository;
     private RouterInterface $router;
 
     protected function setUp(): void
@@ -18,13 +22,17 @@ class SignalementFileControllerTest extends WebTestCase
         $this->client = static::createClient();
         $this->router = self::getContainer()->get(RouterInterface::class);
         $this->userRepository = static::getContainer()->get(UserRepository::class);
+        $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
 
-        $user = $this->userRepository->findOneBy(['email' => 'user-13-05@histologe.fr']);
+        $user = $this->userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
         $this->client->loginUser($user);
     }
 
     public function testAddFileSignalementNotDeny(): void
     {
+        $user = $this->userRepository->findOneBy(['email' => 'user-13-05@histologe.fr']);
+        $this->client->loginUser($user);
+
         $route = $this->router->generate('back_signalement_add_file', ['uuid' => '00000000-0000-0000-2023-000000000009']);
         $this->client->request('POST', $route);
 
@@ -41,5 +49,51 @@ class SignalementFileControllerTest extends WebTestCase
         $this->client->request('POST', $route);
 
         $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testEditFileSignalementSucces(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000009']);
+        $route = $this->router->generate('back_signalement_edit_file', ['uuid' => $signalement->getUuid()]);
+        $this->client->request(
+            'POST',
+            $route,
+            [
+                'file_id' => $signalement->getFiles()[0]->getId(),
+                'documentType' => 'AUTRE',
+                'description' => 'Comme on peux le voir la situation est critique, il faut agir rapidement.',
+                '_token' => $this->generateCsrfToken($this->client, 'signalement_edit_file_'.$signalement->getId()),
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.fr-alert--success p', 'La photo a bien été modifiée.');
+    }
+
+    public function testEditFileSignalementError(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000009']);
+        $route = $this->router->generate('back_signalement_edit_file', ['uuid' => $signalement->getUuid()]);
+
+        $message = 'Je vais écrire un roman, lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        Nulla nec purus feugiat, ultricies nunc nec, tincidunt nunc. Nulla facilisi.
+        Nullam nec... Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec purus feugiat, ultricies nunc nec, tincidunt nunc.
+        Nulla facilisi. Nullam nec...';
+
+        $this->client->request(
+            'POST',
+            $route,
+            [
+                'file_id' => $signalement->getFiles()[0]->getId(),
+                'documentType' => 'AUTRE',
+                'description' => $message,
+                '_token' => $this->generateCsrfToken($this->client, 'signalement_edit_file_'.$signalement->getId()),
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.fr-alert--error p', 'La description ne doit pas dépasser 255 caractères');
     }
 }


### PR DESCRIPTION
## Ticket

#2740

## Description
- Ajout de contraintes sur les request correspondant au différente popup d'édition du signalement
- Contrôle des longueurs des champs pour les tags, suivis, cloture, description des doc, 
- Fix sur l'affectation (contrôle du partenaire)

## Tests
- [ ] Vérifier que les différents popup d'édition continue de fonctionner correctement
