### PR TITLE
[BO - Fiche signalement] Modifier couleurs / position des badges dans l'en-tête

### DIFF
--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -9,60 +9,67 @@
 
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-7">
-            <div class="fr-mb-4v">
-                {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                    {% if signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') %}
-                        <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
-                    {% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_ACTIVE') %}
-                        <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
-                    {% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') %}
-                        <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
-                    {% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
-                        or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_ARCHIVED') %}
-                        <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
+            <div class="fr-mb-4v">      
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">          
+                    {% if signalement.isLogementSocial is null %}
+                        Parc non renseigné
+                    {% elseif signalement.isLogementSocial %}
+                        Parc public
+                    {% else %}
+                        Parc privé
                     {% endif %}
-                {% else %}
-                    {% if isAffected and not isAccepted and not isRefused and not needValidation and not isClosed and not isClosedForMe %}
-                        <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
-                    {% elseif isAccepted %}
-                        <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
-                    {% elseif isRefused %}
-                        <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
-                    {% elseif isClosedForMe %}
-                        <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
+                </span>
+
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
+                    {% if signalement.isAllocataire in [null, ''] %}
+                        Allocataire non renseigné
+                    {% elseif signalement.isAllocataire in ['oui', '1'] %}
+                        Allocataire
+                    {% elseif signalement.isAllocataire in ['non', '0'] %}
+                        Non allocataire
+                    {% elseif signalement.isAllocataire %}
+                        Allocataire {{ signalement.isAllocataire }}
                     {% endif %}
-                {% endif %}
-                
-                {% if signalement.isLogementSocial is null %}
-                    <span class="fr-badge fr-badge--new fr-badge--no-icon">Parc non renseigné</span>
-                {% elseif signalement.isLogementSocial %}
-                    <span class="fr-badge fr-badge--no-icon">Parc public</span>
-                {% else %}
-                    <span class="fr-badge fr-badge--no-icon">Parc privé</span>
-                {% endif %}
+                </span>
 
-                {% if signalement.isAllocataire in [null, ''] %}
-                    <span class="fr-badge fr-badge--new fr-badge--no-icon">Allocataire non renseigné</span>
-                {% elseif signalement.isAllocataire in ['oui', '1'] %}
-                    <span class="fr-badge fr-badge--success fr-badge--no-icon">Allocataire</span>
-                {% elseif signalement.isAllocataire in ['non', '0'] %}
-                    <span class="fr-badge fr-badge--error fr-badge--no-icon">Non allocataire</span>
-                {% elseif signalement.isAllocataire %}
-                    <span class="fr-badge fr-badge--success fr-badge--no-icon">Allocataire {{ signalement.isAllocataire }}</span>
-                {% endif %}
-
-                {% if signalement.isProprioAverti is null %}
-                    <span class="fr-badge fr-badge--new fr-badge--no-icon">Bailleur averti : NSP</span>
-                {% elseif signalement.isProprioAverti %}
-                    <span class="fr-badge fr-badge--success fr-badge--no-icon">Bailleur averti</span>
-                {% else %}
-                    <span class="fr-badge fr-badge--error fr-badge--no-icon">Bailleur non-averti</span>
-                {% endif %}
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
+                    {% if signalement.isProprioAverti is null %}
+                        Bailleur averti : NSP
+                    {% elseif signalement.isProprioAverti %}
+                        Bailleur averti
+                    {% else %}
+                        Bailleur non-averti
+                    {% endif %}
+                </span>
 
             </div>
 
-            <div>
+            <div class="fr-display-inline-flex fr-align-items-center">
                 <h1 class="fr-h2">#{{ signalement.reference }} {{ signalement.nomOccupant|upper }} {{ signalement.prenomOccupant }}</h1>
+                <div class="fr-h2 fr-ml-3v">
+                    {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+                        {% if signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') %}
+                            <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
+                        {% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_ACTIVE') %}
+                            <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
+                        {% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') %}
+                            <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
+                        {% elseif signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED')
+                            or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_ARCHIVED') %}
+                            <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
+                        {% endif %}
+                    {% else %}
+                        {% if isAffected and not isAccepted and not isRefused and not needValidation and not isClosed and not isClosedForMe %}
+                            <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
+                        {% elseif isAccepted %}
+                            <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
+                        {% elseif isRefused %}
+                            <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
+                        {% elseif isClosedForMe %}
+                            <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
+                        {% endif %}
+                    {% endif %}
+                </div>
             </div>
 
             <div data-ajax-form>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -10,7 +10,7 @@
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-7">
             <div class="fr-mb-4v">      
-                <span class="fr-badge fr-badge--blue-france-975 fr-badge--no-icon fr-m-1v">          
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">          
                     {% if signalement.isLogementSocial is null %}
                         Parc non renseigné
                     {% elseif signalement.isLogementSocial %}
@@ -20,7 +20,7 @@
                     {% endif %}
                 </span>
 
-                <span class="fr-badge fr-badge--blue-france-975 fr-badge--no-icon fr-m-1v">   
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
                     {% if signalement.isAllocataire in [null, ''] %}
                         Allocataire non renseigné
                     {% elseif signalement.isAllocataire in ['oui', '1'] %}
@@ -32,7 +32,7 @@
                     {% endif %}
                 </span>
 
-                <span class="fr-badge fr-badge--blue-france-975 fr-badge--no-icon fr-m-1v">   
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
                     {% if signalement.isProprioAverti is null %}
                         Bailleur averti : NSP
                     {% elseif signalement.isProprioAverti %}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -10,7 +10,7 @@
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-7">
             <div class="fr-mb-4v">      
-                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">          
+                <span class="fr-badge fr-badge--blue-france-975 fr-badge--no-icon fr-m-1v">          
                     {% if signalement.isLogementSocial is null %}
                         Parc non renseigné
                     {% elseif signalement.isLogementSocial %}
@@ -20,7 +20,7 @@
                     {% endif %}
                 </span>
 
-                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
+                <span class="fr-badge fr-badge--blue-france-975 fr-badge--no-icon fr-m-1v">   
                     {% if signalement.isAllocataire in [null, ''] %}
                         Allocataire non renseigné
                     {% elseif signalement.isAllocataire in ['oui', '1'] %}
@@ -32,7 +32,7 @@
                     {% endif %}
                 </span>
 
-                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
+                <span class="fr-badge fr-badge--blue-france-975 fr-badge--no-icon fr-m-1v">   
                     {% if signalement.isProprioAverti is null %}
                         Bailleur averti : NSP
                     {% elseif signalement.isProprioAverti %}

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -7,7 +7,7 @@
 <div>
     <div class="fr-my-3v">
         {% for tag in signalement.tags %}
-            <span class="fr-badge fr-badge--blue-ecume fr-m-1v">{{ tag.label }}</span>
+            <span class="fr-badge fr-badge--info fr-badge--no-icon fr-m-1v">{{ tag.label }}</span>
         {% else %}
             <em class="fr-text-default--warning fr-fi-close-line fr-icon--xs">
                 <small>Aucune étiquette attribuée à ce signalement.</small>


### PR DESCRIPTION
## Ticket

#3040
  
## Description
Pour une meilleure lisibilité, il faudrait :

    Passer tous les badges au-dessus du nom en bleu france
    Mettre le badge "en cours" à droite du nom
    Passer les badges des étiquettes en bleu info


## Changements apportés
* Changement de twig

## Pré-requis

## Tests
- [ ] Ouvrir une fiche signalement, et vérifier les changements d'UI du tickets
