### PR TITLE
[FO - Signalement] Contrôle des entrées de formulaire

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -277,8 +277,7 @@
           },
           "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 15,
-            "required": false
+            "maxLength": 15
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -274,6 +274,11 @@
           "slug": "type_logement_nature_autre_precision",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
+          },
+          "description": "25 caractères maximum",
+          "validate": {
+            "maxLength": 25,
+            "required": false
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -275,9 +275,9 @@
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
           },
-          "description": "25 caractères maximum",
+          "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 25,
+            "maxLength": 15,
             "required": false
           }
         },

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -218,6 +218,11 @@
           "slug": "type_logement_nature_autre_precision",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
+          },
+          "description": "25 caractères maximum",
+          "validate": {
+            "maxLength": 25,
+            "required": false
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -219,9 +219,9 @@
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
           },
-          "description": "25 caractères maximum",
+          "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 25,
+            "maxLength": 15,
             "required": false
           }
         },

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -221,8 +221,7 @@
           },
           "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 15,
-            "required": false
+            "maxLength": 15
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -308,13 +308,13 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Précisez le type :",
-          "slug": "type_logement_nature_autre_precision",
+          "slug": "c",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
           },
-          "description": "25 caractères maximum",
+          "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 25,
+            "maxLength": 15,
             "required": false
           }
         },

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -314,8 +314,7 @@
           },
           "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 15,
-            "required": false
+            "maxLength": 15
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -308,7 +308,7 @@
         {
           "type": "SignalementFormTextfield",
           "label": "Précisez le type :",
-          "slug": "c",
+          "slug": "type_logement_nature_autre_precision",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
           },

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -311,6 +311,11 @@
           "slug": "type_logement_nature_autre_precision",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
+          },
+          "description": "25 caractères maximum",
+          "validate": {
+            "maxLength": 25,
+            "required": false
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -383,6 +383,11 @@
           "slug": "type_logement_nature_autre_precision",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
+          },
+          "description": "25 caractères maximum",
+          "validate": {
+            "maxLength": 25,
+            "required": false
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -386,8 +386,7 @@
           },
           "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 15,
-            "required": false
+            "maxLength": 15
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -384,9 +384,9 @@
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
           },
-          "description": "25 caractères maximum",
+          "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 25,
+            "maxLength": 15,
             "required": false
           }
         },

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -390,8 +390,7 @@
           },
           "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 15,
-            "required": false
+            "maxLength": 15
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -387,6 +387,11 @@
           "slug": "type_logement_nature_autre_precision",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
+          },
+          "description": "25 caractères maximum",
+          "validate": {
+            "maxLength": 25,
+            "required": false
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -388,9 +388,9 @@
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
           },
-          "description": "25 caractères maximum",
+          "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 25,
+            "maxLength": 15,
             "required": false
           }
         },

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -375,9 +375,9 @@
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
           },
-          "description": "25 caractères maximum",
+          "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 25,
+            "maxLength": 15,
             "required": false
           }
         },

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -377,8 +377,7 @@
           },
           "description": "15 caractères maximum",
           "validate": {
-            "maxLength": 15,
-            "required": false
+            "maxLength": 15
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -374,6 +374,11 @@
           "slug": "type_logement_nature_autre_precision",
           "conditional": {
             "show": "formStore.data.type_logement_nature === 'autre'"
+          },
+          "description": "25 caractères maximum",
+          "validate": {
+            "maxLength": 25,
+            "required": false
           }
         },
         {

--- a/src/Dto/DemandeLienSignalement.php
+++ b/src/Dto/DemandeLienSignalement.php
@@ -36,9 +36,11 @@ class DemandeLienSignalement
         return $this->email;
     }
 
-    public function setEmail(string $email): void
+    public function setEmail(string $email): self
     {
         $this->email = $email;
+
+        return $this;
     }
 
     public function getAdresseHelper(): string
@@ -46,9 +48,11 @@ class DemandeLienSignalement
         return $this->adresseHelper;
     }
 
-    public function setAdresseHelper(string $adresseHelper): void
+    public function setAdresseHelper(string $adresseHelper): self
     {
         $this->adresseHelper = $adresseHelper;
+
+        return $this;
     }
 
     public function getAdresse(): string
@@ -56,9 +60,11 @@ class DemandeLienSignalement
         return $this->adresse;
     }
 
-    public function setAdresse(string $adresse): void
+    public function setAdresse(string $adresse): self
     {
         $this->adresse = $adresse;
+
+        return $this;
     }
 
     public function getCodePostal(): string
@@ -66,9 +72,11 @@ class DemandeLienSignalement
         return $this->codePostal;
     }
 
-    public function setCodePostal(string $codePostal): void
+    public function setCodePostal(string $codePostal): self
     {
         $this->codePostal = $codePostal;
+
+        return $this;
     }
 
     public function getVille(): string
@@ -76,8 +84,10 @@ class DemandeLienSignalement
         return $this->ville;
     }
 
-    public function setVille(string $ville): void
+    public function setVille(string $ville): self
     {
         $this->ville = $ville;
+
+        return $this;
     }
 }

--- a/src/Dto/Request/Signalement/CompositionLogementRequest.php
+++ b/src/Dto/Request/Signalement/CompositionLogementRequest.php
@@ -21,12 +21,12 @@ class CompositionLogementRequest implements RequestInterface
             ],
         )]
         #[Assert\Length(
-            max: 100,
+            max: 15,
             maxMessage: 'Le type de logement autre ne doit pas dépasser {{ limit }} caractères.',
         )]
         private readonly ?string $typeLogementNatureAutrePrecision = null,
         #[Assert\NotBlank(
-            message: 'Merci de sélectioner pièce unique ou plusieurs pièces.',
+            message: 'Merci de sélectionner pièce unique ou plusieurs pièces.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS']
         )]
         #[Assert\Choice(

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -17,6 +17,7 @@ class CoordonneesFoyerRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de saisir un nom de structure.'),
             ],
         )]
+        #[Assert\Length(max: 200, maxMessage: 'Le nom de la structure ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $nomStructure = null,
         #[Assert\NotBlank(message: 'Merci de sélectionner une civilité.', groups: ['LOCATAIRE'])]
         #[Assert\Choice(choices: ['mme', 'mr'], message: 'La civilité est incorrecte.')]

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -231,7 +231,7 @@ class SignalementDraftRequest
     )]
     private ?string $typeLogementNature = null;
     #[Assert\Length(
-        max: 25,
+        max: 15,
         maxMessage: 'Le champs typeLogementNatureAutrePrecision ne doit pas dépasser {{ limit }} caractères.')
     ]
     private ?string $typeLogementNatureAutrePrecision = null;

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -202,9 +202,9 @@ class SignalementDraftRequest
     private ?string $coordonneesOccupantTel = null;
     #[AppAssert\TelephoneFormat]
     private ?string $coordonneesOccupantTelSecondaire = null;
-    #[Assert\Length(max: 255, maxMessage: 'Le nom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 250, maxMessage: 'Le nom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesBailleurNom = null;
-    #[Assert\Length(max: 255, maxMessage: 'Le prénom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 250, maxMessage: 'Le prénom du bailleur ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesBailleurPrenom = null;
     #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
     private ?string $coordonneesBailleurEmail = null;

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -29,11 +29,18 @@ class SignalementDraftRequest
         'service_secours', ],
         message: 'Le profil est incorrect.'
     )]
+    #[Assert\When(
+        expression: 'this.getCurrentStep() == "validation_signalement"',
+        constraints: [
+            new Assert\NotBlank(message: 'Le profil est obligatoire.'),
+        ],
+    )]
     private ?string $profil = null;
 
     #[Assert\Length(max: 128, maxMessage: 'Le nom d\'étape de formulaire ne peut pas dépasser {{ limit }} caractères.')]
     private ?string $currentStep = null;
     #[Assert\NotBlank(message: 'Merci de saisir une adresse.')]
+    #[Assert\Length(max: 255, maxMessage: 'L\'adresse ne peut pas dépasser {{ limit }} caractères.')]
     private ?string $adresseLogementAdresse = null;
 
     #[Assert\Length(max: 100, maxMessage: 'L\'adresse ne peut pas dépasser {{ limit }} caractères.')]
@@ -406,7 +413,7 @@ class SignalementDraftRequest
     )]
     private ?string $infoProcedureBailleurPrevenu = null;
     #[Assert\Choice(
-        choices: ['oui', 'non', 'pas_assurance_logement'],
+        choices: ['oui', 'non', 'pas_assurance_logement', 'nsp'],
         message: 'Le champ "infoProcedureAssuranceContactee" est incorrect.',
     )]
     private ?string $infoProcedureAssuranceContactee = null;

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -20,42 +20,103 @@ class SignalementDraftRequest
     public const PATTERN_NOMBRE = '/_nb_|_nombre_/';
     public const FILE_UPLOAD_KEY = 'files';
 
+    #[Assert\Choice(choices: [
+        'locataire',
+        'bailleur_occupant',
+        'bailleur',
+        'tiers_pro',
+        'tiers_particulier',
+        'service_secours', ],
+        message: 'Le profil est incorrect.'
+    )]
     private ?string $profil = null;
+
+    #[Assert\Length(max: 128, maxMessage: 'Le nom d\'étape de formulaire ne peut pas dépasser {{ limit }} caractères.')]
     private ?string $currentStep = null;
     #[Assert\NotBlank(message: 'Merci de saisir une adresse.')]
     private ?string $adresseLogementAdresse = null;
+
+    #[Assert\Length(max: 100, maxMessage: 'L\'adresse ne peut pas dépasser {{ limit }} caractères.')]
     private ?string $adresseLogementAdresseDetailNumero = null;
     #[Assert\NotBlank(message: 'Merci de saisir un code postal.')]
     #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
     private ?string $adresseLogementAdresseDetailCodePostal = null;
     #[Assert\NotBlank(message: 'Merci de saisir une ville.')]
+    #[Assert\Length(max: 100, maxMessage: 'La ville ne peut pas dépasser {{ limit }} caractères.')]
     private ?string $adresseLogementAdresseDetailCommune = null;
     #[Assert\NotBlank(message: 'Merci de saisir un code INSEE.')]
+    #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code insee doit être composé de 5 chiffres.')]
     private ?string $adresseLogementAdresseDetailInsee = null;
+    #[Assert\Length(max: 50, maxMessage: 'La latitude ne peut pas dépasser {{ limit }} caractères.')]
+    #[Assert\Regex(
+        pattern: '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/',
+        message: 'La latitude doit être un nombre décimal.'
+    )]
     private ?float $adresseLogementAdresseDetailGeolocLat = null;
+    #[Assert\Length(max: 50, maxMessage: 'La longitude ne peut pas dépasser {{ limit }} caractères.')]
+    #[Assert\Regex(
+        pattern: '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/',
+        message: 'La longitude doit être un nombre décimal.'
+    )]
     private ?float $adresseLogementAdresseDetailGeolocLng = null;
     private ?bool $adresseLogementAdresseDetailManual = null;
-    #[Assert\Length(max: 3)]
+    #[Assert\Length(max: 3, maxMessage: 'L\'escalier ne doit pas dépasser {{ limit }} caractères')]
     private ?string $adresseLogementComplementAdresseEscalier = null;
-    #[Assert\Length(max: 5)]
+    #[Assert\Length(max: 5, maxMessage: 'L\'étage ne doit pas dépasser {{ limit }} caractères')]
     private ?string $adresseLogementComplementAdresseEtage = null;
     #[Assert\Length(max: 5, maxMessage: 'Le numéro d\'appartement ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $adresseLogementComplementAdresseNumeroAppartement = null;
     #[Assert\Length(max: 255)]
     private ?string $adresseLogementComplementAdresseAutre = null;
     #[Assert\NotBlank(message: 'Le profil du déclarant n\'est pas défini.')]
+    #[Assert\Choice(
+        choices: ['logement_occupez', 'autre_logement'],
+        message: 'Le champs "signalementConcerneProfil" est incorrect'
+    )]
     private ?string $signalementConcerneProfil = null;
+    #[Assert\Choice(
+        choices: ['locataire', 'bailleur_occupant'],
+        message: 'Le champs "signalementConcerneProfilDetailOccupant" est incorrect.'
+    )]
     private ?string $signalementConcerneProfilDetailOccupant = null;
+
+    #[Assert\Choice(
+        choices: ['tiers_particulier', 'tiers_pro', 'bailleur', 'service_secours'],
+        message: 'Le champs "signalementConcerneProfilDetailTiers" est incorrect.'
+    )]
     private ?string $signalementConcerneProfilDetailTiers = null;
