### PR TITLE
[BO] Normaliser les noms des bailleurs publics

### DIFF
--- a/migrations/Version20240709130023.php
+++ b/migrations/Version20240709130023.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240709130023 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add raison sociale and siret to bailleur';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bailleur ADD raison_sociale VARCHAR(255) DEFAULT NULL, ADD siret VARCHAR(20) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_7ABB27F3E2B45978 ON bailleur (raison_sociale)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_7ABB27F326E94372 ON bailleur (siret)');
+        $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511457B5D0A2');
+        $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B5511457B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_7ABB27F3E2B45978 ON bailleur');
+        $this->addSql('DROP INDEX UNIQ_7ABB27F326E94372 ON bailleur');
+        $this->addSql('ALTER TABLE bailleur DROP raison_sociale, DROP siret');
+        $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511457B5D0A2');
+        $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B5511457B5D0A2 FOREIGN KEY (bailleur_id) REFERENCES bailleur (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+    }
+}

--- a/scripts/upload-s3.sh
+++ b/scripts/upload-s3.sh
@@ -31,7 +31,7 @@ else
   option=$1
   zip=$2
   debug=${3:null}
-  if [ -z "$zip" ] && [ "$option" != "desordres" ]; then
+  if [ -z "$zip" ] && [ "$option" != "desordres" ] && [ "$option" != "bailleurs" ]; then
     echo "zip argument is missing: ./scripts/upload-s3.sh [option] [zip]"
     exit 1
   fi

--- a/src/Command/AddBailleurLinkOnSignalementCommand.php
+++ b/src/Command/AddBailleurLinkOnSignalementCommand.php
@@ -32,10 +32,11 @@ class AddBailleurLinkOnSignalementCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $this->bailleursByNom = $this->bailleurRepository->findAllIndexedByNameSanitizedWithBailleurTerritories();
-        $this->bailleursByRaison = $this->bailleurRepository->findAllIndexedByNameSanitizedWithBailleurTerritories(true);
+        $this->bailleursByNom = $this->bailleurRepository->findBailleursIndexedByName();
+        $this->bailleursByRaison = $this->bailleurRepository->findBailleursIndexedByName(raisonSociale: true);
 
-        $signalements = $this->signalementRepository->findAllWithoutBailleurPublicLink();
+        $signalements = $this->signalementRepository->findLogementSocialWithoutBailleurLink();
+
         foreach ($signalements as $signalement) {
             $nomProprioSanitized = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', mb_strtoupper($signalement->getNomProprio()));
             if (isset($this->bailleursByNom[$nomProprioSanitized])) {

--- a/src/Command/AddBailleurLinkOnSignalementCommand.php
+++ b/src/Command/AddBailleurLinkOnSignalementCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\BailleurRepository;
+use App\Repository\SignalementRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:add-bailleur-link-on-signalement',
+    description: 'Add Bailleur link on Signalement',
+)]
+class AddBailleurLinkOnSignalementCommand extends Command
+{
+    private $bailleursByNom = [];
+    private $bailleursByRaison = [];
+    private $nbLinkAdded = 0;
+
+    public function __construct(
+        private readonly SignalementRepository $signalementRepository,
+        private readonly BailleurRepository $bailleurRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $this->bailleursByNom = $this->bailleurRepository->findAllIndexedByNameSanitizedWithBailleurTerritories();
+        $this->bailleursByRaison = $this->bailleurRepository->findAllIndexedByNameSanitizedWithBailleurTerritories(true);
+
+        $signalements = $this->signalementRepository->findAllWithoutBailleurPublicLink();
+        foreach ($signalements as $signalement) {
+            $nomProprioSanitized = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', mb_strtoupper($signalement->getNomProprio()));
+            if (isset($this->bailleursByNom[$nomProprioSanitized])) {
+                $bailleur = $this->bailleursByNom[$nomProprioSanitized];
+                $signalement->setBailleur($bailleur);
+                ++$this->nbLinkAdded;
+            } elseif (isset($this->bailleursByRaison[$nomProprioSanitized])) {
+                $bailleur = $this->bailleursByRaison[$nomProprioSanitized];
+                $signalement->setBailleur($bailleur);
+                ++$this->nbLinkAdded;
+            }
+        }
+
+        $this->entityManager->flush();
+
+        $io->success(sprintf('%s bailleur(s) have been linked to signalements.', $this->nbLinkAdded));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/ImportBailleurCommand.php
+++ b/src/Command/ImportBailleurCommand.php
@@ -52,7 +52,9 @@ class ImportBailleurCommand extends Command
             $io->warning($error);
         }
 
-        $io->success(sprintf('%s bailleur(s) have been imported.', $metadata['count_bailleurs']));
+        $io->success(sprintf('%s new bailleur(s) have been imported.', $metadata['new_bailleurs']));
+        $io->success(sprintf('%s bailleur(s) have been updated.', $metadata['updated_bailleurs']));
+        $io->success(sprintf('%s bailleur(s) have been deleted.', $metadata['deleted_bailleurs']));
 
         return Command::SUCCESS;
     }

