### PR TITLE
[QA][FO] limiter taille du code postal bailleur

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -197,14 +197,11 @@ export default defineComponent({
     validateComponents (components: any) {
       for (const component of components) {
         const value = formStore.data[component.slug]
-        if (this.isRequired(component)) {
-          // Cas particulier de validation de composant de type adresse SignalementFormAddress
-          if (component.type === 'SignalementFormAddress') {
-            this.validateComponentAddress(component.slug)
-          // Les autres composants requis doivent avoir une valeur correspondante dans le Store
-          } else if (!value) {
+        if (this.isRequired(component) && component.type !== 'SignalementFormAddress' && !value ) {
             formStore.validationErrors[component.slug] = 'Ce champ est requis'
-          }
+        }
+        if (component.type === 'SignalementFormAddress') {
+          this.validateComponentAddress(component.slug, this.isRequired(component))
         }
 
         componentValidator.validate(component)
@@ -215,28 +212,35 @@ export default defineComponent({
         }
       }
     },
-    validateComponentAddress (componentSlug: any) {
-      const validationError = 'Ce champ est requis'
-      // tous les champs sont vides, on affiche l'erreur sur le champs de recherche
-      if (!formStore.data[componentSlug] &&
-            !formStore.data[componentSlug + '_detail_numero'] &&
-            !formStore.data[componentSlug + '_detail_code_postal'] &&
-            !formStore.data[componentSlug + '_detail_commune']
-      ) {
-        formStore.validationErrors[componentSlug] = validationError
+    validateComponentAddress (componentSlug: any, required: boolean) {
+      if(required) {
+        const validationError = 'Ce champ est requis'
+        // tous les champs sont vides, on affiche l'erreur sur le champs de recherche
+        if (!formStore.data[componentSlug] &&
+              !formStore.data[componentSlug + '_detail_numero'] &&
+              !formStore.data[componentSlug + '_detail_code_postal'] &&
+              !formStore.data[componentSlug + '_detail_commune']
+        ) {
+          formStore.validationErrors[componentSlug] = validationError
 
-      // il y a eu une édition manuelle : on vérifie tous les sous-champs
-      } else if (formStore.data[componentSlug + '_detail_manual'] !== 0) {
-        if (!formStore.data[componentSlug + '_detail_numero']) {
-          formStore.validationErrors[componentSlug + '_detail_numero'] = validationError
-        }
-        if (!formStore.data[componentSlug + '_detail_code_postal']) {
-          formStore.validationErrors[componentSlug + '_detail_code_postal'] = validationError
-        }
-        if (!formStore.data[componentSlug + '_detail_commune']) {
-          formStore.validationErrors[componentSlug + '_detail_commune'] = validationError
+        // il y a eu une édition manuelle : on vérifie tous les sous-champs
+        } else if (formStore.data[componentSlug + '_detail_manual'] !== 0) {
+          if (!formStore.data[componentSlug + '_detail_numero']) {
+            formStore.validationErrors[componentSlug + '_detail_numero'] = validationError
+          }
+          if (!formStore.data[componentSlug + '_detail_code_postal']) {
+            formStore.validationErrors[componentSlug + '_detail_code_postal'] = validationError
+          }
+          if (!formStore.data[componentSlug + '_detail_commune']) {
+            formStore.validationErrors[componentSlug + '_detail_commune'] = validationError
+          }
         }
       }
+      // vérification du code postal
+      if (formStore.data[componentSlug + '_detail_code_postal'] && !/^\d{5}$/.test(formStore.data[componentSlug + '_detail_code_postal'])) {
+        formStore.validationErrors[componentSlug + '_detail_code_postal'] = 'Le code postal doit être composé de 5 chiffres'
+      }
+
     },
     updateFormData (slug: string, value: any) {
       this.formStore.data[slug] = value

--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -10,6 +10,7 @@ class AdresseOccupantRequest implements RequestInterface
         #[Assert\NotBlank(message: 'Merci de saisir une adresse.')]
         private readonly ?string $adresse = null,
         #[Assert\NotBlank(message: 'Merci de saisir un code postal.')]
+        #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
         private readonly ?string $codePostal = null,
         #[Assert\NotBlank(message: 'Merci de saisir une ville.')]
         private readonly ?string $ville = null,

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -30,6 +30,7 @@ class CoordonneesBailleurRequest implements RequestInterface
         #[Assert\NotBlank(message: 'Merci de saisir l\'adresse du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $adresse = null,
         #[Assert\NotBlank(message: 'Merci de saisir le code postal du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
+        #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
         private readonly ?string $codePostal = null,
         #[Assert\NotBlank(message: 'Merci de saisir la ville du bailleur.', groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $ville = null,

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -26,6 +26,7 @@ class SignalementDraftRequest
     private ?string $adresseLogementAdresse = null;
     private ?string $adresseLogementAdresseDetailNumero = null;
     #[Assert\NotBlank(message: 'Merci de saisir un code postal.')]
+    #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
     private ?string $adresseLogementAdresseDetailCodePostal = null;
     #[Assert\NotBlank(message: 'Merci de saisir une ville.')]
     private ?string $adresseLogementAdresseDetailCommune = null;
@@ -143,6 +144,7 @@ class SignalementDraftRequest
     private ?string $coordonneesBailleurTelSecondaire = null;
     private ?string $coordonneesBailleurAdresse = null;
     private ?string $coordonneesBailleurAdresseDetailNumero = null;
+    #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal du bailleur doit être composé de 5 chiffres.')]
     private ?string $coordonneesBailleurAdresseDetailCodePostal = null;
     private ?string $coordonneesBailleurAdresseDetailCommune = null;
     private ?string $zoneConcerneeZone = null;

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -111,6 +111,7 @@ class Signalement
     private $adresseProprio;
 
     #[ORM\Column(type: 'string', length: 5, nullable: true)]
+    #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal être composé de 5 chiffres.')]
     private ?string $codePostalProprio;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
@@ -194,6 +195,7 @@ class Signalement
 
     #[ORM\Column(type: 'string', length: 5, nullable: true)]
     #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
     private $cpOccupant;
 
     #[ORM\Column(type: 'string', length: 100, nullable: true)]


### PR DESCRIPTION
## Ticket

#2803

## Description
Ajout de contrôle sur le format du code postal (5 chiffre) pour corriger le crash base de données en cas d'injection d'une valeur supérieur a 5 carractères

## Pré-requis
`make npm-build`

## Tests
- [ ] Essayer d'injecter un code postal (bailleur en particulier) comportant + de 5 caractères
