### PR TITLE
[FO - Signalement] Modales d'édition et suppression de photo

### DIFF
--- a/templates/back/signalement/view-old.html.twig
+++ b/templates/back/signalement/view-old.html.twig
@@ -18,6 +18,8 @@
     {% if is_granted('ROLE_ADMIN') %}
         {% include '_partials/_modal_send_lien_suivi.html.twig' %}
     {% endif %}
+    {% include '_partials/_modal_file_delete.html.twig' %}
+    {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
     <section id="signalement-{{ signalement.id }}-content"
         class="fr-p-5v fr-background--white
             {{ (isClosedForMe and not is_granted('ROLE_ADMIN_TERRITORY'))


### PR DESCRIPTION
## Ticket

#2895    

## Description
Les modales de suppression et d'édition ne s'affichent plus dans l'ancienne version de la fiche signalement.

## Changements apportés
* Ajout des fichiers twig dans l'ancienne version

## Tests
- [ ] Vérifier que l'édition / suppression est à nouveau possible
