### PR TITLE
[BO - AutoAffectation] Création d'une page admin de gestion des règles d'auto-affectations, et affichage des règles d'auto-affectation concernant un partenaire

### DIFF
--- a/assets/app-back-bo.ts
+++ b/assets/app-back-bo.ts
@@ -13,6 +13,7 @@ import './controllers/form_notification';
 import './controllers/form_visite';
 
 import './controllers/back_archived_signalements/back_archived_signalements_reactiver'
+import './controllers/back_auto_affectation_rule/form_auto_affectation_rule'
 import './controllers/back_partner_view/form_partner';
 import './controllers/back_signalement_view/back_view_signalement';
 import './controllers/back_signalement_view/form_edit_modal';

--- a/assets/controllers/back_auto_affectation_rule/form_auto_affectation_rule.js
+++ b/assets/controllers/back_auto_affectation_rule/form_auto_affectation_rule.js
@@ -1,0 +1,12 @@
+document.querySelectorAll('.btn-delete-autoaffectationrule').forEach(swbtn => {
+    swbtn.addEventListener('click', evt => {
+        const target = evt.target
+        document.querySelector('.fr-modal-autoaffectationrule-delete-description').innerHTML = target.getAttribute('data-autoaffectationrule-description')
+        document.querySelector('#fr-modal-autoaffectationrule-delete-id').value = target.getAttribute('data-autoaffectationrule-id')
+        document.querySelector('#autoaffectationrule_delete_form').addEventListener('submit', (e) => {
+            document.querySelector('#autoaffectationrule_delete_form_submit').innerHTML = 'Suppression en cours...'
+            document.querySelector('#autoaffectationrule_delete_form_submit').disabled = true
+        })
+    })
+})
+

--- a/migrations/Version20240729083340.php
+++ b/migrations/Version20240729083340.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240729083340 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add field partner_to_exclude to auto_affectation_rule';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auto_affectation_rule ADD partner_to_exclude JSON DEFAULT NULL COMMENT \'Value possible null or an array of partner ids\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auto_affectation_rule DROP partner_to_exclude');
+    }
+}

--- a/src/Command/AddAutoAffectationRuleCommand.php
+++ b/src/Command/AddAutoAffectationRuleCommand.php
@@ -36,6 +36,7 @@ class AddAutoAffectationRuleCommand extends Command
         'PROFILE_DECLARANT' => 'profileDeclarant',
         'INSEE_TO_INCLUDE' => 'inseeToInclude',
         'INSEE_TO_EXCLUDE' => 'inseeToExclude',
+        'PARTNER_TO_EXCLUDE' => 'partnerToExclude',
         'PARC' => 'parc',
         'ALLOCATAIRE' => 'allocataire',
     ];
@@ -58,6 +59,7 @@ class AddAutoAffectationRuleCommand extends Command
             ->addArgument(self::FIELDS['PROFILE_DECLARANT'], InputArgument::OPTIONAL, 'The profile_declarant concerned, "all" if not specified')
             ->addArgument(self::FIELDS['INSEE_TO_INCLUDE'], InputArgument::OPTIONAL, '"partner_list" if not specified')
             ->addArgument(self::FIELDS['INSEE_TO_EXCLUDE'], InputArgument::OPTIONAL, 'null if not specified')
+            ->addArgument(self::FIELDS['PARTNER_TO_EXCLUDE'], InputArgument::OPTIONAL, 'null if not specified')
             ->addArgument(self::FIELDS['PARC'], InputArgument::OPTIONAL, 'Parc concerned, "all" if not specified')
             ->addArgument(self::FIELDS['ALLOCATAIRE'], InputArgument::OPTIONAL, 'allocataire concerned, "all" if not specified');
     }
@@ -81,7 +83,7 @@ class AddAutoAffectationRuleCommand extends Command
             'If you prefer to not use this interactive wizard, provide the',
             'arguments required by this command as follows:',
             '',
-            ' $ php bin/console app:add-auto-affectation-rule territory partnerType status profileDeclarant inseeToInclude inseeToExclude parc allocataire',
+            ' $ php bin/console app:add-auto-affectation-rule territory partnerType status profileDeclarant inseeToInclude inseeToExclude partnerToExclude parc allocataire',
             '',
             'Now we\'ll ask you for the value of all the missing command arguments.',
         ]);
@@ -172,6 +174,17 @@ class AddAutoAffectationRuleCommand extends Command
             $input->setArgument(self::FIELDS['INSEE_TO_EXCLUDE'], $inseeToExclude);
         }
 
+        $partnerToExclude = $input->getArgument(self::FIELDS['PARTNER_TO_EXCLUDE']);
+        if (!empty($partnerToExclude)) {
+            $this->io->table([self::FIELDS['PARTNER_TO_EXCLUDE']], $partnerToExclude);
+        } else {
+            /** @var QuestionHelper $helper */
+            $helper = $this->getHelper('question');
+            $question = new Question('Enter code'.self::FIELDS['PARTNER_TO_EXCLUDE'].' separated by comma ');
+            $partnerToExclude = $helper->ask($input, $output, $question);
+            $input->setArgument(self::FIELDS['PARTNER_TO_EXCLUDE'], $partnerToExclude);
+        }
+
         $parc = $input->getArgument(self::FIELDS['PARC']);
         if (null !== $parc) {
             $this->io->text(' > <info>'.ucfirst(self::FIELDS['PARC']).'</info>: '.$parc);
@@ -226,6 +239,7 @@ class AddAutoAffectationRuleCommand extends Command
         $profileDeclarant = $input->getArgument('profileDeclarant');
         $inseeToInclude = $input->getArgument('inseeToInclude');
         $inseeToExclude = $input->getArgument('inseeToExclude');
+        $partnerToExclude = $input->getArgument('partnerToExclude');
         $parc = $input->getArgument('parc');
         $allocataire = $input->getArgument('allocataire');
 
@@ -251,6 +265,7 @@ class AddAutoAffectationRuleCommand extends Command
             profileDeclarant : $profileDeclarant,
             inseeToInclude : $inseeToInclude,
             inseeToExclude : $inseeToExclude,
+            partnerToExclude : $partnerToExclude,
             parc : $parc,
             allocataire : $allocataire
         );

--- a/src/Command/AddAutoAffectationRuleCommand.php
+++ b/src/Command/AddAutoAffectationRuleCommand.php
@@ -251,13 +251,6 @@ class AddAutoAffectationRuleCommand extends Command
             return Command::FAILURE;
         }
 
