### PR TITLE
[BO - Export] Correction de l'export de la liste filtrée

### DIFF
--- a/src/Controller/Back/CartographieController.php
+++ b/src/Controller/Back/CartographieController.php
@@ -29,12 +29,13 @@ class CartographieController extends AbstractController
         Request $request,
         CritereRepository $critereRepository,
     ): Response {
-        $title = 'Cartographie';
-        $filters = $this->searchFilter->setRequest($request)->setFilters()->getFilters();
-        $countActiveFilters = $this->searchFilter->getCountActive();
-
         /** @var User $user */
         $user = $this->getUser();
+
+        $title = 'Cartographie';
+        $filters = $this->searchFilter->setRequest($request)->setFilters($user)->getFilters();
+        $countActiveFilters = $this->searchFilter->getCountActive();
+
         if ($request->get('load_markers')) {
             $filters['authorized_codes_insee'] = $this->getParameter('authorized_codes_insee');
             $filters['partner_name'] = $user->getPartner()->getNom();

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -32,7 +32,7 @@ class SignalementListController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
         $filters = null !== $signalementQuery
-            ? $searchFilter->setRequest($signalementQuery)->buildFilters()
+            ? $searchFilter->setRequest($signalementQuery)->buildFilters($user)
             : [
                 'maxItemsPerPage' => SignalementSearchQuery::MAX_LIST_PAGINATION,
                 'orderBy' => 'DESC',

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -782,7 +782,7 @@ class SignalementManager extends AbstractManager
         );
     }
 
-    public function findSignalementAffectationList(User|UserInterface|null $user, array $options, bool $count = false): array|int
+    public function findSignalementAffectationList(User|UserInterface $user, array $options, bool $count = false): array|int
     {
         $maxListPagination = $options['maxItemsPerPage'] ?? SignalementAffectationListView::MAX_LIST_PAGINATION;
         $options['authorized_codes_insee'] = $this->parameterBag->get('authorized_codes_insee');
@@ -819,7 +819,7 @@ class SignalementManager extends AbstractManager
     }
 
     public function findSignalementAffectationIterable(
-        User|UserInterface|null $user,
+        User|UserInterface $user,
         ?array $options = null,
     ): \Generator {
         $options['authorized_codes_insee'] = $this->parameterBag->get('authorized_codes_insee');

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -60,7 +60,7 @@ class SignalementRepository extends ServiceEntityRepository
         }
     }
 
-    public function findAllWithGeoData(?User $user, array $options, int $offset): array
+    public function findAllWithGeoData(User $user, array $options, int $offset): array
     {
         $firstResult = $offset;
 
@@ -417,7 +417,7 @@ class SignalementRepository extends ServiceEntityRepository
     }
 
     public function findSignalementAffectationListPaginator(
-        ?User $user,
+        User $user,
         array $options,
     ): Paginator {
         $maxResult = $options['maxItemsPerPage'] ?? SignalementAffectationListView::MAX_LIST_PAGINATION;
@@ -433,7 +433,7 @@ class SignalementRepository extends ServiceEntityRepository
     }
 
     public function findSignalementAffectationQuery(
-        ?User $user,
+        User $user,
         array $options
     ): QueryBuilder {
         $qb = $this->createQueryBuilder('s');
@@ -521,7 +521,7 @@ class SignalementRepository extends ServiceEntityRepository
             }
         }
         $qb->setParameter('status', Signalement::STATUS_ARCHIVED);
-        $qb = $this->searchFilter->applyFilters($qb, $options);
+        $qb = $this->searchFilter->applyFilters($qb, $options, $user);
 
         if (isset($options['sortBy'])) {
             switch ($options['sortBy']) {
@@ -549,7 +549,7 @@ class SignalementRepository extends ServiceEntityRepository
         return $qb;
     }
 
-    public function findSignalementAffectationIterable(?User $user, array $options): \Generator
+    public function findSignalementAffectationIterable(User $user, array $options): \Generator
     {
         $qb = $this->findSignalementAffectationQuery($user, $options);
 


### PR DESCRIPTION
## Ticket

#3049    

## Description
Lorsque la liste était filtrée, le mail avec l'export n'arrivait jamais.
C'était du au fait que certaines fonctions utilisaient `Security` plutôt que le `User` enregistré dans `Messenger`.

## Changements apportés
* Suppression du fait que `User` soit optionnel dans les méthodes de filtres
* Remplacement de `Security` par un paramètre `User`

## Tests
- [ ] Tester le nouvel export avec ou sans filtre `FEATURE_EXPORT_CUSTOM=1`
- [ ] Tester l'ancien export avec ou sans filtre `FEATURE_EXPORT_CUSTOM=0`
- [ ] Tester la cartographie avec ou sans filtre
