### PR TITLE
[BO - Signalement] Ajouter option de tri Commune listing

### DIFF
--- a/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
@@ -61,6 +61,7 @@ export default defineComponent({
         { Id: 'nomOccupant-ASC', Text: 'Ordre alphabétique (A -> Z)' },
         { Id: 'nomOccupant-DESC', Text: 'Ordre alphabétique inversé (Z -> A)' },
         { Id: 'lastSuiviAt-DESC', Text: 'Suivi le plus récent' },
+        { Id: 'lastSuiviAt-ASC', Text: 'Suivi le plus ancien' },
         { Id: 'villeOccupant-ASC', Text: 'Nom de commune (A -> Z)' },
         { Id: 'villeOccupant-DESC', Text: 'Nom de commune (Z -> A)' }
       ]

--- a/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
@@ -61,7 +61,8 @@ export default defineComponent({
         { Id: 'nomOccupant-ASC', Text: 'Ordre alphabétique (A -> Z)' },
         { Id: 'nomOccupant-DESC', Text: 'Ordre alphabétique inversé (Z -> A)' },
         { Id: 'lastSuiviAt-DESC', Text: 'Suivi le plus récent' },
-        { Id: 'lastSuiviAt-ASC', Text: 'Suivi le plus ancien' }
+        { Id: 'villeOccupant-ASC', Text: 'Nom de commune (A -> Z)' },
+        { Id: 'villeOccupant-DESC', Text: 'Nom de commune (Z -> A)' }
       ]
     }
   }

--- a/src/Dto/Request/Signalement/SignalementSearchQuery.php
+++ b/src/Dto/Request/Signalement/SignalementSearchQuery.php
@@ -71,7 +71,7 @@ class SignalementSearchQuery
         #[Assert\Choice(['oui'])]
         private readonly ?string $nouveauSuivi = null,
         private readonly ?int $sansSuiviPeriode = null,
-        #[Assert\Choice(['reference', 'nomOccupant', 'lastSuiviAt'])]
+        #[Assert\Choice(['reference', 'nomOccupant', 'lastSuiviAt', 'villeOccupant'])]
         private readonly string $sortBy = 'reference',
         #[Assert\Choice(['ASC', 'DESC', 'asc', 'desc'])]
         private readonly string $orderBy = 'DESC',

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -539,6 +539,9 @@ class SignalementRepository extends ServiceEntityRepository
                 case 'lastSuiviAt':
                     $qb->orderBy('s.lastSuiviAt', $options['orderBy']);
                     break;
+                case 'villeOccupant':
+                    $qb->orderBy('s.villeOccupant', $options['orderBy']);
+                    break;
                 default:
                     $qb->orderBy('s.createdAt', 'DESC');
             }


### PR DESCRIPTION
## Ticket

#3073

## Description
Ajout d'un tri par nom de commune dans la liste des signalements

## Pré-requis
`make npm-build`

## Tests
- [ ] Vérifier que le tri par nom de commune alphabétique et inversé fonctionne correctement
