### PR TITLE
[BO - SA] Uniformiser le nom des territoires dans le BO

### DIFF
--- a/assets/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -111,7 +111,7 @@ export default defineComponent({
       for (const id in requestResponse.territories) {
         const optionItem = new HistoInterfaceSelectOption()
         optionItem.Id = requestResponse.territories[id].id
-        optionItem.Text = requestResponse.territories[id].name
+        optionItem.Text = requestResponse.territories[id].zip + ' - ' + requestResponse.territories[id].name
         this.sharedState.territories.push(optionItem)
       }
     },

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -177,7 +177,9 @@ class PartnerType extends AbstractType
             },
             'data' => !empty($territory) ? $territory : null,
             'disabled' => !$options['can_edit_territory'],
-            'choice_label' => 'name',
+            'choice_label' => function (Territory $territory) {
+                return $territory->getZip().' - '.$territory->getName();
+            },
             'attr' => [
                 'class' => 'fr-select',
             ],

--- a/src/Service/Statistics/ListTerritoryStatisticProvider.php
+++ b/src/Service/Statistics/ListTerritoryStatisticProvider.php
@@ -17,7 +17,7 @@ class ListTerritoryStatisticProvider
         $territories = $this->territoryRepository->findAllList();
         /** @var Territory $territory */
         foreach ($territories as $territory) {
-            $data[$territory->getId()] = $territory->getName();
+            $data[$territory->getId()] = $territory->getZip().' - '.$territory->getName();
         }
 
         return $data;

--- a/templates/_partials/_search_filter_form.html.twig
+++ b/templates/_partials/_search_filter_form.html.twig
@@ -58,7 +58,7 @@
                                             <option value="">TOUS</option>
                                             {% for territory in territories %}
                                                 <option value="{{ territory.id }}"
-                                                        class="{% if territory.id in filters.territories %}fr-hidden{% endif %}">{{ territory.name|upper }}</option>
+                                                        class="{% if territory.id in filters.territories %}fr-hidden{% endif %}">{{ territory.zip ~ ' - ' ~ territory.name }}</option>
                                             {% endfor %}
                                         </select>
                                         <div class="selected__value">
@@ -67,7 +67,7 @@
                                             {% for territory in filters.territories %}
                                                 <input type="hidden" name="bo-filters-territories[]" value="{{ territory }}">
                                                 <span class="fr-badge fr-badge--success fr-m-1v" data-value="{{ territory }}"
-                                                      data-removable="true">{{ territories[territory] is defined ? territories[territory].name|upper : 'AUCUN' }}</span>
+                                                      data-removable="true">{{ territories[territory] is defined ? territories[territory].name : 'AUCUN' }}</span>
                                             {% else %}
                                                 {% set visible = 0 %}
                                             {% endfor %}
@@ -81,7 +81,7 @@
                                         <option value="">TOUTES</option>
                                         {% for city in cities %}
                                             <option value="{{ city.city }}"
-                                                    class="{% if city.city in filters.cities %}fr-hidden{% endif %}">{{ city.city|upper }}</option>
+                                                    class="{% if city.city in filters.cities %}fr-hidden{% endif %}">{{ city.city }}</option>
                                         {% endfor %}
                                     </select>
                                     <div class="selected__value">
@@ -103,7 +103,7 @@
                                         <option value="">TOUS</option>
                                         {% for status,wording in statuses %}
                                             <option value="{{ status }}"
-                                                    class="{% if status in  filters.statuses %}fr-hidden{% endif %}">{{ wording|upper }}</option>
+                                                    class="{% if status in  filters.statuses %}fr-hidden{% endif %}">{{ wording }}</option>
                                         {% endfor %}
                                     </select>
                                     <div class="selected__value">
@@ -130,13 +130,13 @@
                                             <optgroup label="COMMUNES">
                                                 {% for partner in partners|filter(v=> v.isCommune == 1) %}
                                                     <option value="{{ partner.id }}"
-                                                            class="{% if partner.id in filters.partners %}fr-hidden{% endif %}">{{ partner.nom|upper }}</option>
+                                                            class="{% if partner.id in filters.partners %}fr-hidden{% endif %}">{{ partner.nom }}</option>
                                                 {% endfor %}
                                             </optgroup>
                                             <optgroup label="PARTENAIRES">
                                                 {% for partner in partners|filter(v=> v.isCommune == 0) %}
                                                     <option value="{{ partner.id }}"
-                                                            class="{% if partner.id in filters.partners %}fr-hidden{% endif %}">{{ partner.nom|upper }}</option>
+                                                            class="{% if partner.id in filters.partners %}fr-hidden{% endif %}">{{ partner.nom }}</option>
                                                 {% endfor %}
                                             </optgroup>
 
@@ -206,7 +206,7 @@
                                         <option value="">TOUS</option>
                                         {% for critere in criteres %}
                                             <option value="{{ critere.id }}"
