### PR TITLE
[BO - Export] Mauvais format date de visite

### DIFF
--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -11,6 +11,7 @@ use App\Entity\Intervention;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\User;
 use App\Service\Signalement\SignalementAffectationHelper;
+use App\Utils\DateHelper;
 
 class SignalementExportFactory
 {
@@ -46,7 +47,10 @@ class SignalementExportFactory
         );
         $statusVisite = $interventionExploded[0];
         $dateVisite = !empty($interventionExploded[1]) ? $interventionExploded[1] : '';
-        $dateVisite = !empty($dateVisite) ? (new \DateTime($dateVisite))->format(self::DATE_FORMAT) : '';
+        dump($dateVisite);
+        if (DateHelper::isValidDate($dateVisite)) {
+            $dateVisite = !empty($dateVisite) ? (new \DateTime($dateVisite))->format(self::DATE_FORMAT) : '';
+        }
         $isOccupantPresentVisite = !empty($interventionExploded[2]) ? $interventionExploded[2] : '';
 
         $enfantsM6 = null;
@@ -105,8 +109,8 @@ class SignalementExportFactory
             modifiedAt: $modifiedAt,
             closedAt: $closedAt,
             motifCloture: $motifCloture,
-            longitude: is_array($geoloc) ? $geoloc['lng'] : '',
-            latitude: is_array($geoloc) ? $geoloc['lat'] : '',
+            longitude: is_array($geoloc) ? $geoloc['lng'] ?? '' : '',
+            latitude: is_array($geoloc) ? $geoloc['lat'] ?? '' : '',
         );
     }
 

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -47,7 +47,6 @@ class SignalementExportFactory
         );
         $statusVisite = $interventionExploded[0];
         $dateVisite = !empty($interventionExploded[1]) ? $interventionExploded[1] : '';
-        dump($dateVisite);
         if (DateHelper::isValidDate($dateVisite)) {
             $dateVisite = !empty($dateVisite) ? (new \DateTime($dateVisite))->format(self::DATE_FORMAT) : '';
         }

--- a/src/Service/Signalement/Export/SignalementExportLoader.php
+++ b/src/Service/Signalement/Export/SignalementExportLoader.php
@@ -5,11 +5,14 @@ namespace App\Service\Signalement\Export;
 use App\Entity\User;
 use App\Manager\SignalementManager;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-class SignalementExportLoader
+readonly class SignalementExportLoader
 {
     public function __construct(
-        private readonly SignalementManager $signalementManager,
+        private SignalementManager $signalementManager,
+        #[Autowire(env: 'FEATURE_EXPORT_CUSTOM')]
+        private string $featureExportCustom
     ) {
     }
 
@@ -23,7 +26,9 @@ class SignalementExportLoader
         if (empty($selectedColumns)) {
             $selectedColumns = [];
         }
-        $headers = $this->getHeadersWithSelectedColumns($headers, $keysToRemove, $selectedColumns);
+        if ($this->featureExportCustom) {
+            $headers = $this->getHeadersWithSelectedColumns($headers, $keysToRemove, $selectedColumns);
+        }
         $sheetData = [$headers];
 
         foreach ($this->signalementManager->findSignalementAffectationIterable($user, $filters) as $signalementExportItem) {

--- a/src/Utils/DateHelper.php
+++ b/src/Utils/DateHelper.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Utils;
+
+class DateHelper
+{
+    public static function isValidDate($date, $format = 'Y-m-d H:i:s'): bool
+    {
+        $datetime = \DateTimeImmutable::createFromFormat($format, $date);
+
+        return $datetime && $datetime->format($format) === $date;
+    }
+}

--- a/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
+++ b/tests/Unit/Service/Signalement/Export/SignalementExportLoaderTest.php
@@ -30,7 +30,7 @@ class SignalementExportLoaderTest extends TestCase
             ->with($user, $filters)
             ->willReturn($this->getSignalementExportGenerator($signalementExports));
 
-        $loader = new SignalementExportLoader($signalementManager);
+        $loader = new SignalementExportLoader($signalementManager, 0);
         $spreadsheet = $loader->load($user, $filters);
         $this->assertInstanceOf(Spreadsheet::class, $spreadsheet);
         $this->assertEquals('Référence', $spreadsheet->getActiveSheet()->getCell('A1')->getValue());

--- a/tests/Unit/Utils/DateHelperTest.php
+++ b/tests/Unit/Utils/DateHelperTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Utils;
+
+use App\Utils\DateHelper;
+use PHPUnit\Framework\TestCase;
+
+class DateHelperTest extends TestCase
+{
+    /** @dataProvider provideDates */
+    public function testIsValidDate($date, $format, $expected): void
+    {
+        $result = DateHelper::isValidDate($date, $format);
+        $this->assertSame($expected, $result);
+    }
+
+    public function provideDates(): \Generator
+    {
+        yield 'valid date default format' => ['2023-10-05 12:34:56', 'Y-m-d H:i:s', true];
+        yield 'invalid date default format' => ['2023-30-02 12:34:56', 'Y-m-d H:i:s', false];
+        yield 'valid date custom format' => ['05-10-2023', 'd-m-Y', true];
+        yield 'invalid date custom format' => ['31-02-2023', 'd-m-Y', false];
+        yield 'empty date string' => ['', 'Y-m-d H:i:s', false];
+        yield 'null date' => [null, 'Y-m-d H:i:s', false];
+        yield 'non-date string' => ['not-a-date', 'Y-m-d H:i:s', false];
+        yield 'partial date' => ['2023-10-05', 'Y-m-d H:i:s', false];
+    }
+}


### PR DESCRIPTION
## Ticket

#3026   

## Description
La structure actuelle avec les infos de visite peut faire planter l'export, il faut donc vérifier que la chaîne est bien une date avant de créer un objet datetime

https://sentry.incubateur.net/organizations/betagouv/issues/120243/?environment=prod&project=61&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=4

## Changements apportés
* Vérifie que la chaîne de date de visite est bien une date
* Vérification sur le tableau de géolocalisation
* Afficher l'export CSV avec toute les colonnes tant que le nouvel export n'est pas activé

## Pré-requis
*  Récupérer une base de prod
* `make load-data`

## Tests
- [ ] Faire un export sur les Bouches-du-Rhône