### PR TITLE
[BO - Partenaires] Ajout de toutes les compétences impossible

### DIFF
--- a/migrations/Version20240712154158.php
+++ b/migrations/Version20240712154158.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240712154158 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change competence column type in partner table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE partner CHANGE competence competence LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:simple_array)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE partner CHANGE competence competence TINYTEXT DEFAULT NULL COMMENT \'(DC2Type:simple_array)\'');
+    }
+}

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -65,7 +65,7 @@ class Partner
     #[ORM\Column(type: 'string', nullable: true, enumType: PartnerType::class)]
     private ?PartnerType $type = null;
 
-    #[ORM\Column(type: Types::SIMPLE_ARRAY, length: 255, nullable: true, enumType: Qualification::class)]
+    #[ORM\Column(type: Types::SIMPLE_ARRAY, nullable: true, enumType: Qualification::class)]
     private array $competence = [];
 
     #[ORM\Column(nullable: true)]


### PR DESCRIPTION
## Ticket

#2806

## Description
Changement du type de la colonne `competence` de `Partner` afin de pouvoir enregistrer toutes les compétences sans avoir un crash base de données

## Pré-requis
`make load-migrations`

## Tests
- [ ] Modifier un partenaire en sélectionnant toutes les compétences de la liste et vérifier que l'enregistrement en bas fonctionne
