### PR TITLE
[BO - Liste signalements] Les filtres sélections multiple ne fonctionnent plus

### DIFF
--- a/assets/vue/components/common/HistoMultiSelect.vue
+++ b/assets/vue/components/common/HistoMultiSelect.vue
@@ -2,7 +2,6 @@
   <div
     :class="['histo-multi-select', active ? 'active' : 'inactive']"
     @focusout="isExpanded = false"
-    tabindex="0"
     >
     <div
       class="selector fr-select"


### PR DESCRIPTION
## Ticket

#2920    

## Description
Il existe un problème de focus  que j'ai pas réussi à identifier sur chrome, cependant la suppression du tabindex sur le composant rend le composant de nouveau fonctionnel

Inconvénient est que le composant n'est plus accessible via le clavier. Faudrait un autre ticket pour investiguer davantage ou attendre l'upgrade de ce composant avec le nouveau composant qui est en beta actuellement
https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants-beta/liste-deroulante-riche

## Changements apportés
* Suppression de l'attribut tabindex

## Pré-requis

```
make npm-build
```

## Tests
- [ ] Tester les filtre sur la liste sur chrome, firefox, edge
- [ ] Tester les filtres sur les stats sur chrome, firefox, edge
