### PR TITLE
[BO - stats et dashboard] uniformisation couleur fond

### DIFF
--- a/assets/scripts/vue/components/common/HistoMultiSelect.vue
+++ b/assets/scripts/vue/components/common/HistoMultiSelect.vue
@@ -140,7 +140,7 @@ export default defineComponent({
   }
 
   .histo-multi-select .selector {
-    background-color: #FFF;
+    background-color: var(--background-contrast-grey);
     cursor: pointer;
   }
   .histo-multi-select.inactive .selector {
@@ -153,7 +153,7 @@ export default defineComponent({
     width: 100%;
     font-size: 1rem;
     line-height: 1.5rem;
-    background-color: #FFF;
+    background-color: var(--background-contrast-grey);
     border-radius: 4px;
   }
 

--- a/assets/scripts/vue/components/common/HistoSelect.vue
+++ b/assets/scripts/vue/components/common/HistoSelect.vue
@@ -72,6 +72,6 @@ export default defineComponent({
 
 <style>
   .histo-select select {
-    background-color: #FFF;
+    background-color: var(--background-contrast-grey);
   }
 </style>

--- a/assets/scripts/vue/components/common/external/HistoDataTable.vue
+++ b/assets/scripts/vue/components/common/external/HistoDataTable.vue
@@ -54,8 +54,14 @@ export default defineComponent({
 <style>
   @import 'datatables.net-dt';
 
+  .histo-data-table table {
+    border: 1px solid var(--border-contrast-grey);
+  }
+
   .histo-data-table table thead {
-    color: var(--blue-france-sun-113-625);
+    color: var(--text-default-grey);
+    background-color: var(--background-alt-grey);
+    text-decoration: underline;
   }
 
   .histo-data-table table.dataTable.display tbody td {
@@ -63,9 +69,7 @@ export default defineComponent({
     background-color: #FFF;
     text-align: left;
   }
-  .histo-data-table table.dataTable.display > tbody > tr.odd > td {
-    background-color: #CACAFBA6;
-  }
+
   .histo-data-table table.dataTable.display > tbody > tr.even > td.sorting_1, .histo-data-table table.dataTable.display > tbody > tr.odd > td.sorting_1 {
     box-shadow: none;
   }
@@ -78,11 +82,12 @@ export default defineComponent({
   }
   .histo-data-table .dataTables_wrapper .dataTables_paginate .paginate_button.current {
     border: 0px;
-    background: var(--blue-france-850-200);
+    background-color: var(--background-active-blue-france);
+    color: var(--text-inverted-blue-france) !important;
   }
   .histo-data-table .dataTables_wrapper .dataTables_paginate .paginate_button:hover {
     color: #161616 !important;
     background-color: #E5E5E5;
-
+    --hover-tint: var(--hover);
   }
 </style>

--- a/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -247,7 +247,7 @@ export default defineComponent({
 
 <style>
   #app-dashboard {
-    background-color: #F6F6F6;
+    background-color: #fff;
     height: 100%;
   }
 </style>

--- a/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -247,7 +247,6 @@ export default defineComponent({
 
 <style>
   #app-dashboard {
-    background-color: #fff;
     height: 100%;
   }
 </style>

--- a/assets/scripts/vue/components/dashboard/TheHistoDashboardCards.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoDashboardCards.vue
@@ -293,6 +293,7 @@ export default defineComponent({
 <style>
   .histo-dashboard-cards .fr-card .fr-card__body {
     padding: 1.5rem;
+    box-shadow: 0px 3px 6px #16161633;
   }
   .histo-dashboard-cards .fr-card .fr-card__content {
     padding: 0px;

--- a/assets/scripts/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -511,12 +511,6 @@ export default defineComponent({
 </script>
 <style>
   .grey-background {
-    .histo-select select {
-      background-color: var(--background-contrast-grey);
-    }
-    .histo-multi-select .selector {
-      background-color: var(--background-contrast-grey);
-    }
     .histo-date-picker input {
       background-color: var(--background-contrast-grey);
       box-shadow: inset 0 -2px 0 0 var(--border-plain-grey);

--- a/assets/scripts/vue/components/stats/TheHistoAppStats.vue
+++ b/assets/scripts/vue/components/stats/TheHistoAppStats.vue
@@ -194,7 +194,7 @@ export default defineComponent({
 
 <style>
   .histo-app-stats {
-    background-color: var(--background-alt-grey);
+    background-color: #FFF;
   }
 
   .histo-app-stats a {

--- a/assets/scripts/vue/components/stats/TheHistoAppStats.vue
+++ b/assets/scripts/vue/components/stats/TheHistoAppStats.vue
@@ -193,14 +193,6 @@ export default defineComponent({
 </script>
 
 <style>
-  .histo-app-stats {
-    background-color: #FFF;
-  }
-
-  .histo-app-stats a {
-    color: var(--blue-france-sun-113-625);
-  }
-
   .loading {
     font-size: 2rem;
   }

--- a/assets/scripts/vue/components/stats/TheHistoStatsDetails.vue
+++ b/assets/scripts/vue/components/stats/TheHistoStatsDetails.vue
@@ -10,7 +10,7 @@
           <template #title>Criticité moyenne</template>
         </TheHistoStatsDetailsItem>
 
-        <div class="fr-col-12">
+        <div class="fr-col-12 histo-chart-line">
           <HistoChartLine :items=sharedState.stats.countSignalementPerMonth>
             <template #title>Nombre total de signalements</template>
           </HistoChartLine>
@@ -145,5 +145,9 @@ export default defineComponent({
   .histo-data-table .histo-data-table-description {
     font-style: italic;
     font-size: 0.8rem;
+  }
+
+  .histo-chart-line {
+    border: 1px solid var(--blue-france-sun-113-625);
   }
 </style>

--- a/assets/scripts/vue/components/stats/TheHistoStatsDetailsItem.vue
+++ b/assets/scripts/vue/components/stats/TheHistoStatsDetailsItem.vue
@@ -25,6 +25,7 @@ export default defineComponent({
     font-weight: bold;
     background: #FFF;
     padding: 1rem 0.5rem;
+    border: 1px solid var(--border-default-grey);
   }
   .histo-stats-details-item div p:first-child {
     font-size: 0.8rem;

--- a/assets/scripts/vue/components/stats/TheHistoStatsFilters.vue
+++ b/assets/scripts/vue/components/stats/TheHistoStatsFilters.vue
@@ -75,7 +75,7 @@
           </HistoCheckbox>
         </div>
         <div class="fr-col-12 fr-col-lg-12 fr-col-xl-3 align-right">
-          <a href="#" @click="onReinitLocalEvent"><span class="fr-fi-refresh-line"></span>Tout réinitialiser</a>
+          <a href="#" @click="onReinitLocalEvent" class="fr-link"><span class="fr-fi-refresh-line"></span>Tout réinitialiser</a>
         </div>
       </div>
     </div>

--- a/assets/scripts/vue/components/stats/TheHistoStatsFilters.vue
+++ b/assets/scripts/vue/components/stats/TheHistoStatsFilters.vue
@@ -172,4 +172,9 @@ export default defineComponent({
     color: var(--blue-france-sun-113-625);
     --icon-size: 1.1rem;
   }
+  .histo-date-picker input {
+    background-color: var(--background-contrast-grey);
+    box-shadow: inset 0 -2px 0 0 var(--border-plain-grey);
+    border-radius: .25rem .25rem 0 0;
+  }
 </style>


### PR DESCRIPTION
## Ticket

#3011   

## Description
Pour le dashboard,
-     il faut s'assurer qu'il y a bien une bordure et une ombre sur les widgets (voir capture ci-après)
-     RT et SA : passer les tableaux signalements par territoire / affectations des partenaires / ESABORA sur le design du DSFR (comme ceux sur la liste des partenaires et des étiquettes)
-     SA : passer le filtre territoire avec un fond gris comme ceux sur la liste des signalements

Pour la page stats
-     Passer les filtres avec un fond gris comme ceux sur la liste des signalements
-     Passer le tableau répartition par partenaire sur le design du DSFR
-     Pour les cartes avec les chiffres fixes : ajouter une bordure comme les widgets sur le dashboard (mais sans ombre) couleur #dddddd
-     Pour les graphs : ajouter une bordure couleur blue france (# 000091) comme ci-après




## Changements apportés
* Mise à jour de quelques styles css dans les app vue de stats et dashboard

## Pré-requis
`npm run build`

## Tests
- [ ] Vérifier l'aspect du dashboard et des stats
- [ ] Vérifier l'aspect des autres app vue pour éviter une régression