### PR TITLE
[FO - Formulaire] Compatibilité W3C

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -27,7 +27,7 @@
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_les_desordres_text",
           "customCss": "fr-mt-5v",
-          "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p> <p>Vous pourrez aussi ajouter des photos des problèmes.<p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>"
+          "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p><p>Vous pourrez aussi ajouter des photos des problèmes.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>"
         }
       ],
       "footer": [

--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -1678,7 +1678,7 @@
               },
               {
                 "type": "SignalementFormInfo",
-                "label": "Conseils : vous pouvez nettoyer la moisissure avec de l'eau de javel ou du vinaigre blanc. Dans tous les cas : protégez vous avec un masque et des gants ! Pour plus d'info, <a href='https://www.auvergne-rhone-alpes.ars.sante.fr/lutter-contre-les-moisissures-dans-le-logement' target='_blank' rel='noopener' title='Le site de l'ARS Auvergne-Rhône-Alpes - Ouvre une nouvelle fenêtre'>cliquez sur ce lien</a>.",
+                "label": "Conseils : vous pouvez nettoyer la moisissure avec de l'eau de javel ou du vinaigre blanc. Dans tous les cas : protégez vous avec un masque et des gants ! Pour plus d'info, <a href=\"https://www.auvergne-rhone-alpes.ars.sante.fr/lutter-contre-les-moisissures-dans-le-logement\" target=\"_blank\" rel=\"noopener\" title=\"Le site de l'ARS Auvergne-Rhône-Alpes - Ouvre une nouvelle fenêtre\">cliquez sur ce lien</a>.",
                 "slug": "desordres_logement_humidite_piece_a_vivre_details_moisissure_info",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_humidite_piece_a_vivre_details_moisissure_apres_nettoyage ===  'nsp'"
@@ -1775,7 +1775,7 @@
               },
               {
                 "type": "SignalementFormInfo",
-                "label": "Conseils : vous pouvez nettoyer la moisissure avec de l'eau de javel ou du vinaigre blanc. Dans tous les cas : protégez vous avec un masque et des gants ! Pour plus d'info, <a href='https://www.auvergne-rhone-alpes.ars.sante.fr/lutter-contre-les-moisissures-dans-le-logement' target='_blank' rel='noopener' title='Le site de l'ARS Auvergne-Rhône-Alpes - Ouvre une nouvelle fenêtre'>cliquez sur ce lien</a>.",
+                "label": "Conseils : vous pouvez nettoyer la moisissure avec de l'eau de javel ou du vinaigre blanc. Dans tous les cas : protégez vous avec un masque et des gants ! Pour plus d'info, <a href=\"https://www.auvergne-rhone-alpes.ars.sante.fr/lutter-contre-les-moisissures-dans-le-logement\" target=\"_blank\" rel=\"noopener\" title=\"Le site de l'ARS Auvergne-Rhône-Alpes - Ouvre une nouvelle fenêtre\">cliquez sur ce lien</a>.",
                 "slug": "desordres_logement_humidite_cuisine_details_moisissure_info",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_humidite_cuisine_details_moisissure_apres_nettoyage ===  'nsp'"
@@ -1872,7 +1872,7 @@
               },
               {
                 "type": "SignalementFormInfo",
-                "label": "Conseils : vous pouvez nettoyer la moisissure avec de l'eau de javel ou du vinaigre blanc. Dans tous les cas : protégez vous avec un masque et des gants ! Pour plus d'info, <a href='https://www.auvergne-rhone-alpes.ars.sante.fr/lutter-contre-les-moisissures-dans-le-logement' target='_blank' rel='noopener' title='Le site de l'ARS Auvergne-Rhône-Alpes - Ouvre une nouvelle fenêtre'>cliquez sur ce lien</a>.",
+                "label": "Conseils : vous pouvez nettoyer la moisissure avec de l'eau de javel ou du vinaigre blanc. Dans tous les cas : protégez-vous avec un masque et des gants ! Pour plus d'info, <a href=\"https://www.auvergne-rhone-alpes.ars.sante.fr/lutter-contre-les-moisissures-dans-le-logement\" target=\"_blank\" rel=\"noopener\" title=\"Le site de l'ARS Auvergne-Rhône-Alpes - Ouvre une nouvelle fenêtre\">cliquez sur ce lien</a>.",
                 "slug": "desordres_logement_humidite_salle_de_bain_details_moisissure_info",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_humidite_salle_de_bain_details_moisissure_apres_nettoyage ===  'nsp'"

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -27,7 +27,7 @@
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_les_desordres_text",
           "customCss": "fr-mt-5v",
-          "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p> <p>Vous pourrez aussi ajouter des photos des problèmes.<p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>"
+          "description": "<p>Vous avez indiqué que votre signalement concerne {{dictionaryStore::formStore.data.zone_concernee_zone}}.</p><p>Sélectionnez le ou les problèmes rencontrés parmi les catégories et répondez aux questions.</p><p>Vous pourrez aussi ajouter des photos des problèmes.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>"
         }
       ],
       "footer": [

--- a/assets/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -2,20 +2,6 @@
     <div
       id="app-signalement-form"
       class="signalement-form"
-      :data-ajaxurl="sharedProps.ajaxurl"
-      :data-ajaxurl-dictionary="sharedProps.ajaxurlDictionary"
-      :data-ajaxurl-questions="sharedProps.ajaxurlQuestions"
-      :data-ajaxurl-desordres="sharedProps.ajaxurlDesordres"
-      :data-ajaxurl-post-signalement-draft="sharedProps.ajaxurlPostSignalementDraft"
-      :data-ajaxurl-put-signalement-draft="sharedProps.ajaxurlPutSignalementDraft"
-      :data-ajaxurl-handle-upload="sharedProps.ajaxurlHandleUpload"
-      :data-ajaxurl-get-signalement-draft="sharedProps.ajaxurlGetSignalementDraft"
-      :data-ajaxurl-platform-name="sharedProps.platformName"
-      :data-ajaxurl-check-territory="sharedProps.ajaxurlCheckTerritory"
-      :data-ajaxurl-check-signalement-or-draft-already-exists="sharedProps.ajaxurlCheckSignalementOrDraftAlreadyExists"
-      :data-ajaxurl-send-mail-continue-from-draft="sharedProps.ajaxurlSendMailContinueFromDraft"
-      :data-ajaxurl-send-mail-get-lien-suivi="sharedProps.ajaxurlSendMailGetLienSuivi"
-      :data-ajaxurl-archive-draft="sharedProps.ajaxurlArchiveDraft"
       >
       <div v-if="isLoadingInit" class="loading fr-m-10w fr-grid-row fr-grid-row--center">
         Initialisation du formulaire...
@@ -77,7 +63,7 @@ import SignalementFormScreen from './components/SignalementFormScreen.vue'
 import SignalementFormBreadCrumbs from './components/SignalementFormBreadCrumbs.vue'
 import SignalementFormModal from './components/SignalementFormModal.vue'
 import SignalementFormModalAlreadyExists from './components/SignalementFormModalAlreadyExists.vue'
-const initElements:any = document.querySelector('#app-signalement-form')
+const initElements:any = document.querySelector('#app-signalement-form-container')
 
 export default defineComponent({
   name: 'TheSignalementAppForm',

--- a/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -30,7 +30,6 @@
       :id="idShow"
       label="Saisir une adresse manuellement"
       :customCss="buttonCss + ' btn-link fr-btn--icon-left fr-icon-edit-line'"
-      :validate="validate"
       :action="actionShow"
       :clickEvent="handleClickButton"
     />
@@ -41,7 +40,6 @@
       label=""
       :customCss="subscreenCss + ' fr-mt-3v'"
       :components="screens"
-      :validate="validate"
       v-model="formStore.data[idSubscreen]"
       :hasError="formStore.validationErrors[idSubscreen] !== undefined"
       :error="formStore.validationErrors[idSubscreen]"
@@ -76,7 +74,14 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
-    clickEvent: Function
+    clickEvent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    components: Object,
+    handleClickComponent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     const updatedSubscreenData = subscreenManager.generateSubscreenData(this.id, subscreenData.body, this.validate)

--- a/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -8,7 +8,8 @@
         :description="description"
         :placeholder="placeholder"
         :validate="validate"
-        :autocomplete="autocomplete"
+        :access_name="access_name"
+        :access_autocomplete="access_autocomplete"
         :hasError="hasError"
         :error="error"
         @keydown.down.prevent="handleDownSuggestion"
@@ -52,7 +53,14 @@ export default defineComponent({
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
     autocomplete: { type: Object, default: null },
-    disabled: { type: Boolean, default: false }
+    disabled: { type: Boolean, default: false },
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    clickEvent: Function,
+    handleClickComponent: Function
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormBreadCrumbs.vue
@@ -13,7 +13,7 @@
 
       <!-- Fil d'ariane -->
       <div class="fr-px-5w">
-        <nav role="navigation" class="fr-breadcrumb" aria-label="vous êtes ici :">
+        <nav class="fr-breadcrumb" aria-label="vous êtes ici :">
           <button class="fr-breadcrumb__button" aria-expanded="false" aria-controls="breadcrumb-1">Voir le fil d’Ariane</button>
           <div class="fr-collapse" id="breadcrumb-1">
             <ol class="fr-breadcrumb__list">
@@ -34,7 +34,7 @@
       <SignalementFormModalBackHome />
     </div>
 
-    <nav class="fr-sidemenu fr-hidden fr-unhidden-md force-height-max" aria-labelledby="fr-sidemenu-title">
+    <nav class="fr-sidemenu fr-hidden fr-unhidden-md force-height-max">
       <div class="fr-sidemenu__inner force-height-max">
         <div class="fr-collapse" id="fr-sidemenu-wrapper">
           <ul class="fr-sidemenu__list">

--- a/assets/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -36,8 +36,14 @@ export default defineComponent({
     },
     type: { type: String as PropType<'button' | 'submit' | 'reset' | undefined>, default: 'button' },
     customCss: { type: String, default: '' },
-    ariaControls: { type: String, default: '' },
-    clickEvent: Function
+    ariaControls: { type: String, default: undefined },
+    clickEvent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: undefined },
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -41,6 +41,7 @@ export default defineComponent({
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
+    handleClickComponent: Function,
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined }

--- a/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -8,13 +8,13 @@
           :value="modelValue"
           :class="[ customCss ]"
           @input="updateValue($event)"
-          aria-describedby="checkbox-error-messages"
+          :aria-describedby="hasError ? idCheckbox + '-checkbox-error-messages' : undefined"
           :checked="Boolean(modelValue)"
           >
       <label :class="[ customCss, 'fr-label' ]" :for="idCheckbox" v-html="variablesReplacer.replace(label)"></label>
-      <div class="fr-messages-group" id="checkbox-error-messages" aria-live="assertive">
+      <div class="fr-messages-group" aria-live="assertive">
         <p
-          id="checkbox-error-messages"
+          :id="idCheckbox + '-checkbox-error-messages'"
           class="fr-message fr-message--error"
           v-if="hasError"
           >
@@ -40,7 +40,14 @@ export default defineComponent({
     customCss: { type: String, default: '' },
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
-    error: { type: String, default: '' }
+    error: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    clickEvent: Function,
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormConfirmation.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormConfirmation.vue
@@ -21,7 +21,15 @@ export default defineComponent({
   name: 'SignalementFormConfirmation',
   props: {
     id: { type: String, default: null },
-    customCss: { type: String, default: '' }
+    customCss: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    clickEvent: Function,
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   }
 })
 </script>

--- a/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="fr-input-group" :id="id">
+  <div class="fr-input-group" :id="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'" v-html="variablesReplacer.replace(label)"></label>
     <input
-        type="number"
+        type="text"
         pattern="[0-9]*"
         inputmode="numeric"
         :id="id + '_input'"
@@ -10,16 +10,16 @@
         :value="internalValue"
         :class="[ customCss, 'fr-input' ]"
         @input="updateValue($event)"
-        aria-describedby="text-input-error-desc-error"
+        :aria-describedby="hasError ? id + 'text-input-error-desc-error' : undefined"
         >
     <div
-      id="text-input-error-desc-error"
+      :id="id + 'text-input-error-desc-error'"
       class="fr-error-text"
       v-if="hasError"
       >
       {{ error }}
     </div>
-    </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -37,7 +37,14 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
-    defaultValue: { type: Number, default: null }
+    defaultValue: { type: Number, default: null },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    handleClickComponent: Function,
+    clickEvent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -9,10 +9,10 @@
         :value="internalValue"
         :class="[ customCss, 'fr-input' ]"
         @input="updateValue($event)"
-        aria-describedby="text-input-error-desc-error"
+        :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
         >
     <div
-      id="text-input-error-desc-error"
+      :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
       v-if="hasError"
       >
@@ -33,7 +33,14 @@ export default defineComponent({
     modelValue: { type: String, default: null },
     customCss: { type: String, default: '' },
     hasError: { type: Boolean, default: false },
-    error: { type: String, default: '' }
+    error: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    handleClickComponent: Function,
+    clickEvent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   computed: {
     internalValue: {

--- a/assets/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -1,16 +1,16 @@
 <template>
-    <div class="fr-input-group" :id="id">
+  <div class="fr-input-group" :id="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">{{ label }}</label>
     <span v-if="hint !== ''" class="fr-hint-text">{{ hint }}</span>
     <input
-        type="date"
-        :id="id + '_input'"
-        :name="id"
-        :value="internalValue"
-        :class="[ customCss, 'fr-input' ]"
-        @input="updateValue($event)"
-        :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
-        >
+      type="date"
+      :id="id + '_input'"
+      :name="id"
+      :value="internalValue"
+      :class="[ customCss, 'fr-input' ]"
+      @input="updateValue($event)"
+      :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
+      >
     <div
       :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
@@ -18,7 +18,7 @@
       >
       {{ error }}
     </div>
-    </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -37,6 +37,7 @@ export default defineComponent({
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
+    validate: { type: Object, default: null },
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -32,7 +32,14 @@ export default defineComponent({
     id: { type: String, default: null },
     action: { type: String, default: '' },
     components: Object,
-    clickEvent: Function
+    clickEvent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -106,7 +106,15 @@ export default defineComponent({
   props: {
     id: { type: String, default: null },
     icons: { type: Object },
-    isValidationScreen: { type: Boolean, default: false }
+    isValidationScreen: { type: Boolean, default: false },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    clickEvent: Function,
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -6,21 +6,21 @@
     </label>
     <div :class="[ customCss, 'fr-input-wrap' ]">
       <input
-          type="email"
-          :id="id + '_input'"
-          :name="access_name"
-          :autocomplete="access_autocomplete"
-          :value="internalValue"
-          :class="[ customCss, 'fr-input' ]"
-          @input="updateValue($event)"
-          aria-describedby="text-input-error-desc-error"
-          :disabled="disabled"
+        type="email"
+        :id="id + '_input'"
+        :name="access_name"
+        :autocomplete="access_autocomplete"
+        :value="internalValue"
+        :class="[ customCss, 'fr-input' ]"
+        @input="updateValue($event)"
+        :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
+        :disabled="disabled"
       >
     </div>
     <div
-        id="text-input-error-desc-error"
-        class="fr-error-text"
-        v-if="hasError"
+      :id="id + '-text-input-error-desc-error'"
+      class="fr-error-text"
+      v-if="hasError"
     >
       {{ error }}
     </div>
@@ -43,7 +43,12 @@ export default defineComponent({
     disabled: { type: Boolean, default: false },
     error: { type: String, default: '' },
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    clickEvent: Function,
+    handleClickComponent: Function
   },
   computed: {
     internalValue: {

--- a/assets/vue/components/signalement-form/components/SignalementFormInfo.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormInfo.vue
@@ -17,7 +17,15 @@ export default defineComponent({
   name: 'SignalementFormInfo',
   props: {
     id: { type: String, default: null },
-    label: { type: String, default: null }
+    label: { type: String, default: null },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    clickEvent: Function,
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormLink.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormLink.vue
@@ -25,11 +25,17 @@ export default defineComponent({
     id: { type: String, default: null },
     label: { type: String, default: '' },
     link: { type: String, default: '' },
-    linktarget: { type: String, default: '' },
+    linktarget: { type: String, default: undefined },
     description: { type: String, default: null },
     customCss: { type: String, default: '' },
-    ariaControls: { type: String, default: '' },
-    clickEvent: Function
+    ariaControls: { type: String, default: undefined },
+    clickEvent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: undefined },
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   methods: {
     handleClick () {

--- a/assets/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -1,8 +1,7 @@
 <template>
   <dialog
     :class="{ 'fr-modal--opened': modelValue }"
-    aria-labelledby="fr-modal-title"
-    role="dialog"
+    :aria-labelledby="label !== '' ? 'fr-modal-title' : undefined"
     :id="id"
     class="fr-modal"
     ref="modalDialog"
@@ -22,7 +21,7 @@
               </button>
             </div>
             <div class="fr-modal__content">
-              <h1 id="fr-modal-title">{{ label }}</h1>
+              <h1 id="fr-modal-title" v-if="label !== ''">{{ label }}</h1>
               <p v-html="description"></p>
             </div>
           </div>

--- a/assets/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -1,7 +1,7 @@
 <template>
   <dialog
     :class="{ 'fr-modal--opened': modelValue }"
-    :aria-labelledby="label !== '' ? 'fr-modal-title' : undefined"
+    :aria-labelledby="label !== '' ? id + '-fr-modal-title' : undefined"
     :id="id"
     class="fr-modal"
     ref="modalDialog"
@@ -21,8 +21,8 @@
               </button>
             </div>
             <div class="fr-modal__content">
-              <h1 id="fr-modal-title" v-if="label !== ''">{{ label }}</h1>
-              <p v-html="description"></p>
+              <h1 :id="id + '-fr-modal-title'" v-if="label !== ''">{{ label }}</h1>
+              <div v-html="description"></div>
             </div>
           </div>
         </div>
@@ -40,7 +40,15 @@ export default defineComponent({
     id: String,
     label: String,
     description: String,
-    modelValue: Boolean
+    modelValue: Boolean,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    handleClickComponent: Function,
+    clickEvent: Function,
+    hasError: { type: Boolean, default: undefined },
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   methods: {
     closeModal () {

--- a/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog aria-labelledby="fr-modal-title-modal-already-exists" role="dialog" id="fr-modal-already-exists" class="fr-modal signalement-form-modal-already-exists">
+  <dialog aria-labelledby="fr-modal-title-modal-already-exists" id="fr-modal-already-exists" class="fr-modal signalement-form-modal-already-exists">
     <div class="fr-container fr-container--fluid fr-container-md">
       <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/assets/vue/components/signalement-form/components/SignalementFormModalBackHome.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormModalBackHome.vue
@@ -1,5 +1,5 @@
 <template>
-  <dialog aria-labelledby="fr-modal-title-modal-back-home" role="dialog" id="fr-modal-back-home" class="fr-modal">
+  <dialog aria-labelledby="fr-modal-title-modal-back-home" id="fr-modal-back-home" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
       <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">

--- a/assets/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -1,6 +1,6 @@
 <template>
-  <fieldset :id="id" :class="[customCss, 'signalement-form-only-choice fr-fieldset']" aria-labelledby="radio-hint-legend radio-hint-messages">
-      <legend :class="['fr-fieldset__legend--regular', 'fr-fieldset__legend', customLegendCss]" id="radio-hint-legend">
+  <fieldset :id="id" :class="[customCss, 'signalement-form-only-choice fr-fieldset']" :aria-labelledby="id + '-radio-hint-legend'">
+      <legend :class="['fr-fieldset__legend--regular', 'fr-fieldset__legend', customLegendCss]" :id="id + '-radio-hint-legend'">
         {{ variablesReplacer.replace(label) }}
       </legend>
       <div v-for="radioValue in values" :class="['fr-fieldset__element', (radioValue.value === 'oui' || radioValue.value === 'non') ? 'item-divided' : '']" :key="radioValue.value">
@@ -14,14 +14,14 @@
               class="fr-input"
               @input="updateValue($event)"
               :checked="radioValue.value === modelValue"
-              aria-describedby="radio-error-messages"
+              :aria-describedby="id + '-radio-hint-messages'"
               >
             <label class="fr-label" :for="id + '_' + radioValue.value">
                 {{ variablesReplacer.replace(radioValue.label) }}
             </label>
           </div>
       </div>
-      <div class="fr-messages-group" :id="id + '-messages'" aria-live="assertive">
+      <div class="fr-messages-group" :id="id + '-radio-hint-messages'" aria-live="assertive">
           <p class="fr-message fr-message--error fr-error-text" :id="id + '-messages-error'" v-if="hasError">{{ error }}</p>
       </div>
   </fieldset>
@@ -41,7 +41,14 @@ export default defineComponent({
     customCss: { type: String, default: '' },
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
-    error: { type: String, default: '' }
+    error: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    clickEvent: Function,
+    handleClickComponent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -201,7 +201,14 @@ export default defineComponent({
   },
   props: {
     id: { type: String, default: null },
-    clickEvent: Function
+    clickEvent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -12,7 +12,7 @@
             :name="idCountryCode"
             v-model="formStore.data[idCountryCode]"
             title="Indicatif national"
-            :aria-describedby="'text-input-error-desc-error-'+id"
+            :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
             >
             <option
               v-for="countryItem in countryList"
@@ -32,13 +32,13 @@
               :autocomplete="access_autocomplete"
               v-model="formStore.data[id]"
               class="fr-input"
-              :aria-describedby="'text-input-error-desc-error-'+id"
+              :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
               >
           </div>
         </div>
       </div>
       <div
-        :id="'text-input-error-desc-error-'+id"
+        :id="id + '-text-input-error-desc-error'"
         class="fr-error-text"
         v-if="formStore.validationErrors[id] !== undefined"
         >
@@ -69,7 +69,7 @@
             :name="idCountryCodeSecond"
             v-model="formStore.data[idCountryCodeSecond]"
             title="Indicatif national"
-            :aria-describedby="'text-input-error-desc-error-'+idSecond"
+            :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
             >
             <option
               v-for="countryItem in countryList"
@@ -88,14 +88,14 @@
               :name="idSecond"
               v-model="formStore.data[idSecond]"
               class="fr-input"
-              :aria-describedby="'text-input-error-desc-error-'+idSecond"
+              :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
               :autocomplete="access_autocomplete"
               >
           </div>
         </div>
       </div>
       <div
-        :id="'text-input-error-desc-error-'+idSecond"
+        :id="idSecond + '-text-input-error-desc-error'"
         class="fr-error-text"
         v-if="formStore.validationErrors[idSecond] !== undefined"
         >
@@ -128,7 +128,11 @@ export default defineComponent({
     error: { type: String, default: '' },
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    clickEvent: Function
+    clickEvent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    handleClickComponent: Function
   },
   data () {
     if (formStore.data[this.id + '_countrycode'] === '' || formStore.data[this.id + '_countrycode'] === undefined) {

--- a/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -132,6 +132,7 @@ export default defineComponent({
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
+    modelValue: { type: String, default: null },
     handleClickComponent: Function
   },
   data () {

--- a/assets/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -63,7 +63,13 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
-    clickEvent: Function
+    clickEvent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -37,7 +37,7 @@
         :ariaControls="component.ariaControls"
         :tagWhenEdit="component.tagWhenEdit"
         v-model="formStore.data[component.slug]"
-        :hasError="formStore.validationErrors[component.slug]  !== undefined"
+        :hasError="formStore.validationErrors[component.slug] !== undefined"
         :error="formStore.validationErrors[component.slug]"
         :class="{ 'fr-hidden': component.conditional && !formStore.shouldShowField(component.conditional.show) }"
         :autocomplete="component.autocomplete"

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -94,7 +94,14 @@ export default defineComponent({
     description: String,
     components: Object,
     customCss: { type: String, default: '' },
-    handleClickComponent: Function
+    handleClickComponent: Function,
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' },
+    clickEvent: Function
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -98,9 +98,9 @@ export default defineComponent({
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
-    hasError: { type: Boolean, default: false },
-    access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' },
+    hasError: { type: Boolean, default: undefined },
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined },
     clickEvent: Function
   },
   data () {

--- a/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="[ customCss ]" :id="id">
     <h3 v-if="label">{{ variablesReplacer.replace(label) }}</h3>
-    <p v-if="description" v-html="variablesReplacer.replace(description)"></p>
+    <div v-if="description" v-html="variablesReplacer.replace(description)"></div>
     <div
       v-if="components != undefined"
       >

--- a/assets/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -6,20 +6,19 @@
   </label>
     <div :class="[ customCss, 'fr-input-wrap' ]">
       <textarea
-        type="text"
         :id="id + '_input'"
         :name="id"
         :value="internalValue"
         :placeholder="placeholder"
         :class="[ customCss, 'fr-input' ]"
         @input="updateValue($event)"
-        aria-describedby="text-input-error-desc-error"
+        :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
         :disabled="disabled"
       >
       </textarea>
     </div>
     <div
-      id="text-input-error-desc-error"
+      :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
       v-if="hasError"
       >
@@ -43,7 +42,14 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
-    error: { type: String, default: '' }
+    error: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    clickEvent: Function,
+    handleClickComponent: Function,
+    access_name: { type: String, default: '' },
+    access_autocomplete: { type: String, default: '' }
   },
   computed: {
     internalValue: {

--- a/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -14,13 +14,13 @@
         :placeholder="placeholder"
         :class="[ customCss, 'fr-input' ]"
         @input="updateValue($event)"
-        aria-describedby="text-input-error-desc-error"
+        :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
         :disabled="disabled"
         :maxlength="validate?.maxLength"
         >
     </div>
     <div
-      id="text-input-error-desc-error"
+      :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
       v-if="hasError"
       >
@@ -49,7 +49,12 @@ export default defineComponent({
     error: { type: String, default: '' },
     tagWhenEdit: { type: String, default: '' },
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    clickEvent: Function,
+    handleClickComponent: Function
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -29,7 +29,6 @@
       </div>
       <div class="fr-col-4 fr-signalement-form-upload-delete-button">
         <button
-          id="signalement_uploadedfile_delete"
           class="fr-link fr-icon-close-circle-line fr-link--icon-left fr-link--error"
           @click="deleteFile(file)"
           >

--- a/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -10,7 +10,7 @@
       :id="id + '_input'"
       :name="id"
       class="custom-file-input"
-      aria-describedby="text-upload-error-desc-error"
+      :aria-describedby="hasError ? id + '-text-upload-error-desc-error' : undefined"
       :disabled="disabled"
       :multiple="multiple"
       @change="uploadFile($event)"
@@ -39,7 +39,7 @@
     </div>
   </div>
   <div
-    id="text-upload-error-desc-error"
+    :id="id + '-text-upload-error-desc-error'"
     class="fr-error-text"
     v-if="hasError"
     >
@@ -78,7 +78,15 @@ export default defineComponent({
     validate: { type: Object, default: null },
     disabled: { type: Boolean, default: false },
     multiple: { type: Boolean, default: false },
-    type: { type: String, default: 'documents' }
+    type: { type: String, default: 'documents' },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    handleClickComponent: Function,
+    clickEvent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
@@ -37,7 +37,15 @@ export default defineComponent({
       default: () => []
     },
     labelInfo: { type: String, default: null },
-    labelUpload: { type: String, default: null }
+    labelUpload: { type: String, default: null },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    handleClickComponent: Function,
+    clickEvent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {

--- a/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormWarning.vue
@@ -17,7 +17,15 @@ export default defineComponent({
   name: 'SignalementFormWarning',
   props: {
     id: { type: String, default: null },
-    label: { type: String, default: null }
+    label: { type: String, default: null },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    hasError: { type: Boolean, default: false },
+    handleClickComponent: Function,
+    clickEvent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {

--- a/assets/vue/signalement-form.ts
+++ b/assets/vue/signalement-form.ts
@@ -3,7 +3,7 @@ import TheSignalementAppForm from './components/signalement-form/TheSignalementA
 // import '@vuepic/vue-datepicker/dist/main.css'
 
 const app = createApp(TheSignalementAppForm)
-const dashboardComponent = document.getElementById('app-signalement-form')
+const dashboardComponent = document.getElementById('app-signalement-form-container')
 if (dashboardComponent !== null) {
-  app.mount('#app-signalement-form')
+  app.mount('#app-signalement-form-container')
 }

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -12,7 +12,7 @@
 
 {% block body %}
   <main class="fr-my-5v">
-    <div id="app-signalement-form"
+    <div id="app-signalement-form-container"
         data-ajaxurl="{{ path('front_signalement') }}"
         data-ajaxurl-dictionary="{{ path('api_dictionary') }}"
         data-ajaxurl-questions="{{ path('api_question_profile') }}?profil="


### PR DESCRIPTION
## Ticket

#2543    

## Description
Mise en conformité W3C du formulaire de signalement, afin d'avancer sur l'accessibilité

## Changements apportés
* Gestion différente du chargement du container Vue pour ne pas doubler l'id de balise de conteneur
* Ajout de paramètres sur certains composants pour qu'ils ne soient pas considérés comme des propriétés html
* Passage de paramètres à `undefined` par défaut pour qu'ils ne soient pas ajoutés au DOM
* Suppression du `role=dialog` sur les balises `dialog`

## Pré-requis
`npm run watch`

## Test à chaque changement d'écran
- [ ] `copy(document.documentElement.outerHTML);`
- [ ] Copier le presse-papier dans `https://validator.w3.org/nu/#textarea`
- [ ] Vérifier qu'il n'y a pas d'erreur sauf celles-ci
  - sur chaque écran : `Start tag seen without seeing a doctype first. Expected <!DOCTYPE html>` (ce n'est pas copié par la console)
  - sur chaque écran : `Element [style](https://html.spec.whatwg.org/multipage/#the-style-element) not allowed as child of element [body](https://html.spec.whatwg.org/multipage/#the-body-element) in this context.` (ajouté par la toolbar de Symfony)
  - à partir de l'écran de sélection de profil : `Bad value https://api-adresse.data.gouv.fr/search/?q=2 rue principale for attribute href on element [a](https://html.spec.whatwg.org/multipage/#the-a-element): Illegal character in query: space is not allowed.` (les adresses avec espaces ne sont pas compatibles, mais c'est dans la toolbar de Symfony)
  - quand il y a des champs de type Nombre : `The inputmode attribute is not supported in all browsers. Please be sure to test, and consider using a polyfill.`
  - quand il y a des modales, une erreur liée au DSFR : `Bad value true for attribute open on element dialog`
