### PR TITLE
[BO - Statistiques] Correction conversion date quand non définie

### DIFF
--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -88,9 +88,9 @@ class BackStatistiquesController extends AbstractController
         $etiquettes = array_map(fn ($value): int => $value * 1, $strEtiquettes);
         $type = $request->get('type');
         $dateStartInput = $request->get('dateStart');
-        $dateStart = new \DateTime($dateStartInput);
+        $dateStart = (null !== $dateStartInput) ? new \DateTime($dateStartInput) : null;
         $dateEndInput = $request->get('dateEnd');
-        $dateEnd = new \DateTime($dateEndInput);
+        $dateEnd = (null !== $dateEndInput) ? new \DateTime($dateEndInput) : null;
         $hasCountRefused = '1' == $request->get('countRefused');
         $hasCountArchived = '1' == $request->get('countArchived');
 


### PR DESCRIPTION
## Ticket

#3009   

## Description
Dans les stats du BO, lorsque les dates ne sont pas définies, l'instantiation de l'objet `DateTime` ne fonctionne pas.

## Tests
- [ ] Tester les statistiques du BO en supprimant les dates et vérifier le fonctionnement