-        $autoAffectationRule = $this->autoAffectationRuleManager->findOneBy(['territory' => $territory, 'partnerType' => $partnerType]);
-        if ($autoAffectationRule) {
-            $this->io->error('There is already a rule for this territory and this type of partner');
-
-            return Command::FAILURE;
-        }
-
         $autoAffectationRule = $this->autoAffectationRulerFactory->createInstanceFrom(
             territory : $territory,
             status : $status,

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\AutoAffectationRule;
+use App\Entity\Partner;
+use App\Form\AutoAffectationRuleType;
+use App\Repository\AutoAffectationRuleRepository;
+use App\Repository\TerritoryRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/bo/auto-affectation')]
+class AutoAffectationRuleController extends AbstractController
+{
+    #[Route('/', name: 'back_auto_affectation_rule_index', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function index(
+        Request $request,
+        TerritoryRepository $territoryRepository,
+        AutoAffectationRuleRepository $autoAffectationRuleRepository
+    ): Response {
+        $page = $request->get('page') ?? 1;
+
+        $currentTerritory = $territoryRepository->find((int) $request->get('territory'));
+
+        $paginatedAutoAffectationRule = $autoAffectationRuleRepository->getAutoAffectationRules(
+            territory: $currentTerritory,
+            page: (int) $page
+        );
+
+        if ($request->isMethod(Request::METHOD_POST)) {
+            $currentTerritory = $territoryRepository->find((int) $request->request->get('territory'));
+
+            return $this->redirect($this->generateUrl('back_auto_affectation_rule_index', [
+                'page' => 1,
+                'territory' => $currentTerritory?->getId(),
+            ]));
+        }
+
+        $totalAutoAffectationRule = \count($paginatedAutoAffectationRule);
+
+        return $this->render('back/auto-affectation-rule/index.html.twig', [
+            'currentTerritory' => $currentTerritory,
+            'territories' => $territoryRepository->findAllList(),
+            'autoaffectationrules' => $paginatedAutoAffectationRule,
+            'total' => $totalAutoAffectationRule,
+            'page' => $page,
+            'pages' => (int) ceil($totalAutoAffectationRule / Partner::MAX_LIST_PAGINATION),
+        ]);
+    }
+
+    #[Route('/supprimerregle', name: 'back_auto_affectation_rule_delete', methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function deleteAutoAffectationRule(
+        Request $request,
+        AutoAffectationRuleRepository $autoAffectationRuleRepository,
+        EntityManagerInterface $entityManager
+    ): Response {
+        $ruleId = $request->request->get('autoaffectationrule_id');
+        if (!$this->isCsrfTokenValid('autoaffectationrule_delete', $request->request->get('_token'))) {
+            $this->addFlash('error', 'Token CSRF invalide, merci d\'actualiser la page et réessayer.');
+
+            return $this->redirectToRoute('back_auto_affectation_rule_index', [], Response::HTTP_SEE_OTHER);
+        }
+        /** @var AutoAffectationRule $autoAffectationRule */
+        $autoAffectationRule = $autoAffectationRuleRepository->findOneBy(['id' => $ruleId]);
+        if (AutoAffectationRule::STATUS_ARCHIVED === $autoAffectationRule->getStatus()) {
+            $this->addFlash('error', 'Cette règle est déjà archivée.');
+        } else {
+            $autoAffectationRule->setStatus(AutoAffectationRule::STATUS_ARCHIVED);
+            $entityManager->persist($autoAffectationRule);
+            $entityManager->flush();
+            $this->addFlash('success', 'La règle a bien été archivée.');
+        }
+
+        return $this->redirectToRoute(
+            'back_auto_affectation_rule_index',
+            [],
+            Response::HTTP_SEE_OTHER
+        );
+    }
+
+    #[Route('/{id}/reactiverregle', name: 'back_auto_affectation_rule_reactive', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function reactiveAutoAffectationRule(
+        Request $request,
+        AutoAffectationRule $autoAffectationRule,
+        EntityManagerInterface $entityManager
+    ): Response {
+        $ruleId = $request->request->get('autoaffectationrule_id');
+        if (AutoAffectationRule::STATUS_ACTIVE === $autoAffectationRule->getStatus()) {
+            $this->addFlash('error', 'Cette règle est déjà active.');
+        } else {
+            $autoAffectationRule->setStatus(AutoAffectationRule::STATUS_ACTIVE);
+            $entityManager->persist($autoAffectationRule);
+            $entityManager->flush();
+            $this->addFlash('success', 'La règle a bien été réactivée.');
+        }
+
+        return $this->redirectToRoute(
+            'back_auto_affectation_rule_index',
+            [],
+            Response::HTTP_SEE_OTHER
+        );
+    }
+
+    #[Route('/{id}/editer', name: 'back_auto_affectation_rule_edit', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function editAutoAffectationRule(
+        Request $request,
+        AutoAffectationRule $autoAffectationRule,
+        EntityManagerInterface $entityManager,
+    ): Response {
+        $form = $this->createForm(AutoAffectationRuleType::class, $autoAffectationRule, [
+            'create' => false,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $entityManager->flush();
+            $this->addFlash('success', 'La règle a bien été modifiée.');
+
+            return $this->redirectToRoute('back_auto_affectation_rule_index', []);
+        }
+
+        $this->displayErrors($form);
+
+        return $this->render('back/auto-affectation-rule/edit.html.twig', [
+            'autoAffectationRule' => $autoAffectationRule,
+            'form' => $form,
+            'create' => false,
+        ]);
+    }
+
+    #[Route('/ajout', name: 'back_auto_affectation_rule_new', methods: ['GET', 'POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function new(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $autoAffectationRule = new AutoAffectationRule();
+        $form = $this->createForm(AutoAffectationRuleType::class, $autoAffectationRule, [
+            'create' => true,
+            'route' => 'back_auto_affectation_rule_new',
+        ]);
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $entityManager->persist($autoAffectationRule);
+            $entityManager->flush();
+            $this->addFlash('success', 'La règle a bien été créée.');
+
+            return $this->redirectToRoute('back_auto_affectation_rule_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        $this->displayErrors($form);
+
+        return $this->render('back/auto-affectation-rule/edit.html.twig', [
+            'autoAffectationRule' => $autoAffectationRule,
+            'form' => $form,
+            'create' => true,
+        ]);
+    }
+
+    private function displayErrors(FormInterface $form): void
+    {
+        /** @var FormError $error */
+        foreach ($form->getErrors(true) as $error) {
+            $this->addFlash('error', $error->getMessage());
+        }
+    }
+}

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -48,7 +48,7 @@ class AutoAffectationRuleController extends AbstractController
 
         return $this->render('back/auto-affectation-rule/index.html.twig', [
             'currentTerritory' => $currentTerritory,
-            'territories' => $territoryRepository->findAllList(),
+            'territories' => $territoryRepository->findAllWithAutoAffectationRules(),
             'autoaffectationrules' => $paginatedAutoAffectationRule,
             'total' => $totalAutoAffectationRule,
             'page' => $page,
@@ -89,7 +89,6 @@ class AutoAffectationRuleController extends AbstractController
     #[Route('/{id}/reactiverregle', name: 'back_auto_affectation_rule_reactive', methods: ['GET', 'POST'])]
     #[IsGranted('ROLE_ADMIN')]
     public function reactiveAutoAffectationRule(
-        Request $request,
         AutoAffectationRule $autoAffectationRule,
         EntityManagerInterface $entityManager
     ): Response {

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -94,7 +94,6 @@ class AutoAffectationRuleController extends AbstractController
         AutoAffectationRule $autoAffectationRule,
         EntityManagerInterface $entityManager
     ): Response {
-        $ruleId = $request->request->get('autoaffectationrule_id');
         if (AutoAffectationRule::STATUS_ACTIVE === $autoAffectationRule->getStatus()) {
             $this->addFlash('error', 'Cette règle est déjà active.');
         } else {

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -75,7 +75,6 @@ class AutoAffectationRuleController extends AbstractController
             $this->addFlash('error', 'Cette règle est déjà archivée.');
         } else {
             $autoAffectationRule->setStatus(AutoAffectationRule::STATUS_ARCHIVED);
-            $entityManager->persist($autoAffectationRule);
             $entityManager->flush();
             $this->addFlash('success', 'La règle a bien été archivée.');
         }
@@ -98,7 +97,6 @@ class AutoAffectationRuleController extends AbstractController
             $this->addFlash('error', 'Cette règle est déjà active.');
         } else {
             $autoAffectationRule->setStatus(AutoAffectationRule::STATUS_ACTIVE);
-            $entityManager->persist($autoAffectationRule);
             $entityManager->flush();
             $this->addFlash('success', 'La règle a bien été réactivée.');
         }

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -3,7 +3,6 @@
 namespace App\Controller\Back;
 
 use App\Entity\Affectation;
-use App\Entity\AutoAffectationRule;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\PartnerType as EnumPartnerType;
 use App\Entity\Enum\Qualification;
@@ -150,14 +149,10 @@ class PartnerController extends AbstractController
 
         $partnerAutoAffectationRules = null;
         if ($this->isGranted('ROLE_ADMIN')) {
-            $partnerAutoAffectationRules = $autoAffectationRuleRepository->findBy([
-                'territory' => $partner->getTerritory(),
-                'partnerType' => $partner->getType(),
-                'status' => AutoAffectationRule::STATUS_ACTIVE,
-                ]);
+            $partnerAutoAffectationRules = $autoAffectationRuleRepository->findForPartner($partner);
         }
 
-        return $this->renderForm('back/partner/view.html.twig', [
+        return $this->render('back/partner/view.html.twig', [
             'partner' => $partner,
             'partners' => $partnerRepository->findAllList($partner->getTerritory()),
             'last_job_date' => $lastJobEventDate,

--- a/src/DataFixtures/Loader/LoadAutoAffectationRuleData.php
+++ b/src/DataFixtures/Loader/LoadAutoAffectationRuleData.php
@@ -35,6 +35,7 @@ class LoadAutoAffectationRuleData extends Fixture implements OrderedFixtureInter
             ->setPartnerType(PartnerType::tryFrom($row['partner_type']))
             ->setInseeToInclude($row['insee_to_include'])
             ->setInseeToExclude($row['insee_to_exclude'])
+            ->setPartnerToExclude($row['partner_to_exclude'] ?? [])
             ->setParc($row['parc'])
             ->setAllocataire($row['allocataire'])
         ;

--- a/src/Entity/AutoAffectationRule.php
+++ b/src/Entity/AutoAffectationRule.php
@@ -51,6 +51,10 @@ class AutoAffectationRule
     #[AppAssert\InseeToExclude()]
     private ?array $inseeToExclude = null;
 
+    #[ORM\Column(nullable: true, options: ['comment' => 'Value possible null or an array of partner ids'])]
+    #[AppAssert\PartnerToExclude()]
+    private ?array $partnerToExclude = null;
+
     #[ORM\Column(length: 32, options: ['comment' => 'Value possible all, non_renseigne, prive or public'])]
     #[Assert\NotBlank]
     #[Assert\Choice(choices: ['all', 'prive', 'public', 'non_renseigne'], message: 'Choisissez une option valide: all, non_renseigne, prive ou public')]
@@ -141,6 +145,18 @@ class AutoAffectationRule
     public function setInseeToExclude(?array $inseeToExclude): self
     {
         $this->inseeToExclude = $inseeToExclude;
+
+        return $this;
+    }
+
+    public function getPartnerToExclude(): ?array
+    {
+        return $this->partnerToExclude;
+    }
+
+    public function setPartnerToExclude(?array $partnerToExclude): self
+    {
+        $this->partnerToExclude = $partnerToExclude;
 
         return $this;
     }

--- a/src/Entity/AutoAffectationRule.php
+++ b/src/Entity/AutoAffectationRule.php
@@ -27,7 +27,7 @@ class AutoAffectationRule
     #[ORM\Column(type: 'string', options: ['comment' => 'Value possible ACTIVE or ARCHIVED'])]
     #[Assert\NotBlank]
     #[Assert\Choice(choices: [self::STATUS_ACTIVE, self::STATUS_ARCHIVED], message: 'Choisissez une option valide: ACTIVE or ARCHIVED')]
-    private string $status;
+    private string $status = self::STATUS_ACTIVE;
 
     #[ORM\Column(type: 'string', enumType: PartnerType::class, options: ['comment' => 'Value possible enum PartnerType'])]
     #[Assert\NotBlank]
@@ -164,5 +164,22 @@ class AutoAffectationRule
         $this->allocataire = $allocataire;
 
         return $this;
+    }
+
+    public function getDescription(): string
+    {
+        $description = 'Règle d\'auto-affectation pour les partenaires '.$this->getPartnerType()->label();
+        $description .= ' du territoire '.$this->getTerritory()->getName().' concernant ';
+        if ('prive' === $this->getParc()) {
+            $description .= 'les logements du parc privé';
+        } elseif ('public' === $this->getParc()) {
+            $description .= 'les logements du parc public';
+        } else {
+            $description .= 'tous les logements.';
+        }
+        // TODO code insee
+        // TODO profil déclarant
+        // TODO allocataire
+        return $description;
     }
 }

--- a/src/Entity/AutoAffectationRule.php
+++ b/src/Entity/AutoAffectationRule.php
@@ -22,27 +22,27 @@ class AutoAffectationRule
 
     #[ORM\ManyToOne(targetEntity: Territory::class, inversedBy: 'autoAffectationRules')]
     #[ORM\JoinColumn()]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de choisir un territoire.')]
     private Territory $territory;
 
     #[ORM\Column(type: 'string', options: ['comment' => 'Value possible ACTIVE or ARCHIVED'])]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de choisir un statut.')]
     #[Assert\Choice(choices: [self::STATUS_ACTIVE, self::STATUS_ARCHIVED], message: 'Choisissez une option valide: ACTIVE or ARCHIVED')]
     private string $status = self::STATUS_ACTIVE;
 
     #[ORM\Column(type: 'string', enumType: PartnerType::class, options: ['comment' => 'Value possible enum PartnerType'])]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de choisir un type de partenaire.')]
     #[AppAssert\ValidPartnerType]
     private PartnerType $partnerType;
 
     #[ORM\Column(length: 255, type: 'string', options: ['comment' => 'Value possible enum ProfileDeclarant or all, tiers or occupant'])]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de choisir un profil déclarant.')]
     #[Assert\Length(max: 255)]
     #[AppAssert\ValidProfileDeclarant()]
     private string $profileDeclarant;
 
     #[ORM\Column(length: 255, options: ['comment' => 'Value possible all, partner_list or an array of code insee'])]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de renseigner les code insee des communes concernées.')]
     #[Assert\Length(max: 255)]
     #[AppAssert\InseeToInclude()]
     private string $inseeToInclude;
@@ -56,12 +56,12 @@ class AutoAffectationRule
     private ?array $partnerToExclude = null;
 
     #[ORM\Column(length: 32, options: ['comment' => 'Value possible all, non_renseigne, prive or public'])]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de renseigner le type de parc.')]
     #[Assert\Choice(choices: ['all', 'prive', 'public', 'non_renseigne'], message: 'Choisissez une option valide: all, non_renseigne, prive ou public')]
     private string $parc;
 
     #[ORM\Column(length: 32, options: ['comment' => 'Value possible all, non, oui, caf or msa'])]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de renseigner le profil d\'allocataire.')]
     #[Assert\Choice(choices: ['all', 'non', 'oui', 'caf', 'msa'], message: 'Choisissez une option valide: all, non, oui, caf ou msa')]
     private string $allocataire;
 
@@ -188,78 +188,82 @@ class AutoAffectationRule
     public function getDescription(bool $isShort = true): string
     {
         $description = 'Règle d\'auto-affectation pour les partenaires '.$this->getPartnerType()->label();
-        $description .= ' du territoire '.$this->getTerritory()->getName();
-        if (!$isShort) {
-            $description .= ' concernant ';
-            switch ($this->getParc()) {
-                case 'prive':
-                    $description .= 'les logements du parc privé.';
-                    break;
-                case 'public':
-                    $description .= 'les logements du parc public.';
-                    break;
-                case 'non_renseigne':
-                    $description .= 'les logements de parc inconnu.';
-                    break;
-                default:
-                    $description .= 'tous les logements.';
-                    break;
-            }
-            $description .= ' Cette règle concerne les signalements faits par ';
-            switch ($this->getProfileDeclarant()) {
-                case 'all':
-                    $description .= 'tous profils de déclarant.';
-                    break;
-                case 'tiers':
-                    $description .= 'un tiers.';
-                    break;
-                case 'occupant':
-                    $description .= 'un occupant.';
-                    break;
-                default:
-                    $description .= ProfileDeclarant::tryFrom($this->getProfileDeclarant())?->label().'.';
-                    break;
-            }
-            $description .= ' Elle concerne les foyers ';
-            switch ($this->getAllocataire()) {
-                case 'oui':
-                    $description .= 'allocataires.';
-                    break;
-                case 'non':
-                    $description .= 'non-allocataires.';
-                    break;
-                case 'caf':
-                    $description .= 'allocataires à la CAF.';
-                    break;
-                case 'msa':
-                    $description .= 'allocataires à la MSA.';
-                    break;
-                default:
-                    $description .= 'allocataires et non-allocataires.';
-                    break;
-            }
-
-            $description .= ' Elle s\'applique ';
-            switch ($this->getInseeToInclude()) {
-                case 'all':
-                    $description .= 'à tous les logements du territoire';
-                    break;
-                case 'partner_list':
-                    $description .= 'aux logements situés dans le périmètre du partenaire (codes insee)';
-                    break;
-                default:
-                    $description .= 'aux logements situés dans les communes aux codes insee suivants : '.$this->getInseeToInclude();
-                    break;
-            }
-            if (null !== $this->getInseeToExclude()) {
-                $description .= ' à l\'exclusion des logements situés dans les communes aux codes insee suivants : '
-                .implode(',', $this->getInseeToExclude());
-            } else {
-                $description .= '.';
-            }
-
-            $description .= ' (Règle '.strtolower($this->getStatus()).')';
+        if (!$isShort && $this->getPartnerToExclude()) {
+            $description .= ' (à l\'exclusion des partenaires '.implode(',', $this->getPartnerToExclude()).')';
         }
+        $description .= ' du territoire '.$this->getTerritory()->getName();
+        if ($isShort) {
+            return $description;
+        }
+
+        $description .= ' concernant ';
+        switch ($this->getParc()) {
+            case 'prive':
+                $description .= 'les logements du parc privé.';
+                break;
+            case 'public':
+                $description .= 'les logements du parc public.';
+                break;
+            case 'non_renseigne':
+                $description .= 'les logements de parc inconnu.';
+                break;
+            default:
+                $description .= 'tous les logements.';
+                break;
+        }
+        $description .= ' Cette règle concerne les signalements faits par ';
+        switch ($this->getProfileDeclarant()) {
+            case 'all':
+                $description .= 'tous profils de déclarant.';
+                break;
+            case 'tiers':
+                $description .= 'un tiers.';
+                break;
+            case 'occupant':
+                $description .= 'un occupant.';
+                break;
+            default:
+                $description .= ProfileDeclarant::tryFrom($this->getProfileDeclarant())?->label().'.';
+                break;
+        }
+        $description .= ' Elle concerne les foyers ';
+        switch ($this->getAllocataire()) {
+            case 'oui':
+                $description .= 'allocataires.';
+                break;
+            case 'non':
+                $description .= 'non-allocataires.';
+                break;
+            case 'caf':
+                $description .= 'allocataires à la CAF.';
+                break;
+            case 'msa':
+                $description .= 'allocataires à la MSA.';
+                break;
+            default:
+                $description .= 'allocataires et non-allocataires.';
+                break;
+        }
+
+        $description .= ' Elle s\'applique ';
+        switch ($this->getInseeToInclude()) {
+            case 'all':
+                $description .= 'à tous les logements du territoire';
+                break;
+            case 'partner_list':
+                $description .= 'aux logements situés dans le périmètre du partenaire (codes insee)';
+                break;
+            default:
+                $description .= 'aux logements situés dans les communes aux codes insee suivants : '.$this->getInseeToInclude();
+                break;
+        }
+        if ($this->getInseeToExclude()) {
+            $description .= ' à l\'exclusion des logements situés dans les communes aux codes insee suivants : '
+            .implode(',', $this->getInseeToExclude());
+        } else {
+            $description .= '.';
+        }
+        $description .= ' (Règle '.strtolower($this->getStatus()).')';
 
         return $description;
     }

--- a/src/Factory/AutoAffectationRuleFactory.php
+++ b/src/Factory/AutoAffectationRuleFactory.php
@@ -15,6 +15,7 @@ class AutoAffectationRuleFactory
         string $profileDeclarant = null,
         string $inseeToInclude = null,
         ?string $inseeToExclude = null,
+        ?string $partnerToExclude = null,
         string $parc = null,
         string $allocataire = null
     ): AutoAffectationRule {
@@ -29,6 +30,9 @@ class AutoAffectationRuleFactory
 
         if (!empty($inseeToExclude)) {
             $autoAffectationRule->setInseeToExclude(array_map('trim', explode(',', $inseeToExclude)));
+        }
+        if (!empty($partnerToExclude)) {
+            $autoAffectationRule->setPartnerToExclude(array_map('trim', explode(',', $partnerToExclude)));
         }
 
         return $autoAffectationRule;

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -7,7 +7,6 @@ use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Territory;
 use App\Repository\TerritoryRepository;
-use App\Validator as AppAssert;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -16,7 +15,6 @@ use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints as Assert;
 
 class AutoAffectationRuleType extends AbstractType
 {
@@ -39,17 +37,12 @@ class AutoAffectationRuleType extends AbstractType
                     'class' => 'fr-input-group',
                 ],
                 'label' => 'Territoire',
-                'required' => true,
-                'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de choisir un territoire.'),
-                ],
             ])
             ->add('partnerType', EnumType::class, [
                 'class' => PartnerType::class,
                 'choice_label' => function ($choice) {
                     return $choice->label();
                 },
-                'disabled' => !$options['create'],
                 'row_attr' => [
                     'class' => 'fr-select-group',
                 ],
@@ -57,10 +50,7 @@ class AutoAffectationRuleType extends AbstractType
                 'attr' => [
                     'class' => 'fr-select',
                 ],
-                'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de choisir un partnerType.'),
-                    new AppAssert\ValidPartnerType(),
-                ],
+                'label' => 'Type de partenaire',
             ])
             ->add('profileDeclarant', ChoiceType::class, [
                 'choices' => ProfileDeclarant::getListWithGroup(),
@@ -76,11 +66,6 @@ class AutoAffectationRuleType extends AbstractType
                 'attr' => [
                     'class' => 'fr-select',
                 ],
-                'required' => true,
-                'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de choisir un profil déclarant.'),
-                    new AppAssert\ValidProfileDeclarant(),
-                ],
             ])
             ->add('status', ChoiceType::class, [
                 'label' => 'Statut',
@@ -94,16 +79,8 @@ class AutoAffectationRuleType extends AbstractType
                 'attr' => [
                     'class' => 'fr-select',
                 ],
-                'required' => true,
                 'disabled' => true,
                 'data' => 'ACTIVE',
-                'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de choisir un statut.'),
-                    new Assert\Choice(
-                        choices: [AutoAffectationRule::STATUS_ACTIVE, AutoAffectationRule::STATUS_ARCHIVED],
-                        message: 'Choisissez une option valide: ACTIVE or ARCHIVED'
-                    ),
-                ],
             ])
             ->add('parc', ChoiceType::class, [
                 'label' => 'Parc de logements concerné',
@@ -119,14 +96,6 @@ class AutoAffectationRuleType extends AbstractType
                 ],
                 'attr' => [
                     'class' => 'fr-select',
-                ],
-                'required' => true,
-                'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de renseigner le type de parc.'),
-                    new Assert\Choice(
-                        choices: ['all', 'prive', 'public', 'non_renseigne'],
-                        message: 'Choisissez une option valide: all, non_renseigne, prive ou public'
-                    ),
                 ],
             ])
             ->add('allocataire', ChoiceType::class, [
@@ -145,14 +114,6 @@ class AutoAffectationRuleType extends AbstractType
                 'attr' => [
                     'class' => 'fr-select',
                 ],
-                'required' => true,
-                'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de renseigner le profil d\'allocataire.'),
-                    new Assert\Choice(
-                        choices: ['all', 'non', 'oui', 'caf', 'msa'],
-                        message: 'Choisissez une option valide: all, non, oui, caf ou msa'
-                    ),
-                ],
             ])
             ->add('inseeToInclude', TextType::class, [
                 'label' => 'Code insee à inclure',
@@ -163,11 +124,6 @@ class AutoAffectationRuleType extends AbstractType
                 'help' => 'Valeurs possibles : "all", "partner_list" ou une liste de codes insee séparés par des virgules.',
                 'help_attr' => [
                     'class' => 'fr-hint-text',
-                ],
-                'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de renseigner les code insee des communes concernées.'),
-                    new Assert\Length(max: 255),
-                    new AppAssert\InseeToInclude(),
                 ],
             ])
             ->add('inseeToExclude', TextType::class, [
@@ -180,9 +136,6 @@ class AutoAffectationRuleType extends AbstractType
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],
-                'constraints' => [
-                    new AppAssert\InseeToExclude(),
-                ],
             ])
             ->add('partnerToExclude', TextType::class, [
                 'label' => 'IDs partenaire à exclure (facultatif)',
@@ -193,9 +146,6 @@ class AutoAffectationRuleType extends AbstractType
                 'help' => 'Une liste d\'id de partenaires séparés par des virgules.',
                 'help_attr' => [
                     'class' => 'fr-hint-text',
-                ],
-                'constraints' => [
-                    new AppAssert\PartnerToExclude(),
                 ],
             ])
         ;

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -83,7 +83,7 @@ class AutoAffectationRuleType extends AbstractType
                 ],
             ])
             ->add('status', ChoiceType::class, [
-                'label' => 'Status',
+                'label' => 'Statut',
                 'choices' => [
                     'Règle active' => 'ACTIVE',
                     'Règle archivée' => 'ARCHIVED',
@@ -98,7 +98,7 @@ class AutoAffectationRuleType extends AbstractType
                 'disabled' => true,
                 'data' => 'ACTIVE',
                 'constraints' => [
-                    new Assert\NotBlank(message: 'Merci de choisir un status.'),
+                    new Assert\NotBlank(message: 'Merci de choisir un statut.'),
                     new Assert\Choice(
                         choices: [AutoAffectationRule::STATUS_ACTIVE, AutoAffectationRule::STATUS_ARCHIVED],
                         message: 'Choisissez une option valide: ACTIVE or ARCHIVED'

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -20,15 +20,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class AutoAffectationRuleType extends AbstractType
 {
-    public function __construct()
-    {
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        /** @var AutoAffectationRule $autoAffectationRule */
-        $autoAffectationRule = $builder->getData();
-
         $builder
             ->add('territory', EntityType::class, [
                 'class' => Territory::class,

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\AutoAffectationRule;
+use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Territory;
+use App\Repository\TerritoryRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class AutoAffectationRuleType extends AbstractType
+{
+    public function __construct()
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var AutoAffectationRule $autoAffectationRule */
+        $autoAffectationRule = $builder->getData();
+
+        $builder
+            ->add('territory', EntityType::class, [
+                'class' => Territory::class,
+                'query_builder' => function (TerritoryRepository $tr) {
+                    return $tr->createQueryBuilder('t')->andWhere('t.isActive = 1')->orderBy('t.id', 'ASC');
+                },
+                'disabled' => !$options['create'],
+                'choice_label' => function (Territory $territory) {
+                    return $territory->getZip().' - '.$territory->getName();
+                },
+                'attr' => [
+                    'class' => 'fr-select',
+                ],
+                'row_attr' => [
+                    'class' => 'fr-input-group',
+                ],
+                'label' => 'Territoire',
+                'required' => true,
+            ])
+            ->add('partnerType', EnumType::class, [
+                'class' => PartnerType::class,
+                'choice_label' => function ($choice) {
+                    return $choice->label();
+                },
+                'disabled' => !$options['create'],
+                'row_attr' => [
+                    'class' => 'fr-select-group',
+                ],
+                'placeholder' => 'Sélectionner le type de partenaire concerné par cette règle',
+                'attr' => [
+                    'class' => 'fr-select',
+                ],
+            ])
+            ->add('profileDeclarant', ChoiceType::class, [
+                'choices' => ProfileDeclarant::getListWithGroup(),
+                'choice_label' => function ($choice) {
+                    return $choice;
+                },
+                'row_attr' => [
+                    'class' => 'fr-select-group',
+                ],
+                'placeholder' => 'Choisissez un profil de déclarant parmi la liste ci-dessous.',
+                'multiple' => false,
+                'expanded' => false,
+                'attr' => [
+                    'class' => 'fr-select',
+                ],
+                'required' => true,
+            ])
+            ->add('status', ChoiceType::class, [
+                'label' => 'Status',
+                'choices' => [
+                    'Règle active' => 'ACTIVE',
+                    'Règle archivée' => 'ARCHIVED',
+                ],
+                'row_attr' => [
+                    'class' => 'fr-select-group',
+                ],
+                'attr' => [
+                    'class' => 'fr-select',
+                ],
+                'required' => true,
+                'disabled' => true,
+                'data' => 'ACTIVE',
+            ])
+            ->add('parc', ChoiceType::class, [
+                'label' => 'Parc de logements concerné',
+                'choices' => [
+                    'Sélectionnez un type de parc' => '',
+                    'Tous les logements' => 'all',
+                    'Parc privé' => 'prive',
+                    'Parc public' => 'public',
+                    'Parc non renseigné' => 'non_renseigne',
+                ],
+                'row_attr' => [
+                    'class' => 'fr-select-group',
+                ],
+                'attr' => [
+                    'class' => 'fr-select',
+                ],
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de renseigner le type de parc.'),
+                ],
+                'required' => true,
+            ])
+            ->add('allocataire', ChoiceType::class, [
+                'label' => 'Allocataire',
+                'choices' => [
+                    'Sélectionnez quels profils d\'allocataire sont concernés' => '',
+                    'Tous' => 'all',
+                    'Tous les allocataires' => 'oui',
+                    'Tous les  non-allocataires' => 'non',
+                    'Allocataires CAF' => 'caf',
+                    'Allocataires MSA' => 'msa',
+                ],
+                'row_attr' => [
+                    'class' => 'fr-select-group',
+                ],
+                'attr' => [
+                    'class' => 'fr-select',
+                ],
+                'required' => true,
+            ])
+            ->add('inseeToInclude', TextType::class, [
+                'label' => 'Code insee à inclure',
+                'attr' => [
+                    'class' => 'fr-input',
+                ],
+                'required' => true,
+                'help' => 'Valeurs possibles : "all", "partner_list" ou une liste de codes insee séparés par des virgules.',
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
+            ])
+            ->add('inseeToExclude', TextType::class, [
+                'label' => 'Codes insee à exclure (facultatif)',
+                'attr' => [
+                    'class' => 'fr-input',
+                ],
+                'required' => false,
+                'help' => 'Une liste de codes insee séparés par des virgules.',
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
+            ])
+        ;
+        $builder->get('inseeToExclude')->addModelTransformer(new CallbackTransformer(
+            function ($tagsAsArray) {
+                // transform the array to a string
+                return null !== $tagsAsArray ? implode(',', $tagsAsArray) : null;
+            },
+            function ($tagsAsString) {
+                // transform the string back to an array
+                $pattern = '/(\s*,*\s*)*,+(\s*,*\s*)*/';
+
+                return null !== $tagsAsString ? preg_split($pattern, $tagsAsString, -1, \PREG_SPLIT_NO_EMPTY) : [];
+            }
+        ));
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => AutoAffectationRule::class,
+            'allow_extra_fields' => true,
+            'territory' => null,
+            'route' => null,
+            'create' => true,
+            'constraints' => [
+            ],
+        ]);
+    }
+}

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -7,6 +7,7 @@ use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Territory;
 use App\Repository\TerritoryRepository;
+use App\Validator as AppAssert;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -46,6 +47,9 @@ class AutoAffectationRuleType extends AbstractType
                 ],
                 'label' => 'Territoire',
                 'required' => true,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de choisir un territoire.'),
+                ],
             ])
             ->add('partnerType', EnumType::class, [
                 'class' => PartnerType::class,
@@ -59,6 +63,10 @@ class AutoAffectationRuleType extends AbstractType
                 'placeholder' => 'Sélectionner le type de partenaire concerné par cette règle',
                 'attr' => [
                     'class' => 'fr-select',
+                ],
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de choisir un partnerType.'),
+                    new AppAssert\ValidPartnerType(),
                 ],
             ])
             ->add('profileDeclarant', ChoiceType::class, [
@@ -76,6 +84,10 @@ class AutoAffectationRuleType extends AbstractType
                     'class' => 'fr-select',
                 ],
                 'required' => true,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de choisir un profil déclarant.'),
+                    new AppAssert\ValidProfileDeclarant(),
+                ],
             ])
             ->add('status', ChoiceType::class, [
                 'label' => 'Status',
@@ -92,6 +104,13 @@ class AutoAffectationRuleType extends AbstractType
                 'required' => true,
                 'disabled' => true,
                 'data' => 'ACTIVE',
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de choisir un status.'),
+                    new Assert\Choice(
+                        choices: [AutoAffectationRule::STATUS_ACTIVE, AutoAffectationRule::STATUS_ARCHIVED],
+                        message: 'Choisissez une option valide: ACTIVE or ARCHIVED'
+                    ),
+                ],
             ])
             ->add('parc', ChoiceType::class, [
                 'label' => 'Parc de logements concerné',
@@ -108,10 +127,14 @@ class AutoAffectationRuleType extends AbstractType
                 'attr' => [
                     'class' => 'fr-select',
                 ],
+                'required' => true,
                 'constraints' => [
                     new Assert\NotBlank(message: 'Merci de renseigner le type de parc.'),
+                    new Assert\Choice(
+                        choices: ['all', 'prive', 'public', 'non_renseigne'],
+                        message: 'Choisissez une option valide: all, non_renseigne, prive ou public'
+                    ),
                 ],
-                'required' => true,
             ])
             ->add('allocataire', ChoiceType::class, [
                 'label' => 'Allocataire',
@@ -130,6 +153,13 @@ class AutoAffectationRuleType extends AbstractType
                     'class' => 'fr-select',
                 ],
                 'required' => true,
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de renseigner le profil d\'allocataire.'),
+                    new Assert\Choice(
+                        choices: ['all', 'non', 'oui', 'caf', 'msa'],
+                        message: 'Choisissez une option valide: all, non, oui, caf ou msa'
+                    ),
+                ],
             ])
             ->add('inseeToInclude', TextType::class, [
                 'label' => 'Code insee à inclure',
@@ -141,6 +171,11 @@ class AutoAffectationRuleType extends AbstractType
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],
+                'constraints' => [
+                    new Assert\NotBlank(message: 'Merci de renseigner les code insee des communes concernées.'),
+                    new Assert\Length(max: 255),
+                    new AppAssert\InseeToInclude(),
+                ],
             ])
             ->add('inseeToExclude', TextType::class, [
                 'label' => 'Codes insee à exclure (facultatif)',
@@ -151,6 +186,9 @@ class AutoAffectationRuleType extends AbstractType
                 'help' => 'Une liste de codes insee séparés par des virgules.',
                 'help_attr' => [
                     'class' => 'fr-hint-text',
+                ],
+                'constraints' => [
+                    new AppAssert\InseeToExclude(),
                 ],
             ])
         ;

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -125,6 +125,7 @@ class AutoAffectationRuleType extends AbstractType
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],
+                'empty_data' => '',
             ])
             ->add('inseeToExclude', TextType::class, [
                 'label' => 'Codes insee à exclure (facultatif)',
@@ -156,7 +157,7 @@ class AutoAffectationRuleType extends AbstractType
             },
             function ($tagsAsString) {
                 // transform the string back to an array
-                $pattern = '/(\s*,*\s*)*,+(\s*,*\s*)*/';
+                $pattern = '/\s*,\s*/';
 
                 return null !== $tagsAsString ? preg_split($pattern, $tagsAsString, -1, \PREG_SPLIT_NO_EMPTY) : [];
             }
@@ -168,7 +169,7 @@ class AutoAffectationRuleType extends AbstractType
             },
             function ($tagsAsString) {
                 // transform the string back to an array
-                $pattern = '/(\s*,*\s*)*,+(\s*,*\s*)*/';
+                $pattern = '/\s*,\s*/';
 
                 return null !== $tagsAsString ? preg_split($pattern, $tagsAsString, -1, \PREG_SPLIT_NO_EMPTY) : [];
             }

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -184,8 +184,34 @@ class AutoAffectationRuleType extends AbstractType
                     new AppAssert\InseeToExclude(),
                 ],
             ])
