### PR TITLE
[QA - FO] error : Call to a member function getSuperficie() on null

### DIFF
--- a/src/Factory/SignalementQualificationFactory.php
+++ b/src/Factory/SignalementQualificationFactory.php
@@ -49,6 +49,7 @@ class SignalementQualificationFactory
         ?string $dataDateDPE = '',
     ): SignalementQualification {
         $signalementQualification = new SignalementQualification();
+        $signalementQualification->setSignalement($signalement);
         $signalementQualification->setQualification(Qualification::NON_DECENCE_ENERGETIQUE);
 
         $dataHasDPEToSave = null;


### PR DESCRIPTION
## Ticket

#2879

## Description
L'erreur fait suite à la PR #2854 à ce niveau https://github.com/MTES-MCT/histologe/commit/83f429d07dd5ac96d5974e680a3149fa7af1c123#diff-34685d38e6efd749be48ed577ec9539392b731851420bdd7eb751e10d70df97d mais le problème était plus profond (signalement non attribué à la `SignalementQualification` avant les checks `getNDEStatus`

## Tests
- [ ] Voir le payload partagé sur mattermost
