### PR TITLE
[BO - Filtres] Affectation partenaire -AUCUN

### DIFF
--- a/assets/vue/components/common/HistoMultiSelect.vue
+++ b/assets/vue/components/common/HistoMultiSelect.vue
@@ -115,10 +115,16 @@ export default defineComponent({
   computed: {
     strCountSelectedItems () {
       const selectLabel:string = this.isInnerLabelFemale ? 'sélectionnée' : 'sélectionné'
-      if (this.modelValue.length > 1) {
-        return this.modelValue.length + ' ' + selectLabel + 's'
+
+      const validSelectedItems = this.modelValue.filter(item =>
+        this.optionItems.some(option => option.Id === item)
+      )
+
+      if (validSelectedItems.length > 1) {
+        return validSelectedItems.length + ' ' + selectLabel + 's'
       }
-      return this.modelValue.length + ' ' + selectLabel
+
+      return validSelectedItems.length + ' ' + selectLabel
     }
   }
 })

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -19,7 +19,7 @@
                         ref="withoutAffectationButton"
                         :aria-pressed="ariaPressed.showWithoutAffectationOnly.toString()"
                         @click="toggleWithoutAffectation">
-                  Afficher les signalements sans affectations
+                  Afficher les signalements sans affectations uniquement
                 </button>
               </li>
               <li>

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -404,6 +404,7 @@ export default defineComponent({
     },
     selectPartnerInList () {
       this.sharedState.input.filters.partenaires = this.sharedState.input.filters.partenaires.filter(partenaire => partenaire !== 'AUCUN')
+      this.deactiveWithoutAffectationsOnly()
       if (typeof this.onChange === 'function') {
         this.onChange(false)
       }

--- a/assets/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -14,6 +14,14 @@
                   Afficher mes affectations uniquement
                 </button>
               </li>
+              <li v-if="sharedState.user.canSeeFilterPartner">
+                <button class="fr-tag"
+                        ref="withoutAffectationButton"
+                        :aria-pressed="ariaPressed.showWithoutAffectationOnly.toString()"
+                        @click="toggleWithoutAffectation">
+                  Afficher les signalements sans affectations
+                </button>
+              </li>
               <li>
                 <button
                     v-if="sharedState.hasSignalementImported"
@@ -154,7 +162,7 @@
                 <HistoMultiSelect
                     id="filter-partenaires"
                     v-model="sharedState.input.filters.partenaires"
-                    @update:modelValue="onChange(false)"
+                    @update:modelValue="selectPartnerInList()"
                     inner-label="Partenaires"
                     :option-items=sharedState.partenaires
                     :isInnerLabelFemale="false"
@@ -323,7 +331,7 @@ export default defineComponent({
   computed: {
     filtersSanitized () {
       const filters = Object.entries(this.sharedState.input.filters).filter(([key, value]) => {
-        if (key === 'isImported' || key === 'showMyAffectationOnly') {
+        if (key === 'isImported' || key === 'showMyAffectationOnly' || key === 'showWithoutAffectationOnly') {
           return false
         }
         if (value !== null) {
@@ -353,6 +361,7 @@ export default defineComponent({
           this.sharedState.input.filters.showMyAffectationOnly !== 'oui' ? 'oui' : null
 
       if (this.sharedState.input.filters.showMyAffectationOnly === 'oui') {
+        this.deactiveWithoutAffectationsOnly()
         const currentPartner = this.sharedState.partenaires.filter((partner: HistoInterfaceSelectOption) => {
           return partner.Id === this.sharedState.user.partnerId?.toString() || ''
         })
@@ -365,14 +374,48 @@ export default defineComponent({
         this.onChange(false)
       }
     },
+    toggleWithoutAffectation () {
+      this.sharedState.input.filters.partenaires = []
+      this.sharedState.input.filters.showWithoutAffectationOnly =
+          this.sharedState.input.filters.showWithoutAffectationOnly !== 'oui' ? 'oui' : null
+
+      if (this.sharedState.input.filters.showWithoutAffectationOnly === 'oui') {
+        this.deactiveMyAffectationsOnly()
+        this.sharedState.input.filters.partenaires = ['AUCUN']
+      } else {
+        delete this.sharedState.input.filters.partenaires[0]
+      }
+
+      if (typeof this.onChange === 'function') {
+        this.onChange(false)
+      }
+    },
+    deactiveMyAffectationsOnly () {
+      this.sharedState.input.filters.showMyAffectationOnly = null
+      if (this.$refs.myAffectationButton) {
+        (this.$refs.myAffectationButton as HTMLElement).setAttribute('aria-pressed', 'false')
+      }
+    },
+    deactiveWithoutAffectationsOnly () {
+      this.sharedState.input.filters.showWithoutAffectationOnly = null
+      if (this.$refs.withoutAffectationButton) {
+        (this.$refs.withoutAffectationButton as HTMLElement).setAttribute('aria-pressed', 'false')
+      }
+    },
+    selectPartnerInList () {
+      this.sharedState.input.filters.partenaires = this.sharedState.input.filters.partenaires.filter(partenaire => partenaire !== 'AUCUN')
+      if (typeof this.onChange === 'function') {
+        this.onChange(false)
+      }
+    },
     removeFilter (key: string) {
       const currentMyAffectationOnly = (this.sharedState.input.filters as any)[key][0]
       const showMyAffectationOnly = this.sharedState.input.filters.showMyAffectationOnly
       if (showMyAffectationOnly === 'oui' && currentMyAffectationOnly === this.sharedState.user.partnerId?.toString()) {
-        this.sharedState.input.filters.showMyAffectationOnly = null
-        if (this.$refs.myAffectationButton) {
-          (this.$refs.myAffectationButton as HTMLElement).setAttribute('aria-pressed', 'false')
-        }
+        this.deactiveMyAffectationsOnly()
+      }
+      if (this.sharedState.input.filters.showWithoutAffectationOnly === 'oui') {
+        this.deactiveWithoutAffectationsOnly()
       }
 
       delete (this.sharedState.input.filters as any)[key]
@@ -409,6 +452,7 @@ export default defineComponent({
         dateDernierSuivi: null,
         isImported: null,
         showMyAffectationOnly: null,
+        showWithoutAffectationOnly: null,
         statusAffectation: null,
         criticiteScoreMin: null,
         criticiteScoreMax: null
@@ -417,6 +461,10 @@ export default defineComponent({
 
       if (this.$refs.myAffectationButton) {
         (this.$refs.myAffectationButton as HTMLElement).setAttribute('aria-pressed', 'false')
+      }
+
+      if (this.$refs.withoutAffectationButton) {
+        (this.$refs.withoutAffectationButton as HTMLElement).setAttribute('aria-pressed', 'false')
       }
 
       if (this.$refs.isImportedButton) {
@@ -443,7 +491,8 @@ export default defineComponent({
       sharedState: store.state,
       ariaPressed: {
         isImported: store.state.input.filters.isImported === 'oui',
-        showMyAffectationOnly: store.state.input.filters.showMyAffectationOnly === 'oui'
+        showMyAffectationOnly: store.state.input.filters.showMyAffectationOnly === 'oui',
+        showWithoutAffectationOnly: store.state.input.filters.showWithoutAffectationOnly === 'oui'
       },
       statusSignalementList: store.state.statusSignalementList,
       statusAffectationList: store.state.statusAffectationList,

--- a/assets/vue/components/signalement-list/interfaces/filters.ts
+++ b/assets/vue/components/signalement-list/interfaces/filters.ts
@@ -25,6 +25,7 @@ export const SEARCH_FILTERS = [
   { type: 'text', name: 'sansSuiviPeriode', showOptions: false, defaultValue: '30' },
   { type: 'text', name: 'nouveauSuivi', showOptions: false, defaultValue: 'oui' },
   { type: 'text', name: 'showMyAffectationOnly', showOptions: true, defaultValue: null },
+  { type: 'text', name: 'showWithoutAffectationOnly', showOptions: true, defaultValue: null },
   { type: 'text', name: 'isImported', showOptions: false, defaultValue: null },
   { type: 'collection', name: 'communes', showOptions: false, defaultValue: null },
   { type: 'collection', name: 'epcis', showOptions: false, defaultValue: null },

--- a/assets/vue/components/signalement-list/services/badgeFilterLabelBuilder.ts
+++ b/assets/vue/components/signalement-list/services/badgeFilterLabelBuilder.ts
@@ -1,4 +1,5 @@
 import { PATTERN_BADGE_EPCI, store } from '../store'
+import HistoInterfaceSelectOption from '../../common/HistoInterfaceSelectOption'
 
 export function buildBadge (key: string, value: any): string | undefined | null {
   if (typeof value === 'undefined') {
@@ -16,6 +17,12 @@ export function buildBadge (key: string, value: any): string | undefined | null 
     const matchedItems = store.state[key]
       .filter(item => item.Id !== '' && Array.from(value).includes(item.Id.toString()))
 
+    if (Array.from(value)[0] === 'AUCUN') {
+      const optionItem = new HistoInterfaceSelectOption()
+      optionItem.Id = '0'
+      optionItem.Text = 'Aucun'
+      matchedItems.push(optionItem)
+    }
     if (matchedItems.length > 0) {
       const label = `${key.charAt(0).toUpperCase()}${key.slice(1)} : `
       return `${label} ${matchedItems[0].Text}${matchedItems.length > 1

--- a/assets/vue/components/signalement-list/store.ts
+++ b/assets/vue/components/signalement-list/store.ts
@@ -32,6 +32,7 @@ export const store = {
         dateDernierSuivi: null,
         isImported: 'oui' as 'oui' | null,
         showMyAffectationOnly: null as 'oui' | null,
+        showWithoutAffectationOnly: null as 'oui' | null,
         statusAffectation: null,
         criticiteScoreMin: null,
         criticiteScoreMax: null


### PR DESCRIPTION
## Ticket

#2963   

## Description
Ajout d'une option "Afficher les signalements sans affectations" pour les RT et les SA afin d'afficher les signalements sans partenaires affectés

## Changements apportés
* Création du bouton dans SignalementListFilters (et dans le store et le filters)
* Mise à jour de la fonction de création de badges

## Pré-requis
`npm run watch`
## Tests
- [ ] Vérifier que ce nouveau bouton apparait pour les RT et les SA, et pas pour les autres agents
- [ ] Cliquer sur ce nouveau bouton, vérifier que ça déselectionne le bouton "Afficher mes affectations uniquement" et vice-versa
- [ ] Vérifier que le bhoix d'un partenaire dans la liste déselection le bouton "Afficher les signalements sans affectations"
- [ ] Vérifier que la liste des signalements est cohérente