+            ->add('partnerToExclude', TextType::class, [
+                'label' => 'IDs partenaire à exclure (facultatif)',
+                'attr' => [
+                    'class' => 'fr-input',
+                ],
+                'required' => false,
+                'help' => 'Une liste d\'id de partenaires séparés par des virgules.',
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
+                'constraints' => [
+                    new AppAssert\PartnerToExclude(),
+                ],
+            ])
         ;
         $builder->get('inseeToExclude')->addModelTransformer(new CallbackTransformer(
+            function ($tagsAsArray) {
+                // transform the array to a string
+                return null !== $tagsAsArray ? implode(',', $tagsAsArray) : null;
+            },
+            function ($tagsAsString) {
+                // transform the string back to an array
+                $pattern = '/(\s*,*\s*)*,+(\s*,*\s*)*/';
+
+                return null !== $tagsAsString ? preg_split($pattern, $tagsAsString, -1, \PREG_SPLIT_NO_EMPTY) : [];
+            }
+        ));
+        $builder->get('partnerToExclude')->addModelTransformer(new CallbackTransformer(
             function ($tagsAsArray) {
                 // transform the array to a string
                 return null !== $tagsAsArray ? implode(',', $tagsAsArray) : null;

--- a/src/Repository/AutoAffectationRuleRepository.php
+++ b/src/Repository/AutoAffectationRuleRepository.php
@@ -36,4 +36,24 @@ class AutoAffectationRuleRepository extends ServiceEntityRepository
 
         return new Paginator($queryBuilder->getQuery(), false);
     }
+
+    public function findForPartner(Partner $partner): array
+    {
+        $territory = $partner->getTerritory();
+        $partnerType = $partner->getType();
+        $status = AutoAffectationRule::STATUS_ACTIVE;
+        $partnerToExclude = $partner->getId();
+
+        return $this->createQueryBuilder('aar')
+            ->andWhere('aar.territory = :territory')
+            ->andWhere('aar.partnerType = :partnerType')
+            ->andWhere('aar.status = :status')
+            ->andWhere('JSON_CONTAINS(aar.partnerToExclude, :partnerToExclude) = 0')
+            ->setParameter('territory', $territory)
+            ->setParameter('partnerType', $partnerType)
+            ->setParameter('status', $status)
+            ->setParameter('partnerToExclude', json_encode((string) $partnerToExclude))
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/AutoAffectationRuleRepository.php
+++ b/src/Repository/AutoAffectationRuleRepository.php
@@ -3,7 +3,10 @@
 namespace App\Repository;
 
 use App\Entity\AutoAffectationRule;
+use App\Entity\Partner;
+use App\Entity\Territory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -14,5 +17,25 @@ class AutoAffectationRuleRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, AutoAffectationRule::class);
+    }
+
+    public function getAutoAffectationRules(
+        Territory|null $territory,
+        $page
+    ): Paginator {
+        $maxResult = Partner::MAX_LIST_PAGINATION;
+        $firstResult = ($page - 1) * $maxResult;
+
+        $queryBuilder = $this->createQueryBuilder('aar');
+
+        if ($territory) {
+            $queryBuilder->andWhere('aar.territory = :territory')->setParameter('territory', $territory);
+        }
+
+        $queryBuilder->setFirstResult($firstResult)->setMaxResults($maxResult);
+
+        $paginator = new Paginator($queryBuilder->getQuery(), false);
+
+        return $paginator;
     }
 }

