### PR TITLE
[BUG] Fix command "app:clear-storage-original-file"

### DIFF
--- a/migrations/Version20240916094002.php
+++ b/migrations/Version20240916094002.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240916094002 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set is_original_deleted to false for all files';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE `file` SET `is_original_deleted`=0 WHERE `is_original_deleted` = 1');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Command/Cron/ClearStorageOriginalFileCommand.php
+++ b/src/Command/Cron/ClearStorageOriginalFileCommand.php
@@ -52,8 +52,9 @@ class ClearStorageOriginalFileCommand extends AbstractCronCommand
         $progressBar = new ProgressBar($output, $nbFilesToProcess);
         $progressBar->start();
         $nbErrors = 0;
-        $nbTmp = 0;
+        $ids = [];
         foreach ($files as $file) {
+            $ids[] = $file->getId();
             $filename = $file->getFilename();
             if ($this->fileStorage->fileExists($filename)) {
                 $this->fileStorage->delete($filename);
@@ -61,9 +62,8 @@ class ClearStorageOriginalFileCommand extends AbstractCronCommand
                 ++$nbErrors;
             }
             $progressBar->advance();
-            ++$nbTmp;
         }
-        $this->fileRepository->updateWithOriginalAndVariants($limit);
+        $this->fileRepository->updateWithOriginalAndVariants($ids);
         $progressBar->finish();
         $this->io->newLine();
         $this->io->success($nbFilesToProcess.' files processed with '.$nbErrors.' files not found');

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -66,13 +66,18 @@ class FileRepository extends ServiceEntityRepository
         return $this->initQueryWithOriginalAndVariants($limit)->select('count(f)')->getQuery()->getSingleScalarResult();
     }
 
-    public function updateWithOriginalAndVariants(\DateTimeInterface $limit): void
+    public function updateWithOriginalAndVariants(array $ids): void
     {
-        $this->initQueryWithOriginalAndVariants($limit)
-            ->update()
-            ->set('f.isOriginalDeleted', true)
-            ->getQuery()
-            ->execute();
+        if (!empty($ids)) {
+            // Étape 2 : Mettre à jour les enregistrements sélectionnés
+            $this->createQueryBuilder('f')
+                ->update()
+                ->set('f.isOriginalDeleted', true)
+                ->where('f.id IN (:ids)')
+                ->setParameter('ids', $ids)
+                ->getQuery()
+                ->execute();
+        }
     }
 
     private function initQueryWithOriginalAndVariants(\DateTimeInterface $limit): QueryBuilder


### PR DESCRIPTION
## Ticket

#3039

## Description
Correction d'une belle bourde dans la #3015 : en fin de commande la requête faisait un update sur tous les fichiers (datant de plus d'un mois) et non pas uniquement ceux traité.

## Tests
- [ ] Lancer la commande `app:clear-storage-original-file` et s'assurer que seul le lot de fichiers traités et mis à jour avec le flag `isOriginalDeleted` a true 
