### PR TITLE
[QA - Dashboard] Ajout d'index pour améliorer des requêtes trop lentes

### DIFF
--- a/migrations/Version20240718194157.php
+++ b/migrations/Version20240718194157.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240718194157 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index on suivi, signalement and job_event';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_suivi_created_at ON suivi (created_at)');
+        $this->addSql('CREATE INDEX idx_suivi_type ON suivi (type)');
+
+        $this->addSql('CREATE INDEX idx_signalement_is_imported ON signalement (is_imported)');
+        $this->addSql('CREATE INDEX idx_signalement_uuid ON signalement (uuid)');
+
+        $this->addSql('CREATE INDEX idx_job_event_created_at ON job_event (created_at)');
+        $this->addSql('CREATE INDEX idx_job_event_service ON job_event (service)');
+        $this->addSql('CREATE INDEX idx_job_event_partner_id ON job_event (partner_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_suivi_created_at ON suivi');
+        $this->addSql('DROP INDEX idx_suivi_type ON suivi');
+
+        $this->addSql('DROP INDEX idx_signalement_uuid ON signalement');
+        $this->addSql('DROP INDEX idx_signalement_is_imported ON signalement');
+
+        $this->addSql('DROP INDEX idx_job_event_created_at ON job_event');
+        $this->addSql('DROP INDEX idx_job_event_service ON job_event');
+        $this->addSql('DROP INDEX idx_job_event_partner_id ON job_event');
+    }
+}


### PR DESCRIPTION
## Ticket

#2750    

## Description
Ajout d'index sur les tables suivi, signalement et job_event pour améliorer les performances de certaines requêtes.
Cf le ticket pour la description détaillée des gains de performances

## Changements apportés
* Ajout d'une migration

## Pré-requis
`make load-migrations`

## Tests
- [ ] Faire de la TNR sur le dashboard, la fiche signalement et la fiche partenaire
