### PR TITLE
[FO - Signalement] Restriction aux valeurs numériques pour le composant Counter

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -1516,11 +1516,13 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "{{dictionaryStore::desordres_logement_chauffage_details_dpe_conso_finale}}",
+                "description": "Saisir un nombre entier",
                 "slug": "desordres_logement_chauffage_details_dpe_conso_finale",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_dpe_annee === 'post2023'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 },
                 "defaultValue": 1
@@ -1528,23 +1530,27 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la superficie de votre logement ? (m²)",
+                "description": "Saisir un nombre entier",
                 "slug": "composition_logement_superficie",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_dpe_annee === 'before2023'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },
               {
                 "type": "SignalementFormCounter",
                 "label": "Quelle est la consommation en énergie indiquée sur le DPE ? (kWh/an)",
+                "description": "Saisir un nombre entier",
                 "slug": "desordres_logement_chauffage_details_dpe_conso",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_dpe_annee === 'before2023'"
                 },
                 "defaultValue": 1,
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -1545,11 +1545,13 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "{{dictionaryStore::desordres_logement_chauffage_details_dpe_conso_finale}}",
+                "description": "Saisir un nombre entier",
                 "slug": "desordres_logement_chauffage_details_dpe_conso_finale",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_dpe_annee === 'post2023'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 },
                 "defaultValue": 1
@@ -1557,23 +1559,27 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "{{dictionaryStore::composition_logement_superficie}}",
+                "description": "Saisir un nombre entier",
                 "slug": "composition_logement_superficie",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_dpe_annee === 'before2023'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },
               {
                 "type": "SignalementFormCounter",
                 "label": "{{dictionaryStore::desordres_logement_chauffage_details_dpe_conso}}",
+                "description": "Saisir un nombre entier",
                 "slug": "desordres_logement_chauffage_details_dpe_conso",
                 "conditional": {
                   "show": "formStore.data.desordres_logement_chauffage_details_dpe_annee === 'before2023'"
                 },
                 "defaultValue": 1,
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -396,8 +396,10 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quelle est la superficie du logement (taille en m²) (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_superficie",
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         },
@@ -423,10 +425,14 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le nombre de pièces à vivre (salon, chambre) dans votre logement ?",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_nb_pieces",
           "defaultValue": 1,
           "conditional": {
             "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+          },
+          "validate": {
+            "pattern": "^[0-9]*$"
           }
         }
       ],
@@ -659,7 +665,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Combien de personnes vivent dans le logement ?",
-          "slug": "composition_logement_nombre_personnes"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_nombre_personnes",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -932,11 +942,13 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le montant de l'allocation ? (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         }
@@ -1231,8 +1243,10 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quel est le montant du loyer, sans les charges ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_montant_loyer",
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               }
@@ -1249,11 +1263,13 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Le logement est sur combien d'étages ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_nombre_etages",
                 "conditional": {
                   "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },
@@ -1319,8 +1335,10 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quel est votre revenu fiscal de référence ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_situation_bailleur_revenu_fiscal",
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -340,7 +340,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quelle est la superficie de votre logement (taille en m²)",
-          "slug": "composition_logement_superficie"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_superficie",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -364,10 +368,14 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le nombre de pièces à vivre (salon, chambre) dans votre logement ?",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_nb_pieces",
           "defaultValue": 1,
           "conditional": {
             "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+          },
+          "validate": {
+            "pattern": "^[0-9]*$"
           }
         }
       ],
