### PR TITLE
[QA] Erreur d'ouverture de fichier depuis MEP du 20 janvier

### DIFF
--- a/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -28,9 +28,7 @@ function histoUpdateDesordreSelect(target, selectedDocumentType) {
 
 function histoCreateMiniatureImage(target) {
   histoDeleteMiniatureImage()
-  const filename = target.getAttribute('data-filename')
-  const uuidSignalement = target.getAttribute('data-signalement-uuid')
-  const url = window.location.origin + '/_up/' + filename +'/'  + uuidSignalement + '?variant=thumb'
+  const url = target.getAttribute('data-file-path');
   const modalFileEditType = document.querySelector('#fr-modal-edit-file-miniature');
   const newDiv = '<div id="fr-modal-edit-file-miniature-image" class="fr-col-6 fr-col-offset-3 fr-col-md-2 fr-col-offset-md-5 fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center" style="background: url(\'' + url + '\') no-repeat center center/cover;"></div>';
   modalFileEditType.insertAdjacentHTML('afterbegin', newDiv);

--- a/migrations/Version20240819083216.php
+++ b/migrations/Version20240819083216.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240819083216 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add UUID to file';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file ADD uuid VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE file SET uuid = UUID()');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8C9F3610D17F50A6 ON file (uuid)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_8C9F3610D17F50A6 ON file');
+        $this->addSql('ALTER TABLE file DROP uuid');
+    }
+}

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -75,7 +75,7 @@ class SignalementFileController extends AbstractController
         if ($request->get('documentType') && $request->get('documentType') === DocumentType::AUTRE_PROCEDURE->name) {
             $documentType = DocumentType::AUTRE_PROCEDURE;
         }
-        list($fileList) = $signalementFileProcessor->process($files, $inputName, $documentType);
+        $fileList = $signalementFileProcessor->process($files, $inputName, $documentType);
 
         if (!$signalementFileProcessor->isValid()) {
             $errorMessages = $signalementFileProcessor->getErrorMessages();

--- a/src/Controller/FileController.php
+++ b/src/Controller/FileController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\File;
+use App\Service\ImageManipulationHandler;
+use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class FileController extends AbstractController
+{
+    #[Route('/show/{uuid}', name: 'show_file')]
+    public function showFile(
+        File $file,
+        Request $request,
+        LoggerInterface $logger,
+        FilesystemOperator $fileStorage,
+    ): BinaryFileResponse {
+        try {
+            $variant = $request->query->get('variant');
+            $filename = $file->getFilename();
+            $variantNames = ImageManipulationHandler::getVariantNames($filename);
+
+            if ('thumb' == $variant && $fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
+                $filename = $variantNames[ImageManipulationHandler::SUFFIX_THUMB];
+            } elseif ($fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE])) {
+                $filename = $variantNames[ImageManipulationHandler::SUFFIX_RESIZE];
+            }
+            if (!$fileStorage->fileExists($filename)) {
+                throw new \Exception('File "'.$filename.'" not found');
+            }
+            $tmpFilepath = $this->getParameter('uploads_tmp_dir').$filename;
+            $bucketFilepath = $this->getParameter('url_bucket').'/'.$filename;
+            $content = file_get_contents($bucketFilepath);
+            file_put_contents($tmpFilepath, $content);
+            $file = new SymfonyFile($tmpFilepath);
+
+            return new BinaryFileResponse($file);
+        } catch (\Throwable $exception) {
+            $logger->error($exception->getMessage());
+        }
+
+        return new BinaryFileResponse(
+            new SymfonyFile($this->getParameter('images_dir').'image-404.png'),
+        );
+    }
+}

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -36,6 +36,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[Route('/')]
@@ -624,7 +625,8 @@ class SignalementController extends AbstractController
                     continue;
                 }
                 $doc->setIsTemp(false);
-                $descriptionList[] = $signalementFileProcessor->generateListItemDescription($doc);
+                $url = $this->generateUrl('show_file', ['uuid' => $doc->getUuid()], UrlGeneratorInterface::ABSOLUTE_URL);
+                $descriptionList[] = '<li><a class="fr-link" target="_blank" rel="noopener" href="'.$url.'">'.$doc->getTitle().'</a></li>';
             }
             $description .= '<br>Ajout de pièces au signalement<ul>'.implode('', $descriptionList).'</ul>';
         }

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -624,7 +624,7 @@ class SignalementController extends AbstractController
                     continue;
                 }
                 $doc->setIsTemp(false);
