### PR TITLE
[BO - CGU] Ajout d'une modale de notification de mise à jour des CGU

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -38,6 +38,7 @@ import './controllers/back_partner_view/form_partner';
 import './controllers/form_visite';
 import './controllers/cookie_banner';
 import './controllers/maintenance_banner';
+import './controllers/modale_cgu_bo';
 import './controllers/activate_account/activate_account';
 import './controllers/back_signalement_view/back_view_signalement';
 import './controllers/back_signalement_view/form_edit_modal';

--- a/assets/controllers/cookie_banner.js
+++ b/assets/controllers/cookie_banner.js
@@ -7,7 +7,6 @@ const acceptRadioButtonList = document.querySelectorAll('.accept input[type="rad
 const refuseRadioButtonList = document.querySelectorAll('.refuse input[type="radio"]');
 const consentButtons = document.querySelector('.fr-consent-banner__buttons');
 const consentConfirmationChoice = document.querySelector('.fr-consent-manager__buttons .fr-btn');
-const cookieManagementButton = document.querySelector('button.fr-footer__bottom-link ');
 const modalConsent = document.getElementById('fr-consent-modal');
 
 function initChoiceUserBasedOnConsent() {

--- a/assets/controllers/modale_cgu_bo.js
+++ b/assets/controllers/modale_cgu_bo.js
@@ -1,0 +1,45 @@
+const modalCguBo = document.getElementById('fr-modal-cgu-bo')
+const acceptCguBoCheckbox = document.getElementById('checkboxes-modal-cgu-bo-accept')
+const acceptCguBoButton = document.getElementById('fr-modal-cgu-bo-btn')
+
+function handleModalDisclose() {
+   setTimeout(() => {
+      const divContent = modalCguBo.querySelector('.fr-modal__body')
+      divContent.scrollTo({ top: 0 })
+   }, 200)
+}
+
+function handleAcceptCheck() {
+   acceptCguBoButton.disabled = !acceptCguBoCheckbox.checked
+}
+
+function handleAcceptButton() {
+   const url = document.getElementById('form-cgu-bo-url').value
+   const data = { 
+       _token: document.getElementById('form-cgu-bo-token').value,
+   };
+   const options = {
+       method: 'POST',
+       headers: {
+         "Content-Type": "application/json",
+       },
+       body: JSON.stringify(data),
+   };
+
+   fetch(url, options)
+      .then((response) => {
+         if (response.ok) {
+            dsfr(modalCguBo).modal.conceal()
+         } else {
+            alert('Erreur lors de l\'enregistrement de votre validation')
+         }
+      })
+      .catch((error) => {
+         console.error("Error:", error)
+         alert('Erreur lors de l\'enregistrement de votre validation')
+      })
+}
+
+acceptCguBoCheckbox?.addEventListener('click', handleAcceptCheck)
+acceptCguBoButton?.addEventListener('click', handleAcceptButton)
+modalCguBo?.addEventListener('dsfr.disclose', handleModalDisclose);

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -8,6 +8,7 @@ twig:
             logosvg: 'logo-histologe.svg'
             url: '%host_url%'
             demo: 'https://app.livestorm.co/mte/demonstration-histologe'
+            cgu_current_version: '%cgu_current_version%'
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -46,6 +46,7 @@ parameters:
     idoss_password: '%env(resolve:IDOSS_PASSWORD)%'
     feature_archive_inactive_account: '%env(bool:FEATURE_ARCHIVE_INACTIVE_ACCOUNT)%'
     feature_anonymize_expired_account: '%env(bool:FEATURE_ANONYMIZE_EXPIRED_ACCOUNT)%'
+    cgu_current_version: 3
 
 services:
     # default configuration for services in *this* file

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -46,7 +46,7 @@ parameters:
     idoss_password: '%env(resolve:IDOSS_PASSWORD)%'
     feature_archive_inactive_account: '%env(bool:FEATURE_ARCHIVE_INACTIVE_ACCOUNT)%'
     feature_anonymize_expired_account: '%env(bool:FEATURE_ANONYMIZE_EXPIRED_ACCOUNT)%'
-    cgu_current_version: 3
+    cgu_current_version: '05/06/2024'
 
 services:
     # default configuration for services in *this* file

--- a/migrations/Version20240717081056.php
+++ b/migrations/Version20240717081056.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\User;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240717081056 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add cgu_version_checked to user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD cgu_version_checked VARCHAR(255) DEFAULT NULL');
+
+        $this->addSql("
+            UPDATE user
+            SET cgu_version_checked = '3'
+            WHERE last_login_at IS NOT NULL
+              AND statut = " . User::STATUS_ACTIVE . "
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP cgu_version_checked');
+    }
+}

--- a/migrations/Version20240717081056.php
+++ b/migrations/Version20240717081056.php
@@ -21,10 +21,10 @@ final class Version20240717081056 extends AbstractMigration
 
         $this->addSql("
             UPDATE user
-            SET cgu_version_checked = '3'
+            SET cgu_version_checked = '05/06/2024'
             WHERE last_login_at IS NOT NULL
-              AND statut = " . User::STATUS_ACTIVE . "
-        ");
+              AND statut = ".User::STATUS_ACTIVE.'
+        ');
     }
 
     public function down(Schema $schema): void

--- a/src/Controller/Back/CguController.php
+++ b/src/Controller/Back/CguController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/bo/cgu')]
+class CguController extends AbstractController
+{
+    #[Route('/valider', name: 'cgu_bo_confirm', methods: 'POST')]
+    public function index(
+        Request $request,
+        EntityManagerInterface $entityManager,
+        ParameterBagInterface $parameterBag,
+    ): Response {
+        $decodedRequest = json_decode($request->getContent());
+        if ($this->isCsrfTokenValid('cgu_bo_confirm', $decodedRequest->_token)) {
+            $currentCguVersion = $parameterBag->get('cgu_current_version');
+            /** @var User $user */
+            $user = $this->getUser();
+            $user->setCguVersionChecked($currentCguVersion);
+            $entityManager->persist($user);
+            $entityManager->flush();
+
+            return $this->json(['response' => 'success']);
+        }
+
+        return $this->json(['response' => 'error'], 400);
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -145,6 +145,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $authCode;
 
+    #[ORM\Column(type: 'string', nullable: true)]
+    private ?string $cguVersionChecked;
+
     public function __construct()
     {
         $this->suivis = new ArrayCollection();
@@ -597,5 +600,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
     public function setEmailAuthCode(string $authCode): void
     {
         $this->authCode = $authCode;
+    }
+
+    public function getCguVersionChecked(): string
+    {
+        return $this->cguVersionChecked;
+    }
+
+    public function setCguVersionChecked(string $cguVersionChecked): void
+    {
+        $this->cguVersionChecked = $cguVersionChecked;
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -602,13 +602,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         $this->authCode = $authCode;
     }
 
-    public function getCguVersionChecked(): string
+    public function getCguVersionChecked(): ?string
     {
         return $this->cguVersionChecked;
     }
 
-    public function setCguVersionChecked(string $cguVersionChecked): void
+    public function setCguVersionChecked(string $cguVersionChecked): self
     {
         $this->cguVersionChecked = $cguVersionChecked;
+
+        return $this;
     }
 }

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -90,10 +90,12 @@ class UserManager extends AbstractManager
     public function resetPassword(User $user, string $password): User
     {
         $password = $this->passwordHasherFactory->getPasswordHasher($user)->hash($password);
+        $currentCguVersion = $this->parameterBag->get('cgu_current_version');
         $user
             ->setPassword($password)
             ->setToken(null)
             ->setStatut(User::STATUS_ACTIVE)
+            ->setCguVersionChecked($currentCguVersion)
             ->setTokenExpiredAt(null);
 
         $this->save($user);

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -89,14 +89,19 @@ class UserManager extends AbstractManager
 
     public function resetPassword(User $user, string $password): User
     {
-        $password = $this->passwordHasherFactory->getPasswordHasher($user)->hash($password);
+        // if the user is not active yet, he is activating his account, so he just saw the cgu
         $currentCguVersion = $this->parameterBag->get('cgu_current_version');
+        if (User::STATUS_ACTIVE !== $user->getStatut()) {
+            $user->setCguVersionChecked($currentCguVersion);
+        }
+
+        $password = $this->passwordHasherFactory->getPasswordHasher($user)->hash($password);
         $user
             ->setPassword($password)
             ->setToken(null)
             ->setStatut(User::STATUS_ACTIVE)
-            ->setCguVersionChecked($currentCguVersion)
             ->setTokenExpiredAt(null);
+        
 
         $this->save($user);
 

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -101,7 +101,6 @@ class UserManager extends AbstractManager
             ->setToken(null)
             ->setStatut(User::STATUS_ACTIVE)
             ->setTokenExpiredAt(null);
-        
 
         $this->save($user);
 

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -24,6 +24,9 @@
     </main>
 {% endblock %}
 
+{% block javascripts %}
+{% endblock %}
+
 {% block chatbot %}
     {% if chatbot.enable %}
         <div class="faq-redirection">
@@ -35,5 +38,58 @@
         </div>
     {% endif %}
 {% endblock %}
-{% block javascripts %}
+
+{% block cgumodale %}
+    {% if platform.cgu_current_version is not same as app.user.cguVersionChecked %}
+        <button class="fr-hidden" data-fr-opened="true" aria-controls="fr-modal-cgu-bo"></button>
+        <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-cgu-bo" class="fr-modal" role="dialog" open="true">
+            <div class="fr-container fr-container--fluid fr-container-md">
+                <div class="fr-grid-row fr-grid-row--center">
+                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                        <div class="fr-modal__body">
+                            <div class="fr-modal__header">
+                                <h1 id="fr-modal-cgu-bo-title" class="fr-modal__title">
+                                    <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
+                                    Mise à jour des conditions d'utilisation
+                                </h1>
+                            </div>
+                            <div class="fr-modal__content">
+                                <div>
+                                    <p>
+                                        Les conditions générales d'utilisation du service ont été mises à jour le {{platform.cgu_current_version}}.
+                                        Veuillez en prendre connaissance pour continuer à utiliser le service.
+                                    </p>
+                                </div>
+
+                                {% include 'back/cgu_bo.html.twig' %}
+
+                                <fieldset class="fr-fieldset" id="checkboxes-modal-cgu-bo">
+                                    <div class="fr-fieldset__element">
+                                        <div class="fr-checkbox-group">
+                                            <input name="checkboxes-modal-cgu-bo-accept" id="checkboxes-modal-cgu-bo-accept" type="checkbox" aria-describedby="checkboxes-modal-cgu-bo-accept-messages">
+                                            <label class="fr-label" for="checkboxes-modal-cgu-bo-accept">
+                                                J'ai pris connaissance des conditions d'utilisation du service.
+                                            </label>
+                                            <div class="fr-messages-group fr-hidden" id="checkboxes-modal-cgu-bo-accept-messages" aria-live="assertive">
+                                                <p class="fr-message fr-message--error" id="checkbox-error-message-error">Merci de cocher cette case pour valider</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                            <div class="fr-modal__footer">
+                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    <input type="hidden" id="form-cgu-bo-url" value="{{ path('cgu_bo_confirm') }}">
+                                    <input type="hidden" id="form-cgu-bo-token" value="{{ csrf_token('cgu_bo_confirm') }}">
+                                    <button id="fr-modal-cgu-bo-btn" class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left" disabled>
+                                        Accepter et continuer
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </dialog>
+    {% endif %}
 {% endblock %}

--- a/templates/back/cgu_bo.html.twig
+++ b/templates/back/cgu_bo.html.twig
@@ -406,7 +406,10 @@
         votre demande ne sera traitée que si vous rapportez la preuve de votre identité.
         <br>
         Pour vous aider dans votre démarche, vous trouverez ici 
-        <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces">https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces</a>, 
+        <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces"
+            target="_blank" rel="noreferrer noopener"
+            title="Modèle de courrier élaboré par la CNIL - Ouvre une nouvelle fenêtre"
+            >https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces</a>, 
         un modèle de courrier élaboré par la CNIL.
         <br>
         Vous avez la possibilité de vous opposer à un traitement de vos données personnelles. 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -215,5 +215,6 @@
 </script>
 {% block javascripts %}{% endblock %}
 {% block chatbot %}{% endblock %}
+{% block cgumodale %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Ticket

#2359   

## Description
Jusqu'ici, les mises à jour des CGU passaient inaperçu pour les agents qui les avaient déjà validées lors de l'activation de leur compte.
On met donc en place une modale pour pouvoir les valider.

## Changements apportés
* Ajout d'un paramètre qui stocke la dernière date de mise à jour des CGU
* Ajout d'un champ à l'entité User pour stocker la dernière version validée par l'utilisateur
  * Dans la migration, on en profite pour dire que les utilisateurs dont le statut est actif ET qui ont une date de login renseignée, n'ont pas besoin de re-valider les CGU
* Modale présente dans tout le bo
* Fichier js correspondant

## Pré-requis
`npm run watch`

## Tests
- `make execute-migration name=Version20240717081056 direction=up`
- [ ] Seuls les comptes actifs avec une date de dernier login ont une version mise à jour
- [ ] Si j'active un compte inactif (ou renouvelle mon mot de passe), la valeur est MAJ en BDD, je ne vois pas la modale
- [ ] Si je me connecte avec un compte avec aucune valeur, la modale des CGU s'affiche
- [ ] Si je valide la modale, elle ne s'affiche plus au prochain passage