+
+    #[Assert\Choice(
+        choices: ['particulier', 'organisme_societe'],
+        message: 'Le champs "signalementConcerneProfilDetailBailleurProprietaire" est incorrect.'
+    )]
     private ?string $signalementConcerneProfilDetailBailleurProprietaire = null;
+
+    #[Assert\Choice(
+        choices: ['particulier', 'organisme_societe'],
+        message: 'Le champs "signalementConcerneProfilDetailBailleurBailleur" est incorrect.'
+    )]
     private ?string $signalementConcerneProfilDetailBailleurBailleur = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'ne-sais-pas'],
+        message: 'Le champs "signalementConcerneLogementSocialServiceSecours" est incorrect.'
+    )]
     private ?string $signalementConcerneLogementSocialServiceSecours = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "signalementConcerneLogementSocialAutreTiers" est incorrect.'
+    )]
     private ?string $signalementConcerneLogementSocialAutreTiers = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner le nom de l\'organisme.',
         groups: ['POST_TIERS_PRO', 'POST_SERVICE_SECOURS']
     )]
+    #[Assert\Length(max: 200, maxMessage: 'Le nom de la structure ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesTiersNomOrganisme = null;
+    #[Assert\Choice(
+        choices: ['proche', 'voisin', 'autre'],
+        message: 'Le champs "vosCoordonneesTiersLien" est incorrect.'
+    )]
     private ?string $vosCoordonneesTiersLien = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre nom.',
@@ -74,6 +135,7 @@ class SignalementDraftRequest
         groups: ['POST_TIERS_PARTICULIER', 'POST_TIERS_PRO', 'POST_BAILLEUR', 'POST_SERVICE_SECOURS']
     )]
     #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
+    #[Assert\Length(max: 255, maxMessage: 'Votre email en tant que tiers ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesTiersEmail = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre numéro de téléphone.',
@@ -87,7 +149,12 @@ class SignalementDraftRequest
         message: 'Merci de renseigner votre civilité.',
         groups: ['POST_LOCATAIRE', 'POST_BAILLEUR_OCCUPANT']
     )]
+    #[Assert\Choice(
+        choices: ['mr', 'mme'],
+        message: 'Le champs "vosCoordonneesOccupantCivilite" est incorrect.'
+    )]
     private ?string $vosCoordonneesOccupantCivilite = null;
+    #[Assert\Length(max: 200, maxMessage: 'Le nom de la structure ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantNomOrganisme = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre nom.',
@@ -106,6 +173,7 @@ class SignalementDraftRequest
         groups: ['POST_LOCATAIRE', 'POST_BAILLEUR_OCCUPANT']
     )]
     #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
+    #[Assert\Length(max: 255, maxMessage: 'Votre email ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $vosCoordonneesOccupantEmail = null;
     #[Assert\NotBlank(
         message: 'Merci de renseigner votre numéro de téléphone.',
@@ -127,6 +195,8 @@ class SignalementDraftRequest
     )]
     #[Assert\Length(max: 50, maxMessage: 'Le prénom de l\'occupant ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesOccupantPrenom = null;
+    #[Assert\Email(mode: Email::VALIDATION_MODE_STRICT)]
+    #[Assert\Length(max: 255, maxMessage: 'L\'email de l\'occupant ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesOccupantEmail = null;
     #[AppAssert\TelephoneFormat]
     private ?string $coordonneesOccupantTel = null;
@@ -142,18 +212,53 @@ class SignalementDraftRequest
     private ?string $coordonneesBailleurTel = null;
     #[AppAssert\TelephoneFormat]
     private ?string $coordonneesBailleurTelSecondaire = null;
+    #[Assert\Length(max: 255, maxMessage: 'L\'adresse du bailleur ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesBailleurAdresse = null;
+    #[Assert\Length(max: 255, maxMessage: 'L\'adresse du bailleur ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesBailleurAdresseDetailNumero = null;
     #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal du bailleur doit être composé de 5 chiffres.')]
     private ?string $coordonneesBailleurAdresseDetailCodePostal = null;
+    #[Assert\Length(max: 255, maxMessage: 'La ville du bailleur ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $coordonneesBailleurAdresseDetailCommune = null;
+    #[Assert\Choice(
+        choices: ['batiment', 'logement', 'batiment_logement'],
+        message: 'Le champs "zoneConcerneeZone" est incorrect.'
+    )]
     private ?string $zoneConcerneeZone = null;
+    #[Assert\Choice(
+        choices: ['appartement', 'maison', 'autre'],
+        message: 'Le champs "typeLogementNature" est incorrect.'
+    )]
     private ?string $typeLogementNature = null;
+    #[Assert\Length(
+        max: 25,
+        maxMessage: 'Le champs typeLogementNatureAutrePrecision ne doit pas dépasser {{ limit }} caractères.')
+    ]
     private ?string $typeLogementNatureAutrePrecision = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementRdc" est incorrect.'
+    )]
     private ?string $typeLogementRdc = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementDernierEtage" est incorrect.'
+    )]
     private ?string $typeLogementDernierEtage = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementSousSolSansFenetre" est incorrect.'
+    )]
     private ?string $typeLogementSousSolSansFenetre = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementSousCombleSansFenetre" est incorrect.'
+    )]
     private ?string $typeLogementSousCombleSansFenetre = null;
+    #[Assert\Choice(
+        choices: ['piece_unique', 'plusieurs_pieces'],
+        message: 'Le champs "compositionLogementPieceUnique" est incorrect.'
+    )]
     private ?string $compositionLogementPieceUnique = null;
     #[Assert\NotBlank(
         message: 'Merci de définir la superficie.',
@@ -163,7 +268,17 @@ class SignalementDraftRequest
         ]
     )]
     #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs superficie.')]
+    #[Assert\Type(type: 'numeric', message: 'Le nombre de pièces à vivre doit être un nombre.')]
+    #[Assert\Length(
+        max: 10,
+        maxMessage: 'La superficie ne doit pas dépasser {{ limit }} caractères.',
+    )]
     private ?string $compositionLogementSuperficie = null;
+
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'nsp'],
+        message: 'Le champs "compositionLogementHauteur" est incorrect.'
+    )]
     private ?string $compositionLogementHauteur = null;
     #[Assert\NotBlank(
         message: 'Merci de définir le nombre de pièces à vivre.',
@@ -177,55 +292,178 @@ class SignalementDraftRequest
         ]
     )]
     #[Assert\Positive(message: 'Merci de saisir une information numérique dans le champs nombre de pièces à vivre.')]
+    #[Assert\Type(type: 'numeric', message: 'Le nombre de pièces à vivre doit être un nombre.')]
+    #[Assert\Length(
+        max: 10,
+        maxMessage: 'Le nombre de pièces à vivre ne doit pas dépasser {{ limit }} caractères.',
+    )]
     private ?string $compositionLogementNbPieces = null;
+
+    #[Assert\Positive(message: 'Le nombre de personnes doit être un nombre positif.')]
+    #[Assert\Type(type: 'numeric', message: 'Le nombre de personnes doit être un nombre.')]
+    #[Assert\Length(
+        max: 10,
+        maxMessage: 'Le nombre de personnes ne doit pas dépasser {{ limit }} caractères.',
+    )]
     private ?string $compositionLogementNombrePersonnes = null;
+
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "compositionLogementEnfants" est incorrect.'
+    )]
     private ?string $compositionLogementEnfants = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'nsp'],
+        message: 'Le champs "typeLogementCommoditesPieceAVivre9m" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesPieceAVivre9m = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementCommoditesCuisine" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesCuisine = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementCommoditesCuisineCollective" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesCuisineCollective = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementCommoditesSalleDeBain" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesSalleDeBain = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementCommoditesSalleDeBainCollective" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesSalleDeBainCollective = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementCommoditesWc" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesWc = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementCommoditesWcCollective" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesWcCollective = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champs "typeLogementCommoditesWcCuisine" est incorrect.'
+    )]
     private ?string $typeLogementCommoditesWcCuisine = null;
     #[Assert\DateTime('Y-m-d')]
     private ?string $bailDpeDateEmmenagement = null;
+    #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "bailDpeBail" est incorrect.')]
     private ?string $bailDpeBail = null;
     private ?array $bailDpeBailUpload = null;
+
+    #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "bailDpeEtatDesLieux" est incorrect.')]
     private ?string $bailDpeEtatDesLieux = null;
+    #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "bailDpeDpe" est incorrect.')]
     private ?string $bailDpeDpe = null;
     private ?array $bailDpeDpeUpload = null;
+    #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "logementSocialDemandeRelogement" est incorrect.')]
     private ?string $logementSocialDemandeRelogement = null;
+    #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "logementSocialAllocation" est incorrect.')]
     private ?string $logementSocialAllocation = null;
+    #[Assert\Choice(choices: ['caf', 'msa'], message: 'Le champ "logementSocialAllocationCaisse" est incorrect.')]
     private ?string $logementSocialAllocationCaisse = null;
     #[Assert\DateTime('Y-m-d')]
     private ?string $logementSocialDateNaissance = null;
+    #[Assert\Length(max: 20, maxMessage: 'Le montant de l\'allocation ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $logementSocialMontantAllocation = null;
+    #[Assert\Length(max: 50, maxMessage: 'Le numéro d\'allocataire ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $logementSocialNumeroAllocataire = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'nsp'],
+        message: 'Le champ "travailleurSocialQuitteLogement" est incorrect.',
+    )]
     private ?string $travailleurSocialQuitteLogement = null;
+
+    #[Assert\When(
+        expression: 'this.getTravailleurSocialQuitteLogement() == "oui"',
+        constraints: [
+            new Assert\NotBlank(message: 'Merci de préciser s\'il y a un préavis de départ.'),
+        ],
+    )]
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'nsp'],
+        message: 'Le champ "travailleurSocialPreavisDepart" est incorrect.',
+    )]
     private ?string $travailleurSocialPreavisDepart = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'nsp'],
+        message: 'Le champ "travailleurSocialAccompagnement" est incorrect.',
+    )]
     private ?string $travailleurSocialAccompagnement = null;
+    #[Assert\Length(max: 50)]
     private ?string $travailleurSocialAccompagnementDeclarant = null;
+
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'nsp'],
+        message: 'Le champ "infoProcedureBailleurPrevenu" est incorrect.',
+    )]
     private ?string $infoProcedureBailleurPrevenu = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'pas_assurance_logement'],
+        message: 'Le champ "infoProcedureAssuranceContactee" est incorrect.',
+    )]
     private ?string $infoProcedureAssuranceContactee = null;
+    #[Assert\Length(
+        max: 255,
+        maxMessage: 'La réponse de l\'assurance ne doit pas dépasser {{ limit }} caractères.',
+    )]
     private ?string $infoProcedureReponseAssurance = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non', 'nsp'],
+        message: 'Le champ "infoProcedureDepartApresTravaux" est incorrect.',
+    )]
     private ?string $infoProcedureDepartApresTravaux = null;
     private ?bool $utilisationServiceOkPrevenirBailleur = null;
     private ?bool $utilisationServiceOkVisite = null;
     private ?bool $utilisationServiceOkDemandeLogement = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champ "informationsComplementairesSituationOccupantsBeneficiaireRsa" est incorrect.',
+    )]
     private ?string $informationsComplementairesSituationOccupantsBeneficiaireRsa = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champ "informationsComplementairesSituationOccupantsBeneficiaireFsl" est incorrect.',
+    )]
     private ?string $informationsComplementairesSituationOccupantsBeneficiaireFsl = null;
     #[Assert\DateTime('Y-m-d')]
     private ?string $informationsComplementairesSituationOccupantsDateNaissance = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champ "informationsComplementairesSituationOccupantsDemandeRelogement" est incorrect.',
+    )]
     private ?string $informationsComplementairesSituationOccupantsDemandeRelogement = null;
+    #[Assert\DateTime('Y-m-d')]
     private ?string $informationsComplementairesSituationOccupantsDateEmmenagement = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champ "informationsComplementairesSituationOccupantsLoyersPayes" est incorrect.',
+    )]
     private ?string $informationsComplementairesSituationOccupantsLoyersPayes = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champ "informationsComplementairesSituationBailleurBeneficiaireRsa" est incorrect.',
+    )]
     private ?string $informationsComplementairesSituationBailleurBeneficiaireRsa = null;
+    #[Assert\Choice(
+        choices: ['oui', 'non'],
+        message: 'Le champ "informationsComplementairesSituationBailleurBeneficiaireFsl" est incorrect.',
+    )]
     private ?string $informationsComplementairesSituationBailleurBeneficiaireFsl = null;
+    #[Assert\Length(max: 50, maxMessage: 'Le revenu fiscal ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $informationsComplementairesSituationBailleurRevenuFiscal = null;
     #[Assert\DateTime('Y-m-d')]
     private ?string $informationsComplementairesSituationBailleurDateNaissance = null;
