### PR TITLE
[FO - Formulaire] Amélioration de la navigation au clavier - accessibilité

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -21,7 +21,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormSubscreen",
@@ -32,18 +35,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_les_desordres_previous",
-          "action": "goto:travailleur_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "ecran_intermediaire_les_desordres_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_les_desordres_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "ecran_intermediaire_les_desordres_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_les_desordres_previous",
+                "action": "goto:travailleur_social",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -77,6 +89,9 @@
                 },
                 "validate": {
                   "required": false
+                },
+                "accessibility": {
+                  "focus": true
                 }
               },
               {
@@ -189,7 +204,7 @@
       "footer": [
         {
           "type": "SignalementFormSubscreen",
-          "slug": "desordres_batiment_boutons",
+          "slug": "desordres_batiment_footer",
           "customCss": "button-group-full-size fr-mt-5v",
           "components": {
             "body": [
@@ -231,6 +246,9 @@
           "label": "{{dictionaryStore::desordres_batiment_proprete_interieur}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -268,18 +286,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_proprete_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_proprete_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_proprete_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_proprete_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_proprete_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -302,6 +329,9 @@
           "label": "{{dictionaryStore::desordres_batiment_eau_pas_eau_potable}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -331,18 +361,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_eau_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_eau_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_eau_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_eau_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_eau_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -365,6 +404,9 @@
           "label": "{{dictionaryStore::desordres_batiment_isolation_porte_fenetres}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -405,18 +447,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_isolation_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_isolation_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_isolation_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_isolation_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_isolation_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -439,6 +490,9 @@
           "label": "{{dictionaryStore::desordres_batiment_maintenance_ascenseur}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -463,18 +517,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_maintenance_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_maintenance_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_maintenance_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_maintenance_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_maintenance_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -497,6 +560,9 @@
           "label": "{{dictionaryStore::desordres_batiment_nuisibles_cafards}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -570,18 +636,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_nuisibles_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_nuisibles_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_nuisibles_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_nuisibles_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_nuisibles_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -604,6 +679,9 @@
           "label": "{{dictionaryStore::desordres_batiment_securite_sol}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -781,18 +859,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_securite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_securite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_securite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_securite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_securite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -815,6 +902,9 @@
           "label": "{{dictionaryStore::desordres_batiment_incendie_odeur_gaz}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -828,18 +918,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_incendie_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_incendie_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_incendie_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_incendie_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_incendie_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -862,6 +961,9 @@
           "label": "{{dictionaryStore::desordres_batiment_accessibilite_eclairage}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -925,18 +1027,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_accessibilite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_accessibilite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_accessibilite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_accessibilite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_accessibilite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -959,6 +1070,9 @@
           "label": "{{dictionaryStore::desordres_batiment_bruit_exterieur}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -972,18 +1086,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_bruit_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_bruit_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_bruit_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_bruit_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_bruit_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1007,7 +1130,10 @@
               "src": "/img/form/LOGEMENT/Picto-logement.svg",
               "alt": ""
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormWarning",
@@ -1073,6 +1199,9 @@
                 },
                 "validate": {
                   "required": false
+                },
+                "accessibility": {
+                  "focus": true
                 }
               },
               {
@@ -1188,7 +1317,7 @@
       "footer": [
         {
           "type": "SignalementFormSubscreen",
-          "slug": "desordres_logement_boutons",
+          "slug": "desordres_logement_footer",
           "customCss": "button-group-full-size fr-mt-5v",
           "components": {
             "body": [
@@ -1230,6 +1359,9 @@
           "label": "Je n'ai pas l'eau potable dans mon logement",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -1251,18 +1383,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_eau_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_eau_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_eau_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_eau_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_eau_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1285,6 +1426,9 @@
           "label": "{{dictionaryStore::desordres_logement_aeration_aucune_aeration}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -1352,18 +1496,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_aeration_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_aeration_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_aeration_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_aeration_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_aeration_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1401,7 +1554,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormRoomList",
@@ -1571,18 +1727,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_chauffage_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_chauffage_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_chauffage_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_chauffage_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_chauffage_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1605,6 +1770,9 @@
           "slug": "desordres_logement_humidite_piece_a_vivre",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -1898,18 +2066,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_humidite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_humidite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_humidite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_humidite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_humidite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1932,6 +2109,9 @@
           "label": "{{dictionaryStore::desordres_logement_securite_sol_glissant}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2060,18 +2240,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_securite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_securite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_securite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_securite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_securite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2094,6 +2283,9 @@
           "label": "Il n'y a pas d'électricité dans mon logement",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2172,18 +2364,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_electricite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_electricite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_electricite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_electricite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_electricite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2206,6 +2407,9 @@
           "label": "{{dictionaryStore::desordres_logement_nuisibles_cafards}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2365,18 +2569,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_nuisibles_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_nuisibles_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_nuisibles_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_nuisibles_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_nuisibles_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2399,6 +2612,9 @@
           "label": "J'entends le bruit extérieur, même si je ferme les portes et les fenêtres",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2430,18 +2646,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_bruit_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_bruit_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_bruit_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_bruit_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_bruit_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2464,6 +2689,9 @@
           "label": "Mon logement n'est pas éclairé par la lumière du jour. Je dois allumer la lumière en plein jour",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2495,18 +2723,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_lumiere_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_lumiere_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_lumiere_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_lumiere_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_lumiere_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2530,7 +2767,10 @@
               "src": "/img/form/LOGEMENT/Picto-logement.svg",
               "alt": ""
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormWarning",

--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -45,8 +45,7 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_les_desordres_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -297,8 +296,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_proprete_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -373,8 +371,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -460,8 +457,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_isolation_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -531,8 +527,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_maintenance_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -651,8 +646,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -875,8 +869,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -935,8 +928,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_incendie_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1045,8 +1037,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_accessibilite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1105,8 +1096,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1403,8 +1393,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1517,8 +1506,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_aeration_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1749,8 +1737,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_chauffage_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2089,8 +2076,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_humidite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2264,8 +2250,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2389,8 +2374,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_electricite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2595,8 +2579,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2673,8 +2656,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2751,8 +2733,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_lumiere_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2814,8 +2795,7 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.hasDesordre('desordres_') === false"
-                },
-                "validOnEnter": true
+                }
               },
               {
                 "type": "SignalementFormButton",
@@ -2835,8 +2815,7 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.hasDesordre('desordres_') === true"
-                },
-                "validOnEnter": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -45,7 +45,8 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_les_desordres_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -296,7 +297,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_proprete_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -371,7 +373,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -457,7 +460,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_isolation_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -527,7 +531,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_maintenance_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -646,7 +651,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -869,7 +875,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -928,7 +935,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_incendie_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1037,7 +1045,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_accessibilite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1096,7 +1105,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1393,7 +1403,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1506,7 +1517,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_aeration_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1737,7 +1749,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_chauffage_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2076,7 +2089,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_humidite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2250,7 +2264,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2374,7 +2389,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_electricite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2579,7 +2595,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2656,7 +2673,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2733,7 +2751,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_lumiere_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2795,7 +2814,8 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.hasDesordre('desordres_') === false"
-                }
+                },
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2815,7 +2835,8 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.hasDesordre('desordres_') === true"
-                }
+                },
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -45,8 +45,7 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_les_desordres_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -310,8 +309,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_proprete_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -386,8 +384,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -473,8 +470,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_isolation_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -544,8 +540,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_maintenance_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -664,8 +659,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -888,8 +882,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -948,8 +941,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_incendie_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1058,8 +1050,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_accessibilite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1118,8 +1109,7 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1425,8 +1415,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1543,8 +1532,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_aeration_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1775,8 +1763,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_chauffage_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2046,8 +2033,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_humidite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2221,8 +2207,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2350,8 +2335,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_electricite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2572,8 +2556,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2650,8 +2633,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2728,8 +2710,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_lumiere_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2777,8 +2758,7 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_proprete_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -2840,8 +2820,7 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "(formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur') && formStore.hasDesordre('desordres_') === false"
-                },
-                "validOnEnter": true
+                }
               },
               {
                 "type": "SignalementFormButton",
@@ -2851,8 +2830,7 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours' && formStore.hasDesordre('desordres_') === false"
-                },
-                "validOnEnter": true
+                }
               },
               {
                 "type": "SignalementFormButton",
@@ -2872,8 +2850,7 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.hasDesordre('desordres_') === true"
-                },
-                "validOnEnter": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -45,7 +45,8 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_les_desordres_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -309,7 +310,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_proprete_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -384,7 +386,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -470,7 +473,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_isolation_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -540,7 +544,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_maintenance_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -659,7 +664,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -882,7 +888,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -941,7 +948,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_incendie_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1050,7 +1058,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_accessibilite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1109,7 +1118,8 @@
                 "label": "Suivant",
                 "slug": "desordres_batiment_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1415,7 +1425,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_eau_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1532,7 +1543,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_aeration_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1763,7 +1775,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_chauffage_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2033,7 +2046,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_humidite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2207,7 +2221,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_securite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2335,7 +2350,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_electricite_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2556,7 +2572,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2633,7 +2650,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_bruit_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2710,7 +2728,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_lumiere_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2758,7 +2777,8 @@
                 "label": "Suivant",
                 "slug": "desordres_logement_proprete_next",
                 "action": "resolve.save:findNextScreen",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2820,7 +2840,8 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "(formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur') && formStore.hasDesordre('desordres_') === false"
-                }
+                },
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2830,7 +2851,8 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours' && formStore.hasDesordre('desordres_') === false"
-                }
+                },
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -2850,7 +2872,8 @@
                 "customCss": "fr-mb-3v",
                 "conditional": {
                   "show": "formStore.hasDesordre('desordres_') === true"
-                }
+                },
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -21,7 +21,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormSubscreen",
@@ -32,31 +35,40 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_les_desordres_previous_autre",
-          "action": "goto:travailleur_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
-          "conditional": {
-            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_les_desordres_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "ecran_intermediaire_les_desordres_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_les_desordres_previous_autre",
+                "action": "goto:travailleur_social",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+                "conditional": {
+                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier' || formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_pro' || formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_les_desordres_previous_secours",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
+                "conditional": {
+                  "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
+                }
+              }
+            ]
           }
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_les_desordres_previous_secours",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line",
-          "conditional": {
-            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'service_secours'"
-          }
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "ecran_intermediaire_les_desordres_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
         }
       ]
     }
