### PR TITLE
[Signalements] Revoir les références des signalements importés

### DIFF
--- a/migrations/Version20240711084455.php
+++ b/migrations/Version20240711084455.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240711084455 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Migrate references for signalements in the Oise (territory_id=61) and Seine-Maritime (territory_id=77)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $connection = $this->connection;
+        $signalementsOise = $this->getSignalements($connection, 61);
+
+        foreach ($signalementsOise as $signalement) {
+            $newReference = $this->generateNewReference($connection, $signalement, 61);
+            if ($newReference) {
+                $this->updateSignalementReference($connection, $signalement['id'], $newReference);
+            }
+        }
+
+        $signalementsSeineMaritime = $this->getSignalements($connection, 77);
+
+        foreach ($signalementsSeineMaritime as $signalement) {
+            $newReference = $this->generateNewReference($connection, $signalement, 77);
+            if ($newReference) {
+                $this->updateSignalementReference($connection, $signalement['id'], $newReference);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // This migration is not reversible.
+    }
+
+    private function getSignalements(Connection $connection, int $territoryId): array
+    {
+        return $connection->fetchAllAssociative(
+            'SELECT uuid, id, reference, is_imported, created_at
+            FROM signalement
+            WHERE territory_id = :territoryId',
+            ['territoryId' => $territoryId]
+        );
+    }
+
+    private function generateNewReference(Connection $connection, array $signalement, int $territoryId): ?string
+    {
+        $isImported = (bool) $signalement['is_imported'];
+        $createdAt = new \DateTime($signalement['created_at']);
+        $year = $createdAt->format('Y');
+
+        if ($isImported) {
+            $reference = $signalement['reference'];
+            if (61 === $territoryId && preg_match('/^\d{6}[a-z]?-(\d{3})$/', $reference, $matches)) {
+                $newReference = sprintf('%s-%s', $year, substr($reference, 2, 4));
+            } elseif (77 === $territoryId && preg_match('/^\d{5}\s*-\s*\d{4}$/', $reference, $matches)) {
+                $newReference = sprintf('%s-%s', $year, substr($reference, 2, 3));
+            } else {
+                $newReference = null;
+            }
+        } else {
+            $reference = $signalement['reference'];
+            if (!preg_match('/^\d{4}-\d+$/', $reference)) {
+                $lastReferenceNumber = $this->getLastReferenceNumberForYear($connection, $year, $territoryId);
+                $newReference = sprintf('%s-%s', $year, $lastReferenceNumber + 1);
+            } else {
+                $newReference = null;
+            }
+        }
+
+        $suffix = '';
+        while ($newReference && !$this->isReferenceUniqueInTerritory($connection, $newReference.$suffix, $territoryId)) {
+            $suffix .= '0';
+        }
+        $newReference .= $suffix;
+
+        return $newReference;
+    }
+
+    private function getLastReferenceNumberForYear(Connection $connection, string $year, int $territoryId): int
+    {
+        $result = $connection->fetchOne(
+            'SELECT CAST(SUBSTRING_INDEX(s.reference, \'-\', -1) AS SIGNED) AS reference_index
+            FROM signalement s
+            WHERE YEAR(s.created_at) = :year
+            AND territory_id = :territoryId
+            AND s.reference REGEXP :regex
+            ORDER BY `reference_index` DESC
+            LIMIT 1',
+            [
+                'territoryId' => $territoryId,
+                'year' => $year,
+                'regex' => '^[0-9]{4}-[0-9]+$',
+            ]
+        );
+
+        return $result ? (int) $result : 0;
+    }
+
+    private function isReferenceUniqueInTerritory(Connection $connection, string $reference, int $territoryId): bool
+    {
+        $result = $connection->fetchOne(
+            'SELECT COUNT(*)
+            FROM signalement
+            WHERE territory_id = :territoryId
+            AND reference = :reference',
+            [
+                'territoryId' => $territoryId,
+                'reference' => $reference,
+            ]
+        );
+
+        return 0 === (int) $result;
+    }
+
+    private function updateSignalementReference(Connection $connection, int $signalementId, string $newReference): void
+    {
+        $connection->executeStatement(
+            'UPDATE signalement SET reference = :newReference WHERE id = :id',
+            ['newReference' => $newReference, 'id' => $signalementId]
+        );
+    }
+}

