### PR TITLE
[QA - Export PDF] Fournir un peu d’élément en cas de crash

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 postdeploy: ./scripts/postdeploy.sh
-worker: php bin/console messenger:consume async_priority_high async
+worker: php bin/console messenger:consume async_priority_high async --time-limit=3600
 clock: php bin/console app:scheduled-task


### PR DESCRIPTION
## Ticket

#2953   

## Description
Logger les erreurs d'export PDF pou avoir plus d'info sur sentry

## Changements apportés
* Ajout d'un try catch
* Redemarrer le worker toutes les heures (https://symfony.com/doc/current/messenger.html#:~:text=Don%27t%20Let%20Workers%20Run%20Forever)

## Pré-requis

```
make worker-start
```
## Tests
- [ ] Faire en export et télécharger l'export