### PR TITLE
[BO - Signalement] Afficher les étiquettes sur les signalements fermés

### DIFF
--- a/assets/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/controllers/back_signalement_view/back_view_signalement.js
@@ -69,7 +69,7 @@ document?.querySelector('.back-link')?.addEventListener('click', (event) => {
 
 document?.querySelectorAll('.signalement-tag-add')?.forEach(element => {
     element.addEventListener('click', (event) => {
-        element.classList?.add('fr-hidden')
+        element.classList?.add('fr-hidden', 'disabled')
 
         const etiquette = document.createElement('span');
         etiquette.classList.add('fr-badge', 'fr-badge--blue-ecume', 'fr-m-1v', 'signalement-tag-remove')
@@ -98,7 +98,7 @@ const inputEtiquetteFilter = document?.querySelector('#etiquette-filter-input')
 inputEtiquetteFilter?.addEventListener('input', (event) => {
     const inputValue = event.target.value.toLowerCase()
     document?.querySelectorAll('.signalement-tag-add')?.forEach(element => {
-        if (element.getAttribute('data-taglabel').toLowerCase().indexOf(inputValue) > -1) {
+        if (element.getAttribute('data-taglabel').toLowerCase().indexOf(inputValue) > -1 && !element.classList.contains('disabled')) {
             element.classList?.remove('fr-hidden')
         } else {
             element.classList?.add('fr-hidden')
@@ -115,7 +115,7 @@ document?.querySelectorAll('.signalement-tag-remove')?.forEach(element => {
 const removeEtiquette = (element) => {
     const tagId = element.getAttribute('data-tagid')
     const etiquetteBadgeAdd = document.querySelector('#etiquette-badge-add-' + tagId);
-    etiquetteBadgeAdd.classList?.remove('fr-hidden')
+    etiquetteBadgeAdd.classList?.remove('fr-hidden', 'disabled');
 
     element.remove();
 

--- a/assets/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/controllers/back_signalement_view/back_view_signalement.js
@@ -96,9 +96,10 @@ document?.querySelectorAll('.signalement-tag-add')?.forEach(element => {
 
 const inputEtiquetteFilter = document?.querySelector('#etiquette-filter-input')
 inputEtiquetteFilter?.addEventListener('input', (event) => {
-    const inputValue = event.target.value.toLowerCase()
+    const inputValue = event.target.value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
     document?.querySelectorAll('.signalement-tag-add')?.forEach(element => {
-        if (element.getAttribute('data-taglabel').toLowerCase().indexOf(inputValue) > -1 && !element.classList.contains('disabled')) {
+        const normalizedTagLabel = element.getAttribute('data-taglabel').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+        if (normalizedTagLabel.indexOf(inputValue) > -1 && !element.classList.contains('disabled')) {
             element.classList?.remove('fr-hidden')
         } else {
             element.classList?.add('fr-hidden')

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -1760,7 +1760,9 @@ class Signalement
      */
     public function getTags(): Collection
     {
-        return $this->tags;
+        return $this->tags->filter(function (Tag $tag) {
+            return !$tag->getIsArchive();
+        });
     }
 
     public function addTag(Tag $tag): self

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -52,7 +52,7 @@
                                     {% for tag in tags %}
                                         <span
                                             id="etiquette-badge-add-{{ tag.id }}"
-                                            class="fr-badge fr-m-1v signalement-tag-add {% if tag in signalement.tags %}fr-hidden{% endif %}"
+                                            class="fr-badge fr-m-1v signalement-tag-add {% if tag in signalement.tags %}fr-hidden disabled{% endif %}"
                                             data-tagid="{{ tag.id }}" data-taglabel="{{ tag.label }}"
                                             >{{ tag.label }} <span class="fr-icon-add-line" aria-hidden="true"></span></span>
                                     {% else %}

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -3,18 +3,18 @@
         <a class="fr-btn--icon-left fr-a-edit fr-icon-bookmark-line fr-ml-2v" id="tags_select_tooltip_btn" href="#"
         data-fr-opened="false" aria-controls="fr-modal-etiquettes">Gérer les étiquettes</a>
     </button>
-    <div>
-        <div class="fr-my-3v">
-            {% for tag in signalement.tags %}
-                <span class="fr-badge fr-badge--blue-ecume fr-m-1v">{{ tag.label }}</span>
-            {% else %}
-                <em class="fr-text-default--warning fr-fi-close-line fr-icon--xs">
-                    <small>Aucune étiquette attribuée à ce signalement.</small>
-                </em>
-            {% endfor %}
-        </div>
-    </div>
 {% endif %}
+<div>
+    <div class="fr-my-3v">
+        {% for tag in signalement.tags %}
+            <span class="fr-badge fr-badge--blue-ecume fr-m-1v">{{ tag.label }}</span>
+        {% else %}
+            <em class="fr-text-default--warning fr-fi-close-line fr-icon--xs">
+                <small>Aucune étiquette attribuée à ce signalement.</small>
+            </em>
+        {% endfor %}
+    </div>
+</div>
 
 <dialog aria-labelledby="fr-modal-title-modal-etiquettes" role="dialog" id="fr-modal-etiquettes" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">


### PR DESCRIPTION
## Ticket

#2918 
#2921 
#2922

## Description
- Les étiquettes sont à présent affiché dans tous les cas sur la fiche signalement (même si le signalement n'est pas éditable)
- Uniquement les étiquettes qui ne sont pas archivés sont affichées sur les signalements
- Impossible de sélectionner plusieurs fois une même etiquette dans la gestion des étiquette d'un signalement (via input de recherche)

## Pré-requis
`make npm-buil`

## Tests
- [ ] Vérifier que les trois points fonctionne correctement
