### PR TITLE
[BO - Partenaires] Contrôle back des champs de formulaire d'ajout et édition d'utilisateurs

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -461,6 +461,12 @@ class PartnerController extends AbstractController
 
     private function canAttributeRole(string $role): bool
     {
+        if (empty($role)) {
+            $this->addFlash('error', 'Merci de sélectionner un rôle.');
+
+            return false;
+        }
+
         $authorizedRoles = ['ROLE_USER_PARTNER', 'ROLE_ADMIN_PARTNER'];
         if ($this->isGranted('ROLE_ADMIN_TERRITORY')) {
             $authorizedRoles[] = 'ROLE_ADMIN_TERRITORY';

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -9,6 +9,7 @@ use App\Entity\Enum\Qualification;
 use App\Entity\Intervention;
 use App\Entity\Partner;
 use App\Entity\User;
+use App\Factory\UserFactory;
 use App\Form\PartnerType;
 use App\Manager\InterventionManager;
 use App\Manager\PartnerManager;
@@ -31,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 #[Route('/bo/partenaires')]
@@ -335,7 +337,9 @@ class PartnerController extends AbstractController
         Request $request,
         Partner $partner,
         UserManager $userManager,
+        UserFactory $userFactory,
         PartnerRepository $partnerRepository,
+        ValidatorInterface $validator,
     ): Response {
         $this->denyAccessUnlessGranted('USER_CREATE', $partner);
         $data = $request->get('user_create');
@@ -359,8 +363,6 @@ class PartnerController extends AbstractController
 
         if (null !== $partnerExist) {
             $this->addFlash('error', 'Un partenaire existe déjà avec cette adresse e-mail.');
-
-            return $this->redirectToRoute('back_partner_view', ['id' => $partner->getId()], Response::HTTP_SEE_OTHER);
         } elseif (null !== $user && \in_array('ROLE_USAGER', $user->getRoles())) {
             $data['territory'] = $partner->getTerritory();
             $data['partner'] = $partner;
@@ -368,14 +370,18 @@ class PartnerController extends AbstractController
             $userManager->updateUserFromData($user, $data);
         } elseif (null !== $user) {
             $this->addFlash('error', 'Un utilisateur existe déjà avec cette adresse e-mail.');
-
-            return $this->redirectToRoute('back_partner_view', ['id' => $partner->getId()], Response::HTTP_SEE_OTHER);
         } else {
-            $user = $userManager->createUserFromData($partner, $data);
+            $user = $userFactory->createInstanceFromArray($partner, $data);
+            $errors = $validator->validate($user);
+            foreach ($errors as $error) {
+                $this->addFlash('error', $error->getMessage());
+            }
+            if (0 === \count($errors)) {
+                $userManager->save($user);
+                $message = 'L\'utilisateur a bien été créé. Un e-mail de confirmation a été envoyé à '.$user->getEmail();
+                $this->addFlash('success', $message);
+            }
         }
-
-        $message = 'L\'utilisateur a bien été créé. Un e-mail de confirmation a été envoyé à '.$user->getEmail();
-        $this->addFlash('success', $message);
 
         return $this->redirectToRoute('back_partner_view', ['id' => $partner->getId()], Response::HTTP_SEE_OTHER);
     }
@@ -386,6 +392,7 @@ class PartnerController extends AbstractController
         UserManager $userManager,
         UserRepository $userRepository,
         PartnerRepository $partnerRepository,
+        ValidatorInterface $validator,
     ): Response {
         $userId = $request->request->get('user_id');
         $user = $userManager->find((int) $userId);
@@ -428,18 +435,26 @@ class PartnerController extends AbstractController
             }
         }
         $user = $userManager->updateUserFromData(
-            $user,
-            [
+            user: $user,
+            data: [
                 'nom' => $data['nom'],
                 'prenom' => $data['prenom'],
                 'roles' => $data['roles'],
                 'email' => $data['email'],
                 'isMailingActive' => $data['isMailingActive'],
-            ]
+            ],
+            save: false
         );
 
-        $message = 'L\'utilisateur a bien été modifié.';
-        $this->addFlash('success', $message);
+        $errors = $validator->validate($user);
+        foreach ($errors as $error) {
+            $this->addFlash('error', $error->getMessage());
+        }
+        if (0 === \count($errors)) {
+            $userManager->save($user);
+            $message = 'L\'utilisateur a bien été modifié.';
+            $this->addFlash('success', $message);
+        }
 
         return $this->redirectToRoute('back_partner_view', ['id' => $user->getPartner()->getId()], Response::HTTP_SEE_OTHER);
     }

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -32,6 +32,7 @@ class Partner
 
     #[ORM\Column(type: 'string', length: 255)]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
     #[Groups(['widget-settings:read'])]
     private ?string $nom = null;
 
@@ -49,6 +50,7 @@ class Partner
 
     #[ORM\Column(type: 'string', length: 100, nullable: true)]
     #[Assert\Email]
+    #[Assert\Length(max: 255)]
     private ?string $email = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -63,7 +63,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
 
     #[ORM\Column(type: 'string', length: 180, unique: false)]
     #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT, groups: ['registration'])]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de saisir une adresse e-mail.')]
     #[Assert\Length(max: 255)]
     private $email;
 
@@ -100,12 +100,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     private $partner;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de saisir un nom.')]
     #[Assert\Length(max: 255)]
     private $nom;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de saisir un prénom.')]
     #[Assert\Length(max: 255)]
     private $prenom;
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -64,6 +64,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     #[ORM\Column(type: 'string', length: 180, unique: false)]
     #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT, groups: ['registration'])]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
     private $email;
 
     #[ORM\Column(type: 'json')]
@@ -100,10 +101,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
     private $nom;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
     private $prenom;
 
     #[ORM\Column(type: 'integer')]

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -33,7 +33,7 @@ class UserManager extends AbstractManager
         parent::__construct($managerRegistry, $entityName);
     }
 
-    public function updateUserFromData(User $user, array $data): User
+    public function updateUserFromData(User $user, array $data, bool $save = true): User
     {
         $user
             ->setNom($data['nom'])
@@ -50,7 +50,10 @@ class UserManager extends AbstractManager
         if (\array_key_exists('statut', $data)) {
             $user->setStatut($data['statut']);
         }
-        $this->save($user);
+
+        if ($save) {
+            $this->save($user);
+        }
 
         return $user;
     }


### PR DESCRIPTION
## Ticket

#2741   

## Description
Ajout de contrôles côté back sur les formulaires d'ajout et d'édition d'utilisateur.
Les champs Nom, Prénom et E-mail n'étaient pas vérifiés.
Mise en place d'une validation de l'entité avant enregistrement.

## Tests
Pour tester, j'ai supprimé les `required` des champs de formulaire
- [ ] Ajouter un utilisateur sans certains champs et vérifier qu'on est bloqué
- [ ] Idem pour l'édition
