### PR TITLE
[QA - Sentry]  Avertissement et dépréciations

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 #[Route('/bo/signalements')]

--- a/src/Controller/Back/ArchivedSignalementController.php
+++ b/src/Controller/Back/ArchivedSignalementController.php
@@ -11,7 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/signalements-archives')]

--- a/src/Controller/Back/AutoAffectationRuleController.php
+++ b/src/Controller/Back/AutoAffectationRuleController.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/auto-affectation')]

--- a/src/Controller/Back/BackArchivedAccountController.php
+++ b/src/Controller/Back/BackArchivedAccountController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/comptes-archives')]

--- a/src/Controller/Back/BackArchivedPartnerController.php
+++ b/src/Controller/Back/BackArchivedPartnerController.php
@@ -8,7 +8,7 @@ use App\Repository\TerritoryRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/partner-archives')]

--- a/src/Controller/Back/BackDashboardController.php
+++ b/src/Controller/Back/BackDashboardController.php
@@ -4,7 +4,7 @@ namespace App\Controller\Back;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo')]
 class BackDashboardController extends AbstractController

--- a/src/Controller/Back/BackExpiredAccountController.php
+++ b/src/Controller/Back/BackExpiredAccountController.php
@@ -5,7 +5,7 @@ namespace App\Controller\Back;
 use App\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/comptes-expires')]

--- a/src/Controller/Back/BackInactiveAccountController.php
+++ b/src/Controller/Back/BackInactiveAccountController.php
@@ -5,7 +5,7 @@ namespace App\Controller\Back;
 use App\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/comptes-inactifs')]

--- a/src/Controller/Back/BackSignalementQualificationController.php
+++ b/src/Controller/Back/BackSignalementQualificationController.php
@@ -11,7 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/bo/signalements')]

--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -15,7 +15,7 @@ use App\Service\Statistics\ListTerritoryStatisticProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/statistiques')]
 class BackStatistiquesController extends AbstractController

--- a/src/Controller/Back/BackTagController.php
+++ b/src/Controller/Back/BackTagController.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/signalements')]
 class BackTagController extends AbstractController

--- a/src/Controller/Back/CartographieController.php
+++ b/src/Controller/Back/CartographieController.php
@@ -11,7 +11,7 @@ use App\Service\Signalement\SearchFilterOptionDataProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/cartographie')]
 class CartographieController extends AbstractController

--- a/src/Controller/Back/CguController.php
+++ b/src/Controller/Back/CguController.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/cgu')]
 class CguController extends AbstractController

--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/export/signalement')]
 class ExportSignalementController extends AbstractController

--- a/src/Controller/Back/IdossController.php
+++ b/src/Controller/Back/IdossController.php
@@ -11,7 +11,7 @@ use App\Repository\SignalementRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/idoss')]

--- a/src/Controller/Back/NotificationController.php
+++ b/src/Controller/Back/NotificationController.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo')]
 class NotificationController extends AbstractController

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Back/ProfilController.php
+++ b/src/Controller/Back/ProfilController.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/signalements')]

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -32,7 +32,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/signalements')]
 class SignalementController extends AbstractController

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/signalements')]
 class SignalementFileController extends AbstractController

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Attribute\MapQueryString;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo')]
 class SignalementListController extends AbstractController

--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -22,7 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[Route('/bo/signalements')]

--- a/src/Controller/Back/TagController.php
+++ b/src/Controller/Back/TagController.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/etiquettes')]

--- a/src/Controller/Back/WidgetController.php
+++ b/src/Controller/Back/WidgetController.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/bo')]

--- a/src/Controller/Back/WidgetSettingsController.php
+++ b/src/Controller/Back/WidgetSettingsController.php
@@ -10,7 +10,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo')]
 class WidgetSettingsController extends AbstractController

--- a/src/Controller/BailleurController.php
+++ b/src/Controller/BailleurController.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class BailleurController extends AbstractController
 {

--- a/src/Controller/FileController.php
+++ b/src/Controller/FileController.php
@@ -10,7 +10,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class FileController extends AbstractController
 {

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class HomepageController extends AbstractController
 {

--- a/src/Controller/QuestionController.php
+++ b/src/Controller/QuestionController.php
@@ -5,7 +5,7 @@ namespace App\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/api')]
 class QuestionController extends AbstractController

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class SecurityController extends AbstractController

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class UserAccountController extends AbstractController

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -35,7 +35,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -143,7 +143,7 @@ class SignalementController extends AbstractController
                     'already_exists' => true,
                     'type' => 'signalement',
                     'signalements' => $signalements,
-                    'draft_exists' => $existingSignalementDraft ? true : false,
+                    'draft_exists' => (bool) $existingSignalementDraft,
                 ]);
             }
 