@@ -90,6 +102,9 @@
                 },
                 "validate": {
                   "required": false
+                },
+                "accessibility": {
+                  "focus": true
                 }
               },
               {
@@ -202,7 +217,7 @@
       "footer": [
         {
           "type": "SignalementFormSubscreen",
-          "slug": "desordres_batiment_boutons",
+          "slug": "desordres_batiment_footer",
           "customCss": "button-group-full-size fr-mt-5v",
           "components": {
             "body": [
@@ -244,6 +259,9 @@
           "label": "{{dictionaryStore::desordres_batiment_proprete_interieur}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -281,18 +299,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_proprete_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_proprete_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_proprete_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_proprete_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_proprete_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -315,6 +342,9 @@
           "label": "{{dictionaryStore::desordres_batiment_eau_pas_eau_potable}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -344,18 +374,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_eau_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_eau_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_eau_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_eau_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_eau_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -378,6 +417,9 @@
           "label": "{{dictionaryStore::desordres_batiment_isolation_porte_fenetres}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -418,18 +460,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_isolation_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_isolation_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_isolation_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_isolation_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_isolation_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -452,6 +503,9 @@
           "label": "{{dictionaryStore::desordres_batiment_maintenance_ascenseur}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -476,18 +530,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_maintenance_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_maintenance_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_maintenance_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_maintenance_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_maintenance_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -510,6 +573,9 @@
           "label": "{{dictionaryStore::desordres_batiment_nuisibles_cafards}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -583,18 +649,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_nuisibles_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_nuisibles_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_nuisibles_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_nuisibles_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_nuisibles_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -617,6 +692,9 @@
           "label": "{{dictionaryStore::desordres_batiment_securite_sol}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -794,18 +872,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_securite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_securite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_securite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_securite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_securite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -828,6 +915,9 @@
           "label": "{{dictionaryStore::desordres_batiment_incendie_odeur_gaz}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -841,18 +931,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_incendie_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_incendie_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_incendie_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_incendie_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_incendie_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -875,6 +974,9 @@
           "label": "{{dictionaryStore::desordres_batiment_accessibilite_eclairage}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -938,18 +1040,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_accessibilite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_accessibilite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_accessibilite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_accessibilite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_accessibilite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -972,6 +1083,9 @@
           "label": "{{dictionaryStore::desordres_batiment_bruit_exterieur}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -985,18 +1099,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_batiment_bruit_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_batiment_bruit_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_batiment_bruit_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_batiment_bruit_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_batiment_bruit_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1086,6 +1209,9 @@
                 },
                 "validate": {
                   "required": false
+                },
+                "accessibility": {
+                  "focus": true
                 }
               },
               {
@@ -1213,7 +1339,7 @@
       "footer": [
         {
           "type": "SignalementFormSubscreen",
-          "slug": "desordres_logement_boutons",
+          "slug": "desordres_logement_footer",
           "customCss": "button-group-full-size fr-mt-5v",
           "components": {
             "body": [
@@ -1255,6 +1381,9 @@
           "label": "{{dictionaryStore::desordres_logement_eau_eau_potable}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -1276,18 +1405,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_eau_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_eau_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_eau_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_eau_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_eau_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1310,6 +1448,9 @@
           "label": "{{dictionaryStore::desordres_logement_aeration_aucune_aeration}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -1381,18 +1522,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_aeration_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_aeration_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_aeration_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_aeration_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_aeration_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1430,7 +1580,10 @@
               "label": "Je ne sais pas ",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormRoomList",
@@ -1600,18 +1753,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_chauffage_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_chauffage_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_chauffage_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_chauffage_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_chauffage_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1634,6 +1796,9 @@
           "slug": "desordres_logement_humidite_piece_a_vivre",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -1858,18 +2023,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_humidite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_humidite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_humidite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_humidite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_humidite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1892,6 +2066,9 @@
           "label": "{{dictionaryStore::desordres_logement_securite_sol_glissant}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2020,18 +2197,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_securite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_securite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_securite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_securite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_securite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2054,6 +2240,9 @@
           "label": "{{dictionaryStore::desordres_logement_electricite_pas_electricite}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2136,18 +2325,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_electricite_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_electricite_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_electricite_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_electricite_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_electricite_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2170,6 +2368,9 @@
           "label": "{{dictionaryStore::desordres_logement_nuisibles_cafards}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2345,18 +2546,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_nuisibles_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_nuisibles_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_nuisibles_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_nuisibles_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_nuisibles_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2379,6 +2589,9 @@
           "label": "{{dictionaryStore::desordres_logement_bruit_exterieur}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -2410,18 +2623,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_bruit_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_bruit_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_bruit_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_bruit_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_bruit_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2444,6 +2666,9 @@
           "label": "{{dictionaryStore::desordres_logement_lumiere_pas_lumiere}}",
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },   
         {
@@ -2475,18 +2700,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_lumiere_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_lumiere_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_lumiere_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_lumiere_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_lumiere_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2506,23 +2740,35 @@
         {
           "type": "SignalementFormRoomList",
           "label": "",
-          "slug": "desordres_logement_proprete_pieces"
+          "slug": "desordres_logement_proprete_pieces",
+          "accessibility": {
+            "focus": true
+          }
         }
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "desordres_logement_proprete_previous",
-          "action": "resolve:findPreviousScreen",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "desordres_logement_proprete_next",
-          "action": "resolve.save:findNextScreen",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_logement_proprete_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_logement_proprete_next",
+                "action": "resolve.save:findNextScreen",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_logement_proprete_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -2546,7 +2792,10 @@
               "src": "/img/form/LOGEMENT/Picto-logement.svg",
               "alt": ""
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormWarning",

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -15,7 +15,8 @@
           },
           "accessibility": {
             "name": "organizationName",
-            "autocomplete": "organization"
+            "autocomplete": "organization",
+            "focus": true
           }
         },
         {
@@ -27,7 +28,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -63,18 +65,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "vos_coordonnees_tiers_previous",
-          "action": "goto:signalement_concerne",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "vos_coordonnees_tiers_next",
-          "action": "goto.save:coordonnees_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "vos_coordonnees_tiers_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "vos_coordonnees_tiers_next",
+                "action": "goto.save:coordonnees_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "vos_coordonnees_tiers_previous",
+                "action": "goto:signalement_concerne",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -95,7 +106,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -137,18 +149,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_occupant_previous",
-          "action": "goto:vos_coordonnees_tiers",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_occupant_next",
-          "action": "goto.save:zone_concernee",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_occupant_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_occupant_previous",
+                "action": "goto:vos_coordonnees_tiers",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -171,7 +192,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -195,18 +219,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "zone_concernee_zone_previous",
-          "action": "goto:coordonnees_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "zone_concernee_zone_next",
-          "action": "goto.save:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "zone_concernee_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "zone_concernee_zone_next",
+                "action": "goto.save:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "zone_concernee_zone_previous",
+                "action": "goto:coordonnees_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -226,18 +259,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_type_composition_previous",
-          "action": "goto:zone_concernee",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "C'est parti",
-          "slug": "ecran_intermediaire_type_composition_next",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_type_composition_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "C'est parti",
+                "slug": "ecran_intermediaire_type_composition_next",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_type_composition_previous",
+                "action": "goto:zone_concernee",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -266,7 +308,10 @@
               "label": "Autre",
               "value": "autre"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -355,18 +400,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_previous",
-          "action": "goto:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_next",
-          "action": "goto.save:composition_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_next",
+                "action": "goto.save:composition_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_previous",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -391,7 +445,10 @@
               "label": "Plusieurs pièces",
               "value": "plusieurs_pieces"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCounter",
@@ -438,17 +495,26 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_previous",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_next",
-          "action": "goto.save:type_logement_commodites"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_next",
+                "action": "goto.save:type_logement_commodites"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_previous",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -487,7 +553,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormIcon",
@@ -639,18 +708,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_commodites_previous",
-          "action": "goto:composition_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_commodites_next",
-          "action": "goto.save:composition_logement_personnes",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_commodites_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_commodites_next",
+                "action": "goto.save:composition_logement_personnes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_commodites_previous",
+                "action": "goto:composition_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -669,6 +747,9 @@
           "slug": "composition_logement_nombre_personnes",
           "validate": {
             "pattern": "^[0-9]*$"
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -689,18 +770,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_personnes_previous",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_personnes_next",
-          "action": "goto.save:bail_dpe",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_personnes_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_personnes_next",
+                "action": "goto.save:bail_dpe",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_personnes_previous",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -729,7 +819,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormInfo",
@@ -829,18 +922,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "bail_dpe_previous",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "bail_dpe_next",
-          "action": "goto.save:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "bail_dpe_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "bail_dpe_next",
+                "action": "goto.save:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "bail_dpe_previous",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -858,18 +960,27 @@
     "components": {
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_situation_occupant_previous",
-          "action": "goto:bail_dpe",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "ecran_intermediaire_situation_occupant_next",
-          "action": "goto.save:logement_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_situation_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "ecran_intermediaire_situation_occupant_next",
+                "action": "goto.save:logement_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_situation_occupant_previous",
+                "action": "goto:bail_dpe",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -898,7 +1009,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -955,18 +1069,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "logement_social_previous",
-          "action": "goto:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "logement_social_next",
-          "action": "goto.save:travailleur_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "logement_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "logement_social_next",
+                "action": "goto.save:travailleur_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "logement_social_previous",
+                "action": "goto:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -995,7 +1118,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1041,18 +1167,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "travailleur_social_previous",
-          "action": "goto:logement_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "travailleur_social_next",
-          "action": "goto.save:ecran_intermediaire_les_desordres",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "travailleur_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "travailleur_social_next",
+                "action": "goto.save:ecran_intermediaire_les_desordres",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "travailleur_social_previous",
+                "action": "goto:logement_social",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1072,17 +1207,26 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:desordres_renseignes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "J'y suis presque !",
-          "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:info_procedure"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "J'y suis presque !",
+                "slug": "ecran_intermediaire_procedure_next",
+                "action": "goto:info_procedure"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_procedure_previous",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1112,7 +1256,10 @@
               "label": "Je n'ai pas d'assurance logement",
               "value": "pas_assurance_logement"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextarea",
@@ -1141,18 +1288,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "info_procedure_utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "info_procedure_utilisation_service_next",
-          "action": "goto.save:utilisation_service",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "info_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "info_procedure_utilisation_service_next",
+                "action": "goto.save:utilisation_service",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "info_procedure_utilisation_service_previous",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1168,7 +1324,10 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_visite",
-          "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement."
+          "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement.",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCheckbox",
@@ -1183,18 +1342,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "utilisation_service_previous",
-          "action": "goto:desordres_renseignes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "utilisation_service_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "utilisation_service_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "utilisation_service_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "utilisation_service_previous",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1220,6 +1388,9 @@
                 "slug": "informations_complementaires_situation_bailleur_date_effet_bail",
                 "validate": {
                   "required": false
+                },
+                "accessibility": {
+                  "focus": true
                 }
               },
               {
@@ -1356,18 +1527,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "informations_complementaires_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Enregistrer",
-          "slug": "informations_complementaires_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "informations_complementaires_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Enregistrer",
+                "slug": "informations_complementaires_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "informations_complementaires_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1387,18 +1567,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "validation_signalement_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Valider mon signalement",
-          "slug": "validation_signalement_next",
-          "action": "goto.save:confirmation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "validation_signalement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Valider mon signalement",
+                "slug": "validation_signalement_next",
+                "action": "goto.save:confirmation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "validation_signalement_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1427,7 +1616,10 @@
                 "label": "Accéder à ma page de suivi",
                 "slug": "confirmation_signalement_suivi",
                 "customCss": "fr-btn",
-                "link": "{{formStore.data.lienSuivi}}"
+                "link": "{{formStore.data.lienSuivi}}",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormLink",
@@ -1466,7 +1658,10 @@
                 "label": "Compléter mon signalement",
                 "slug": "signalement_incomplet_complete",
                 "action": "goto:ecran_intermediaire_type_composition",
-                "customCss": "fr-mb-3v"
+                "customCss": "fr-mb-3v",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -75,7 +75,8 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -159,7 +160,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -229,7 +231,8 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -410,7 +413,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -504,7 +508,8 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "composition_logement_next",
-                "action": "goto.save:type_logement_commodites"
+                "action": "goto.save:type_logement_commodites",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -718,7 +723,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -780,7 +786,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -932,7 +939,8 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -970,7 +978,8 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1079,7 +1088,8 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1177,7 +1187,8 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1298,7 +1309,8 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1352,7 +1364,8 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1537,7 +1550,8 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1577,7 +1591,8 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -75,8 +75,7 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -160,8 +159,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -231,8 +229,7 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -413,8 +410,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -508,8 +504,7 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "composition_logement_next",
-                "action": "goto.save:type_logement_commodites",
-                "validOnEnter": true
+                "action": "goto.save:type_logement_commodites"
               },
               {
                 "type": "SignalementFormButton",
@@ -723,8 +718,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -786,8 +780,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -939,8 +932,7 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -978,8 +970,7 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1088,8 +1079,7 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1187,8 +1177,7 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1309,8 +1298,7 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1364,8 +1352,7 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1550,8 +1537,7 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1591,8 +1577,7 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -94,8 +94,7 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_occupant_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -165,8 +164,7 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -347,8 +345,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -442,8 +439,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -657,8 +653,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -720,8 +715,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -803,8 +797,7 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -842,8 +835,7 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -968,8 +960,7 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1041,8 +1032,7 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1182,8 +1172,7 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1237,8 +1226,7 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1366,8 +1354,7 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1407,8 +1394,7 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -22,7 +22,10 @@
               "label": "Monsieur",
               "value": "mr"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -81,18 +84,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "vos_coordonnees_occupant_previous",
-          "action": "goto:signalement_concerne",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "vos_coordonnees_occupant_next",
-          "action": "goto.save:zone_concernee",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "vos_coordonnees_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "vos_coordonnees_occupant_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "vos_coordonnees_occupant_previous",
+                "action": "goto:signalement_concerne",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -115,7 +127,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -139,18 +154,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "zone_concernee_zone_previous",
-          "action": "goto:vos_coordonnees_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "zone_concernee_zone_next",
-          "action": "goto.save:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "zone_concernee_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "zone_concernee_zone_next",
+                "action": "goto.save:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "zone_concernee_zone_previous",
+                "action": "goto:vos_coordonnees_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -170,18 +194,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_type_composition_previous",
-          "action": "goto:zone_concernee",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "C'est parti",
-          "slug": "ecran_intermediaire_type_composition_next",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_type_composition_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "C'est parti",
+                "slug": "ecran_intermediaire_type_composition_next",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_type_composition_previous",
+                "action": "goto:zone_concernee",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -210,7 +243,10 @@
               "label": "Autre",
               "value": "autre"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -299,18 +335,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_previous",
-          "action": "goto:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_next",
-          "action": "goto.save:composition_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_next",
+                "action": "goto.save:composition_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_previous",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -335,7 +380,10 @@
               "label": "Plusieurs pièces",
               "value": "plusieurs_pieces"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCounter",
@@ -381,18 +429,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_previous",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_next",
-          "action": "goto.save:type_logement_commodites",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_next",
+                "action": "goto.save:type_logement_commodites",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_previous",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -431,7 +488,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormIcon",
@@ -583,18 +643,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_commodites_previous",
-          "action": "goto:composition_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_commodites_next",
-          "action": "goto.save:composition_logement_personnes",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_commodites_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_commodites_next",
+                "action": "goto.save:composition_logement_personnes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_commodites_previous",
+                "action": "goto:composition_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -613,6 +682,9 @@
           "slug": "composition_logement_nombre_personnes",
           "validate": {
             "pattern": "^[0-9]*$"
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -633,18 +705,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_personnes_previous",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_personnes_next",
-          "action": "goto.save:bail_dpe",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_personnes_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_personnes_next",
+                "action": "goto.save:bail_dpe",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_personnes_previous",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -660,7 +741,10 @@
           "type": "SignalementFormDate",
           "label": "A quelle date avez-vous emménagé dans le logement ?",
           "hint": "Si vous ne connaissez pas la date exacte, sélectionnez un jour du mois d'emménagement",
-          "slug": "bail_dpe_date_emmenagement"
+          "slug": "bail_dpe_date_emmenagement",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -703,18 +787,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "bail_dpe_previous",
-          "action": "goto:type_logement_composition",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "bail_dpe_next",
-          "action": "goto.save:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "bail_dpe_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "bail_dpe_next",
+                "action": "goto.save:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "bail_dpe_previous",
+                "action": "goto:type_logement_composition",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -732,18 +825,27 @@
     "components": {
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_situation_occupant_previous",
-          "action": "goto:bail_dpe",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "ecran_intermediaire_situation_occupant_next",
-          "action": "goto.save:logement_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_situation_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "ecran_intermediaire_situation_occupant_next",
+                "action": "goto.save:logement_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_situation_occupant_previous",
+                "action": "goto:bail_dpe",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -768,7 +870,10 @@
               "label": "Non",
               "value": "non"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormWarning",
@@ -845,18 +950,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "logement_social_previous",
-          "action": "goto:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "logement_social_next",
-          "action": "goto.save:travailleur_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "logement_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "logement_social_next",
+                "action": "goto.save:travailleur_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "logement_social_previous",
+                "action": "goto:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -885,7 +999,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -905,18 +1022,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "travailleur_social_previous",
-          "action": "goto:logement_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "travailleur_social_next",
-          "action": "goto.save:ecran_intermediaire_les_desordres",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "travailleur_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "travailleur_social_next",
+                "action": "goto.save:ecran_intermediaire_les_desordres",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "travailleur_social_previous",
+                "action": "goto:logement_social",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -936,17 +1062,26 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:desordres_renseignes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "J'y suis presque !",
-          "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:info_procedure"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "J'y suis presque !",
+                "slug": "ecran_intermediaire_procedure_next",
+                "action": "goto:info_procedure"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_procedure_previous",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -976,7 +1111,10 @@
               "label": "Je n'ai pas d'assurance logement",
               "value": "pas_assurance_logement"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextarea",
@@ -1024,18 +1162,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "info_procedure_utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "info_procedure_utilisation_service_next",
-          "action": "goto.save:utilisation_service",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "info_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "info_procedure_utilisation_service_next",
+                "action": "goto.save:utilisation_service",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "info_procedure_utilisation_service_previous",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1051,7 +1198,10 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_visite",
-          "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement."
+          "label": "Je comprends qu'une visite du logement pourra être faite pour évaluer l'état du logement.",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCheckbox",
@@ -1066,18 +1216,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "utilisation_service_previous",
-          "action": "goto:info_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "utilisation_service_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "utilisation_service_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "utilisation_service_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "utilisation_service_previous",
+                "action": "goto:info_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1113,7 +1272,10 @@
                     "label": "Non",
                     "value": "non"
                   }
-                ]
+                ],
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",
@@ -1182,18 +1344,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "informations_complementaires_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Enregistrer",
-          "slug": "informations_complementaires_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "informations_complementaires_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Enregistrer",
+                "slug": "informations_complementaires_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "informations_complementaires_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1213,18 +1384,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "validation_signalement_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Valider mon signalement",
-          "slug": "validation_signalement_next",
-          "action": "goto.save:confirmation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "validation_signalement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Valider mon signalement",
+                "slug": "validation_signalement_next",
+                "action": "goto.save:confirmation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "validation_signalement_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1253,7 +1433,10 @@
                 "label": "Accéder à ma page de suivi",
                 "slug": "confirmation_signalement_suivi",
                 "customCss": "fr-btn",
-                "link": "{{formStore.data.lienSuivi}}"
+                "link": "{{formStore.data.lienSuivi}}",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormLink",
@@ -1292,7 +1475,10 @@
                 "label": "Compléter mon signalement",
                 "slug": "signalement_incomplet_complete",
                 "action": "goto:ecran_intermediaire_type_composition",
-                "customCss": "fr-mb-3v"
+                "customCss": "fr-mb-3v",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -94,7 +94,8 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_occupant_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -164,7 +165,8 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -345,7 +347,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -439,7 +442,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -653,7 +657,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -715,7 +720,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -797,7 +803,8 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -835,7 +842,8 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -960,7 +968,8 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1032,7 +1041,8 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1172,7 +1182,8 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1226,7 +1237,8 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1354,7 +1366,8 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1394,7 +1407,8 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -79,8 +79,7 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_occupant_next",
                 "action": "goto.save:coordonnees_bailleur",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -201,8 +200,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -272,8 +270,7 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -454,8 +451,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -549,8 +545,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -764,8 +759,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -827,8 +821,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -986,8 +979,7 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1025,8 +1017,7 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1151,8 +1142,7 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1238,8 +1228,7 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1404,8 +1393,7 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1464,8 +1452,7 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1604,8 +1591,7 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1645,8 +1631,7 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -69,18 +69,28 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "vos_coordonnees_occupant_previous",
-          "action": "goto:signalement_concerne",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "vos_coordonnees_occupant_next",
-          "action": "goto.save:coordonnees_bailleur",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "vos_coordonnees_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "vos_coordonnees_occupant_next",
+                "action": "goto.save:coordonnees_bailleur",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "vos_coordonnees_occupant_previous",
+                "action": "goto:signalement_concerne",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -191,7 +201,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -261,7 +272,8 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -442,7 +454,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -536,7 +549,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -750,7 +764,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -812,7 +827,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -970,7 +986,8 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1008,7 +1025,8 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1133,7 +1151,8 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1219,7 +1238,8 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1384,7 +1404,8 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1443,7 +1464,8 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1582,7 +1604,8 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1622,7 +1645,8 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -109,7 +109,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -180,18 +181,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_bailleur_previous",
-          "action": "goto:vos_coordonnees_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_bailleur_next",
-          "action": "goto.save:zone_concernee",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_bailleur_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_bailleur_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_bailleur_previous",
+                "action": "goto:vos_coordonnees_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -214,7 +224,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -238,18 +251,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "zone_concernee_zone_previous",
-          "action": "goto:coordonnees_bailleur",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "zone_concernee_zone_next",
-          "action": "goto.save:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "zone_concernee_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "zone_concernee_zone_next",
+                "action": "goto.save:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "zone_concernee_zone_previous",
+                "action": "goto:coordonnees_bailleur",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -269,18 +291,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_type_composition_previous",
-          "action": "goto:zone_concernee",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "C'est parti",
-          "slug": "ecran_intermediaire_type_composition_next",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_type_composition_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "C'est parti",
+                "slug": "ecran_intermediaire_type_composition_next",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_type_composition_previous",
+                "action": "goto:zone_concernee",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -309,7 +340,10 @@
               "label": "Autre",
               "value": "autre"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -398,18 +432,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_previous",
-          "action": "goto:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_next",
-          "action": "goto.save:composition_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_next",
+                "action": "goto.save:composition_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_previous",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -434,7 +477,10 @@
               "label": "Plusieurs pièces",
               "value": "plusieurs_pieces"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCounter",
@@ -480,18 +526,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_previous",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_next",
-          "action": "goto.save:type_logement_commodites",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_next",
+                "action": "goto.save:type_logement_commodites",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_previous",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -530,7 +585,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormIcon",
@@ -682,18 +740,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_commodites_previous",
-          "action": "goto:composition_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_commodites_next",
-          "action": "goto.save:composition_logement_personnes",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_commodites_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_commodites_next",
+                "action": "goto.save:composition_logement_personnes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_commodites_previous",
+                "action": "goto:composition_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -712,6 +779,9 @@
           "slug": "composition_logement_nombre_personnes",
           "validate": {
             "pattern": "^[0-9]*$"
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -732,18 +802,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_personnes_previous",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_personnes_next",
-          "action": "goto.save:bail_dpe",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_personnes_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_personnes_next",
+                "action": "goto.save:bail_dpe",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_personnes_previous",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -759,7 +838,10 @@
           "type": "SignalementFormDate",
           "label": "A quelle date avez-vous emménagé dans le logement ?",
           "hint": "Si vous ne connaissez pas la date exacte, sélectionnez un jour du mois d'emménagement",
-          "slug": "bail_dpe_date_emmenagement"
+          "slug": "bail_dpe_date_emmenagement",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -878,18 +960,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "bail_dpe_previous",
-          "action": "goto:composition_logement_personnes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "bail_dpe_next",
-          "action": "goto.save:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "bail_dpe_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "bail_dpe_next",
+                "action": "goto.save:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "bail_dpe_previous",
+                "action": "goto:composition_logement_personnes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -907,18 +998,27 @@
     "components": {
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_situation_occupant_previous",
-          "action": "goto:bail_dpe",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "ecran_intermediaire_situation_occupant_next",
-          "action": "goto.save:logement_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_situation_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "ecran_intermediaire_situation_occupant_next",
+                "action": "goto.save:logement_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_situation_occupant_previous",
+                "action": "goto:bail_dpe",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -943,7 +1043,10 @@
               "label": "Non",
               "value": "non"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormWarning",
@@ -1020,18 +1123,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "logement_social_previous",
-          "action": "goto:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "logement_social_next",
-          "action": "goto.save:travailleur_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "logement_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "logement_social_next",
+                "action": "goto.save:travailleur_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "logement_social_previous",
+                "action": "goto:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1056,7 +1168,10 @@
               "label": "Non",
               "value": "non"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1094,18 +1209,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "travailleur_social_previous",
-          "action": "goto:logement_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "travailleur_social_next",
-          "action": "goto.save:ecran_intermediaire_les_desordres",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "travailleur_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "travailleur_social_next",
+                "action": "goto.save:ecran_intermediaire_les_desordres",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "travailleur_social_previous",
+                "action": "goto:logement_social",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1125,17 +1249,29 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:desordres_renseignes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "J'y suis presque !",
-          "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:info_procedure"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "J'y suis presque !",
+                "slug": "ecran_intermediaire_procedure_next",
+                "action": "goto:info_procedure",
+                "accessibility": {
+                  "focus": true
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_procedure_previous",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1160,7 +1296,10 @@
               "label": "Non",
               "value": "non"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormInfo",
@@ -1235,18 +1374,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "info_procedure_utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "info_procedure_utilisation_service_next",
-          "action": "goto.save:utilisation_service",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "info_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "info_procedure_utilisation_service_next",
+                "action": "goto.save:utilisation_service",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "info_procedure_utilisation_service_previous",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1262,7 +1410,10 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement."
+          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) de mon logement.",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCheckbox",
@@ -1282,18 +1433,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "utilisation_service_previous",
-          "action": "goto:info_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "utilisation_service_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "utilisation_service_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "utilisation_service_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "utilisation_service_previous",
+                "action": "goto:info_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1329,7 +1489,10 @@
                     "label": "Non",
                     "value": "non"
                   }
-                ]
+                ],
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",
@@ -1409,18 +1572,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "informations_complementaires_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Enregistrer",
-          "slug": "informations_complementaires_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "informations_complementaires_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Enregistrer",
+                "slug": "informations_complementaires_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "informations_complementaires_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1440,18 +1612,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "validation_signalement_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Valider mon signalement",
-          "slug": "validation_signalement_next",
-          "action": "goto.save:confirmation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "validation_signalement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Valider mon signalement",
+                "slug": "validation_signalement_next",
+                "action": "goto.save:confirmation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "validation_signalement_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1480,7 +1661,10 @@
                 "label": "Accéder à ma page de suivi",
                 "slug": "confirmation_signalement_suivi",
                 "customCss": "fr-btn",
-                "link": "{{formStore.data.lienSuivi}}"
+                "link": "{{formStore.data.lienSuivi}}",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormLink",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -19,7 +19,10 @@
               "label": "Monsieur",
               "value": "mr"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -124,6 +127,9 @@
           "autocomplete": {
             "isAbsoluteLink": false,
             "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete_textfield}}&sanitize=true"
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -75,7 +75,8 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -162,7 +163,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:coordonnees_bailleur",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -278,7 +280,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -348,7 +351,8 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -529,7 +533,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -624,7 +629,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -838,7 +844,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -885,7 +892,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1037,7 +1045,8 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1186,7 +1195,8 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1249,7 +1259,8 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1289,7 +1300,8 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -75,8 +75,7 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -163,8 +162,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:coordonnees_bailleur",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -280,8 +278,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -351,8 +348,7 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -533,8 +529,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -629,8 +624,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -844,8 +838,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -892,8 +885,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1045,8 +1037,7 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1195,8 +1186,7 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1259,8 +1249,7 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1300,8 +1289,7 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -15,7 +15,8 @@
           },
           "accessibility": {
             "name": "organizationName",
-            "autocomplete": "organization"
+            "autocomplete": "organization",
+            "focus": true
           }
         },
         {
@@ -27,7 +28,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -63,18 +65,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "vos_coordonnees_tiers_previous",
-          "action": "goto:signalement_concerne",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "vos_coordonnees_tiers_next",
-          "action": "goto.save:coordonnees_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "vos_coordonnees_tiers_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "vos_coordonnees_tiers_next",
+                "action": "goto.save:coordonnees_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "vos_coordonnees_tiers_previous",
+                "action": "goto:signalement_concerne",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -96,7 +107,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -140,18 +152,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_occupant_previous",
-          "action": "goto:vos_coordonnees_tiers",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_occupant_next",
-          "action": "goto.save:coordonnees_bailleur",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_occupant_next",
+                "action": "goto.save:coordonnees_bailleur",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_occupant_previous",
+                "action": "goto:vos_coordonnees_tiers",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -176,7 +197,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -246,18 +268,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_bailleur_previous",
-          "action": "goto:coordonnees_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_bailleur_next",
-          "action": "goto.save:zone_concernee",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_bailleur_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_bailleur_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_bailleur_previous",
+                "action": "goto:coordonnees_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -280,7 +311,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -304,18 +338,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "zone_concernee_zone_previous",
-          "action": "goto:coordonnees_bailleur",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "zone_concernee_zone_next",
-          "action": "goto.save:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "zone_concernee_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "zone_concernee_zone_next",
+                "action": "goto.save:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "zone_concernee_zone_previous",
+                "action": "goto:coordonnees_bailleur",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -335,18 +378,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_type_composition_previous",
-          "action": "goto:zone_concernee",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "C'est parti",
-          "slug": "ecran_intermediaire_type_composition_next",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_type_composition_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "C'est parti",
+                "slug": "ecran_intermediaire_type_composition_next",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_type_composition_previous",
+                "action": "goto:zone_concernee",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -375,7 +427,10 @@
               "label": "Autre",
               "value": "autre"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -464,18 +519,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_previous",
-          "action": "goto:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_next",
-          "action": "goto.save:composition_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_next",
+                "action": "goto.save:composition_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_previous",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -500,7 +564,10 @@
               "label": "Plusieurs pièces",
               "value": "plusieurs_pieces"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCounter",
@@ -547,18 +614,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_previous",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_next",
-          "action": "goto.save:type_logement_commodites",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_next",
+                "action": "goto.save:type_logement_commodites",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_previous",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -597,7 +673,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormIcon",
@@ -749,18 +828,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_commodites_previous",
-          "action": "goto:composition_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_commodites_next",
-          "action": "goto.save:composition_logement_personnes",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_commodites_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_commodites_next",
+                "action": "goto.save:composition_logement_personnes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_commodites_previous",
+                "action": "goto:composition_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -779,23 +867,35 @@
           "slug": "composition_logement_nombre_personnes",
           "validate": {
             "pattern": "^[0-9]*$"
+          },
+          "accessibility": {
+            "focus": true
           }
         }
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_personnes_previous",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_personnes_next",
-          "action": "goto.save:bail_dpe",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_personnes_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_personnes_next",
+                "action": "goto.save:bail_dpe",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_personnes_previous",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -824,7 +924,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormInfo",
@@ -924,18 +1027,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "bail_dpe_previous",
-          "action": "goto:composition_logement_personnes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "bail_dpe_next",
-          "action": "goto.save:ecran_intermediaire_les_desordres",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "bail_dpe_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "bail_dpe_next",
+                "action": "goto.save:ecran_intermediaire_les_desordres",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "bail_dpe_previous",
+                "action": "goto:composition_logement_personnes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -955,17 +1067,26 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:desordres_renseignes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "J'y suis presque !",
-          "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:info_procedure"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "J'y suis presque !",
+                "slug": "ecran_intermediaire_procedure_next",
+                "action": "goto:info_procedure"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_procedure_previous",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -994,7 +1115,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1052,18 +1176,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "info_procedure_utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "info_procedure_utilisation_service_next",
-          "action": "goto.save:utilisation_service",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "info_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "info_procedure_utilisation_service_next",
+                "action": "goto.save:utilisation_service",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "info_procedure_utilisation_service_previous",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1083,7 +1216,10 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement."
+          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement.",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCheckbox",
@@ -1103,18 +1239,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "utilisation_service_previous",
-          "action": "goto:info_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "utilisation_service_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "utilisation_service_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "utilisation_service_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "utilisation_service_previous",
+                "action": "goto:info_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1134,18 +1279,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "validation_signalement_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Valider mon signalement",
-          "slug": "validation_signalement_next",
-          "action": "goto.save:confirmation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "validation_signalement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Valider mon signalement",
+                "slug": "validation_signalement_next",
+                "action": "goto.save:confirmation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "validation_signalement_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1174,7 +1328,10 @@
                 "label": "Accéder à ma page de suivi",
                 "slug": "confirmation_signalement_suivi",
                 "customCss": "fr-btn",
-                "link": "{{formStore.data.lienSuivi}}"
+                "link": "{{formStore.data.lienSuivi}}",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormLink",
@@ -1213,7 +1370,10 @@
                 "label": "Compléter mon signalement",
                 "slug": "signalement_incomplet_complete",
                 "action": "goto:ecran_intermediaire_type_composition",
-                "customCss": "fr-mb-3v"
+                "customCss": "fr-mb-3v",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -26,6 +26,9 @@
           ],
           "validate": {
             "required": false
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -73,18 +76,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "vos_coordonnees_tiers_previous",
-          "action": "goto:signalement_concerne",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "vos_coordonnees_tiers_next",
-          "action": "goto.save:coordonnees_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "vos_coordonnees_tiers_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "vos_coordonnees_tiers_next",
+                "action": "goto.save:coordonnees_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "vos_coordonnees_tiers_previous",
+                "action": "goto:signalement_concerne",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -105,7 +117,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": "true"
           }
         },
         {
@@ -147,18 +160,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_occupant_previous",
-          "action": "goto:vos_coordonnees_tiers",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_occupant_next",
-          "action": "goto.save:coordonnees_bailleur",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_occupant_next",
+                "action": "goto.save:coordonnees_bailleur",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_occupant_previous",
+                "action": "goto:vos_coordonnees_tiers",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -182,7 +204,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -200,6 +223,9 @@
           "autocomplete": {
             "isAbsoluteLink": false,
             "route": "/bailleurs?postcode={{formStore.data.adresse_logement_adresse_detail_code_postal}}&name={{formStore.data.coordonnees_bailleur_nom_autocomplete_textfield}}&sanitize=true"
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -250,18 +276,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_bailleur_previous",
-          "action": "goto:coordonnees_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_bailleur_next",
-          "action": "goto.save:zone_concernee",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_bailleur_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_bailleur_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_bailleur_previous",
+                "action": "goto:coordonnees_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -284,7 +319,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -308,18 +346,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "zone_concernee_zone_previous",
-          "action": "goto:coordonnees_bailleur",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "zone_concernee_zone_next",
-          "action": "goto.save:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "zone_concernee_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "zone_concernee_zone_next",
+                "action": "goto.save:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "zone_concernee_zone_previous",
+                "action": "goto:coordonnees_bailleur",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -339,18 +386,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_type_composition_previous",
-          "action": "goto:zone_concernee",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "C'est parti",
-          "slug": "ecran_intermediaire_type_composition_next",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_type_composition_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "C'est parti",
+                "slug": "ecran_intermediaire_type_composition_next",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_type_composition_previous",
+                "action": "goto:zone_concernee",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -379,7 +435,10 @@
               "label": "Autre",
               "value": "autre"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -468,18 +527,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_previous",
-          "action": "goto:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_next",
-          "action": "goto.save:composition_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_next",
+                "action": "goto.save:composition_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_previous",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -504,7 +572,10 @@
               "label": "Plusieurs pièces",
               "value": "plusieurs_pieces"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCounter",
@@ -551,18 +622,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_previous",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_next",
-          "action": "goto.save:type_logement_commodites",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_next",
+                "action": "goto.save:type_logement_commodites",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_previous",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -601,7 +681,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormIcon",
@@ -753,18 +836,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_commodites_previous",
-          "action": "goto:composition_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_commodites_next",
-          "action": "goto.save:composition_logement_personnes",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_commodites_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_commodites_next",
+                "action": "goto.save:composition_logement_personnes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_commodites_previous",
+                "action": "goto:composition_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -783,6 +875,9 @@
           "slug": "composition_logement_nombre_personnes",
           "validate": {
             "pattern": "^[0-9]*$"
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -803,18 +898,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_personnes_previous",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_personnes_next",
-          "action": "goto.save:bail_dpe",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_personnes_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_personnes_next",
+                "action": "goto.save:bail_dpe",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_personnes_previous",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -843,7 +947,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormInfo",
@@ -943,18 +1050,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "bail_dpe_previous",
-          "action": "goto:composition_logement_personnes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "bail_dpe_next",
-          "action": "goto.save:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "bail_dpe_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "bail_dpe_next",
+                "action": "goto.save:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "bail_dpe_previous",
+                "action": "goto:composition_logement_personnes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -972,18 +1088,27 @@
     "components": {
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_situation_occupant_previous",
-          "action": "goto:composition_logement_personnes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "ecran_intermediaire_situation_occupant_next",
-          "action": "goto.save:logement_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_situation_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "ecran_intermediaire_situation_occupant_next",
+                "action": "goto.save:logement_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_situation_occupant_previous",
+                "action": "goto:composition_logement_personnes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1012,7 +1137,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1069,18 +1197,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "logement_social_previous",
-          "action": "goto:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "logement_social_next",
-          "action": "goto.save:travailleur_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "logement_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "logement_social_next",
+                "action": "goto.save:travailleur_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "logement_social_previous",
+                "action": "goto:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1109,7 +1246,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1155,18 +1295,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "travailleur_social_previous",
-          "action": "goto:logement_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "travailleur_social_next",
-          "action": "goto.save:ecran_intermediaire_les_desordres",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "travailleur_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "travailleur_social_next",
+                "action": "goto.save:ecran_intermediaire_les_desordres",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "travailleur_social_previous",
+                "action": "goto:logement_social",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1186,17 +1335,26 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:desordres_renseignes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "J'y suis presque !",
-          "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:info_procedure"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "J'y suis presque !",
+                "slug": "ecran_intermediaire_procedure_next",
+                "action": "goto:info_procedure"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_procedure_previous",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1225,7 +1383,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1283,18 +1444,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "info_procedure_utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "info_procedure_utilisation_service_next",
-          "action": "goto.save:utilisation_service",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "info_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "info_procedure_utilisation_service_next",
+                "action": "goto.save:utilisation_service",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "info_procedure_utilisation_service_previous",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1310,7 +1480,10 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement."
+          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement.",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCheckbox",
@@ -1330,18 +1503,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "utilisation_service_previous",
-          "action": "goto:info_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "utilisation_service_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "utilisation_service_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "utilisation_service_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "utilisation_service_previous",
+                "action": "goto:info_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1377,7 +1559,10 @@
                     "label": "Non",
                     "value": "non"
                   }
-                ]
+                ],
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",
@@ -1472,18 +1657,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "informations_complementaires_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Enregistrer",
-          "slug": "informations_complementaires_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "informations_complementaires_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Enregistrer",
+                "slug": "informations_complementaires_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "informations_complementaires_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1503,18 +1697,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "validation_signalement_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Valider mon signalement",
-          "slug": "validation_signalement_next",
-          "action": "goto.save:confirmation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "validation_signalement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Valider mon signalement",
+                "slug": "validation_signalement_next",
+                "action": "goto.save:confirmation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "validation_signalement_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1543,7 +1746,10 @@
                 "label": "Accéder à ma page de suivi",
                 "slug": "confirmation_signalement_suivi",
                 "customCss": "fr-btn",
-                "link": "{{formStore.data.lienSuivi}}"
+                "link": "{{formStore.data.lienSuivi}}",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormLink",
@@ -1582,7 +1788,10 @@
                 "label": "Compléter mon signalement",
                 "slug": "signalement_incomplet_complete",
                 "action": "goto:ecran_intermediaire_type_composition",
-                "customCss": "fr-mb-3v"
+                "customCss": "fr-mb-3v",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -86,7 +86,8 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -170,7 +171,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:coordonnees_bailleur",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -286,7 +288,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -356,7 +359,8 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -537,7 +541,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -632,7 +637,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -846,7 +852,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -908,7 +915,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1060,7 +1068,8 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1098,7 +1107,8 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1207,7 +1217,8 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1305,7 +1316,8 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1454,7 +1466,8 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1513,7 +1526,8 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1667,7 +1681,8 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1707,7 +1722,8 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -86,8 +86,7 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -171,8 +170,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:coordonnees_bailleur",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -288,8 +286,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -359,8 +356,7 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -541,8 +537,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -637,8 +632,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -852,8 +846,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -915,8 +908,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1068,8 +1060,7 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1107,8 +1098,7 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1217,8 +1207,7 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1316,8 +1305,7 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1466,8 +1454,7 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1526,8 +1513,7 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1681,8 +1667,7 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1722,8 +1707,7 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -12,7 +12,8 @@
           "slug": "vos_coordonnees_tiers_nom_organisme",
           "accessibility": {
             "name": "organizationName",
-            "autocomplete": "organization"
+            "autocomplete": "organization",
+            "focus": true
           }
         },
         {
@@ -60,18 +61,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "vos_coordonnees_tiers_previous",
-          "action": "goto:signalement_concerne",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "vos_coordonnees_tiers_next",
-          "action": "goto.save:coordonnees_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "vos_coordonnees_tiers_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "vos_coordonnees_tiers_next",
+                "action": "goto.save:coordonnees_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "vos_coordonnees_tiers_previous",
+                "action": "goto:signalement_concerne",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -92,7 +102,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -134,18 +145,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_occupant_previous",
-          "action": "goto:vos_coordonnees_tiers",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_occupant_next",
-          "action": "goto.save:coordonnees_bailleur",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_occupant_next",
+                "action": "goto.save:coordonnees_bailleur",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_occupant_previous",
+                "action": "goto:vos_coordonnees_tiers",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -169,7 +189,8 @@
           },
           "accessibility": {
             "name": "lastName",
-            "autocomplete": "family-name"
+            "autocomplete": "family-name",
+            "focus": true
           }
         },
         {
@@ -237,18 +258,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "coordonnees_bailleur_previous",
-          "action": "goto:coordonnees_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "coordonnees_bailleur_next",
-          "action": "goto.save:zone_concernee",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "coordonnees_bailleur_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "coordonnees_bailleur_next",
+                "action": "goto.save:zone_concernee",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "coordonnees_bailleur_previous",
+                "action": "goto:coordonnees_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -271,7 +301,10 @@
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
-          "ariaControls": "zone_concernee_modal"
+          "ariaControls": "zone_concernee_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -295,18 +328,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "zone_concernee_zone_previous",
-          "action": "goto:coordonnees_bailleur",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "zone_concernee_zone_next",
-          "action": "goto.save:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "zone_concernee_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "zone_concernee_zone_next",
+                "action": "goto.save:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "zone_concernee_zone_previous",
+                "action": "goto:coordonnees_bailleur",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -326,18 +368,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_type_composition_previous",
-          "action": "goto:zone_concernee",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "C'est parti",
-          "slug": "ecran_intermediaire_type_composition_next",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_type_composition_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "C'est parti",
+                "slug": "ecran_intermediaire_type_composition_next",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_type_composition_previous",
+                "action": "goto:zone_concernee",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -366,7 +417,10 @@
               "label": "Autre",
               "value": "autre"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormTextfield",
@@ -455,18 +509,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_previous",
-          "action": "goto:ecran_intermediaire_type_composition",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_next",
-          "action": "goto.save:composition_logement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_next",
+                "action": "goto.save:composition_logement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_previous",
+                "action": "goto:ecran_intermediaire_type_composition",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -491,7 +554,10 @@
               "label": "Plusieurs pièces",
               "value": "plusieurs_pieces"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCounter",
@@ -538,18 +604,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_previous",
-          "action": "goto:type_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_next",
-          "action": "goto.save:type_logement_commodites",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_next",
+                "action": "goto.save:type_logement_commodites",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_previous",
+                "action": "goto:type_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -588,7 +663,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormIcon",
@@ -740,18 +818,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "type_logement_commodites_previous",
-          "action": "goto:composition_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "type_logement_commodites_next",
-          "action": "goto.save:composition_logement_personnes",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "type_logement_commodites_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "type_logement_commodites_next",
+                "action": "goto.save:composition_logement_personnes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "type_logement_commodites_previous",
+                "action": "goto:composition_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -770,6 +857,9 @@
           "slug": "composition_logement_nombre_personnes",
           "validate": {
             "pattern": "^[0-9]*$"
+          },
+          "accessibility": {
+            "focus": true
           }
         },
         {
@@ -790,18 +880,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "composition_logement_personnes_previous",
-          "action": "goto:type_logement_commodites",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "composition_logement_personnes_next",
-          "action": "goto.save:bail_dpe",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "composition_logement_personnes_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "composition_logement_personnes_next",
+                "action": "goto.save:bail_dpe",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "composition_logement_personnes_previous",
+                "action": "goto:type_logement_commodites",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -830,7 +929,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormInfo",
@@ -930,18 +1032,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "bail_dpe_previous",
-          "action": "goto:composition_logement_personnes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "bail_dpe_next",
-          "action": "goto.save:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "bail_dpe_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "bail_dpe_next",
+                "action": "goto.save:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "bail_dpe_previous",
+                "action": "goto:composition_logement_personnes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -959,18 +1070,27 @@
     "components": {
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_situation_occupant_previous",
-          "action": "goto:composition_logement_personnes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "ecran_intermediaire_situation_occupant_next",
-          "action": "goto.save:logement_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_situation_occupant_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "ecran_intermediaire_situation_occupant_next",
+                "action": "goto.save:logement_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_situation_occupant_previous",
+                "action": "goto:composition_logement_personnes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -999,7 +1119,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1056,18 +1179,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "logement_social_previous",
-          "action": "goto:ecran_intermediaire_situation_occupant",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "logement_social_next",
-          "action": "goto.save:travailleur_social",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "logement_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "logement_social_next",
+                "action": "goto.save:travailleur_social",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "logement_social_previous",
+                "action": "goto:ecran_intermediaire_situation_occupant",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1096,7 +1228,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1153,18 +1288,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "travailleur_social_previous",
-          "action": "goto:logement_social",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "travailleur_social_next",
-          "action": "goto.save:ecran_intermediaire_les_desordres",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "travailleur_social_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "travailleur_social_next",
+                "action": "goto.save:ecran_intermediaire_les_desordres",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "travailleur_social_previous",
+                "action": "goto:logement_social",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1184,17 +1328,26 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "ecran_intermediaire_procedure_previous",
-          "action": "goto:desordres_renseignes",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "J'y suis presque !",
-          "slug": "ecran_intermediaire_procedure_next",
-          "action": "goto:info_procedure"
+          "type": "SignalementFormSubscreen",
+          "slug": "ecran_intermediaire_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "J'y suis presque !",
+                "slug": "ecran_intermediaire_procedure_next",
+                "action": "goto:info_procedure"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "ecran_intermediaire_procedure_previous",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1223,7 +1376,10 @@
               "label": "Je ne sais pas",
               "value": "nsp"
             }
-          ]
+          ],
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",
@@ -1281,18 +1437,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "info_procedure_utilisation_service_previous",
-          "action": "goto:ecran_intermediaire_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "info_procedure_utilisation_service_next",
-          "action": "goto.save:utilisation_service",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "info_procedure_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "info_procedure_utilisation_service_next",
+                "action": "goto.save:utilisation_service",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "info_procedure_utilisation_service_previous",
+                "action": "goto:ecran_intermediaire_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1308,7 +1473,10 @@
         {
           "type": "SignalementFormCheckbox",
           "slug": "utilisation_service_ok_prevenir_bailleur",
-          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement."
+          "label": "Je comprends que {{formStore.props.platformName}} va prévenir le bailleur (propriétaire) du logement.",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormCheckbox",
@@ -1328,18 +1496,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "utilisation_service_previous",
-          "action": "goto:info_procedure",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "utilisation_service_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "utilisation_service_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "utilisation_service_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "utilisation_service_previous",
+                "action": "goto:info_procedure",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1375,7 +1552,10 @@
                     "label": "Non",
                     "value": "non"
                   }
-                ]
+                ],
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormOnlyChoice",
@@ -1470,18 +1650,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "informations_complementaires_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Enregistrer",
-          "slug": "informations_complementaires_next",
-          "action": "goto.save:validation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "informations_complementaires_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Enregistrer",
+                "slug": "informations_complementaires_next",
+                "action": "goto.save:validation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "informations_complementaires_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1501,18 +1690,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "validation_signalement_previous",
-          "action": "goto:utilisation_service",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Valider mon signalement",
-          "slug": "validation_signalement_next",
-          "action": "goto.save:confirmation_signalement",
-          "customCss": "fr-btn--icon-left fr-icon-check-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "validation_signalement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Valider mon signalement",
+                "slug": "validation_signalement_next",
+                "action": "goto.save:confirmation_signalement",
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "validation_signalement_previous",
+                "action": "goto:utilisation_service",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -1541,7 +1739,10 @@
                 "label": "Accéder à ma page de suivi",
                 "slug": "confirmation_signalement_suivi",
                 "customCss": "fr-btn",
