### PR TITLE
[BO - Liste partenaires + liste notif] Affichage des boutons d'action

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -126,7 +126,8 @@ pre {
     margin-top: -0.75rem !important;
 }
 
-.fr-ws-nowrap {
+.fr-ws-nowrap,
+.fr-table__content .fr-cell--multiline .fr-ws-nowrap {
     white-space: nowrap;
 }
 

--- a/templates/back/inactive-account/index.html.twig
+++ b/templates/back/inactive-account/index.html.twig
@@ -46,10 +46,10 @@
 						<tbody>
 							{% for user in inactiveUsers %}
 								<tr class="user-row">
-									<td>{{ user.nom}}</td>
-									<td>{{ user.prenom}}</td>
-									<td>{{ user.email}}</td>
-									<td>{{ user.roles[0]}}</td>
+									<td class="word-wrap-anywhere">{{ user.nom}}</td>
+									<td class="word-wrap-anywhere">{{ user.prenom}}</td>
+									<td class="word-wrap-anywhere">{{ user.email}}</td>
+									<td class="word-wrap-anywhere">{{ user.roles[0]}}</td>
 									<td>{{ user.statutLabel }}</td>
 									<td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y H:i')}}</td>
 									<td>{{ user.territory ? user.territory.zip ~ ' - ' ~ user.territory.name : 'aucun' }}</td>

--- a/templates/back/notifications/index.html.twig
+++ b/templates/back/notifications/index.html.twig
@@ -65,7 +65,7 @@
                                     |sanitize_html('app.message_sanitizer') }}
                                 </td>
                                 <td>{{ notification.suivi.createdBy ? notification.suivi.createdBy.nomComplet : notification.signalement.nomOccupant|upper~' '~notification.signalement.prenomOccupant|capitalize }}</td>
-                                <td class="fr-text--right">
+                                <td class="fr-text--right fr-ws-nowrap">
                                     <a href="{{ path('back_signalement_view',{uuid:notification.suivi.signalement.uuid}) }}#suivis"
                                     class="fr-btn fr-btn--sm {{ notification.isSeen ? 'fr-fi-check-line fr-btn--success':'fr-fi-eye-fill' }}"></a>
                                     <a href="{{ path('back_notifications_delete_notification',{id:notification.id}) }}?_token={{ csrf_token('back_delete_notification_'~notification.id) }}"

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -101,7 +101,7 @@
                                         /
                                     {% endif %}
                                 </td>
-                                <td class="fr-text--right">
+                                <td class="fr-text--right fr-ws-nowrap">
                                     <a href="{{ path('back_partner_view', {'id': partner.id}) }}"
                                     class="fr-btn fr-fi-arrow-right-line fr-btn--sm"></a>
                                     <a href="#" class="fr-btn fr-btn--danger fr-fi-delete-line fr-btn--sm btn-delete-partner"


### PR DESCRIPTION
## Ticket

#2910 
#2911

## Description
Tableaux admin page partenaires et notifications : fixé les bouton d'action sur une ligne
Tableau admin page comptes inactifs : faire en sorte que le tableau entre entièrement dans la page

## Pré-requis
`make npm-build`

## Tests
- [ ] Vérifier que le comportement décrit dans les tickets est bien corrigé