-                $descriptionList[] = $signalementFileProcessor->generateListItemDescription($doc->getFilename(), $doc->getTitle(), true);
+                $descriptionList[] = $signalementFileProcessor->generateListItemDescription($doc);
             }
             $description .= '<br>Ajout de pièces au signalement<ul>'.implode('', $descriptionList).'</ul>';
         }

--- a/src/Controller/SignalementFileController.php
+++ b/src/Controller/SignalementFileController.php
@@ -35,7 +35,7 @@ class SignalementFileController extends AbstractController
             return $this->json(['response' => 'Token CSRF invalide ou paramètre manquant, veuillez rechargez la page'], Response::HTTP_BAD_REQUEST);
         }
         $inputName = isset($files[File::INPUT_NAME_DOCUMENTS]) ? File::INPUT_NAME_DOCUMENTS : File::INPUT_NAME_PHOTOS;
-        list($fileList) = $signalementFileProcessor->process($files, $inputName);
+        $fileList = $signalementFileProcessor->process($files, $inputName);
         if (!$signalementFileProcessor->isValid()) {
             return $this->json(['response' => $signalementFileProcessor->getErrorMessages()], Response::HTTP_BAD_REQUEST);
         }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -7,6 +7,7 @@ use App\Repository\FileRepository;
 use App\Service\ImageManipulationHandler;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: FileRepository::class)]
@@ -114,8 +115,12 @@ class File
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $scannedAt = null;
 
+    #[ORM\Column(length: 255, unique: true)]
+    private ?string $uuid = null;
+
     public function __construct()
     {
+        $this->uuid = Uuid::v4();
         $this->createdAt = new \DateTimeImmutable();
         $this->isVariantsGenerated = false;
         $this->isWaitingSuivi = false;
@@ -364,6 +369,18 @@ class File
     public function setScannedAt(?\DateTimeImmutable $scannedAt): static
     {
         $this->scannedAt = $scannedAt;
+
+        return $this;
+    }
+
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(string $uuid): static
+    {
+        $this->uuid = $uuid;
 
         return $this;
     }

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -52,10 +52,10 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
                 $description .= '<br>Rapport de visite : ';
 
                 $urlDocument = $this->urlGenerator->generate(
-                    'show_uploaded_file',
-                    ['filename' => $intervention->getFiles()->first()->getFilename()],
+                    'show_file',
+                    ['uuid' => $intervention->getFiles()->first()->getUuid()],
                     UrlGeneratorInterface::ABSOLUTE_URL
-                ).'?t=___TOKEN___';
+                );
 
                 $description .= '<a href="'.$urlDocument.'" title="Afficher le document" rel="noopener" target="_blank">Afficher le document</a>';
             }

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -41,10 +41,10 @@ class InterventionEditedSubscriber implements EventSubscriberInterface
                 $description .= '<br>Rapport de visite : ';
 
                 $urlDocument = $this->urlGenerator->generate(
-                    'show_uploaded_file',
-                    ['filename' => $intervention->getFiles()->first()->getFilename()],
+                    'show_file',
+                    ['uuid' => $intervention->getFiles()->first()->getUuid()],
                     UrlGeneratorInterface::ABSOLUTE_URL
-                ).'?t=___TOKEN___';
+                );
 
                 $description .= '<a href="'.$urlDocument.'" title="Afficher le document" rel="noopener" target="_blank">Afficher le document</a>';
             }