--- a/src/Repository/AutoAffectationRuleRepository.php
+++ b/src/Repository/AutoAffectationRuleRepository.php
@@ -34,8 +34,6 @@ class AutoAffectationRuleRepository extends ServiceEntityRepository
 
         $queryBuilder->setFirstResult($firstResult)->setMaxResults($maxResult);
 
-        $paginator = new Paginator($queryBuilder->getQuery(), false);
-
-        return $paginator;
+        return new Paginator($queryBuilder->getQuery(), false);
     }
 }

--- a/src/Repository/TerritoryRepository.php
+++ b/src/Repository/TerritoryRepository.php
@@ -58,4 +58,14 @@ class TerritoryRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getSingleScalarResult();
     }
+
+    public function findAllWithAutoAffectationRules(): array
+    {
+        $qb = $this->createQueryBuilder('t')
+            ->innerJoin('t.autoAffectationRules', 'aar')
+            ->addSelect('aar')
+            ->orderBy('t.zip', 'ASC');
+
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -17,6 +17,7 @@ use App\Messenger\InterconnectionBus;
 use App\Specification\Affectation\AllocataireSpecification;
 use App\Specification\Affectation\CodeInseeSpecification;
 use App\Specification\Affectation\ParcSpecification;
+use App\Specification\Affectation\PartnerExcludeSpecification;
 use App\Specification\Affectation\PartnerTypeSpecification;
 use App\Specification\Affectation\ProfilDeclarantSpecification;
 use App\Specification\AndSpecification;
@@ -56,6 +57,7 @@ class AutoAssigner
                     new ProfilDeclarantSpecification($rule->getProfileDeclarant()),
                     new PartnerTypeSpecification($rule->getPartnerType()),
                     new CodeInseeSpecification($rule->getInseeToInclude(), $rule->getInseeToExclude()),
+                    new PartnerExcludeSpecification($rule->getPartnerToExclude()),
                     new ParcSpecification($rule->getParc()),
                     new AllocataireSpecification($rule->getAllocataire()),
                 );

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -63,6 +63,9 @@ class AutoAssigner
                 );
 
                 foreach ($partners as $partner) {
+                    if ($partner->getIsArchive()) {
+                        continue;
+                    }
                     $context = new PartnerSignalementContext($partner, $signalement);
                     if ($specification->isSatisfiedBy($context)) {
                         $assignablePartners[] = $partner;

--- a/src/Specification/Affectation/PartnerExcludeSpecification.php
+++ b/src/Specification/Affectation/PartnerExcludeSpecification.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Specification\Affectation;
+
+use App\Entity\Partner;
+use App\Entity\Signalement;
+use App\Specification\Context\PartnerSignalementContext;
+use App\Specification\Context\SpecificationContextInterface;
+use App\Specification\SpecificationInterface;
+
+class PartnerExcludeSpecification implements SpecificationInterface
+{
+    public function __construct(private array|string $partnerToExclude)
+    {
+        $this->partnerToExclude = $partnerToExclude;
+    }
+
+    public function isSatisfiedBy(SpecificationContextInterface $context): bool
+    {
+        if (!$context instanceof PartnerSignalementContext) {
+            return false;
+        }
+
+        /** @var Partner $partner */
+        $partner = $context->getPartner();
+
+        if (!empty($this->partnerToExclude) && \in_array($partner->getId(), $this->partnerToExclude)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Specification/Affectation/PartnerExcludeSpecification.php
+++ b/src/Specification/Affectation/PartnerExcludeSpecification.php
@@ -3,7 +3,6 @@
 namespace App\Specification\Affectation;
 
 use App\Entity\Partner;
-use App\Entity\Signalement;
 use App\Specification\Context\PartnerSignalementContext;
 use App\Specification\Context\SpecificationContextInterface;
 use App\Specification\SpecificationInterface;

--- a/src/Validator/InseeToExclude.php
+++ b/src/Validator/InseeToExclude.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class InseeToExclude extends Constraint
+{
+    public $message = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.';
+
+    public function getTargets(): string
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+}

--- a/src/Validator/InseeToExcludeValidator.php
+++ b/src/Validator/InseeToExcludeValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class InseeToExcludeValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof InseeToExclude) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\InseeToExclude');
+        }
+        /* @var InseeToExclude $constraint */
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        foreach ($value as $code) {
+            if (!preg_match('/^\d{5}$/', trim($code))) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', implode(',', $value))
+                    ->addViolation();
+
+                return;
+            }
+        }
+    }
+}

