### PR TITLE
[QA - sentry] NotFoundHttpException sur les exports pdf des signalements

### DIFF
--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -42,7 +42,7 @@ class SecurityController extends AbstractController
         $request = Request::createFromGlobals();
 
         if (!$this->isCsrfTokenValid('suivi_signalement_ext_file_view', $request->get('t')) && !$this->isGranted('SIGN_VIEW', $signalement)) {
-            throw $this->createNotFoundException();
+            throw $this->createAccessDeniedException();
         }
         try {
             $variant = $request->query->get('variant');

--- a/tests/Functional/Controller/SecurityControllerTest.php
+++ b/tests/Functional/Controller/SecurityControllerTest.php
@@ -46,6 +46,6 @@ class SecurityControllerTest extends WebTestCase
         $client = static::createClient();
         $client->request('GET', '/_up/check.png');
 
-        $this->assertResponseStatusCodeSame(404);
+        $this->assertResponseRedirects('/connexion');
     }
 }


### PR DESCRIPTION
## Ticket

#3010

## Description
En cas de suivi d'un lien d'export PDF sans être connecté le voter levé une exception not found au lieu d'une access denied (qui redirige vers la page de connexion)

## Tests
- [ ] Générer l'export PDF d'un signalement, se déconecter, cliquer sur le lien du mail et vérifier que l'on est à présent dirigé vers la page de login