--- a/src/Controller/BailleurController.php
+++ b/src/Controller/BailleurController.php
@@ -42,7 +42,7 @@ class BailleurController extends AbstractController
                     $name = strtolower($name);
                     $name = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $name);
 
-                    return str_contains(strtolower($this->sanitizeName($bailleurItem->getName())), $name);
+                    return str_contains(strtolower($this->sanitizeName($bailleurItem->getName())), $name) || str_contains(strtolower($bailleurItem->getRaisonSociale()), $name);
                 }
 
                 return true;

--- a/src/Entity/Bailleur.php
+++ b/src/Entity/Bailleur.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Ignore;
 
 #[ORM\Entity(repositoryClass: BailleurRepository::class)]
-#[ORM\UniqueConstraint(columns: ['name'])]
 class Bailleur
 {
     public const BAILLEUR_RADIE = '[Radié(e)]';
@@ -20,7 +19,7 @@ class Bailleur
     #[Ignore]
     private ?int $id = null;
 
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, unique: true)]
     private ?string $name = null;
 
     #[ORM\OneToMany(mappedBy: 'bailleur', targetEntity: Signalement::class)]
@@ -30,6 +29,12 @@ class Bailleur
     #[ORM\OneToMany(mappedBy: 'bailleur', targetEntity: BailleurTerritory::class, cascade: ['persist'])]
     #[Ignore]
     private Collection $bailleurTerritories;
+
+    #[ORM\Column(length: 255, unique: true, nullable: true)]
+    private ?string $raisonSociale = null;
+
+    #[ORM\Column(length: 20, unique: true, nullable: true)]
+    private ?string $siret = null;
 
     public function __construct()
     {
@@ -88,6 +93,30 @@ class Bailleur
     {
         $bailleurTerritory = (new BailleurTerritory())->setTerritory($territory);
         $this->addBailleurTerritory($bailleurTerritory);
+
+        return $this;
+    }
+
+    public function getRaisonSociale(): ?string
+    {
+        return $this->raisonSociale;
+    }
+
+    public function setRaisonSociale(?string $raisonSociale): static
+    {
+        $this->raisonSociale = $raisonSociale;
+
+        return $this;
+    }
+
+    public function getSiret(): ?string
+    {
+        return $this->siret;
+    }
+
+    public function setSiret(?string $siret): static
+    {
+        $this->siret = $siret;
 
         return $this;
     }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -408,6 +408,7 @@ class Signalement
     private Collection $desordrePrecisions;
 
     #[ORM\ManyToOne(inversedBy: 'signalements')]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
     private ?Bailleur $bailleur = null;
 
     #[ORM\Column(nullable: true)]

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -34,7 +34,7 @@ class BailleurRepository extends ServiceEntityRepository
         foreach ($terms as $index => $term) {
             $placeholder = 'term_'.$index;
             $queryBuilder
-                ->andWhere($queryBuilder->expr()->like('b.name', ':'.$placeholder))
+                ->andWhere('b.name LIKE :'.$placeholder.' OR b.raisonSociale LIKE :'.$placeholder)
                 ->setParameter($placeholder, '%'.$term.'%');
         }
 

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -61,7 +61,7 @@ class BailleurRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery()->getOneOrNullResult();
     }
 
