### PR TITLE
[BO - Liste des signalements] Ajouter la possibilité de voir les signalements importés aux agents

### DIFF
--- a/assets/vue/components/signalement-form/matomo.ts
+++ b/assets/vue/components/signalement-form/matomo.ts
@@ -1,6 +1,6 @@
 export const matomo = {
   pushEvent (eventAction: string, eventName: string) {
-    const _paq = Object(window)._paq = Object(window)._paq || [];
+    const _paq = Object(window)._paq = Object(window)._paq || []
     const eventCategory = 'Signaler un problème de logement'
     _paq.push(['trackEvent', eventCategory, eventAction, eventName])
   }

--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -146,6 +146,7 @@ export default defineComponent({
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       const isAdminOrAdminTerritoire = this.sharedState.user.isAdmin || this.sharedState.user.isResponsableTerritoire
       this.sharedState.user.canSeeStatusAffectation = isAdminOrAdminTerritoire
+      this.sharedState.user.canSeeFilterPartner = isAdminOrAdminTerritoire
       this.sharedState.user.canDeleteSignalement = isAdminOrAdminTerritoire
       this.sharedState.user.canSeeScore = isAdminOrAdminTerritoire
       this.sharedState.user.partnerId = requestResponse.partnerId

--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -148,7 +148,6 @@ export default defineComponent({
       this.sharedState.user.canSeeStatusAffectation = isAdminOrAdminTerritoire
       this.sharedState.user.canDeleteSignalement = isAdminOrAdminTerritoire
       this.sharedState.user.canSeeScore = isAdminOrAdminTerritoire
-      this.sharedState.user.canSeeImportedButton = isAdminOrAdminTerritoire
       this.sharedState.user.partnerId = requestResponse.partnerId
       this.sharedState.hasSignalementImported = requestResponse.hasSignalementImported
       this.sharedState.input.order = 'reference-DESC'

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -150,7 +150,7 @@
                 />
               </div>
               <div class="fr-col-12 fr-col-lg-4 fr-col-xl-3 grey-background"
-                   v-if="sharedState.partenaires.length > 0">
+                   v-if="sharedState.user.canSeeFilterPartner && sharedState.partenaires.length > 0">
                 <HistoMultiSelect
                     id="filter-partenaires"
                     v-model="sharedState.input.filters.partenaires"

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -16,7 +16,7 @@
               </li>
               <li>
                 <button
-                    v-if="sharedState.hasSignalementImported && sharedState.user.canSeeImportedButton"
+                    v-if="sharedState.hasSignalementImported"
                     ref="isImportedButton"
                     class="fr-tag"
                     :aria-pressed="ariaPressed.isImported.toString()"

--- a/assets/vue/components/signalement-list/store.ts
+++ b/assets/vue/components/signalement-list/store.ts
@@ -42,7 +42,6 @@ export const store = {
       isAdministrateurPartenaire: false,
       isAgent: false,
       canSeeStatusAffectation: false,
-      canSeeImportedButton: false,
       canDeleteSignalement: false,
       canSeeNonDecenceEnergetique: false,
       canSeeScore: false,

--- a/assets/vue/components/signalement-list/store.ts
+++ b/assets/vue/components/signalement-list/store.ts
@@ -45,6 +45,7 @@ export const store = {
       canDeleteSignalement: false,
       canSeeNonDecenceEnergetique: false,
       canSeeScore: false,
+      canSeeFilterPartner: false,
       partnerId: null as number | null
     },
     showOptions: false,

--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -464,3 +464,15 @@ partners:
     insee: "[\"93066\"]"
     territory: "Seine-Saint-Denis"
     type: "COMMUNE_SCHS"
+
+  - nom: "Partenaire 38-01"
+    email: "partenaire-38-01@histologe.fr"
+    is_archive: 0
+    territory: "Isère"
+    type: "COMMUNE_SCHS"
+    competence:
+      - 'ACCOMPAGNEMENT_SOCIAL'
+      - 'ACCOMPAGNEMENT_TRAVAUX'
+      - 'FSL'
+      - 'VISITES'
+      - 'RSD'

--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -438,7 +438,7 @@ partners:
     territory: "Yonne"
     type: "COMMUNE_SCHS"
   -
-    nom: "DDT"
+    nom: "DDT 38"
     email: "partenaire-38-01@histologe.fr"
     is_archive: 0
     insee: "[\"\"]"
@@ -465,8 +465,8 @@ partners:
     territory: "Seine-Saint-Denis"
     type: "COMMUNE_SCHS"
 
-  - nom: "Partenaire 38-01"
-    email: "partenaire-38-01@histologe.fr"
+  - nom: "Partenaire 38-02"
+    email: "partenaire-38-02@histologe.fr"
     is_archive: 0
     territory: "Isère"
     type: "COMMUNE_SCHS"

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -396,10 +396,12 @@ users:
     is_mailing_active: 0
   -
     email: user-38-01@histologe.fr
-    roles: "[\"ROLE_ADMIN_TERRITORY\"]"
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partner: "Partenaire 38-01"
     statut: 1
     is_generique: 0
     is_mailing_active: 0
+    territory: "Isère"
   -
     email: admin-territoire-62-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -395,9 +395,17 @@ users:
     is_generique: 0
     is_mailing_active: 0
   -
+    email: admin-territoire-38-01@histologe.fr
+    roles: "[\"ROLE_ADMIN_TERRITORY\"]"
+    partner: "DDT 38"
+    statut: 1
+    is_generique: 0
+    is_mailing_active: 0
+    territory: "Isère"
+  -
     email: user-38-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    partner: "Partenaire 38-01"
+    partner: "Partenaire 38-02"
     statut: 1
     is_generique: 0
     is_mailing_active: 0

--- a/src/Service/Signalement/SearchFilterOptionDataProvider.php
+++ b/src/Service/Signalement/SearchFilterOptionDataProvider.php
@@ -13,8 +13,8 @@ use App\Repository\TagRepository;
 use App\Repository\TerritoryRepository;
 use App\Service\Signalement\Qualification\QualificationStatusService;
 use Psr\Cache\InvalidArgumentException;
-use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 class SearchFilterOptionDataProvider
 {
@@ -25,7 +25,7 @@ class SearchFilterOptionDataProvider
         private readonly PartnerRepository $partnerRepository,
         private readonly TagRepository $tagsRepository,
         private readonly SignalementRepository $signalementRepository,
-        private readonly CacheInterface $cache,
+        private readonly TagAwareCacheInterface $cache,
         private readonly QualificationStatusService $qualificationStatusService,
     ) {
     }
@@ -43,6 +43,9 @@ class SearchFilterOptionDataProvider
             $this->getCacheKey($user, $territory),
             function (ItemInterface $item) use ($territory, $user) {
                 $item->expiresAfter(3600);
+                if ($territory) {
+                    $item->tag([$territory->getZip()]);
+                }
 
                 return [
                     'criteres' => $this->critereRepository->findAllList(),

--- a/src/Service/Signalement/SearchFilterOptionDataProvider.php
+++ b/src/Service/Signalement/SearchFilterOptionDataProvider.php
@@ -54,7 +54,7 @@ class SearchFilterOptionDataProvider
                     'zipcodes' => $this->signalementRepository->findZipcodes($user, $territory),
                     'listQualificationStatus' => $this->qualificationStatusService->getList(),
                     'listVisiteStatus' => VisiteStatus::getLabelList(),
-                    'hasSignalementsImported' => $this->signalementRepository->countImported($territory),
+                    'hasSignalementsImported' => $this->signalementRepository->countImported($territory, $user),
                 ];
             }
         );

--- a/tests/Functional/Controller/BackArchivedAccountControllerTest.php
+++ b/tests/Functional/Controller/BackArchivedAccountControllerTest.php
@@ -35,7 +35,7 @@ class BackArchivedAccountControllerTest extends WebTestCase
             $client->getResponse()->getStatusCode(),
             sprintf('Result value: %d', $client->getResponse()->getStatusCode())
         );
-        $this->assertEquals(1, $crawler->filter('h1:contains("10 comptes archivés ou sans territoires et/ou partenaires trouvés")')->count());
+        $this->assertEquals(1, $crawler->filter('h1:contains("9 comptes archivés ou sans territoires et/ou partenaires trouvés")')->count());
     }
 
     public function testAccountListWithTerritory(): void

--- a/tests/Functional/Service/Signalement/SearchFilterOptionDataProviderTest.php
+++ b/tests/Functional/Service/Signalement/SearchFilterOptionDataProviderTest.php
@@ -12,6 +12,7 @@ use App\Service\Signalement\Qualification\QualificationStatusService;
 use App\Service\Signalement\SearchFilterOptionDataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 class SearchFilterOptionDataProviderTest extends KernelTestCase
 {
@@ -22,7 +23,7 @@ class SearchFilterOptionDataProviderTest extends KernelTestCase
     private PartnerRepository $partnerRepository;
     private TagRepository $tagsRepository;
     private SignalementRepository $signalementRepository;
-    private CacheInterface $cache;
+    private TagAwareCacheInterface $cache;
     private QualificationStatusService $qualificationStatusService;
 
     protected function setUp(): void
@@ -35,7 +36,7 @@ class SearchFilterOptionDataProviderTest extends KernelTestCase
         $this->partnerRepository = self::getContainer()->get(PartnerRepository::class);
         $this->tagsRepository = self::getContainer()->get(TagRepository::class);
         $this->signalementRepository = self::getContainer()->get(SignalementRepository::class);
-        $this->cache = self::getContainer()->get(CacheInterface::class);
+        $this->cache = self::getContainer()->get(TagAwareCacheInterface::class);
         $this->qualificationStatusService = self::getContainer()->get(QualificationStatusService::class);
 
         $this->searchFilterOptionDataProvider = new SearchFilterOptionDataProvider(

--- a/tests/Functional/Service/Signalement/SearchFilterOptionDataProviderTest.php
+++ b/tests/Functional/Service/Signalement/SearchFilterOptionDataProviderTest.php
@@ -11,7 +11,6 @@ use App\Repository\TerritoryRepository;
 use App\Service\Signalement\Qualification\QualificationStatusService;
 use App\Service\Signalement\SearchFilterOptionDataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 class SearchFilterOptionDataProviderTest extends KernelTestCase


### PR DESCRIPTION
## Ticket

#2797    

## Description
Le bouton n'est plus limité aux SUPER ADMIN et RT. Il doit aussi être affiché aux agents (admin et user partenaire) si ces derniers ont des signalements importées.

## Changements apportés
*  Mise à jour de la méthode `countImported` pour compter le nombre de signalements importés pour l'utilisateur
* Permettre au cache de gérer l'invalidation via les tags
* Mise à jour des fixtures

## Pré-requis
Vider le pool de cache
```
make clear-pool pool="--all"
```
Importer des signalements du 38
```
make console app="import-signalement 38"
```

## Tests
- [ ] Se connecter en admin-partenaire `admin-partenaire-13-01@histologe.fr` le bouton *Afficher les signalements importés* doit s'afficher et au clic, les signalements importé doit s'afficher.
- [ ] Se connecter en tant qu'agent du 38 `user-38-01@histologe.fr`.  le bouton *Afficher les signalements importés* ne doiit pas  s'afficher car il n'est affecté à un signalement importés.
- [ ] En tant que `admin-territoire-38-01@histologe.fr`, affecter des signalements  au partenaire Partenaire 38-02.
- [ ] En tant que `user-38-01@histologe.fr` du Partenaire 38-02, le bouton *Afficher les signalements importés* doit s'afficher et au clic les signalements doivent s'afficher.