-                                                    class="{% if critere.id in filters.criteres %}fr-hidden{% endif %}">{{ critere.label|upper }}</option>
+                                                    class="{% if critere.id in filters.criteres %}fr-hidden{% endif %}">{{ critere.label }}</option>
                                         {% endfor %}
                                     </select>
                                     <div class="selected__value">
@@ -228,7 +228,7 @@
                                         <option value="">TOUS</option>
                                         {% for tag in tags %}
                                             <option value="{{ tag.id }}"
-                                                    class="{% if tag.id in filters.tags %}fr-hidden{% endif %}">{{ tag.label|upper }}</option>
+                                                    class="{% if tag.id in filters.tags %}fr-hidden{% endif %}">{{ tag.label }}</option>
                                         {% endfor %}
                                     </select>
                                     <div class="selected__value">

--- a/templates/back/account/index.html.twig
+++ b/templates/back/account/index.html.twig
@@ -31,7 +31,7 @@
                     <option value="" {{ not isNoneTerritory and currentTerritory is null ? 'selected' : '' }}>Tous les territoires</option>
                     <option value="none" {{ isNoneTerritory ? 'selected' : '' }}>Aucun</option>
                     {% for territory in territories %}
-                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.name|upper }}</option>
+                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.zip ~ ' - ' ~ territory.name }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -40,7 +40,7 @@
                     <option value="" {{ not isNonePartner and currentPartner is null ? 'selected' : '' }}>Tous les partenaires</option>
                     <option value="none" {{ isNonePartner ? 'selected' : '' }}>Aucun</option>
                     {% for partner in partners %}
-                        <option value="{{ partner.id }}" {{ currentPartner ? (partner.id == currentPartner.id ? 'selected' : '') : '' }}>{{ partner.nom|upper }}</option>
+                        <option value="{{ partner.id }}" {{ currentPartner ? (partner.id == currentPartner.id ? 'selected' : '') : '' }}>{{ partner.nom }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -57,7 +57,7 @@
         <table class="fr-display-inline-table sortable" aria-label="Liste des comptes archivés ou sans territoires et/ou partenaires" aria-describedby="desc-table">
             <thead>
             <tr>
-                <th>Dpt.</th>
+                <th>Territoire</th>
                 <th>Partenaire</th>
                 <th>Statut part.</th>
                 <th>E-mail</th>
@@ -79,7 +79,7 @@
                     {% set statut = 'actif' %}
                 {% endif %}
                 <tr class="user-row">
-                    <td>{{ user.territory }}</td>
+                    <td>{{ user.territory ? user.territory.zip ~ ' - ' ~ user.territory.name : 'aucun' }}</td>
                     <td>{{ user.partner ? user.partner.nom : 'aucun' }}</td>
                     <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
                     <td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>

--- a/templates/back/expired-account/index.html.twig
+++ b/templates/back/expired-account/index.html.twig
@@ -64,7 +64,7 @@
                     <th>Role</th>
 					<th>Statut</th>
 					<th>Date de connexion</th>
-					<th>Département</th>
+					<th>Territoire</th>
 					<th>Partenaire</th>
 				</tr>
 			</thead>
@@ -77,7 +77,7 @@
                         <td>{{ user.roles[0]}}</td>
 						<td>{{ user.statutLabel}}</td>
 						<td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y H:i')}}</td>
-						<td>{{ user.territory }}</td>
+                    	<td>{{ user.territory ? user.territory.zip ~ ' - ' ~ user.territory.name : 'aucun' }}</td>
 						<td>{{ user.partner ? user.partner.nom : 'aucun' }}</td>
 					</tr>
 				{% endfor %}

--- a/templates/back/inactive-account/index.html.twig
+++ b/templates/back/inactive-account/index.html.twig
@@ -35,7 +35,7 @@
                     <th>Role</th>
 					<th>Status</th>
 					<th>Date de connexion</th>
-					<th>Département</th>
+					<th>Territoire</th>
 					<th>Partenaire</th>
 					<th>Archivage prévue le</th>
 				</tr>
@@ -49,7 +49,7 @@
                         <td>{{ user.roles[0]}}</td>
 						<td>{{ user.statutLabel }}</td>
 						<td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y H:i')}}</td>
-						<td>{{ user.territory }}</td>
+                    	<td>{{ user.territory ? user.territory.zip ~ ' - ' ~ user.territory.name : 'aucun' }}</td>
 						<td>{{ user.partner ? user.partner.nom : 'aucun' }}</td>
 						<td>{{ user.archivingScheduledAt ? user.archivingScheduledAt|date('d/m/Y') }}</td>
 					</tr>

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -31,9 +31,9 @@
         {% if is_granted('ROLE_ADMIN') %}
             <div class="fr-col-3 fr-p-2v">
                 <select id="bo-filters-territories" class="fr-select fr-select-submit" name="territory">
-                    <option value="" {{ currentTerritory is null ? 'selected' : '' }}>Territoires</option>
+                    <option value="" {{ currentTerritory is null ? 'selected' : '' }}>Tous les territoires</option>
                     {% for territory in territories %}
-                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.name|upper }}</option>
+                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.zip ~ ' - ' ~ territory.name }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -42,7 +42,7 @@
             <select id="bo-filters-types" class="fr-select fr-select-submit" name="type">
                 <option value="" {{ currentType is null ? 'selected' : '' }}>Type</option>
                 {% for key, type in types %}
