### PR TITLE
[BO - Liste] Badge NDE ne s'affiche plus

### DIFF
--- a/src/Dto/SignalementAffectationListView.php
+++ b/src/Dto/SignalementAffectationListView.php
@@ -130,6 +130,7 @@ class SignalementAffectationListView
         return $this->qualifications;
     }
 
+    #[Groups(['signalements:read'])]
     public function hasNde(): bool
     {
         if (null !== $this->qualifications) {
@@ -156,8 +157,8 @@ class SignalementAffectationListView
             foreach ($this->qualificationsStatuses as $qualificationStatus) {
                 $qualificationStatusName = QualificationStatus::tryFrom($qualificationStatus)?->name;
                 if ($qualificationStatusName
-                        && false === strpos($qualificationStatusName, 'NDE')
-                        && false !== strpos($qualificationStatusName, 'CHECK')
+                        && !str_contains($qualificationStatusName, 'NDE')
+                        && str_contains($qualificationStatusName, 'CHECK')
                 ) {
                     $this->qualificationsStatusesLabels[] = QualificationStatus::tryFrom($qualificationStatus)?->label();
                 }

--- a/tests/Functional/Factory/SignalementAffectationListViewFactoryTest.php
+++ b/tests/Functional/Factory/SignalementAffectationListViewFactoryTest.php
@@ -52,8 +52,8 @@ class SignalementAffectationListViewFactoryTest extends KernelTestCase
             'lastSuiviIsPublic' => false,
             'profileDeclarant' => ProfileDeclarant::LOCATAIRE,
             'rawAffectations' => 'Partenaire 13-02||1;Partenaire 13-03||1;Partenaire 13-04||1',
-            'qualifications' => null,
-            'qualificationsStatuses' => null,
+            'qualifications' => 'NON_DECENCE_ENERGETIQUE',
+            'qualificationsStatuses' => 'NDE_AVEREE',
             'conclusionsProcedure' => $procedures,
         ];
 
@@ -92,6 +92,7 @@ class SignalementAffectationListViewFactoryTest extends KernelTestCase
         $this->assertEquals($dataSignalement['lastSuiviBy'], $signalementAffectationListView->getLastSuiviBy());
         $this->assertEquals('Locataire', $signalementAffectationListView->getProfileDeclarant());
         $this->assertSame($expectedAffectations, $signalementAffectationListView->getAffectations());
+        $this->assertTrue($signalementAffectationListView->hasNde());
         $this->assertEquals(
             $dataSignalement['lastSuiviIsPublic'],
             $signalementAffectationListView->getLastSuiviIsPublic());


### PR DESCRIPTION
## Ticket

#2905   

## Description
Par défaut le serializer s'applique sur les propriétés de classe, hasNde n'avait plus de propriété donc la valeur n'était plus retourné.

## Changements apportés
* Ajout de l'attribut de serialisation sur le getter `hasNde`

## Pré-requis

## Tests
- [ ] Filtrer sur non décence énergétique et vérifier que le badge NDE s'affiche. http://localhost:8080/bo/signalements/?procedure=non_decence_energetique&isImported=oui&sortBy=reference&direction=DESC
