### PR TITLE
[QA] The PDF generation...exceeded the timeout of 60 seconds.

### DIFF
--- a/src/Service/Signalement/Export/SignalementExportPdfGenerator.php
+++ b/src/Service/Signalement/Export/SignalementExportPdfGenerator.php
@@ -10,6 +10,7 @@ class SignalementExportPdfGenerator
 {
     public function __construct(private readonly Pdf $pdf, private readonly ParameterBagInterface $parameterBag)
     {
+        $this->pdf->setTimeout(300);
     }
 
     public function generate(string $content, ?array $options = null): string


### PR DESCRIPTION
## Ticket

#3067

## Description
Augmentation du time out de snappy PDF (par defaut a 60 sec) afin de pouvoir générer des PDF avec plein plein d'images

## Pré-requis
`make worker-start`

## Tests
- [ ] Générer des PDF avec beaucoup d'images (ex : id gagnant de prod "62021", "59481", "61852") et vérifier que ca fonctionne
