### PR TITLE
[QA] Erreur affichage bloc visite

### DIFF
--- a/src/Dto/Request/Signalement/VisiteRequest.php
+++ b/src/Dto/Request/Signalement/VisiteRequest.php
@@ -12,11 +12,13 @@ class VisiteRequest
      */
     public function __construct(
         private readonly ?int $idIntervention = null,
+        #[Assert\NotBlank]
         #[Assert\DateTime('Y-m-d')]
         private readonly ?string $date = null,
         #[Assert\DateTime('H:i')]
         private readonly ?string $time = null,
         private readonly ?string $timezone = TimezoneProvider::TIMEZONE_EUROPE_PARIS,
+        #[Assert\NotBlank]
         private readonly ?int $idPartner = null,
         private readonly ?string $details = null,
         private readonly ?array $concludeProcedure = [],
@@ -63,7 +65,7 @@ class VisiteRequest
                 new \DateTimeZone($this->getTimezone())
             );
 
-            return $localDateTime->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+            return $localDateTime->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i');
         }
 
         return $this->getDate();

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -45,10 +45,13 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
      * @throws \Exception
      */
     public function customDateFilter(
-        string|\DateTimeImmutable|\DateTime $dateTime,
+        string|\DateTimeImmutable|\DateTime|null $dateTime,
         string $format = 'F j, Y H:i',
         ?string $timezone = null
-    ): string {
+    ): ?string {
+        if (null === $dateTime) {
+            return null;
+        }
         $dateTimeZone = null !== $timezone ? new \DateTimeZone($timezone) : $this->timezoneProvider->getDateTimezone();
         if ($dateTime instanceof \DateTimeInterface) {
             return $dateTime->setTimezone($dateTimeZone)->format($format);

--- a/templates/back/signalement/view/visites/modals/visites-modal-edit.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-edit.html.twig
@@ -1,45 +1,47 @@
-<dialog aria-labelledby="fr-modal-edit-visite-modal-{{intervention.id}}" role="dialog" id="edit-visite-modal-{{intervention.id}}" class="fr-modal">
-    <div class="fr-container fr-container--fluid fr-container-md">
-        <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                <form method="POST" name="signalement-edit-visite" class="signalement-edit-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_edit',{uuid:signalement.uuid}) }}">
-                        
-                    <div class="fr-modal__body">
-                        <div class="fr-modal__header">
-                            <button type="button" class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="edit-visite-modal-{{intervention.id}}">Fermer</button>
-                        </div>
-                        <div class="fr-modal__content">
-                            <h1 id="fr-modal-edit-visite-modal-{{intervention.id}}" class="fr-modal__title">
-                                Edition de la visite du
-                                {{ (intervention.scheduledAt.format('H')) > 0 ? intervention.scheduledAt|date('d/m/Y à H:i') : intervention.scheduledAt.format('d/m/Y') }}
-                            </h1>
+{% if intervention.scheduledAt is not empty %}
+    <dialog aria-labelledby="fr-modal-edit-visite-modal-{{intervention.id}}" role="dialog" id="edit-visite-modal-{{intervention.id}}" class="fr-modal">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <form method="POST" name="signalement-edit-visite" class="signalement-edit-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_edit',{uuid:signalement.uuid}) }}">
 
-                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-my-3w">
-                                <div class="fr-col-12 fr-mb-3v">
-                                    {% set formType = 'edit' %}
-                                    {% include 'back/signalement/view/visites/visites-form-confirm-fields.html.twig' %}
-                                </div>
+                        <div class="fr-modal__body">
+                            <div class="fr-modal__header">
+                                <button type="button" class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="edit-visite-modal-{{intervention.id}}">Fermer</button>
                             </div>
-                            <input type="hidden" name="visite-edit[intervention]" value="{{intervention.id}}">
-                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_visit_'~intervention.id) }}">
+                            <div class="fr-modal__content">
+                                <h1 id="fr-modal-edit-visite-modal-{{intervention.id}}" class="fr-modal__title">
+                                    Edition de la visite du
+                                    {{ (intervention.scheduledAt.format('H')) > 0 ? intervention.scheduledAt|date('d/m/Y à H:i') : intervention.scheduledAt.format('d/m/Y') }}
+                                </h1>
+
+                                <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-my-3w">
+                                    <div class="fr-col-12 fr-mb-3v">
+                                        {% set formType = 'edit' %}
+                                        {% include 'back/signalement/view/visites/visites-form-confirm-fields.html.twig' %}
+                                    </div>
+                                </div>
+                                <input type="hidden" name="visite-edit[intervention]" value="{{intervention.id}}">
+                                <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_visit_'~intervention.id) }}">
+                            </div>
+                            <div class="fr-modal__footer">
+                                <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    <li>
+                                        <button type="button" class="fr-btn fr-btn--secondary" aria-controls="edit-visite-modal-{{intervention.id}}">
+                                            Annuler
+                                        </button>
+                                    </li>
+                                    <li>
+                                        <button type="submit" class="fr-btn">
+                                            Valider
+                                        </button>
+                                    </li>
+                                </ul>
+                            </div>
                         </div>
-                        <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary" aria-controls="edit-visite-modal-{{intervention.id}}">
-                                        Annuler
-                                    </button>
-                                </li>
-                                <li>
-                                    <button type="submit" class="fr-btn">
-                                        Valider
-                                    </button>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
-    </div>
-</dialog>
+    </dialog>
+{% endif %}

--- a/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
@@ -41,7 +41,7 @@
                                         <p id="signalement-reschedule-visite-date-error" class="fr-error-text fr-hidden fr-my-3v">
                                             Veuillez préciser l'heure de la visite.
                                         </p>
-                                        <input type="time" class="fr-input" data-fields="visite-reschedule-past-date-complementary-fields" name="visite-reschedule[time]" value="{{ intervention.scheduledAt|date('H:i') }}">
+                                        <input type="time" class="fr-input" data-fields="visite-reschedule-past-date-complementary-fields" name="visite-reschedule[time]" value="{{ (intervention.scheduledAt.format('H')) > 0 ? intervention.scheduledAt|date('H:i')  : '' }}">
                                     </fieldset>
                                     
                                     {% if is_granted('ROLE_ADMIN_TERRITORY') %}

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -14,7 +14,7 @@
             {% if signalement.interventions is empty or intervention.scheduledAt is empty %}
                 Non renseignée
             {% else %}
-                {{ (intervention.scheduledAt|date('H')) > 0
+                {{ (intervention.scheduledAt.format('H')) > 0
                 ? intervention.scheduledAt|date('d/m/Y à H:i', signalement.getTimezone)
                 : intervention.scheduledAt|date('d/m/Y') }}
             {% endif %}

--- a/tests/Unit/Dto/Request/Signalement/VisiteRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/VisiteRequestTest.php
@@ -3,22 +3,38 @@
 namespace App\Tests\Unit\Dto\Request\Signalement;
 
 use App\Dto\Request\Signalement\VisiteRequest;
-use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class VisiteRequestTest extends TestCase
+class VisiteRequestTest extends KernelTestCase
 {
     /**
      * @dataProvider visiteRequestDataProvider
      *
      * @throws \Exception
      */
-    public function testDatesVisiteRequestDTO(string $date, string $time, string $timezone, string $expectedLocale, string $expectedUTC): void
+    public function testDatesVisiteRequestDTO(
+        string $date,
+        string $time,
+        string $timezone,
+        string $idPartner,
+        string $expectedLocale,
+        string $expectedUTC): void
     {
+        self::bootKernel();
+
+        /** @var ValidatorInterface $validator */
+        $validator = self::getContainer()->get('validator');
+
         $visiteRequest = new VisiteRequest(
             date: $date,
             time: $time,
             timezone: $timezone,
+            idPartner: $idPartner,
         );
+
+        $validationResult = $validator->validate($visiteRequest);
+        $this->assertCount(0, $validationResult);
 
         $this->assertEquals($expectedLocale, $visiteRequest->getDateTimeLocale());
         $this->assertEquals($expectedUTC, $visiteRequest->getDateTimeUTC());
@@ -28,18 +44,20 @@ class VisiteRequestTest extends TestCase
     {
         yield 'France' => [
             'date' => '2024-08-13',
-            'time' => '12:00:00',
+            'time' => '12:00',
             'timezone' => 'Europe/Paris',
-            'expectedLocale' => '2024-08-13 12:00:00',
-            'expectedUTC' => '2024-08-13 10:00:00',
+            'idPartner' => '1',
+            'expectedLocale' => '2024-08-13 12:00',
+            'expectedUTC' => '2024-08-13 10:00',
         ];
 
         yield 'Martinique' => [
             'date' => '2024-08-13',
-            'time' => '12:00:00',
+            'time' => '12:00',
             'timezone' => 'America/Martinique',
-            'expectedLocale' => '2024-08-13 12:00:00',
-            'expectedUTC' => '2024-08-13 16:00:00',
+            'idPartner' => '2',
+            'expectedLocale' => '2024-08-13 12:00',
+            'expectedUTC' => '2024-08-13 16:00',
         ];
     }
 }


### PR DESCRIPTION
## Ticket

#2955

## Description
Sur staging on a 5160 interventions 😱 crées sans date, je me demande comment c'est possible. 
J'ai vérifié en production tous les interventions ont bien une date.
https://histologe-staging.incubateur.net/bo/signalements/2f14a3f2-c91a-44c0-824c-9b3789f91c36

Bien qu'on aurait pas le bug à la prochaine MEP, j'ai quand même ajouter des contrôles supplémentaires et des contraintes coté entité intervention pour sécuriser.

## Changements apportés
* Gestion du cas de la date de visite vide
* Mise à jour condition d'affichage heure (heure non saisi (minuit) affiche 2h du matin) 
* Ajout de contrainte sur la date et le partenaire de l'entité intervention

## Pré-requis

Récupération de la base de staging
```
make load-data
```
## Tests
- [ ] Afficher la fiche http://localhost:8080/bo/signalements/2f14a3f2-c91a-44c0-824c-9b3789f91c36
- [ ] Saisir une date de visite sans l'heure et vérifier que l'heure n'est pas affiché 
- [ ] Saisir une date de visite avec l'heure et vérifier que l'heure s'affiche correctement
- [ ] Editer la date et vérifier que la date