--- a/src/Validator/InseeToInclude.php
+++ b/src/Validator/InseeToInclude.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class InseeToInclude extends Constraint
+{
+    public $message = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.';
+
+    public function getTargets(): string
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+}

--- a/src/Validator/InseeToIncludeValidator.php
+++ b/src/Validator/InseeToIncludeValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class InseeToIncludeValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof InseeToInclude) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\InseeToInclude');
+        }
+        /* @var InseeToInclude $constraint */
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (\in_array($value, ['all', 'partner_list'], true)) {
+            return;
+        }
+
+        $inseeCodes = explode(',', $value);
+        foreach ($inseeCodes as $code) {
+            if (!preg_match('/^\d{5}$/', trim($code))) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $value)
+                    ->addViolation();
+
+                return;
+            }
+        }
+    }
+}

--- a/src/Validator/PartnerToExclude.php
+++ b/src/Validator/PartnerToExclude.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class PartnerToExclude extends Constraint
+{
+    public $message = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste d\'Id partenaires séparés par des virgules ou vide.';
+
+    public function getTargets(): string
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+}

--- a/src/Validator/PartnerToExcludeValidator.php
+++ b/src/Validator/PartnerToExcludeValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class PartnerToExcludeValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof PartnerToExclude) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\PartnerToExclude');
+        }
+        /* @var PartnerToExclude $constraint */
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        foreach ($value as $code) {
+            if (!preg_match('/^\d*$/', trim($code))) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', implode(',', $value))
+                    ->addViolation();
+
+                return;
+            }
+        }
+    }
+}

--- a/templates/back/auto-affectation-rule/_form.html.twig
+++ b/templates/back/auto-affectation-rule/_form.html.twig
@@ -40,11 +40,7 @@
 
 <div class="fr-grid-row">
 	<div class="fr-col-6">
-		{% if create %}
-			<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_auto_affectation_rule_index') }}">Annuler</a>
-		{% else %}
-			<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_auto_affectation_rule_index') }}">Annuler</a>
-		{% endif %}
+		<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_auto_affectation_rule_index') }}">Annuler</a>
 	</div>
 	<div class="fr-col-6 fr-text--right">
 		{% if create %}

--- a/templates/back/auto-affectation-rule/_form.html.twig
+++ b/templates/back/auto-affectation-rule/_form.html.twig
@@ -1,0 +1,57 @@
+{{ form_start(form,{attr:{'class':'needs-validation','novalidate':true}}) }}
+
+<div class="fr-grid-row fr-grid-row--gutters">
+	<div class="fr-col-6">
+		{{ form_row(form.territory,{}) }}
+	</div>
+	<div class="fr-col-6">
+		{{ form_row(form.partnerType,{}) }}
+	</div>
+</div>
+
+<div class="fr-grid-row fr-grid-row--gutters">
+	<div class="fr-col-6">
+		{{ form_row(form.status,{}) }}
+	</div>
+	<div class="fr-col-6">
+		{{ form_row(form.profileDeclarant,{}) }}
+	</div>
+</div>
+
+<div class="fr-grid-row fr-grid-row--gutters">
+	<div class="fr-col-6">
+		{{ form_row(form.parc,{}) }}
+	</div>
+	<div class="fr-col-6">
+		{{ form_row(form.allocataire,{}) }}
+	</div>
+</div>
+
+<div class="fr-grid-row fr-grid-row--gutters">
+	<div class="fr-col-6">
+		{{ form_row(form.inseeToInclude,{}) }}
+	</div>
+	<div class="fr-col-6">
+		{{ form_row(form.inseeToExclude,{}) }}
+	</div>
+</div>
+
+
+
+<div class="fr-grid-row">
+	<div class="fr-col-6">
+		{% if create %}
+			<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_auto_affectation_rule_index') }}">Annuler</a>
+		{% else %}
+			<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_auto_affectation_rule_index') }}">Annuler</a>
+		{% endif %}
+	</div>
+	<div class="fr-col-6 fr-text--right">
+		{% if create %}
+			<button class="fr-btn fr-btn--success fr-fi-check-line fr-btn--icon-left" id="submit_btn_autoaffectationrule">Créer la règle d'auto-affectation</button>
+		{% else %}
+			<button class="fr-btn fr-btn--success fr-fi-check-line fr-btn--icon-left" id="submit_btn_autoaffectationrule">Enregistrer</button>
+		{% endif %}
+	</div>
+</div>
+{{ form_end(form) }}

--- a/templates/back/auto-affectation-rule/_form.html.twig
+++ b/templates/back/auto-affectation-rule/_form.html.twig
@@ -36,9 +36,15 @@
 	</div>
 </div>
 
+<div class="fr-grid-row fr-grid-row--gutters">
+	<div class="fr-col-6">
+		{{ form_row(form.partnerToExclude,{}) }}
+	</div>
+</div>
 
 
-<div class="fr-grid-row">
+
+<div class="fr-grid-row fr-mt-3v">
 	<div class="fr-col-6">
 		<a class="fr-btn fr-btn--danger fr-fi-close-line fr-btn--icon-left" href="{{ path('back_auto_affectation_rule_index') }}">Annuler</a>
 	</div>

--- a/templates/back/auto-affectation-rule/_modal_autoaffectationrule_delete.html.twig
+++ b/templates/back/auto-affectation-rule/_modal_autoaffectationrule_delete.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="fr-autoaffectationrule-delete-title" id="fr-modal-autoaffectationrule-delete" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-autoaffectationrule-delete-title" id="fr-modal-autoaffectationrule-delete" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/templates/back/auto-affectation-rule/_modal_autoaffectationrule_delete.html.twig
+++ b/templates/back/auto-affectation-rule/_modal_autoaffectationrule_delete.html.twig
@@ -1,0 +1,43 @@
+<dialog aria-labelledby="fr-autoaffectationrule-delete-title" id="fr-modal-autoaffectationrule-delete" class="fr-modal" role="dialog">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <h1 id="fr-modal-autoaffectationrule-delete-title" class="fr-modal__title">
+                            <span class="fr-fi-arrow-right-line" aria-hidden="true"></span>
+                            Suppression d'une règle d'auto-affectation 
+                        </h1>   
+                       <button class="fr-link--close fr-link" aria-controls="fr-modal-autoaffectationrule-delete">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <form action="{{ path('back_auto_affectation_rule_delete') }}" name="autoaffectationrule_delete"
+                              id="autoaffectationrule_delete_form" method="POST">
+                            <div>
+                                Vous êtes sur le point de supprimer la <span class="fr-modal-autoaffectationrule-delete-description"></span> 
+                            </div>
+                            <input type="hidden" name="autoaffectationrule_id" id="fr-modal-autoaffectationrule-delete-id">
+                            <input type="hidden" name="_token" value="{{ csrf_token('autoaffectationrule_delete') }}">
+                        </form>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button class="fr-btn" form="autoaffectationrule_delete_form"
+                                        id="autoaffectationrule_delete_form_submit">
+                                    Oui, supprimer
+                                </button>
+                            </li>
+                            <li>
+                                <button class="fr-btn fr-btn--secondary"
+                                        aria-controls="fr-modal-autoaffectationrule-delete">
+                                    Non, annuler
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/back/auto-affectation-rule/edit.html.twig
+++ b/templates/back/auto-affectation-rule/edit.html.twig
@@ -1,0 +1,24 @@
+{% extends 'back/base_bo.html.twig' %}
+
+{% block title %}Règle d'auto-affectation{% endblock %}
+
+{% block content %}
+    <section class="fr-col-12 fr-p-5v">
+        {% if create %}
+            <h2 class="fr-h2 fr-mb-0"> Ajouter une règle d'auto-affectation </h2>
+            <span>Remplissez le formulaire ci-dessous pour créer une règle d'auto-affectation.</span><br>
+            <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
+                
+        {% else %}
+            <h2 class="fr-h2 fr-mb-0"> Modifier la règle d'auto-affectation : {{ autoAffectationRule.description }} </h2>
+            <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
+        {% endif %}
+        <div class="fr-pt-5v">
+            {{ include('back/auto-affectation-rule/_form.html.twig') }}
+        </div>
+    </section>
+{% endblock %}
+{% block javascripts %}
+    {{ encore_entry_script_tags('app') }}
+{% endblock %}
+

