### PR TITLE
[Optimisation] Commande pour supprimer les images originales quand miniature générées

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -10,6 +10,9 @@
       "command": "0 0 * * * php bin/console app:clear-storage-tmp-folder"
     },
     {
+      "command": "15 1-5 * * * php bin/console app:cclear-storage-original-file"
+    },
+    {
       "command": "0 6,18 * * * php bin/console app:sync-esabora-schs"
     },
     {

--- a/cron.json
+++ b/cron.json
@@ -10,7 +10,7 @@
       "command": "0 0 * * * php bin/console app:clear-storage-tmp-folder"
     },
     {
-      "command": "15 1-5 * * * php bin/console app:cclear-storage-original-file"
+      "command": "15 1-5 * * * php bin/console app:clear-storage-original-file"
     },
     {
       "command": "0 6,18 * * * php bin/console app:sync-esabora-schs"

--- a/migrations/Version20240903092746.php
+++ b/migrations/Version20240903092746.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240903092746 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_original_deleted column to file table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file ADD is_original_deleted TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file DROP is_original_deleted');
+    }
+}

--- a/src/Command/Cron/ClearStorageOriginalFileCommand.php
+++ b/src/Command/Cron/ClearStorageOriginalFileCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 )]
 class ClearStorageOriginalFileCommand extends AbstractCronCommand
 {
+    private const int MAX_FILES_PROCESSED = 2500;
     private SymfonyStyle $io;
 
     public function __construct(
@@ -41,12 +42,12 @@ class ClearStorageOriginalFileCommand extends AbstractCronCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $count = $this->fileRepository->findWithOriginalAndVariants(count : true);
-        $files = $this->fileRepository->findWithOriginalAndVariants();
+        $count = $this->fileRepository->countWithOriginalAndVariants();
+        $files = $this->fileRepository->findWithOriginalAndVariants(self::MAX_FILES_PROCESSED);
         $nbFilesToProcess = count($files);
+        $this->io->info('Found '.$count.' files with original and variants, process '.$nbFilesToProcess.' files');
         $progressBar = new ProgressBar($output, $nbFilesToProcess);
         $progressBar->start();
-        $this->io->info('Found '.$count.' files with original and variants, process '.$nbFilesToProcess.' files');
         $nbErrors = 0;
         $nbTmp = 0;
         foreach ($files as $file) {

--- a/src/Command/Cron/ClearStorageOriginalFileCommand.php
+++ b/src/Command/Cron/ClearStorageOriginalFileCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Command\Cron;
+
+use App\Repository\FileRepository;
+use App\Service\Mailer\NotificationMail;
+use App\Service\Mailer\NotificationMailerRegistry;
+use App\Service\Mailer\NotificationMailerType;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(
+    name: 'app:clear-storage-original-file',
+    description: 'Clear original files from object storage S3 when resized files exist',
+)]
+class ClearStorageOriginalFileCommand extends AbstractCronCommand
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private readonly ParameterBagInterface $parameterBag,
+        private readonly FileRepository $fileRepository,
+        private readonly FilesystemOperator $fileStorage,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly NotificationMailerRegistry $notificationMailerRegistry,
+    ) {
+        parent::__construct($this->parameterBag);
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $count = $this->fileRepository->findWithOriginalAndVariants(count : true);
+        $files = $this->fileRepository->findWithOriginalAndVariants();
+        $nbFilesToProcess = count($files);
+        $progressBar = new ProgressBar($output, $nbFilesToProcess);
+        $progressBar->start();
+        $this->io->info('Found '.$count.' files with original and variants, process '.$nbFilesToProcess.' files');
+        $nbErrors = 0;
+        $nbTmp = 0;
+        foreach ($files as $file) {
+            $filename = $file->getFilename();
+            if ($this->fileStorage->fileExists($filename)) {
+                $this->fileStorage->delete($filename);
+                ++$nbTmp;
+            } else {
+                ++$nbErrors;
+            }
+            $file->setIsOriginalDeleted(true);
+            if ($nbTmp > 50) {
+                $this->entityManager->flush();
+                $nbTmp = 0;
+            }
+            $progressBar->advance();
+        }
+        $this->entityManager->flush();
+        $progressBar->finish();
+        $this->io->newLine();
+        $this->io->success($nbFilesToProcess.' files processed with '.$nbErrors.' files not found');
+
+        $this->notificationMailerRegistry->send(
+            new NotificationMail(
+                type: NotificationMailerType::TYPE_CRON,
+                to: $this->parameterBag->get('admin_email'),
+                message: sprintf('fichiers ont été traités dont %s fichiers introuvables sur un total de %s', $nbErrors, $count),
+                cronLabel: 'Suppression de fichier(s) originaux s3://',
+                cronCount: $nbFilesToProcess,
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -50,7 +50,7 @@ class SecurityController extends AbstractController
 
             if ('thumb' == $variant && $fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_THUMB])) {
                 $filename = $variantNames[ImageManipulationHandler::SUFFIX_THUMB];
-            } elseif ('resize' == $variant && $fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE])) {
+            } elseif ($fileStorage->fileExists($variantNames[ImageManipulationHandler::SUFFIX_RESIZE])) {
                 $filename = $variantNames[ImageManipulationHandler::SUFFIX_RESIZE];
             }
             if (!$fileStorage->fileExists($filename)) {

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -265,6 +265,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             ],
         ];
 
