### PR TITLE
[Migration] - Fix déploiement

### DIFF
--- a/migrations/Version20240726144731.php
+++ b/migrations/Version20240726144731.php
@@ -16,21 +16,15 @@ final class Version20240726144731 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('DROP INDEX `primary` ON desordre_categorie_signalement');
-        $this->addSql('ALTER TABLE desordre_categorie_signalement ADD PRIMARY KEY (signalement_id, desordre_categorie_id)');
-        $this->addSql('DROP INDEX `primary` ON desordre_critere_signalement');
-        $this->addSql('ALTER TABLE desordre_critere_signalement ADD PRIMARY KEY (signalement_id, desordre_critere_id)');
-        $this->addSql('DROP INDEX `primary` ON desordre_precision_signalement');
-        $this->addSql('ALTER TABLE desordre_precision_signalement ADD PRIMARY KEY (signalement_id, desordre_precision_id)');
+        $this->addSql('ALTER TABLE desordre_categorie_signalement DROP PRIMARY KEY, ADD PRIMARY KEY (signalement_id, desordre_categorie_id)');
+        $this->addSql('ALTER TABLE desordre_critere_signalement DROP PRIMARY KEY, ADD PRIMARY KEY (signalement_id, desordre_critere_id)');
+        $this->addSql('ALTER TABLE desordre_precision_signalement DROP PRIMARY KEY, ADD PRIMARY KEY (signalement_id, desordre_precision_id)');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP INDEX `PRIMARY` ON desordre_categorie_signalement');
-        $this->addSql('ALTER TABLE desordre_categorie_signalement ADD PRIMARY KEY (desordre_categorie_id, signalement_id)');
-        $this->addSql('DROP INDEX `PRIMARY` ON desordre_critere_signalement');
-        $this->addSql('ALTER TABLE desordre_critere_signalement ADD PRIMARY KEY (desordre_critere_id, signalement_id)');
-        $this->addSql('DROP INDEX `PRIMARY` ON desordre_precision_signalement');
-        $this->addSql('ALTER TABLE desordre_precision_signalement ADD PRIMARY KEY (desordre_precision_id, signalement_id)');
+        $this->addSql('ALTER TABLE desordre_categorie_signalement DROP PRIMARY KEY, ADD PRIMARY KEY (desordre_categorie_id, signalement_id)');
+        $this->addSql('ALTER TABLE desordre_critere_signalement DROP PRIMARY KEY, ADD PRIMARY KEY (desordre_critere_id, signalement_id)');
+        $this->addSql('ALTER TABLE desordre_precision_signalement DROP PRIMARY KEY, ADD PRIMARY KEY (desordre_precision_id, signalement_id)');
     }
 }


### PR DESCRIPTION
## Ticket

#2885

## Description
Corrige l'erreur de déploiement Scalingo : "Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set." qui fait suite au remplacement des clé primaire dans #2857
