### PR TITLE
[BO - Filtre] Gestion de chevauchement de requête

### DIFF
--- a/assets/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/vue/components/signalement-list/TheSignalementAppList.vue
@@ -68,6 +68,11 @@ export default defineComponent({
   methods: {
     init (reset: boolean = false) {
       if (initElements !== null) {
+        if (this.abortRequest) {
+          this.abortRequest?.abort()
+        }
+        this.abortRequest = new AbortController()
+
         this.sharedProps.ajaxurlSignalement = initElements.dataset.ajaxurl
         this.sharedProps.ajaxurlRemoveSignalement = initElements.dataset.ajaxurlRemoveSignalement
         this.sharedProps.ajaxurlSettings = initElements.dataset.ajaxurlSettings
@@ -79,7 +84,7 @@ export default defineComponent({
 
         this.buildUrl()
         requests.getSettings(this.handleSettings)
-        requests.getSignalements(this.handleSignalements)
+        requests.getSignalements(this.handleSignalements, { signal: this.abortRequest?.signal })
       } else {
         this.hasErrorLoading = true
       }


### PR DESCRIPTION
## Ticket

#3022    

## Description
Lors de l'affichage de la liste, la première requête en tant que super admin, qui récupère tous les signalements, prend un peu plus de temps à s'exécuter (Pas urgent mais optimisations à étudier). 

Pendant ce temps, il est possible d'appliquer un filtre, mais la première requête reste en cours et peut afficher ses résultats même si un filtre a été appliqué entre-temps.

La solution retenue est d'annuler la requête en cours dès qu'un filtre est appliqué, comme c'est déjà le cas pour les filtres en général.

## Changements apportés
* Utilisation d'`AbortController` pour annuler les requêtes en cours.

## Pré-requis
Le test avec les données des fixtures est impossible, il faut donc récupérer un jeu de donnée de production
* `make load-data `
* `make npm-watch`
* Ouvrir l'inspecteur du navigateur.

## Tests 
- [ ] En tant que super admin, afficher la liste, puis appliquer immédiatement un filtre sans attendre la réponse de la première requête. Le résultat doit correspondre au filtre appliqué.
![Capture d’écran du 2024-09-12 15-32-59](https://github.com/user-attachments/assets/e5da9cf8-af64-4280-b52d-ef9a9440c91e)
