### PR TITLE
[BO - Modale Confirm] Modifier Modale "Suppression"

### DIFF
--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -335,8 +335,11 @@ export default defineComponent({
       this.buildUrl()
       requests.getSignalements(this.handleSignalements)
     },
-    async deleteItem (item: SignalementItem) {
+    async deleteItem (item: SignalementItem|null) {
       this.clearScreen()
+      if (!item) {
+        return
+      }
       await requests.deleteSignalement(
         item.uuid,
         item.csrfToken,

--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -148,7 +148,6 @@ export default defineComponent({
       this.sharedState.user.canSeeStatusAffectation = isAdminOrAdminTerritoire
       this.sharedState.user.canSeeBailleurSocial = isAdminOrAdminTerritoire
       this.sharedState.user.canSeeFilterPartner = isAdminOrAdminTerritoire
-      this.sharedState.user.canDeleteSignalement = isAdminOrAdminTerritoire
       this.sharedState.user.canSeeScore = isAdminOrAdminTerritoire
       this.sharedState.user.partnerId = requestResponse.partnerId
       this.sharedState.hasSignalementImported = requestResponse.hasSignalementImported

--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -65,7 +65,7 @@
             <div class="fr-grid-row">
               <div class="fr-col-12 fr-text--right">
                 <div class="fr-display-inline-flex">
-                  <button v-if="sharedState.user.canDeleteSignalement" @click="deleteSignalementItem(item)"
+                  <button v-if="item.canDeleteSignalement" @click="deleteSignalementItem(item)"
                           class="fr-btn fr-btn--icon-left fr-btn--secondary fr-mx-1w fr-icon-delete-line">
                     Supprimer le signalement
                   </button>

--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -97,7 +97,7 @@
                         </h1>
                         <div class="fr-alert fr-alert--warning fr-mb-1w">
                           <h3 class="fr-alert__title">Attention</h3>
-                          <p>la suppression d'un signalement est définitive. Assurez-vous de la nécessité de supprimer le signalement avant de le faire !</p>
+                          <p>La suppression d'un signalement est définitive. Assurez-vous de la nécessité de supprimer le signalement avant de le faire !</p>
                         </div>
                         <p>Vous êtes sur le point de supprimer le signalement <strong>{{selectedItem?.reference}}</strong> 
                           de <strong>{{ selectedItem?.nomOccupant && selectedItem?.nomOccupant.toUpperCase()  + ' ' + selectedItem?.prenomOccupant }}</strong>. 

--- a/assets/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListCards.vue
@@ -65,7 +65,9 @@
             <div class="fr-grid-row">
               <div class="fr-col-12 fr-text--right">
                 <div class="fr-display-inline-flex">
-                  <button v-if="item.canDeleteSignalement" @click="deleteSignalementItem(item)"
+                  <button v-if="item.canDeleteSignalement" data-fr-opened="false" 
+                          aria-controls="modal-delete-signalement" 
+                          @click="selectItem(item)"
                           class="fr-btn fr-btn--icon-left fr-btn--secondary fr-mx-1w fr-icon-delete-line">
                     Supprimer le signalement
                   </button>
@@ -80,6 +82,49 @@
       </div>
     </div>
   </div>
+  <dialog aria-labelledby="modal-delete-signalement-title" id="modal-delete-signalement" class="fr-modal" role="dialog" >
+    <div class="fr-container fr-container--fluid fr-container-lg">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" aria-controls="modal-delete-signalement">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="modal-delete-signalement-title" class="fr-modal__title">
+                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
+                            Supprimer le signalement {{ selectedItem?.reference }}
+                        </h1>
+                        <div class="fr-alert fr-alert--warning fr-mb-1w">
+                          <h3 class="fr-alert__title">Attention</h3>
+                          <p>la suppression d'un signalement est définitive. Assurez-vous de la nécessité de supprimer le signalement avant de le faire !</p>
+                        </div>
+                        <p>Vous êtes sur le point de supprimer le signalement <strong>{{selectedItem?.reference}}</strong> 
+                          de <strong>{{ selectedItem?.nomOccupant && selectedItem?.nomOccupant.toUpperCase()  + ' ' + selectedItem?.prenomOccupant }}</strong>. 
+                          Une fois le signalement supprimé :</p>
+                        <ul>
+                            <li>Le signalement sera supprimé, <strong>il ne sera plus accessible dans Histologe.</strong></li>
+                            <li>Vous ne pourrez plus assurer le suivi du dossier.</li>
+                            <li>Les partenaires ne pourront plus être affectés et les affectations en cours seront supprimées.</li>
+                            <li>L'usager ne pourra plus accéder au suivi de son signalement.</li>
+                        </ul>
+                        <p>Voulez-vous vraiment supprimer ce signalement ?</p>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" @click="emitDeleteSignalementItem(selectedItem)">
+                              Oui, supprimer
+                            </button>
+                            <button class="fr-btn fr-icon-check-line" aria-controls="modal-delete-signalement">
+                              Non, annuler
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+  </dialog>
 </template>
 
 <script lang="ts">
@@ -97,7 +142,8 @@ export default defineComponent({
   emits: ['deleteSignalementItem'],
   data () {
     return {
-      sharedState: store.state
+      sharedState: store.state,
+      selectedItem: null as SignalementItem | null
     }
   },
   methods: {
@@ -212,11 +258,11 @@ export default defineComponent({
     getSuiviVisibility (label: boolean): string {
       return label ? 'Visible par l\'usager' : 'Suivi interne'
     },
-    deleteSignalementItem (item: SignalementItem) {
-      const confirmation = confirm('Êtes-vous sûr de vouloir supprimer ce signalement ?')
-      if (confirmation) {
-        this.$emit('deleteSignalementItem', item)
-      }
+    selectItem (item: SignalementItem) {
+      this.selectedItem = item
+    },
+    emitDeleteSignalementItem(item: SignalementItem|null) {
+      this.$emit('deleteSignalementItem', item);
     }
   }
 })

--- a/assets/vue/components/signalement-list/store.ts
+++ b/assets/vue/components/signalement-list/store.ts
@@ -44,7 +44,6 @@ export const store = {
       isAgent: false,
       canSeeStatusAffectation: false,
       canSeeBailleurSocial: false,
-      canDeleteSignalement: false,
       canSeeNonDecenceEnergetique: false,
       canSeeScore: false,
       canSeeFilterPartner: false,

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Dto\DemandeLienSignalement;
 use App\Dto\Request\Signalement\SignalementDraftRequest;
 use App\Entity\Enum\SignalementDraftStatus;
 use App\Entity\File;
@@ -10,6 +11,7 @@ use App\Entity\SignalementDraft;
 use App\Entity\Suivi;
 use App\Entity\User;
 use App\Factory\SuiviFactory;
+use App\Form\DemandeLienSignalementType;
 use App\Manager\SignalementDraftManager;
 use App\Manager\SuiviManager;
 use App\Manager\UserManager;
@@ -539,7 +541,7 @@ class SignalementController extends AbstractController
         UserManager $userManager,
         SignalementDesordresProcessor $signalementDesordresProcessor
     ) {
-        if ($signalement = $signalementRepository->findOneByCodeForPublic($code)) {
+        if ($signalement = $signalementRepository->findOneByCodeForPublic($code, false)) {
             $requestEmail = $request->get('from');
             $fromEmail = \is_array($requestEmail) ? array_pop($requestEmail) : $requestEmail;
 
@@ -548,11 +550,17 @@ class SignalementController extends AbstractController
 
             $infoDesordres = $signalementDesordresProcessor->process($signalement);
 
+            $demandeLienSignalement = new DemandeLienSignalement();
+            $formDemandeLienSignalement = $this->createForm(DemandeLienSignalementType::class, $demandeLienSignalement, [
+                'action' => $this->generateUrl('front_demande_lien_signalement'),
+            ]);
+
             return $this->render('front/suivi_signalement.html.twig', [
                 'signalement' => $signalement,
                 'email' => $fromEmail,
                 'type' => $type,
                 'infoDesordres' => $infoDesordres,
+                'formDemandeLienSignalement' => $formDemandeLienSignalement,
             ]);
         }
         $this->addFlash('error', 'Le lien utilisé est invalide, vérifiez votre saisie.');

--- a/src/Dto/SignalementAffectationListView.php
+++ b/src/Dto/SignalementAffectationListView.php
@@ -37,6 +37,7 @@ class SignalementAffectationListView
         private ?array $qualificationsStatuses = null,
         private ?array $conclusionsProcedure = null,
         private ?string $csrfToken = null,
+        private ?bool $canDeleteSignalement = false,
     ) {
     }
 
@@ -183,5 +184,10 @@ class SignalementAffectationListView
     public function getConclusionsProcedure(): ?array
     {
         return $this->conclusionsProcedure;
+    }
+
+    public function getCanDeleteSignalement(): bool
+    {
+        return $this->canDeleteSignalement;
     }
 }

--- a/src/Factory/SignalementAffectationListViewFactory.php
+++ b/src/Factory/SignalementAffectationListViewFactory.php
@@ -15,8 +15,7 @@ class SignalementAffectationListViewFactory
     public function __construct(
         private CsrfTokenManagerInterface $csrfTokenManager,
         private Security $security,
-        )
-    {
+        ) {
     }
 
     public function createInstanceFrom(UserInterface|User $user, array $data): SignalementAffectationListView

--- a/src/Factory/SignalementAffectationListViewFactory.php
+++ b/src/Factory/SignalementAffectationListViewFactory.php
@@ -15,7 +15,7 @@ class SignalementAffectationListViewFactory
     public function __construct(
         private CsrfTokenManagerInterface $csrfTokenManager,
         private Security $security,
-        ) {
+    ) {
     }
 
     public function createInstanceFrom(UserInterface|User $user, array $data): SignalementAffectationListView

--- a/src/Factory/SignalementAffectationListViewFactory.php
+++ b/src/Factory/SignalementAffectationListViewFactory.php
@@ -6,17 +6,24 @@ use App\Dto\SignalementAffectationListView;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\User;
 use App\Service\Signalement\SignalementAffectationHelper;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class SignalementAffectationListViewFactory
 {
-    public function __construct(private ?CsrfTokenManagerInterface $csrfTokenManager = null)
+    public function __construct(
+        private CsrfTokenManagerInterface $csrfTokenManager,
+        private Security $security,
+        )
     {
     }
 
     public function createInstanceFrom(UserInterface|User $user, array $data): SignalementAffectationListView
     {
+        $signalement = SignalementAffectationHelper::getSignalementFromDataForVoter($data);
+        $canDeleteSignalement = $this->security->isGranted('SIGN_DELETE', $signalement);
+
         list($status, $affectations) = SignalementAffectationHelper::getStatusAndAffectationFrom($user, $data);
 
         /** @var ?ProfileDeclarant $profileDeclarant */
@@ -42,14 +49,9 @@ class SignalementAffectationListViewFactory
             qualifications: SignalementAffectationHelper::getQualificationFrom($data),
             qualificationsStatuses: SignalementAffectationHelper::getQualificationStatusesFrom($data),
             conclusionsProcedure: SignalementAffectationHelper::parseConclusionProcedure($data['conclusionsProcedure']),
+            canDeleteSignalement: $canDeleteSignalement,
+            csrfToken: $canDeleteSignalement ? $this->csrfTokenManager->getToken('signalement_delete_'.$data['id']) : null,
         );
-
-        /** @var User $user */
-        if ($this->csrfTokenManager && ($user->isSuperAdmin() || $user->isTerritoryAdmin())) {
-            $signalementAffectationListView->setCsrfToken(
-                $this->csrfTokenManager->getToken('signalement_delete_'.$signalementAffectationListView->getId())->getValue()
-            );
-        }
 
         return $signalementAffectationListView;
     }

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -5,11 +5,13 @@ namespace App\Repository;
 use App\Dto\CountSignalement;
 use App\Dto\StatisticsFilters;
 use App\Entity\Affectation;
+use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\Qualification;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\Persistence\ManagerRegistry;
@@ -220,5 +222,45 @@ class AffectationRepository extends ServiceEntityRepository
             ->setParameter('day_delay', self::DELAY_VISITE_AFTER_AFFECTATION);
 
         return $qb->getQuery()->getResult();
+    }
+
+    public function deleteByStatusAndSignalement(int $status, Signalement $signalement): void
+    {
+        $qb = $this->createQueryBuilder('a');
+        $qb->delete()
+            ->where('a.statut = :status')
+            ->andWhere('a.signalement = :signalement')
+            ->setParameter('status', $status)
+            ->setParameter('signalement', $signalement)
+            ->getQuery()
+            ->execute();
+    }
+
+    public function updateStatusBySignalement(int $status, Signalement $signalement): void
+    {
+        $qb = $this->createQueryBuilder('a');
+        $qb->update()
+            ->set('a.statut', ':status')
+            ->where('a.signalement = :signalement')
+            ->setParameter('status', $status)
+            ->setParameter('signalement', $signalement)
+            ->getQuery()
+            ->execute();
+    }
+
+    public function closeBySignalement(Signalement $signalement, MotifCloture $motif, User $user): void
+    {
+        $qb = $this->createQueryBuilder('a');
+        $qb->update()
+            ->set('a.statut', ':status')
+            ->set('a.answeredBy', ':answeredBy')
+            ->set('a.motifCloture', ':motif')
+            ->where('a.signalement = :signalement')
+            ->setParameter('status', Affectation::STATUS_CLOSED)
+            ->setParameter('answeredBy', $user)
+            ->setParameter('motif', $motif)
+            ->setParameter('signalement', $signalement)
+            ->getQuery()
+            ->execute();
     }
 }

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -215,4 +215,14 @@ class NotificationRepository extends ServiceEntityRepository
 
         $qb->getQuery()->execute();
     }
+
+    public function deleteBySignalement(Signalement $signalement): void
+    {
+        $qb = $this->createQueryBuilder('n')
+            ->delete()
+            ->where('n.signalement = :signalement')
+            ->setParameter('signalement', $signalement);
+
+        $qb->getQuery()->execute();
+    }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -454,6 +454,7 @@ class SignalementRepository extends ServiceEntityRepository
             s.lastSuiviBy,
             s.lastSuiviIsPublic,
             s.profileDeclarant,
+            territory.id as territoryId,
             GROUP_CONCAT(DISTINCT CONCAT(p.nom, :concat_separator, a.statut) SEPARATOR :group_concat_separator) as rawAffectations,
             GROUP_CONCAT(DISTINCT p.nom SEPARATOR :group_concat_separator) as affectationPartnerName,
             GROUP_CONCAT(DISTINCT a.statut SEPARATOR :group_concat_separator) as affectationStatus,
@@ -465,6 +466,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->leftJoin('a.partner', 'p')
             ->leftJoin('s.signalementQualifications', 'sq', 'WITH', 'sq.status LIKE \'%AVEREE%\' OR sq.status LIKE \'%CHECK%\'')
             ->leftJoin('s.interventions', 'i', 'WITH', 'i.type LIKE \'VISITE\'')
+            ->leftJoin('s.territory', 'territory')
             ->where('s.statut != :status')
             ->groupBy('s.id')
             ->setParameter('concat_separator', SignalementAffectationListView::SEPARATOR_CONCAT)

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -646,17 +646,20 @@ class SignalementRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function findOneByCodeForPublic($code): ?Signalement
+    public function findOneByCodeForPublic($code, ?bool $excludeArchived = true): ?Signalement
     {
-        return $this->createQueryBuilder('s')
+        $qb = $this->createQueryBuilder('s')
             ->andWhere('s.codeSuivi = :code')
             ->setParameter('code', $code)
-            ->andWhere('s.statut != :status')
-            ->setParameter('status', Signalement::STATUS_ARCHIVED)
             ->leftJoin('s.suivis', 'suivis', Join::WITH, 'suivis.isPublic = 1')
-            ->addSelect('suivis')
-            ->getQuery()
-            ->getOneOrNullResult();
+            ->addSelect('suivis');
+
+        if ($excludeArchived) {
+            $qb->andWhere('s.statut != :status')
+            ->setParameter('status', Signalement::STATUS_ARCHIVED);
+        }
+
+        return $qb->getQuery()->getOneOrNullResult();
     }
 
     /**

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -19,7 +19,6 @@ class SignalementVoter extends Voter
     public const DELETE = 'SIGN_DELETE';
     public const EDIT = 'SIGN_EDIT';
     public const VIEW = 'SIGN_VIEW';
-    public const REOPEN = 'SIGN_REOPEN';
     public const ADD_VISITE = 'SIGN_ADD_VISITE';
     public const USAGER_EDIT = 'SIGN_USAGER_EDIT';
     public const EDIT_NDE = 'SIGN_EDIT_NDE';
@@ -30,7 +29,7 @@ class SignalementVoter extends Voter
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::VALIDATE, self::REOPEN, self::CLOSE, self::ADD_VISITE, self::USAGER_EDIT, self::EDIT_NDE])
+        return \in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::VALIDATE, self::CLOSE, self::ADD_VISITE, self::USAGER_EDIT, self::EDIT_NDE])
             && ($subject instanceof Signalement);
     }
 
@@ -54,7 +53,7 @@ class SignalementVoter extends Voter
             return $this->canEditNDE($subject, $user);
         }
 
-        if ($this->security->isGranted('ROLE_ADMIN') && $attribute !== self::DELETE) {
+        if ($this->security->isGranted('ROLE_ADMIN') && self::DELETE !== $attribute) {
             return true;
         }
 
@@ -62,7 +61,6 @@ class SignalementVoter extends Voter
             self::VALIDATE => $this->canValidate($subject, $user),
             self::CLOSE => $this->canClose($subject, $user),
             self::DELETE => $this->canDelete($subject, $user),
-            self::REOPEN => $this->canReopen($subject, $user),
             self::EDIT => $this->canEdit($subject, $user),
             self::VIEW => $this->canView($subject, $user),
             default => false,
@@ -100,21 +98,17 @@ class SignalementVoter extends Voter
 
     private function canDelete(Signalement $signalement, User $user): bool
     {
-        if(!in_array($signalement->getStatut(), [Signalement::STATUS_CLOSED, Signalement::STATUS_REFUSED])) {
+        if (!\in_array($signalement->getStatut(), [Signalement::STATUS_CLOSED, Signalement::STATUS_REFUSED])) {
             return false;
         }
         if ($this->security->isGranted('ROLE_ADMIN')) {
             return true;
         }
-        if($this->security->isGranted('ROLE_ADMIN_TERRITORY') && $user->getTerritory()->getId() === $signalement->getTerritory()->getId()){
+        if ($this->security->isGranted('ROLE_ADMIN_TERRITORY') && $user->getTerritory()->getId() === $signalement->getTerritory()->getId()) {
             return true;
         }
-        return false;
-    }
 
-    private function canReopen(Signalement $signalement, User $user): bool
-    {
-        return Signalement::STATUS_CLOSED === $signalement->getStatut() && $user->isTerritoryAdmin() && $user->getTerritory() === $signalement->getTerritory();
+        return false;
     }
 
     private function canEdit(Signalement $signalement, User $user): bool

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -54,7 +54,7 @@ class SignalementVoter extends Voter
             return $this->canEditNDE($subject, $user);
         }
 
-        if ($user->isSuperAdmin()) {
+        if ($this->security->isGranted('ROLE_ADMIN') && $attribute !== self::DELETE) {
             return true;
         }
 
@@ -100,7 +100,16 @@ class SignalementVoter extends Voter
 
     private function canDelete(Signalement $signalement, User $user): bool
     {
-        return $user->isTerritoryAdmin() && $user->getTerritory() === $signalement->getTerritory();
+        if(!in_array($signalement->getStatut(), [Signalement::STATUS_CLOSED, Signalement::STATUS_REFUSED])) {
+            return false;
+        }
+        if ($this->security->isGranted('ROLE_ADMIN')) {
+            return true;
+        }
+        if($this->security->isGranted('ROLE_ADMIN_TERRITORY') && $user->getTerritory()->getId() === $signalement->getTerritory()->getId()){
+            return true;
+        }
+        return false;
     }
 
     private function canReopen(Signalement $signalement, User $user): bool

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -6,7 +6,10 @@ use App\Dto\SignalementAffectationListView;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\ProcedureType;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\Signalement;
+use App\Entity\Territory;
 use App\Entity\User;
+use ReflectionClass;
 
 class SignalementAffectationHelper
 {
@@ -85,4 +88,22 @@ class SignalementAffectationHelper
             return ProcedureType::from($procedure)->label();
         }, $lastProcedures);
     }
+
+    public static function getSignalementFromDataForVoter(array $data): Signalement
+    {
+        $signalement = new Signalement();
+        $territory = new Territory();
+
+        $reflectionClass = new ReflectionClass($territory);
+        $property = $reflectionClass->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($territory, $data['territoryId']);
+
+        $signalement->setTerritory($territory);
+        $signalement->setStatut($data['statut']);
+
+        return $signalement;
+    }
+
+
 }

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -104,6 +104,4 @@ class SignalementAffectationHelper
 
         return $signalement;
     }
-
-
 }

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -9,7 +9,6 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\Signalement;
 use App\Entity\Territory;
 use App\Entity\User;
-use ReflectionClass;
 
 class SignalementAffectationHelper
 {
@@ -94,7 +93,7 @@ class SignalementAffectationHelper
         $signalement = new Signalement();
         $territory = new Territory();
 
-        $reflectionClass = new ReflectionClass($territory);
+        $reflectionClass = new \ReflectionClass($territory);
         $property = $reflectionClass->getProperty('id');
         $property->setAccessible(true);
         $property->setValue($territory, $data['territoryId']);

--- a/templates/_partials/_demande-lien-signalement.html.twig
+++ b/templates/_partials/_demande-lien-signalement.html.twig
@@ -1,12 +1,19 @@
-<h2 class="fr-mt-5w">J'ai déposé un signalement et je veux accéder à mon suivi</h2>
-
-<p>
-	Après le dépôt de votre signalement, vous avez reçu un e-mail contenant le lien vers votre page de suivi. 
-	N'hésitez pas à consulter votre boîte mail et vos courriers indésirables (spam) pour retrouver votre lien !
-	<br>
-	Vous pouvez aussi demander un nouveau lien vers votre page de suivi en remplissant les champs ci-dessous. 
-	Un e-mail avec le lien vers votre page de suivi vous sera alors envoyé.
-</p>
+{% if motifRefusDoublon is defined and motifRefusDoublon %}
+	<h2 class="fr-mt-5w">Vous avez déposé un autre signalement ?</h2>
+	<p>
+		Pour recevoir le lien vers la page de suivi de votre signalement, remplissez les champs ci-dessous. 
+		Un e-mail avec le lien vers votre page de suivi vous sera alors envoyé.
+	</p>
+{% else %}
+	<h2 class="fr-mt-5w">J'ai déposé un signalement et je veux accéder à mon suivi</h2>
+	<p>
+		Après le dépôt de votre signalement, vous avez reçu un e-mail contenant le lien vers votre page de suivi. 
+		N'hésitez pas à consulter votre boîte mail et vos courriers indésirables (spam) pour retrouver votre lien !
+		<br>
+		Vous pouvez aussi demander un nouveau lien vers votre page de suivi en remplissant les champs ci-dessous. 
+		Un e-mail avec le lien vers votre page de suivi vous sera alors envoyé.
+	</p>
+{% endif %}
 <div id="container-form-demande-lien-signalement">
 	{% include '_partials/_form-demande-lien-signalement.html.twig' with {'form': formDemandeLienSignalement} only %}
 </div>

--- a/templates/back/signalement/list/index.html.twig
+++ b/templates/back/signalement/list/index.html.twig
@@ -8,7 +8,7 @@
          data-ajaxurl-export-csv="{{ path('back_signalement_list_export') }}"
          data-ajaxurl-settings="{{ path('back_widget_settings') }}"
          data-ajaxurl-contact="{{ path('front_contact') }}"
-         data-ajaxurl-remove-signalement="{{ path('back_v2_signalement_delete', {'uuid' : '<uuid>'}) }}"
+         data-ajaxurl-remove-signalement="{{ path('back_signalement_delete', {'uuid' : '<uuid>'}) }}"
     >
 
     </div>

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -41,6 +41,10 @@
 		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
 			<p>Votre dossier a été clôturé il y a plus de 30 jours, vous ne pouvez plus envoyer de messages.</p>
 		</div>
+	{% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_ARCHIVED') %}
+		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
+			<p>Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.</p>
+		</div>
 	{% else %}
 		<form action="{{ path('front_suivi_signalement_user_response',{code:signalement.codeSuivi}) }}" class="needs-validation fr-disable-button-when-submit" novalidate method="POST">
 			<div class="fr-input-group">

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -101,6 +101,18 @@
 			{% include 'front/_partials/_suivi_signalement_tab_infos.html.twig' %}
 		</div>
 	</div>
+
+	{% if 
+		(signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_ARCHIVED')) 
+		and signalement.motifRefus is same as constant('App\\Entity\\Enum\\MotifRefus::DOUBLON') %}
+			<div class="fr-mb-1w">
+			{{ include ('_partials/_demande-lien-signalement.html.twig', {motifRefusDoublon: true}) }}
+			</div>
+	{% endif %}
+
+
+
+
 </main>
 {% endblock %}
 {% block javascripts %}

--- a/tests/Functional/Controller/Back/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementControllerTest.php
@@ -304,7 +304,7 @@ class SignalementControllerTest extends WebTestCase
 
         $client->request(
             'POST',
-            '/bo/signalements/v2/'.$uuid.'/supprimer',
+            '/bo/signalements/'.$uuid.'/supprimer',
             [],
             [],
             ['Content-Type' => 'application/json'],

--- a/tests/Functional/Controller/Back/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementControllerTest.php
@@ -290,7 +290,7 @@ class SignalementControllerTest extends WebTestCase
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = self::getContainer()->get(SignalementRepository::class);
         /** @var Signalement $signalement */
-        $signalement = $signalementRepository->findOneBy(['reference' => '2022-10']);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2022-13']);
 
         /** @var UserRepository $userRepository */
         $userRepository = self::getContainer()->get(UserRepository::class);

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -82,7 +82,10 @@ class SignalementControllerTest extends WebTestCase
 
         $crawler = $client->request('GET', $urlSuiviSignalementUser);
         if (Signalement::STATUS_ARCHIVED === $status) {
-            $this->assertResponseRedirects('/');
+            $this->assertEquals(
+                'Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.',
+                $crawler->filter('.fr-alert--error p')->text()
+            );
         } elseif (Signalement::STATUS_ACTIVE === $status) {
             $this->assertEquals('Signalement #2022-1 '.$signalement->getPrenomOccupant().' '.$signalement->getNomOccupant(), $crawler->filter('h1')->eq(2)->text());
         } elseif (Signalement::STATUS_CLOSED === $status) {

--- a/tests/Functional/Factory/SignalementAffectationListViewFactoryTest.php
+++ b/tests/Functional/Factory/SignalementAffectationListViewFactoryTest.php
@@ -19,7 +19,6 @@ class SignalementAffectationListViewFactoryTest extends KernelTestCase
     private CsrfTokenManagerInterface $csrfTokenManager;
     private Security $security;
 
-
     protected function setUp(): void
     {
         self::bootKernel();

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -15,6 +15,7 @@ use App\Factory\SignalementExportFactory;
 use App\Factory\SignalementFactory;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
+use App\Repository\AffectationRepository;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordrePrecisionRepository;
 use App\Service\DataGouv\AddressService;
@@ -55,6 +56,7 @@ class SignalementManagerTest extends WebTestCase
     private SuiviManager $suiviManager;
     private BailleurRepository $bailleurRepository;
     private AddressService $addressService;
+    private AffectationRepository $affectationRepository;
 
     protected function setUp(): void
     {
@@ -79,6 +81,7 @@ class SignalementManagerTest extends WebTestCase
         $this->suiviManager = static::getContainer()->get(SuiviManager::class);
         $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
         $this->addressService = static::getContainer()->get(AddressService::class);
+        $this->affectationRepository = static::getContainer()->get(AffectationRepository::class);
 
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
@@ -97,6 +100,7 @@ class SignalementManagerTest extends WebTestCase
             $this->suiviManager,
             $this->bailleurRepository,
             $this->addressService,
+            $this->affectationRepository
         );
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
         $client->loginUser($user);

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -4,7 +4,9 @@ namespace App\Tests\Functional\Repository;
 
 use App\Entity\Affectation;
 use App\Entity\Enum\PartnerType;
+use App\Entity\Signalement;
 use App\Repository\AffectationRepository;
+use App\Repository\SignalementRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -41,5 +43,17 @@ class AffectationRepositoryTest extends KernelTestCase
         );
 
         $this->assertCount(1, $affectationsSubscribedToEsabora);
+    }
+
+    public function testUpdateStatusBySignalement(): void
+    {
+        /** @var AffectationRepository $affectationRepository */
+        $affectationRepository = $this->entityManager->getRepository(Affectation::class);
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $signalement = $signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2024-000000000004']);
+        $affectationRepository->updateStatusBySignalement(Affectation::STATUS_WAIT, $signalement);
+        $affectations = $affectationRepository->findBy(['signalement' => $signalement, 'statut' => Affectation::STATUS_WAIT]);
+        $this->assertCount(2, $affectations);
     }
 }

--- a/tests/Functional/Service/Signalement/PhotoHelperTest.php
+++ b/tests/Functional/Service/Signalement/PhotoHelperTest.php
@@ -8,6 +8,7 @@ use App\Factory\SignalementExportFactory;
 use App\Factory\SignalementFactory;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
+use App\Repository\AffectationRepository;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordrePrecisionRepository;
 use App\Service\DataGouv\AddressService;
@@ -42,6 +43,7 @@ class PhotoHelperTest extends KernelTestCase
     private SuiviManager $suiviManager;
     private BailleurRepository $bailleurRepository;
     private AddressService $addressService;
+    private AffectationRepository $affectationRepository;
 
     protected function setUp(): void
     {
@@ -64,6 +66,7 @@ class PhotoHelperTest extends KernelTestCase
         $this->suiviManager = static::getContainer()->get(SuiviManager::class);
         $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
         $this->addressService = static::getContainer()->get(AddressService::class);
+        $this->affectationRepository = static::getContainer()->get(AffectationRepository::class);
 
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
@@ -82,6 +85,7 @@ class PhotoHelperTest extends KernelTestCase
             $this->suiviManager,
             $this->bailleurRepository,
             $this->addressService,
+            $this->affectationRepository
         );
     }
 


### PR DESCRIPTION
## Ticket

#2780

## Description
Modification du processus de suppression (archivage) d'un signalement

## Changements apportés
* Seul les signalements clôturés ou archivés peuvent à présent être supprimés : centralisation de la logique de contrôle back et front dans le voter
* Remplacement de l'alerte de confirmation de suppression par une modale
* Suppression des notifications du signalement lors de l'archivage (+ suppression de l'ancienne route de suppression inutilisé)
* La fiche de suivi utilisateur reste accessible en lecture aprés archivage d'un signalement, ajout du formulaire de récupération de lien de signalement dans le cas d'un motif de refus pour doublon
* Quelques simplifications/optimisations de code

## Pré-requis
`make npm-build`

## Tests
- [ ] Vérifier le fonctionnement du bouton suppression des signalement (présent uniquement sur les statut cloturé/refusé)
- [ ] cloturé un signalement pour le motif doublon, l'archivé et vérifier que le lien usager et toujours valide et que la page contient le formulaire de demande de lien de signalement