@@ -601,7 +609,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Combien de personnes vivent dans votre logement ?",
-          "slug": "composition_logement_nombre_personnes"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_nombre_personnes",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -820,11 +832,13 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le montant de votre allocation ? (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         }
@@ -1121,9 +1135,11 @@
               },
               {
                 "type": "SignalementFormCounter",
-                "label": "Quel est votre revenu fiscal de référence ?",
+                "label": "Quel est votre revenu fiscal de référence ? (facultatif)",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_situation_occupants_revenu_fiscal",
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               }
@@ -1139,18 +1155,20 @@
             "body": [
               {
                 "type": "SignalementFormCounter",
-                "label": "Votre logement est sur combien d'étages ?",
+                "label": "Votre logement est sur combien d'étages ? (facultatif)",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_nombre_etages",
                 "conditional": {
                   "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },
               {
                 "type": "SignalementFormTextfield",
-                "label": "En quelle année votre logement a-t-il été construit ?",
+                "label": "En quelle année votre logement a-t-il été construit ? (facultatif)",
                 "slug": "informations_complementaires_logement_annee_construction",
                 "placeholder": "1970",
                 "validate": {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -433,7 +433,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quelle est la superficie de votre logement (taille en m²)",
-          "slug": "composition_logement_superficie"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_superficie",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -457,10 +461,14 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le nombre de pièces à vivre (salon, chambre) dans votre logement ?",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_nb_pieces",
           "defaultValue": 1,
           "conditional": {
             "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+          },
+          "validate": {
+            "pattern": "^[0-9]*$"
           }
         }
       ],
@@ -694,7 +702,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Combien de personnes vivent dans votre logement ?",
-          "slug": "composition_logement_nombre_personnes"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_nombre_personnes",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -989,11 +1001,13 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le montant de votre allocation ? (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         }
@@ -1353,19 +1367,23 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quel est le montant de votre loyer, sans les charges ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_montant_loyer",
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },
               {
                 "type": "SignalementFormCounter",
                 "label": "Votre logement est sur combien d'étages ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_nombre_etages",
                 "conditional": {
                   "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -505,8 +505,10 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quelle est la superficie du logement (taille en m²) (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_superficie",
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         },
@@ -532,10 +534,14 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le nombre de pièces à vivre (salon, chambre) dans votre logement ?",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_nb_pieces",
           "defaultValue": 1,
           "conditional": {
             "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+          },
+          "validate": {
+            "pattern": "^[0-9]*$"
           }
         }
       ],
@@ -769,7 +775,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Combien de personnes vivent dans le logement ?",
-          "slug": "composition_logement_nombre_personnes"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_nombre_personnes",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -509,8 +509,10 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quelle est la superficie du logement (taille en m²) (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_superficie",
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         },
@@ -536,10 +538,14 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le nombre de pièces à vivre (salon, chambre) dans votre logement ?",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_nb_pieces",
           "defaultValue": 1,
           "conditional": {
             "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+          },
+          "validate": {
+            "pattern": "^[0-9]*$"
           }
         }
       ],
@@ -773,7 +779,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Combien de personnes vivent dans le logement ?",
-          "slug": "composition_logement_nombre_personnes"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_nombre_personnes",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1046,11 +1056,13 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le montant de l'allocation ? (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         }
@@ -1388,8 +1400,10 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quel est le montant du loyer, sans les charges ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_montant_loyer",
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },
@@ -1432,11 +1446,13 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Le logement est sur combien d'étages ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_nombre_etages",
                 "conditional": {
                   "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -496,8 +496,10 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quelle est la superficie du logement (taille en m²) (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_superficie",
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         },
@@ -523,10 +525,14 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le nombre de pièces à vivre (salon, chambre) dans votre logement ?",
+          "description": "Saisir un nombre entier",
           "slug": "composition_logement_nb_pieces",
           "defaultValue": 1,
           "conditional": {
             "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
+          },
+          "validate": {
+            "pattern": "^[0-9]*$"
           }
         }
       ],
