### PR TITLE
[BO - Liste signalements] Afficher tous les partenaires affectés, même si on filtre sur le partenaire

### DIFF
--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -270,12 +270,13 @@ class SearchFilter
                 ->setParameter('affectations', $filters['affectations']);
         }
         if (!empty($filters['partners'])) {
+            $qb->leftJoin('s.affectations', 'afilt');
             if (\in_array('AUCUN', $filters['partners'])) {
-                $qb->andWhere('a.partner IS NULL');
+                $qb->andWhere('afilt.partner IS NULL');
             } else {
-                $qb->andWhere('a.partner IN (:partners)');
+                $qb->andWhere('afilt.partner IN (:partners)');
                 if (!empty($filters['affectations'])) {
-                    $qb->andWhere('a.statut IN (:affectations)')
+                    $qb->andWhere('afilt.statut IN (:affectations)')
                     ->setParameter('affectations', $filters['affectations']);
                 }
                 $qb->setParameter('partners', $filters['partners']);


### PR DESCRIPTION
## Ticket

#2877   

## Description
Afficher tous les partenaires affectés, même si on filtre sur le partenaire

## Changements apportés
* Ajout d'une jointure si on filtre par ce biais, pour ne pas mélanger jointure de donnée et de filtre

## Tests
- [ ] Afficher la liste des signalements, filtrer par partenaire, vérifier que l'ensemble des partenaires affectés s'affiche