--- a/templates/back/auto-affectation-rule/edit.html.twig
+++ b/templates/back/auto-affectation-rule/edit.html.twig
@@ -6,13 +6,11 @@
     <section class="fr-col-12 fr-p-5v">
         {% if create %}
             <h2 class="fr-h2 fr-mb-0"> Ajouter une règle d'auto-affectation </h2>
-            <span>Remplissez le formulaire ci-dessous pour créer une règle d'auto-affectation.</span><br>
-            <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
-                
+            <span>Remplissez le formulaire ci-dessous pour créer une règle d'auto-affectation.</span><br>                
         {% else %}
             <h2 class="fr-h2 fr-mb-0"> Modifier la règle d'auto-affectation : {{ autoAffectationRule.description }} </h2>
-            <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
         {% endif %}
+        <span>Tous les champs sont obligatoires, sauf mention contraire.</span>
         <div class="fr-pt-5v">
             {{ include('back/auto-affectation-rule/_form.html.twig') }}
         </div>

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -88,7 +88,7 @@
                                         {% endif %}
                                     </td>
                                     <td class="fr-text--right">
-                                        <a class="fr-btn fr-btn--icon-left fr-btn--sm fr-fi-edit-line" href="{{ path('back_auto_affectation_rule_edit', {'id': autoaffectationrule.id}) }}"></a>
+                                        <a class="fr-btn fr-btn--sm fr-fi-edit-line" href="{{ path('back_auto_affectation_rule_edit', {'id': autoaffectationrule.id}) }}"></a>
                                         {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
                                             <a href="#" class="fr-btn fr-btn--danger fr-btn--sm fr-fi-delete-line fr-mt-3v btn-delete-autoaffectationrule"
                                             id="autoaffectationrule_delete_{{ autoaffectationrule.id }}" aria-controls="fr-modal-autoaffectationrule-delete"

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -1,0 +1,121 @@
+{% extends 'back/base_bo.html.twig' %}
+
+{% block title %}Règles d'auto-affectation{% endblock %}
+
+{% block content %}
+    {% if is_granted('ROLE_ADMIN') %}
+    {% include 'back/auto-affectation-rule/_modal_autoaffectationrule_delete.html.twig' %}
+    <section class="fr-p-5v">
+        <header>
+            <div class="fr-grid-row">
+                <div class="fr-col-6 fr-text--left">
+                    <h1 class="fr-h1 fr-mb-0">Règles d'auto-affectation</h1>
+                </div>
+                <div class="fr-col-6 fr-text--right">
+                    <a class="fr-btn fr-btn--success fr-btn--icon-left fr-btn--md fr-fi-add-circle-line" href="{{ path('back_auto_affectation_rule_new') }}"
+                        >Ajouter une règle d'auto-affection</a>
+                </div>
+            </div>
+        </header>
+    </section>
+    <section class="fr-container--fluid">
+        <form action="#" name="bo-filters-form" id="bo_filters_form" method="POST"
+              class="fr-background--grey fr-p-2v fr-grid-row fr-grid-row--bottom">
+              
+            <div class="fr-col-3 fr-p-2v">
+                <select id="bo-filters-territories" class="fr-select fr-select-submit" name="territory">
+                    <option value="" {{ currentTerritory is null ? 'selected' : '' }}>Tous les territoires</option>
+                    {% for territory in territories %}
+                        <option value="{{ territory.id }}" {{ currentTerritory ? (territory.id == currentTerritory.id ? 'selected' : '') : ''  }}>{{ territory.zip ~ ' - ' ~ territory.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </form>
+    </section>
+    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
+        <h2 class="fr-h2 fr-mb-0" id="desc-table">{{total}} règles d'auto-affectation</h2>
+    </section>    
+    <section class="fr-col-12 fr-table fr-table--lg fr-pt-0 fr-px-5v">
+		<div class="fr-table__wrapper">
+			<div class="fr-table__container">
+				<div class="fr-table__content">
+                    <table class="fr-display-inline-table fr-cell--multiline sortable" aria-label="Liste des règles d'auto-affectation">
+                        <thead>
+                        <tr>
+                            <th scope="col">Territoire</th>
+                            <th scope="col">Statut</th>
+                            <th scope="col">Type de partenaire</th>
+                            <th scope="col">Profil déclarant</th>
+                            <th scope="col">Parc</th>
+                            <th scope="col">Allocataire</th>
+                            <th scope="col">Code insee inclus</th>
+                            <th scope="col">Code insee exclus</th>
+                            <th scope="col" class="fr-text--right">Actions</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            {% for autoaffectationrule in autoaffectationrules %}
+                                <tr class="autoaffectationrule-row">
+                                    <td>{{ autoaffectationrule.territory.zip}} - {{ autoaffectationrule.territory.name}}</td>
+                                    <td>
+                                        {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
+                                            {% set classe = 'fr-badge--green-emeraude' %}
+                                        {% else %}
+                                            {% set classe = 'fr-badge--blue-ecume' %}
+                                        {% endif %}
+                                        <span class="fr-badge {{ classe }} fr-mb-1v">{{ autoaffectationrule.status  }}</span></td>
+                                    </td>
+                                    <td>{{ autoaffectationrule.partnerType.label }}</td>
+                                    <td>{{ autoaffectationrule.profileDeclarant }}</td>
+                                    <td>{{ autoaffectationrule.parc }}</td>
+                                    <td>{{ autoaffectationrule.allocataire }}</td>
+                                    <td>
+                                        {% if autoaffectationrule.inseeToInclude is same as('all') or autoaffectationrule.inseeToInclude is same as('partner_list') %}
+                                            {{ autoaffectationrule.inseeToInclude }}
+                                        {% else %}
+                                            {% for insee in autoaffectationrule.inseeToInclude|split(',') %}
+                                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
+                                            {% endfor %}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if autoaffectationrule.inseeToExclude %}
+                                            {% for insee in autoaffectationrule.inseeToExclude %}
+                                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
+                                            {% endfor %}
+                                        {% else %}
+                                            /
+                                        {% endif %}
+                                    </td>
+                                    <td class="fr-text--right">
+                                        <a class="fr-btn fr-btn--icon-left fr-btn--sm fr-fi-edit-line" href="{{ path('back_auto_affectation_rule_edit', {'id': autoaffectationrule.id}) }}"></a>
+                                        {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
+                                            <a href="#" class="fr-btn fr-btn--danger fr-btn--sm fr-fi-delete-line fr-mt-3v btn-delete-autoaffectationrule"
+                                            id="autoaffectationrule_delete_{{ autoaffectationrule.id }}" aria-controls="fr-modal-autoaffectationrule-delete"
+                                            data-fr-opened="false" data-autoaffectationrule-id="{{ autoaffectationrule.id }}" data-autoaffectationrule-description="{{ autoaffectationrule.description }}"></a>
+                                        {% else %}
+                                            <a href="{{ path('back_auto_affectation_rule_reactive', {'id': autoaffectationrule.id}) }}"
+                                                class="fr-btn fr-icon-flashlight-fill fr-btn--sm fr-mt-3v" title="Réactiver la règle {{autoaffectationrule.id}}"></a>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                            {% else %}
+                                <tr>
+                                    <td colspan="3">Aucune règle d'auto-affectation trouvée</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+				</div>
+			</div>
+		</div>
+        <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
+            {% import '_partials/macros.html.twig' as macros %}
+            {{ macros.customPagination(pages, page, 'back_auto_affectation_rule_index', {territory: (currentTerritory ? currentTerritory.id :  null)}) }}
+        </div>
+    </section>
+    {% endif %}
+{% endblock %}
+{% block javascripts %}
+    {{ encore_entry_script_tags('app') }}
+{% endblock %}

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -90,9 +90,9 @@
                                     <td class="fr-text--right">
                                         <a class="fr-btn fr-btn--sm fr-fi-edit-line" href="{{ path('back_auto_affectation_rule_edit', {'id': autoaffectationrule.id}) }}"></a>
                                         {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
-                                            <a href="#" class="fr-btn fr-btn--danger fr-btn--sm fr-fi-delete-line fr-mt-3v btn-delete-autoaffectationrule"
+                                            <button class="fr-btn fr-btn--danger fr-btn--sm fr-fi-delete-line fr-mt-3v btn-delete-autoaffectationrule"
                                             id="autoaffectationrule_delete_{{ autoaffectationrule.id }}" aria-controls="fr-modal-autoaffectationrule-delete"
-                                            data-fr-opened="false" data-autoaffectationrule-id="{{ autoaffectationrule.id }}" data-autoaffectationrule-description="{{ autoaffectationrule.description }}"></a>
+                                            data-fr-opened="false" data-autoaffectationrule-id="{{ autoaffectationrule.id }}" data-autoaffectationrule-description="{{ autoaffectationrule.description }}"></button>
                                         {% else %}
                                             <a href="{{ path('back_auto_affectation_rule_reactive', {'id': autoaffectationrule.id}) }}"
                                                 class="fr-btn fr-icon-flashlight-fill fr-btn--sm fr-mt-3v" title="Réactiver la règle {{autoaffectationrule.id}}"></a>

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -50,6 +50,7 @@
                             <th scope="col">Allocataire</th>
                             <th scope="col">Code insee inclus</th>
                             <th scope="col">Code insee exclus</th>
+                            <th scope="col">Id partenaires exclus</th>
                             <th scope="col" class="fr-text--right">Actions</th>
                         </tr>
                         </thead>
@@ -82,6 +83,15 @@
                                         {% if autoaffectationrule.inseeToExclude %}
                                             {% for insee in autoaffectationrule.inseeToExclude %}
                                                 <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
+                                            {% endfor %}
+                                        {% else %}
+                                            /
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if autoaffectationrule.partnerToExclude %}
+                                            {% for idPartner in autoaffectationrule.partnerToExclude %}
+                                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ idPartner }}</div>
                                             {% endfor %}
                                         {% else %}
                                             /

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -71,7 +71,7 @@
                     </ul>
                 </div>
                 {% if is_granted('ROLE_ADMIN_PARTNER') %}
-                    {% set routesAdmin = ['back_user_report_index', 'back_situation_', 'back_partner_', 'back_account_', 'back_inactive_account_', 'back_expired_account_', 'back_archived_partner', 'back_archived_signalements_index'] %}
+                    {% set routesAdmin = ['back_user_report_index', 'back_situation_', 'back_partner_', 'back_account_', 'back_inactive_account_', 'back_expired_account_', 'back_archived_partner', 'back_archived_signalements_index', 'back_auto_affectation'] %}
                     <button class="fr-sidemenu__btn"
                             aria-expanded="{% if routesAdmin|filter(route => app.request.get('_route') starts with route)|length > 0  %}true{% else %}false{% endif %}"
                             aria-controls="fr-sidemenu-outils-admin">Outils Admin
@@ -108,15 +108,20 @@
                                         target="_self"
                                         {% if 'back_inactive_account_' in app.request.get('_route') %}aria-current="page"{% endif %}>Comptes inactifs</a>
                                     </li>
-                                    <li class="fr-sidemenu__item {% if 'back_inactive_account_' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
+                                    <li class="fr-sidemenu__item {% if 'back_expired_account_' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
                                         <a class="fr-sidemenu__link" href="{{ path('back_expired_account_index') }}"
                                         target="_self"
                                         {% if 'back_expired_account_' in app.request.get('_route') %}aria-current="page"{% endif %}>Comptes expirés</a>
                                     </li>
-                                    <li class="fr-sidemenu__item {% if 'back_inactive_account_' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
+                                    <li class="fr-sidemenu__item {% if 'back_archived_signalements' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
                                         <a class="fr-sidemenu__link" href="{{ path('back_archived_signalements_index') }}"
                                         target="_self"
                                         {% if 'back_archived_signalements' in app.request.get('_route') %}aria-current="page"{% endif %}>Signalements archivés</a>
+                                    </li>
+                                    <li class="fr-sidemenu__item {% if 'back_auto_affectation' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
+                                        <a class="fr-sidemenu__link" href="{{ path('back_auto_affectation_rule_index') }}"
+                                        target="_self"
+                                        {% if 'back_auto_affectation' in app.request.get('_route') %}aria-current="page"{% endif %}>Règles d'auto-affectation</a>
                                     </li>
                                 {% endif %}
                             {% endif %}

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -23,6 +23,16 @@
                         le partenaire</a>
                 </div>
             </div>
+        {% if is_granted('ROLE_ADMIN') %}
+            {% if partnerAutoAffectationRules|length > 0 %}
+                <span>Règles d'auto-affectation concernant ce partenaire</span>
+                <ul>
+                {% for partnerAutoAffectationRule in partnerAutoAffectationRules %}
+                    <li>{{ partnerAutoAffectationRule.description(false)}}</li>
+                {% endfor %}
+                </ul>
+            {% endif %}
+        {% endif %}            
         </header>
     </section>
     <section class="fr-p-5v">

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -23,15 +23,13 @@
                         le partenaire</a>
                 </div>
             </div>
-        {% if is_granted('ROLE_ADMIN') %}
-            {% if partnerAutoAffectationRules|length > 0 %}
-                <span>Règles d'auto-affectation concernant ce partenaire</span>
-                <ul>
-                {% for partnerAutoAffectationRule in partnerAutoAffectationRules %}
-                    <li>{{ partnerAutoAffectationRule.description(false)}}</li>
-                {% endfor %}
-                </ul>
-            {% endif %}
+        {% if is_granted('ROLE_ADMIN') and partnerAutoAffectationRules|length > 0 %}
+            <span>Règles d'auto-affectation concernant ce partenaire</span>
+            <ul>
+            {% for partnerAutoAffectationRule in partnerAutoAffectationRules %}
+                <li>{{ partnerAutoAffectationRule.description(false)}}</li>
+            {% endfor %}
+            </ul>
         {% endif %}            
         </header>
     </section>

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -498,6 +498,7 @@ trait FixturesHelper
             ->setAllocataire('oui')
             ->setInseeToInclude('partner_list')
             ->setInseeToExclude(null)
+            ->setPartnerToExclude([])
             ->setStatus(AutoAffectationRule::STATUS_ACTIVE);
     }
 }

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -3,6 +3,7 @@
 namespace App\Tests;
 
 use App\Entity\Affectation;