--- a/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
+++ b/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
@@ -18,7 +18,6 @@ use App\Messenger\Message\Oilhi\DossierMessage;
 use App\Service\HtmlCleaner;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class DossierMessageFactory implements DossierMessageFactoryInterface
 {
@@ -26,7 +25,6 @@ class DossierMessageFactory implements DossierMessageFactoryInterface
 
     public function __construct(
         private UrlGeneratorInterface $urlGenerator,
-        private CsrfTokenManagerInterface $csrfTokenManager,
         #[Autowire(env: 'FEATURE_OILHI_ENABLE')]
         private bool $featureEnable,
     ) {
@@ -225,9 +223,9 @@ class DossierMessageFactory implements DossierMessageFactoryInterface
         }
 
         return $this->urlGenerator->generate(
-            'show_uploaded_file',
-            ['filename' => $intervention->getFiles()->first()->getFilename()],
+            'show_file',
+            ['uuid' => $intervention->getFiles()->first()->getUuid()],
             UrlGeneratorInterface::ABSOLUTE_URL
-        ).'?t='.$this->csrfTokenManager->getToken('suivi_signalement_ext_file_view');
+        );
     }
 }

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -162,10 +162,10 @@ class SuiviManager extends Manager
         $descriptionList = [];
         foreach ($files as $file) {
             $fileUrl = $this->urlGenerator->generate(
-                'show_uploaded_file',
-                ['filename' => $file->getFilename()],
+                'show_file',
+                ['uuid' => $file->getUuid()],
                 UrlGeneratorInterface::ABSOLUTE_URL
-            ).'?t=___TOKEN___';
+            );
 
             $linkFile = '<li><a class="fr-link" target="_blank" rel="noopener" href="'.$fileUrl.'">'.$file->getTitle().'</a>';
             if (DocumentType::PHOTO_SITUATION === $file->getDocumentType() && null !== $file->getDesordreSlug()) {

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -40,8 +40,7 @@ class SignalementFileProcessor
         string $inputName,
         ?DocumentType $documentType = DocumentType::AUTRE
     ): array {
-        $fileList = $descriptionList = [];
-        $withTokenGenerated = false;
+        $fileList = [];
         foreach ($files[$inputName] as $key => $file) {
             if ($file instanceof UploadedFile) {
                 try {
@@ -103,7 +102,6 @@ class SignalementFileProcessor
                     } else {
                         $filename = $this->uploadHandlerService->moveFromBucketTempFolder($file);
                         $title = $key;
-                        $withTokenGenerated = true;
                     }
                 } catch (\Exception $exception) {
                     $this->logger->error($exception->getMessage());
@@ -111,13 +109,12 @@ class SignalementFileProcessor
                     continue;
                 }
                 if (!empty($filename)) {
-                    $descriptionList[] = $this->generateListItemDescription($filename, $title, $withTokenGenerated);
                     $fileList[] = $this->createFileItem($filename, $title, $inputTypeDetection, $documentType);
                 }
             }
         }
 
-        return [$fileList, $descriptionList];
+        return $fileList;
     }
 
     public function addFilesToSignalement(
@@ -166,24 +163,11 @@ class SignalementFileProcessor
         return implode('<br>', $this->errors);
     }
 
