### PR TITLE
[FO - Signalement] Correction du validateur quand les valeurs sont égales à null

### DIFF
--- a/assets/vue/components/signalement-form/services/componentValidator.ts
+++ b/assets/vue/components/signalement-form/services/componentValidator.ts
@@ -8,9 +8,9 @@ export const componentValidator = {
 
     let regexPattern
     // s'il y a une valeur, on vérifie si un pattern est requis (ou si c'est un type email)
-    if (value !== undefined && value !== '' && component.type === 'SignalementFormEmailfield') {
+    if (value !== undefined && value !== null && value !== '' && component.type === 'SignalementFormEmailfield') {
       regexPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    } else if (value !== undefined && value !== '' && component.validate?.pattern !== undefined) {
+    } else if (value !== undefined && value !== null && value !== '' && component.validate?.pattern !== undefined) {
       regexPattern = new RegExp(component.validate.pattern)
     }
     if (regexPattern !== undefined) {
@@ -19,14 +19,14 @@ export const componentValidator = {
       }
     }
 
-    if (value !== undefined && value !== '' && component.type === 'SignalementFormPhonefield') {
+    if (value !== undefined && value !== null && value !== '' && component.type === 'SignalementFormPhonefield') {
       const countryCode = formStore.data[componentSlug + '_countrycode'].split(':')[0]
       if (!isValidPhoneNumber(value, countryCode)) {
         formStore.validationErrors[componentSlug] = 'Format invalide'
       }
 
       const valueTelSecond = formStore.data[componentSlug + '_secondaire']
-      if (valueTelSecond !== undefined && valueTelSecond !== '') {
+      if (valueTelSecond !== undefined && valueTelSecond !== null && valueTelSecond !== '') {
         const countryCodeSecond = formStore.data[componentSlug + '_secondaire_countrycode'].split(':')[0]
         if (!isValidPhoneNumber(valueTelSecond, countryCodeSecond)) {
           formStore.validationErrors[componentSlug + '_secondaire'] = 'Format invalide'
@@ -38,7 +38,7 @@ export const componentValidator = {
       this.validateAddress(component)
     }
 
-    if (value !== undefined && value !== '' && component.validate?.maxLength !== undefined) {
+    if (value !== undefined && value !== null && value !== '' && component.validate?.maxLength !== undefined) {
       if (value.length > component.validate?.maxLength) {
         const maxLength: string = component.validate?.maxLength.toString()
         formStore.validationErrors[componentSlug] = 'La valeur dépasse la longueur autorisée ' + maxLength

--- a/assets/vue/components/signalement-form/services/componentValidator.ts
+++ b/assets/vue/components/signalement-form/services/componentValidator.ts
@@ -1,5 +1,6 @@
 import formStore from '../store'
 import { isValidPhoneNumber } from 'libphonenumber-js'
+import { variableTester } from './variableTester'
 
 export const componentValidator = {
   validate (component: any) {
@@ -8,9 +9,9 @@ export const componentValidator = {
 
     let regexPattern
     // s'il y a une valeur, on vérifie si un pattern est requis (ou si c'est un type email)
-    if (value !== undefined && value !== null && value !== '' && component.type === 'SignalementFormEmailfield') {
+    if (variableTester.isNotEmtpy(value) && component.type === 'SignalementFormEmailfield') {
       regexPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    } else if (value !== undefined && value !== null && value !== '' && component.validate?.pattern !== undefined) {
+    } else if (variableTester.isNotEmtpy(value) && component.validate?.pattern !== undefined) {
       regexPattern = new RegExp(component.validate.pattern)
     }
     if (regexPattern !== undefined) {
@@ -19,14 +20,14 @@ export const componentValidator = {
       }
     }
 
-    if (value !== undefined && value !== null && value !== '' && component.type === 'SignalementFormPhonefield') {
+    if (variableTester.isNotEmtpy(value) && component.type === 'SignalementFormPhonefield') {
       const countryCode = formStore.data[componentSlug + '_countrycode'].split(':')[0]
       if (!isValidPhoneNumber(value, countryCode)) {
         formStore.validationErrors[componentSlug] = 'Format invalide'
       }
 
       const valueTelSecond = formStore.data[componentSlug + '_secondaire']
-      if (valueTelSecond !== undefined && valueTelSecond !== null && valueTelSecond !== '') {
+      if (variableTester.isNotEmtpy(valueTelSecond)) {
         const countryCodeSecond = formStore.data[componentSlug + '_secondaire_countrycode'].split(':')[0]
         if (!isValidPhoneNumber(valueTelSecond, countryCodeSecond)) {
           formStore.validationErrors[componentSlug + '_secondaire'] = 'Format invalide'
@@ -38,7 +39,7 @@ export const componentValidator = {
       this.validateAddress(component)
     }
 
-    if (value !== undefined && value !== null && value !== '' && component.validate?.maxLength !== undefined) {
+    if (variableTester.isNotEmtpy(value) && component.validate?.maxLength !== undefined) {
       if (value.length > component.validate?.maxLength) {
         const maxLength: string = component.validate?.maxLength.toString()
         formStore.validationErrors[componentSlug] = 'La valeur dépasse la longueur autorisée ' + maxLength

--- a/assets/vue/components/signalement-form/services/componentValidator.ts
+++ b/assets/vue/components/signalement-form/services/componentValidator.ts
@@ -9,9 +9,9 @@ export const componentValidator = {
 
     let regexPattern
     // s'il y a une valeur, on vérifie si un pattern est requis (ou si c'est un type email)
-    if (variableTester.isNotEmtpy(value) && component.type === 'SignalementFormEmailfield') {
+    if (variableTester.isNotEmpty(value) && component.type === 'SignalementFormEmailfield') {
       regexPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    } else if (variableTester.isNotEmtpy(value) && component.validate?.pattern !== undefined) {
+    } else if (variableTester.isNotEmpty(value) && component.validate?.pattern !== undefined) {
       regexPattern = new RegExp(component.validate.pattern)
     }
     if (regexPattern !== undefined) {
@@ -20,14 +20,14 @@ export const componentValidator = {
       }
     }
 
-    if (variableTester.isNotEmtpy(value) && component.type === 'SignalementFormPhonefield') {
+    if (variableTester.isNotEmpty(value) && component.type === 'SignalementFormPhonefield') {
       const countryCode = formStore.data[componentSlug + '_countrycode'].split(':')[0]
       if (!isValidPhoneNumber(value, countryCode)) {
         formStore.validationErrors[componentSlug] = 'Format invalide'
       }
 
       const valueTelSecond = formStore.data[componentSlug + '_secondaire']
-      if (variableTester.isNotEmtpy(valueTelSecond)) {
+      if (variableTester.isNotEmpty(valueTelSecond)) {
         const countryCodeSecond = formStore.data[componentSlug + '_secondaire_countrycode'].split(':')[0]
         if (!isValidPhoneNumber(valueTelSecond, countryCodeSecond)) {
           formStore.validationErrors[componentSlug + '_secondaire'] = 'Format invalide'
@@ -39,7 +39,7 @@ export const componentValidator = {
       this.validateAddress(component)
     }
 
-    if (variableTester.isNotEmtpy(value) && component.validate?.maxLength !== undefined) {
+    if (variableTester.isNotEmpty(value) && component.validate?.maxLength !== undefined) {
       if (value.length > component.validate?.maxLength) {
         const maxLength: string = component.validate?.maxLength.toString()
         formStore.validationErrors[componentSlug] = 'La valeur dépasse la longueur autorisée ' + maxLength

--- a/assets/vue/components/signalement-form/services/variableTester.ts
+++ b/assets/vue/components/signalement-form/services/variableTester.ts
@@ -1,0 +1,5 @@
+export const variableTester = {
+  isNotEmtpy (value: any): boolean {
+    return value !== undefined && value !== null && value !== ''
+  }
+}

--- a/assets/vue/components/signalement-form/services/variableTester.ts
+++ b/assets/vue/components/signalement-form/services/variableTester.ts
@@ -1,5 +1,5 @@
 export const variableTester = {
-  isNotEmtpy (value: any): boolean {
+  isNotEmpty (value: any): boolean {
     return value !== undefined && value !== null && value !== ''
   }
 }


### PR DESCRIPTION
## Ticket

#2995   

## Description
La modification du pattern sur les champs numériques a fait apparaitre un souci de validation pour les champs dont la valeur est `null` (plutôt que `undefined` ou `vide`).

## Changements apportés
* Ajout de test sur les valeurs `null`

## Tests
- [ ] Parcourir le formulaire, vérifier qu'on n'est pas bloqué et que le validator valide toujours les données quand nécessaire
