### PR TITLE
[BO - Notifications] Optimisation de la fonction pour tout marquer comme lu

### DIFF
--- a/src/Controller/Back/NotificationController.php
+++ b/src/Controller/Back/NotificationController.php
@@ -45,7 +45,7 @@ class NotificationController extends AbstractController
             }
         } else {
             if ($this->isCsrfTokenValid('mark_as_read_'.$user->getId(), $request->get('mark_as_read'))) {
-                $this->markAllAsRead($entityManager);
+                $notificationRepository->markUserNotificationAsRead($user);
                 $this->addFlash('success', 'Toutes les notifications ont été marquées comme lues.');
             }
         }
@@ -88,21 +88,7 @@ class NotificationController extends AbstractController
         foreach ($notifications as $notification) {
             $this->denyAccessUnlessGranted('NOTIF_MARK_AS_READ', $notification);
             $notification->setIsSeen(true);
-            $em->persist($notification);
         }
-        $em->flush();
-    }
-
-    private function markAllAsRead($em)
-    {
-        /** @var User $user */
-        $user = $this->getUser();
-        $notifications = $user->getNotifications();
-        $notifications->filter(function (Notification $notification) use ($em) {
-            $this->denyAccessUnlessGranted('NOTIF_MARK_AS_READ', $notification);
-            $notification->setIsSeen(true);
-            $em->persist($notification);
-        });
         $em->flush();
     }
 

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -198,4 +198,15 @@ class NotificationRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function markUserNotificationAsRead(User $user): void
+    {
+        $qb = $this->createQueryBuilder('n');
+        $qb->update()
+            ->set('n.isSeen', 1)
+            ->andWhere('n.isSeen = 0')
+            ->andWhere('n.user = :user')
+            ->setParameter('user', $user);
+        $qb->getQuery()->execute();
+    }
 }


### PR DESCRIPTION
## Ticket

#2865   

## Description
Optimisation de la fonction qui permet de tout marquer comme lu

## Changements apportés
* Utilisation d'un `update where` plutôt que le parcours de toutes les notifications, peu importe le statut

## Tests
- [ ] Marquer tout comme lu, et vérifier que tout est ok, et uniquement pour l'utilisateur en cours