--- a/src/Command/ImportSignalementCommand.php
+++ b/src/Command/ImportSignalementCommand.php
@@ -69,14 +69,19 @@ class ImportSignalementCommand extends Command
 
         $this->uploadHandlerService->createTmpFileFromBucket($fromFile, $toFile);
 
-        $this->signalementImportLoader->load(
-            $territory,
-            $this->csvParser->parseAsDict($toFile),
-            $this->csvParser->getHeaders($toFile),
-            $output
-        );
+        try {
+            $this->signalementImportLoader->load(
+                $territory,
+                $this->csvParser->parseAsDict($toFile),
+                $this->csvParser->getHeaders($toFile),
+                $output
+            );
+        } catch (\Exception $e) {
+            $output->writeln('Erreur inattendue : '.$e->getMessage());
 
-        $metadata = $this->signalementImportLoader->getMetadata();
+            return Command::FAILURE;
+        }
+            $metadata = $this->signalementImportLoader->getMetadata();
         if (\count($metadata['files_not_found'])) {
             $msg = [];
             foreach ($metadata['files_not_found'] as $fileNotFound) {

--- a/src/Service/Import/Signalement/SignalementImportMapper.php
+++ b/src/Service/Import/Signalement/SignalementImportMapper.php
@@ -128,22 +128,31 @@ class SignalementImportMapper
             return $dataMapped;
         }
         $situations = [];
+        $createdAt = $this->transformToDatetime($data['Date de creation signalement']);
         foreach ($this->getMapping() as $fileColumn => $fieldColumn) {
             if (\in_array($fileColumn, $columns)) {
                 $fieldValue = 'NSP' !== $data[$fileColumn] ? $data[$fileColumn] : '';
                 $fieldValue = trim($fieldValue, '"');
                 switch ($fieldColumn) {
                     case 'reference':
-                        if (preg_match('/20\d{2}-\d{4}/', $fieldValue)) {
+                        // TODO que fait-on si on n'a pas de date de création du signalement ?
+                        if (null === $createdAt) {
                             break;
                         }
-                        $result = preg_split('/[-|\/]/', $fieldValue);
-                        if (\count($result) > 1) {
-                            list($index, $year) = $result;
-                            $fieldValue = '20'.$year.'-'.$index;
-                        } else {
-                            $fieldValue = array_shift($result);
+                        $yearCreatedAt = $createdAt->format('Y');
+
+                        if (preg_match('/^20\d{2}-\d{4}$/', $fieldValue)) {
+                            list($year, $index) = explode('-', $fieldValue);
+                            if ($year == $yearCreatedAt) {
+                                break;
+                            }
                         }
+
+                        $digits = preg_replace('/\D/', '', $fieldValue);
+                        if ('' === $digits) {
+                            $digits = $fieldValue;
+                        }
+                        $fieldValue = $yearCreatedAt.'-'.$digits;
                         break;
                     case 'modeContactProprio':
                         $modes = array_filter(preg_split('(-|/)', $fieldValue));

--- a/src/Service/Import/Signalement/SignalementImportMapper.php
+++ b/src/Service/Import/Signalement/SignalementImportMapper.php
@@ -129,6 +129,7 @@ class SignalementImportMapper
         }
         $situations = [];
         $createdAt = $this->transformToDatetime($data['Date de creation signalement']);
+        $todayYear = (new \DateTime())->format('Y');
         foreach ($this->getMapping() as $fileColumn => $fieldColumn) {
             if (\in_array($fileColumn, $columns)) {
                 $fieldValue = 'NSP' !== $data[$fileColumn] ? $data[$fileColumn] : '';
@@ -141,7 +142,7 @@ class SignalementImportMapper
                         }
                         $yearCreatedAt = $createdAt->format('Y');
 
-                        if (preg_match('/^20\d{2}-\d{4}$/', $fieldValue)) {
+                        if (preg_match('/^20\d{2}-\d+$/', $fieldValue)) {
                             list($year, $index) = explode('-', $fieldValue);
                             if ($year == $yearCreatedAt) {
                                 break;
@@ -149,8 +150,15 @@ class SignalementImportMapper
                         }
 
                         $digits = preg_replace('/\D/', '', $fieldValue);
+                        $digits = str_replace($yearCreatedAt, '', $digits);
+                        if (!empty($year)) {
+                            $digits = str_replace($year, '', $digits);
+                        }
                         if ('' === $digits) {
                             $digits = $fieldValue;
+                        }
+                        if ($yearCreatedAt === $todayYear && \strlen($digits) > 4) {
+                            throw new \Exception(sprintf('La référence %s concerne une année en cours et risque de semer la confusion', $fieldValue));
                         }
                         $fieldValue = $yearCreatedAt.'-'.$digits;
                         break;

--- a/src/Service/Signalement/ReferenceGenerator.php
+++ b/src/Service/Signalement/ReferenceGenerator.php
@@ -14,12 +14,16 @@ class ReferenceGenerator
     public function generate(Territory $territory): string
     {
         $result = $this->signalementRepository->findLastReferenceByTerritory($territory);
-
+        $todayYear = (new \DateTime())->format('Y');
         if (!empty($result)) {
             list($year, $id) = explode('-', $result['reference']);
 
             $id = (int) $id;
             ++$id;
+            // s'il y a eu des erreurs d'année dans les références, on ne les prolonge pas
+            if ($year !== $todayYear) {
+                $year = $todayYear;
+            }
 
             return $year.'-'.$id;
         }

--- a/tests/Functional/Service/Signalement/ReferenceGeneratorTest.php
+++ b/tests/Functional/Service/Signalement/ReferenceGeneratorTest.php
@@ -25,6 +25,7 @@ class ReferenceGeneratorTest extends KernelTestCase
         $territoryRepository = $this->entityManager->getRepository(Territory::class);
         $territory = $territoryRepository->findOneBy(['zip' => 13]);
 
+        $todayYear = (new \DateTime())->format('Y');
         $signalementRepository = $this->createMock(SignalementRepository::class);
         $signalementRepository
             ->expects($this->once())
@@ -35,8 +36,7 @@ class ReferenceGeneratorTest extends KernelTestCase
         $referenceGenerator = new ReferenceGenerator($signalementRepository);
 
         $referenceGenerated = $referenceGenerator->generate($territory);
-
-        $this->assertEquals('2022-12', $referenceGenerated);
+        $this->assertEquals($todayYear.'-12', $referenceGenerated);
     }
 
     public function testGenerateReferenceFromNoSignalement()


### PR DESCRIPTION
## Ticket

#2789    

## Description

- Fix de la commande d'import de signalements pour éviter les références non conformes
- Fix du service de génération de référence pour éviter de continuer à créer des références non conformes après import
- migration pour corriger les références des signalements de l'Oise et de la Seine-Maritime

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis

## Tests
- [ ] Tester l'import de signalements `make console app="import-signalement 60"` --> vérifier que les références commencent bien par aaaa- (aaaa étant l'année de création du signalement) et qu'après le tiret il y a des chiffres seulement
- [ ] Idem avec `make console app="import-signalement 76"`
- [ ] Créer un nouveau signalement et vérifier que sa référence est correcte (dans `aaaa-yy` vérifier que `aaaa` est bien `2024` et que `yy` est bien 1 de plus que l'index le plus haut des signalements du territoire créés en 2024 indépendamment de l'année indiquée dans leur référence)
- [ ] Récupérer des données de prod, et lancer la migration `docker compose exec -ti histologe_phpfpm php bin/console doctrine:migrations:execute --up 'DoctrineMigrations\Version20240711084455'` --> vérifier que les références des signalements de l'Oise et de la Seine-Maritime ont bien été corrigées