+        $dateMinusTwoMonth = (new \DateTimeImmutable())->modify('-2 months');
         foreach ($documentsAndPhotos as $document) {
             $user = $this->userRepository->findOneBy(['id' => $document['user']]);
             $file = $this->fileFactory->createInstanceFrom(
@@ -277,6 +278,10 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 user: $user,
                 documentType: DocumentType::AUTRE
             );
+            if (in_array(pathinfo($document['file'], \PATHINFO_EXTENSION), File::IMAGE_EXTENSION)) {
+                $file->setIsVariantsGenerated(true);
+                $file->setCreatedAt($dateMinusTwoMonth);
+            }
             $manager->persist($file);
         }
 

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -118,11 +118,15 @@ class File
     #[ORM\Column(length: 255, unique: true)]
     private ?string $uuid = null;
 
+    #[ORM\Column]
+    private ?bool $isOriginalDeleted = null;
+
     public function __construct()
     {
         $this->uuid = Uuid::v4();
         $this->createdAt = new \DateTimeImmutable();
         $this->isVariantsGenerated = false;
+        $this->isOriginalDeleted = false;
         $this->isWaitingSuivi = false;
         $this->isTemp = false;
     }
@@ -381,6 +385,18 @@ class File
     public function setUuid(string $uuid): static
     {
         $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    public function getIsOriginalDeleted(): ?bool
+    {
+        return $this->isOriginalDeleted;
+    }
+
+    public function setIsOriginalDeleted(bool $isOriginalDeleted): static
+    {
+        $this->isOriginalDeleted = $isOriginalDeleted;
 
         return $this;
     }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\File;
 use App\Entity\Territory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -55,18 +56,24 @@ class FileRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function findWithOriginalAndVariants($count = false)
+    public function findWithOriginalAndVariants(int $max)
+    {
+        return $this->initQueryWithOriginalAndVariants()->select('f')->setMaxResults($max)->getQuery()->getResult();
+    }
+
+    public function countWithOriginalAndVariants()
+    {
+        return $this->initQueryWithOriginalAndVariants()->select('count(f)')->getQuery()->getSingleScalarResult();
+    }
+
+    private function initQueryWithOriginalAndVariants(): QueryBuilder
     {
         $limit = (new \DateTime())->modify('-1 month');
-        $qb = $this->createQueryBuilder('f')
+
+        return $this->createQueryBuilder('f')
             ->andWhere('f.isVariantsGenerated = true')
             ->andWhere('f.isOriginalDeleted = false')
             ->andWhere('f.createdAt < :limit')
             ->setParameter('limit', $limit);
-        if ($count) {
-            return $qb->select('count(f)')->getQuery()->getSingleScalarResult();
-        }
-
-        return $qb->select('f')->setMaxResults(2500)->getQuery()->getResult();
     }
 }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -56,12 +56,12 @@ class FileRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function findWithOriginalAndVariants(int $max)
+    public function findWithOriginalAndVariants(int $max): array
     {
         return $this->initQueryWithOriginalAndVariants()->select('f')->setMaxResults($max)->getQuery()->getResult();
     }
 
-    public function countWithOriginalAndVariants()
+    public function countWithOriginalAndVariants(): int
     {
         return $this->initQueryWithOriginalAndVariants()->select('count(f)')->getQuery()->getSingleScalarResult();
     }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -54,4 +54,19 @@ class FileRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function findWithOriginalAndVariants($count = false)
+    {
+        $limit = (new \DateTime())->modify('-1 month');
+        $qb = $this->createQueryBuilder('f')
+            ->andWhere('f.isVariantsGenerated = true')
+            ->andWhere('f.isOriginalDeleted = false')
+            ->andWhere('f.createdAt < :limit')
+            ->setParameter('limit', $limit);
+        if ($count) {
+            return $qb->select('count(f)')->getQuery()->getSingleScalarResult();
+        }
+
+        return $qb->select('f')->setMaxResults(2500)->getQuery()->getResult();
+    }
 }

--- a/tests/Functional/Command/Cron/ClearStorageOriginalFileCommandTest.php
+++ b/tests/Functional/Command/Cron/ClearStorageOriginalFileCommandTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests\Functional\Command\Cron;
+
+use App\Command\Cron\ClearStorageOriginalFileCommand;
+use App\Repository\FileRepository;
+use App\Service\Mailer\NotificationMailerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ClearStorageOriginalFileCommandTest extends KernelTestCase
+{
+    private ParameterBagInterface $parameterBag;
+    private FileRepository $fileRepository;
+    private MockObject|FilesystemOperator $fileStorage;
+
+    private EntityManagerInterface $entityManager;
+    private NotificationMailerRegistry $mailerRegistry;
+
+    protected function setUp(): void
+    {
+        $this->parameterBag = self::getContainer()->getParameterBag();
+        $this->fileRepository = self::getContainer()->get(FileRepository::class);
+        $this->fileStorage = $this->createMock(FilesystemOperator::class);
+        $this->entityManager = self::getContainer()->get('doctrine')->getManager();
+        $this->mailerRegistry = self::getContainer()->get(NotificationMailerRegistry::class);
+    }
+
+    public function testExecuteTwice(): void
+    {
+        $command = new ClearStorageOriginalFileCommand(
+            $this->parameterBag,
+            $this->fileRepository,
+            $this->fileStorage,
+            $this->entityManager,
+            $this->mailerRegistry,
+        );
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('129 files processed with 129 files not found', $output);
+        $this->assertEquals(Command::SUCCESS, $commandTester->getStatusCode());
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('0 files processed with 0 files not found', $output);
+        $this->assertEquals(Command::SUCCESS, $commandTester->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Ticket

#2285

## Description
Ajout d'une commande qui sera joué en cron afin de supprimer tous les fichier originaux des File ayant les variant (resize) de généré
Par sécurité la commande supprime uniquement les File crée depuis plus d'un mois

## Tests
- [ ] Ajouter des photo et ou document de type image sur un signalement, modifier leur date de création en base (antérieure a un mois en arrière)
- [ ] lancer la commande `app:clear-storage-original-file` et vérifier que les originaux sont supprimés
