### PR TITLE
[BO - Etiquettes] Mettre les étiquettes sous forme de label

### DIFF
--- a/templates/back/tags/index.html.twig
+++ b/templates/back/tags/index.html.twig
@@ -197,7 +197,7 @@
                             {% for index,tag in tags %}
                                 <tr class="signalement-row">
                                     <td>{{ tag.id }}</td>
-                                    <td>{{ tag.label }}</td>
+                                    <td><span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon">{{ tag.label }}</span></td>
                                     <td>{{ tag.signalements|length }}</td>
                                     <td>{{ tag.territory.name }}</td>
                                     <td class="fr-text--right fr-ws-nowrap">


### PR DESCRIPTION
## Ticket

#3082

## Description
Dans la page outil admin -> étiquettes, afficher les tag sous forme de badge dans le tableau
