### PR TITLE
[BO - Etiquettes] Quand accès au signalement en tant que SA, il manque le filtre sur le territoire

### DIFF
--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -184,7 +184,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
 
         if (isset($row['tags'])) {
             foreach ($row['tags'] as $tag) {
-                $signalement->addTag($this->tagRepository->findOneBy(['label' => $tag]));
+                $signalement->addTag($this->tagRepository->findOneBy(['label' => $tag, 'territory' => $signalement->getTerritory()]));
             }
         }
 

--- a/templates/back/tags/index.html.twig
+++ b/templates/back/tags/index.html.twig
@@ -217,7 +217,11 @@
                                             >Editer l'étiquette {{ tag.label }}</button>
                                         <a class="fr-btn fr-icon-list-unordered"
                                             title="Voir la liste des signalements avec l'étiquette {{ tag.label }}"
-                                            href="{{ path('back_index', { 'etiquettes[]': tag.id, 'isImported': 'oui' }) }}"
+                                            {% if is_granted('ROLE_ADMIN') %}
+                                                href="{{ path('back_index', { 'etiquettes[]': tag.id, 'isImported': 'oui', 'territoire': tag.territory.id }) }}"
+                                            {% else %}
+                                                href="{{ path('back_index', { 'etiquettes[]': tag.id, 'isImported': 'oui' }) }}"
+                                            {% endif %}
                                             >Voir la liste des signalements avec l'étiquette {{ tag.label }}</a>
                                         <button class="fr-btn fr-btn--secondary fr-icon-delete-line"
                                             title="Supprimer l'étiquette {{ tag.label }}"

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -193,7 +193,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Commune code postal' => [['communes' => ['13002']], 1];
         yield 'Search by EPCIS' => [['epcis' => ['244400503']], 1];
         yield 'Search by Partner' => [['partenaires' => ['5']], 2];
-        yield 'Search by Etiquettes' => [['etiquettes' => ['3']], 4];
+        yield 'Search by Etiquettes' => [['etiquettes' => ['5']], 4];
         yield 'Search by Parc public' => [['natureParc' => 'public'], 5];
         yield 'Search by Parc public/prive non renseigné' => [['natureParc' => 'non_renseigne'], 1];
         yield 'Search by Enfant moins de 6ans (non)' => [['enfantsM6' => 'non'], 1];


### PR DESCRIPTION
## Ticket

#2917

## Description
- Ajout du filtre territoire pour les SA accédant a une liste de signalement depuis la page étiquette
- Correction des fixture et tests afin que les tag en doublon (sur territoire différents) soit placé sur les bon signalement en fonction de son territoire

## Pré-requis
`make load-fixtures`

## Tests
- [ ] Les différentes étapes des tests à faire
