### PR TITLE
[BO - Esabora] Email de reporting - problème de compteur sur les synchronisations visite et arrête

### DIFF
--- a/tests/Functional/Repository/JobEventRepositoryTest.php
+++ b/tests/Functional/Repository/JobEventRepositoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Repository;
+
+use App\Entity\Enum\PartnerType;
+use App\Repository\JobEventRepository;
+use App\Service\Esabora\AbstractEsaboraService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class JobEventRepositoryTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        self::bootKernel();
+    }
+
+    public function testGetReportEsaboraIntervention(): void
+    {
+        $container = static::getContainer();
+        $jobEventRepository = $container->get(JobEventRepository::class);
+
+        ['success_count' => $successCount, 'failed_count' => $failedCount] =
+            $jobEventRepository->getReportEsaboraAction(
+                AbstractEsaboraService::ACTION_PUSH_DOSSIER,
+                AbstractEsaboraService::ACTION_SYNC_DOSSIER);
+
+        $this->assertEquals(4, $successCount);
+        $this->assertEquals(3, $failedCount);
+    }
+
+    public function testFindLastJobEventByInterfacageType(): void
+    {
+        $container = static::getContainer();
+        $jobEventRepository = $container->get(JobEventRepository::class);
+
+        $jobEvents = $jobEventRepository->findLastJobEventByInterfacageType(
+            'esabora',
+            7,
+            null
+        );
+
+        $this->assertCount(2, $jobEvents);
+    }
+
+    public function testFindFailedEsaboraDossierByPartnerTypeByAction(): void
+    {
+        $container = static::getContainer();
+        $jobEventRepository = $container->get(JobEventRepository::class);
+
+        $jobEvents = $jobEventRepository->findFailedEsaboraDossierByPartnerTypeByAction(
+            PartnerType::ARS,
+            'push_dossier'
+        );
+
+        $this->assertCount(3, $jobEvents);
+    }
+}

--- a/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
@@ -6,6 +6,7 @@ use App\Command\Cron\SynchronizeInterventionSISHCommand;
 use App\Entity\Enum\PartnerType;
 use App\Manager\JobEventManager;
 use App\Repository\AffectationRepository;
+use App\Repository\JobEventRepository;
 use App\Service\Esabora\EsaboraManager;
 use App\Service\Esabora\Handler\InterventionArreteServiceHandler;
 use App\Service\Esabora\Handler\InterventionVisiteServiceHandler;
@@ -29,8 +30,15 @@ class SynchronizeInterventionSISHCommandTest extends KernelTestCase
 
         $esaboraManagerMock = $this->createMock(EsaboraManager::class);
         $serializerMock = $this->createMock(SerializerInterface::class);
-        $jobEventManagerMock = $this->createMock(JobEventManager::class);
         $affectationRepositoryMock = $this->createMock(AffectationRepository::class);
+        $jobEventRepositoryMock = $this->createMock(JobEventRepository::class);
+        $jobEventRepositoryMock
+            ->expects($this->once())
+            ->method('getReportEsaboraAction')
+            ->willReturn(['success_count' => 4, 'failed_count' => 2]);
+
+        $jobEventManagerMock = $this->createMock(JobEventManager::class);
+        $jobEventManagerMock->expects($this->once())->method('getRepository')->willReturn($jobEventRepositoryMock);
 
         $collection = (new ArrayCollection([$this->getAffectation(PartnerType::ARS)]));
         $affectationRepositoryMock


### PR DESCRIPTION
## Ticket

#1824    

## Description
Problème de compteur dans le rapport envoyé par mail

## Changements apportés
* Aller chercher les informations via une requête 
* Supprimer les incrémentations  

## Pré-requis
```
make create-db
```
## Tests
- [ ] Executer la commande `make console app="sync-esabora-sish-intervention"` et vérifier que cela correspond bien à ce que vous avez en base (cad les appels sur les visites et arrêtés )