+use App\Entity\AutoAffectationRule;
 use App\Entity\Critere;
 use App\Entity\Criticite;
 use App\Entity\Enum\InterventionType;
@@ -485,5 +486,18 @@ trait FixturesHelper
             'informations_complementaires_situation_occupants_beneficiaire_fsl' => 'non',
             'informations_complementaires_situation_occupants_beneficiaire_rsa' => 'non',
         ];
+    }
+
+    public function getAutoAffectationRule(
+    ): AutoAffectationRule {
+        return (new AutoAffectationRule())
+            ->setTerritory($this->getTerritory())
+            ->setPartnerType(PartnerType::CAF_MSA)
+            ->setProfileDeclarant('all')
+            ->setParc('prive')
+            ->setAllocataire('oui')
+            ->setInseeToInclude('partner_list')
+            ->setInseeToExclude(null)
+            ->setStatus(AutoAffectationRule::STATUS_ACTIVE);
     }
 }

--- a/tests/Functional/Command/AddAutoAffectationRuleCommandTest.php
+++ b/tests/Functional/Command/AddAutoAffectationRuleCommandTest.php
@@ -23,6 +23,7 @@ class AddAutoAffectationRuleCommandTest extends KernelTestCase
         $profileDeclarant = 'occupant';
         $inseeToInclude = 'partner_list';
         $inseeToExclude = '44850,44600';
+        $partnerToExclude = '';
         $parc = 'public';
         $allocataire = 'caf';
         $commandTester->execute([
@@ -32,6 +33,7 @@ class AddAutoAffectationRuleCommandTest extends KernelTestCase
             'profileDeclarant' => $profileDeclarant,
             'inseeToInclude' => $inseeToInclude,
             'inseeToExclude' => $inseeToExclude,
+            'partnerToExclude' => $partnerToExclude,
             'parc' => $parc,
             'allocataire' => $allocataire,
         ]);
@@ -57,6 +59,7 @@ class AddAutoAffectationRuleCommandTest extends KernelTestCase
         $profileDeclarant = 'occupant';
         $inseeToInclude = 'partner_list';
         $inseeToExclude = '44850,44600';
+        $partnerToExclude = '';
         $parc = 'public';
         $allocataire = 'caf';
         $commandTester->execute([
@@ -66,6 +69,7 @@ class AddAutoAffectationRuleCommandTest extends KernelTestCase
             'profileDeclarant' => $profileDeclarant,
             'inseeToInclude' => $inseeToInclude,
             'inseeToExclude' => $inseeToExclude,
+            'partnerToExclude' => $partnerToExclude,
             'parc' => $parc,
             'allocataire' => $allocataire,
         ]);

--- a/tests/Functional/Command/AddAutoAffectationRuleCommandTest.php
+++ b/tests/Functional/Command/AddAutoAffectationRuleCommandTest.php
@@ -53,7 +53,7 @@ class AddAutoAffectationRuleCommandTest extends KernelTestCase
 
         $commandTester = new CommandTester($command);
 
-        $territory = 44;
+        $territory = 440;
         $partnerType = 'EPCI';
         $status = 'ACTIVE';
         $profileDeclarant = 'occupant';
@@ -75,6 +75,6 @@ class AddAutoAffectationRuleCommandTest extends KernelTestCase
         ]);
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('There is already a rule for this territory and this type of partner', $output);
+        $this->assertStringContainsString('Territory does not exists', $output);
     }
 }

--- a/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
@@ -54,6 +54,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
                 'auto_affectation_rule[allocataire]' => 'oui',
                 'auto_affectation_rule[inseeToInclude]' => 'all',
                 'auto_affectation_rule[inseeToExclude]' => '',
+                'auto_affectation_rule[partnerToExclude]' => '',
             ]
         );
 
@@ -78,6 +79,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
                 'auto_affectation_rule[allocataire]' => 'oui',
                 'auto_affectation_rule[inseeToInclude]' => 'all',
                 'auto_affectation_rule[inseeToExclude]' => '',
+                'auto_affectation_rule[partnerToExclude]' => '',
             ]
         );
 

--- a/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\AutoAffectationRule;
+use App\Entity\Enum\PartnerType;
+use App\Repository\AutoAffectationRuleRepository;
+use App\Repository\UserRepository;
+use App\Tests\SessionHelper;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class AutoAffectationRuleControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    private ?KernelBrowser $client = null;
+    private UserRepository $userRepository;
+    private AutoAffectationRuleRepository $autoAffectationRuleRepository;
+    private RouterInterface $router;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->userRepository = static::getContainer()->get(UserRepository::class);
+        $this->router = self::getContainer()->get(RouterInterface::class);
+        $this->autoAffectationRuleRepository = static::getContainer()->get(AutoAffectationRuleRepository::class);
+
+        $user = $this->userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $this->client->loginUser($user);
+    }
+
+    public function testAutoAffectationRulesSuccessfullyDisplay()
+    {
+        $route = $this->router->generate('back_auto_affectation_rule_index');
+        $this->client->request('GET', $route);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testAutoAffectationRuleFormSubmit(): void
+    {
+        $route = $this->router->generate('back_auto_affectation_rule_new');
+        $this->client->request('GET', $route);
+
+        $this->client->submitForm(
+            'Créer la règle d\'auto-affectation',
+            [
+                'auto_affectation_rule[territory]' => 1,
+                'auto_affectation_rule[partnerType]' => PartnerType::ARS->value,
+                'auto_affectation_rule[profileDeclarant]' => 'occupant',
+                'auto_affectation_rule[parc]' => 'all',
+                'auto_affectation_rule[allocataire]' => 'oui',
+                'auto_affectation_rule[inseeToInclude]' => 'all',
+                'auto_affectation_rule[inseeToExclude]' => '',
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/auto-affectation/');
+    }
+
+    public function testAutoAffectationRuleEditFormSubmit(): void
+    {
+        /** @var AutoAffectationRule $autoAffectationRule */
+        $autoAffectationRule = $this->autoAffectationRuleRepository->findOneBy(['territory' => 94]);
+
+        $route = $this->router->generate('back_auto_affectation_rule_edit', ['id' => $autoAffectationRule->getId()]);
+        $this->client->request('GET', $route);
+
+        $this->client->submitForm(
+            'Enregistrer',
+            [
+                'auto_affectation_rule[territory]' => 94,
+                'auto_affectation_rule[partnerType]' => PartnerType::ARS->value,
+                'auto_affectation_rule[profileDeclarant]' => 'occupant',
+                'auto_affectation_rule[parc]' => 'all',
+                'auto_affectation_rule[allocataire]' => 'oui',
+                'auto_affectation_rule[inseeToInclude]' => 'all',
+                'auto_affectation_rule[inseeToExclude]' => '',
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/auto-affectation/');
+    }
+
+    public function testDeleteAutoAffectationRule()
+    {
+        /** @var AutoAffectationRule $autoAffectationRule */
+        $autoAffectationRule = $this->autoAffectationRuleRepository->findOneBy(['territory' => 94]);
+
+        $route = $this->router->generate('back_auto_affectation_rule_delete');
+        $this->client->request(
+            'POST',
+            $route,
+            [
+                'autoaffectationrule_id' => $autoAffectationRule->getId(),
+                '_token' => $this->generateCsrfToken($this->client, 'autoaffectationrule_delete'),
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/auto-affectation/');
+        $this->assertEquals(AutoAffectationRule::STATUS_ARCHIVED, $autoAffectationRule->getStatus());
+    }
+
+    public function testReactiveAutoAffectationRule()
+    {
+        /** @var AutoAffectationRule $autoAffectationRule */
+        $autoAffectationRule = $this->autoAffectationRuleRepository->findOneBy(['territory' => 45]);
+        $this->assertEquals(AutoAffectationRule::STATUS_ARCHIVED, $autoAffectationRule->getStatus());
+
+        $route = $this->router->generate('back_auto_affectation_rule_reactive', ['id' => $autoAffectationRule->getId()]);
+        $this->client->request(
+            'POST',
+            $route,
+            [
+                'id' => $autoAffectationRule->getId(),
+            ]
+        );
+
+        $this->assertResponseRedirects('/bo/auto-affectation/');
+        $this->assertEquals(AutoAffectationRule::STATUS_ACTIVE, $autoAffectationRule->getStatus());
+    }
+}

--- a/tests/Functional/Repository/AutoAffectationRuleRepositoryTest.php
+++ b/tests/Functional/Repository/AutoAffectationRuleRepositoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Functional\Repository;
+
+use App\Entity\AutoAffectationRule;
+use App\Entity\Territory;
+use App\Repository\AutoAffectationRuleRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AutoAffectationRuleRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+    }
+
+    public function testGetAutoAffectationRules(): void
+    {
+        /** @var AutoAffectationRuleRepository $autoAffectationRuleRepository */
+        $autoAffectationRuleRepository = $this->entityManager->getRepository(AutoAffectationRule::class);
+
+        $allAutoAffectationRule = $autoAffectationRuleRepository->getAutoAffectationRules(null, 1);
+        $this->assertCount(6, $allAutoAffectationRule);
+
+        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '34']);
+        $heraultAffectationRule = $autoAffectationRuleRepository->getAutoAffectationRules($territory, 1);
+        $this->assertCount(4, $heraultAffectationRule);
+    }
+}

--- a/tests/Unit/Entity/AutoAffectationRuleTest.php
+++ b/tests/Unit/Entity/AutoAffectationRuleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\AutoAffectationRule;
+use App\Entity\Enum\PartnerType;
+use App\Tests\FixturesHelper;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AutoAffectationRuleTest extends KernelTestCase
+{
+    use FixturesHelper;
+
+    public function testDescriptionShort(): void
+    {
+        $autoAffectationRule = $this->getAutoAffectationRule();
+        $this->assertEquals(PartnerType::CAF_MSA, $autoAffectationRule->getPartnerType());
+        $this->assertEquals('Ain', $autoAffectationRule->getTerritory()->getName());
+        $this->assertEquals('Règle d\'auto-affectation pour les partenaires CAF / MSA du territoire Ain', $autoAffectationRule->getDescription());
+    }
+
+    public function testDescriptionLong(): void
+    {
+        $autoAffectationRule = $this->getAutoAffectationRule();
+        $this->assertEquals(PartnerType::CAF_MSA, $autoAffectationRule->getPartnerType());
+        $this->assertEquals('Ain', $autoAffectationRule->getTerritory()->getName());
+        $this->assertEquals('prive', $autoAffectationRule->getParc());
+        $this->assertEquals('all', $autoAffectationRule->getProfileDeclarant());
+        $this->assertEquals('oui', $autoAffectationRule->getAllocataire());
+        $this->assertEquals('partner_list', $autoAffectationRule->getInseeToInclude());
+        $this->assertNull($autoAffectationRule->getInseeToExclude());
+        $this->assertEquals(AutoAffectationRule::STATUS_ACTIVE, $autoAffectationRule->getStatus());
+        $this->assertEquals('Règle d\'auto-affectation pour les partenaires CAF / MSA du territoire Ain concernant les logements du parc privé. Cette règle concerne les signalements faits par tous profils de déclarant. Elle concerne les foyers allocataires. Elle s\'applique aux logements situés dans le périmètre du partenaire (codes insee). (Règle active)', $autoAffectationRule->getDescription(false));
+    }
+}

--- a/tests/Unit/Entity/AutoAffectationRuleTest.php
+++ b/tests/Unit/Entity/AutoAffectationRuleTest.php
@@ -29,6 +29,7 @@ class AutoAffectationRuleTest extends KernelTestCase
         $this->assertEquals('oui', $autoAffectationRule->getAllocataire());
         $this->assertEquals('partner_list', $autoAffectationRule->getInseeToInclude());
         $this->assertNull($autoAffectationRule->getInseeToExclude());
+        $this->assertEmpty($autoAffectationRule->getPartnerToExclude());
         $this->assertEquals(AutoAffectationRule::STATUS_ACTIVE, $autoAffectationRule->getStatus());
         $this->assertEquals('Règle d\'auto-affectation pour les partenaires CAF / MSA du territoire Ain concernant les logements du parc privé. Cette règle concerne les signalements faits par tous profils de déclarant. Elle concerne les foyers allocataires. Elle s\'applique aux logements situés dans le périmètre du partenaire (codes insee). (Règle active)', $autoAffectationRule->getDescription(false));
     }

--- a/tests/Unit/Factory/AutoAffectationRuleFactoryTest.php
+++ b/tests/Unit/Factory/AutoAffectationRuleFactoryTest.php
@@ -32,6 +32,7 @@ class AutoAffectationRuleFactoryTest extends KernelTestCase
             profileDeclarant : 'all',
             inseeToInclude : 'all',
             inseeToExclude : null,
+            partnerToExclude : null,
             parc : 'all',
             allocataire : 'all'
         );
