### PR TITLE
[BO - Export] Impossible d'exporter quand filtre "sans affectation" actif

### DIFF
--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -157,10 +157,16 @@ class SignalementExportFiltersDisplay
 
     private function getPartnersFilterValue(string $filterValue): string
     {
+        if ('AUCUN' === $filterValue) {
+            return 'AUCUN';
+        }
         $listPartners = explode(', ', $filterValue);
         $filterValue = '';
         foreach ($listPartners as $idPartner) {
             $partner = $this->partnerRepository->find($idPartner);
+            if (!$partner) {
+                continue;
+            }
             if (!empty($filterValue)) {
                 $filterValue .= ', ';
             }


### PR DESCRIPTION
## Ticket

#3047

## Description
Fix de la méthode `getPartnersFilterValue` pour le cas ou le filtre "Afficher les signalements sans affectations uniquement" est sélectionné

## Tests
- [ ] Se connecter en tant que RT, sélectionner le filtre "Afficher les signalements sans affectations uniquement", rendre sur la page d'export et vérifier que tout s'affiche sans erreur (en particulier le filtre partenaires)
