### PR TITLE
[QA] Migration - Synchroniser les nouveaux indexes avec les entités 

### DIFF
--- a/migrations/Version20240805165820.php
+++ b/migrations/Version20240805165820.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240805165820 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update history_entry migration';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE history_entry CHANGE event event VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE history_entry RENAME INDEX idx_8f3f68c5a76ed395 TO IDX_72999517A76ED395');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE history_entry CHANGE event event VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE history_entry RENAME INDEX idx_72999517a76ed395 TO IDX_8F3F68C5A76ED395');
+    }
+}

--- a/src/Entity/JobEvent.php
+++ b/src/Entity/JobEvent.php
@@ -10,6 +10,9 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: JobEventRepository::class)]
 #[ORM\HasLifecycleCallbacks()]
+#[ORM\Index(columns: ['created_at'], name: 'idx_job_event_created_at')]
+#[ORM\Index(columns: ['service'], name: 'idx_job_event_service')]
+#[ORM\Index(columns: ['partner_id'], name: 'idx_job_event_partner_id')]
 class JobEvent
 {
     use TimestampableTrait;

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -27,6 +27,8 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Entity(repositoryClass: SignalementRepository::class)]
 #[ORM\Index(columns: ['statut'], name: 'idx_signalement_statut')]
 #[ORM\Index(columns: ['created_at'], name: 'idx_signalement_created_at')]
+#[ORM\Index(columns: ['is_imported'], name: 'idx_signalement_is_imported')]
+#[ORM\Index(columns: ['uuid'], name: 'idx_signalement_uuid')]
 class Signalement
 {
     public const STATUS_NEED_VALIDATION = 1;

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -7,6 +7,8 @@ use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: SuiviRepository::class)]
+#[ORM\Index(columns: ['type'], name: 'idx_suivi_type')]
+#[ORM\Index(columns: ['created_at'], name: 'idx_suivi_created_at')]
 class Suivi
 {
     public const TYPE_AUTO = 1;


### PR DESCRIPTION
## Ticket

#2908   

## Description
Synchroniser les nouveaux indexes avec les entités appropriées

## Changements apportés
* Ajout des attributs PHP

## Pré-requis
```
make create-db
```
## Tests
- [ ] Executer make migration, aucune migration ne doit être généré
![image](https://github.com/user-attachments/assets/d3dc5f15-d781-46eb-b818-c8a7bd4d460b)

