### PR TITLE
[scalingo] ne pas dépasser 10 crontask

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -22,12 +22,6 @@
       "command": "0 5 * * * php bin/console app:notify-visits"
     },
     {
-      "command": "0 4 * * * php bin/console app:notify-and-archive-inactive-accounts"
-    },
-    {
-      "command": "30 4 * * * php bin/console app:anonymize-expired-account"
-    },
-    {
       "command": "0 22 * * * php bin/console app:synchronize-idoss"
     },
     {


### PR DESCRIPTION
## Ticket

#3002

## Description
Suppression des deux crontask dont les feature sont désactivé pour ne as dépasser la limite de 10.
Note de ces crontask dans le ticket #2627
