### PR TITLE
[Historique] simplifier l'historisation des suppression

### DIFF
--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -10,7 +10,6 @@ use App\Repository\AffectationRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: AffectationRepository::class)]
 class Affectation implements EntityHistoryInterface
@@ -26,44 +25,34 @@ class Affectation implements EntityHistoryInterface
 
     #[ORM\ManyToOne(targetEntity: Signalement::class, inversedBy: 'affectations')]
     #[ORM\JoinColumn(nullable: false)]
-    #[Groups(['history_entry:read'])]
     private ?Signalement $signalement;
 
     #[ORM\ManyToOne(targetEntity: Partner::class, inversedBy: 'affectations')]
     #[ORM\JoinColumn(nullable: false)]
-    #[Groups(['history_entry:read'])]
     private ?Partner $partner;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
-    #[Groups(['history_entry:read'])]
     private ?\DateTimeImmutable $answeredAt;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    #[Groups(['history_entry:read'])]
     private \DateTimeImmutable $createdAt;
 
     #[ORM\Column(type: 'integer')]
-    #[Groups(['history_entry:read'])]
     private int $statut;
 
     #[ORM\Column(type: 'boolean')]
-    #[Groups(['history_entry:read'])]
     private bool $isSynchronized = false;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[Groups(['history_entry:read'])]
     private ?User $answeredBy;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
-    #[Groups(['history_entry:read'])]
     private ?User $affectedBy;
 
     #[ORM\Column(type: 'string', nullable: true, enumType: MotifRefus::class)]
-    #[Groups(['history_entry:read'])]
     private ?MotifRefus $motifRefus;
 
     #[ORM\Column(type: 'string', nullable: true, enumType: MotifCloture::class)]
-    #[Groups(['history_entry:read'])]
     private ?MotifCloture $motifCloture;
 
     #[ORM\OneToMany(mappedBy: 'affectation', targetEntity: Notification::class)]

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -9,7 +9,6 @@ use App\Repository\FileRepository;
 use App\Service\ImageManipulationHandler;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -72,28 +71,22 @@ class File implements EntityHistoryInterface
 
     #[ORM\ManyToOne(inversedBy: 'files')]
     #[ORM\JoinColumn(nullable: false)]
-    #[Groups(['history_entry:read'])]
     private ?Signalement $signalement = null;
 
     #[ORM\Column(length: 255)]
-    #[Groups(['history_entry:read'])]
     private ?string $filename = null;
 
     #[ORM\Column(length: 255)]
-    #[Groups(['history_entry:read'])]
     private ?string $title = null;
 
     #[ORM\Column(length: 32, options: ['comment' => 'Value possible photo or document'])]
-    #[Groups(['history_entry:read'])]
     private ?string $fileType = null;
 
     #[ORM\Column(nullable: true)]
-    #[Groups(['history_entry:read'])]
     private ?\DateTimeImmutable $createdAt = null;
 
     #[ORM\ManyToOne(inversedBy: 'files')]
     #[ORM\JoinColumn(nullable: true)]
-    #[Groups(['history_entry:read'])]
     private ?Intervention $intervention = null;
 
     #[ORM\Column(type: Types::BIGINT, nullable: true)]
@@ -103,7 +96,6 @@ class File implements EntityHistoryInterface
     private ?DocumentType $documentType = null;
 
     #[ORM\Column(nullable: true)]
-    #[Groups(['history_entry:read'])]
     private ?string $desordreSlug = null;
 
     #[ORM\Column]
@@ -111,7 +103,6 @@ class File implements EntityHistoryInterface
 
     #[ORM\Column(type: 'text', nullable: true, length: 250)]
     #[Assert\Length(max: 250)]
-    #[Groups(['history_entry:read'])]
     private ?string $description;
 
     #[ORM\Column]

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -13,7 +13,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: InterventionRepository::class)]
 #[ORM\HasLifecycleCallbacks()]
@@ -29,7 +28,6 @@ class Intervention implements EntityHistoryInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
-    #[Groups(['history_entry:read'])]
     private ?int $id = null;
 
     #[ORM\Column(nullable: true)]

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use App\Repository\NotificationRepository;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: NotificationRepository::class)]
 class Notification
@@ -22,31 +21,24 @@ class Notification
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'notifications')]
     #[ORM\JoinColumn(nullable: false)]