-                "link": "{{formStore.data.lienSuivi}}"
+                "link": "{{formStore.data.lienSuivi}}",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormLink",
@@ -1580,7 +1781,10 @@
                 "label": "Compléter mon signalement",
                 "slug": "signalement_incomplet_complete",
                 "action": "goto:ecran_intermediaire_type_composition",
-                "customCss": "fr-mb-3v"
+                "customCss": "fr-mb-3v",
+                "accessibility": {
+                  "focus": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -71,7 +71,8 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -155,7 +156,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:coordonnees_bailleur",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -268,7 +270,8 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -338,7 +341,8 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -519,7 +523,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -614,7 +619,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -828,7 +834,8 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -890,7 +897,8 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1042,7 +1050,8 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1080,7 +1089,8 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1189,7 +1199,8 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1298,7 +1309,8 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1447,7 +1459,8 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1506,7 +1519,8 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1660,7 +1674,8 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -1700,7 +1715,8 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -71,8 +71,7 @@
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
                 "action": "goto.save:coordonnees_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -156,8 +155,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_occupant_next",
                 "action": "goto.save:coordonnees_bailleur",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -270,8 +268,7 @@
                 "label": "Suivant",
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:zone_concernee",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -341,8 +338,7 @@
                 "label": "Suivant",
                 "slug": "zone_concernee_zone_next",
                 "action": "goto.save:ecran_intermediaire_type_composition",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -523,8 +519,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_next",
                 "action": "goto.save:composition_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -619,8 +614,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -834,8 +828,7 @@
                 "label": "Suivant",
                 "slug": "type_logement_commodites_next",
                 "action": "goto.save:composition_logement_personnes",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -897,8 +890,7 @@
                 "label": "Suivant",
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1050,8 +1042,7 @@
                 "label": "Suivant",
                 "slug": "bail_dpe_next",
                 "action": "goto.save:ecran_intermediaire_situation_occupant",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1089,8 +1080,7 @@
                 "label": "Suivant",
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1199,8 +1189,7 @@
                 "label": "Suivant",
                 "slug": "logement_social_next",
                 "action": "goto.save:travailleur_social",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1309,8 +1298,7 @@
                 "label": "Suivant",
                 "slug": "travailleur_social_next",
                 "action": "goto.save:ecran_intermediaire_les_desordres",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1459,8 +1447,7 @@
                 "label": "Suivant",
                 "slug": "info_procedure_utilisation_service_next",
                 "action": "goto.save:utilisation_service",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1519,8 +1506,7 @@
                 "label": "Suivant",
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1674,8 +1660,7 @@
                 "label": "Enregistrer",
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -1715,8 +1700,7 @@
                 "label": "Valider mon signalement",
                 "slug": "validation_signalement_next",
                 "action": "goto.save:confirmation_signalement",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -174,7 +174,10 @@
           "label": "En savoir plus",
           "slug": "signalement_concerne_savoir_plus",
           "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
-          "ariaControls": "signalement_concerne_modal"
+          "ariaControls": "signalement_concerne_modal",
+          "accessibility": {
+            "focus": true
+          }
         },
         {
           "type": "SignalementFormOnlyChoice",

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -18,8 +18,7 @@
                 "label": "Je démarre",
                 "slug": "introduction_go",
                 "action": "goto:adresse_logement_intro",
-                "customCss": "fr-btn--icon-left fr-icon-check-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-left fr-icon-check-line"
               },
               {
                 "type": "SignalementFormLink",
@@ -58,8 +57,7 @@
                 "label": "C'est parti",
                 "slug": "adresse_logement_intro_go",
                 "action": "goto:adresse_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormLink",
@@ -152,8 +150,7 @@
                 "label": "Suivant",
                 "slug": "adresse_logement_next",
                 "action": "goto.checkloc:signalement_concerne",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-                "validOnEnter": true
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {
                 "type": "SignalementFormButton",
@@ -342,8 +339,7 @@
                 "action": "goto.save:vos_coordonnees_occupant",
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_profil === 'logement_occupez'"
-                },
-                "validOnEnter": true
+                }
               },
               {
                 "type": "SignalementFormButton",
@@ -353,8 +349,7 @@
                 "action": "goto.save:vos_coordonnees_tiers",
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_profil === 'autre_logement'"
-                },
-                "validOnEnter": true
+                }
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -58,7 +58,8 @@
                 "label": "C'est parti",
                 "slug": "adresse_logement_intro_go",
                 "action": "goto:adresse_logement",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormLink",
