### PR TITLE
[BUG] code insee de la corse refusé

### DIFF
--- a/src/Dto/Request/Signalement/AdresseOccupantRequest.php
+++ b/src/Dto/Request/Signalement/AdresseOccupantRequest.php
@@ -31,7 +31,7 @@ class AdresseOccupantRequest implements RequestInterface
         #[Assert\Length(max: 50, maxMessage: 'La latitude ne peut pas dépasser {{ limit }} caractères.')]
         #[Assert\Regex(pattern: '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/', message: 'La latitude doit être un nombre décimal.')]
         private readonly ?string $geolocLat = null,
-        #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code insee doit être composé de 5 chiffres.')]
+        #[Assert\Regex(pattern: '/^[0-9][0-9A-Za-z][0-9]{3}$/', message: 'Le code insee doit être composé de 5 caractères.')]
         private readonly ?string $insee = null,
         #[Assert\Choice(choices: ['1'], message: 'Le champ "manual" est incorrect.')]
         private readonly ?string $manual = null,

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -52,7 +52,7 @@ class SignalementDraftRequest
     #[Assert\Length(max: 100, maxMessage: 'La ville ne peut pas dépasser {{ limit }} caractères.')]
     private ?string $adresseLogementAdresseDetailCommune = null;
     #[Assert\NotBlank(message: 'Merci de saisir un code INSEE.')]
-    #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code insee doit être composé de 5 chiffres.')]
+    #[Assert\Regex(pattern: '/^[0-9][0-9A-Za-z][0-9]{3}$/', message: 'Le code insee doit être composé de 5 caractères.')]
     private ?string $adresseLogementAdresseDetailInsee = null;
     #[Assert\Length(max: 50, maxMessage: 'La latitude ne peut pas dépasser {{ limit }} caractères.')]
     #[Assert\Regex(


### PR DESCRIPTION
## Ticket

#2898

## Description
Les code indee commencant par le numéro du département, pour la corse il contienne une lettre en seconde position. Correction du contrôle pour accepter ce format

## Tests
- [ ] Déposer un signalement en Corse et sur un autre département et s'assurer qu'aucun message d'erreur ne survient
