### PR TITLE
[FO - Formulaire - Accessibilité - 10.7] Dans chaque page web, pour chaque élément recevant le focus, la prise de focus est-elle visible ?

### DIFF
--- a/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -3,19 +3,19 @@
     :class="['signalement-form-disorder-category-item fr-container--fluid fr-p-3v', isSelected || isAlreadySelected ? categoryZoneCss : '']"
     @click="handleClick"
     >
+      <input
+      type="checkbox"
+      :id="id + '_input'"
+      :name="id"
+      v-model="isSelected"
+      @change="handleChange"
+      @click.stop
+      >
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
         <div class="fr-col-12 fr-col-md-4">
           <img :src="iconSrc" alt="">
         </div>
         <div class="fr-col-12 fr-col-md-8">
-          <input
-            type="checkbox"
-            :id="id + '_input'"
-            :name="id"
-            v-model="isSelected"
-            @change="handleChange"
-            @click.stop
-            >
           <label :for="id + '_input'" class="fr-label" @click.stop>{{ label }}</label>
         </div>
       </div>
@@ -77,6 +77,12 @@ export default defineComponent({
 <style>
 .signalement-form-disorder-category-item {
   border: 1px solid var(--border-default-grey);
+}
+.signalement-form-disorder-category-item:has(:focus){
+  outline-color: #0a76f6;
+  outline-offset: -4px;
+  outline-style: solid;
+  outline-width: 2px;
 }
 .signalement-form-disorder-category-item.is-selected-batiment {
   border: 1px solid var(--border-default-orange-terre-battue);

--- a/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -1,10 +1,6 @@
 <template>
-<div :class="['fr-mb-5v fr-upload-group', { 'fr-upload-group--disabled': disabled }]" :id="id">
+<div :class="['fr-mb-6w fr-upload-group', { 'fr-upload-group--disabled': disabled }]" :id="id">
   <div :class="[ customCss, 'fr-upload-wrap', 'fr-py-3v' ]">
-    <label :for="id + '_input'" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
-      {{ label }}
-    </label>
-    <span class="fr-hint-text">{{ description }}</span>
     <input
       type="file"
       :id="id + '_input'"
@@ -16,6 +12,10 @@
       @change="uploadFile($event)"
       :accept="accept"
       >
+      <label :for="id + '_input'" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
+        {{ label }}
+      </label>
+      <span class="fr-hint-text">{{ description }}</span>
   </div>
 
   <div v-if="formStore.data[id] !== undefined">
@@ -234,10 +234,13 @@ export default defineComponent({
 <style>
 .custom-file-input {
   opacity: 0;
-  position: relative;
-  line-height: 2.5rem;
-  top: -2.5rem;
-  width: 100%;
+  position: absolute;
+}
+.custom-file-input:focus + label{
+  outline-color: #0a76f6;
+  outline-offset: 2px;
+  outline-style: solid;
+  outline-width: 2px;
 }
 .fr-link--error {
   color: var(--text-default-error);


### PR DESCRIPTION
## Ticket

#2992

## Description
Faire en sorte que tous les éléments qui prennent le focus sur le formulaire de signalement soit marqué visuellement

## Changements apportés
* Modification de la structure et css des bloc item de sélection des désordre pour afficher un focus propre
* Modification de la structure et css des bouton d'upload afin d'afficher le focus qui n'était pas visible

## Pré-requis
`make npm-build`

## Tests
- [ ] Vérifier que le focus s'affiche bien sur tout les éléments du formulaire

ticket liés : #2991 #2993