@@ -151,7 +152,8 @@
                 "label": "Suivant",
                 "slug": "adresse_logement_next",
                 "action": "goto.checkloc:signalement_concerne",
-                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -340,7 +342,8 @@
                 "action": "goto.save:vos_coordonnees_occupant",
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_profil === 'logement_occupez'"
-                }
+                },
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",
@@ -350,7 +353,8 @@
                 "action": "goto.save:vos_coordonnees_tiers",
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_profil === 'autre_logement'"
-                }
+                },
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -18,7 +18,8 @@
                 "label": "Je démarre",
                 "slug": "introduction_go",
                 "action": "goto:adresse_logement_intro",
-                "customCss": "fr-btn--icon-left fr-icon-check-line"
+                "customCss": "fr-btn--icon-left fr-icon-check-line",
+                "validOnEnter": true
               },
               {
                 "type": "SignalementFormLink",
@@ -140,18 +141,27 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "adresse_logement_previous",
-          "action": "goto:adresse_logement_intro",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "adresse_logement_next",
-          "action": "goto.checkloc:signalement_concerne",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+          "type": "SignalementFormSubscreen",
+          "slug": "adresse_logement_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "adresse_logement_next",
+                "action": "goto.checkloc:signalement_concerne",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "adresse_logement_previous",
+                "action": "goto:adresse_logement_intro",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
         }
       ]
     }
