### PR TITLE
[BO - Fiche signalement] Le libellé Liste signalement du fil d’Ariane doit avoir le même comportement que le bouton retour actuel

### DIFF
--- a/assets/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/controllers/back_signalement_view/back_view_signalement.js
@@ -57,7 +57,7 @@ const displayPhotoAlbum = (photoId) => {
     })
 }
 
-document?.querySelector('.back-link')?.addEventListener('click', (event) => {
+document?.querySelector('[data-filter-list-signalement]')?.addEventListener('click', (event) => {
     if (window.history.length > 1) {
         event.preventDefault()
         const backLinkQueryParams = localStorage.getItem('back_link_signalement_view')

--- a/templates/back/breadcrumb_bo.html.twig
+++ b/templates/back/breadcrumb_bo.html.twig
@@ -8,7 +8,7 @@
             </li>
             <li>
                 <a class="fr-breadcrumb__link"
-                    {% if level2Link %}href="{{ level2Link }}"{% else %}aria-current="page"{% endif %}
+                    {% if level2Link %}  data-filter-list-signalement href="{{ level2Link }}"{% else %}aria-current="page"{% endif %}
                     {% if level2Label %}aria-label="{{ level2Label }}"{% endif %}
                     >{{ level2Title }}</a>
             </li>

--- a/templates/back/breadcrumb_bo.html.twig
+++ b/templates/back/breadcrumb_bo.html.twig
@@ -8,7 +8,8 @@
             </li>
             <li>
                 <a class="fr-breadcrumb__link"
-                    {% if level2Link %}  data-filter-list-signalement href="{{ level2Link }}"{% else %}aria-current="page"{% endif %}
+                    {% if level2Link %}  href="{{ level2Link }}"{% else %}aria-current="page"{% endif %}
+                    {% if level2Link == path('back_index') %} data-filter-list-signalement {% endif %}
                     {% if level2Label %}aria-label="{{ level2Label }}"{% endif %}
                     >{{ level2Title }}</a>
             </li>


### PR DESCRIPTION
## Ticket

#2957   

## Description
Le clic sur la lien  Liste des signalements doit nous afficher la liste filtré si des filtres sont présents.

## Changements apportés
* Ajout d'un data-attributes sur le lien du fil ariane 

## Pré-requis
```
make npm-watch
```

## Tests
- [ ] Faire une recherche avec plusieurs filtre puis sélectionner une fiche. Effectuer des actions et revenir à la liste en cliquant sur le lien de la liste du fil d’Ariane.