-    public function generateListItemDescription(
-        string $filename,
-        string $title,
-        bool $withTokenGenerated = false,
-    ): string {
-        $queryTokenUrl = $withTokenGenerated ? '&t=___TOKEN___' : '';
+    public function generateListItemDescription(File $file): string
+    {
+        $fileUrl = $this->urlGenerator->generate('show_file', ['uuid' => $file->getUuid()]);
 
-        $fileUrl = $this->urlGenerator->generate(
-            'show_uploaded_file',
-            ['folder' => '_up', 'filename' => $filename]
-        )
-            .$queryTokenUrl;
-
-        return '<li><a class="fr-link" target="_blank" rel="noopener" href="'
-            .$fileUrl
-            .'">'
-            .$title
-            .'</a></li>';
+        return '<li><a class="fr-link" target="_blank" rel="noopener" href="'.$fileUrl.'">'.$file->getTitle().'</a></li>';
     }
 
     private function createFileItem(

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -14,7 +14,6 @@ use App\Service\UploadHandlerService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class SignalementFileProcessor
@@ -26,7 +25,6 @@ class SignalementFileProcessor
         private readonly UploadHandlerService $uploadHandlerService,
         private readonly LoggerInterface $logger,
         private readonly FilenameGenerator $filenameGenerator,
-        private readonly UrlGeneratorInterface $urlGenerator,
         private readonly FileFactory $fileFactory,
         private readonly ImageManipulationHandler $imageManipulationHandler,
         private readonly FileScanner $fileScanner,
@@ -161,13 +159,6 @@ class SignalementFileProcessor
     public function getErrorMessages(): string
     {
         return implode('<br>', $this->errors);
-    }
-
-    public function generateListItemDescription(File $file): string
-    {
-        $fileUrl = $this->urlGenerator->generate('show_file', ['uuid' => $file->getUuid()]);
-
-        return '<li><a class="fr-link" target="_blank" rel="noopener" href="'.$fileUrl.'">'.$file->getTitle().'</a></li>';
     }
 
     private function createFileItem(

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -15,7 +15,7 @@
                 </div>
                 <div>
                     <img
-                        src="{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=resize') }}"
+                        src="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize"
                         alt="Photo ajoutée par : {{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
                         >
                 </div>

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -79,7 +79,8 @@
                 <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
                     data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
                     data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
-                    style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
+                    style="background: url('{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb')no-repeat center center/cover"
+                    >
                     <button 
                         class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" 
                         data-id={{ photo.id }} 
@@ -95,7 +96,7 @@
                             data-filename="{{ photo.filename }}" 
                             data-type="photo" 
                             data-file-id="{{ photo.id}}" 
-                            data-signalement-uuid="{{ signalement.uuid}}" 
+                            data-file-path="{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb"
                             data-description="{{ photo.description }}" 
                             data-documentType="{{ photo.documentType.name }}" 
                             data-documentType-list="{{ DocumentType.getOrderedPhotosList() | json_encode }}"
@@ -156,7 +157,7 @@
             </div>
         </div>
         <div class="fr-col-3 fr-text--right">
-            <a href="{{ asset('_up/'~doc.filename~'/'~signalement.uuid) }}"
+            <a href="{{ path('show_file', {uuid: doc.uuid}) }}"
                 class="fr-btn fr-btn--sm fr-icon-eye-fill img-box" title="Afficher le document {{ doc.filename }}"
                 target="_blank" rel="noopener"></a>           
             {% if is_granted('FILE_EDIT', doc) and doc.intervention is null %}

--- a/templates/back/signalement/view/user-declaration-desordre-photo.html.twig
+++ b/templates/back/signalement/view/user-declaration-desordre-photo.html.twig
@@ -2,7 +2,7 @@
     <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
         data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
         data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
-        style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
+        style="background: url('{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb')no-repeat center center/cover">
         <button class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" data-id={{ photo.id }} title="Voir la photo"></button>
     </div>
 </div>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -85,7 +85,7 @@
             <div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center part-infos-hover"
                  data-user="{{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
                  data-mail="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
-                 style="background: url('{{ asset('_up/'~photo.filename~'/'~signalement.uuid~'?variant=thumb') }}')no-repeat center center/cover">
+                 style="background: url('{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb')no-repeat center center/cover">
                 <button 
                     class="fr-btn fr-btn--sm fr-icon-eye-line open-photo-album" 
                     data-id={{ photo.id }} 

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -37,7 +37,7 @@
                         Editer le rapport
                     </button>
                 {% endif %}
-                <a href="{{ asset('_up/'~intervention.getRapportDeVisite.first.filename)~'/' ~ signalement.uuid }}"
+                <a href="{{ path('show_file', {uuid: intervention.getRapportDeVisite.first.uuid}) }}"
                     class="fr-btn fr-btn--secondary"
                     title="Voir le rapport de visite"
                     rel="noopener"
@@ -60,7 +60,7 @@
             {% endif %}
         {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_NOT_DONE') %}
             {% if intervention.getRapportDeVisite is not empty %}
-                <a href="{{ asset('_up/'~intervention.getRapportDeVisite.first.filename)~'/' ~ signalement.uuid }}"
+                <a href="{{ path('show_file', {uuid: intervention.getRapportDeVisite.first.uuid}) }}"
                     class="fr-btn fr-btn--secondary"
                     title="Voir le rapport de visite"
                     rel="noopener"

--- a/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
+++ b/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
@@ -110,7 +110,7 @@
 <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
 	<ul class="fr-btns-group fr-btns-group--inline-sm fr-btns-group--sm">
 		<li>
-			<a href="{{ asset('_up/'~intervention.files[0].filename)~'/' ~ intervention.signalement.uuid }}" class="fr-btn" title="Afficher le document" rel="noopener" target="_blank">Voir le rapport de visite
+			<a href="{{ path('show_file', {uuid: intervention.files[0].uuid}) }}" class="fr-btn" title="Afficher le document" rel="noopener" target="_blank">Voir le rapport de visite
 			</a>
 		</li>
 		<li>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -186,7 +186,7 @@
                                 type: 'menuitem',
                                 text: '{{ doc.title }}',
                                 onAction: function () {
-                                    editor.insertContent('&nbsp;<a href="{{ asset('_up/'~doc.filename) }}?t=___TOKEN___" class="fr-btn fr-fi-eye-fill fr-btn--icon-left" title="Afficher le document" target="_blank" rel="noopener">Consulter "{{ doc.title }}"</a>');
+                                    editor.insertContent('&nbsp;<a href="{{ path('show_file', {uuid: doc.uuid}) }}" class="fr-btn fr-fi-eye-fill fr-btn--icon-left" title="Afficher le document" target="_blank" rel="noopener">Consulter "{{ doc.title }}"</a>');
                                 }
                             },
                             {% endfor %}

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -297,8 +297,8 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 		Cliquez sur la photo pour l'ouvrir dans un nouvel onglet.
 		<br>
 		{% for photo in signalement.files|filter(photo => photo.fileType == 'photo') %}
-			<a href="{{ asset('_up/'~photo.filename~'?variant=resize') }}&t={{ csrf_token('suivi_signalement_ext_file_view') }}" class="photo-preview" target="_blank" rel="noopener">
-				<img src="{{ asset('_up/'~photo.filename~'?variant=thumb') }}&t={{ csrf_token('suivi_signalement_ext_file_view') }}" alt="{{photo.title}}">
+			<a href="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize" class="photo-preview" target="_blank" rel="noopener">
+				<img src="{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb" alt="{{photo.title}}">
 			</a>
 		{% endfor %}
 	{% else %}

--- a/tests/Functional/Controller/SecurityControllerTest.php
+++ b/tests/Functional/Controller/SecurityControllerTest.php
@@ -48,15 +48,4 @@ class SecurityControllerTest extends WebTestCase
 
         $this->assertResponseStatusCodeSame(404);
     }
-
-    /*public function testShowUploadedWithValidToken(): void
-    {
-        $client = static::createClient();
-        $token = $this->generateCsrfToken($client, 'suivi_signalement_ext_file_view');
-        $client->request('GET', '/_up/check.png?t=' . $token);
-
-        $response = $client->getResponse();
-        $this->assertTrue($response->isSuccessful());
-        $this->assertInstanceOf(BinaryFileResponse::class, $response);
-    }*/
 }

--- a/tests/Functional/Factory/Oilhi/DossierMessageFactoryTest.php
+++ b/tests/Functional/Factory/Oilhi/DossierMessageFactoryTest.php
@@ -12,8 +12,6 @@ use App\Tests\FixturesHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Csrf\CsrfToken;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class DossierMessageFactoryTest extends KernelTestCase
 {
@@ -49,13 +47,8 @@ class DossierMessageFactoryTest extends KernelTestCase
         }
 
         $urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
-        $csrfTokenManager
-            ->expects($this->atMost(1))
-            ->method('getToken')
-            ->willReturn(new CsrfToken('suivi_signalement_ext_file_view', 'random_value'));
 
-        $dossierMessageFactory = new DossierMessageFactory($urlGenerator, $csrfTokenManager, true);
+        $dossierMessageFactory = new DossierMessageFactory($urlGenerator, true);
 
         $this->assertTrue($dossierMessageFactory->supports($affectation));
 

--- a/tests/Unit/Service/Signalement/SignalementFileProcessorTest.php
+++ b/tests/Unit/Service/Signalement/SignalementFileProcessorTest.php
@@ -13,7 +13,6 @@ use App\Tests\FixturesHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SignalementFileProcessorTest extends TestCase
 {
@@ -33,7 +32,6 @@ class SignalementFileProcessorTest extends TestCase
     private MockObject|UploadHandlerService $uploadHandlerService;
     private MockObject|LoggerInterface $logger;
     private MockObject|FilenameGenerator $filenameGenerator;
-    private MockObject|UrlGeneratorInterface $urlGenerator;
     private MockObject|FileFactory $fileFactory;
     private MockObject|ImageManipulationHandler $imageManipulationHandler;
     private MockObject|FileScanner $fileScanner;
@@ -43,7 +41,6 @@ class SignalementFileProcessorTest extends TestCase
         $this->uploadHandlerService = $this->createMock(UploadHandlerService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->filenameGenerator = $this->createMock(FilenameGenerator::class);
-        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $this->fileFactory = $this->createMock(FileFactory::class);
         $this->imageManipulationHandler = $this->createMock(ImageManipulationHandler::class);
         $this->fileScanner = $this->createMock(FileScanner::class);
@@ -60,7 +57,6 @@ class SignalementFileProcessorTest extends TestCase
             $this->uploadHandlerService,
             $this->logger,
             $this->filenameGenerator,
-            $this->urlGenerator,
             $this->fileFactory,
             $this->imageManipulationHandler,
             $this->fileScanner,
@@ -96,7 +92,6 @@ class SignalementFileProcessorTest extends TestCase
             $this->uploadHandlerService,
             $this->logger,
             $this->filenameGenerator,
-            $this->urlGenerator,
             $this->fileFactory,
             $this->imageManipulationHandler,
             $this->fileScanner,

--- a/tests/Unit/Service/Signalement/SignalementFileProcessorTest.php
+++ b/tests/Unit/Service/Signalement/SignalementFileProcessorTest.php
@@ -67,35 +67,16 @@ class SignalementFileProcessorTest extends TestCase
             false
         );
 
-        [$fileList, $descriptionList] = $signalementFileProcessor->process(self::FILE_LIST, 'documents');
+        $fileList = $signalementFileProcessor->process(self::FILE_LIST, 'documents');
         $this->assertTrue($signalementFileProcessor->isValid());
         $this->assertEmpty($signalementFileProcessor->getErrors());
         $this->assertCount(2, $fileList);
-        $this->assertCount(2, $descriptionList);
 
         foreach ($fileList as $fileItem) {
             $this->assertArrayHasKey('title', $fileItem);
             $this->assertArrayHasKey('date', $fileItem);
             $this->assertArrayHasKey('type', $fileItem);
             $this->assertEquals(File::FILE_TYPE_DOCUMENT, $fileItem['type']);
-        }
-
-        foreach ($descriptionList as $descriptionItem) {
-            $dom = new \DOMDocument();
-            libxml_use_internal_errors(true);
-            $dom->loadHTML($descriptionItem);
-            libxml_use_internal_errors(false);
-            $liTags = $dom->getElementsByTagName('li');
-            $this->assertCount(1, $liTags);
-
-            $liTag = $liTags->item(0);
-            $aTags = $liTag->getElementsByTagName('a');
-            $this->assertCount(1, $aTags);
-
-            $aTag = $aTags->item(0);
-            $this->assertEquals('fr-link', $aTag->getAttribute('class'));
-            $this->assertEquals('_blank', $aTag->getAttribute('target'));
-            $this->assertEquals('&t=___TOKEN___', $aTag->getAttribute('href'));
         }
     }
 
@@ -122,8 +103,7 @@ class SignalementFileProcessorTest extends TestCase
             false
         );
         $signalement = $this->getSignalement();
-        [$fileList, $descriptionList] = $signalementFileProcessor->process(self::FILE_LIST, 'photos');
-        $this->assertNotEmpty($descriptionList);
+        $fileList = $signalementFileProcessor->process(self::FILE_LIST, 'photos');
         $signalementFileProcessor->addFilesToSignalement($fileList, $signalement); // TODO
         $this->assertNotNull($signalement->getFiles());
     }


### PR DESCRIPTION
## Ticket

#2751

## Description
Mise en place d'une nouvelle route permettant de visualiser les documents uploadé sur des URL durable

## Changements apportés
* Ajout d'un uuid sur l'entité File
* Création de la nouvelle route `show_file` basé sur cet uuid
* Utilisation de cette nouvelle route de partout, on garde l'ancienne pour les suivi historique et les export PDF

## Pré-requis
`make execute-migration name=Version20240819083216 direction=up`
`make npm-build`

## Tests
- [ ] Tester l'upload d'image FO et BO et vérifier que leur affichage utilise la nouvelle route
- [ ] Vérifier que les anciens liens dans les suivi restent fonctionnel
