### PR TITLE
[BO - Dashboard / Menu / Profil] fix UI UX profil

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -835,6 +835,10 @@ a.photo-preview {
     cursor: pointer;
 }
 
+.avatar-histologe{
+    border-radius: 50%;
+    border: 1px solid var(--blue-france-main-525);
+}
 .avatar-placeholder {
     display: flex;
     align-items: center;

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -873,3 +873,7 @@ a.photo-preview {
     height: 26px;
     font-size: 13px;
 }
+
+.text-decoration-underline{
+    text-decoration: underline;
+}

--- a/src/Service/UserAvatar.php
+++ b/src/Service/UserAvatar.php
@@ -29,14 +29,14 @@ class UserAvatar implements RuntimeExtensionInterface
             $src = "data:image/$type;base64,$data64";
 
             return sprintf(
-                '<img src="%s" alt="Avatar de l\'utilisateur" class="avatar-%s">',
+                '<img src="%s" alt="Avatar de l\'utilisateur" class="avatar-histologe avatar-%s">',
                 $src,
                 $size
             );
         }
 
         return sprintf(
-            '<span class="avatar-placeholder avatar-%s">%s</span>',
+            '<span class="avatar-histologe avatar-placeholder avatar-%s">%s</span>',
             $size,
             $zipCode
         );

--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -14,7 +14,7 @@
                         {{ user_avatar_or_placeholder(app.user, 26) }}
                         <div class="fr-ml-3v">
                             <span class="fr-display-block">
-                                <a class="fr-link fr-link--lg" href="{{ path('back_profil') }}" target="_self">{{ app.user.prenom ~' '~app.user.nom[:1]|capitalize~'.' }}</a>
+                                <a class="fr-link fr-link--lg text-decoration-underline" href="{{ path('back_profil') }}" target="_self">{{ app.user.prenom ~' '~app.user.nom[:1]|capitalize~'.' }}</a>
                             </span>
                         </div>
                     </div>

--- a/templates/emails/profil_edit_email.html.twig
+++ b/templates/emails/profil_edit_email.html.twig
@@ -3,6 +3,6 @@
 {% block body %}
     <p>Bonjour,</p>
     <p>Voici le code de confirmation à renseigner pour confirmer votre adresse mail :</p>
-    <p>{{ authCode }}</p>
+    <p><strong style="font-size: 18px;background-color:#ececfe;padding:10px;">{{ authCode }}</strong></p>
     <p>A bientôt sur {{ platform.name }} !</p>
 {% endblock %}

--- a/tests/Unit/Service/UserAvatarTest.php
+++ b/tests/Unit/Service/UserAvatarTest.php
@@ -23,15 +23,15 @@ class UserAvatarTest extends WebTestCase
         $user = (new User())
         ->setRoles([User::ROLES['Super Admin']]);
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user);
-        $this->assertEquals('<span class="avatar-placeholder avatar-74">SA</span>', $outputSpan);
+        $this->assertEquals('<span class="avatar-histologe avatar-placeholder avatar-74">SA</span>', $outputSpan);
 
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user, 80);
-        $this->assertEquals('<span class="avatar-placeholder avatar-80">SA</span>', $outputSpan);
+        $this->assertEquals('<span class="avatar-histologe avatar-placeholder avatar-80">SA</span>', $outputSpan);
 
         $user->setRoles([User::ROLES['Administrateur']]);
         $user->setTerritory((new Territory())->setZip('44'));
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user);
-        $this->assertEquals('<span class="avatar-placeholder avatar-74">44</span>', $outputSpan);
+        $this->assertEquals('<span class="avatar-histologe avatar-placeholder avatar-74">44</span>', $outputSpan);
 
         /** @var ParameterBagInterface $parameterBag */
         $parameterBag = $this->createMock(ParameterBagInterface::class);
@@ -50,11 +50,11 @@ class UserAvatarTest extends WebTestCase
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user);
 
         $this->assertStringContainsString('<img src="data:image/jpg;base64,', $outputSpan);
-        $this->assertStringContainsString('alt="Avatar de l\'utilisateur" class="avatar-74">', $outputSpan);
+        $this->assertStringContainsString('alt="Avatar de l\'utilisateur" class="avatar-histologe avatar-74">', $outputSpan);
 
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user, 100);
 
         $this->assertStringContainsString('<img src="data:image/jpg;base64,', $outputSpan);
-        $this->assertStringContainsString('alt="Avatar de l\'utilisateur" class="avatar-100">', $outputSpan);
+        $this->assertStringContainsString('alt="Avatar de l\'utilisateur" class="avatar-histologe avatar-100">', $outputSpan);
     }
 }


### PR DESCRIPTION
## Ticket

#3042 
#3043 
#3045

## Description
- L'avatar s'affiche dans un cercle entouré d'une bordure (#3042)
- Le nom de l'utilisateur accolé à l'avatar est souligné (#3043)
- Le code de confirmation dans l'email de validation de l'email est sur un fond, en gras et plus gros que le reste du texte (#3045)

## Pré-requis
`make npm-build`

## Tests
- [ ] Vérifier que l'affichage correspond au 3 points de la description