+    #[Assert\Length(max: 20, maxMessage: 'Le montant de l\'allocation ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $informationsComplementairesLogementMontantLoyer = null;
+    #[Assert\Length(max: 5, maxMessage: 'L\'étage ne peut pas dépasser {{ limit }} caractères.')]
     private ?string $informationsComplementairesLogementNombreEtages = null;
     #[Assert\DateTime('Y')]
     private ?string $informationsComplementairesLogementAnneeConstruction = null;

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller\Back;
 
+use App\Entity\Signalement;
 use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
 use App\Tests\SessionHelper;
@@ -17,6 +18,7 @@ class SignalementEditControllerTest extends WebTestCase
     private UserRepository $userRepository;
     private SignalementRepository $signalementRepository;
     private RouterInterface $router;
+    private ?Signalement $signalement = null;
 
     protected function setUp(): void
     {
@@ -29,6 +31,7 @@ class SignalementEditControllerTest extends WebTestCase
         $this->router = static::getContainer()->get(RouterInterface::class);
         $user = $this->userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
         $this->client->loginUser($user);
+        $this->signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2024-000000000004']);
     }
 
     public function testEditCoordonneesBailleurWithBailleur(): void
@@ -43,7 +46,7 @@ class SignalementEditControllerTest extends WebTestCase
             ['uuid' => $signalement->getUuid()]
         );
 
-        $payload = $this->getPayload('13 habitat', $signalement->getId());
+        $payload = $this->getPayloadCoordonneesBailleur('13 habitat', $signalement->getId());
         $this->client->request('POST', $route, [], [], [], json_encode($payload));
 
         $this->assertResponseIsSuccessful();
@@ -60,7 +63,7 @@ class SignalementEditControllerTest extends WebTestCase
             ['uuid' => $signalement->getUuid()]
         );
 
-        $payload = $this->getPayload('Habitat Social Solidaire', $signalement->getId());
+        $payload = $this->getPayloadCoordonneesBailleur('Habitat Social Solidaire', $signalement->getId());
         $this->client->request('POST', $route, [], [], [], json_encode($payload));
 
         $this->assertResponseIsSuccessful();
@@ -68,9 +71,26 @@ class SignalementEditControllerTest extends WebTestCase
         $this->assertEquals('Habitat Social Solidaire', $signalement->getNomProprio());
     }
 
