### PR TITLE
Refaire la migration des dates d'intervention liée aux fuseaus horaires

### DIFF
--- a/migrations/Version20240910091939.php
+++ b/migrations/Version20240910091939.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240910091939 extends AbstractMigration
+{
+    public const string DATE_MIGRATION_FAILED_INTERVENTION = '2024-08-29 10:36:19';
+
+    public function getDescription(): string
+    {
+        return 'Convert intervention dates from local to UTC using timezone from territoire table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->connection->beginTransaction();
+        try {
+            foreach ($this->getInterventions() as $intervention) {
+                $scheduledAt = new \DateTimeImmutable(
+                    $intervention['scheduled_at'],
+                    new \DateTimeZone($intervention['timezone'])
+                );
+                $scheduledUTCAt = $scheduledAt->setTimezone(new \DateTimeZone('UTC'));
+                $this->connection->executeStatement(
+                    'UPDATE intervention SET scheduled_at = :scheduledAt WHERE id = :interventionId', [
+                        'scheduledAt' => $scheduledUTCAt->format('Y-m-d H:i'),
+                        'interventionId' => $intervention['id'],
+                    ]
+                );
+            }
+            $this->connection->commit();
+        } catch (\Throwable $exception) {
+            $this->connection->rollBack();
+            $this->write($exception->getMessage());
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->connection->beginTransaction();
+        try {
+            foreach ($this->getInterventions() as $intervention) {
+                $scheduledAtUTC = new \DateTimeImmutable(
+                    $intervention['scheduled_at'],
+                    new \DateTimeZone('UTC')
+                );
+                $scheduledLocalAt = $scheduledAtUTC->setTimezone(new \DateTimeZone($intervention['timezone']));
+                $this->connection->executeStatement(
+                    'UPDATE intervention SET scheduled_at = :scheduledAt WHERE id = :interventionId', [
+                        'scheduledAt' => $scheduledLocalAt->format('Y-m-d H:i'),
+                        'interventionId' => $intervention['id'],
+                    ]
+                );
+            }
+            $this->connection->commit();
+        } catch (\Throwable $exception) {
+            $this->connection->rollBack();
+            $this->write($exception->getMessage());
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getInterventions(): array
+    {
+        $query = '
+            SELECT i.id, i.scheduled_at, t.timezone, i.created_at
+            FROM intervention i
+            INNER JOIN signalement s ON s.id = i.signalement_id
+            INNER JOIN territory t ON t.id = s.territory_id
+            WHERE i.scheduled_at IS NOT NULL AND i.created_at < :date_migration_fixed
+            ORDER BY i.created_at DESC;';
+
+        return $this->connection->fetchAllAssociative(
+            $query,
+            ['date_migration_fixed' => self::DATE_MIGRATION_FAILED_INTERVENTION]
+        );
+    }
+}


### PR DESCRIPTION
## Ticket

#2976 

## Description
Les fonctions lié à la timezone ne sont pas pris en charge par scalingo. Il est nécessaire de refaire la migration en PHP sans utiliser les fonctions natives de MYSQL
Voir réponse de scalingo => https://github.com/MTES-MCT/histologe/issues/2976#issuecomment-2340094147

## Changements apportés
* Ajout migration

## Pré-requis
1. Récupérer une base de prod
2. Exécuter `make load-data` en mettant un point d’arrêt sur la migration pour empêcher son exécution
![image](https://github.com/user-attachments/assets/b334a503-3c45-4d65-a73f-e87f9bdedb9a)

4. Ouvrir un signalement sur la timezone *Europe/Paris* http://localhost:8080/bo/signalements/87fc12b9-ff1d-4fde-b916-c2c2f49f0c4c 
   - Il est noté 11h sur la fiche avec 9h en base
5. Ouvir un signalement sur une autre timezone *America/Martinique* http://localhost:8080/bo/signalements/288e8117-c148-42ff-8b99-3cd16a214106
   - Il est noté 11h sur la fiche avec 15h en base

## Tests
- [ ] Lever ce point d'arret
- [ ] Vérifier qu'il existe aucune intervention avec une date null 
```sql
SELECT i.id, i.scheduled_at, t.timezone, i.created_at
FROM intervention i
INNER JOIN signalement s ON s.id = i.signalement_id
INNER JOIN territory t ON t.id = s.territory_id
WHERE i.scheduled_at IS NULL;
```
- [ ] Ouvrir un signalement sur la timezone *Europe/Paris* http://localhost:8080/bo/signalements/87fc12b9-ff1d-4fde-b916-c2c2f49f0c4c 
   - Il est noté 9h sur la fiche avec 7h en base
- [ ] Ouvir un signalement sur une autre timezone *America/Martinique* http://localhost:8080/bo/signalements/288e8117-c148-42ff-8b99-3cd16a214106
   - Il est noté 15h sur la fiche avec 19h en base
- [ ] Annuler la migration pour revenir au dates locales en base et vérifier que les cas cités dans les pré-requis sont conformes
```
make execute-migration name="Version20240910091939" direction="down"
```