### PR TITLE
[FO - Signalement] Affichage visite et bandeau d'information

### DIFF
--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -131,11 +131,11 @@
                     </form>
                     {% include '_partials/_modal_refus_affectation.html.twig' %}
 
-                    <div class="fr-notice fr-notice--info fr-my-4v">
+                    <div class="fr-notice fr-notice--info fr-my-4v fr-text--left">
                         <div class="fr-container">
                             <div class="fr-notice__body">
                                 <p>
-                                    <span class="fr-notice__desc">Vous devez accepter l'affectation pour pouvoir traiter le dossier.</span>
+                                    <span class="fr-notice__title">Vous devez accepter l'affectation pour pouvoir traiter le dossier.</span>
                                 </p>
                             </div>
                         </div>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -172,11 +172,11 @@
                         </a>
                     </div>
 
-                    <div class="fr-notice fr-notice--info fr-my-4v">
+                    <div class="fr-notice fr-notice--info fr-my-4v fr-text--left">
                         <div class="fr-container">
                             <div class="fr-notice__body">
                                 <p>
-                                    <span class="fr-notice__desc">En tant que responsable de territoire, vous devez valider ou refuser ce signalement.</span>
+                                    <span class="fr-notice__title">En tant que responsable de territoire, vous devez valider ou refuser ce signalement.</span>
                                 </p>
                             </div>
                         </div>

--- a/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
+++ b/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
@@ -67,20 +67,22 @@
 {% endif %}
 
 {% if formType is not same as 'confirm' %}
-<div class="fr-form-group">
-    <div class="fr-toggle">
-        <input type="checkbox" class="fr-toggle__input"
-            id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-notify-usager"
-            name="visite-{{ formType }}[notifyUsager]"
-            value="1">
-        <label class="fr-toggle__label"
-            for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-notify-usager">
-            {% if formType is same as 'edit' %}
-                En cochant cette case, l'usager sera notifié des modifications
-            {% else %}
-                En cochant cette case, l'usager sera notifié des informations de cette visite
-            {% endif %}
-        </label>
+<div class="fr-fieldset fr-mb-5v">
+    <div class="fr-form-group">
+        <div class="fr-toggle">
+            <input type="checkbox" class="fr-toggle__input"
+                id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-notify-usager"
+                name="visite-{{ formType }}[notifyUsager]"
+                value="1">
+            <label class="fr-toggle__label"
+                for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-notify-usager">
+                {% if formType is same as 'edit' %}
+                    En cochant cette case, l'usager sera notifié des modifications
+                {% else %}
+                    En cochant cette case, l'usager sera notifié des informations de cette visite
+                {% endif %}
+            </label>
+        </div>
     </div>
 </div>
 {% endif %}

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -36,7 +36,7 @@
     {% include 'back/signalement/view/visites/visite-item.html.twig' %}
 {% else %}
     {% for intervention in signalement.interventions | filter(intervention => intervention.type != enum('App\\Entity\\Enum\\InterventionType').ARRETE_PREFECTORAL) %}
-        <div class="fr-background-alt--grey fr-p-5v">
+        <div class="fr-background-alt--grey fr-p-5v fr-mb-5v">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-col-md-6 fr-h6 fr-mb-3v">
                     Visite #{{loop.index}}


### PR DESCRIPTION
## Ticket

#2870
#2872
#2890

## Description
Modification d'affichage dans la fiche signalement pour les visites et le bandeau d'info à destination des RT

## Tests
- [ ] Il y a une marge entre elles quand il y a plusieurs visites
- [ ] Dans la modale d'ajout de visite : il y a un espace au dessus du champ de commentaire ET le toggle est aligné sur les boutons radio
- [ ] Dans le bandeau d'information quand un signalement est en attente de validation du RT : le texte est aligné à gauche, l'icone apparait
