### PR TITLE
[QA] Appel à une route keep-alive pour garder la session active sur la page de suivi usager

### DIFF
--- a/assets/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -294,6 +294,11 @@ document.addEventListener("DOMContentLoaded", function() {
         elmnt = document.getElementById(window.location.hash.substring(1))
         elmnt.scrollIntoView({behavior:'instant'})
     }
+
+    setInterval(function() {
+        fetch('/keep-session-alive')
+            .then(response => response.json());
+    }, 600000);
 })
 const closeNoticeButtons = document.querySelectorAll('button[name="closeNotice"]');
 closeNoticeButtons.forEach(button => {

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -10,6 +10,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -77,5 +78,11 @@ class SecurityController extends AbstractController
     public function logout(): void
     {
         throw new LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
+    }
+
+    #[Route('/keep-session-alive', name: 'keep_session_alive')]
+    public function keepSessionAlive()
+    {
+        return new JsonResponse(['status' => 'ok']);
     }
 }


### PR DESCRIPTION
## Ticket

#2751   

## Description
Depuis la mise à jour du 20 juin et un changement dans le SecurityController, nous avons reçu 32000 erreurs d'ouvertures des fichiers miniatures sur la page de suivi usager.
Je n'ai pas réussi à reproduire ce pb par contre j'ai reproduit un pb similaire quand je laisse la page suivi usager ouverte longtemps avant de cliquer sur les photos.
Cela est dû au token qui n'est plus valide car la session est dépassée
Conversation ici : https://mattermost.incubateur.net/betagouv/pl/pnewaijo63fo8x9xxttgeqdh8a

## Changements apportés
* Création d'une route keep-alive qu'on appelle toutes les 10 minutes en js depuis la page de suivi usager pour prolonger la session

## Pré-requis

## Tests
- [ ] Vérifier que la page usager s'affiche toujours bien que les photos s'ouvrent et que tout fonctionne normalement.