-    public function findAllIndexedByNameSanitizedWithBailleurTerritories(?bool $raisonSociale = false): array
+    public function findBailleursIndexedByName(?bool $raisonSociale = false): array
     {
         $list = $this->createQueryBuilder('b')
             ->leftJoin('b.bailleurTerritories', 'bt')

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -61,7 +61,7 @@ class BailleurRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery()->getOneOrNullResult();
     }
 
-    public function findAllIndexedByNameSanitizedWithBailleurTerritories(): array
+    public function findAllIndexedByNameSanitizedWithBailleurTerritories(?bool $raisonSociale = false): array
     {
         $list = $this->createQueryBuilder('b')
             ->leftJoin('b.bailleurTerritories', 'bt')
@@ -70,7 +70,11 @@ class BailleurRepository extends ServiceEntityRepository
             ->getResult();
         $indexed = [];
         foreach ($list as $bailleur) {
-            $name = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', mb_strtoupper($bailleur->getName()));
+            if ($raisonSociale) {
+                $name = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', mb_strtoupper($bailleur->getRaisonSociale()));
+            } else {
+                $name = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', mb_strtoupper($bailleur->getName()));
+            }
             $indexed[$name] = $bailleur;
         }
 

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -60,4 +60,20 @@ class BailleurRepository extends ServiceEntityRepository
 
         return $queryBuilder->getQuery()->getOneOrNullResult();
     }
+
+    public function findAllIndexedByNameSanitizedWithBailleurTerritories(): array
+    {
+        $list = $this->createQueryBuilder('b')
+            ->leftJoin('b.bailleurTerritories', 'bt')
+            ->addSelect('bt')
+            ->getQuery()
+            ->getResult();
+        $indexed = [];
+        foreach ($list as $bailleur) {
+            $name = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', mb_strtoupper($bailleur->getName()));
+            $indexed[$name] = $bailleur;
+        }
+
+        return $indexed;
+    }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1280,4 +1280,14 @@ class SignalementRepository extends ServiceEntityRepository
 
         return new Paginator($queryBuilder->getQuery(), false);
     }
+
+    public function findAllWithoutBailleurPublicLink(): array
+    {
+        return $this->createQueryBuilder('s')
+            ->where('s.isLogementSocial = 1')
+            ->andWhere('s.bailleur IS NULL')
+            ->andWhere('s.nomProprio IS NOT NULL')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1281,7 +1281,7 @@ class SignalementRepository extends ServiceEntityRepository
         return new Paginator($queryBuilder->getQuery(), false);
     }
 