@@ -760,7 +766,11 @@
         {
           "type": "SignalementFormCounter",
           "label": "Combien de personnes vivent dans le logement ?",
-          "slug": "composition_logement_nombre_personnes"
+          "description": "Saisir un nombre entier",
+          "slug": "composition_logement_nombre_personnes",
+          "validate": {
+            "pattern": "^[0-9]*$"
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1033,11 +1043,13 @@
         {
           "type": "SignalementFormCounter",
           "label": "Quel est le montant de l'allocation ? (facultatif)",
+          "description": "Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },
           "validate": {
+            "pattern": "^[0-9]*$",
             "required": false
           }
         }
@@ -1386,8 +1398,10 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Quel est le montant du loyer, sans les charges ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_montant_loyer",
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },
@@ -1430,11 +1444,13 @@
               {
                 "type": "SignalementFormCounter",
                 "label": "Le logement est sur combien d'étages ?",
+                "description": "Saisir un nombre entier",
                 "slug": "informations_complementaires_logement_nombre_etages",
                 "conditional": {
                   "show": "formStore.data.composition_logement_piece_unique === 'plusieurs_pieces'"
                 },
                 "validate": {
+                  "pattern": "^[0-9]*$",
                   "required": false
                 }
               },

--- a/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="fr-input-group" :id="id">
-    <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'" v-html="variablesReplacer.replace(label)"></label>
+    <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">
+      {{ variablesReplacer.replace(label) }}
+      <span class="fr-hint-text">{{ description }}</span>
+    </label>
     <input
         type="text"
         pattern="[0-9]*"
@@ -64,7 +67,6 @@ export default defineComponent({
   methods: {
     updateValue (event: Event) {
       let value = (event.target as HTMLInputElement).value
-      value = value.replace(',', '.').replace(/[^\d.-]/g, '')
       this.$emit('update:modelValue', value)
     }
   },

--- a/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -63,7 +63,8 @@ export default defineComponent({
   },
   methods: {
     updateValue (event: Event) {
-      const value = (event.target as HTMLInputElement).value
+      let value = (event.target as HTMLInputElement).value
+      value = value.replace(',', '.').replace(/[^\d.-]/g, '')
       this.$emit('update:modelValue', value)
     }
   },

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -550,8 +550,10 @@ class SignalementBuilder
 
     private function convertStringToNumber(?string $value, $returnInt = true): float|int
     {
-        $pattern = $returnInt ? '/[^0-9]+/' : '/[^0-9.]+/';
-
-        return preg_replace($pattern, '', $value);
+        if ($returnInt) {
+            return (int) preg_replace('/[^0-9]+/', '', $value);
+        } else {
+            return (float) preg_replace('/[^0-9.]+/', '', $value);
+        }
     }
 }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -94,15 +94,17 @@ class SignalementBuilder
 
     public function withTypeCompositionLogement(): self
     {
+        $nbOccupantsLogement = $this->convertStringToNumber($this->signalementDraftRequest->getCompositionLogementNombrePersonnes());
+        $nbPiecesLogement = $this->convertStringToNumber($this->signalementDraftRequest->getCompositionLogementNbPieces());
         $this->signalement
             ->setTypeCompositionLogement(
                 $this->typeCompositionLogementFactory->createFromSignalementDraftPayload($this->payload)
             )
-            ->setNbOccupantsLogement($this->signalementDraftRequest->getCompositionLogementNombrePersonnes())
+            ->setNbOccupantsLogement($nbOccupantsLogement)
             ->setNatureLogement($this->signalementDraftRequest->getTypeLogementNature())
             ->setTypeLogement($this->signalementDraftRequest->getTypeLogementNature())
             ->setSuperficie($this->signalementDraftRequest->getCompositionLogementSuperficie())
-            ->setNbPiecesLogement($this->signalementDraftRequest->getCompositionLogementNbPieces())
+            ->setNbPiecesLogement($nbPiecesLogement)
             ->setIsBailEnCours($this->evalBoolean($this->signalementDraftRequest->getBailDpeBail()))
             ->setDateEntree($this->resolveDateEmmenagement());
 
@@ -111,6 +113,7 @@ class SignalementBuilder
 
     public function withSituationFoyer(): self
     {
+        $montantAllocation = $this->convertStringToNumber($this->signalementDraftRequest->getLogementSocialMontantAllocation(), false);
         $this->signalement
             ->setSituationFoyer($this->situationFoyerFactory->createFromSignalementDraftPayload($this->payload))
             ->setIsPreavisDepart(
@@ -118,7 +121,7 @@ class SignalementBuilder
             )
             ->setIsAllocataire($this->resolveIsAllocataire())
             ->setNumAllocataire($this->signalementDraftRequest->getLogementSocialNumeroAllocataire())
-            ->setMontantAllocation($this->signalementDraftRequest->getLogementSocialMontantAllocation())
+            ->setMontantAllocation($montantAllocation)
             ->setDateNaissanceOccupant($this->resolveDateNaissanceOccupant());
 
         return $this;
@@ -256,15 +259,15 @@ class SignalementBuilder
 
     public function withProcedure(): self
     {
+        $loyer = $this->convertStringToNumber($this->signalementDraftRequest->getInformationsComplementairesLogementMontantLoyer(), false);
+        $nbEtages = $this->convertStringToNumber($this->signalementDraftRequest->getInformationsComplementairesLogementNombreEtages());
         $this->signalement
             ->setInformationProcedure(
                 $this->informationProcedureFactory->createFromSignalementDraftPayload($this->payload)
             )
             ->setIsProprioAverti($this->evalBoolean($this->signalementDraftRequest->getInfoProcedureBailleurPrevenu()))
-            ->setLoyer($this->signalementDraftRequest->getInformationsComplementairesLogementMontantLoyer())
-            ->setNbNiveauxLogement(
-                (int) $this->signalementDraftRequest->getInformationsComplementairesLogementNombreEtages()
-            )
+            ->setLoyer($loyer)
+            ->setNbNiveauxLogement($nbEtages)
             ->setIsFondSolidariteLogement(
                 $this->evalBoolean(
                     $this->signalementDraftRequest->getInformationsComplementairesSituationOccupantsBeneficiaireFsl()
@@ -543,5 +546,12 @@ class SignalementBuilder
         return $this->isServiceSecours()
             ? $this->evalBoolean($this->signalementDraftRequest->getSignalementConcerneLogementSocialServiceSecours())
             : $this->evalBoolean($this->signalementDraftRequest->getSignalementConcerneLogementSocialAutreTiers());
+    }
+
+    private function convertStringToNumber(?string $value, $returnInt = true): float|int
+    {
+        $pattern = $returnInt ? '/[^0-9]+/' : '/[^0-9.]+/';
+
+        return preg_replace($pattern, '', $value);
     }
 }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -552,8 +552,8 @@ class SignalementBuilder
     {
         if ($returnInt) {
             return (int) preg_replace('/[^0-9]+/', '', $value);
-        } else {
-            return (float) preg_replace('/[^0-9.]+/', '', $value);
         }
+
+        return (float) preg_replace('/[^0-9.]+/', '', $value);
     }
 }


### PR DESCRIPTION
## Ticket

#2983   

## Description
Une nouvelle erreur Sentry est apparue : problème d'enregistrement du montant d'allocation.
Ce souci est du aux modification W3C sur le composant Counter : avant le champ était de type `number`, il est passé en type `text`. (Voir ici : https://github.com/MTES-MCT/histologe/commit/5fbb88fc82c0c61cb65884853b9e632c51bce1dd#diff-18a10404bf4d57a155f4cb5dec465c6ea5955693ec7e867db53e22dc8fb24c07)
Problème : si on passe en number et qu'il y a un caractère non-numérique, l'ensemble de la valeur saute. Et de toute façon, ce n'était pas compatible W3C tel quel.

## Changements apportés
* Ajout d'un pattern de vérification pour les valeurs numériques côté front
* Ajout d'un pattern de conversion pour les valeurs numériques côté back

## Pré-requis
`npm run watch`

## Tests
- [ ] Tester différentes valeurs dans le montant d'allocation pour voir ce qui est conservé et vérifier l'enregistrement correct
- [ ] Idem pour nombre de personnes dans le logement, nombre d'étages, superficie, nombre de pièces, montant du loyer
