### PR TITLE
[QA login] Doctrine\DBAL\Exception\DeadlockException

### DIFF
--- a/src/EventListener/LoginListener.php
+++ b/src/EventListener/LoginListener.php
@@ -3,10 +3,12 @@
 namespace App\EventListener;
 
 use App\Entity\Enum\HistoryEntryEvent;
+use App\Entity\HistoryEntry;
 use App\Entity\User;
 use App\Manager\HistoryEntryManager;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
 class LoginListener
@@ -15,7 +17,8 @@ class LoginListener
 
     public function __construct(
         private EntityManagerInterface $em,
-        private HistoryEntryManager $historyEntryManager
+        private HistoryEntryManager $historyEntryManager,
+        private LoggerInterface $logger
     ) {
     }
 
@@ -25,18 +28,30 @@ class LoginListener
         $user = $event->getAuthenticationToken()->getUser();
         $user->setLastLoginAt(new DateTimeImmutable());
 
-        if (self::CHECK_2FA_PATH !== $event->getRequest()->getPathInfo()) {
-            $this->historyEntryManager->create(
-                historyEntryEvent: HistoryEntryEvent::LOGIN,
-                entityId: $user->getId(),
-                entityName: User::class,
-                user: $user
-            );
-        }
+        try {
+            if (self::CHECK_2FA_PATH !== $event->getRequest()->getPathInfo()) {
+                /*$this->historyEntryManager->create(
+                    historyEntryEvent: HistoryEntryEvent::LOGIN,
+                    entityId: $user->getId(),
+                    entityName: User::class,
+                    user: $user
+                );*/
+                $historyEntry = new HistoryEntry();
+                $historyEntry->setEvent(HistoryEntryEvent::LOGIN);
+                $historyEntry->setEntityId($user->getId());
+                $historyEntry->setEntityName(User::class);
+                $historyEntry->setUser($user);
+                $this->em->persist($historyEntry);
+            }
 
-        $event->getRequest()->getSession()->set('_security.territory', $user->getTerritory());
-        // Persist the data to database.
-        $this->em->persist($user);
-        $this->em->flush();
+            $event->getRequest()->getSession()->set('_security.territory', $user->getTerritory());
+            // Persist the data to database.
+            $this->em->persist($user);
+            $this->em->flush();
+        } catch (\Exception $e) {
+            $msg = 'Failed to create login history entry ('.$e->getMessage().') on user :"'.$user->getId();
+            $this->logger->error($msg);
+            throw new \Exception($msg);
+        }
     }
 }


### PR DESCRIPTION
## Ticket

#2786 

## Description
- Ajout d'un try catch pour avoir l'id de l'user dans l'erreur remonté
- bypass du historyEntryManager pour que le flush soit fait dans la même transaction que l'update user
