### PR TITLE
[OPTI] update en masse sur commande clear-storage-original-file

### DIFF
--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -56,20 +56,27 @@ class FileRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function findWithOriginalAndVariants(int $max): array
+    public function findWithOriginalAndVariants(\DateTimeInterface $limit, int $max): array
     {
-        return $this->initQueryWithOriginalAndVariants()->select('f')->setMaxResults($max)->getQuery()->getResult();
+        return $this->initQueryWithOriginalAndVariants($limit)->select('f')->setMaxResults($max)->getQuery()->getResult();
     }
 
-    public function countWithOriginalAndVariants(): int
+    public function countWithOriginalAndVariants(\DateTimeInterface $limit): int
     {
-        return $this->initQueryWithOriginalAndVariants()->select('count(f)')->getQuery()->getSingleScalarResult();
+        return $this->initQueryWithOriginalAndVariants($limit)->select('count(f)')->getQuery()->getSingleScalarResult();
     }
 
-    private function initQueryWithOriginalAndVariants(): QueryBuilder
+    public function updateWithOriginalAndVariants(\DateTimeInterface $limit): void
     {
-        $limit = (new \DateTime())->modify('-1 month');
+        $this->initQueryWithOriginalAndVariants($limit)
+            ->update()
+            ->set('f.isOriginalDeleted', true)
+            ->getQuery()
+            ->execute();
+    }
 
+    private function initQueryWithOriginalAndVariants(\DateTimeInterface $limit): QueryBuilder
+    {
         return $this->createQueryBuilder('f')
             ->andWhere('f.isVariantsGenerated = true')
             ->andWhere('f.isOriginalDeleted = false')

--- a/tests/Functional/Command/Cron/ClearStorageOriginalFileCommandTest.php
+++ b/tests/Functional/Command/Cron/ClearStorageOriginalFileCommandTest.php
@@ -5,7 +5,6 @@ namespace App\Tests\Functional\Command\Cron;
 use App\Command\Cron\ClearStorageOriginalFileCommand;
 use App\Repository\FileRepository;
 use App\Service\Mailer\NotificationMailerRegistry;
-use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -18,8 +17,6 @@ class ClearStorageOriginalFileCommandTest extends KernelTestCase
     private ParameterBagInterface $parameterBag;
     private FileRepository $fileRepository;
     private MockObject|FilesystemOperator $fileStorage;
-
-    private EntityManagerInterface $entityManager;
     private NotificationMailerRegistry $mailerRegistry;
 
     protected function setUp(): void
@@ -27,7 +24,6 @@ class ClearStorageOriginalFileCommandTest extends KernelTestCase
         $this->parameterBag = self::getContainer()->getParameterBag();
         $this->fileRepository = self::getContainer()->get(FileRepository::class);
         $this->fileStorage = $this->createMock(FilesystemOperator::class);
-        $this->entityManager = self::getContainer()->get('doctrine')->getManager();
         $this->mailerRegistry = self::getContainer()->get(NotificationMailerRegistry::class);
     }
 
@@ -37,7 +33,6 @@ class ClearStorageOriginalFileCommandTest extends KernelTestCase
             $this->parameterBag,
             $this->fileRepository,
             $this->fileStorage,
-            $this->entityManager,
             $this->mailerRegistry,
         );
         $commandTester = new CommandTester($command);

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -50,7 +50,7 @@ class PartnerControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains(
-            '.fr-display-inline-table',
+            '.fr-table__wrapper',
             'Compétences',
         );
     }


### PR DESCRIPTION
## Ticket

#3014

## Description
Optimisation du nombre de requête généré par la commande `app:clear-storage-original-file`
Jusqu’à présent l'update du champ `isOriginalDeleted` était fait unitairement, et déclenché en plus une requete d'historisation de l'entité `File`, un update de masse et maintenant fait après la suppression effective des fichiers ce qui permet aussi d'ignorer l'historisation (inutile ici)

## Tests
- [ ] Jouer `make symfony cmd="--profile app:clear-storage-original-file"` et vérifier via le profiler que seules 3 requêtes sont effectués
