### PR TITLE
[IDOSS] ajout référence

### DIFF
--- a/src/Service/Idoss/IdossService.php
+++ b/src/Service/Idoss/IdossService.php
@@ -161,6 +161,7 @@ class IdossService
             'Dossier' => [
                 'UUIDSignalement' => $dossierMessage->getSignalementUuid(),
                 'dateDepotSignalement' => $dossierMessage->getDateDepotSignalement(),
+                'referenceHistologe' => $dossierMessage->getReference(),
                 'declarant' => $dossierMessage->getDeclarant(),
                 'occupant' => $dossierMessage->getOccupant(),
                 'proprietaire' => $dossierMessage->getProprietaire(),


### PR DESCRIPTION
## Ticket

#3023

## Description
Ajout de la référence du dossier dans le champs dédié "referenceHistologe" lors d'un envoie de dossier à IDOSS

## Pré-requis
s'assurer d'avoir 
```
FEATURE_IDOSS_ENABLE=1
```
`make worker-start`

## Tests
- [ ] Se connecter avec user-13-05@histologe.fr et accepter l'affectation sur le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012
- [ ] Vérifier qu'il y'a une nouvelle entrée dans la table `job_event` de service `idoss` avec un statut `success` et le champ `referenceHistologe` bien renseigné dans la colonne message
