### PR TITLE
[BO - Page export] Masquer les filtres territoire / import en fonction des rôles

### DIFF
--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -31,7 +31,7 @@ class ExportSignalementController extends AbstractController
         $user = $this->getUser();
         $filters = $options = $request->getSession()->get('filters') ?? ['isImported' => '1'];
         $count_signalements = $signalementManager->findSignalementAffectationList($user, $options, true);
-        $textFilters = $signalementExportFiltersDisplay->filtersToText($filters, $user);
+        $textFilters = $signalementExportFiltersDisplay->filtersToText($filters);
 
         return $this->render('back/signalement_export/index.html.twig', [
             'filters' => $textFilters,

--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -31,7 +31,7 @@ class ExportSignalementController extends AbstractController
         $user = $this->getUser();
         $filters = $options = $request->getSession()->get('filters') ?? ['isImported' => '1'];
         $count_signalements = $signalementManager->findSignalementAffectationList($user, $options, true);
-        $textFilters = $signalementExportFiltersDisplay->filtersToText($filters);
+        $textFilters = $signalementExportFiltersDisplay->filtersToText($filters, $user);
 
         return $this->render('back/signalement_export/index.html.twig', [
             'filters' => $textFilters,

--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -4,7 +4,6 @@ namespace App\Service\Signalement\Export;
 
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\SignalementStatus;
-use App\Entity\User;
 use App\Repository\PartnerRepository;
 use App\Repository\TagRepository;
 use App\Repository\TerritoryRepository;
@@ -80,7 +79,8 @@ class SignalementExportFiltersDisplay
     ) {
     }
 
-    public function filtersToText(array $filters): array {
+    public function filtersToText(array $filters): array
+    {
         unset($filters['page']);
         unset($filters['maxItemsPerPage']);
         unset($filters['sortBy']);

--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Repository\PartnerRepository;
 use App\Repository\TagRepository;
 use App\Repository\TerritoryRepository;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class SignalementExportFiltersDisplay
 {
@@ -75,22 +76,20 @@ class SignalementExportFiltersDisplay
         private readonly TerritoryRepository $territoryRepository,
         private readonly PartnerRepository $partnerRepository,
         private readonly TagRepository $tagRepository,
+        private readonly Security $security,
     ) {
     }
 
-    public function filtersToText(
-        array $filters,
-        User $user
-    ): array {
+    public function filtersToText(array $filters): array {
         unset($filters['page']);
         unset($filters['maxItemsPerPage']);
         unset($filters['sortBy']);
         unset($filters['orderBy']);
 
-        if (!\in_array('ROLE_ADMIN', $user->getRoles())) {
+        if (!$this->security->isGranted('ROLE_ADMIN')) {
             unset($filters['territories']);
 
-            if (!\in_array('ROLE_ADMIN_TERRITORY', $user->getRoles())) {
+            if (!$this->security->isGranted('ROLE_ADMIN_TERRITORY')) {
                 unset($filters['isImported']);
             }
         }

--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -89,7 +89,7 @@ class SignalementExportFiltersDisplay
 
         if (!\in_array('ROLE_ADMIN', $user->getRoles())) {
             unset($filters['territories']);
-            
+
             if (!\in_array('ROLE_ADMIN_TERRITORY', $user->getRoles())) {
                 unset($filters['isImported']);
             }

--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -4,6 +4,7 @@ namespace App\Service\Signalement\Export;
 
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\User;
 use App\Repository\PartnerRepository;
 use App\Repository\TagRepository;
 use App\Repository\TerritoryRepository;
@@ -79,11 +80,20 @@ class SignalementExportFiltersDisplay
 
     public function filtersToText(
         array $filters,
+        User $user
     ): array {
         unset($filters['page']);
         unset($filters['maxItemsPerPage']);
         unset($filters['sortBy']);
         unset($filters['orderBy']);
+
+        if (!\in_array('ROLE_ADMIN', $user->getRoles())) {
+            unset($filters['territories']);
+            
+            if (!\in_array('ROLE_ADMIN_TERRITORY', $user->getRoles())) {
+                unset($filters['isImported']);
+            }
+        }
 
         $result = [];
         foreach ($filters as $filterName => $filterValue) {


### PR DESCRIPTION
## Ticket

#3048    

## Description
Sur la page qui permet les exports PDF, on affiche les filtres sélectionnés.
Pour les utilisateurs / admin territoires, on affichait le filtre de territoire, alors qu'ils ne l'ont pas sélectionné (qu'il est juste là par défaut).
Pour les utilisateurs, on affichait le filtre de signalements importés, alors qu'ils ne peuvent pas le sélectionner non plus.

## Changements apportés
* Dans la fonction qui détermine les filtres à afficher, on fait des cas particuliers pour ces deux filtres.

## Tests
- [ ] Tester avec tous les profils, en pré-sélectionnant des filtres, si les filtres affichés sont corrects
