### PR TITLE
[BO - Liste Signalement] Visibilité statuts affectations

### DIFF
--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -231,7 +231,7 @@ export default defineComponent({
   }
 
   .card-signalement--new {
-    border: 3px solid var(--red-marianne-425-625-active);
+    border: 2px solid #D64D00;
   }
 
   @media (max-width: 1250px) {

--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fr-grid-row fr-my-2w" v-for=" (item, index) in list" :key="index">
     <div class="fr-col-12">
-      <div class="fr-card">
+      <div class="fr-card" :class="{ 'card-signalement--new': item.statut === 1 }">
         <div class="fr-card__body">
           <div class="fr-card__content">
             <div class="fr-grid-row">
@@ -228,6 +228,10 @@ export default defineComponent({
 
   .fr-card__footer {
     margin: 0 -2.5rem;
+  }
+
+  .card-signalement--new {
+    border: 3px solid var(--red-marianne-425-625-active);
   }
 
   @media (max-width: 1250px) {

--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -115,9 +115,6 @@ export default defineComponent({
     },
     getBadgeStyleAffectation (affectation: any): string {
       let className = 'fr-badge'
-      if (!this.sharedState.user.canSeeStatusAffectation) {
-        return ''
-      }
       switch (affectation.statut) {
         case 0:
           className += ' fr-badge--info'


### PR DESCRIPTION
## Ticket

#2801    
#2805 

## Description
Les statuts des affectations n'est plus limité aux admin et aux RT

## Changements apportés
* Suppression de la condition
* Ajout d'une bordure pour les nouveaux signalements
![image](https://github.com/MTES-MCT/histologe/assets/5757116/235201e7-e0ac-4e5f-90ee-2a4e52cc0121)


## Pré-requis

```
make npm-watch
```

## Tests
- [ ] Se connecter en tant qu'utilisateur et admin partenaire et constater que les badges de statuts s'affiche
- [ ] Se connecter en tant que super admin et RT et constater que les badges de statuts continue de s'afficher
- [ ] En tant que RT affecter un partenaire à un signalement et connecter vous en tant qu'utilisateur, le nouveau signalement doit apparaître avec une bordure rouge
