### PR TITLE
[BO - Liste] Listes étiquettes et partenaires tronquées

### DIFF
--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -374,3 +374,9 @@ export default defineComponent({
 })
 
 </script>
+
+<style>
+#histo-app-signalement-list .fr-container--fluid {
+  overflow: visible;
+}
+</style>

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -309,12 +309,6 @@ export default defineComponent({
     onChange: { type: Function }
   },
   emits: ['changeTerritory', 'clickReset'],
-  mounted () {
-    const container = document.querySelector('.fr-container--fluid') as HTMLElement
-    if (container) {
-      container.style.overflow = 'visible'
-    }
-  },
   computed: {
     filtersSanitized () {
       const filters = Object.entries(this.sharedState.input.filters).filter(([key, value]) => {


### PR DESCRIPTION
## Ticket

#2796    

## Description
Rendre le overflow visible de manière statique en CSS au lieu de le faire en JS

## Changements apportés
* Suppression de l'affichage de l'overflow de manière dynamique
* Appliquer une règle CSS pour rendre le overflow statique

## Pré-requis

## Tests
- [ ] Dérouler la liste des étiquettes ou partenaires, celles ci ne doivent pas être tronquées