-                    <option value="{{ key }}" {{ currentType ? (key == currentType ? 'selected' : '') : '' }}>{{ type|upper }}</option>
+                    <option value="{{ key }}" {{ currentType ? (key == currentType ? 'selected' : '') : '' }}>{{ type }}</option>
                 {% endfor %}
             </select>
         </div>
@@ -61,7 +61,7 @@
             <tr>
                 <th>Id</th>
                 {% if is_granted('ROLE_ADMIN') %}
-                    <th class="number">Dpt.</th>
+                    <th class="number">Territoire</th>
                 {% endif %}
                 <th>Nom</th>
                 <th>Type</th>
@@ -75,7 +75,7 @@
                 <tr class="partner-row">
                     <td>{{ partner.id }}</td>
                     {% if is_granted('ROLE_ADMIN') %}
-                        <td>{{ partner.territory ? partner.territory.zip : 0 }}</td>
+                        <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
                     {% endif %}
                     <td>{{ partner.nom }}</td>
                     <td>{{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'Partenaire') }}</td>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -31,7 +31,7 @@
                 <div><b>Nom :</b> {{ partner.nom }}</div>
             </div>
             <div class="fr-col-6">
-                <div><b>Territoire :</b> {{ partner.territory ? partner.territory.name : ''}}</div>
+                <div><b>Territoire :</b> {{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : ''}}</div>
             </div>
         </div>
         <div class="fr-col-12 fr-grid-row fr-grid-row--gutters">

--- a/templates/back/partner_archived/index.html.twig
+++ b/templates/back/partner_archived/index.html.twig
@@ -31,7 +31,7 @@
                     <option value="" {{ not isNoneTerritory and currentTerritory is null ? 'selected' : '' }}>Tous les territoires</option>
                     <option value="none" {{ isNoneTerritory ? 'selected' : '' }}>Aucun</option>
                     {% for territory in territories %}
-                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.name|upper }}</option>
+                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.zip ~ ' - ' ~ territory.name }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -48,7 +48,7 @@
         <table class="fr-display-inline-table sortable" aria-label="Liste des partenaires archivés ou sans territoires" aria-describedby="desc-table">
             <thead>
             <tr>
-                <th>Dpt.</th>
+                <th>Territoire</th>
                 <th>Statut</th>
                 <th>E-mail</th>
                 <th>Nom</th>
@@ -68,7 +68,7 @@
                     {% set statut = 'actif' %}
                 {% endif %}
                 <tr class="user-row">
-                    <td>{{ partner.territory }}</td>
+                    <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
                     <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
                     <td>{{ partner.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
                     <td>{{ partner.nom}}</ail td>

--- a/templates/back/signalement_archived/index.html.twig
+++ b/templates/back/signalement_archived/index.html.twig
@@ -29,7 +29,7 @@
                 <select id="bo-filters-territories" class="fr-select fr-select-submit" name="territory">
                     <option value="" {{ currentTerritory is null ? 'selected' : '' }}>Tous les territoires</option>
                     {% for territory in territories %}
-                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.name|upper }}</option>
+                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.zip ~ ' - ' ~ territory.name }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -63,7 +63,7 @@
                             <a href="{{ path('back_signalement_view',{uuid:signalement.uuid}) }}"
                             class="fr-ws-nowrap">{{ signalement.reference }}</a>
                         </td>
-                        <td>{{ signalement.territory.name}} ({{ signalement.territory.zip}}) </td>
+                        <td>{{ signalement.territory.zip}} - {{ signalement.territory.name}} </td>
                         <td>{{ signalement.createdAt|date('d/m/Y') }}</td>
                         <td>
                             {{ signalement.nomOccupant|upper }}<br>{{ signalement.prenomOccupant|capitalize }}


### PR DESCRIPTION
## Ticket

#2813    

## Description
Pour faciliter l'usage et la lecture je propose qu'on utilise le format numéro de département - Nom du territoire partout (pour les filtres et l'affichage des info dans les listes) ainsi que "Territoire" en titre de colonne pour tout l'existant et les futures fonctionnalités

## Changements apportés
* Changement en twig et VueJS

## Pré-requis

## Tests
- [ ] Faire le tour de toutes les pages pour vérifier l'affichage du filtre de territoire et de la colonne territoire
