### PR TITLE
[BUG - TECH] Mettre le serveur de prod à l'heure réelle pour eviter soucis sur dépot de visite le jour même

### DIFF
--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && docker-php-ext-enable opcache \
         && rm /usr/src/php/ext/*.tgz \
         && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer  \
-        && mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+        && mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini" \
+        && echo "date.timezone = Europe/Paris" >> "$PHP_INI_DIR/php.ini"
 
 RUN sed -E -i -e 's/memory_limit = 128M/memory_limit = 512M/' "$PHP_INI_DIR/php.ini" \
     && sed -E -i -e 's/post_max_size = 8M/post_max_size = 75M/' "$PHP_INI_DIR/php.ini" \

--- a/.docker/php-worker/Dockerfile
+++ b/.docker/php-worker/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && docker-php-ext-enable opcache \
         && rm /usr/src/php/ext/*.tgz \
         && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer  \
-        && mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+        && mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini" \
+        && echo "date.timezone = Europe/Paris" >> "$PHP_INI_DIR/php.ini"
 
 RUN sed -E -i -e 's/memory_limit = 128M/memory_limit = 512M/' "$PHP_INI_DIR/php.ini" \
     && sed -E -i -e 's/post_max_size = 8M/post_max_size = 75M/' "$PHP_INI_DIR/php.ini" \


### PR DESCRIPTION
## Ticket

#2884

## Description
Spécification du timezone PHP à l'heure française

## Pré-requis
`make build`

## Tests
- [ ] Ajouter un suivi et vérifier que son champ created_at en base de donnée correspond à l'heure française
