### PR TITLE
[QA] Augmentation de la durée de vie du worker à 24H avant redemarrage

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 postdeploy: ./scripts/postdeploy.sh
-worker: php bin/console messenger:consume async_priority_high async --time-limit=3600
+worker: php bin/console messenger:consume async_priority_high async --time-limit=86400
 clock: php bin/console app:scheduled-task


### PR DESCRIPTION
## Ticket

#2982    

## Description
Eviter de se faire spammer toutes les heures pour des "crash" de worker. 
Scalingo n'a pas de système native pour détecter un arrêt volontaire 

## Changements apportés
* Augmentation de la durée de vie du worker avant de redémarrage

## Pré-requis

## Tests
n/a
