### PR TITLE
[BO - Export] Correction de la prise en compte et de l'affichage des filtres

### DIFF
--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -34,6 +34,8 @@ class SignalementExportFiltersDisplay
         'tags' => 'Etiquettes',
         'housetypes' => 'Nature du parc',
         'allocs' => 'Allocataire',
+        'delays' => 'Nb jours sans suivi',
+        'nouveau_suivi' => 'Avec nouveau suivi',
     ];
 
     private const STATUS_AFFECTATION = [
@@ -85,6 +87,7 @@ class SignalementExportFiltersDisplay
         unset($filters['maxItemsPerPage']);
         unset($filters['sortBy']);
         unset($filters['orderBy']);
+        unset($filters['signalement_ids']);
 
         if (!$this->security->isGranted('ROLE_ADMIN')) {
             unset($filters['territories']);

--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -88,6 +88,8 @@ class SignalementExportFiltersDisplay
         unset($filters['sortBy']);
         unset($filters['orderBy']);
         unset($filters['signalement_ids']);
+        unset($filters['delays_partner']);
+        unset($filters['delays_territory']);
 
         if (!$this->security->isGranted('ROLE_ADMIN')) {
             unset($filters['territories']);


### PR DESCRIPTION
## Ticket

#3077   

## Description
Les filtres automatiques provenant du dashboard mais non-éditables dans la liste des signalements n'étaient pas repris correctement dans la page d'export, tant en terme d'affichage que de filtre.

## Tests
- [ ] Cliquer sur les cartes du dashboard, vérifier les filtres appliqués et le nombre de signalements
- [ ] Puis vérifier dans la page de l'export que les données correspondent et que le filtre s'affiche correctement
