### PR TITLE
[BO - Listes] Enlever le tri alphabétique sur les listes de territoires

### DIFF
--- a/src/Repository/TerritoryRepository.php
+++ b/src/Repository/TerritoryRepository.php
@@ -30,8 +30,7 @@ class TerritoryRepository extends ServiceEntityRepository
     public function findAllList()
     {
         $qb = $this->createQueryBuilder('t')
-            ->where('t.isActive = 1')
-            ->orderBy('t.name', 'ASC');
+            ->where('t.isActive = 1');
 
         return $qb->indexBy('t', 't.id')
             ->getQuery()


### PR DESCRIPTION
## Ticket

#2856    

## Description
on a rajouté l'indicatif departement sur les liste de territoire mais on à laissé le tri alphabétique (sur la page partenaire par exemple) c'est perturbant

## Changements apportés
* Retrait de l'orderBy Name dans la requête

## Pré-requis

## Tests
- [ ] Vérifier toutes les listes de territoires en SA (stats front, stats BO, pages admin, cartographie, dashboard, liste de signalements)
