### PR TITLE
[BO - Signalement] Garder filtres actifs après cloture signalement

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -26,7 +26,6 @@ use App\Service\Signalement\SignalementDesordresProcessor;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -52,7 +51,6 @@ class SignalementController extends AbstractController
         InterventionRepository $interventionRepository,
         DesordrePrecisionRepository $desordrePrecisionsRepository,
         SignalementDesordresProcessor $signalementDesordresProcessor,
-        ContainerBagInterface $params,
         DesordreCategorieRepository $desordreCategorieRepository,
         DesordreCritereRepository $desordreCritereRepository,
     ): Response {
@@ -127,8 +125,10 @@ class SignalementController extends AbstractController
                 $eventDispatcher->dispatch(new SignalementClosedEvent($entity, $eventParams), SignalementClosedEvent::NAME);
                 $this->addFlash('success', sprintf('Signalement #%s cloturé avec succès !', $reference));
             }
+            $signalementSearchQuery = $request->getSession()->get('signalementSearchQuery');
+            $url = $signalementSearchQuery ? $this->generateUrl('back_index').$signalementSearchQuery->getQueryStringForUrl() : $this->generateUrl('back_index');
 
-            return $this->redirectToRoute('back_index');
+            return $this->redirect($url);
         }
         $infoDesordres = $signalementDesordresProcessor->process($signalement);
 

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -41,6 +41,7 @@ class SignalementListController extends AbstractController
             ];
 
         $session->set('filters', $filters);
+        $session->set('signalementSearchQuery', $signalementQuery);
         $signalements = $signalementManager->findSignalementAffectationList($user, $filters);
 
         return $this->json(

--- a/src/Dto/Request/Signalement/SignalementSearchQuery.php
+++ b/src/Dto/Request/Signalement/SignalementSearchQuery.php
@@ -4,6 +4,7 @@ namespace App\Dto\Request\Signalement;
 
 use App\Entity\Enum\SignalementStatus;
 use App\Service\Signalement\SearchFilter;
+use App\Service\UrlHelper;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class SignalementSearchQuery
@@ -311,5 +312,20 @@ class SignalementSearchQuery
         $filters['orderBy'] = $this->getOrderBy();
 
         return array_filter($filters);
+    }
+
+    public function getQueryStringForUrl(): string
+    {
+        $params = [];
+        foreach (get_object_vars($this) as $key => $value) {
+            if (null !== $value) {
+                $params[$key] = $value;
+            }
+        }
+        if (isset($params['page']) && 1 === $params['page']) {
+            unset($params['page']);
+        }
+
+        return UrlHelper::arrayToQueryString($params);
     }
 }

--- a/src/Service/UrlHelper.php
+++ b/src/Service/UrlHelper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Service;
+
+class UrlHelper
+{
+    public static function arrayToQueryString(array $params): string
+    {
+        $query = '';
+        foreach ($params as $key => $value) {
+            if (is_array($value)) {
+                foreach ($value as $v) {
+                    $query .= '&'.urlencode($key.'[]').'='.urlencode($v);
+                }
+            } else {
+                $query .= '&'.urlencode($key).'='.urlencode($value);
+            }
+        }
+
+        return preg_replace('/&/', '?', $query, 1);
+    }
+}

--- a/tests/Unit/Service/UrlHelperTest.php
+++ b/tests/Unit/Service/UrlHelperTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\UrlHelper;
+use PHPUnit\Framework\TestCase;
+
+class UrlHelperTest extends TestCase
+{
+    /**
+     * @dataProvider providePartnerType
+     */
+    public function testArrayToQueryString(array $origin, string $result): void
+    {
+        $this->assertEquals(UrlHelper::arrayToQueryString($origin), $result);
+    }
+
+    public function providePartnerType(): \Generator
+    {
+        yield 'empty' => [[], ''];
+        yield 'single' => [['searchTerms' => 'saint médard'], '?searchTerms=saint+m%C3%A9dard'];
+        yield 'multiple' => [['searchTerms' => '2024', 'isImported' => 'oui'], '?searchTerms=2024&isImported=oui'];
+        yield 'nested' => [['status' => 'en_cours', 'etiquettes' => [1424, 479]], '?status=en_cours&etiquettes%5B%5D=1424&etiquettes%5B%5D=479'];
+    }
+}

--- a/tests/Unit/Service/UrlHelperTest.php
+++ b/tests/Unit/Service/UrlHelperTest.php
@@ -8,14 +8,14 @@ use PHPUnit\Framework\TestCase;
 class UrlHelperTest extends TestCase
 {
     /**
-     * @dataProvider providePartnerType
+     * @dataProvider provideDataToQueryString
      */
     public function testArrayToQueryString(array $origin, string $result): void
     {
         $this->assertEquals(UrlHelper::arrayToQueryString($origin), $result);
     }
 
-    public function providePartnerType(): \Generator
+    public function provideDataToQueryString(): \Generator
     {
         yield 'empty' => [[], ''];
         yield 'single' => [['searchTerms' => 'saint médard'], '?searchTerms=saint+m%C3%A9dard'];


### PR DESCRIPTION
## Ticket

#3074

## Description
Ré afficher la liste de signalements filtrés après cloture d'un signalement 

## Tests
- [ ] Se rendre sur la liste des signalement et sélectionner des filtres. Choisir un signalement et le clôturer, la cloture doit rediriger sur la liste des signalements avec les filtres précédents sélectionnés
