### PR TITLE
[BO - SISH] Mise à jour message arrếtés

### DIFF
--- a/src/Service/Intervention/InterventionDescriptionGenerator.php
+++ b/src/Service/Intervention/InterventionDescriptionGenerator.php
@@ -47,7 +47,7 @@ class InterventionDescriptionGenerator
     public static function buildDescriptionArreteCreated(DossierArreteSISH $dossierArreteSISH): string
     {
         $description = sprintf(
-            'L\'arrêté %s du %s dans le dossier de n°%s.<br>',
+            'L\'arrêté %s du %s a été pris dans le dossier de n°%s.<br>',
             $dossierArreteSISH->getArreteNumero(),
             $dossierArreteSISH->getArreteDate(),
             $dossierArreteSISH->getDossNum(),
@@ -56,10 +56,13 @@ class InterventionDescriptionGenerator
         $description .= sprintf('Type arrêté: %s<br>', $dossierArreteSISH->getArreteType());
 
         if ($dossierArreteSISH->getArreteMLDate()) {
-            $description .= sprintf(
-                'Pour cet arrêté, il a également été pris un arrêté de mainlevée %s du %s.',
+            $description = sprintf(
+                'Un arrêté de mainlevée %s du %s a été pris pour l\'arrêté %s du %s dans le dossier de n°%s.',
                 $dossierArreteSISH->getArreteMLNumero(),
-                $dossierArreteSISH->getArreteMLDate()
+                $dossierArreteSISH->getArreteMLDate(),
+                $dossierArreteSISH->getArreteNumero(),
+                $dossierArreteSISH->getArreteDate(),
+                $dossierArreteSISH->getDossNum()
             );
         }
 

--- a/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
+++ b/tests/Unit/Service/Intervention/InterventionDescriptionGeneratorTest.php
@@ -40,7 +40,6 @@ class InterventionDescriptionGeneratorTest extends TestCase
         $dossierArreteSISH = $this->getDossierArreteSISHCollectionResponse()->getCollection()[0];
         $description = InterventionDescriptionGenerator::buildDescriptionArreteCreated($dossierArreteSISH);
 
-        $this->assertStringContainsString('Arrêté L.511-11', $description, 'Type arrêté incorrect');
         $this->assertStringContainsString('2023/DD13/00664', $description, 'N° arrêté incorrect');
         $this->assertStringContainsString('14/06/2023', $description, 'Date arrêté incorrecte');
         $this->assertStringContainsString('n°2023/DD13/0010', $description, 'N° dossier incorrect');


### PR DESCRIPTION
## Ticket

#2808    

## Description
Mise à jour message arrêtés

## Changements apportés
* Fix typo message arrêtés
* Mise à jour message arrêtés mainlevée

## Pré-requis
```sh
make worker-start
make mock-start
````
## Tests
- [ ] Exécuter la commande `make sync-sish` et vérifier les messages dans le dossier http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012

![image](https://github.com/MTES-MCT/histologe/assets/5757116/da2b5046-e0bb-4c64-ab46-ae6a5fedb514)

