### PR TITLE
 [BO - Partenaire] Ne pas vérifier les mails usagers pour le changement de mail et le changement de type de partenaire réservé aux RT et SA

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -447,6 +447,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TwoFact
         return \in_array(self::ROLE_USER_PARTNER, $this->getRoles());
     }
 
+    public function isUsager(): bool
+    {
+        return \in_array(self::ROLE_USAGER, $this->getRoles());
+    }
+
     public function getTerritory(): ?Territory
     {
         return $this->territory;

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -92,6 +92,7 @@ class PartnerType extends AbstractType
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],
+                'disabled' => !$this->isAdminTerritory,
             ])
             ->add('competence', EnumType::class, [
                 'class' => Qualification::class,
@@ -261,9 +262,10 @@ class PartnerType extends AbstractType
             if (empty($partner->getEmail())) {
                 return;
             }
+            /** @var ?User $user */
             $user = $this->userRepository->findOneBy(['email' => $partner->getEmail()]);
 
-            if (!empty($user)) {
+            if (!empty($user) && !$user->isUsager()) {
                 $context->addViolation('Un utilisateur existe déjà avec cette adresse e-mail.');
             }
         }


### PR DESCRIPTION
## Ticket

#2602 
#2655    

## Description
Ne pas vérifier les mails usagers pour mettre un mail générique à un partenaire 
Un admin partenaire ne doit pas pouvoir modifier le type de son partenaire

## Changements apportés
* Modification du FormType PartnerType pour ne pas pouvoir modifier le type de partner si l'utilisateur n'est pas au moins RT et pour ne mettre une erreur sur l'email générique que si l'utilisateur ayant déjà cette adresse email a au moins un rôle userPartner
* Ajout d'une fonction isUsager dans l'entité User

## Pré-requis

## Tests
- [ ] Se connecter en adminPartner, vérifier qu'on ne peut pas modifier le type de son partenaire
- [ ] Se connecter en SA et en RT, vérifier qu'on peut modifier le type des partenaires
- [ ] Sur un partenaire, tenter de changer l'adresse mail générique
- [ ] - avec une adresse existant pour un SA -> KO
- [ ] - avec une adresse existant pour un RT -> KO
- [ ] - avec une adresse existant pour un admin partenaire -> KO
- [ ] - avec une adresse existant pour un partenaire -> KO
- [ ] - avec une adresse existant pour un usager -> OK
- [ ] - avec une adresse n'existant pas -> OK
