### PR TITLE
[Formulaire] Ajout de contraintes de saisies pour l'adresse, pour éviter d'avoir uniquement des chiffres

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -197,11 +197,9 @@ export default defineComponent({
     validateComponents (components: any) {
       for (const component of components) {
         const value = formStore.data[component.slug]
-        if (this.isRequired(component) && component.type !== 'SignalementFormAddress' && !value ) {
-            formStore.validationErrors[component.slug] = 'Ce champ est requis'
-        }
-        if (component.type === 'SignalementFormAddress') {
-          this.validateComponentAddress(component.slug, this.isRequired(component))
+        // Les autres composants requis doivent avoir une valeur correspondante dans le Store
+        if (this.isRequired(component) && !value && component.type !== 'SignalementFormAddress') {
+          formStore.validationErrors[component.slug] = 'Ce champ est requis'
         }
 
         componentValidator.validate(component)
@@ -211,36 +209,6 @@ export default defineComponent({
           this.validateComponents(component.components.body)
         }
       }
-    },
-    validateComponentAddress (componentSlug: any, required: boolean) {
-      if(required) {
-        const validationError = 'Ce champ est requis'
-        // tous les champs sont vides, on affiche l'erreur sur le champs de recherche
-        if (!formStore.data[componentSlug] &&
-              !formStore.data[componentSlug + '_detail_numero'] &&
-              !formStore.data[componentSlug + '_detail_code_postal'] &&
-              !formStore.data[componentSlug + '_detail_commune']
-        ) {
-          formStore.validationErrors[componentSlug] = validationError
-
-        // il y a eu une édition manuelle : on vérifie tous les sous-champs
-        } else if (formStore.data[componentSlug + '_detail_manual'] !== 0) {
-          if (!formStore.data[componentSlug + '_detail_numero']) {
-            formStore.validationErrors[componentSlug + '_detail_numero'] = validationError
-          }
-          if (!formStore.data[componentSlug + '_detail_code_postal']) {
-            formStore.validationErrors[componentSlug + '_detail_code_postal'] = validationError
-          }
-          if (!formStore.data[componentSlug + '_detail_commune']) {
-            formStore.validationErrors[componentSlug + '_detail_commune'] = validationError
-          }
-        }
-      }
-      // vérification du code postal
-      if (formStore.data[componentSlug + '_detail_code_postal'] && !/^\d{5}$/.test(formStore.data[componentSlug + '_detail_code_postal'])) {
-        formStore.validationErrors[componentSlug + '_detail_code_postal'] = 'Le code postal doit être composé de 5 chiffres'
-      }
-
     },
     updateFormData (slug: string, value: any) {
       this.formStore.data[slug] = value

--- a/assets/vue/components/signalement-form/services/componentValidator.ts
+++ b/assets/vue/components/signalement-form/services/componentValidator.ts
@@ -34,10 +34,55 @@ export const componentValidator = {
       }
     }
 
+    if (component.type === 'SignalementFormAddress') {
+      this.validateAddress(componentSlug)
+    }
+
     if (value !== undefined && value !== '' && component.validate?.maxLength !== undefined) {
       if (value.length > component.validate?.maxLength) {
         const maxLength: string = component.validate?.maxLength.toString()
         formStore.validationErrors[componentSlug] = 'La valeur dépasse la longueur autorisée ' + maxLength
+      }
+    }
+  },
+
+  validateAddress (componentSlug: string) {
+    const validationError = 'Ce champ est requis'
+    // tous les champs sont vides, on affiche l'erreur sur le champs de recherche
+    if (
+      (formStore.data[componentSlug] === undefined || formStore.data[componentSlug] === '') &&
+      (formStore.data[componentSlug + '_detail_numero'] === undefined || formStore.data[componentSlug + '_detail_numero'] === '') &&
+      (formStore.data[componentSlug + '_detail_code_postal'] === undefined || formStore.data[componentSlug + '_detail_code_postal'] === '') &&
+      (formStore.data[componentSlug + '_detail_commune'] === undefined || formStore.data[componentSlug + '_detail_commune'] === '')
+    ) {
+      formStore.validationErrors[componentSlug] = validationError
+
+    // il y a eu une édition manuelle : on vérifie tous les sous-champs
+    } else if (formStore.data[componentSlug + '_detail_manual'] !== 0) {
+      const addressDetailNumero = formStore.data[componentSlug + '_detail_numero']
+      if (addressDetailNumero === undefined || addressDetailNumero === '') {
+        formStore.validationErrors[componentSlug + '_detail_numero'] = validationError
+      } else {
+        const regexPattern = /^[0-9]*$/
+        if (regexPattern.test(addressDetailNumero) || addressDetailNumero.length < 6) {
+          formStore.validationErrors[componentSlug + '_detail_numero'] = 'Format invalide'
+        }
+      }
+
+      if (formStore.data[componentSlug + '_detail_code_postal'] === undefined ||
+        formStore.data[componentSlug + '_detail_code_postal'] === ''
+      ) {
+        formStore.validationErrors[componentSlug + '_detail_code_postal'] = validationError
+
+      // vérification du code postal
+      } else if (!/^\d{5}$/.test(formStore.data[componentSlug + '_detail_code_postal'])) {
+        formStore.validationErrors[componentSlug + '_detail_code_postal'] = 'Le code postal doit être composé de 5 chiffres'
+      }
+
+      if (formStore.data[componentSlug + '_detail_commune'] === undefined ||
+        formStore.data[componentSlug + '_detail_commune'] === ''
+      ) {
+        formStore.validationErrors[componentSlug + '_detail_commune'] = validationError
       }
     }
   }

--- a/assets/vue/components/signalement-form/services/componentValidator.ts
+++ b/assets/vue/components/signalement-form/services/componentValidator.ts
@@ -64,7 +64,7 @@ export const componentValidator = {
         formStore.validationErrors[componentSlug + '_detail_numero'] = validationError
       } else {
         const regexPattern = /^[0-9]*$/
-        if (regexPattern.test(addressDetailNumero) || addressDetailNumero.length < 6) {
+        if (regexPattern.test(addressDetailNumero) || addressDetailNumero.length < 6 || addressDetailNumero.length > 100) {
           formStore.validationErrors[componentSlug + '_detail_numero'] = 'Format invalide'
         }
       }

--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -8,7 +8,8 @@ class AdresseOccupantRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\NotBlank(message: 'Merci de saisir une adresse.')]
-        #[Assert\Length(max: 100, maxMessage: 'L\'adresse ne peut pas dépasser {{ limit }} caractères.')]
+        #[Assert\Length(min: 6, minMessage: 'L\'adresse n\'est pas au bon format.', max: 100, maxMessage: 'L\'adresse ne peut pas dépasser {{ limit }} caractères.')]
+        #[Assert\Regex('/.*[^0-9].*/')]
         private readonly ?string $adresse = null,
         #[Assert\NotBlank(message: 'Merci de saisir un code postal.')]
         #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]


### PR DESCRIPTION
## Ticket

#2758   

## Description
Certaines adresses se sont retrouvées avec uniquement le numéro de rue, mais pas le nom de la voie.
On ajoute des contraintes de saisie pour l'adresse, côté FO et côté BO
- pas vide
- pas juste des chiffres
- minimum 6 caractères
- maximum 100 caractères

## Tests
- [ ] FO : vérifier différents cas de saisie d'adresse
- [ ] Idem BO
