### PR TITLE
[BO] Fix sur quelques bugs sentry

### DIFF
--- a/assets/controllers/form_nde.js
+++ b/assets/controllers/form_nde.js
@@ -61,8 +61,8 @@ formBtn?.addEventListener('click', evt => {
             dpe: stringToBoolean(document.querySelector('input[name=dpe]:checked')?.value),
             dateDernierBail: document.querySelector('input[name=dateDernierBail]:checked')?.value,
             dateDernierDPE: document.querySelector('input[name=dateDernierDPE]:checked')?.value,
-            consommationEnergie: Number(document.getElementById('signalement-edit-nde-conso-energie')?.value),
-            superficie: Number(document.getElementById('signalement-edit-nde-superficie')?.value),
+            consommationEnergie:Math.round( Number(document.getElementById('signalement-edit-nde-conso-energie')?.value)),
+            superficie: Math.round(Number(document.getElementById('signalement-edit-nde-superficie')?.value)),
         };
 
         const options = {

--- a/src/Dto/StatisticsFilters.php
+++ b/src/Dto/StatisticsFilters.php
@@ -11,8 +11,8 @@ class StatisticsFilters
     private ?string $statut;
     private array $etiquettes;
     private ?string $type;
-    private \DateTime $dateStart;
-    private \DateTime $dateEnd;
+    private ?\DateTime $dateStart;
+    private ?\DateTime $dateEnd;
     private bool $countRefused;
     private bool $countArchived;
     private ?Territory $territory;
@@ -23,8 +23,8 @@ class StatisticsFilters
         ?string $statut,
         array $etiquettes,
         ?string $type,
-        \DateTime $dateStart,
-        \DateTime $dateEnd,
+        ?\DateTime $dateStart,
+        ?\DateTime $dateEnd,
         bool $countRefused,
         bool $countArchived,
         ?Territory $territory,
@@ -95,7 +95,7 @@ class StatisticsFilters
         return $this->dateStart;
     }
 
-    public function setDateStart(\DateTime $dateStart): self
+    public function setDateStart(?\DateTime $dateStart): self
     {
         $this->dateStart = $dateStart;
 
@@ -107,7 +107,7 @@ class StatisticsFilters
         return $this->dateEnd;
     }
 
-    public function setDateEnd(\DateTime $dateEnd): self
+    public function setDateEnd(?\DateTime $dateEnd): self
     {
         $this->dateEnd = $dateEnd;
 

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -108,12 +108,14 @@ class AffectationManager extends Manager
 
     public function flagAsSynchronized(DossierMessageInterface $dossierMessage): void
     {
-        /** @var Affectation $affectation */
+        /** @var ?Affectation $affectation */
         $affectation = $this->getRepository()->findOneBy([
             'partner' => $dossierMessage->getPartnerId(),
             'signalement' => $dossierMessage->getSignalementId(),
         ]);
-        $affectation->setIsSynchronized(true);
-        $this->save($affectation);
+        if (isset($affectation)) {
+            $affectation->setIsSynchronized(true);
+            $this->save($affectation);
+        }
     }
 }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -267,13 +267,13 @@ class SignalementManager extends AbstractManager
     public function findUsersAffectedToSignalement(
         Signalement $signalement,
         AffectationStatus $statusAffectation,
-        Partner $partnerToExclude
+        ?Partner $partnerToExclude
     ): array {
         $list = [];
         $affectations = $signalement->getAffectations();
         foreach ($affectations as $affectation) {
             $partner = $affectation->getPartner();
-            if ((!$partnerToExclude || $partnerToExclude != $partner) && $affectation->getStatut() === $statusAffectation->value) {
+            if ((null === $partnerToExclude || $partnerToExclude != $partner) && $affectation->getStatut() === $statusAffectation->value) {
                 $list = array_merge($list, $partner->getUsers()->toArray());
             }
         }


### PR DESCRIPTION
## Ticket

#2672 
#2753 
#2752 
#2673    

## Description
Arrondi sur la superficie et la consommation énergétique lors de l'édition de la non-décence énergétique
SignalementManager->findUsersAffectedToSignalement rendre $partnerToExclude nullable
Les dates peuvent être null lors du filtre sur les statistiques
Appel de setIsSynchronized sur une affectation que si celle-ci n'est pas null

## Changements apportés
* cf ci-dessus

## Pré-requis
`npm run watch`
## Tests
- [ ] Dans un signalement avec Non-décence énergétique, modifier la superficie et la consommation énergétique en mettant un float, et vérifier que c'est arrondi à l'entier le plus proche
- [ ] Pour le deuxième ticket, je ne sais pas comment tester
- [ ] Pour le troisième pareil, je n'arrive pas à reproduire, mais les dates étant optionnelles dans la requête, je les ai juste rendues nullable
- [ ] Pour le 4ème, j'avoue ne pas avoir testé, mais j'imagine que ça arrive quand on retire l'affectation sur un partenaire qui était synchronisé avec Esabora
