### PR TITLE
 [BO - Tag] Recréer les tags pour le territoire 62

### DIFF
--- a/migrations/Version20240826130414.php
+++ b/migrations/Version20240826130414.php
@@ -65,7 +65,7 @@ final class Version20240826130414 extends AbstractMigration
                         );
                         // Récupérer l'ID du tag inséré directement
                         $newTagId = $this->connection->fetchOne(
-                            'SELECT id FROM tag WHERE label = :label AND territory_id = :territory_id',
+                            'SELECT id FROM tag WHERE label = :label AND territory_id = :territory_id AND is_archive = 0',
                             ['label' => $label, 'territory_id' => $territoryId]
                         );
 

--- a/migrations/Version20240826130414.php
+++ b/migrations/Version20240826130414.php
@@ -23,7 +23,7 @@ final class Version20240826130414 extends AbstractMigration
         );
 
         if (!$territory) {
-            throw new \RuntimeException('Territory with zip 62 not found.');
+            return;
         }
 
         $territoryId = $territory['id'];

--- a/migrations/Version20240826130414.php
+++ b/migrations/Version20240826130414.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240826130414 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Recréer les tags pour le territoire 62';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Récupérer l'ID du territoire où le zip est 62
+        $territory = $this->connection->fetchAssociative(
+            'SELECT id FROM territory WHERE zip = :zip',
+            ['zip' => 62]
+        );
+
+        if (!$territory) {
+            throw new \RuntimeException('Territory with zip 62 not found.');
+        }
+
+        $territoryId = $territory['id'];
+
+        $this->connection->beginTransaction();
+
+        try {
+            // Récupère tous les tags concaténés par un | , non-archivés pour le territoire 62
+            $tags = $this->connection->fetchAllAssociative(
+                "SELECT * FROM tag WHERE is_archive = 0 AND territory_id = :territory_id AND label LIKE '%|%'",
+                ['territory_id' => $territoryId]
+            );
+
+            foreach ($tags as $tag) {
+                $tagId = $tag['id'];
+                // Récupère les signalements liés à ce tag concaténé
+                $signalementIds = $this->connection->fetchAllAssociative(
+                    'SELECT signalement_id FROM tag_signalement WHERE tag_id = :tag_id',
+                    ['tag_id' => $tagId]
+                );
+
+                // Récupère les différents labels des tags
+                $labelParts = explode('|', $tag['label']);
+                foreach ($labelParts as $label) {
+                    $label = trim($label);
+                    // On regarde si un tag avec ce label existe déjà pour ce label (dans le territoire)
+                    $existingTag = $this->connection->fetchAssociative(
+                        'SELECT id FROM tag WHERE label = :label AND territory_id = :territory_id AND is_archive = 0',
+                        ['label' => $label, 'territory_id' => $territoryId]
+                    );
+
+                    if ($existingTag) {
+                        $newTagId = $existingTag['id'];
+                    } else {
+                        // s'il n'existe pas, on le créé
+                        $this->connection->executeStatement(
+                            'INSERT INTO tag (label, is_archive, territory_id) VALUES (:label, 0, :territory_id)',
+                            ['label' => $label, 'territory_id' => $territoryId]
+                        );
+                        // Récupérer l'ID du tag inséré directement
+                        $newTagId = $this->connection->fetchOne(
+                            'SELECT id FROM tag WHERE label = :label AND territory_id = :territory_id',
+                            ['label' => $label, 'territory_id' => $territoryId]
+                        );
+
+                        if (!$newTagId) {
+                            throw new \RuntimeException('Failed to retrieve the tag ID after insertion.');
+                        }
+                    }
+
+                    // On lie tous les signalements liés au tag concaténé d'origine à ce tag créé
+                    foreach ($signalementIds as $signalement) {
+                        $this->addSql(
+                            'INSERT INTO tag_signalement (tag_id, signalement_id) VALUES (:tag_id, :signalement_id)
+                            ON DUPLICATE KEY UPDATE tag_id = tag_id',
+                            ['tag_id' => $newTagId, 'signalement_id' => $signalement['signalement_id']]
+                        );
+                    }
+                }
+
+                // archive le tag concaté d'origine
+                $this->addSql('UPDATE tag SET is_archive = 1 WHERE id = :id', ['id' => $tagId]);
+            }
+
+            $this->connection->commit();
+        } catch (\Exception $e) {
+            $this->connection->rollBack();
+            throw $e;
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#2967    

## Description
Recréation de tags pour le 62 car lors de l'import de signalements les tags ont été mal créés.
On a des tags de type `CUA|CM|NON DECENCE` au lieu de 3 tags `CUA`, `CM` et `NON DECENCE`

## Changements apportés
* Création d'une migration qui récupère tous ces tags concaténés, en créé des nouveaux si besoin, les attache aux signalements concernés et archive les tags concaténés

## Pré-requis
- Créer 3 tags "concaténés" pour le territoire 62 (par exemple `CUA|CM|NON DECENCE`, `CC DU TERNOIS|CM|NON DECENCE` et `CAPSO|CM|NON DÉCENCE RÉSOLUE`)
- Les attribuer (pas forcément tous) aux signalements du 62 (en s'assurant qu'un tag est sur au moins 2 signalements)
- Archiver un de ces tags
- Noter quels tags pour quels signalements (pour vérifier après migration)

## Tests
- [ ] Lancer la migration `docker compose exec -ti histologe_phpfpm php bin/console doctrine:migrations:execute --up 'DoctrineMigrations\Version20240826130414'`
- [ ] Vérifier que des snouveaux tags ont bien été créés, mais pas pour le tag concaténé archivé
- [ ] Vérifier qu'il n'y a pas de doublon de tag (par exemple le tag `CM` a été créé une seule fois)
- [ ] Vérifier que les signalements sont bien liés aux tags explodés créés
- [ ] Vérifier que les tags concaténés sont bien archivés