@@ -317,30 +327,39 @@
       ],
       "footer": [
         {
-          "type": "SignalementFormButton",
-          "label": "Précédent",
-          "slug": "signalement_concerne_previous",
-          "action": "goto:adresse_logement",
-          "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "signalement_concerne_next_occupant",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-          "action": "goto.save:vos_coordonnees_occupant",
-          "conditional": {
-            "show": "formStore.data.signalement_concerne_profil === 'logement_occupez'"
-          }
-        },
-        {
-          "type": "SignalementFormButton",
-          "label": "Suivant",
-          "slug": "signalement_concerne_next_tiers",
-          "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
-          "action": "goto.save:vos_coordonnees_tiers",
-          "conditional": {
-            "show": "formStore.data.signalement_concerne_profil === 'autre_logement'"
+          "type": "SignalementFormSubscreen",
+          "slug": "signalement_concerne_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "signalement_concerne_next_occupant",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "action": "goto.save:vos_coordonnees_occupant",
+                "conditional": {
+                  "show": "formStore.data.signalement_concerne_profil === 'logement_occupez'"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "signalement_concerne_next_tiers",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line",
+                "action": "goto.save:vos_coordonnees_tiers",
+                "conditional": {
+                  "show": "formStore.data.signalement_concerne_profil === 'autre_logement'"
+                }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "signalement_concerne_previous",
+                "action": "goto:adresse_logement",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
           }
         }
       ]

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -22,7 +22,6 @@
         v-for="(suggestion, index) in suggestions"
         :key="index"
         :class="['fr-col-12 fr-p-3v fr-text-label--blue-france fr-address-suggestion', { 'fr-autocomplete-suggestion-highlighted': index === selectedSuggestionIndex }]"
-        ref="addressSuggestions"
         tabindex="0"
         @click="handleClickSuggestion(index)"
         >

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -15,6 +15,7 @@
       @keydown.down.prevent="handleDownSuggestion"
       @keydown.up.prevent="handleUpSuggestion"
       @keydown.enter.prevent="handleEnterSuggestion"
+      @keydown.tab="handleTabSuggestion"
     />
 
     <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
@@ -212,6 +213,9 @@ export default defineComponent({
         this.handleClickSuggestion(this.selectedSuggestionIndex)
         this.selectedSuggestionIndex = -1
       }
+    },
+    handleTabSuggestion () {
+      this.suggestions.length = 0
     },
     handleAddressFound (requestResponse: any) {
       this.suggestions = requestResponse.features

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -83,7 +83,8 @@ export default defineComponent({
     components: Object,
     handleClickComponent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     const updatedSubscreenData = subscreenManager.generateSubscreenData(this.id, subscreenData.body, this.validate)

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -85,8 +85,7 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     const updatedSubscreenData = subscreenManager.generateSubscreenData(this.id, subscreenData.body, this.validate)

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -85,7 +85,8 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     const updatedSubscreenData = subscreenManager.generateSubscreenData(this.id, subscreenData.body, this.validate)

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -19,7 +19,9 @@
         v-for="(suggestion, index) in suggestions"
         :key="index"
         class="fr-col-12 fr-p-3v fr-text-label--blue-france fr-address-suggestion"
+        tabindex="0"
         @click="handleClickSuggestion(index)"
+        @keyup="handleKeyboardSuggestion($event, index)"
         >
         {{ suggestion.properties.label }}
       </div>
@@ -187,6 +189,24 @@ export default defineComponent({
         setTimeout(() => {
           this.isSearchSkipped = false
         }, 200)
+      }
+    },
+    handleKeyboardSuggestion (event: any, index: number) {
+      if (event.key === 'Enter') {
+        this.handleClickSuggestion(index)
+      } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+        event.preventDefault()
+        const suggestionElements = document.querySelectorAll('.fr-address-suggestion')
+        if (suggestionElements.length > 0) {
+          let newIndex = index
+          if (event.key === 'ArrowUp') {
+            newIndex = (index === 0) ? suggestionElements.length - 1 : index - 1
+          } else if (event.key === 'ArrowDown') {
+            newIndex = (index === suggestionElements.length - 1) ? 0 : index + 1
+          }
+          const nextElement = suggestionElements[newIndex] as HTMLElement
+          nextElement.focus()
+        }
       }
     },
     handleAddressFound (requestResponse: any) {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -19,6 +19,7 @@
         v-for="(suggestion, index) in suggestions"
         :key="index"
         class="fr-col-12 fr-p-3v fr-text-label--blue-france fr-address-suggestion"
+        ref="addressSuggestions"
         tabindex="0"
         @click="handleClickSuggestion(index)"
         @keyup="handleKeyboardSuggestion($event, index)"
@@ -193,12 +194,12 @@ export default defineComponent({
       }
     },
     handleKeyboardSuggestion (event: any, index: number) {
-      if (event.key === 'Enter') {
+      if (event.key === ' ' || event.key === 'Spacebar') {
         this.handleClickSuggestion(index)
       } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
         event.preventDefault()
-        const suggestionElements = document.querySelectorAll('.fr-address-suggestion')
-        if (suggestionElements.length > 0) {
+        const suggestionElements = this.$refs.addressSuggestions as HTMLElement[]
+        if (suggestionElements && suggestionElements.length > 0) {
           let newIndex = index
           if (event.key === 'ArrowUp') {
             newIndex = (index === 0) ? suggestionElements.length - 1 : index - 1

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -62,8 +62,7 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     clickEvent: Function,
-    handleClickComponent: Function,
-    validOnEnter: { type: Boolean, default: false }
+    handleClickComponent: Function
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -62,7 +62,8 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     clickEvent: Function,
-    handleClickComponent: Function
+    handleClickComponent: Function,
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -10,6 +10,7 @@
         :validate="validate"
         :access_name="access_name"
         :access_autocomplete="access_autocomplete"
+        :access_focus="access_focus"
         :hasError="hasError"
         :error="error"
         @keydown.down.prevent="handleDownSuggestion"
@@ -71,16 +72,6 @@ export default defineComponent({
       formStore,
       selectedSuggestion: '',
       selectedSuggestionIndex: -1
-    }
-  },
-  mounted () {
-    if (this.access_focus) {
-      this.$nextTick(() => {
-        const element = document.querySelector('#' + this.idAutocomplete + '_input') as HTMLElement
-        if (element) {
-          element.focus()
-        }
-      })
     }
   },
   created () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAutocomplete.vue
@@ -56,6 +56,7 @@ export default defineComponent({
     disabled: { type: Boolean, default: false },
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
@@ -70,6 +71,16 @@ export default defineComponent({
       formStore,
       selectedSuggestion: '',
       selectedSuggestionIndex: -1
+    }
+  },
+  mounted () {
+    if (this.access_focus) {
+      this.$nextTick(() => {
+        const element = document.querySelector('#' + this.idAutocomplete + '_input') as HTMLElement
+        if (element) {
+          element.focus()
+        }
+      })
     }
   },
   created () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="signalement-form-button" :id="id">
       <button
+        id="button"
         :type="type"
         :class="[ 'fr-btn', customCss, formStore.lastButtonClicked === id ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
         :disabled="formStore.lastButtonClicked !== ''"
@@ -38,6 +39,7 @@ export default defineComponent({
     customCss: { type: String, default: '' },
     ariaControls: { type: String, default: undefined },
     clickEvent: Function,
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
@@ -49,6 +51,16 @@ export default defineComponent({
   data () {
     return {
       formStore
+    }
+  },
+  mounted () {
+    if (this.access_focus) {
+      this.$nextTick(() => {
+        const element = document.querySelector('#button') as HTMLElement
+        if (element) {
+          element.focus()
+        }
+      })
     }
   },
   computed: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -57,9 +57,17 @@ export default defineComponent({
   },
   mounted () {
     const element = this.$refs.button as HTMLElement
-    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
-      this.focusInput()
+    if (element && !element.classList.contains('fr-hidden')) {
+      if (this.access_focus) {
+        this.focusInput()
+      }
+      if (this.validOnEnter) {
+        window.addEventListener('keyup', this.handleGlobalEnter)
+      }
     }
+  },
+  beforeUnmount () {
+    window.removeEventListener('keyup', this.handleGlobalEnter)
   },
   computed: {
     actionType (): string {
@@ -85,6 +93,11 @@ export default defineComponent({
       const focusableElement = this.$refs[this.id + '_ref'] as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
+      }
+    },
+    handleGlobalEnter (event: KeyboardEvent) {
+      if (event.key === 'Enter') {
+        this.handleClick()
       }
     }
   }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="signalement-form-button" :id="id" ref="button">
+    <div class="signalement-form-button" :id="id" :ref="id">
       <button
         :id="id + '_button'"
-        :ref="id + '_ref'"
+        :ref="idRef"
         :type="type"
         :class="[ 'fr-btn', customCss, formStore.lastButtonClicked === id ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
         :disabled="formStore.lastButtonClicked !== ''"
@@ -41,7 +41,6 @@ export default defineComponent({
     ariaControls: { type: String, default: undefined },
     clickEvent: Function,
     access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
@@ -52,22 +51,17 @@ export default defineComponent({
   },
   data () {
     return {
-      formStore
+      formStore,
+      idRef: this.id + '_ref'
     }
   },
   mounted () {
-    const element = this.$refs.button as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (element && !element.classList.contains('fr-hidden')) {
       if (this.access_focus) {
         this.focusInput()
       }
-      if (this.validOnEnter) {
-        window.addEventListener('keyup', this.handleGlobalEnter)
-      }
     }
-  },
-  beforeUnmount () {
-    window.removeEventListener('keyup', this.handleGlobalEnter)
   },
   computed: {
     actionType (): string {
@@ -84,20 +78,16 @@ export default defineComponent({
     }
   },
   methods: {
-    handleClick () {
+    handleClick (event: any) {
       if (this.clickEvent !== undefined) {
+        event.preventDefault()
         this.clickEvent(this.actionType, this.actionParam, this.id)
       }
     },
     focusInput () {
-      const focusableElement = this.$refs[this.id + '_ref'] as HTMLElement
+      const focusableElement = this.$refs[this.idRef] as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
-      }
-    },
-    handleGlobalEnter (event: KeyboardEvent) {
-      if (event.key === 'Enter') {
-        this.handleClick()
       }
     }
   }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -1,7 +1,8 @@
 <template>
-    <div class="signalement-form-button" :id="id">
+    <div class="signalement-form-button" :id="id" ref="button">
       <button
-        id="button"
+        :id="id + '_button'"
+        :ref="id + '_ref'"
         :type="type"
         :class="[ 'fr-btn', customCss, formStore.lastButtonClicked === id ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
         :disabled="formStore.lastButtonClicked !== ''"
@@ -40,6 +41,7 @@ export default defineComponent({
     ariaControls: { type: String, default: undefined },
     clickEvent: Function,
     access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
@@ -54,13 +56,9 @@ export default defineComponent({
     }
   },
   mounted () {
-    if (this.access_focus) {
-      this.$nextTick(() => {
-        const element = document.querySelector('#button') as HTMLElement
-        if (element) {
-          element.focus()
-        }
-      })
+    const element = this.$refs.button as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
     }
   },
   computed: {
@@ -81,6 +79,12 @@ export default defineComponent({
     handleClick () {
       if (this.clickEvent !== undefined) {
         this.clickEvent(this.actionType, this.actionParam, this.id)
+      }
+    },
+    focusInput () {
+      const focusableElement = this.$refs[this.id + '_ref'] as HTMLElement
+      if (focusableElement) {
+        focusableElement.focus()
       }
     }
   }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -49,7 +49,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -1,9 +1,10 @@
 <template>
-  <div class="fr-fieldset__element signalement-form-checkbox">
+  <div class="fr-fieldset__element signalement-form-checkbox" ref="checkbox">
     <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]" :id="id">
       <input
           type="checkbox"
           :id="idCheckbox"
+          :ref="id + '_ref'"
           :name="idCheckbox"
           :value="modelValue"
           :class="[ customCss ]"
@@ -41,20 +42,26 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {
       formStore,
       variablesReplacer,
       idCheckbox: this.id + '_check'
+    }
+  },
+  mounted () {
+    const element = this.$refs.checkbox as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
     }
   },
   methods: {
@@ -67,6 +74,12 @@ export default defineComponent({
             formStore.data[dataname] = null
           }
         }
+      }
+    },
+    focusInput () {
+      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      if (focusableElement) {
+        focusableElement.focus()
       }
     }
   },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="fr-fieldset__element signalement-form-checkbox" ref="checkbox">
+  <div class="fr-fieldset__element signalement-form-checkbox" :ref="id">
     <div :class="['fr-checkbox-group', { 'fr-checkbox-group--error': hasError }]" :id="id">
       <input
           type="checkbox"
           :id="idCheckbox"
-          :ref="id + '_ref'"
+          :ref="idRef"
           :name="idCheckbox"
           :value="modelValue"
           :class="[ customCss ]"
@@ -49,18 +49,18 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' },
-    validOnEnter: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {
       formStore,
       variablesReplacer,
-      idCheckbox: this.id + '_check'
+      idCheckbox: this.id + '_check',
+      idRef: this.id + '_ref'
     }
   },
   mounted () {
-    const element = this.$refs.checkbox as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }
@@ -78,7 +78,7 @@ export default defineComponent({
       }
     },
     focusInput () {
-      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      const focusableElement = (this.$refs[this.idRef]) as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
       }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -47,7 +47,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormConfirmation.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormConfirmation.vue
@@ -29,7 +29,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   }
 })
 </script>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormConfirmation.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormConfirmation.vue
@@ -30,8 +30,7 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   }
 })
 </script>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormConfirmation.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormConfirmation.vue
@@ -30,7 +30,8 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   }
 })
 </script>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -49,7 +49,8 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-input-group" :id="id" ref="counter">
+  <div class="fr-input-group" :id="id" :ref="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">
       {{ variablesReplacer.replace(label) }}
       <span class="fr-hint-text">{{ description }}</span>
@@ -9,7 +9,7 @@
         pattern="[0-9]*"
         inputmode="numeric"
         :id="id + '_input'"
-        :ref="id + '_ref'"
+        :ref="idRef"
         :name="id"
         :value="internalValue"
         :class="[ customCss, 'fr-input' ]"
@@ -49,12 +49,12 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined },
-    validOnEnter: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {
-      variablesReplacer
+      variablesReplacer,
+      idRef: this.id + '_ref'
     }
   },
   computed: {
@@ -73,7 +73,7 @@ export default defineComponent({
       this.$emit('update:modelValue', value)
     },
     focusInput () {
-      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      const focusableElement = (this.$refs[this.idRef]) as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
       }
@@ -84,7 +84,7 @@ export default defineComponent({
     if (this.modelValue === null) {
       this.$emit('update:modelValue', this.internalValue)
     }
-    const element = this.$refs.counter as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-input-group" :id="id">
+  <div class="fr-input-group" :id="id" ref="counter">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">
       {{ variablesReplacer.replace(label) }}
       <span class="fr-hint-text">{{ description }}</span>
@@ -9,6 +9,7 @@
         pattern="[0-9]*"
         inputmode="numeric"
         :id="id + '_input'"
+        :ref="id + '_ref'"
         :name="id"
         :value="internalValue"
         :class="[ customCss, 'fr-input' ]"
@@ -41,14 +42,14 @@ export default defineComponent({
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
     defaultValue: { type: Number, default: null },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {
@@ -69,12 +70,22 @@ export default defineComponent({
     updateValue (event: Event) {
       const value = (event.target as HTMLInputElement).value
       this.$emit('update:modelValue', value)
+    },
+    focusInput () {
+      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      if (focusableElement) {
+        focusableElement.focus()
+      }
     }
   },
   emits: ['update:modelValue'],
   mounted () {
     if (this.modelValue === null) {
       this.$emit('update:modelValue', this.internalValue)
+    }
+    const element = this.$refs.counter as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -47,7 +47,8 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {
@@ -66,7 +67,7 @@ export default defineComponent({
   },
   methods: {
     updateValue (event: Event) {
-      let value = (event.target as HTMLInputElement).value
+      const value = (event.target as HTMLInputElement).value
       this.$emit('update:modelValue', value)
     }
   },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -41,7 +41,8 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   computed: {
     internalValue: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="fr-input-group" :id="id" ref="date">
+  <div class="fr-input-group" :id="id" :ref="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">{{ label }}</label>
     <span v-if="hint !== ''" class="fr-hint-text">{{ hint }}</span>
     <input
       type="date"
       :id="id + '_input'"
-      :ref="id + '_ref'"
+      :ref="idRef"
       :name="id"
       :value="internalValue"
       :class="[ customCss, 'fr-input' ]"
@@ -43,11 +43,15 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined },
-    validOnEnter: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: undefined }
+  },
+  data () {
+    return {
+      idRef: this.id + '_ref'
+    }
   },
   mounted () {
-    const element = this.$refs.date as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }
@@ -68,7 +72,7 @@ export default defineComponent({
       this.$emit('update:modelValue', value)
     },
     focusInput () {
-      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      const focusableElement = (this.$refs[this.idRef]) as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
       }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -43,7 +43,8 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    validOnEnter: { type: Boolean, default: false }
   },
   mounted () {
     const element = this.$refs.date as HTMLElement

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -1,10 +1,11 @@
 <template>
-  <div class="fr-input-group" :id="id">
+  <div class="fr-input-group" :id="id" ref="date">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">{{ label }}</label>
     <span v-if="hint !== ''" class="fr-hint-text">{{ hint }}</span>
     <input
       type="date"
       :id="id + '_input'"
+      :ref="id + '_ref'"
       :name="id"
       :value="internalValue"
       :class="[ customCss, 'fr-input' ]"
@@ -34,6 +35,7 @@ export default defineComponent({
     customCss: { type: String, default: '' },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
@@ -41,8 +43,13 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: undefined }
+  },
+  mounted () {
+    const element = this.$refs.date as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
+    }
   },
   computed: {
     internalValue: {
@@ -58,6 +65,12 @@ export default defineComponent({
     updateValue (event: Event) {
       const value = (event.target as HTMLInputElement).value
       this.$emit('update:modelValue', value)
+    },
+    focusInput () {
+      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      if (focusableElement) {
+        focusableElement.focus()
+      }
     }
   },
   emits: ['update:modelValue']

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -2,10 +2,12 @@
   <div
     :class="['signalement-form-disorder-category-item fr-container--fluid fr-p-3v', isSelected || isAlreadySelected ? categoryZoneCss : '']"
     @click="handleClick"
+    ref="disordercategoryitem"
     >
       <input
       type="checkbox"
       :id="id + '_input'"
+      :ref="id + '_ref'"
       :name="id"
       v-model="isSelected"
       @change="handleChange"
@@ -33,12 +35,19 @@ export default defineComponent({
     label: { type: String, default: '' },
     iconSrc: { type: String, default: '' },
     modelValue: { type: Boolean, default: false },
-    clickEvent: Function
+    clickEvent: Function,
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {
       isSelected: this.modelValue,
       formStore
+    }
+  },
+  mounted () {
+    const element = this.$refs.disordercategoryitem as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
     }
   },
   computed: {
@@ -68,6 +77,12 @@ export default defineComponent({
     },
     updateValue () {
       this.$emit('update:modelValue', this.isSelected)
+    },
+    focusInput () {
+      const focusableElement = this.$refs[this.id + '_ref'] as HTMLElement
+      if (focusableElement) {
+        focusableElement.focus()
+      }
     }
   },
   emits: ['update:modelValue']

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -36,7 +36,8 @@ export default defineComponent({
     iconSrc: { type: String, default: '' },
     modelValue: { type: Boolean, default: false },
     clickEvent: Function,
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -2,12 +2,12 @@
   <div
     :class="['signalement-form-disorder-category-item fr-container--fluid fr-p-3v', isSelected || isAlreadySelected ? categoryZoneCss : '']"
     @click="handleClick"
-    ref="disordercategoryitem"
+    :ref="id"
     >
       <input
       type="checkbox"
       :id="id + '_input'"
-      :ref="id + '_ref'"
+      :ref="idRef"
       :name="id"
       v-model="isSelected"
       @change="handleChange"
@@ -36,17 +36,17 @@ export default defineComponent({
     iconSrc: { type: String, default: '' },
     modelValue: { type: Boolean, default: false },
     clickEvent: Function,
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {
       isSelected: this.modelValue,
-      formStore
+      formStore,
+      idRef: this.id + '_ref'
     }
   },
   mounted () {
-    const element = this.$refs.disordercategoryitem as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }
@@ -80,7 +80,7 @@ export default defineComponent({
       this.$emit('update:modelValue', this.isSelected)
     },
     focusInput () {
-      const focusableElement = this.$refs[this.id + '_ref'] as HTMLElement
+      const focusableElement = this.$refs[this.idRef] as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
       }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -39,7 +39,8 @@ export default defineComponent({
     hasError: { type: Boolean, default: false },
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -11,6 +11,7 @@
             :id="component.slug"
             :label="component.label"
             :iconSrc="component.icon.src"
+            :access_focus="component.accessibility?.focus"
             :clickEvent="handleUpdateSelected"
             />
       </div>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -41,8 +41,7 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryList.vue
@@ -41,7 +41,8 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="id" class="signalement-form-disorder-overview fr-container--fluid fr-my-3v" ref="disorderoverview">
+  <div :id="id" class="signalement-form-disorder-overview fr-container--fluid fr-my-3v" :ref="id">
     <div v-if="formStore.data.categorieDisorders.batiment.length > 0">
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
         <div class="fr-col-2 fr-col-md-1"><img :src="icons ? icons[0].src : ''" :alt="icons ? icons[0].alt : ''" class="fr-disorder-overview-image"></div>
@@ -20,7 +20,7 @@
                 class="fr-accordion__btn"
                 aria-expanded="false"
                 :aria-controls="'accordion-disorder-batiment-' + index"
-                :ref="id + '_ref'"
+                :ref="idRef"
                 >
                 {{ dictionaryStore[disorder].default }}
               </button>
@@ -30,7 +30,7 @@
                 class="fr-accordion__btn"
                 aria-expanded="false"
                 :aria-controls="'accordion-disorder-batiment-' + index"
-                :ref="id + '_ref'"
+                :ref="idRef"
                 >
                 {{ dictionaryStore[disorder].default }}
               </button>
@@ -68,7 +68,7 @@
                 class="fr-accordion__btn"
                 aria-expanded="false"
                 :aria-controls="'accordion-disorder-logement-' + index"
-                :ref="id + '_ref'"
+                :ref="idRef"
                 >
                 {{ dictionaryStore[disorder].default }}
               </button>
@@ -78,7 +78,7 @@
                 class="fr-accordion__btn"
                 aria-expanded="false"
                 :aria-controls="'accordion-disorder-logement-' + index"
-                :ref="id + '_ref'"
+                :ref="idRef"
                 >
                 {{ dictionaryStore[disorder].default }}
               </button>
@@ -143,18 +143,18 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' },
-    validOnEnter: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {
       formStore,
       dictionaryStore,
-      idMessageAdministration: 'message_administration'
+      idMessageAdministration: 'message_administration',
+      idRef: this.id + '_ref'
     }
   },
   mounted () {
-    const element = this.$refs.disorderoverview as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }
@@ -253,7 +253,7 @@ export default defineComponent({
       this.formStore.data[this.idMessageAdministration] = value
     },
     focusInput () {
-      const focusableElement = (this.$refs[this.id + '_ref']) as Array<HTMLElement>
+      const focusableElement = (this.$refs[this.idRef]) as Array<HTMLElement>
       if (focusableElement[0]) {
         focusableElement[0].focus()
       }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="id" class="signalement-form-disorder-overview fr-container--fluid fr-my-3v">
+  <div :id="id" class="signalement-form-disorder-overview fr-container--fluid fr-my-3v" ref="disorderoverview">
     <div v-if="formStore.data.categorieDisorders.batiment.length > 0">
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
         <div class="fr-col-2 fr-col-md-1"><img :src="icons ? icons[0].src : ''" :alt="icons ? icons[0].alt : ''" class="fr-disorder-overview-image"></div>
@@ -16,10 +16,24 @@
             v-if="hasCategoryFields(disorder)"
             >
             <h6 v-if="isValidationScreen" class="fr-accordion__title">
-              <button class="fr-accordion__btn" aria-expanded="false" :aria-controls="'accordion-disorder-batiment-' + index">{{ dictionaryStore[disorder].default }}</button>
+              <button
+                class="fr-accordion__btn"
+                aria-expanded="false"
+                :aria-controls="'accordion-disorder-batiment-' + index"
+                :ref="id + '_ref'"
+                >
+                {{ dictionaryStore[disorder].default }}
+              </button>
             </h6>
             <h4 v-else  class="fr-accordion__title">
-              <button class="fr-accordion__btn" aria-expanded="false" :aria-controls="'accordion-disorder-batiment-' + index">{{ dictionaryStore[disorder].default }}</button>
+              <button
+                class="fr-accordion__btn"
+                aria-expanded="false"
+                :aria-controls="'accordion-disorder-batiment-' + index"
+                :ref="id + '_ref'"
+                >
+                {{ dictionaryStore[disorder].default }}
+              </button>
             </h4>
             <div class="fr-collapse" :id="'accordion-disorder-batiment-' + index">
               <div
@@ -50,10 +64,24 @@
             v-if="hasCategoryFields(disorder)"
             >
             <h6 v-if="isValidationScreen" class="fr-accordion__title">
-              <button class="fr-accordion__btn" aria-expanded="false" :aria-controls="'accordion-disorder-logement-' + index">{{ dictionaryStore[disorder].default }}</button>
+              <button
+                class="fr-accordion__btn"
+                aria-expanded="false"
+                :aria-controls="'accordion-disorder-logement-' + index"
+                :ref="id + '_ref'"
+                >
+                {{ dictionaryStore[disorder].default }}
+              </button>
             </h6>
             <h4 v-else class="fr-accordion__title">
-              <button class="fr-accordion__btn" aria-expanded="false" :aria-controls="'accordion-disorder-logement-' + index">{{ dictionaryStore[disorder].default }}</button>
+              <button
+                class="fr-accordion__btn"
+                aria-expanded="false"
+                :aria-controls="'accordion-disorder-logement-' + index"
+                :ref="id + '_ref'"
+                >
+                {{ dictionaryStore[disorder].default }}
+              </button>
             </h4>
             <div class="fr-collapse" :id="'accordion-disorder-logement-' + index">
               <div
@@ -107,6 +135,7 @@ export default defineComponent({
     id: { type: String, default: null },
     icons: { type: Object },
     isValidationScreen: { type: Boolean, default: false },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
@@ -114,14 +143,19 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {
       formStore,
       dictionaryStore,
       idMessageAdministration: 'message_administration'
+    }
+  },
+  mounted () {
+    const element = this.$refs.disorderoverview as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
     }
   },
   methods: {
@@ -216,6 +250,12 @@ export default defineComponent({
     updateValue (event: Event) {
       const value = (event.target as HTMLInputElement).value
       this.formStore.data[this.idMessageAdministration] = value
+    },
+    focusInput () {
+      const focusableElement = (this.$refs[this.id + '_ref']) as Array<HTMLElement>
+      if (focusableElement[0]) {
+        focusableElement[0].focus()
+      }
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -143,7 +143,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -114,7 +114,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -49,7 +49,8 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     clickEvent: Function,
-    handleClickComponent: Function
+    handleClickComponent: Function,
+    validOnEnter: { type: Boolean, default: false }
   },
   computed: {
     internalValue: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -44,6 +44,7 @@ export default defineComponent({
     error: { type: String, default: '' },
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -8,6 +8,7 @@
       <input
         type="email"
         :id="id + '_input'"
+        :ref="idRef"
         :name="access_name"
         :autocomplete="access_autocomplete"
         :value="internalValue"
@@ -49,8 +50,12 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     clickEvent: Function,
-    handleClickComponent: Function,
-    validOnEnter: { type: Boolean, default: false }
+    handleClickComponent: Function
+  },
+  data () {
+    return {
+      idRef: this.id + '_ref'
+    }
   },
   computed: {
     internalValue: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormInfo.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormInfo.vue
@@ -25,7 +25,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormInfo.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormInfo.vue
@@ -26,7 +26,8 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormInfo.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormInfo.vue
@@ -26,8 +26,7 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
@@ -37,7 +37,8 @@ export default defineComponent({
     // et ça soulève des erreurs W3C
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
@@ -1,7 +1,8 @@
 <template>
-  <div class="signalement-form-link">
+  <div class="signalement-form-link" ref="link">
     <a
       :id="id"
+      :ref="id + '_ref'"
       :class="[ customCss ]"
       :href="variablesReplacer.replace(link)"
       :target="linktarget"
@@ -30,24 +31,36 @@ export default defineComponent({
     customCss: { type: String, default: '' },
     ariaControls: { type: String, default: undefined },
     clickEvent: Function,
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: undefined }
+  },
+  data () {
+    return {
+      variablesReplacer
+    }
+  },
+  mounted () {
+    const element = this.$refs.link as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
+    }
   },
   methods: {
     handleClick () {
       if (this.clickEvent !== undefined) {
         this.clickEvent(this.id)
       }
-    }
-  },
-  data () {
-    return {
-      variablesReplacer
+    },
+    focusInput () {
+      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      if (focusableElement) {
+        focusableElement.focus()
+      }
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="signalement-form-link" ref="link">
+  <div class="signalement-form-link" :ref="id">
     <a
       :id="id"
-      :ref="id + '_ref'"
+      :ref="idRef"
       :class="[ customCss ]"
       :href="variablesReplacer.replace(link)"
       :target="linktarget"
@@ -37,16 +37,16 @@ export default defineComponent({
     // et ça soulève des erreurs W3C
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined },
-    validOnEnter: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {
-      variablesReplacer
+      variablesReplacer,
+      idRef: this.id + '_ref'
     }
   },
   mounted () {
-    const element = this.$refs.link as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }
@@ -58,7 +58,7 @@ export default defineComponent({
       }
     },
     focusInput () {
-      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      const focusableElement = (this.$refs[this.idRef]) as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
       }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormLink.vue
@@ -35,7 +35,8 @@ export default defineComponent({
     // et ça soulève des erreurs W3C
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   methods: {
     handleClick () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -48,7 +48,8 @@ export default defineComponent({
     clickEvent: Function,
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   methods: {
     closeModal () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -49,8 +49,7 @@ export default defineComponent({
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   methods: {
     closeModal () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormModal.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormModal.vue
@@ -49,7 +49,8 @@ export default defineComponent({
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   methods: {
     closeModal () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -62,7 +62,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -42,6 +42,7 @@ export default defineComponent({
     validate: { type: Object, default: null },
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
@@ -53,6 +54,16 @@ export default defineComponent({
   data () {
     return {
       variablesReplacer
+    }
+  },
+  mounted () {
+    if (this.access_focus) {
+      this.$nextTick(() => {
+        const element = document.querySelector('#' + this.id + '_' + this.values[0].value) as HTMLElement
+        if (element) {
+          element.focus()
+        }
+      })
     }
   },
   methods: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -1,13 +1,26 @@
 <template>
-  <fieldset :id="id" :class="[customCss, 'signalement-form-only-choice fr-fieldset']" :aria-labelledby="id + '-radio-hint-legend'">
-      <legend :class="['fr-fieldset__legend--regular', 'fr-fieldset__legend', customLegendCss]" :id="id + '-radio-hint-legend'">
+  <fieldset
+    :id="id"
+    :class="[customCss, 'signalement-form-only-choice fr-fieldset']"
+    :aria-labelledby="id + '-radio-hint-legend'"
+    ref="onlychoice"
+    >
+      <legend
+        :class="['fr-fieldset__legend--regular', 'fr-fieldset__legend', customLegendCss]"
+        :id="id + '-radio-hint-legend'"
+        >
         {{ variablesReplacer.replace(label) }}
       </legend>
-      <div v-for="radioValue in values" :class="['fr-fieldset__element', (radioValue.value === 'oui' || radioValue.value === 'non') ? 'item-divided' : '']" :key="radioValue.value">
+      <div
+        v-for="radioValue in values"
+        :class="['fr-fieldset__element', (radioValue.value === 'oui' || radioValue.value === 'non') ? 'item-divided' : '']"
+        :key="radioValue.value"
+        >
           <div :class="['fr-radio-group', modelValue == radioValue.value ? 'is-checked' : '']">
             <input
               type="radio"
               :id="id + '_' + radioValue.value"
+              :ref="id + '_' + radioValue.value + '_ref'"
               :name="id"
               v-bind:key="radioValue.value"
               :value="radioValue.value"
@@ -57,19 +70,21 @@ export default defineComponent({
     }
   },
   mounted () {
-    if (this.access_focus) {
-      this.$nextTick(() => {
-        const element = document.querySelector('#' + this.id + '_' + this.values[0].value) as HTMLElement
-        if (element) {
-          element.focus()
-        }
-      })
+    const element = this.$refs.onlychoice as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
     }
   },
   methods: {
     updateValue (event: Event) {
       const value = (event.target as HTMLInputElement).getAttribute('value')
       this.$emit('update:modelValue', value)
+    },
+    focusInput () {
+      const focusableElement = (this.$refs[this.id + '_' + this.values[0].value + '_ref']) as Array<HTMLElement>
+      if (focusableElement[0]) {
+        focusableElement[0].focus()
+      }
     }
   },
   computed: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -3,7 +3,7 @@
     :id="id"
     :class="[customCss, 'signalement-form-only-choice fr-fieldset']"
     :aria-labelledby="id + '-radio-hint-legend'"
-    ref="onlychoice"
+    :ref="id"
     >
       <legend
         :class="['fr-fieldset__legend--regular', 'fr-fieldset__legend', customLegendCss]"
@@ -62,16 +62,16 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined },
-    validOnEnter: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: undefined }
   },
   data () {
     return {
-      variablesReplacer
+      variablesReplacer,
+      idRef: this.id + '_ref'
     }
   },
   mounted () {
-    const element = this.$refs.onlychoice as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -209,8 +209,7 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -208,7 +208,8 @@ export default defineComponent({
     hasError: { type: Boolean, default: false },
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -209,7 +209,8 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -11,7 +11,7 @@
             <h4 class="fr-h6">Adresse du logement</h4>
           </div>
           <div class="fr-col-4 fr-text--right">
-            <button @click="handleEdit('adresse_logement')" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-edit-line">Editer</button>
+            <button @click="handleEdit('adresse_logement')" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-edit-line" ref="firstbutton">Editer</button>
           </div>
         </div>
         <p v-html="getFormDataAdresse()"></p>
@@ -219,6 +219,9 @@ export default defineComponent({
       disorderIcons: [{ src: '/img/form/BATIMENT/Picto-batiment.svg', alt: '' }, { src: '/img/form/LOGEMENT/Picto-logement.svg', alt: '' }]
     }
   },
+  mounted () {
+    this.focusInput()
+  },
   methods: {
     getFormDataAdresse (): string {
       let result = ''
@@ -398,6 +401,12 @@ export default defineComponent({
     handleEdit (screenSlug: string) {
       if (this.clickEvent !== undefined) {
         this.clickEvent('goto', screenSlug, '')
+      }
+    },
+    focusInput () {
+      const focusableElement = (this.$refs.firstbutton) as HTMLElement
+      if (focusableElement) {
+        focusableElement.focus()
       }
     }
   }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -27,34 +27,13 @@
           <input
             type="text"
             :id="id"
+            :ref="idRef"
             :name="access_name"
             :autocomplete="access_autocomplete"
             v-model="formStore.data[id]"
             class="fr-input"
             :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
             >
-            <option
-              v-for="countryItem in countryList"
-              v-bind:key="countryItem.code"
-              :value="countryItem.code"
-              >
-              {{ countryItem.label }}
-            </option>
-          </select>
-        </div>
-        <div class="fr-col-12 fr-col-md-8">
-          <div class="fr-input-wrap fr-icon-phone-line">
-            <input
-              type="text"
-              :id="id"
-              :ref="idRef"
-              :name="access_name"
-              :autocomplete="access_autocomplete"
-              v-model="formStore.data[id]"
-              class="fr-input"
-              :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
-              >
-          </div>
         </div>
       </div>
       <div

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -125,6 +125,7 @@ export default defineComponent({
     error: { type: String, default: '' },
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
     clickEvent: Function,
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -33,6 +33,28 @@
             class="fr-input"
             :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
             >
+            <option
+              v-for="countryItem in countryList"
+              v-bind:key="countryItem.code"
+              :value="countryItem.code"
+              >
+              {{ countryItem.label }}
+            </option>
+          </select>
+        </div>
+        <div class="fr-col-12 fr-col-md-8">
+          <div class="fr-input-wrap fr-icon-phone-line">
+            <input
+              type="text"
+              :id="id"
+              :ref="idRef"
+              :name="access_name"
+              :autocomplete="access_autocomplete"
+              v-model="formStore.data[id]"
+              class="fr-input"
+              :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
+              >
+          </div>
         </div>
       </div>
       <div
@@ -131,8 +153,7 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     modelValue: { type: String, default: null },
-    handleClickComponent: Function,
-    validOnEnter: { type: Boolean, default: false }
+    handleClickComponent: Function
   },
   data () {
     if (formStore.data[this.id + '_countrycode'] === '' || formStore.data[this.id + '_countrycode'] === undefined) {
@@ -149,7 +170,8 @@ export default defineComponent({
       idCountryCodeSecond: this.id + '_secondaire_countrycode',
       idShow: this.id + '_ajouter_numero',
       actionShow: 'show:' + this.id + '_secondaire_group',
-      formStore
+      formStore,
+      idRef: this.id + '_ref'
     }
   },
   methods: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -131,7 +131,8 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     modelValue: { type: String, default: null },
-    handleClickComponent: Function
+    handleClickComponent: Function,
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     if (formStore.data[this.id + '_countrycode'] === '' || formStore.data[this.id + '_countrycode'] === undefined) {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -71,7 +71,8 @@ export default defineComponent({
     // et ça soulève des erreurs W3C
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -69,7 +69,8 @@ export default defineComponent({
     // et ça soulève des erreurs W3C
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -18,6 +18,7 @@
         :hasError="formStore.validationErrors[idPieceAVivre]  !== undefined"
         :error="formStore.validationErrors[idPieceAVivre]"
         @update:modelValue="handleCheckBox(idPieceAVivre)"
+        :access_focus="access_focus"
       />
       <SignalementFormCheckbox
         v-if="formStore.data.type_logement_commodites_cuisine === 'oui'"
@@ -64,13 +65,13 @@ export default defineComponent({
     hasError: { type: Boolean, default: false },
     error: { type: String, default: '' },
     clickEvent: Function,
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -71,8 +71,7 @@ export default defineComponent({
     // et ça soulève des erreurs W3C
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' },
-    validOnEnter: { type: Boolean, default: false }
+    access_autocomplete: { type: String, default: '' }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -46,6 +46,7 @@
         :access_name="component.accessibility?.name ?? component.slug"
         :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
         :access_focus="component.accessibility?.focus ?? false"
+        :validOnEnter="component.validOnEnter ?? false"
       />
     </div>
   </div>
@@ -81,6 +82,8 @@
         :class="{ 'fr-hidden': component.conditional && !formStore.shouldShowField(component.conditional.show) }"
         :clickEvent="handleClickComponent"
         :handleClickComponent="handleClickComponent"
+        :access_focus="component.accessibility?.focus ?? false"
+        :validOnEnter="component.validOnEnter ?? false"
       />
     </div>
   </div>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -46,8 +46,7 @@
         :access_name="component.accessibility?.name ?? component.slug"
         :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
         :access_focus="component.accessibility?.focus ?? false"
-        :validOnEnter="component.validOnEnter ?? false"
-      />
+        />
     </div>
   </div>
   <div
@@ -83,7 +82,6 @@
         :clickEvent="handleClickComponent"
         :handleClickComponent="handleClickComponent"
         :access_focus="component.accessibility?.focus ?? false"
-        :validOnEnter="component.validOnEnter ?? false"
       />
     </div>
   </div>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -45,6 +45,7 @@
         :handleClickComponent="handleClickComponent"
         :access_name="component.accessibility?.name ?? component.slug"
         :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
+        :access_focus="component.accessibility?.focus ?? false"
       />
     </div>
   </div>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -13,7 +13,6 @@
         :access_name="component.accessibility?.name ?? component.slug"
         :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
         :access_focus="component.accessibility?.focus ?? false"
-        :validOnEnter="component.validOnEnter ?? false"
         :label="component.label"
         :hint="component.hint"
         :labelInfo="component.labelInfo"
@@ -104,8 +103,7 @@ export default defineComponent({
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
     access_focus: { type: Boolean, default: false },
-    clickEvent: Function,
-    validOnEnter: { type: Boolean, default: false }
+    clickEvent: Function
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -12,6 +12,8 @@
         :id="component.slug"
         :access_name="component.accessibility?.name ?? component.slug"
         :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
+        :access_focus="component.accessibility?.focus ?? false"
+        :validOnEnter="component.validOnEnter ?? false"
         :label="component.label"
         :hint="component.hint"
         :labelInfo="component.labelInfo"

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -104,7 +104,8 @@ export default defineComponent({
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
     access_focus: { type: Boolean, default: false },
-    clickEvent: Function
+    clickEvent: Function,
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -101,6 +101,7 @@ export default defineComponent({
     hasError: { type: Boolean, default: undefined },
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false },
     clickEvent: Function
   },
   data () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -50,7 +50,8 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   computed: {
     internalValue: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -49,7 +49,8 @@ export default defineComponent({
     clickEvent: Function,
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
-    access_autocomplete: { type: String, default: '' }
+    access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false }
   },
   computed: {
     internalValue: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -50,8 +50,7 @@ export default defineComponent({
     handleClickComponent: Function,
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   computed: {
     internalValue: {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -1,5 +1,5 @@
 <template>
-<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id">
+<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id" ref="textfield">
   <label class='fr-label' :for="id + '_input'">
     {{ variablesReplacer.replace(label) }}
     <span class="fr-hint-text">{{ description }}</span>
@@ -8,6 +8,7 @@
       <input
         type="text"
         :id="id + '_input'"
+        :ref="id + '_ref'"
         :name="access_name"
         :autocomplete="access_autocomplete"
         :value="internalValue"
@@ -63,6 +64,12 @@ export default defineComponent({
       variablesReplacer
     }
   },
+  mounted () {
+    const element = this.$refs.textfield as HTMLElement
+    if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
+      this.focusInput()
+    }
+  },
   computed: {
     internalValue: {
       get () {
@@ -79,6 +86,16 @@ export default defineComponent({
       this.$emit('update:modelValue', value)
       if (this.tagWhenEdit !== '') {
         formStore.data[this.tagWhenEdit] = 1
+      }
+    },
+    focusInput () {
+      // console.log('focusInput textfield')
+      // console.log(this.id + '_ref')
+      // console.log(this.$refs)
+      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      // console.log(focusableElement)
+      if (focusableElement) {
+        focusableElement.focus()
       }
     }
   },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -1,5 +1,5 @@
 <template>
-<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id" ref="textfield">
+<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id" :ref="id">
   <label class='fr-label' :for="id + '_input'">
     {{ variablesReplacer.replace(label) }}
     <span class="fr-hint-text">{{ description }}</span>
@@ -8,7 +8,7 @@
       <input
         type="text"
         :id="id + '_input'"
-        :ref="id + '_ref'"
+        :ref="idRef"
         :name="access_name"
         :autocomplete="access_autocomplete"
         :value="internalValue"
@@ -56,17 +56,17 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     clickEvent: Function,
-    handleClickComponent: Function,
-    validOnEnter: { type: Boolean, default: false }
+    handleClickComponent: Function
   },
   data () {
     return {
       idFetchTimeout: 0 as unknown as ReturnType<typeof setTimeout>,
-      variablesReplacer
+      variablesReplacer,
+      idRef: this.id + '_ref'
     }
   },
   mounted () {
-    const element = this.$refs.textfield as HTMLElement
+    const element = this.$refs[this.id] as HTMLElement
     if (this.access_focus && element && !element.classList.contains('fr-hidden')) {
       this.focusInput()
     }
@@ -90,7 +90,7 @@ export default defineComponent({
       }
     },
     focusInput () {
-      const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
+      const focusableElement = (this.$refs[this.idRef]) as HTMLElement
       if (focusableElement) {
         focusableElement.focus()
       }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -56,7 +56,8 @@ export default defineComponent({
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
     clickEvent: Function,
-    handleClickComponent: Function
+    handleClickComponent: Function,
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {
@@ -89,11 +90,7 @@ export default defineComponent({
       }
     },
     focusInput () {
-      // console.log('focusInput textfield')
-      // console.log(this.id + '_ref')
-      // console.log(this.$refs)
       const focusableElement = (this.$refs[this.id + '_ref']) as HTMLElement
-      // console.log(focusableElement)
       if (focusableElement) {
         focusableElement.focus()
       }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -50,6 +50,7 @@ export default defineComponent({
     tagWhenEdit: { type: String, default: '' },
     access_name: { type: String, default: '' },
     access_autocomplete: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -81,7 +81,6 @@ export default defineComponent({
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C
-    hasError: { type: Boolean, default: false },
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -85,7 +85,8 @@ export default defineComponent({
     clickEvent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -85,8 +85,7 @@ export default defineComponent({
     clickEvent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -85,7 +85,8 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
@@ -46,7 +46,8 @@ export default defineComponent({
     clickEvent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
@@ -45,7 +45,8 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadPhotos.vue
@@ -46,8 +46,7 @@ export default defineComponent({
     clickEvent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormWarning.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormWarning.vue
@@ -25,7 +25,8 @@ export default defineComponent({
     handleClickComponent: Function,
     clickEvent: Function,
     access_name: { type: String, default: undefined },
-    access_autocomplete: { type: String, default: undefined }
+    access_autocomplete: { type: String, default: undefined },
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormWarning.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormWarning.vue
@@ -26,8 +26,7 @@ export default defineComponent({
     clickEvent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false },
-    validOnEnter: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormWarning.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormWarning.vue
@@ -26,7 +26,8 @@ export default defineComponent({
     clickEvent: Function,
     access_name: { type: String, default: undefined },
     access_autocomplete: { type: String, default: undefined },
-    access_focus: { type: Boolean, default: false }
+    access_focus: { type: Boolean, default: false },
+    validOnEnter: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -71,7 +71,7 @@ suivis:
   type: 1
 -
   created_by: null
-  description: "Ajout d'un signalement postcloture par l'usager"
+  description: "Je ne comprends pas pourquoi mon signalement a été cloturé, j'ai toujours des soucis ! (suivi de type 5 post-cloture)"
   is_public: 1
   signalement: "2022-2"
   type: 5


### PR DESCRIPTION
## Ticket

#2991 
#2993 

## Description
Correction de la navigation au clavier sur le formulaire
- ordre de tabulation
- focus sur le premier élément
- gestion de la navigation au clavier dans les éléments complexes (sélecteur d'adresse par exemple)

## Changements apportés
* Ajout d'un paramètre `focus` dans les paramètres `accessibility` dans tous les json, et gestion de ce paramètre dans tous les composants pour mettre le focus sur l'élément choisi quand on arrive sur l'écran
* Inversion des boutons `suivant` et `précédent` sur tous les écrans, en les mettant dans un `SignalementFormSubscreen` avec la css `button-group-responsive-inverted` pour que le bouton `suivant` soit accessible avant le bouton `précédent` en tabulation
* Gestion de la navigation au clavier dans le composant `SignalementFormAddress`
* Changement d'un texte de suivi dans les fixtures (n'a rien à voir avec la choucroute, mais ça a perturbé Mathilde pendant ces tests sur une reviewapp)

## Pré-requis
`npm run watch`

## Tests
- Dans l'idéal, tester le formulaire au clavier pour tous les profils et tous les désordres et en passant sur tous les écrans. En vrai en faire le max possible, en variant
- Pour chaque écran, vérifier 
- [ ] l'ordre de tabulation
- [ ] le focus mis sur le premier élément
- [ ] le bouton suivant accessible avant le bouton précédent
- [ ] la navigation au clavier sans piège dans les composants plus complexes
