### PR TITLE
[BO - Liste des signalements] Changer l'icône pour procédures constatées

### DIFF
--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -28,7 +28,7 @@
                       >{{ getBadgeLabelQualification(procedure) }} </span>
                   <span v-if="item.nde" class="fr-badge fr-badge--sm fr-badge--no-icon fr-mx-1v fr-badge--info">NON DÉCENCE ÉNERGÉTIQUE</span>
                 </p>
-                <p v-else class="fr-my-1w"><span class="fr-icon-lightbulb-line" aria-hidden="true"></span>
+                <p v-else class="fr-my-1w"><span class="fr-icon-success-line" aria-hidden="true"></span>
                   Procédure(s) constatée(s) :
                   <span
                       v-for="(procedure, index) in item.conclusionsProcedure"


### PR DESCRIPTION
## Ticket

#2815    

## Description
Dans le listing, pour améliorer l'affichage des procédures constatées suite à une visite, il faudrait modifier l'icône utilisée pour mettre fr-icon-success-line

## Changements apportés
* Changement dans VueJS

## Pré-requis
`npm run watch`
## Tests
- [ ] Parcourir la liste de signalements et vérifier les icônes pour précédure constatée et procédure suspectée
