### PR TITLE
  [FO - Page de suivi usager] Laisser la possibilité de mettre un dernier commentaire après clôture + contenu mails

### DIFF
--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -69,3 +69,9 @@ suivis:
   is_public: 1
   signalement: "2023-21"
   type: 1
+-
+  created_by: null
+  description: "Ajout d'un signalement postcloture par l'usager"
+  is_public: 1
+  signalement: "2022-2"
+  type: 5

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -61,14 +61,17 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
      */
     public function loadSuivi(ObjectManager $manager, array $row): void
     {
+        $signalement = $this->signalementRepository->findOneBy(['reference' => $row['signalement']]);
         $suivi = (new Suivi())
-            ->setSignalement($this->signalementRepository->findOneBy(['reference' => $row['signalement']]))
+            ->setSignalement($signalement)
             ->setDescription($row['description'])
             ->setIsPublic($row['is_public'])
             ->setCreatedAt(
                 isset($row['created_at'])
                     ? new \DateTimeImmutable($row['created_at'])
-                    : new \DateTimeImmutable()
+                    : (Suivi::TYPE_USAGER_POST_CLOTURE === $row['type']
+                        ? $signalement->getClosedAt()->modify('+3 days')
+                        : new \DateTimeImmutable())
             )
             ->setType($row['type']);
         if (isset($row['created_by'])) {

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -34,7 +34,6 @@ class Signalement
     public const STATUS_CLOSED = 6;
     public const STATUS_ARCHIVED = 7;
     public const STATUS_REFUSED = 8;
-    public const DISABLED_STATUSES = [self::STATUS_CLOSED, self::STATUS_ARCHIVED, self::STATUS_REFUSED];
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2427,4 +2427,16 @@ class Signalement
 
         return $this;
     }
+
+    public function hasSuiviUsagePostCloture(): bool
+    {
+        $suiviPostCloture = $this->getSuivis()->filter(function (Suivi $suivi) {
+            return Suivi::TYPE_USAGER_POST_CLOTURE === $suivi->getType();
+        });
+        if ($suiviPostCloture->isEmpty()) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -13,6 +13,7 @@ class Suivi
     public const TYPE_USAGER = 2;
     public const TYPE_PARTNER = 3;
     public const TYPE_TECHNICAL = 4;
+    public const TYPE_USAGER_POST_CLOTURE = 5;
 
     public const CONTEXT_INTERVENTION = 'intervention';
 

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -73,13 +73,11 @@ class SignalementVoter extends Voter
     {
         if (Signalement::STATUS_ARCHIVED !== $signalement->getStatut()
             && Signalement::STATUS_REFUSED !== $signalement->getStatut()
-            && !$signalement->hasSuiviUsagePostCloture()
         ) {
-            if (Signalement::STATUS_CLOSED === $signalement->getStatut()
-            || Signalement::STATUS_REFUSED === $signalement->getStatut()) {
+            if (Signalement::STATUS_CLOSED === $signalement->getStatut()) {
                 $datePostCloture = $signalement->getClosedAt()->modify('+ 30days');
                 $today = new \DateTimeImmutable();
-                if ($today < $datePostCloture) {
+                if ($today < $datePostCloture && !$signalement->hasSuiviUsagePostCloture()) {
                     return true;
                 }
             } else {

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -39,7 +39,7 @@ class SignalementVoter extends Voter
         /** @var User $user */
         $user = $token->getUser();
         if (!$user instanceof UserInterface) {
-            if (self::USAGER_EDIT === $attribute && !\in_array($subject->getStatut(), Signalement::DISABLED_STATUSES)) {
+            if (self::USAGER_EDIT === $attribute && $this->canUsagerEdit($subject)) {
                 return true;
             }
 
@@ -67,6 +67,27 @@ class SignalementVoter extends Voter
             self::VIEW => $this->canView($subject, $user),
             default => false,
         };
+    }
+
+    private function canUsagerEdit(Signalement $signalement): bool
+    {
+        if (Signalement::STATUS_ARCHIVED !== $signalement->getStatut()
+            && Signalement::STATUS_REFUSED !== $signalement->getStatut()
+            && !$signalement->hasSuiviUsagePostCloture()
+        ) {
+            if (Signalement::STATUS_CLOSED === $signalement->getStatut()
+            || Signalement::STATUS_REFUSED === $signalement->getStatut()) {
+                $datePostCloture = $signalement->getClosedAt()->modify('+ 30days');
+                $today = new \DateTimeImmutable();
+                if ($today < $datePostCloture) {
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function canValidate(Signalement $signalement, User $user): bool

--- a/src/Service/Mailer/Mail/Signalement/SignalementAskBailDpeMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementAskBailDpeMailer.php
@@ -14,7 +14,7 @@ class SignalementAskBailDpeMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_ASK_BAIL_DPE;
     protected ?string $mailerSubject = 'Votre signalement a été validé : documents à fournir';
-    protected ?string $mailerButtonText = 'Suivre mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'ask_bail_dpe_signalement_email';
 
     public function __construct(

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToUsagerMailer.php
@@ -13,8 +13,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SignalementClosedToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_USAGER;
-    protected ?string $mailerSubject = 'Votre signalement sur %param.platform_name% est terminé.';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerSubject = 'Fermeture de votre signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'closed_to_usager_signalement_email';
     protected ?string $tagHeader = 'Usager Cloture Signalement';
 

--- a/src/Service/Mailer/Mail/Signalement/SignalementConfirmReceptionMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementConfirmReceptionMailer.php
@@ -14,7 +14,7 @@ class SignalementConfirmReceptionMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_CONFIRM_RECEPTION;
     protected ?string $mailerSubject = 'Votre signalement a bien été reçu !';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'accuse_reception_email';
     protected ?string $tagHeader = 'Usager Accusé Reception Signalement';
 

--- a/src/Service/Mailer/Mail/Signalement/SignalementValidationMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementValidationMailer.php
@@ -14,7 +14,7 @@ class SignalementValidationMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_SIGNALEMENT_VALIDATION;
     protected ?string $mailerSubject = 'Votre signalement est validé !';
-    protected ?string $mailerButtonText = 'Suivre mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'validation_signalement_email';
     protected ?string $tagHeader = 'Usager Validation Signalement';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
@@ -14,7 +14,7 @@ class SuiviNewCommentFrontMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_NEW_COMMENT_FRONT;
     protected ?string $mailerSubject = 'Nouvelle mise à jour de votre signalement !';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement et répondre';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier et répondre';
     protected ?string $mailerTemplate = 'nouveau_suivi_signalement_email';
     protected ?string $tagHeader = 'Usager Nouveau Suivi Signalement';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToUsagerMailer.php
@@ -14,7 +14,7 @@ class SuiviVisiteAbortedToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_ABORTED_TO_USAGER;
     protected ?string $mailerSubject = 'Visite du logement non effectuée';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_aborted_email';
     protected ?string $tagHeader = 'Usager Visite Non Effectuee';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledMailer.php
@@ -14,7 +14,7 @@ class SuiviVisiteCanceledMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CANCELED_TO_USAGER;
     protected ?string $mailerSubject = 'Annulation de la visite de votre logement';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_canceled_email';
     protected ?string $tagHeader = 'Usager Annulation Visite Prevue';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledToUsagerMailer.php
@@ -14,7 +14,7 @@ class SuiviVisiteCanceledToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CANCELED_TO_USAGER;
     protected ?string $mailerSubject = 'Annulation de la visite de votre logement';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_canceled_email';
     protected ?string $tagHeader = 'Usager Annulation Visite Prevue';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToUsagerMailer.php
@@ -14,7 +14,7 @@ class SuiviVisiteConfirmedToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CONFIRMED_TO_USAGER;
     protected ?string $mailerSubject = 'Suite à la visite de votre logement';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_confirmed_to_user_email';
 
     public function __construct(

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToUsagerMailer.php
@@ -14,7 +14,7 @@ class SuiviVisiteCreatedToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_CREATED_TO_USAGER;
     protected ?string $mailerSubject = 'Une visite de votre logement est prévue';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_created_to_usager_email';
     protected ?string $tagHeader = 'Usager Date Visite Prevue';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteEditedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteEditedToUsagerMailer.php
@@ -14,7 +14,7 @@ class SuiviVisiteEditedToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_EDITED_TO_USAGER;
     protected ?string $mailerSubject = 'Mise à jour de la conclusion de la visite de votre logement';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_edited_email';
     protected ?string $tagHeader = 'Usager Conclusion Visite Disponible';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class SuiviVisiteFutureReminderToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_FUTURE_REMINDER_TO_USAGER;
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_future_reminder_to_usager_email';
     protected ?string $tagHeader = 'Usager Rappel Visite Prevue';
 

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteRescheduledToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteRescheduledToUsagerMailer.php
@@ -14,7 +14,7 @@ class SuiviVisiteRescheduledToUsagerMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_VISITE_RESCHEDULED_TO_USAGER;
     protected ?string $mailerSubject = 'Modification de la date de visite de votre logement';
-    protected ?string $mailerButtonText = 'Accéder à mon signalement';
+    protected ?string $mailerButtonText = 'Accéder à mon dossier';
     protected ?string $mailerTemplate = 'nouveau_suivi_visite_rescheduled_email';
     protected ?string $tagHeader = 'Usager Modification Date Visite Prevue';
 

--- a/templates/emails/accuse_reception_email.html.twig
+++ b/templates/emails/accuse_reception_email.html.twig
@@ -13,7 +13,7 @@
         <p><strong>Si vous êtes propriétaire occupant, merci de ne pas tenir compte de la demande d'information et
                 du fichier ci-joint</strong></p>
     {% endif %}
-        <br>Pour suivre votre signalement ou nous envoyer un message, cliquez sur le bouton ci-dessous :</p>
+        <br>Pour suivre l'avancée de votre dossier ou nous envoyer un message, cliquez sur le bouton ci-dessous :</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">
         <tbody>

--- a/templates/emails/ask_bail_dpe_signalement_email.html.twig
+++ b/templates/emails/ask_bail_dpe_signalement_email.html.twig
@@ -11,7 +11,7 @@
     veuillez nous envoyer le bail du logement et le diagnostic de performance énergétique (DPE). <br>
     </p>
     
-    <p>Cliquez sur le bouton ci-dessous pour accéder à votre page de suivi et y ajouter les documents.</p>
+    <p>Cliquez sur le bouton ci-dessous pour accéder à votre dossier et y ajouter les documents.</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">
         <tbody>

--- a/templates/emails/closed_to_usager_signalement_email.html.twig
+++ b/templates/emails/closed_to_usager_signalement_email.html.twig
@@ -3,10 +3,10 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>
-        Votre signalement sur la plateforme {{ platform.name }} - {{territory.name}}  a été clôturé par nos équipes pour la raison suivante : {{ motif_cloture }}.
+        Votre signalement sur la plateforme {{ platform.name }} - {{territory.name}}  a été clôturé par nos équipes.
     </p>
     <p>
-        Un commentaire est disponible sur votre page de suivi. Vous pouvez le consulter en cliquant sur le bouton ci-dessous :
+        Vous pouvez consulter le motif de clôture et, si besoin, y répondre en cliquant sur le bouton ci-dessous :
     </p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">

--- a/templates/emails/lien_suivi_signalement_email.html.twig
+++ b/templates/emails/lien_suivi_signalement_email.html.twig
@@ -14,7 +14,7 @@
 
 	<p>Conservez précieusement cet e-mail pour pouvoir y accéder à tout moment.</p>
 
-	<p>Pour accéder à votre page de suivi, cliquez sur le bouton ci-dessous :</p>
+	<p>Pour suivre l'avancée de votre dossier, cliquez sur le bouton ci-dessous :</p>
 
 	<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="text-align: center">
 		<tbody>

--- a/templates/emails/nouveau_suivi_signalement_email.html.twig
+++ b/templates/emails/nouveau_suivi_signalement_email.html.twig
@@ -4,7 +4,7 @@
     <p>Bonjour,</p>
     <p>Une nouvelle mise à jour est disponible pour votre signalement concernant le logement situé <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>
-        <br>ous pouvez consulter votre dossier ou nous envoyer un message en cliquant sur le bouton ci-dessous :</p>
+        <br>Vous pouvez consulter votre dossier ou nous envoyer un message en cliquant sur le bouton ci-dessous :</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">
         <tbody>

--- a/templates/emails/nouveau_suivi_signalement_email.html.twig
+++ b/templates/emails/nouveau_suivi_signalement_email.html.twig
@@ -4,7 +4,7 @@
     <p>Bonjour,</p>
     <p>Une nouvelle mise à jour est disponible pour votre signalement concernant le logement situé <br>
         <strong>{{ signalement.adresseOccupant~', '~signalement.cpOccupant~' '~signalement.villeOccupant|upper }}</strong>
-        <br>Vous pouvez consulter la mise à jour ou nous envoyer un message en cliquant sur le bouton ci-dessous :</p>
+        <br>ous pouvez consulter votre dossier ou nous envoyer un message en cliquant sur le bouton ci-dessous :</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">
         <tbody>

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -31,9 +31,15 @@
 		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
 			<p>Votre signalement a été refusé, vous ne pouvez plus envoyer de messages.</p>
 		</div>
-	{% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
+	{% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') 
+		and signalement.hasSuiviUsagePostCloture %}
 		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
-			<p>Votre signalement a été clôturé, vous ne pouvez plus envoyer de messages.</p>
+			<p>Votre message suite à la clôture de votre dossier a bien été envoyé. Vous ne pouvez désormais plus envoyer de messages.</p>
+		</div>
+	{% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') 
+		and date(signalement.closedAt) < date('-30days') %}
+		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
+			<p>Votre dossier a été clôturé il y a plus de 30 jours, vous ne pouvez plus envoyer de messages.</p>
 		</div>
 	{% else %}
 		<form action="{{ path('front_suivi_signalement_user_response',{code:signalement.codeSuivi}) }}" class="needs-validation fr-disable-button-when-submit" novalidate method="POST">

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -203,7 +203,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Procédure estimée' => [['procedure' => 'rsd'], 5];
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5']], 2];
         yield 'Search by Statut de la visite' => [['visiteStatus' => 'Planifiée'], 5];
-        yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique'], 32];
+        yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique'], 31];
         yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18'], 3];
         yield 'Search by Statut de l\'affectation' => [['statusAffectation' => 'refuse'], 1];
         yield 'Search by Score criticite' => [['criticiteScoreMin' => 5, 'criticiteScoreMax' => 6], 9];

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -82,7 +82,7 @@ class SignalementControllerTest extends WebTestCase
             $this->assertEquals('Signalement #2022-1 '.$signalement->getPrenomOccupant().' '.$signalement->getNomOccupant(), $crawler->filter('h1')->eq(2)->text());
         } elseif (Signalement::STATUS_CLOSED === $status) {
             $this->assertEquals(
-                'Votre signalement a été clôturé, vous ne pouvez plus envoyer de messages.',
+                'Votre message suite à la clôture de votre dossier a bien été envoyé. Vous ne pouvez désormais plus envoyer de messages.',
                 $crawler->filter('.fr-alert--error p')->text()
             );
         } elseif (Signalement::STATUS_REFUSED === $status) {

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -172,7 +172,7 @@ class EsaboraManagerTest extends KernelTestCase
             'reference' => $referenceSignalement,
         ]);
 
-        $this->assertEquals(1, \count($signalement->getSuivis()));
+        $this->assertEquals(2, \count($signalement->getSuivis()));
         /** @var Affectation $affectation */
         $affectation = $signalement->getAffectations()->get(0);
         $this->assertNotEquals($expectedAffectationStatus, $affectation->getStatut());
@@ -199,7 +199,7 @@ class EsaboraManagerTest extends KernelTestCase
 
         /** @var Suivi $suivi */
         $suivi = $signalement->getSuivis()->last();
-        $this->assertEquals(2, \count($signalement->getSuivis()));
+        $this->assertEquals(3, \count($signalement->getSuivis()));
         $this->assertStringContainsString($suiviDescription, $suivi->getDescription());
         $this->assertFalse($suivi->getIsPublic());
         $this->assertEquals($suiviStatus, $suivi->getType());
@@ -213,6 +213,6 @@ class EsaboraManagerTest extends KernelTestCase
         $this->entityManager->refresh($signalement);
 
         // on vérifie qu'aucun suivi n'a été créé
-        $this->assertEquals(2, \count($signalement->getSuivis()));
+        $this->assertEquals(3, \count($signalement->getSuivis()));
     }
 }

--- a/tests/Functional/Service/Notification/NotificationCounterTest.php
+++ b/tests/Functional/Service/Notification/NotificationCounterTest.php
@@ -25,6 +25,6 @@ class NotificationCounterTest extends KernelTestCase
 
         $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
         $notificationCount = (new NotificationCounter($notificationRepository))->countUnseenNotification($user);
-        $this->assertEquals(8, $notificationCount);
+        $this->assertEquals(9, $notificationCount);
     }
 }

--- a/tests/Unit/Entity/SignalementTest.php
+++ b/tests/Unit/Entity/SignalementTest.php
@@ -7,6 +7,7 @@ use App\Entity\Enum\Qualification;
 use App\Entity\Signalement;
 use App\Entity\SignalementDraft;
 use App\Entity\SignalementQualification;
+use App\Repository\SignalementRepository;
 use App\Tests\FixturesHelper;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -95,5 +96,18 @@ class SignalementTest extends KernelTestCase
         yield 'BAILLEUR_OCCUPANT' => [ProfileDeclarant::BAILLEUR_OCCUPANT];
         yield 'SERVICE_SECOURS' => [ProfileDeclarant::SERVICE_SECOURS];
         yield 'LOCATAIRE' => [ProfileDeclarant::LOCATAIRE];
+    }
+
+    public function testHasNoSuiviUsagePostCloture(): void
+    {
+        $signalement = $this->getSignalement($this->getTerritory('Pas-de-calais', '62'));
+        $this->assertFalse($signalement->hasSuiviUsagePostCloture());
+    }
+
+    public function testHasSuiviUsagePostCloture(): void
+    {
+        $signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2022-2']);
+        $this->assertTrue($signalement->hasSuiviUsagePostCloture());
     }
 }


### PR DESCRIPTION
## Ticket

#2818 
#2817    

## Description
Objectif : permettre à l'usager de s'exprimer après la clôture de son dossier pour que le RT puisse rouvrir le dossier si nécessaire.
Il faudrait créer un type de suivi spécifique pour ce commentaire. Cela nous permettra de mesurer combien il y en a.
Objectif : encourager les usagers à se rendre sur leur page de suivi grâce à un langage plus adapté

## Changements apportés
* Ajout d'un type de suivi TYPE_USAGER_POST_CLOTURE
* Modification de la page de suivi pour permettre de laisser UN SEUL suivi de type TYPE_USAGER_POST_CLOTURE dans les 30 jours suivant la cloture du signalement
* Ajout d'un suivi de type TYPE_USAGER_POST_CLOTURE dans les fixtures
* Mise à jour des tests
* Mise à jour des mails envoyés pour parler de "dossier" et plus de "page de suivi"

## Pré-requis


## Tests
- [ ] Fermer un signalement
- [ ] En tant qu'usager, se rendre sur la page de suivi (vérifier le contenu du mail)
- [ ] Vérifier qu'on peut envoyer 1 et 1 seul suivi après la clôture
- [ ] Vérifier les messages affichés
- [ ] En BDD, modifier la date de cloture d'un signalement fermé pour la mettre il y a plus d'un mois
- [ ] Aller sur la page de suivi de ce signalement et vérifier qu'on ne peut pas ajouter de messages (vérifier l'affichage)
- [ ] Vérifier le contenu des mails envoyés
- [ ] Dans les différents affichages et filtres de suivis (page de suivi, liste signalement, fiche signalement) vérifier qque le suivi de type TYPE_USAGER_POST_CLOTURE est bien considéré comme un suivi usager 
