### PR TITLE
[BO - Signalement] Afficher le bouton de rapport de visite même quand elle n'a pas été effectuée

### DIFF
--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -20,7 +20,7 @@
             {% endif %}
         {% endif %}
     {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
-        {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty%}
+        {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty %}
             {% if is_granted('SIGN_ADD_VISITE', intervention.signalement) %}
                 <button 
                     class="fr-btn fr-fi-file-fill"
@@ -59,6 +59,16 @@
                 data-intervention-id="{{intervention.id}}">
                 Ajouter les photos de la visite
             </button>
+        {% endif %}
+    {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_NOT_DONE') %}
+        {% if intervention.getRapportDeVisite is not empty %}
+            <a href="{{ asset('_up/'~intervention.getRapportDeVisite.first.filename)~'/' ~ signalement.uuid }}"
+                class="fr-btn"
+                title="Afficher le document"
+                rel="noopener"
+                target="_blank">
+                <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
+            </a>
         {% endif %}
     {% else %}
         &nbsp;


### PR DESCRIPTION
## Ticket

#2863    

## Description
Afficher le bouton de rapport de visite même quand elle n'a pas été effectuée

## Tests
- [ ] Créer une visite et la marquer comme "pas effectuée", et ajouter une fichier en rapport de visite : vérifier que le bouton est bien visible
