### PR TITLE
[BO - Fiche signalement] Afficher les partenaires affectés + leur statut même après clôture

### DIFF
--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -1,15 +1,15 @@
-{% if is_granted('ROLE_ADMIN_TERRITORY')
-        and signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
-        and not needValidation %}
+{% if is_granted('ROLE_ADMIN_TERRITORY') and not needValidation %}
     <div class="fr-grid-row">
         <div class="fr-col-9 fr-col-md-6">
             <h3 class="fr-h5">Partenaires affectés</h3>
         </div>
-        <div class="fr-col-3 fr-col-md-6 fr-text--right">
-            <button class="fr-btn fr-btn--secondary fr-fi-add-line fr-btn--icon-left" data-fr-opened="false" aria-controls="fr-modal-affectation">
-                Affecter des partenaires
-            </button>
-        </div>
+        {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
+            <div class="fr-col-3 fr-col-md-6 fr-text--right">
+                <button class="fr-btn fr-btn--secondary fr-fi-add-line fr-btn--icon-left" data-fr-opened="false" aria-controls="fr-modal-affectation">
+                    Affecter des partenaires
+                </button>
+            </div>
+        {% endif %}
     </div>
 
     <div class="fr-container--fluid">
@@ -58,12 +58,14 @@
                                     <span class="fr-badge fr-badge--sm fr-fi-close-circle-fill">Clôturée</span>
                                 {% endif %}
                             </div>
-                            <div class="fr-col-2 fr-text--right">
-                                <button title="Désaffecter le partenaire"
-                                        data-delete="{{ path('back_signalement_remove_partner',{uuid:signalement.uuid,affectation:affectation.id}) }}"
-                                        data-token="{{ csrf_token('signalement_remove_partner_'~signalement.id) }}"
-                                        class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line partner-row-delete"></button>
-                            </div>
+                            {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
+                                <div class="fr-col-2 fr-text--right">
+                                    <button title="Désaffecter le partenaire"
+                                            data-delete="{{ path('back_signalement_remove_partner',{uuid:signalement.uuid,affectation:affectation.id}) }}"
+                                            data-token="{{ csrf_token('signalement_remove_partner_'~signalement.id) }}"
+                                            class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line partner-row-delete"></button>
+                                </div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Ticket

#3044

## Description
Affichage des affectation même pour un signalement clôturé
(Cependant leurs statut sera toujours clôturées dans ce cas la)

## Tests
- [ ] Clôturer un signalement ayant une ou des affectations et vérifier qu'elle s'affiche toujours