-    #[Groups(['history_entry:read'])]
     private ?User $user;
 
     #[ORM\Column(type: 'boolean')]
-    #[Groups(['history_entry:read'])]
     private ?bool $isSeen;
 
     #[ORM\Column(type: 'integer')]
-    #[Groups(['history_entry:read'])]
     private ?int $type;
 
     #[ORM\ManyToOne(targetEntity: Signalement::class)]
-    #[Groups(['history_entry:read'])]
     private ?Signalement $signalement;
 
     #[ORM\ManyToOne(targetEntity: Suivi::class)]
-    #[Groups(['history_entry:read'])]
     private ?Suivi $suivi;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    #[Groups(['history_entry:read'])]
     private ?\DateTimeImmutable $createdAt;
 
     #[ORM\ManyToOne(targetEntity: Affectation::class, inversedBy: 'notifications')]
-    #[Groups(['history_entry:read'])]
     private $affectation;
 
     public function __construct()

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -29,13 +29,13 @@ class Partner implements EntityHistoryInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    #[Groups(['widget-settings:read', 'history_entry:read'])]
+    #[Groups(['widget-settings:read'])]
     private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 255)]
-    #[Groups(['widget-settings:read', 'history_entry:read'])]
+    #[Groups(['widget-settings:read'])]
     private ?string $nom = null;
 
     #[ORM\OneToMany(mappedBy: 'partner', targetEntity: User::class, cascade: ['persist'])]
@@ -67,22 +67,18 @@ class Partner implements EntityHistoryInterface
     private ?Territory $territory = null;
 
     #[ORM\Column(type: 'string', nullable: true, enumType: PartnerType::class)]
-    #[Groups(['history_entry:read'])]
     private ?PartnerType $type = null;
 
     #[ORM\Column(type: Types::SIMPLE_ARRAY, nullable: true, enumType: Qualification::class)]
-    #[Groups(['history_entry:read'])]
     private array $competence = [];
 
     #[ORM\Column(nullable: true)]
-    #[Groups(['history_entry:read'])]
     private ?bool $isEsaboraActive = null;
 
     #[ORM\OneToMany(mappedBy: 'partner', targetEntity: Intervention::class)]
     private Collection $interventions;
 
     #[ORM\Column]
-    #[Groups(['history_entry:read'])]
     private ?bool $isIdossActive = null;
 
     #[ORM\Column(length: 255, nullable: true)]

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -21,7 +21,6 @@ use App\Validator as AppAssert;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Email;
@@ -43,11 +42,9 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    #[Groups(['history_entry:read'])]
     private $id;
 
     #[ORM\Column(type: 'string', length: 255)]
-    #[Groups(['history_entry:read'])]
     private $uuid;
 
     #[ORM\Column(type: 'string', nullable: true, enumType: ProfileDeclarant::class)]

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -6,7 +6,6 @@ use App\Entity\Behaviour\EntityHistoryInterface;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Repository\SuiviRepository;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: SuiviRepository::class)]
 #[ORM\Index(columns: ['type'], name: 'idx_suivi_type')]
@@ -51,7 +50,6 @@ class Suivi implements EntityHistoryInterface
     private $isPublic;
 
     #[ORM\Column(type: 'integer')]
-    #[Groups(['history_entry:read'])]
     private $type;
 
     #[ORM\ManyToOne(targetEntity: Signalement::class, inversedBy: 'suivis')]

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -30,7 +30,7 @@ class Tag implements EntityHistoryInterface
     private Collection $signalement;
 
     #[ORM\Column(type: 'string', length: 255)]
-    #[Groups(['widget-settings:read', 'history_entry:read'])]
+    #[Groups(['widget-settings:read'])]
     #[Assert\NotBlank(message: 'Merci de saisir un nom pour l\'étiquette.')]
     private ?string $label = null;
 
@@ -40,7 +40,6 @@ class Tag implements EntityHistoryInterface
     #[ORM\ManyToOne(targetEntity: Territory::class, inversedBy: 'tags')]
     #[ORM\JoinColumn(nullable: false)]
     #[Assert\NotBlank()]
