### PR TITLE
[QA - Sentry] Erreur de type pour PartnerExcludeSpecification

### DIFF
--- a/src/Specification/Affectation/PartnerExcludeSpecification.php
+++ b/src/Specification/Affectation/PartnerExcludeSpecification.php
@@ -9,7 +9,7 @@ use App\Specification\SpecificationInterface;
 
 class PartnerExcludeSpecification implements SpecificationInterface
 {
-    public function __construct(private array|string $partnerToExclude)
+    public function __construct(private ?array $partnerToExclude)
     {
         $this->partnerToExclude = $partnerToExclude;
     }


### PR DESCRIPTION
## Ticket

#2893    

## Description
Erreur Sentry sur le type pour PartnerExcludeSpecification

## Changements apportés
* Correction de type

## Tests
- [ ] Créer une règle d'auto-affectation avec le champ à `null` et vérifier que tout fonctionne
