### PR TITLE
[FO - Formulaire] Correction conversion de valeurs nulles

### DIFF
--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -548,8 +548,12 @@ class SignalementBuilder
             : $this->evalBoolean($this->signalementDraftRequest->getSignalementConcerneLogementSocialAutreTiers());
     }
 
-    private function convertStringToNumber(?string $value, $returnInt = true): float|int
+    private function convertStringToNumber(?string $value, $returnInt = true): float|int|null
     {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
         if ($returnInt) {
             return (int) preg_replace('/[^0-9]+/', '', $value);
         }


### PR DESCRIPTION
## Ticket

#3008   

## Description
Lorsqu'on transforme des données de types string en nombres, on utilise un preg_replace qui supporte mal de recevoir des valeurs nulles.
On commence donc à vérifier si la donnée est vide, pour la retourner nulle directement.

## Tests
- [ ] Faire un signalement avec le moins de données possibles (service de secours) : le signalement s'enregistre, les données sont correctes