@@ -43,6 +44,7 @@ class AutoAffectationRuleFactoryTest extends KernelTestCase
         $this->assertInstanceOf(AutoAffectationRule::class, $autoAffectationRule);
         $this->assertEquals($autoAffectationRule->getPartnerType(), PartnerType::CAF_MSA);
         $this->assertEmpty($autoAffectationRule->getInseeToExclude());
+        $this->assertEmpty($autoAffectationRule->getPartnerToExclude());
     }
 
     public function testCreateAutoAffectationRuleKO(): void
@@ -56,6 +58,7 @@ class AutoAffectationRuleFactoryTest extends KernelTestCase
             profileDeclarant : 'ERROR',
             inseeToInclude : 'all',
             inseeToExclude : null,
+            partnerToExclude : null,
             parc : 'ERROR',
             allocataire : 'ERROR'
         );

--- a/tests/Unit/Validator/InseeToExcludeValidatorTest.php
+++ b/tests/Unit/Validator/InseeToExcludeValidatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Tests\Unit\Validator;
+
+use App\Validator\InseeToExclude;
+use App\Validator\InseeToExcludeValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class InseeToExcludeValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        return new InseeToExcludeValidator();
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testValues(array $insee, bool $isValid, ?string $message = null): void
+    {
+        $constraint = new InseeToExclude();
+        $this->validator->validate($insee, $constraint);
+        if ($isValid) {
+            $this->assertNoViolation();
+        } else {
+            $this->buildViolation($message)
+                ->setParameter('{{ value }}', implode(',', $insee))
+                ->assertRaised();
+        }
+    }
+
+    public function provideValues(): \Generator
+    {
+        yield 'all' => [['all'], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
+        yield '[44058]' => [[44058], true];
+        yield '[44058,44890]' => [[44058, 44890], true];
+        yield 'error' => [['error'], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
+        yield 'on test des trucs, et des machins' => [['on test des trucs', 'et des machins'], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
+        yield '[440589,44890]' => [[440589, 44890], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
+    }
+}

--- a/tests/Unit/Validator/InseeToExcludeValidatorTest.php
+++ b/tests/Unit/Validator/InseeToExcludeValidatorTest.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class InseeToExcludeValidatorTest extends ConstraintValidatorTestCase
 {
+    private const ERROR = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.';
+
     protected function createValidator(): ConstraintValidatorInterface
     {
         return new InseeToExcludeValidator();
@@ -32,11 +34,11 @@ class InseeToExcludeValidatorTest extends ConstraintValidatorTestCase
 
     public function provideValues(): \Generator
     {
-        yield 'all' => [['all'], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
+        yield 'all' => [['all'], false, self::ERROR];
         yield '[44058]' => [[44058], true];
         yield '[44058,44890]' => [[44058, 44890], true];
-        yield 'error' => [['error'], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
-        yield 'on test des trucs, et des machins' => [['on test des trucs', 'et des machins'], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
-        yield '[440589,44890]' => [[440589, 44890], false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste de codes INSEE séparés par des virgules ou vide.'];
+        yield 'error' => [['error'], false, self::ERROR];
+        yield 'on test des trucs, et des machins' => [['on test des trucs', 'et des machins'], false, self::ERROR];
+        yield '[440589,44890]' => [[440589, 44890], false, self::ERROR];
     }
 }

--- a/tests/Unit/Validator/InseeToIncludeValidatorTest.php
+++ b/tests/Unit/Validator/InseeToIncludeValidatorTest.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
 {
+    private const ERROR = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.';
+
     protected function createValidator(): ConstraintValidatorInterface
     {
         return new InseeToIncludeValidator();
@@ -36,8 +38,8 @@ class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
         yield 'partner_list' => ['partner_list', true];
         yield '44058' => ['44058', true];
         yield '44058,44890' => ['44058,44890', true];
-        yield 'error' => ['error', false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.'];
-        yield 'on test des trucs, et des machins' => ['on test des trucs, et des machins', false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.'];
-        yield '440589,44890' => ['440589,44890', false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.'];
+        yield 'error' => ['error', false, self::ERROR];
+        yield 'on test des trucs, et des machins' => ['on test des trucs, et des machins', false, self::ERROR];
+        yield '440589,44890' => ['440589,44890', false, self::ERROR];
     }
 }

--- a/tests/Unit/Validator/InseeToIncludeValidatorTest.php
+++ b/tests/Unit/Validator/InseeToIncludeValidatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Tests\Unit\Validator;
+
+use App\Validator\InseeToInclude;
+use App\Validator\InseeToIncludeValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        return new InseeToIncludeValidator();
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testValues(string $insee, bool $isValid, ?string $message = null): void
+    {
+        $constraint = new InseeToInclude();
+        $this->validator->validate($insee, $constraint);
+        if ($isValid) {
+            $this->assertNoViolation();
+        } else {
+            $this->buildViolation($message)
+                ->setParameter('{{ value }}', $insee)
+                ->assertRaised();
+        }
+    }
+
+    public function provideValues(): \Generator
+    {
+        yield 'all' => ['all', true];
+        yield 'partner_list' => ['partner_list', true];
+        yield '44058' => ['44058', true];
+        yield '44058,44890' => ['44058,44890', true];
+        yield 'error' => ['error', false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.'];
+        yield 'on test des trucs, et des machins' => ['on test des trucs, et des machins', false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.'];
+        yield '440589,44890' => ['440589,44890', false, 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.'];
+    }
+}

--- a/tests/Unit/Validator/PartnerToExcludeValidatorTest.php
+++ b/tests/Unit/Validator/PartnerToExcludeValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Tests\Unit\Validator;
+
+use App\Validator\PartnerToExclude;
+use App\Validator\PartnerToExcludeValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class PartnerToExcludeValidatorTest extends ConstraintValidatorTestCase
+{
+    private const ERROR = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être une liste d\'Id partenaires séparés par des virgules ou vide.';
+
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        return new PartnerToExcludeValidator();
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testValues(array $insee, bool $isValid, ?string $message = null): void
+    {
+        $constraint = new PartnerToExclude();
+        $this->validator->validate($insee, $constraint);
+        if ($isValid) {
+            $this->assertNoViolation();
+        } else {
+            $this->buildViolation($message)
+                ->setParameter('{{ value }}', implode(',', $insee))
+                ->assertRaised();
+        }
+    }
+
+    public function provideValues(): \Generator
+    {
+        yield 'all' => [['all'], false, self::ERROR];
+        yield '[2]' => [[2], true];
+        yield '[22]' => [[22], true];
+        yield '[22,333]' => [[22, 333], true];
+        yield '[440589,44890]' => [[440589, 44890], true];
+        yield 'error' => [['error'], false, self::ERROR];
+        yield 'on test des trucs, et des machins' => [['on test des trucs', 'et des machins'], false, self::ERROR];
+    }
+}


### PR DESCRIPTION
## Ticket

#2833
#2834    

## Description
Afficher sur la page partenaire les règles d'auto-affectation qui le concernent
Création d'une page d'administration des règles d'auto-affectation
[edit] Ajout d'un champ pour exclure des ID de partenaires dans chaque règle

## Changements apportés
* Création des twig, des js, du controller et du formType pour AutoAffectationRule
* Ajout de validateurs et de contraintes pour inseeToInclude et inseeToExclude
* Affichage de la nouvelle page dans la navigation
* Modification du partnerController et de son twig pour afficher les règles concernant les partenaires s'il y en a
* Création de tests

## Pré-requis
```
make composer
npm run watch
```

## Tests
- [ ] Se connecter en superAdmin, aller sur la page d'administration des règles
- [ ] Editer une règle, créer une règle, archiver une règle et réactiver une règle
- [ ] Vérifier qu'on ne peut pas mettre n'importe quelles valeurs pour les règles lors de la création et de l'édition
- [ ] Vérifier que les règles sont mises à jour en BDD
- [ ] Créer un signalement pour vérifier que la règle fonctionne
- [ ] Aller sur une page partenaire concerné par une règle et vérifier que la description de la ou les règles s'affiche
- [ ] Aller sur une page d'un partenaire non-concerné par une règle vérifier que rien ne s'affiche
- [ ] Se connecter en RT et vérifier qu'on n'a pas accès à la page sur les règles et que la page partenaire n'affiche rien
- [ ] Se connecter en admin partenaire et en agent, on ne voit rien non plus
- [ ] Exclure un ou plusieurs ID de partenaires pour vérifier qu'ils ne sont pas affectés automatiquement
