### PR TITLE
[BO - Etiquettes] Correction UI

### DIFF
--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -1,11 +1,12 @@
 {% if canEditSignalement %}
-    <a class="fr-btn--icon-left fr-a-edit fr-icon-bookmark-line fr-ml-2v" id="tags_select_tooltip_btn" href="#"
+    <button>
+        <a class="fr-btn--icon-left fr-a-edit fr-icon-bookmark-line fr-ml-2v" id="tags_select_tooltip_btn" href="#"
         data-fr-opened="false" aria-controls="fr-modal-etiquettes">Gérer les étiquettes</a>
-</button>
+    </button>
     <div>
         <div class="fr-my-3v">
             {% for tag in signalement.tags %}
-                <span class="fr-badge fr-badge--blue-ecume fr-mr-1v">{{ tag.label }}</span>
+                <span class="fr-badge fr-badge--blue-ecume fr-m-1v">{{ tag.label }}</span>
             {% else %}
                 <em class="fr-text-default--warning fr-fi-close-line fr-icon--xs">
                     <small>Aucune étiquette attribuée à ce signalement.</small>

--- a/templates/back/tags/index.html.twig
+++ b/templates/back/tags/index.html.twig
@@ -219,7 +219,7 @@
                                             title="Voir la liste des signalements avec l'étiquette {{ tag.label }}"
                                             href="{{ path('back_index', { 'etiquettes[]': tag.id, 'isImported': 'oui' }) }}"
                                             >Voir la liste des signalements avec l'étiquette {{ tag.label }}</a>
-                                        <button class="fr-btn fr-icon-delete-line"
+                                        <button class="fr-btn fr-btn--secondary fr-icon-delete-line"
                                             title="Supprimer l'étiquette {{ tag.label }}"
                                             data-fr-opened="false" aria-controls="fr-modal-etiquette-delete-{{ tag.id }}"
                                             >Supprimer l'étiquette {{ tag.label }}</button>


### PR DESCRIPTION
## Ticket

#2916  #2923   

## Description
- Mettre bouton suppression en bouton secondaire
- Augmenter l'espace vertical entre les lignes d'étiquettes

## Changements apportés
* Mise à jour classes CSS

## Pré-requis

## Tests
- [ ] Ouvrir la page Gérer les étqiuettes en tant qu'admin et constater le bouton supprimer est bien en secondaire
- [ ] Ajouter plusieurs étiquettes à une fiche et vérifier qu'il y'ai suffisamment d'espace entre les étiquettes du projet
