### PR TITLE
[FO - Signalement] Modification de la méthode de vérification et d'attribution de territoire

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -443,7 +443,7 @@ class SignalementManager extends AbstractManager
         if ($signalement->getIsLogementSocial() && $coordonneesBailleurRequest->getNom()) {
             $bailleur = $this->bailleurRepository->findOneBailleurBy(
                 $coordonneesBailleurRequest->getNom(),
-                ZipcodeProvider::getZipCode($signalement->getCpOccupant())
+                ZipcodeProvider::getZipCode($signalement->getInseeOccupant())
             );
         }
 

--- a/src/Service/Signalement/PostalCodeHomeChecker.php
+++ b/src/Service/Signalement/PostalCodeHomeChecker.php
@@ -14,8 +14,10 @@ class PostalCodeHomeChecker
 
     public function isActive(string $postalCode, ?string $inseeCode = null): bool
     {
+        // Si on a un code Insee, on vérifie en priorité celui-ci car il indique le vrai territoire
+        $codeToCheck = $inseeCode ?? $postalCode;
         $territoryItem = $this->territoryRepository->findOneBy([
-            'zip' => ZipcodeProvider::getZipCode($postalCode),
+            'zip' => ZipcodeProvider::getZipCode($codeToCheck),
             'isActive' => 1,
         ]);
 

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -68,7 +68,7 @@ class SignalementBuilder
 
         $this->territory = $this->territoryRepository->findOneBy([
             'zip' => ZipcodeProvider::getZipCode(
-                $this->signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal()
+                $this->signalementDraftRequest->getAdresseLogementAdresseDetailInsee()
             ),
         ]);
 

--- a/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
+++ b/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
@@ -32,9 +32,19 @@ class PostalCodeHomeCheckerTest extends KernelTestCase
         $this->assertTrue($this->postalCodeHomeChecker->isActive('21000'));
     }
 
+    public function testActiveTerritoryDifferentZip(): void
+    {
+        $this->assertTrue($this->postalCodeHomeChecker->isActive('05130', '04234'));
+    }
+
     public function testInactiveTerritory(): void
     {
         $this->assertFalse($this->postalCodeHomeChecker->isActive('75001'));
+    }
+
+    public function testInactiveTerritoryDifferentZip(): void
+    {
+        $this->assertFalse($this->postalCodeHomeChecker->isActive('01590', '39102'));
     }
 
     public function testTerritoryWithNoAuthorizedInseeCodes(): void


### PR DESCRIPTION
## Ticket

#2761    

## Description
Certaines communes ont un code postal dans un territoire et un code insee dans l'autre.
Voir : https://fr.wikipedia.org/wiki/Liste_des_communes_de_France_dont_le_code_postal_ne_correspond_pas_au_d%C3%A9partement
Par conséquent, les signalements sont attribués au mauvais territoire et peuvent être refusés.

## Changements apportés
* Pas de changement sur le test de code postal de la page d'accueil
* Dans la saisie d'adresse, on récupère le CP et le code Insee, et on vérifie les premiers caractères du code Insee
* A la fin du signalement, on attribue au territoire qui correspond aux deux premier caractères du code Insee

## Pré-requis
`make console app="update-communes"`
`npm run watch`

## Tests
- [ ] Sur la page d'accueil, rien ne change
- [ ] Saisie d'un signalement : `Rue du Jura 01590 Chancia` : le signalement n'est pas valide alors que le 01 est ouvert
- [ ] Saisie d'un signalement : `Rue de l’Acacia 05130 Venterol` : le signalement est valide alors que le 05 n'est pas ouvert
  - [ ] Avec ce signalement, on peut aller au bout, et le signalement est attribué au territoire du `04`
  - [ ] En ayant un admin territoire dans le 04, il voit le signalement