-    #[Groups(['history_entry:read'])]
     private ?Territory $territory = null;
 
     public function __construct()

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -14,7 +14,6 @@ use Scheb\TwoFactorBundle\Model\Email\TwoFactorInterface;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -60,7 +59,6 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    #[Groups(['history_entry:read'])]
     private $id;
 
     #[ORM\Column(type: Types::GUID)]
@@ -70,7 +68,6 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[Email(mode: Email::VALIDATION_MODE_STRICT, groups: ['registration'])]
     #[Assert\NotBlank(message: 'Merci de saisir une adresse e-mail.')]
     #[Assert\Length(max: 255)]
-    #[Groups(['history_entry:read'])]
     private $email;
 
     #[ORM\Column(type: 'json')]

--- a/src/EventListener/AuthentificationHistoryListener.php
+++ b/src/EventListener/AuthentificationHistoryListener.php
@@ -51,7 +51,7 @@ class AuthentificationHistoryListener
                 flush: false
             );
 
-            [, $source] = $this->historyEntryManager->getChangesAndSource($historyEntryEvent, $user);
+            $source = $this->historyEntryManager->getSource();
             $historyEntry->setSource($source);
             $this->historyEntryManager->save($historyEntry);
 

--- a/src/EventListener/EntityHistoryListener.php
+++ b/src/EventListener/EntityHistoryListener.php
@@ -96,10 +96,14 @@ readonly class EntityHistoryListener
                 }
             }
         }
+        if (HistoryEntryEvent::DELETE === $event) {
+            $changes = $this->entityComparator->getEntityPropertiesAndValueNormalized($entity);
+        }
 
-        if (HistoryEntryEvent::UPDATE === $event && empty($changes)) {
+        if (in_array($event, [HistoryEntryEvent::UPDATE, HistoryEntryEvent::DELETE]) && empty($changes)) {
             return;
         }
+
         $this->saveEntityHistory($event, $entity, $changes);
     }
 
@@ -133,13 +137,11 @@ readonly class EntityHistoryListener
         array $changes
     ): void {
         try {
-            $historyEntry = $this->historyEntryManager->create(
+            $this->historyEntryManager->create(
                 historyEntryEvent: $event,
                 entityHistory: $entity,
-                changes: $changes,
-                flush: false
+                changes: $changes
             );
-            $this->historyEntryManager->save($historyEntry);
         } catch (\Throwable $exception) {
             $this->logger->error($exception->getMessage());
         }

--- a/src/Service/History/EntityComparator.php
+++ b/src/Service/History/EntityComparator.php
@@ -74,4 +74,24 @@ class EntityComparator
             'new' => $newValue,
         ];
     }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function getEntityPropertiesAndValueNormalized($entity): array
+    {
+        $reflection = new \ReflectionClass($entity);
+        $properties = $reflection->getProperties();
+        $propertyValues = [];
+
+        foreach ($properties as $property) {
+            $property->setAccessible(true);
+            $value = $this->processValue($property->getValue($entity));
+            if ($value) {
+                $propertyValues[$property->getName()] = $value;
+            }
+        }
+
+        return $propertyValues;
+    }
 }

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -13,12 +13,10 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class HistoryEntryManagerTest extends KernelTestCase
 {
     private EntityManagerInterface $entityManager;
-    private NormalizerInterface $normalizer;
     private RequestStack $requestStack;
     private CommandContext $commandContext;
     private HistoryEntryFactory $historyEntryFactory;
@@ -32,13 +30,11 @@ class HistoryEntryManagerTest extends KernelTestCase
 
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->historyEntryFactory = static::getContainer()->get(HistoryEntryFactory::class);
-        $this->normalizer = static::getContainer()->get(NormalizerInterface::class);
         $this->requestStack = static::getContainer()->get(RequestStack::class);
         $this->commandContext = static::getContainer()->get(CommandContext::class);
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
         $this->historyEntryManager = new HistoryEntryManager(
             $this->historyEntryFactory,
-            $this->normalizer,
             $this->requestStack,
             $this->commandContext,
             $this->managerRegistry,


### PR DESCRIPTION
Remplace https://github.com/MTES-MCT/histologe/pull/2997

## Ticket

#2555

## Description
Simplification de l'historisation des suppression : 
- On parcours tout les champs de l'entité supprimé en transformant les valeur de la même façon que lors de l’enregistrement d'un update (pour les données complexe comme les object et date)
- en conséquence suppression du groupe `'history_entry:read`