@@ -233,9 +233,7 @@ class SignalementController extends AbstractController
             $signalementDraftRequest,
         );
 
-        if (
-            $signalementDraft
-        ) {
+        if ($signalementDraft) {
             $success = $notificationMailerRegistry->send(
                 new NotificationMail(
                     type: NotificationMailerType::TYPE_CONTINUE_FROM_DRAFT,
@@ -251,7 +249,7 @@ class SignalementController extends AbstractController
                 'success' => false,
                 'label' => 'Erreur',
                 'message' => 'L\'envoi du mail n\'a pas fonctionné, veuillez réessayer ou faire un nouveau signalement.',
-            ]);
+            ], Response::HTTP_BAD_REQUEST);
         }
 
         return $this->json(['response' => 'error'], Response::HTTP_BAD_REQUEST);
@@ -420,7 +418,7 @@ class SignalementController extends AbstractController
         EntityManagerInterface $entityManager,
         SuiviFactory $suiviFactory,
         SignalementDesordresProcessor $signalementDesordresProcessor
-    ) {
+    ): RedirectResponse|Response {
         $signalement = $signalementRepository->findOneByCodeForPublic($code);
         if (!$signalement) {
             $this->addFlash('error', 'Le lien utilisé est expiré ou invalide.');
@@ -541,7 +539,7 @@ class SignalementController extends AbstractController
         Request $request,
         UserManager $userManager,
         SignalementDesordresProcessor $signalementDesordresProcessor
-    ) {
+    ): RedirectResponse|Response {
         if ($signalement = $signalementRepository->findOneByCodeForPublic($code, false)) {
             $requestEmail = $request->get('from');
             $fromEmail = \is_array($requestEmail) ? array_pop($requestEmail) : $requestEmail;

--- a/src/Controller/SignalementFileController.php
+++ b/src/Controller/SignalementFileController.php
@@ -14,7 +14,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/signalement')]
 class SignalementFileController extends AbstractController

--- a/src/Controller/StatistiquesController.php
+++ b/src/Controller/StatistiquesController.php
@@ -15,7 +15,7 @@ use App\Service\Statistics\TerritoryStatisticProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class StatistiquesController extends AbstractController
 {

--- a/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
+++ b/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
@@ -28,14 +28,12 @@ class ErrorSignalementMailer extends AbstractNotificationMailer
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
     {
         $event = $notificationMail->getEvent();
-        $attachment = $notificationMail->getAttachment();
 
         return [
             'url' => $_SERVER['SERVER_NAME'] ?? 'non défini',
             'code' => $event->getThrowable()->getCode(),
             'error' => $event->getThrowable()->getMessage(),
             'req' => $event->getRequest()->getContent(),
-            'attachment' => $attachment,
         ];
     }
 }

--- a/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
+++ b/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
@@ -35,7 +35,6 @@ class ErrorSignalementMailer extends AbstractNotificationMailer
             'code' => $event->getThrowable()->getCode(),
             'error' => $event->getThrowable()->getMessage(),
             'req' => $event->getRequest()->getContent(),
-            'signalement' => $event->getRequest()->get('signalement'),
             'attachment' => $attachment,
         ];
     }

--- a/src/Service/Security/FileScanner.php
+++ b/src/Service/Security/FileScanner.php
@@ -28,6 +28,11 @@ class FileScanner
         if (!$this->clamavScanEnable) {
             return true;
         }
+
+        if (empty($filePath)) {
+            return false;
+        }
+
         if ($copy) {
             $copiedFilepath = $this->parameterBag->get('uploads_tmp_dir').'clamav_'.Uuid::v4();
             file_put_contents($copiedFilepath, file_get_contents($filePath));

--- a/src/Service/Signalement/SignalementDraftHelper.php
+++ b/src/Service/Signalement/SignalementDraftHelper.php
@@ -24,6 +24,10 @@ class SignalementDraftHelper
 
     public static function getEmailDeclarant(SignalementDraftRequest $signalementDraftRequest): ?string
     {
+        if (empty($signalementDraftRequest->getProfil())) {
+            return null;
+        }
+
         switch (strtoupper($signalementDraftRequest->getProfil())) {
             case ProfileDeclarant::SERVICE_SECOURS->name:
             case ProfileDeclarant::BAILLEUR->name:

--- a/templates/emails/erreur_signalement_email.html.twig
+++ b/templates/emails/erreur_signalement_email.html.twig
@@ -16,7 +16,4 @@
     {% if req is defined %}
         <p>{{ req|json_encode() }}</p>
     {% endif %}
-    {% if signalement is defined %}
-        <p>{{ signalement|json_encode()|replace({',':',<br>'})|raw }}</p>
-    {% endif %}
 {% endblock %}

--- a/templates/emails/erreur_signalement_email.html.twig
+++ b/templates/emails/erreur_signalement_email.html.twig
@@ -9,10 +9,6 @@
     {% if error is defined %}
         <p>Message erreur: {{ error }}</p>
     {% endif %}
-    {% if attachment is defined %}
-        <p>Documents: {{ attachment.documents }}</p>
-        <p>Photos: {{ attachment.photos }}</p>
-    {% endif %}
     {% if req is defined %}
         <p>{{ req|json_encode() }}</p>
     {% endif %}

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -250,6 +250,19 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
+    public function testSendMailContinueFromNotValidDraft(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router */
+        $router = $client->getContainer()->get(RouterInterface::class);
+        $url = $router->generate('send_mail_continue_from_draft');
+
+        $client->request('POST', $url, [], [], [], '');
+
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
     public function provideSignalementRequestPayload(): \Generator
     {
         yield 'Post signalement as locataire (Mails sent: Occupant + RT)' => [

--- a/tests/Unit/Service/FileScannerTest.php
+++ b/tests/Unit/Service/FileScannerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\Security\FileScanner;
+use PHPUnit\Framework\TestCase;
+use Sineflow\ClamAV\DTO\ScannedFile;
+use Sineflow\ClamAV\Scanner;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class FileScannerTest extends TestCase
+{
+    public function testIsCleanWithEmptyFilePath()
+    {
+        $scanner = $this->createMock(Scanner::class);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+
+        $fileScanner = new FileScanner($scanner, $parameterBag, true);
+        $result = $fileScanner->isClean('');
+
+        $this->assertFalse($result, 'Should return false for empty file path.');
+    }
+
+    public function testIsCleanWithCopyOption()
+    {
+        $scanner = $this->createMock(Scanner::class);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $scannedFile = $this->createMock(ScannedFile::class);
+
+        $parameterBag
+            ->expects($this->once())
+            ->method('get')
+            ->with('uploads_tmp_dir')
+            ->willReturn('tmp/');
+
+        $scannedFile
+            ->expects($this->once())
+            ->method('isClean')
+            ->willReturn(true);
+
+        $scanner
+            ->expects($this->once())
+            ->method('scan')
+            ->with($this->callback(function ($copiedFilepath) {
+                return str_starts_with($copiedFilepath, 'tmp/clamav_');
+            }))
+            ->willReturn($scannedFile);
+
+        $fileScanner = new FileScanner($scanner, $parameterBag, true);
+
+        $dummyFilePath = 'tmp/dummy.txt';
+        file_put_contents($dummyFilePath, 'dummy content');
+
+        $result = $fileScanner->isClean($dummyFilePath);
+
+        unlink($dummyFilePath);
+
+        $this->assertTrue($result, 'Should return true for a clean scanned file.');
+    }
+}


### PR DESCRIPTION
## Ticket

#3088 [QA - Sentry] Gérer dépréciation strtoupper()
#3089 [QA - Sentry] Erreur (erreur 500) de sérialisation envoi de formulaire avec un JSON mal formaté
#3087 [QA - Sentry] Vérifier que le chemin est différent de null

## Description
La route peut provenir soit de l'attribut, soit de l'annotation. Il est recommandé de remplacer l'annotation Route par l'attribut Route, qui est devenu le nouveau standard depuis l'introduction des attributs en PHP 8.
https://symfony.com/doc/current/reference/attributes.html

## Changements apportés
* Vérifier qu'un chemin existe dans FileScanner
* Gérer les erreur 500 si le JSON est mal formaté dans ErrorListener
* Vérification avant usage de strtoupper

## Pré-requis

## Tests
- [ ] Faire une requête postman avec cette payload et vérifier qu'il y'a bien une erreur 400 au lieu d'une erreur 500

```
POST http://localhost:8080/signalement-draft/send_mail
```
```
{
"adresse_logement_adresse_afficher_les_champs": "@@dbj---'"" OR 1=1;
"adresse_logement_adresse_suggestion": "3137 Laguna Street",
"adresse_logement_complement_adresse_autre": "Testing",
"adresse_logement_complement_adresse_escalier": "Testing",
"adresse_logement_complement_adresse_etage": "Testing",
"adresse_logement_complement_adresse_numero_appartement": "Testing",
"currentStep": "adresse_logement_intro",
"lienSuivi": "",
"signalementReference": "",
"uuidSignalementDraft": ""
}
```

- [ ] Faire une requête postman une requête au hasard avec une payload JSON en erreur, une erreur 400 doit être envoyé au lieu d'une erreur 500
