### PR TITLE
[FO] Nettoyage du dossier tmp du bucket

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -7,6 +7,9 @@
       "command": "0 0 * * 0 php bin/console app:clear-entities"
     },
     {
+      "command": "0 0 * * * php bin/console app:clear-storage-tmp-folder"
+    },
+    {
       "command": "0 6,18 * * * php bin/console app:sync-esabora-schs"
     },
     {

--- a/src/Command/Cron/ClearStorageTmpFolderCommand.php
+++ b/src/Command/Cron/ClearStorageTmpFolderCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Command\Cron;
+
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(
+    name: 'app:clear-storage-tmp-folder',
+    description: 'Clear tmp folder from object storage S3',
+)]
+class ClearStorageTmpFolderCommand extends AbstractCronCommand
+{
+    public function __construct(
+        private readonly FilesystemOperator $fileStorage,
+        private readonly ParameterBagInterface $parameterBag,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct($this->parameterBag);
+    }
+
+    /**
+     * @throws FilesystemException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $files = $this->fileStorage->listContents('tmp/');
+        $datetime = (new \DateTimeImmutable('- 179 days'));
+        $timestamp = $datetime->getTimestamp();
+        $io->warning(sprintf(
+            'Les fichiers modifiés avant le %s seront supprimés',
+            $datetime->format('Y-m-d H:i:s'))
+        );
+        $countDeleted = 0;
+        foreach ($files as $file) {
+            if ('file' === $file['type']) {
+                $filePath = $file['path'];
+                $fileTimestamp = $this->fileStorage->lastModified($filePath);
+                $filePathDate = date('Y-m-d H:i:s', $fileTimestamp);
+                if ($fileTimestamp < $timestamp) {
+                    $io->writeln('.');
+                    $this->fileStorage->delete($filePath);
+                    $this->logger->info(
+                        sprintf('Fichier supprimé : %s modifié le %s', $filePath, $filePathDate)
+                    );
+                    ++$countDeleted;
+                } else {
+                    $io->write('.');
+                }
+            }
+        }
+        $io->success(sprintf('%d documents delete in tmp folder', $countDeleted));
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Functional/Command/Cron/ClearStorageTmpFolderCommandTest.php
+++ b/tests/Functional/Command/Cron/ClearStorageTmpFolderCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\Functional\Command\Cron;
+
+use App\Command\Cron\ClearStorageTmpFolderCommand;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ClearStorageTmpFolderCommandTest extends KernelTestCase
+{
+    private MockObject|FilesystemOperator $fileStorage;
+    private MockObject|ParameterBagInterface $parameterBag;
+    private MockObject|LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        $this->fileStorage = $this->createMock(FilesystemOperator::class);
+        $this->parameterBag = self::getContainer()->getParameterBag();
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    /**
+     * @throws FilesystemException
+     */
+    public function testExecuteWithFilesToDelete(): void
+    {
+        $files = [
+            ['type' => 'file', 'path' => 'tmp/file1.txt'],
+            ['type' => 'file', 'path' => 'tmp/file2.txt'],
+        ];
+
+        $this->fileStorage->expects($this->once())
+            ->method('listContents')
+            ->with('tmp/')
+            ->willReturn(new DirectoryListing($files));
+
+        $this->fileStorage->method('lastModified')
+            ->willReturnOnConsecutiveCalls(
+                (new \DateTimeImmutable('- 180 days'))->getTimestamp(),
+                (new \DateTimeImmutable('- 170 days'))->getTimestamp()
+            );
+
+        $this->fileStorage->expects($this->once())
+            ->method('delete')
+            ->with('tmp/file1.txt');
+
+        $command = new ClearStorageTmpFolderCommand($this->fileStorage, $this->parameterBag, $this->logger);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('1 documents delete in tmp folder', $output);
+        $this->assertEquals(Command::SUCCESS, $commandTester->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Ticket

#2682    

## Description
Ajout commande suppression document dans le repertoire tmp

## Changements apportés
* Ajout de la commande
* Déclaration en tant que cron

## Pré-requis

## Tests
- [ ] Exécuter la commande `make console app="clear-storage-tmp-folder"`