-    public function getPayload(string $bailleurName, int $signalementId): array
+    /**
+     * @dataProvider provideEditSignalementRoutes
+     */
+    public function testEditSignalement(string $routeName, array $payload, string $token): void
     {
-        $payload = [
+        $route = $this->router->generate(
+            $routeName,
+            ['uuid' => $this->signalement->getUuid()]
+        );
+
+        $payload['_token'] = $this->getCsrfToken($token, $this->signalement->getId());
+
+        $this->client->request('POST', $route, [], [], [], json_encode($payload));
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    private function getPayloadCoordonneesBailleur(string $bailleurName, int $signalementId): array
+    {
+        return [
             'nom' => $bailleurName,
             'prenom' => '',
             'mail' => 'contact@13habitat.fr',
@@ -80,13 +100,148 @@ class SignalementEditControllerTest extends WebTestCase
             'beneficiaireFsl' => '',
             'revenuFiscal' => '',
             'dateNaissance' => '',
+            '_token' => $this->getCsrfToken('signalement_edit_coordonnees_bailleur_', $signalementId),
+        ];
+    }
+
+    private function getPayloadCoordonneesFoyer(): array
+    {
+        return [
+            'civilite' => 'mme',
+            'nom' => 'Monfort',
+            'prenom' => 'Nelson',
+            'mail' => 'nelson.monfort@yopmail.com',
+            'telephone' => '+33240556677',
+            'telephoneBis' => '0611451264',
+        ];
+    }
+
+    private function getPayloadInformationLogement(): array
+    {
+        return [
+            'nombrePersonnes' => '4',
+            'compositionLogementEnfants' => 'oui',
+            'dateEntree' => '2020-12-01',
+            'bailleurDateEffetBail' => '',
+            'bailDpeBail' => 'oui',
+            'bailDpeEtatDesLieux' => 'oui',
+            'bailDpeDpe' => 'oui',
+            'loyer' => '494',
+            'loyersPayes' => 'oui',
+            'anneeConstruction' => '1994',
+        ];
+    }
+
+    private function getPayloadCompositionLogement(): array
+    {
+        return [
+            'type' => 'maison',
+            'typeLogementNatureAutrePrecision' => '',
+            'typeCompositionLogement' => 'plusieurs_pieces',
+            'superficie' => '55',
+            'compositionLogementHauteur' => 'oui',
+            'compositionLogementNbPieces' => '5',
+            'nombreEtages' => '1',
+            'typeLogementRdc' => 'non',
+            'typeLogementDernierEtage' => 'non',
+            'typeLogementSousCombleSansFenetre' => 'non',
+            'typeLogementSousSolSansFenetre' => 'non',
+            'typeLogementCommoditesPieceAVivre9m' => 'oui',
+            'typeLogementCommoditesCuisine' => 'oui',
+            'typeLogementCommoditesCuisineCollective' => 'oui',
+            'typeLogementCommoditesSalleDeBain' => 'oui',
+            'typeLogementCommoditesSalleDeBainCollective' => 'non',
+            'typeLogementCommoditesWc' => 'oui',
+            'typeLogementCommoditesWcCollective' => 'non',
+            'typeLogementCommoditesWcCuisine' => 'non',
+        ];
+    }
+
+    private function getPayloadSituationFoyer(): array
+    {
+        return [
+            'isLogementSocial' => 'non',
+            'isRelogement' => 'non',
+            'isAllocataire' => 'non',
+            'dateNaissanceOccupant' => '',
+            'numAllocataire' => '702807',
+            'logementSocialMontantAllocation' => '5000',
+            'travailleurSocialQuitteLogement' => 'non',
+            'travailleurSocialPreavisDepart' => 'non',
+            'travailleurSocialAccompagnement' => 'non',
+            'beneficiaireRsa' => 'non',
+            'beneficiaireFsl' => 'non',
+        ];
+    }
+
+    private function getPayloadProcedureDemarches(): array
+    {
+        return [
+            'isProprioAverti' => '1',
+            'infoProcedureAssuranceContactee' => 'oui',
+            'infoProcedureReponseAssurance' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            'infoProcedureDepartApresTravaux' => 'oui',
+        ];
+    }
+
+    private function getPayloadAddress(): array
+    {
+        return [
+                'adresse' => '17 Boulevard saade - quai joliette',
+                'codePostal' => '13002',
+                'ville' => 'Marseille',
+                'needResetInsee' => '0',
+                'manual' => '0',
+                'insee' => '13202',
+                'geolocLat' => '43.301787',
+                'geolocLng' => '5.364626',
+                'etage' => '8',
+                'escalier' => '5',
+                'numAppart' => '369',
+                'autre' => 'Les essentielles',
+        ];
+    }
+
+    public function provideEditSignalementRoutes(): \Generator
+    {
+        yield 'Edition Adresse logement' => [
+            'back_signalement_edit_address',
+            $this->getPayloadAddress(),
+            'signalement_edit_address_',
         ];
 
-        $payload['_token'] = $this->generateCsrfToken(
-            $this->client,
-            'signalement_edit_coordonnees_bailleur_'.$signalementId
-        );
+        yield 'Edition Coordonnées du foyer' => [
+            'back_signalement_edit_coordonnees_foyer',
+            $this->getPayloadCoordonneesFoyer(),
+            'signalement_edit_coordonnees_foyer_',
+        ];
 
-        return $payload;
+        yield 'Edition Informations sur le logement' => [
+            'back_signalement_edit_informations_logement',
+            $this->getPayloadInformationLogement(),
+            'signalement_edit_informations_logement_',
+        ];
+
+        yield 'Edition Description du logement' => [
+            'back_signalement_edit_composition_logement',
+            $this->getPayloadCompositionLogement(),
+            'signalement_edit_composition_logement_',
+        ];
+        yield 'Edition Situation du foyer' => [
+            'back_signalement_edit_situation_foyer',
+            $this->getPayloadSituationFoyer(),
+            'signalement_edit_situation_foyer_',
+        ];
+
+        yield 'Edition Procédure et démarches' => [
+            'back_signalement_edit_procedure_demarches',
+            $this->getPayloadProcedureDemarches(),
+            'signalement_edit_procedure_demarches_',
+        ];
+    }
+
+    private function getCsrfToken(string $tokenId, int $signalementId): string
+    {
+        return $this->generateCsrfToken($this->client, $tokenId.$signalementId);
     }
 }

--- a/tests/Unit/Dto/Request/Signalement/AdresseOccupantRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/AdresseOccupantRequestTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\AdresseOccupantRequest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class AdresseOccupantRequestTest extends KernelTestCase
+{
+    private ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = self::getContainer()->get('validator');
+    }
+
+    public function testValidateSuccess(): void
+    {
+        $adresseOccupantRequest = new AdresseOccupantRequest(
+            adresse: '123 Rue de Exemple',
+            codePostal: '75001',
+            ville: 'Paris',
+            etage: '3',
+            escalier: 'A',
+            numAppart: '42',
+            autre: 'Proche de la boulangerie',
+            geolocLng: '2.3522',
+            geolocLat: '48.8566',
+            insee: '75056',
+            manual: '1',
+            needResetInsee: '1'
+        );
+
+        $this->assertSame('123 Rue de Exemple', $adresseOccupantRequest->getAdresse());
+        $this->assertSame('75001', $adresseOccupantRequest->getCodePostal());
+        $this->assertSame('Paris', $adresseOccupantRequest->getVille());
+        $this->assertSame('3', $adresseOccupantRequest->getEtage());
+        $this->assertSame('A', $adresseOccupantRequest->getEscalier());
+        $this->assertSame('42', $adresseOccupantRequest->getNumAppart());
+        $this->assertSame('Proche de la boulangerie', $adresseOccupantRequest->getAutre());
+        $this->assertSame('2.3522', $adresseOccupantRequest->getGeolocLng());
+        $this->assertSame('48.8566', $adresseOccupantRequest->getGeolocLat());
+        $this->assertSame('75056', $adresseOccupantRequest->getInsee());
+        $this->assertSame('1', $adresseOccupantRequest->getManual());
+        $this->assertSame('1', $adresseOccupantRequest->getNeedResetInsee());
+
+        $errors = $this->validator->validate($adresseOccupantRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateError(): void
+    {
+        $adresseOccupantRequestInvalide = new AdresseOccupantRequest(
+            adresse: '',
+            codePostal: '123',
+            ville: '',
+            etage: 'EtageInvalide',
+            escalier: 'EscalierInvalide',
+            numAppart: 'NumAppInvalide',
+            autre: str_repeat('x', 256),
+            geolocLng: 'LongitudeInvalide',
+            geolocLat: 'LatitudeInvalide',
+            insee: '123',
+            manual: '2',
+            needResetInsee: '2'
+        );
+
+        $errors = $this->validator->validate($adresseOccupantRequestInvalide);
+        $this->assertCount(12, $errors);
+    }
+}

--- a/tests/Unit/Dto/Request/Signalement/CompositionLogementRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/CompositionLogementRequestTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\CompositionLogementRequest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validation;
+
+class CompositionLogementRequestTest extends KernelTestCase
+{
+    public function testValidateSuccess(): void
+    {
+        $compositionLogementRequest = new CompositionLogementRequest(
+            type: 'maison',
+            typeLogementNatureAutrePrecision: null,
+            typeCompositionLogement: 'piece_unique',
+            superficie: '80',
+            compositionLogementHauteur: 'oui',
+            compositionLogementNbPieces: '3',
+            nombreEtages: '2',
+            typeLogementRdc: 'oui',
+            typeLogementDernierEtage: 'non',
+            typeLogementSousCombleSansFenetre: 'non',
+            typeLogementSousSolSansFenetre: 'non',
+            typeLogementCommoditesPieceAVivre9m: 'oui',
+            typeLogementCommoditesCuisine: 'oui',
+            typeLogementCommoditesCuisineCollective: 'non',
+            typeLogementCommoditesSalleDeBain: 'oui',
+            typeLogementCommoditesSalleDeBainCollective: 'non',
+            typeLogementCommoditesWc: 'oui',
+            typeLogementCommoditesWcCollective: 'non',
+            typeLogementCommoditesWcCuisine: 'non'
+        );
+
+        $this->assertSame('maison', $compositionLogementRequest->getType());
+        $this->assertNull($compositionLogementRequest->getTypeLogementNatureAutrePrecision());
+        $this->assertSame('piece_unique', $compositionLogementRequest->getTypeCompositionLogement());
+        $this->assertSame('80', $compositionLogementRequest->getSuperficie());
+        $this->assertSame('oui', $compositionLogementRequest->getCompositionLogementHauteur());
+        $this->assertSame('3', $compositionLogementRequest->getCompositionLogementNbPieces());
+        $this->assertSame('2', $compositionLogementRequest->getNombreEtages());
+        $this->assertSame('oui', $compositionLogementRequest->getTypeLogementRdc());
+        $this->assertSame('non', $compositionLogementRequest->getTypeLogementDernierEtage());
+        $this->assertSame('non', $compositionLogementRequest->getTypeLogementSousCombleSansFenetre());
+        $this->assertSame('non', $compositionLogementRequest->getTypeLogementSousSolSansFenetre());
+        $this->assertSame('oui', $compositionLogementRequest->getTypeLogementCommoditesPieceAVivre9m());
+        $this->assertSame('oui', $compositionLogementRequest->getTypeLogementCommoditesCuisine());
+        $this->assertSame('non', $compositionLogementRequest->getTypeLogementCommoditesCuisineCollective());
+        $this->assertSame('oui', $compositionLogementRequest->getTypeLogementCommoditesSalleDeBain());
+        $this->assertSame('non', $compositionLogementRequest->getTypeLogementCommoditesSalleDeBainCollective());
+        $this->assertSame('oui', $compositionLogementRequest->getTypeLogementCommoditesWc());
+        $this->assertSame('non', $compositionLogementRequest->getTypeLogementCommoditesWcCollective());
+        $this->assertSame('non', $compositionLogementRequest->getTypeLogementCommoditesWcCuisine());
+
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $errors = $validator->validate($compositionLogementRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateError(): void
+    {
+        $compositionLogementRequest = new CompositionLogementRequest(
+            type: 'invalid_type',
+            typeLogementNatureAutrePrecision: str_repeat('a', 101),
+            typeCompositionLogement: 'invalid_choice',
+            superficie: 'invalid_superficie',
+            compositionLogementHauteur: 'invalid_choice',
+            compositionLogementNbPieces: 'invalid_nb',
+            nombreEtages: 'invalid_nb',
+            typeLogementRdc: 'oui',
+            typeLogementDernierEtage: 'oui',
+            typeLogementSousCombleSansFenetre: 'invalid_choice',
+            typeLogementSousSolSansFenetre: 'invalid_choice',
+            typeLogementCommoditesPieceAVivre9m: 'invalid_choice',
+            typeLogementCommoditesCuisine: 'invalid_choice',
+            typeLogementCommoditesCuisineCollective: 'invalid_choice',
+            typeLogementCommoditesSalleDeBain: 'invalid_choice',
+            typeLogementCommoditesSalleDeBainCollective: 'invalid_choice',
+            typeLogementCommoditesWc: 'invalid_choice',
+            typeLogementCommoditesWcCollective: 'invalid_choice',
+            typeLogementCommoditesWcCuisine: 'invalid_choice'
+        );
+
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $errors = $validator->validate($compositionLogementRequest);
+        $this->assertCount(20, $errors);
+    }
+}

--- a/tests/Unit/Dto/Request/Signalement/CoordonneesFoyerRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/CoordonneesFoyerRequestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\CoordonneesFoyerRequest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CoordonneesFoyerRequestTest extends KernelTestCase
+{
+    private ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = self::getContainer()->get('validator');
+    }
+
+    public function testValidateSuccess(): void
+    {
+        $coordonneesFoyerRequest = new CoordonneesFoyerRequest(
+            typeProprio: 'PARTICULIER',
+            nomStructure: null,
+            civilite: 'mr',
+            nom: 'Dupont',
+            prenom: 'Jean',
+            mail: 'jean.dupont@example.com',
+            telephone: '0123456789',
+            telephoneBis: '0987654321'
+        );
+
+        $this->assertSame('PARTICULIER', $coordonneesFoyerRequest->getTypeProprio());
+        $this->assertNull($coordonneesFoyerRequest->getNomStructure());
+        $this->assertSame('mr', $coordonneesFoyerRequest->getCivilite());
+        $this->assertSame('Dupont', $coordonneesFoyerRequest->getNom());
+        $this->assertSame('Jean', $coordonneesFoyerRequest->getPrenom());
+        $this->assertSame('jean.dupont@example.com', $coordonneesFoyerRequest->getMail());
+        $this->assertSame('0123456789', $coordonneesFoyerRequest->getTelephone());
+        $this->assertSame('0987654321', $coordonneesFoyerRequest->getTelephoneBis());
+
+        $errors = $this->validator->validate($coordonneesFoyerRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateError(): void
+    {
+        $coordonneesFoyerRequest = new CoordonneesFoyerRequest(
+            typeProprio: 'INVALID_TYPE',
+            nomStructure: str_repeat('x', 201),
+            civilite: 'invalid',
+            nom: str_repeat('x', 51),
+            prenom: str_repeat('x', 51),
+            mail: 'invalid-email',
+            telephone: 'invalid-phone',
+            telephoneBis: 'invalid-phone-bis'
+        );
+
+        $errors = $this->validator->validate($coordonneesFoyerRequest);
+        $this->assertCount(8, $errors);
+    }
+}

--- a/tests/Unit/Dto/Request/Signalement/CoordonneesTiersRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/CoordonneesTiersRequestTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\CoordonneesTiersRequest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CoordonneesTiersRequestTest extends KernelTestCase
+{
+    private ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = self::getContainer()->get('validator');
+    }
+
+    public function testValidateSuccess(): void
+    {
+        $coordonneesTiersRequest = new CoordonneesTiersRequest(
+            typeProprio: 'PARTICULIER',
+            nom: 'Dupont',
+            prenom: 'Jean',
+            mail: 'jean.dupont@example.com',
+            telephone: '0123456789',
+            lien: 'VOISIN',
+            structure: null
+        );
+
+        $this->assertSame('PARTICULIER', $coordonneesTiersRequest->getTypeProprio());
+        $this->assertSame('Dupont', $coordonneesTiersRequest->getNom());
+        $this->assertSame('Jean', $coordonneesTiersRequest->getPrenom());
+        $this->assertSame('jean.dupont@example.com', $coordonneesTiersRequest->getMail());
+        $this->assertSame('0123456789', $coordonneesTiersRequest->getTelephone());
+        $this->assertSame('VOISIN', $coordonneesTiersRequest->getLien());
+        $this->assertNull($coordonneesTiersRequest->getStructure());
+
+        $errors = $this->validator->validate($coordonneesTiersRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateError(): void
+    {
+        $coordonneesTiersRequest = new CoordonneesTiersRequest(
+            typeProprio: 'INVALID_TYPE',
+            nom: str_repeat('a', 51),
+            prenom: '',
+            mail: 'invalid-email',
+            telephone: 'invalid-phone',
+            lien: 'INVALID_LIEN',
+            structure: str_repeat('b', 201)
+        );
+
+        $this->assertSame('INVALID_TYPE', $coordonneesTiersRequest->getTypeProprio());
+        $this->assertSame(str_repeat('a', 51), $coordonneesTiersRequest->getNom());
+        $this->assertSame('', $coordonneesTiersRequest->getPrenom());
+        $this->assertSame('invalid-email', $coordonneesTiersRequest->getMail());
+        $this->assertSame('invalid-phone', $coordonneesTiersRequest->getTelephone());
+        $this->assertSame('INVALID_LIEN', $coordonneesTiersRequest->getLien());
+        $this->assertSame(str_repeat('b', 201), $coordonneesTiersRequest->getStructure());
+
+        $errors = $this->validator->validate($coordonneesTiersRequest);
+        $this->assertCount(7, $errors);
+    }
+}

--- a/tests/Unit/Dto/Request/Signalement/InformationsLogementRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/InformationsLogementRequestTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\InformationsLogementRequest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class InformationsLogementRequestTest extends KernelTestCase
+{
+    private ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = self::getContainer()->get('validator');
+    }
+
+    public function testValidateSuccess(): void
+    {
+        $informationsLogementRequest = new InformationsLogementRequest(
+            nombrePersonnes: '3',
+            compositionLogementEnfants: 'oui',
+            dateEntree: '2022-01-01',
+            bailleurDateEffetBail: '2022-01-01',
+            bailDpeBail: 'oui',
+            bailDpeEtatDesLieux: 'oui',
+            bailDpeDpe: 'oui',
+            loyer: '750',
+            loyersPayes: 'oui',
+            anneeConstruction: '2000'
+        );
+
+        $this->assertSame('3', $informationsLogementRequest->getNombrePersonnes());
+        $this->assertSame('oui', $informationsLogementRequest->getCompositionLogementEnfants());
+        $this->assertSame('2022-01-01', $informationsLogementRequest->getDateEntree());
+        $this->assertSame('2022-01-01', $informationsLogementRequest->getBailleurDateEffetBail());
+        $this->assertSame('oui', $informationsLogementRequest->getBailDpeBail());
+        $this->assertSame('oui', $informationsLogementRequest->getBailDpeEtatDesLieux());
+        $this->assertSame('oui', $informationsLogementRequest->getBailDpeDpe());
+        $this->assertSame('750', $informationsLogementRequest->getLoyer());
+        $this->assertSame('oui', $informationsLogementRequest->getLoyersPayes());
+        $this->assertSame('2000', $informationsLogementRequest->getAnneeConstruction());
+
+        $errors = $this->validator->validate($informationsLogementRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateError(): void
+    {
+        $informationsLogementRequest = new InformationsLogementRequest(
+            nombrePersonnes: '-1',
+            compositionLogementEnfants: 'maybe',
+            dateEntree: 'invalid-date',
+            bailleurDateEffetBail: 'invalid-date',
+            bailDpeBail: 'unknown',
+            bailDpeEtatDesLieux: 'unknown',
+            bailDpeDpe: 'unknown',
+            loyer: 'invalid-loyer',
+            loyersPayes: 'unknown',
+            anneeConstruction: '20'
+        );
+
+        $errors = $this->validator->validate($informationsLogementRequest);
+        $this->assertCount(10, $errors);
+    }
+}

--- a/tests/Unit/Dto/Request/Signalement/ProcedureDemarchesRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/ProcedureDemarchesRequestTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\ProcedureDemarchesRequest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ProcedureDemarchesRequestTest extends KernelTestCase
+{
+    private ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = self::getContainer()->get('validator');
+    }
+
+    public function testValidateSuccess(): void
+    {
+        $procedureDemarchesRequest = new ProcedureDemarchesRequest(
+            '0',
+            'oui',
+            'L\'assurance a accepté notre demande.',
+            'oui',
+            '2024-05-01'
+        );
+
+        $this->assertSame('0', $procedureDemarchesRequest->getIsProprioAverti());
+        $this->assertSame('oui', $procedureDemarchesRequest->getInfoProcedureAssuranceContactee());
+        $this->assertSame('L\'assurance a accepté notre demande.',
+            $procedureDemarchesRequest->getInfoProcedureReponseAssurance());
+        $this->assertSame('oui', $procedureDemarchesRequest->getInfoProcedureDepartApresTravaux());
+        $this->assertSame('2024-05-01', $procedureDemarchesRequest->getPreavisDepart());
+
+        $errors = $this->validator->validate($procedureDemarchesRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateError(): void
+    {
+        $procedure = new ProcedureDemarchesRequest(
+            '2',
+            'oui-non',
+            str_repeat('a', 256),
+            'oui-non',
+            str_repeat('a', 51)
+        );
+
+        $errors = $this->validator->validate($procedure);
+        $this->assertCount(5, $errors);
+    }
+}

--- a/tests/Unit/Dto/Request/Signalement/SignalementDraftRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SignalementDraftRequestTest.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class SignalementDraftRequestTest extends WebTestCase
+{
+    private ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = self::getContainer()->get('validator');
+    }
+
+    public function testValidateSuccess(): void
+    {
+        $signalementDraftRequest = new SignalementDraftRequest();
+        $signalementDraftRequest
+            ->setProfil('locataire')
+            ->setCurrentStep('Step 1')
+            ->setAdresseLogementAdresse('123 Rue de Exemple')
+            ->setAdresseLogementAdresseDetailNumero('1A')
+            ->setAdresseLogementAdresseDetailCodePostal('13129')
+            ->setAdresseLogementAdresseDetailCommune('Arles')
+            ->setAdresseLogementAdresseDetailInsee('13004')
+            ->setAdresseLogementAdresseDetailGeolocLat(48.8566)
+            ->setAdresseLogementAdresseDetailGeolocLng(2.3522)
+            ->setAdresseLogementAdresseDetailManual(true)
+            ->setAdresseLogementComplementAdresseEscalier('A')
+            ->setAdresseLogementComplementAdresseEtage('3')
+            ->setAdresseLogementComplementAdresseNumeroAppartement('42')
+            ->setAdresseLogementComplementAdresseAutre('Proche de la boulangerie')
+            ->setSignalementConcerneProfil('logement_occupez')
+            ->setSignalementConcerneProfilDetailOccupant('locataire')
+            ->setSignalementConcerneProfilDetailTiers('tiers_pro')
+            ->setSignalementConcerneProfilDetailBailleurProprietaire('particulier')
+            ->setSignalementConcerneProfilDetailBailleurBailleur('organisme_societe')
+            ->setSignalementConcerneLogementSocialServiceSecours('oui')
+            ->setSignalementConcerneLogementSocialAutreTiers('oui')
+            ->setVosCoordonneesTiersNomOrganisme('Organisme Exemple')
+            ->setVosCoordonneesTiersLien('proche')
+            ->setVosCoordonneesTiersNom('Dupont')
+            ->setVosCoordonneesTiersPrenom('Jean')
+            ->setVosCoordonneesTiersEmail('jean.dupont@example.com')
+            ->setVosCoordonneesTiersTel('0123456789')
+            ->setVosCoordonneesOccupantCivilite('mr')
+            ->setVosCoordonneesOccupantNomOrganisme('Organisme Occupant')
+            ->setVosCoordonneesOccupantNom('Dupont')
+            ->setVosCoordonneesOccupantPrenom('Jean')
+            ->setVosCoordonneesOccupantEmail('jean.dupont@example.com')
+            ->setVosCoordonneesOccupantTel('0123456789')
+            ->setCoordonneesOccupantNom('Occupant Nom')
+            ->setCoordonneesOccupantPrenom('Occupant Prenom')
+            ->setCoordonneesOccupantEmail('occupant@example.com')
+            ->setCoordonneesOccupantTel('0123456789')
+            ->setCoordonneesOccupantTelSecondaire('0123456788')
+            ->setCoordonneesBailleurNom('Bailleur Nom')
+            ->setCoordonneesBailleurPrenom('Bailleur Prenom')
+            ->setCoordonneesBailleurEmail('bailleur@example.com')
+            ->setCoordonneesBailleurTel('0123456789')
+            ->setCoordonneesBailleurAdresse('123 Rue Bailleur')
+            ->setCoordonneesBailleurAdresseDetailNumero('2B')
+            ->setCoordonneesBailleurAdresseDetailCodePostal('75002')
+            ->setCoordonneesBailleurAdresseDetailCommune('Paris')
+            ->setZoneConcerneeZone('batiment')
+            ->setTypeLogementNature('appartement')
+            ->setTypeLogementNatureAutrePrecision('Précision')
+            ->setTypeLogementRdc('oui')
+            ->setTypeLogementDernierEtage('non')
+            ->setTypeLogementSousSolSansFenetre('non')
+            ->setTypeLogementSousCombleSansFenetre('oui')
+            ->setCompositionLogementPieceUnique('piece_unique')
+            ->setCompositionLogementSuperficie('50')
+            ->setCompositionLogementHauteur('oui')
+            ->setCompositionLogementNbPieces('2')
+            ->setCompositionLogementNombrePersonnes('3')
+            ->setCompositionLogementEnfants('oui')
+            ->setTypeLogementCommoditesPieceAVivre9m('oui')
+            ->setTypeLogementCommoditesCuisine('oui')
+            ->setTypeLogementCommoditesCuisineCollective('non')
+            ->setTypeLogementCommoditesSalleDeBain('oui')
+            ->setTypeLogementCommoditesSalleDeBainCollective('non')
+            ->setTypeLogementCommoditesWc('oui')
+            ->setTypeLogementCommoditesWcCollective('non')
+            ->setTypeLogementCommoditesWcCuisine('non')
+            ->setBailDpeDateEmmenagement('2022-01-01')
+            ->setBailDpeBail('oui')
+            ->setBailDpeEtatDesLieux('oui')
+            ->setBailDpeDpe('oui')
+            ->setLogementSocialDemandeRelogement('oui')
+            ->setLogementSocialAllocation('oui')
+            ->setLogementSocialAllocationCaisse('caf')
+            ->setLogementSocialDateNaissance('1990-01-01')
+            ->setLogementSocialMontantAllocation('500')
+            ->setLogementSocialNumeroAllocataire('123456')
+            ->setTravailleurSocialQuitteLogement('oui')
+            ->setTravailleurSocialPreavisDepart('oui')
+            ->setTravailleurSocialAccompagnement('oui')
+            ->setTravailleurSocialAccompagnementDeclarant('1')
+            ->setInfoProcedureBailleurPrevenu('oui')
+            ->setInfoProcedureAssuranceContactee('oui')
+            ->setInfoProcedureReponseAssurance('Réponse de l\'assurance')
+            ->setInfoProcedureDepartApresTravaux('oui')
+            ->setUtilisationServiceOkPrevenirBailleur(true)
+            ->setUtilisationServiceOkVisite(true)
+            ->setUtilisationServiceOkDemandeLogement(true)
+            ->setInformationsComplementairesSituationOccupantsBeneficiaireRsa('oui')
+            ->setInformationsComplementairesSituationOccupantsBeneficiaireFsl('non')
+            ->setInformationsComplementairesSituationOccupantsDateNaissance('1990-01-01')
+            ->setInformationsComplementairesSituationOccupantsDemandeRelogement('oui')
+            ->setInformationsComplementairesSituationOccupantsDateEmmenagement('2022-01-01')
+            ->setInformationsComplementairesSituationOccupantsLoyersPayes('oui')
+            ->setInformationsComplementairesSituationBailleurBeneficiaireRsa('non')
+            ->setInformationsComplementairesSituationBailleurBeneficiaireFsl('oui')
+            ->setInformationsComplementairesSituationBailleurRevenuFiscal('30000')
+            ->setInformationsComplementairesSituationBailleurDateNaissance('1980-01-01')
+            ->setInformationsComplementairesLogementMontantLoyer('750')
+            ->setInformationsComplementairesLogementNombreEtages('3')
+            ->setInformationsComplementairesLogementAnneeConstruction('2000')
+            ->setMessageAdministration('Message administration');
+
+        $this->assertSame('logement_occupez', $signalementDraftRequest->getSignalementConcerneProfil());
+        $this->assertSame('locataire', $signalementDraftRequest->getSignalementConcerneProfilDetailOccupant());
+        $this->assertSame('tiers_pro', $signalementDraftRequest->getSignalementConcerneProfilDetailTiers());
+        $this->assertSame('123 Rue Bailleur', $signalementDraftRequest->getCoordonneesBailleurAdresse());
+        $this->assertSame('proche', $signalementDraftRequest->getVosCoordonneesTiersLien());
+        $this->assertSame('batiment', $signalementDraftRequest->getZoneConcerneeZone());
+        $this->assertSame('Précision', $signalementDraftRequest->getTypeLogementNatureAutrePrecision());
+        $this->assertSame('oui', $signalementDraftRequest->getTypeLogementRdc());
+        $this->assertSame('non', $signalementDraftRequest->getTypeLogementDernierEtage());
+        $this->assertSame('non', $signalementDraftRequest->getTypeLogementSousSolSansFenetre());
+        $this->assertSame('oui', $signalementDraftRequest->getTypeLogementSousCombleSansFenetre());
+        $this->assertSame('piece_unique', $signalementDraftRequest->getCompositionLogementPieceUnique());
+        $this->assertSame('oui', $signalementDraftRequest->getCompositionLogementHauteur());
+        $this->assertSame('oui', $signalementDraftRequest->getCompositionLogementEnfants());
+        $this->assertSame('oui', $signalementDraftRequest->getTypeLogementCommoditesPieceAVivre9m());
+        $this->assertSame('oui', $signalementDraftRequest->getTypeLogementCommoditesCuisine());
+        $this->assertSame('non', $signalementDraftRequest->getTypeLogementCommoditesCuisineCollective());
+        $this->assertSame('oui', $signalementDraftRequest->getTypeLogementCommoditesSalleDeBain());
+        $this->assertSame('non', $signalementDraftRequest->getTypeLogementCommoditesSalleDeBainCollective());
+        $this->assertSame('oui', $signalementDraftRequest->getTypeLogementCommoditesWc());
+        $this->assertSame('non', $signalementDraftRequest->getTypeLogementCommoditesWcCollective());
+        $this->assertSame('non', $signalementDraftRequest->getTypeLogementCommoditesWcCuisine());
+        $this->assertSame('oui', $signalementDraftRequest->getBailDpeEtatDesLieux());
+        $this->assertSame('oui', $signalementDraftRequest->getBailDpeDpe());
+        $this->assertSame('oui', $signalementDraftRequest->getTravailleurSocialAccompagnement());
+        $this->assertSame('1', $signalementDraftRequest->getTravailleurSocialAccompagnementDeclarant());
+        $this->assertSame('oui', $signalementDraftRequest->getInfoProcedureAssuranceContactee());
+        $this->assertSame(
+            'Réponse de l\'assurance',
+            $signalementDraftRequest->getInfoProcedureReponseAssurance()
+        );
+        $this->assertSame('oui', $signalementDraftRequest->getInfoProcedureDepartApresTravaux());
+        $this->assertTrue($signalementDraftRequest->getUtilisationServiceOkPrevenirBailleur());
+        $this->assertTrue($signalementDraftRequest->getUtilisationServiceOkVisite());
+        $this->assertTrue($signalementDraftRequest->getUtilisationServiceOkDemandeLogement());
+        $this->assertSame(
+            '1990-01-01',
+            $signalementDraftRequest->getInformationsComplementairesSituationOccupantsDateNaissance()
+        );
+        $this->assertSame(
+            'oui',
+            $signalementDraftRequest->getInformationsComplementairesSituationOccupantsLoyersPayes()
+        );
+        $this->assertSame(
+            'non',
+            $signalementDraftRequest->getInformationsComplementairesSituationBailleurBeneficiaireRsa()
+        );
+        $this->assertSame(
+            'oui',
+            $signalementDraftRequest->getInformationsComplementairesSituationBailleurBeneficiaireFsl()
+        );
+        $this->assertSame(
+            '30000',
+            $signalementDraftRequest->getInformationsComplementairesSituationBailleurRevenuFiscal()
+        );
+        $this->assertSame(
+            '1980-01-01',
+            $signalementDraftRequest->getInformationsComplementairesSituationBailleurDateNaissance()
+        );
+
+        $errors = $this->validator->validate($signalementDraftRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateFailed(): void
+    {
+        $signalementDraftRequest = new SignalementDraftRequest();
+        $signalementDraftRequest->setProfil('invalid_profil')
+            ->setCurrentStep(str_repeat('a', 129))
+            ->setAdresseLogementAdresse('')
+            ->setAdresseLogementAdresseDetailNumero(str_repeat('b', 101))
+            ->setAdresseLogementAdresseDetailCodePostal('1234')
+            ->setAdresseLogementAdresseDetailCommune('')
+            ->setAdresseLogementAdresseDetailInsee('1234')
+            ->setAdresseLogementAdresseDetailGeolocLat(999.999)
+            ->setAdresseLogementAdresseDetailGeolocLng(999.999)
+            ->setAdresseLogementComplementAdresseEscalier(str_repeat('c', 4))
+            ->setAdresseLogementComplementAdresseEtage(str_repeat('d', 6))
+            ->setAdresseLogementComplementAdresseNumeroAppartement(str_repeat('e', 6))
+            ->setAdresseLogementComplementAdresseAutre(str_repeat('f', 256))
+            ->setSignalementConcerneProfil('invalid_profile_detail')
+            ->setSignalementConcerneProfilDetailOccupant('invalid_occupant_detail')
+            ->setSignalementConcerneProfilDetailTiers('invalid_tiers_detail')
+            ->setSignalementConcerneProfilDetailBailleurProprietaire('invalid_proprietaire_detail')
+            ->setSignalementConcerneProfilDetailBailleurBailleur('invalid_bailleur_detail')
+            ->setSignalementConcerneLogementSocialServiceSecours('invalid_service_secours')
+            ->setSignalementConcerneLogementSocialAutreTiers('invalid_autre_tiers')
+            ->setVosCoordonneesTiersNomOrganisme(str_repeat('g', 201))
+            ->setVosCoordonneesTiersNom(str_repeat('h', 51))
+            ->setVosCoordonneesTiersPrenom(str_repeat('i', 51))
+            ->setVosCoordonneesTiersEmail('invalid-email')
+            ->setVosCoordonneesTiersTel('invalid-phone')
+            ->setVosCoordonneesOccupantCivilite('invalid_civilite')
+            ->setVosCoordonneesOccupantNomOrganisme(str_repeat('j', 201))
+            ->setVosCoordonneesOccupantNom(str_repeat('k', 51))
+            ->setVosCoordonneesOccupantPrenom(str_repeat('l', 51))
+            ->setVosCoordonneesOccupantEmail('invalid-email')
+            ->setVosCoordonneesOccupantTel('invalid-phone')
+            ->setCoordonneesOccupantNom(str_repeat('m', 51))
+            ->setCoordonneesOccupantPrenom(str_repeat('n', 51))
+            ->setCoordonneesOccupantEmail('invalid-email')
+            ->setCoordonneesOccupantTel('invalid-phone')
+            ->setCoordonneesBailleurNom(str_repeat('o', 251))
+            ->setCoordonneesBailleurPrenom(str_repeat('p', 251))
+            ->setCoordonneesBailleurEmail('invalid-email')
+            ->setCoordonneesBailleurTel('invalid-phone')
+            ->setCoordonneesBailleurAdresse(str_repeat('q', 256))
+            ->setCoordonneesBailleurAdresseDetailNumero(str_repeat('r', 256))
+            ->setCoordonneesBailleurAdresseDetailCodePostal('1234')
+            ->setCoordonneesBailleurAdresseDetailCommune(str_repeat('s', 256))
+            ->setZoneConcerneeZone('invalid_zone')
+            ->setTypeLogementNature('invalid_nature')
+            ->setTypeLogementNatureAutrePrecision(str_repeat('t', 26))
+            ->setTypeLogementRdc('invalid_rdc')
+            ->setTypeLogementDernierEtage('invalid_dernier_etage')
+            ->setTypeLogementSousSolSansFenetre('invalid_sous_sol')
+            ->setTypeLogementSousCombleSansFenetre('invalid_sous_comble')
+            ->setCompositionLogementPieceUnique('invalid_piece_unique')
+            ->setCompositionLogementSuperficie('invalid_superficie')
+            ->setCompositionLogementHauteur('invalid_hauteur')
+            ->setCompositionLogementNbPieces('invalid_nb_pieces')
+            ->setCompositionLogementNombrePersonnes('invalid_nombre_personnes')
+            ->setCompositionLogementEnfants('invalid_enfants')
+            ->setTypeLogementCommoditesPieceAVivre9m('invalid_9m')
+            ->setTypeLogementCommoditesCuisine('invalid_cuisine')
+            ->setTypeLogementCommoditesCuisineCollective('invalid_cuisine_collective')
+            ->setTypeLogementCommoditesSalleDeBain('invalid_salle_de_bain')
+            ->setTypeLogementCommoditesSalleDeBainCollective('invalid_salle_de_bain_collective')
+            ->setTypeLogementCommoditesWc('invalid_wc')
+            ->setTypeLogementCommoditesWcCollective('invalid_wc_collective')
+            ->setTypeLogementCommoditesWcCuisine('invalid_wc_cuisine')
+            ->setBailDpeDateEmmenagement('invalid_date')
+            ->setBailDpeBail('invalid_bail')
+            ->setBailDpeEtatDesLieux('invalid_etat_des_lieux')
+            ->setBailDpeDpe('invalid_dpe')
+            ->setLogementSocialDemandeRelogement('invalid_demande_relogement')
+            ->setLogementSocialAllocation('invalid_allocation')
+            ->setLogementSocialAllocationCaisse('invalid_caisse')
+            ->setLogementSocialDateNaissance('invalid_date')
+            ->setLogementSocialMontantAllocation('invalid_montant')
+            ->setLogementSocialNumeroAllocataire(str_repeat('u', 51))
+            ->setTravailleurSocialQuitteLogement('invalid_quitte_logement')
+            ->setTravailleurSocialPreavisDepart('invalid_preavis_depart')
+            ->setTravailleurSocialAccompagnement('invalid_accompagnement')
+            ->setInfoProcedureBailleurPrevenu('invalid_bailleur_prevenu')
+            ->setInfoProcedureAssuranceContactee('invalid_assurance_contactee')
+            ->setInfoProcedureReponseAssurance(str_repeat('v', 256))
+            ->setInfoProcedureDepartApresTravaux('invalid_depart_apres_travaux')
+            ->setUtilisationServiceOkPrevenirBailleur(null)
+            ->setUtilisationServiceOkVisite(null)
+            ->setUtilisationServiceOkDemandeLogement(null)
+            ->setInformationsComplementairesSituationOccupantsBeneficiaireRsa('invalid_beneficiaire_rsa')
+            ->setInformationsComplementairesSituationOccupantsBeneficiaireFsl('invalid_beneficiaire_fsl')
+            ->setInformationsComplementairesSituationOccupantsDateNaissance('invalid_date')
+            ->setInformationsComplementairesSituationOccupantsDemandeRelogement('invalid_demande_relogement')
+            ->setInformationsComplementairesSituationOccupantsDateEmmenagement('invalid_date')
+            ->setInformationsComplementairesSituationOccupantsLoyersPayes('invalid_loyers_payes')
+            ->setInformationsComplementairesSituationBailleurBeneficiaireRsa('invalid_beneficiaire_rsa')
+            ->setInformationsComplementairesSituationBailleurBeneficiaireFsl('invalid_beneficiaire_fsl')
+            ->setInformationsComplementairesSituationBailleurRevenuFiscal(str_repeat('w', 51))
+            ->setInformationsComplementairesSituationBailleurDateNaissance('invalid_date')
+            ->setInformationsComplementairesLogementMontantLoyer(str_repeat('x', 21))
+            ->setInformationsComplementairesLogementNombreEtages(str_repeat('y', 6))
+            ->setInformationsComplementairesLogementAnneeConstruction('invalid_annee')
+            ->setMessageAdministration('Message administration');
+
+        $errors = $this->validator->validate($signalementDraftRequest);
+        $this->assertCount(97, $errors);
+    }
+}

--- a/tests/Unit/Dto/Request/Signalement/SignalementSearchQueryTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SignalementSearchQueryTest.php
@@ -4,12 +4,16 @@ namespace App\Tests\Unit\Dto\Request\Signalement;
 
 use App\Dto\Request\Signalement\SignalementSearchQuery;
 use App\Entity\Enum\SignalementStatus;
-use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class SignalementSearchQueryTest extends TestCase
+class SignalementSearchQueryTest extends KernelTestCase
 {
     public function testGetFilters(): void
     {
+        /** @var ValidatorInterface $validator */
+        $validator = self::getContainer()->get('validator');
+
         $query = new SignalementSearchQuery(
             '13',
             'John',
@@ -38,7 +42,7 @@ class SignalementSearchQueryTest extends TestCase
             'NO_SUIVI_AFTER_3_RELANCES',
             'oui',
             30,
-            'createdAt',
+            'reference',
             'DESC',
         );
 
@@ -79,10 +83,12 @@ class SignalementSearchQueryTest extends TestCase
             'nouveau_suivi' => 'oui',
             'page' => 1,
             'maxItemsPerPage' => 25,
-            'sortBy' => 'createdAt',
+            'sortBy' => 'reference',
             'orderBy' => 'DESC',
         ];
 
         static::assertSame($expectedFilters, $query->getFilters());
+        $errors = $validator->validate($query);
+        $this->assertCount(0, $errors);
     }
 }

--- a/tests/Unit/Dto/Request/Signalement/SituationFoyerRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SituationFoyerRequestTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Tests\Unit\Dto\Request\Signalement;
+
+use App\Dto\Request\Signalement\SituationFoyerRequest;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class SituationFoyerRequestTest extends KernelTestCase
+{
+    private ?ValidatorInterface $validator = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = self::getContainer()->get('validator');
+    }
+
+    public function testValidateSuccess(): void
+    {
+        $situationFoyerRequest = new SituationFoyerRequest(
+            isLogementSocial: 'oui',
+            isRelogement: 'non',
+            isAllocataire: 'CAF',
+            dateNaissanceOccupant: '1990-01-01',
+            numAllocataire: '123456789',
+            logementSocialMontantAllocation: '500',
+            travailleurSocialQuitteLogement: 'oui',
+            travailleurSocialPreavisDepart: 'oui',
+            travailleurSocialAccompagnement: 'oui',
+            travailleurSocialAccompagnementDeclarant: '1',
+            beneficiaireRsa: 'oui',
+            beneficiaireFsl: 'non',
+            revenuFiscal: '20000'
+        );
+
+        $this->assertSame('oui', $situationFoyerRequest->getIsLogementSocial());
+        $this->assertSame('non', $situationFoyerRequest->getIsRelogement());
+        $this->assertSame('CAF', $situationFoyerRequest->getIsAllocataire());
+        $this->assertSame('1990-01-01', $situationFoyerRequest->getDateNaissanceOccupant());
+        $this->assertSame('123456789', $situationFoyerRequest->getNumAllocataire());
+        $this->assertSame('500', $situationFoyerRequest->getLogementSocialMontantAllocation());
+        $this->assertSame('oui', $situationFoyerRequest->getTravailleurSocialQuitteLogement());
+        $this->assertSame('oui', $situationFoyerRequest->getTravailleurSocialPreavisDepart());
+        $this->assertSame('oui', $situationFoyerRequest->getTravailleurSocialAccompagnement());
+        $this->assertSame('1', $situationFoyerRequest->getTravailleurSocialAccompagnementDeclarant());
+        $this->assertSame('oui', $situationFoyerRequest->getBeneficiaireRsa());
+        $this->assertSame('non', $situationFoyerRequest->getBeneficiaireFsl());
+        $this->assertSame('20000', $situationFoyerRequest->getRevenuFiscal());
+
+        $errors = $this->validator->validate($situationFoyerRequest);
+        $this->assertCount(0, $errors);
+    }
+
+    public function testValidateError(): void
+    {
+        $situationFoyerRequest = new SituationFoyerRequest(
+            isLogementSocial: 'maybe',
+            isRelogement: '',
+            isAllocataire: 'unknown',
+            dateNaissanceOccupant: 'invalid-date',
+            numAllocataire: str_repeat('a', 51),
+            logementSocialMontantAllocation: 'invalid-amount',
+            travailleurSocialQuitteLogement: 'maybe',
+            travailleurSocialPreavisDepart: '',
+            travailleurSocialAccompagnement: 'unknown',
+            travailleurSocialAccompagnementDeclarant: str_repeat('b', 51),
+            beneficiaireRsa: 'unknown',
+            beneficiaireFsl: 'unknown',
+            revenuFiscal: str_repeat('c', 51)
+        );
+
+        $errors = $this->validator->validate($situationFoyerRequest);
+        $this->assertCount(12, $errors);
+    }
+}

--- a/tools/histologe/histologe.postman_collection.json
+++ b/tools/histologe/histologe.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "2aac4010-9337-4c75-8e39-0b9814fd8f41",
+		"_postman_id": "fcebc7ae-48dd-450b-ab57-469f347b4403",
 		"name": "histologe",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "1569180"
@@ -216,7 +216,8 @@
 											"",
 											""
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -225,7 +226,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"uuidSignalementDraft\": \"\",\n    \"signalementReference\": \"\",\n    \"lienSuivi\": \"\",\n    \"currentStep\": \"coordonnees_bailleur\",\n    \"adresse_logement_adresse_suggestion\": \"17 quai de la joliette\",\n    \"adresse_logement_adresse\": \"17 Boulevard saade - quai joliette 13002 Marseille\",\n    \"adresse_logement_adresse_detail_numero\": \"17 Boulevard saade - quai joliette\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"adresse_logement_adresse_detail_insee\": \"13202\",\n    \"adresse_logement_adresse_detail_geoloc_lng\": 5.364626,\n    \"adresse_logement_adresse_detail_geoloc_lat\": 43.301787,\n    \"adresse_logement_complement_adresse_etage\": \"5\",\n    \"adresse_logement_complement_adresse_escalier\": \"110\",\n    \"adresse_logement_complement_adresse_numero_appartement\": \"152\",\n    \"adresse_logement_complement_adresse_autre\": \"10\",\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"signalement_concerne_logement_social_autre_tiers\": \"oui\",\n    \"profil\": \"locataire\",\n    \"vos_coordonnees_occupant_tel_countrycode\": \"FR:33\",\n    \"vos_coordonnees_occupant_tel_secondaire_countrycode\": \"FR:33\",\n    \"vos_coordonnees_occupant_civilite\": \"mr\",\n    \"vos_coordonnees_occupant_nom\": \"Doe\",\n    \"vos_coordonnees_occupant_prenom\": \"John\",\n    \"vos_coordonnees_occupant_email\": \"john.doe@gmail.com\",\n    \"vos_coordonnees_occupant_tel\": \"0611457845\",\n    \"coordonnees_bailleur_tel_countrycode\": \"FR:33\",\n    \"coordonnees_bailleur_tel_secondaire_countrycode\": \"FR:33\",\n    \"coordonnees_bailleur_nom\": \"Minet\",\n    \"coordonnees_bailleur_prenom\": \"Bernard\",\n    \"coordonnees_bailleur_email\": \"bernard.minet@gmail.com\",\n    \"coordonnees_bailleur_tel\": \"0611571631\",\n    \"coordonnees_bailleur_adresse_suggestion\": \"118 rue de la république\",\n    \"coordonnees_bailleur_adresse\": \"118 Rue de la République 93700 Drancy\",\n    \"coordonnees_bailleur_adresse_detail_numero\": \"118 Rue de la République\",\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"93700\",\n    \"coordonnees_bailleur_adresse_detail_commune\": \"Drancy\",\n    \"coordonnees_bailleur_adresse_detail_insee\": \"93029\",\n    \"coordonnees_bailleur_adresse_detail_geoloc_lng\": 2.436248,\n    \"coordonnees_bailleur_adresse_detail_geoloc_lat\": 48.92517\n}",
+									"raw": "{\n    \"uuidSignalementDraft\": \"\",\n    \"signalementReference\": \"\",\n    \"lienSuivi\": \"\",\n    \"currentStep\": \"coordonnees_bailleur\",\n    \"adresse_logement_adresse_suggestion\": \"25 quai de la joliette\",\n    \"adresse_logement_adresse\": \"25 Boulevard saade - quai joliette 13002 Marseille\",\n    \"adresse_logement_adresse_detail_numero\": \"25 Boulevard saade - quai joliette\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"adresse_logement_adresse_detail_insee\": \"13202\",\n    \"adresse_logement_adresse_detail_geoloc_lng\": 5.364626,\n    \"adresse_logement_adresse_detail_geoloc_lat\": 43.301787,\n    \"adresse_logement_complement_adresse_etage\": \"5\",\n    \"adresse_logement_complement_adresse_escalier\": \"110\",\n    \"adresse_logement_complement_adresse_numero_appartement\": \"152\",\n    \"adresse_logement_complement_adresse_autre\": \"10\",\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"signalement_concerne_logement_social_autre_tiers\": \"oui\",\n    \"profil\": \"locataire\",\n    \"vos_coordonnees_occupant_tel_countrycode\": \"FR:33\",\n    \"vos_coordonnees_occupant_tel_secondaire_countrycode\": \"FR:33\",\n    \"vos_coordonnees_occupant_civilite\": \"mr\",\n    \"vos_coordonnees_occupant_nom\": \"Doe\",\n    \"vos_coordonnees_occupant_prenom\": \"John\",\n    \"vos_coordonnees_occupant_email\": \"john.doe@gmail.com\",\n    \"vos_coordonnees_occupant_tel\": \"0611457845\",\n    \"coordonnees_bailleur_tel_countrycode\": \"FR:33\",\n    \"coordonnees_bailleur_tel_secondaire_countrycode\": \"FR:33\",\n    \"coordonnees_bailleur_nom\": \"Minet\",\n    \"coordonnees_bailleur_prenom\": \"Bernard\",\n    \"coordonnees_bailleur_email\": \"bernard.minet@gmail.com\",\n    \"coordonnees_bailleur_tel\": \"0611571631\",\n    \"coordonnees_bailleur_adresse_suggestion\": \"118 rue de la république\",\n    \"coordonnees_bailleur_adresse\": \"118 Rue de la République 93700 Drancy\",\n    \"coordonnees_bailleur_adresse_detail_numero\": \"118 Rue de la République\",\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"93700\",\n    \"coordonnees_bailleur_adresse_detail_commune\": \"Drancy\",\n    \"coordonnees_bailleur_adresse_detail_insee\": \"93029\",\n    \"coordonnees_bailleur_adresse_detail_geoloc_lng\": 2.436248,\n    \"coordonnees_bailleur_adresse_detail_geoloc_lat\": 48.92517\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -494,7 +495,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"uuidSignalementDraft\": \"{{signalement_draft_uuid_locataire}}\",\n    \"signalementReference\": \"\",\n    \"lienSuivi\": \"\",\n    \"profil\": \"locataire\",\n    \"currentStep\": \"validation_signalement\",\n    \"adresse_logement_adresse\": \"17 Boulevard saade - quai joliette 13002 Marseille\",\n    \"coordonnees_bailleur_nom\": \"Minet\",\n    \"coordonnees_bailleur_tel\": \"0611571631\",\n    \"coordonnees_bailleur_email\": \"bernard.minet@gmail.com\",\n    \"coordonnees_bailleur_prenom\": \"Bernard\",\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"coordonnees_bailleur_adresse\": \"118 Rue de la République 93700 Drancy\",\n    \"vos_coordonnees_occupant_nom\": \"Doe\",\n    \"vos_coordonnees_occupant_tel\": \"0611457845\",\n    \"vos_coordonnees_occupant_email\": \"john.doe@gmail.com\",\n    \"vos_coordonnees_occupant_prenom\": \"John\",\n    \"vos_coordonnees_occupant_civilite\": \"mr\",\n    \"adresse_logement_adresse_suggestion\": \"17 quai de la joliette\",\n    \"coordonnees_bailleur_tel_countrycode\": \"FR:33\",\n    \"adresse_logement_adresse_detail_insee\": \"13202\",\n    \"adresse_logement_adresse_detail_numero\": \"17 Boulevard saade - quai joliette\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"coordonnees_bailleur_adresse_suggestion\": \"118 rue de la république\",\n    \"vos_coordonnees_occupant_tel_countrycode\": \"FR:33\",\n    \"adresse_logement_complement_adresse_autre\": \"10\",\n    \"adresse_logement_complement_adresse_etage\": \"5\",\n    \"coordonnees_bailleur_adresse_detail_insee\": \"93029\",\n    \"adresse_logement_adresse_detail_geoloc_lat\": 43.301787,\n    \"adresse_logement_adresse_detail_geoloc_lng\": 5.364626,\n    \"coordonnees_bailleur_adresse_detail_numero\": \"118 Rue de la République\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"coordonnees_bailleur_adresse_detail_commune\": \"Drancy\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"adresse_logement_complement_adresse_escalier\": \"110\",\n    \"coordonnees_bailleur_adresse_detail_geoloc_lat\": 48.92517,\n    \"coordonnees_bailleur_adresse_detail_geoloc_lng\": 2.436248,\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"93700\",\n    \"coordonnees_bailleur_tel_secondaire_countrycode\": \"FR:33\",\n    \"signalement_concerne_logement_social_autre_tiers\": \"oui\",\n    \"vos_coordonnees_occupant_tel_secondaire_countrycode\": \"FR:33\",\n    \"adresse_logement_complement_adresse_numero_appartement\": \"152\",\n    \"zone_concernee_zone\": \"logement\",\n    \"type_logement_nature\": \"appartement\",\n    \"type_logement_rdc\": \"non\",\n    \"type_logement_dernier_etage\": \"non\",\n    \"type_logement_sous_sol_sans_fenetre\": \"non\",\n    \"composition_logement_nb_pieces\": \"2\",\n    \"composition_logement_superficie\": \"31\",\n    \"composition_logement_piece_unique\": \"plusieurs_pieces\",\n    \"composition_logement_hauteur\": \"oui\",\n    \"type_logement_commodites_piece_a_vivre_9m\": \"oui\",\n    \"type_logement_commodites_cuisine\": \"oui\",\n    \"type_logement_commodites_salle_de_bain\": \"oui\",\n    \"type_logement_commodites_wc\": \"oui\",\n    \"type_logement_commodites_wc_cuisine\": \"non\",\n    \"composition_logement_nombre_personnes\": \"5\",\n    \"composition_logement_enfants\": \"oui\",\n    \"bail_dpe_date_emmenagement\": \"2020-10-10\",\n    \"bail_dpe_bail\": \"oui\",\n    \"bail_dpe_etat_des_lieux\": \"oui\",\n    \"bail_dpe_dpe\": \"oui\",\n    \"logement_social_montant_allocation\": null,\n    \"logement_social_demande_relogement\": \"oui\",\n    \"logement_social_allocation\": \"non\",\n    \"travailleur_social_quitte_logement\": \"oui\",\n    \"travailleur_social_accompagnement\": \"non\",\n    \"categorieDisorders\": {\n        \"batiment\": [],\n        \"logement\": [\n            \"desordres_logement_chauffage\"\n        ]\n    },\n    \"desordres_logement_chauffage_details_dpe_conso_finale\": null,\n    \"desordres_logement_chauffage_details_dpe_conso\": \"152\",\n    \"desordres_logement_chauffage_type\": \"electrique\",\n    \"desordres_logement_chauffage_details_fenetres_permeables\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces_piece_a_vivre\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces_cuisine\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces_salle_de_bain\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces_piece_a_vivre\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces_cuisine\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces_salle_de_bain\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces_piece_a_vivre\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces_cuisine\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces_salle_de_bain\": 1,\n    \"desordres_logement_chauffage_details_dpe_annee\": \"before2023\",\n    \"desordres_logement_chauffage_details_dpe_conso_vide\": null,\n    \"info_procedure_bailleur_prevenu\": \"non\",\n    \"info_procedure_assurance_contactee\": \"non\",\n    \"info_procedure_depart_apres_travaux\": \"non\",\n    \"utilisation_service_ok_prevenir_bailleur\": 1,\n    \"utilisation_service_ok_visite\": 1,\n    \"utilisation_service_ok_demande_logement\": 1,\n    \"utilisation_service_ok_cgu\": 1,\n    \"informations_complementaires_logement_montant_loyer\": \"800\",\n    \"informations_complementaires_logement_nombre_etages\": \"4\",\n    \"informations_complementaires_situation_occupants_beneficiaire_rsa\": \"non\",\n    \"informations_complementaires_situation_occupants_beneficiaire_fsl\": \"non\",\n    \"informations_complementaires_situation_occupants_date_naissance\": \"1985-10-10\",\n    \"informations_complementaires_logement_annee_construction\": \"1990\"\n}",
+									"raw": "{\n    \"uuidSignalementDraft\": \"{{signalement_draft_uuid_locataire}}\",\n    \"signalementReference\": \"\",\n    \"lienSuivi\": \"\",\n    \"profil\": \"locataire\",\n    \"currentStep\": \"validation_signalement\",\n    \"adresse_logement_adresse\": \"17 Boulevard saade - quai joliette 13002 Marseille\",\n    \"coordonnees_bailleur_nom\": \"Minet\",\n    \"coordonnees_bailleur_tel\": \"0611571631\",\n    \"coordonnees_bailleur_email\": \"bernard.minet@gmail.com\",\n    \"coordonnees_bailleur_prenom\": \"Bernard\",\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"coordonnees_bailleur_adresse\": \"118 Rue de la République 93700 Drancy\",\n    \"vos_coordonnees_occupant_nom\": \"Doe\",\n    \"vos_coordonnees_occupant_tel\": \"0611457845\",\n    \"vos_coordonnees_occupant_email\": \"john.doe@gmail.com\",\n    \"vos_coordonnees_occupant_prenom\": \"John\",\n    \"vos_coordonnees_occupant_civilite\": \"mr\",\n    \"adresse_logement_adresse_suggestion\": \"17 quai de la joliette\",\n    \"coordonnees_bailleur_tel_countrycode\": \"FR:33\",\n    \"adresse_logement_adresse_detail_insee\": \"13202\",\n    \"adresse_logement_adresse_detail_numero\": \"17 Boulevard saade - quai joliette\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille\",\n    \"coordonnees_bailleur_adresse_suggestion\": \"118 rue de la république\",\n    \"vos_coordonnees_occupant_tel_countrycode\": \"FR:33\",\n    \"adresse_logement_complement_adresse_autre\": \"10\",\n    \"adresse_logement_complement_adresse_etage\": \"5\",\n    \"coordonnees_bailleur_adresse_detail_insee\": \"93029\",\n    \"adresse_logement_adresse_detail_geoloc_lat\": 43.301787,\n    \"adresse_logement_adresse_detail_geoloc_lng\": 5.364626,\n    \"coordonnees_bailleur_adresse_detail_numero\": \"118 Rue de la République\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"coordonnees_bailleur_adresse_detail_commune\": \"Drancy\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"adresse_logement_complement_adresse_escalier\": \"110\",\n    \"coordonnees_bailleur_adresse_detail_geoloc_lat\": 48.92517,\n    \"coordonnees_bailleur_adresse_detail_geoloc_lng\": 2.436248,\n    \"coordonnees_bailleur_adresse_detail_code_postal\": \"93700\",\n    \"coordonnees_bailleur_tel_secondaire_countrycode\": \"FR:33\",\n    \"signalement_concerne_logement_social_autre_tiers\": \"oui\",\n    \"vos_coordonnees_occupant_tel_secondaire_countrycode\": \"FR:33\",\n    \"adresse_logement_complement_adresse_numero_appartement\": \"152\",\n    \"zone_concernee_zone\": \"logement\",\n    \"type_logement_nature\": \"appartement\",\n    \"type_logement_rdc\": \"non\",\n    \"type_logement_dernier_etage\": \"non\",\n    \"type_logement_sous_sol_sans_fenetre\": \"non\",\n    \"composition_logement_nb_pieces\": \"2\",\n    \"composition_logement_superficie\": \"31\",\n    \"composition_logement_piece_unique\": \"plusieurs_pieces\",\n    \"composition_logement_hauteur\": \"oui\",\n    \"type_logement_commodites_piece_a_vivre_9m\": \"oui\",\n    \"type_logement_commodites_cuisine\": \"oui\",\n    \"type_logement_commodites_salle_de_bain\": \"oui\",\n    \"type_logement_commodites_wc\": \"oui\",\n    \"type_logement_commodites_wc_cuisine\": \"non\",\n    \"composition_logement_nombre_personnes\": \"5\",\n    \"composition_logement_enfants\": \"oui\",\n    \"bail_dpe_date_emmenagement\": \"2020-10-10\",\n    \"bail_dpe_bail\": \"oui\",\n    \"bail_dpe_etat_des_lieux\": \"oui\",\n    \"bail_dpe_dpe\": \"oui\",\n    \"logement_social_montant_allocation\": null,\n    \"logement_social_demande_relogement\": \"oui\",\n    \"logement_social_allocation\": \"non\",\n    \"travailleur_social_quitte_logement\": \"oui\",\n    \"travailleur_social_accompagnement\": \"non\",\n    \"categorieDisorders\": {\n        \"batiment\": [],\n        \"logement\": [\n            \"desordres_logement_chauffage\"\n        ]\n    },\n    \"desordres_logement_chauffage_details_dpe_conso_finale\": null,\n    \"desordres_logement_chauffage_details_dpe_conso\": \"152\",\n    \"desordres_logement_chauffage_type\": \"electrique\",\n    \"desordres_logement_chauffage_details_fenetres_permeables\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces_piece_a_vivre\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces_cuisine\": 1,\n    \"desordres_logement_chauffage_details_fenetres_permeables_pieces_salle_de_bain\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces_piece_a_vivre\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces_cuisine\": 1,\n    \"desordres_logement_chauffage_details_difficultes_chauffage_pieces_salle_de_bain\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces_piece_a_vivre\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces_cuisine\": 1,\n    \"desordres_logement_chauffage_details_chauffage_KO_pieces_salle_de_bain\": 1,\n    \"desordres_logement_chauffage_details_dpe_annee\": \"before2023\",\n    \"desordres_logement_chauffage_details_dpe_conso_vide\": null,\n    \"info_procedure_bailleur_prevenu\": \"non\",\n    \"info_procedure_assurance_contactee\": \"non\",\n    \"info_procedure_depart_apres_travaux\": \"non\",\n    \"utilisation_service_ok_prevenir_bailleur\": 1,\n    \"utilisation_service_ok_visite\": 1,\n    \"utilisation_service_ok_demande_logement\": 1,\n    \"utilisation_service_ok_cgu\": 1,\n    \"informations_complementaires_logement_montant_loyer\": \"800\",\n    \"informations_complementaires_logement_nombre_etages\": \"4\",\n    \"informations_complementaires_situation_occupants_beneficiaire_rsa\": \"non\",\n    \"informations_complementaires_situation_occupants_beneficiaire_fsl\": \"non\",\n    \"informations_complementaires_situation_occupants_date_naissance\": \"1985-10-10\",\n    \"informations_complementaires_logement_annee_construction\": \"1990\",\n    \"travailleur_social_preavis_depart\": \"non\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -689,6 +690,35 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "signalement-draft/check",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"uuidSignalementDraft\": \"\",\n    \"signalementReference\": \"\",\n    \"lienSuivi\": \"\",\n    \"currentStep\": \"vos_coordonnees_occupant\",\n    \"adresse_logement_adresse_suggestion\": \"17 Boulevard saade - quai joliette 13002 Marseille 2e Arrondissement\",\n    \"adresse_logement_adresse_detail_need_refresh_insee\": true,\n    \"adresse_logement_adresse\": \"17 Boulevard saade - quai joliette 13002 Marseille 2e Arrondissement\",\n    \"adresse_logement_adresse_detail_numero\": \"17 Boulevard saade - quai joliette\",\n    \"adresse_logement_adresse_detail_code_postal\": \"13002\",\n    \"adresse_logement_adresse_detail_commune\": \"Marseille 2e Arrondissement\",\n    \"adresse_logement_adresse_detail_insee\": \"13202\",\n    \"adresse_logement_adresse_detail_geoloc_lng\": 5.367338,\n    \"adresse_logement_adresse_detail_geoloc_lat\": 43.315273,\n    \"adresse_logement_adresse_detail_manual\": 0,\n    \"adresse_logement_complement_adresse_etage\": \"5\",\n    \"adresse_logement_complement_adresse_numero_appartement\": \"115\",\n    \"signalement_concerne_profil\": \"logement_occupez\",\n    \"signalement_concerne_profil_detail_occupant\": \"locataire\",\n    \"signalement_concerne_logement_social_autre_tiers\": \"oui\",\n    \"profil\": \"locataire\",\n    \"vos_coordonnees_occupant_tel_countrycode\": \"FR:33\",\n    \"vos_coordonnees_occupant_tel_secondaire_countrycode\": \"FR:33\",\n    \"vos_coordonnees_occupant_civilite\": \"mme\",\n    \"vos_coordonnees_occupant_nom\": \"John\",\n    \"vos_coordonnees_occupant_prenom\": \"Doe\",\n    \"vos_coordonnees_occupant_email\": \"john.doe@gmail.com\",\n    \"vos_coordonnees_occupant_tel\": \"0611571631\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/signalement-draft/check",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"signalement-draft",
+								"check"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -723,423 +753,6 @@
 								"{{zapier_user_id}}",
 								"{{zapier_zap_id}}",
 								""
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "ancien-formulaire",
-			"item": [
-				{
-					"name": "signalement/csrf-token",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"var data = JSON.parse(responseBody);",
-									"",
-									"if (null !== data.data) {",
-									"    postman.setEnvironmentVariable(\"csrf_token\", data.csrf_token.value);",
-									"}",
-									"",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "http://localhost:8080/signalement/csrf-token",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "8080",
-							"path": [
-								"signalement",
-								"csrf-token"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "signalement/envoi",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "signalement[isNotOccupant]",
-									"value": "0",
-									"type": "text"
-								},
-								{
-									"key": "signalement[nomDeclarant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[prenomDeclarant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[telDeclarant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[mailDeclarant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[structureDeclarant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[nomOccupant]",
-									"value": "Doe",
-									"type": "text"
-								},
-								{
-									"key": "signalement[prenomOccupant]",
-									"value": "John",
-									"type": "text"
-								},
-								{
-									"key": "signalement[telOccupant]",
-									"value": "0611000000",
-									"type": "text"
-								},
-								{
-									"key": "signalement[telOccupantBis]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[mailOccupant]",
-									"value": "john.doe@gmail.com",
-									"type": "text"
-								},
-								{
-									"key": "signalement[adresseOccupant]",
-									"value": "25 Rue desiree clary",
-									"type": "text"
-								},
-								{
-									"key": "signalement[cpOccupant]",
-									"value": "13002",
-									"type": "text"
-								},
-								{
-									"key": "signalement[villeOccupant]",
-									"value": "Marseille",
-									"type": "text"
-								},
-								{
-									"key": "signalement[geoloc][lat]",
-									"value": "43.302034",
-									"type": "text"
-								},
-								{
-									"key": "signalement[geoloc][lng]",
-									"value": "5.364699",
-									"type": "text"
-								},
-								{
-									"key": "signalement[inseeOccupant]",
-									"value": "13202",
-									"type": "text"
-								},
-								{
-									"key": "signalement[etageOccupant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[escalierOccupant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[numAppartOccupant]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[adresseAutreOccupant]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[nomProprio]",
-									"value": "13 Habitat",
-									"type": "text"
-								},
-								{
-									"key": "signalement[adresseProprio]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[telProprio]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[mailProprio]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][8][critere][7][criticite]",
-									"value": "6",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][8][critere][10][criticite]",
-									"value": "12",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][8][critere][13][criticite]",
-									"value": "21",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][8][critere][14][criticite]",
-									"value": "134",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][8][critere][15][criticite]",
-									"value": "24",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][8][critere][56][criticite]",
-									"value": "48",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][8][critere][73][criticite]",
-									"value": "54",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][9][critere][54][criticite]",
-									"value": "42",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][9][critere][58][criticite]",
-									"value": "69",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][9][critere][61][criticite]",
-									"value": "135",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][9][critere][67][criticite]",
-									"value": "122",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][10][critere][64][criticite]",
-									"value": "3",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][10][critere][66][criticite]",
-									"value": "60",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][10][critere][72][criticite]",
-									"value": "63",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][10][critere][76][criticite]",
-									"value": "131",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][11][critere][9][criticite]",
-									"value": "109",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][11][critere][11][criticite]",
-									"value": "15",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][11][critere][77][criticite]",
-									"value": "138",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][11][critere][78][criticite]",
-									"value": "141",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][12][critere][47][criticite]",
-									"value": "86",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][12][critere][51][criticite]",
-									"value": "98",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][13][critere][18][criticite]",
-									"value": "33",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][13][critere][68][criticite]",
-									"value": "101",
-									"type": "text"
-								},
-								{
-									"key": "signalement[situation][13][critere][69][criticite]",
-									"value": "104",
-									"type": "text"
-								},
-								{
-									"key": "signalement[details]",
-									"value": "Logement indigne, insalubre, et présentant des risques pour la sécurité des personnes. En dépit de plusieurs démarches auprès du propriétaire, nulle réaction. Un huissier a été mandaté par mes soins et j'attends son constat. Multiplication depuis les alertes d'intimidations de toutes sortes.",
-									"type": "text"
-								},
-								{
-									"key": "signalement[consoSizeYear]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[consoSize]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[consoYear]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[isProprioAverti]",
-									"value": "1",
-									"type": "text"
-								},
-								{
-									"key": "signalement[nbAdultes]",
-									"value": "2",
-									"type": "text"
-								},
-								{
-									"key": "signalement[nbEnfantsM6]",
-									"value": "0",
-									"type": "text"
-								},
-								{
-									"key": "signalement[nbEnfantsP6]",
-									"value": "1",
-									"type": "text"
-								},
-								{
-									"key": "signalement[natureLogement]",
-									"value": "maison",
-									"type": "text"
-								},
-								{
-									"key": "signalement[superficie]",
-									"value": "100",
-									"type": "text"
-								},
-								{
-									"key": "signalement[isAllocataire]",
-									"value": "0",
-									"type": "text"
-								},
-								{
-									"key": "signalement[numAllocataire]",
-									"value": " ",
-									"type": "text"
-								},
-								{
-									"key": "signalement[dateNaissanceOccupant][day]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[dateNaissanceOccupant][month]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[dateNaissanceOccupant][year]",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "signalement[isLogementSocial]",
-									"value": "0",
-									"type": "text"
-								},
-								{
-									"key": "signalement[isPreavisDepart]",
-									"value": "0",
-									"type": "text"
-								},
-								{
-									"key": "signalement[isRelogement]",
-									"value": "0",
-									"type": "text"
-								},
-								{
-									"key": "signalement[isCguAccepted]",
-									"value": "on",
-									"type": "text"
-								},
-								{
-									"key": "is-visite-accepted",
-									"value": "on",
-									"type": "text"
-								},
-								{
-									"key": "_token",
-									"value": "{{csrf_token}}",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "http://localhost:8080/signalement/envoi",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "8080",
-							"path": [
-								"signalement",
-								"envoi"
 							]
 						}
 					},


### PR DESCRIPTION
## Ticket

#2738    

## Description
Ajout de contrôles supplémentaires sur le formulaire de dépôt de signalement. 
Travail effectué à partir : 
- Des fichiers json
- Ticket  https://github.com/MTES-MCT/histologe/issues/2782


## Changements apportés
* Ajout de contrôle choix multiple
* Ajout de contrôle de longueur max
* Ajout de contrôle de type
* Amélioration de la couverture de code sur le dépôt ét l’édition de signalement (78.54%)


## Pré-requis

## Tests
- [ ] Faire des tests de dépôt avec les différents rôles 
