### PR TITLE
[BO] désactiver la nouvelle page etiquette

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -9,6 +9,7 @@ twig:
             url: '%host_url%'
             demo: 'https://app.livestorm.co/mte/demonstration-histologe'
             cgu_current_version: '%cgu_current_version%'
+            feature_signalement_view_enabled: '%feature_signalement_view_enabled%'
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr

--- a/src/Controller/Back/TagController.php
+++ b/src/Controller/Back/TagController.php
@@ -12,6 +12,7 @@ use App\Repository\TerritoryRepository;
 use App\Service\FormHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +23,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class TagController extends AbstractController
 {
     public const MAX_LIST_PAGINATION = 50;
+
+    public function __construct(
+        #[Autowire(env: 'FEATURE_SIGNALEMENT_VIEW_ENABLED')]
+        bool $featureSignalementViewEnable,
+    ) {
+        if (!$featureSignalementViewEnable) {
+            throw $this->createNotFoundException();
+        }
+    }
 
     #[Route('/', name: 'back_tags_index', methods: ['GET', 'POST'])]
     #[IsGranted('ROLE_ADMIN_TERRITORY')]

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -92,11 +92,13 @@
                                        target="_self"
                                        {% if 'back_partner' in app.request.get('_route') %}aria-current="page"{% endif %}>Partenaires</a>
                                 </li>
-                                <li class="fr-sidemenu__item {% if 'back_tags' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
-                                    <a class="fr-sidemenu__link" href="{{ path('back_tags_index') }}"
-                                       target="_self"
-                                       {% if 'back_tags' in app.request.get('_route') %}aria-current="page"{% endif %}>Etiquettes</a>
-                                </li>
+                                {% if platform.feature_signalement_view_enabled %}
+                                    <li class="fr-sidemenu__item {% if 'back_tags' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
+                                        <a class="fr-sidemenu__link" href="{{ path('back_tags_index') }}"
+                                        target="_self"
+                                        {% if 'back_tags' in app.request.get('_route') %}aria-current="page"{% endif %}>Etiquettes</a>
+                                    </li>
+                                {% endif %}
                                 {% if is_granted('ROLE_ADMIN') %}
                                     <li class="fr-sidemenu__item {% if 'back_archived_partner' in app.request.get('_route') %}fr-sidemenu__item--active{% endif %}">
                                         <a class="fr-sidemenu__link" href="{{ path('back_archived_partner_index') }}"

--- a/tests/Functional/Controller/Back/BackTagControllerTest.php
+++ b/tests/Functional/Controller/Back/BackTagControllerTest.php
@@ -26,6 +26,10 @@ class BackTagControllerTest extends WebTestCase
 
         $user = $this->userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
         $this->client->loginUser($user);
+        $featureSignalementViewEnabled = static::getContainer()->getParameter('feature_signalement_view_enabled');
+        if (!$featureSignalementViewEnabled) {
+            $this->markTestSkipped('La fonctionnalité "feature_signalement_view_enabled" est désactivée.');
+        }
     }
 
     public function testCreateTagSuccess(): void


### PR DESCRIPTION
## Ticket

#2939

## Description
- Désactivation du TagController (et ses tests) lorsque la feature `FEATURE_SIGNALEMENT_VIEW_ENABLED` est inactive
- Retrait du lien du menu BO vers la nouvelle page etiquette si la feature est inactive

## Tests
- [ ] Modifier la valeur de la variable `FEATURE_SIGNALEMENT_VIEW_ENABLED` et vérifier que le comportement est correct