-    public function findAllWithoutBailleurPublicLink(): array
+    public function findLogementSocialWithoutBailleurLink(): array
     {
         return $this->createQueryBuilder('s')
             ->where('s.isLogementSocial = 1')

--- a/src/Repository/TerritoryRepository.php
+++ b/src/Repository/TerritoryRepository.php
@@ -38,6 +38,15 @@ class TerritoryRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    public function findAllIndexedByZip(): array
+    {
+        $qb = $this->createQueryBuilder('t');
+
+        return $qb->indexBy('t', 't.zip')
+            ->getQuery()
+            ->getResult();
+    }
+
     /**
      * @throws NonUniqueResultException
      * @throws NoResultException

--- a/src/Service/Import/Bailleur/BailleurHeader.php
+++ b/src/Service/Import/Bailleur/BailleurHeader.php
@@ -4,6 +4,8 @@ namespace App\Service\Import\Bailleur;
 
 class BailleurHeader
 {
-    public const DEPARTEMENT = 'Département du logement attribué';
-    public const ORGANISME_NOM = 'Organisme de l\'attribution';
+    public const DEPARTEMENT = 'DEP';
+    public const ENSEIGNE = 'Enseigne';
+    public const SIRET = 'SIRET';
+    public const RAISON_SOCIALE = 'Raison sociale';
 }

--- a/src/Service/Import/Bailleur/BailleurLoader.php
+++ b/src/Service/Import/Bailleur/BailleurLoader.php
@@ -106,7 +106,7 @@ class BailleurLoader
     private function initData(): void
     {
         $this->territories = $this->territoryRepository->findAllIndexedByZip();
-        $this->bailleurs = $this->bailleurRepository->findAllIndexedByNameSanitizedWithBailleurTerritories();
+        $this->bailleurs = $this->bailleurRepository->findBailleursIndexedByName();
         foreach ($this->bailleurs as $bailleur) {
             foreach ($bailleur->getBailleurTerritories() as $bailleurTerritory) {
                 $bailleur->removeBailleurTerritory($bailleurTerritory);

--- a/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
+++ b/tests/Functional/Service/Import/Bailleur/BailleurLoaderTest.php
@@ -12,8 +12,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class BailleurLoaderTest extends KernelTestCase
 {
-    private const BOUCHE_DU_RHONE = 'Bouches-du-Rhône';
-    private const CHARENTE = 'Charente';
+    private const BOUCHE_DU_RHONE = '13';
+    private const CHARENTE = '16';
 
     public function testLoadValidBailleur(): void
     {
@@ -27,8 +27,10 @@ class BailleurLoaderTest extends KernelTestCase
         $bailleurLoader->load($this->getData());
 
         $metadata = $bailleurLoader->getMetadata();
-        $this->assertEquals(5, $metadata['count_bailleurs']);
-        $this->assertStringContainsString('Le territoire n\'existe pas.', $metadata['errors'][0]);
+        $this->assertEquals(4, $metadata['new_bailleurs']);
+        $this->assertEquals(1, $metadata['updated_bailleurs']);
+        $this->assertStringContainsString('Le nom bailleur est vide.', $metadata['errors'][0]);
+        $this->assertStringContainsString('Le territoire n\'existe pas.', $metadata['errors'][1]);
     }
 
     private function getData(): array
@@ -36,39 +38,51 @@ class BailleurLoaderTest extends KernelTestCase
         return [
             [
                 BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
-                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 1',
+                BailleurHeader::ENSEIGNE => '13 HABITAT',
+                BailleurHeader::RAISON_SOCIALE => 'OPH 13 HABITAT',
+                BailleurHeader::SIRET => '00000000000001',
             ],
             [
                 BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
-                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 2',
+                BailleurHeader::ENSEIGNE => 'MEDITERRANEE 2',
+                BailleurHeader::RAISON_SOCIALE => 'OPH MEDITERRANEE 2',
+                BailleurHeader::SIRET => '00000000000002',
             ],
             [
                 BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
-                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 3',
+                BailleurHeader::ENSEIGNE => 'MEDITERRANEE 3',
+                BailleurHeader::RAISON_SOCIALE => 'OPH MEDITERRANEE 3',
+                BailleurHeader::SIRET => '00000000000003',
             ],
             [
                 BailleurHeader::DEPARTEMENT => self::BOUCHE_DU_RHONE,
-                BailleurHeader::ORGANISME_NOM => '',
+                BailleurHeader::ENSEIGNE => '',
+                BailleurHeader::RAISON_SOCIALE => '',
+                BailleurHeader::SIRET => '',
             ],
             [
                 BailleurHeader::DEPARTEMENT => self::CHARENTE,
-                BailleurHeader::ORGANISME_NOM => 'DOMOFRANCE 1',
+                BailleurHeader::ENSEIGNE => 'DOMOFRANCE 1',
+                BailleurHeader::RAISON_SOCIALE => 'OPH DOMOFRANCE 1',
+                BailleurHeader::SIRET => '00000000000004',
             ],
             [
                 BailleurHeader::DEPARTEMENT => self::CHARENTE,
-                BailleurHeader::ORGANISME_NOM => 'DOMOFRANCE 2',
+                BailleurHeader::ENSEIGNE => 'DOMOFRANCE 2',
+                BailleurHeader::RAISON_SOCIALE => 'OPH DOMOFRANCE 2',
+                BailleurHeader::SIRET => '00000000000005',
             ],
             [
                 BailleurHeader::DEPARTEMENT => self::CHARENTE,
-                BailleurHeader::ORGANISME_NOM => 'MEDITERRANEE 3',
+                BailleurHeader::ENSEIGNE => 'MEDITERRANEE 3',
+                BailleurHeader::RAISON_SOCIALE => 'OPH MEDITERRANEE 3',
+                BailleurHeader::SIRET => '00000000000003',
             ],
             [
-                BailleurHeader::DEPARTEMENT => self::CHARENTE,
-                BailleurHeader::ORGANISME_NOM => '',
-            ],
-            [
-                BailleurHeader::DEPARTEMENT => 'Saint Martin',
-                BailleurHeader::ORGANISME_NOM => 'LOGEMENT HLS',
+                BailleurHeader::DEPARTEMENT => '458',
+                BailleurHeader::ENSEIGNE => 'LOGEMENT HLS',
+                BailleurHeader::RAISON_SOCIALE => '',
+                BailleurHeader::SIRET => '00000000000006',
             ],
         ];
     }

--- a/tests/Unit/Command/ImportBailleurCommandTest.php
+++ b/tests/Unit/Command/ImportBailleurCommandTest.php
@@ -67,8 +67,10 @@ class ImportBailleurCommandTest extends KernelTestCase
             ->expects($this->once())
             ->method('getMetadata')
             ->willReturn([
-                'count_bailleurs' => 10,
-                'errors' => ['[Wallis-et-Futuna] ligne 2 - Le territoire n\'existe pas'],
+                'new_bailleurs' => 10,
+                'updated_bailleurs' => 0,
+                'deleted_bailleurs' => 0,
+                'errors' => ['[125] ligne 2 - Le territoire n\'existe pas'],
             ]);
 
         $command = $application->add(new ImportBailleurCommand(
@@ -84,7 +86,7 @@ class ImportBailleurCommandTest extends KernelTestCase
 
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('Le territoire n\'existe pas ', $output);
-        $this->assertStringContainsString('10 bailleur(s) have been imported', $output);
+        $this->assertStringContainsString('10 new bailleur(s) have been imported', $output);
         $commandTester->assertCommandIsSuccessful();
     }
 }


### PR DESCRIPTION
## Ticket

#2340

## Description
- Adaptation de la commande `app:import-bailleur` pour importer le nouveau fichier bailleurs (elle supprime les bailleurs précédent qui ne corresponde pas)
- Modification de la recherche bailleur via l'autocomplete pour chercher aussi sur le nouveau champ "raison sociale"
- Ajout de la commande `app:add-bailleur-link-on-signalement
`
## Pré-requis
Travailler sur une copie de la base de prod
`make load-migrations`

## Tests
- [ ] Lancer `make console app="import-bailleur"` et voir que les donnée corresponde a celle du fichier https://docs.google.com/spreadsheets/d/1dwpgfqW8quVQjN5dBoUPY2jiHuZ5pUPp/edit?gid=1297351916#gid=1297351916
- [ ] Vérifier que l'autocomplete bailleur fonctionne toujours
- [ ] Lancer la commande `make console app="add-bailleur-link-on-signalement"` et vérifier que les liens ajouté sont correct (ex avec la requete `SELECT s.created_at, s.nom_proprio, b.name, b.raison_sociale FROM signalement s inner join bailleur b on s.bailleur_id = b.id WHERE bailleur_id is not null;`
