### PR TITLE
[BO - Tableau de bord] Correction des liens qui filtrent la liste des signalements

### DIFF
--- a/config/app/widgets.yaml
+++ b/config/app/widgets.yaml
@@ -9,52 +9,61 @@ parameters:
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY]
         link: 'back_index'
         params:
-          statut: 1
+          status: 'nouveau'
       cardNouveauxSuivis:
         label: "Nouveaux suivis"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]
         link: 'back_index'
         params:
-          nouveau_suivi: true
-          sort: 'lastSuiviAt'
+          nouveauSuivi: 'oui'
+          sortBy: 'lastSuiviAt'
+          direction: 'DESC'
       cardSansSuivi:
         label: "Sans suivi"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]
         link: 'back_index'
         params:
-          sans_suivi_periode: 30
-          sort: 'lastSuiviAt'
+          sansSuiviPeriode: 30
+          sortBy: 'lastSuiviAt'
+          direction: 'DESC'
       cardCloturesGlobales:
         label: "Clôtures globales"
         roles: [ROLE_ADMIN]
         link: 'back_index'
         params:
-          statut: 6
-          sort: 'lastSuiviAt'
+          status: 'ferme'
+          sortBy: 'lastSuiviAt'
+          direction: 'DESC'
       cardCloturesPartenaires:
         label: "Clotures partenaires"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY]
         link: 'back_index'
         params:
-          closed_affectation: 'ONE_CLOSED'
-          sort: 'lastSuiviAt'
+          statusAffectation: 'cloture_un_partenaire'
+          sortBy: 'lastSuiviAt'
+          direction: 'DESC'
       cardMesAffectations:
         label: "Mes affectations"
         roles: [ROLE_ADMIN_TERRITORY]
         link: 'back_index'
+        params:
+            showMyAffectationOnly: 'oui'
+            sortBy: 'reference'
+            direction: 'DESC'
       cardNouvellesAffectations:
         label: "Nouvelles affectations"
         roles: [ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]
         link: 'back_index'
         params:
-          statut: 1
+          status: 'nouveau'
       cardNoSuiviAfter3Relances:
         label: "Suggestion de clôture"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_ADMIN_PARTNER, ROLE_USER_PARTNER]
         link: 'back_index'
         params:
-          relances_usager: 'NO_SUIVI_AFTER_3_RELANCES'
-          sort: 'lastSuiviAt'
+          relancesUsager: 'NO_SUIVI_AFTER_3_RELANCES'
+          sortBy: 'lastSuiviAt'
+          direction: 'DESC'
       cardTousLesSignalements:
         label: "Tous les signalements"
         roles: [ROLE_USER_PARTNER, ROLE_ADMIN_PARTNER]
@@ -64,15 +73,15 @@ parameters:
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_ADMIN_PARTNER, ROLE_USER_PARTNER]
         link: 'back_index'
         params:
-          nde: '1'
-          statut: 1
+          procedure: 'non_decence_energetique'
+          status: 'nouveau'
       cardSignalementsEnCoursNonDecence:
         label: "Non décence énergétique en cours"
         roles: [ROLE_ADMIN, ROLE_ADMIN_TERRITORY, ROLE_ADMIN_PARTNER, ROLE_USER_PARTNER]
         link: 'back_index'
         params:
-          nde: '1'
-          statut: 2
+          procedure: 'non_decence_energetique'
+          status: 'en_cours'
 
   affectations-partenaires:
     roles: [ ROLE_ADMIN, ROLE_ADMIN_TERRITORY ]


### PR DESCRIPTION
## Ticket

#2977   

## Description
Les liens qui filtrent la liste des signalements ont sauté. Sûrement quand on a supprimé le code legacy.
