### PR TITLE
[FO - Signalement] Accessibilité : ajout d'étiquettes non-existantes

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -170,12 +170,12 @@
           "type": "SignalementFormButton",
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
-          "customCss": "fr-btn--sm fr-badge fr-badge--info",
+          "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
           "ariaControls": "zone_concernee_modal"
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "",
+          "label": "Quelle zone est concernée ?",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -114,12 +114,12 @@
           "type": "SignalementFormButton",
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
-          "customCss": "fr-btn--sm fr-badge fr-badge--info",
+          "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
           "ariaControls": "zone_concernee_modal"
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "",
+          "label": "Quelle zone est concernée ?",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -207,12 +207,12 @@
           "type": "SignalementFormButton",
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
-          "customCss": "fr-btn--sm fr-badge fr-badge--info",
+          "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
           "ariaControls": "zone_concernee_modal"
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "",
+          "label": "Quelle zone est concernée ?",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -279,12 +279,12 @@
           "type": "SignalementFormButton",
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
-          "customCss": "fr-btn--sm fr-badge fr-badge--info",
+          "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
           "ariaControls": "zone_concernee_modal"
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "",
+          "label": "Quelle zone est concernée ?",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -283,12 +283,12 @@
           "type": "SignalementFormButton",
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
-          "customCss": "fr-btn--sm fr-badge fr-badge--info",
+          "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
           "ariaControls": "zone_concernee_modal"
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "",
+          "label": "Quelle zone est concernée ?",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -270,12 +270,12 @@
           "type": "SignalementFormButton",
           "label": "En savoir plus",
           "slug": "zone_concernee_savoir_plus",
-          "customCss": "fr-btn--sm fr-badge fr-badge--info",
+          "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
           "ariaControls": "zone_concernee_modal"
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "",
+          "label": "Quelle zone est concernée ?",
           "slug": "zone_concernee_zone",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -173,12 +173,12 @@
           "type": "SignalementFormButton",
           "label": "En savoir plus",
           "slug": "signalement_concerne_savoir_plus",
-          "customCss": "fr-btn--sm fr-badge fr-badge--info",
+          "customCss": "fr-btn--sm fr-badge fr-badge--info fr-mb-3v",
           "ariaControls": "signalement_concerne_modal"
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "",
+          "label": "Qui est concerné par votre signalement ?",
           "slug": "signalement_concerne_profil",
           "values": [
             {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -1,50 +1,48 @@
 <template>
   <div>
-    <div class="fr-input-group">
-      <label class='fr-label' :for="id">
+    <fieldset class="fr-fieldset" :aria-labelledby="id + '-legend'">
+      <legend class="fr-fieldset__legend--regular fr-fieldset__legend fr-col-12" :id="id + '-legend'">
         {{ variablesReplacer.replace(label) }}
-      </label>
-      <div class="fr-grid-row fr-grid-row--gutters">
-        <div class="fr-col-12 fr-col-md-4">
-          <select
-            class="fr-select"
-            :id="idCountryCode"
-            :name="idCountryCode"
-            v-model="formStore.data[idCountryCode]"
-            title="Indicatif national"
+      </legend>
+      <div class="fr-fieldset__element fr-col-12 fr-col-md-4">
+        <select
+          class="fr-select"
+          :id="idCountryCode"
+          :name="idCountryCode"
+          v-model="formStore.data[idCountryCode]"
+          title="Indicatif national"
+          :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
+          >
+          <option
+            v-for="countryItem in countryList"
+            v-bind:key="countryItem.code"
+            :value="countryItem.code"
+            >
+            {{ countryItem.label }}
+          </option>
+        </select>
+      </div>
+      <div class="fr-fieldset__element fr-col-12 fr-col-md-8">
+        <div class="fr-input-wrap fr-icon-phone-line">
+          <input
+            type="text"
+            :id="id"
+            :name="access_name"
+            :autocomplete="access_autocomplete"
+            v-model="formStore.data[id]"
+            class="fr-input"
             :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
             >
-            <option
-              v-for="countryItem in countryList"
-              v-bind:key="countryItem.code"
-              :value="countryItem.code"
-              >
-              {{ countryItem.label }}
-            </option>
-          </select>
-        </div>
-        <div class="fr-col-12 fr-col-md-8">
-          <div class="fr-input-wrap fr-icon-phone-line">
-            <input
-              type="text"
-              :id="id"
-              :name="access_name"
-              :autocomplete="access_autocomplete"
-              v-model="formStore.data[id]"
-              class="fr-input"
-              :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
-              >
-          </div>
         </div>
       </div>
       <div
         :id="id + '-text-input-error-desc-error'"
-        class="fr-error-text"
+        class="fr-error-text fr-mt-0 fr-mb-3v fr-ml-2v"
         v-if="formStore.validationErrors[id] !== undefined"
         >
         {{ formStore.validationErrors[id] }}
       </div>
-    </div>
+    </fieldset>
 
     <SignalementFormButton
       :id="idShow"
@@ -54,54 +52,53 @@
       :clickEvent="handleClickButton"
       />
 
-    <div
-      :id="idSecondGroup"
-      :class="[ 'fr-input-group', formStore.data[idSecond] === undefined ? 'fr-hidden' : '' ]"
+    <fieldset
+      :id=idSecondGroup
+      :class="[ 'fr-fieldset', formStore.data[idSecond] === undefined ? 'fr-hidden' : '' ]"
+      :aria-labelledby="id + '-legend-second'"
       >
-      <label class='fr-label' :for="idSecond">
+      <legend class="fr-fieldset__legend--regular fr-fieldset__legend fr-col-12" :id="id + '-legend-second'">
         Téléphone secondaire (facultatif)
-      </label>
-      <div class="fr-grid-row fr-grid-row--gutters">
-        <div class="fr-col-12 fr-col-md-4">
-          <select
-            class="fr-select"
-            :id="idCountryCodeSecond"
-            :name="idCountryCodeSecond"
-            v-model="formStore.data[idCountryCodeSecond]"
-            title="Indicatif national"
-            :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
+      </legend>
+      <div class="fr-fieldset__element fr-col-12 fr-col-md-4">
+        <select
+          class="fr-select"
+          :id="idCountryCodeSecond"
+          :name="idCountryCodeSecond"
+          v-model="formStore.data[idCountryCodeSecond]"
+          title="Indicatif national"
+          :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
+          >
+          <option
+            v-for="countryItem in countryList"
+            v-bind:key="countryItem.code"
+            :value="countryItem.code"
             >
-            <option
-              v-for="countryItem in countryList"
-              v-bind:key="countryItem.code"
-              :value="countryItem.code"
-              >
-              {{ countryItem.label }}
-            </option>
-          </select>
-        </div>
-        <div class="fr-col-12 fr-col-md-8">
-          <div class="fr-input-wrap fr-icon-phone-line">
-            <input
-              type="text"
-              :id="idSecond"
-              :name="idSecond"
-              v-model="formStore.data[idSecond]"
-              class="fr-input"
-              :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
-              :autocomplete="access_autocomplete"
-              >
-          </div>
+            {{ countryItem.label }}
+          </option>
+        </select>
+      </div>
+      <div class="fr-fieldset__element fr-col-12 fr-col-md-8">
+        <div class="fr-input-wrap fr-icon-phone-line">
+          <input
+            type="text"
+            :id="idSecond"
+            :name="idSecond"
+            v-model="formStore.data[idSecond]"
+            class="fr-input"
+            :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
+            :autocomplete="access_autocomplete"
+            >
         </div>
       </div>
       <div
         :id="idSecond + '-text-input-error-desc-error'"
-        class="fr-error-text"
+        class="fr-error-text fr-mt-0 fr-mb-3v fr-ml-2v"
         v-if="formStore.validationErrors[idSecond] !== undefined"
         >
         {{ formStore.validationErrors[idSecond] }}
       </div>
-    </div>
+    </fieldset>
   </div>
 </template>
 


### PR DESCRIPTION
## Ticket

#3035    

## Description
Dans les critères 11.X de l'accessibilité, il est indiqué que chaque champ doit avoir une étiquette.
J'ai fait le tour et il manquait 3 choses :
- sur la page de profil de déclarant, un `label` pour les deux premiers boutons radio
- sur la page de zone concernée (batiment/logement), un `label` pour les deux premiers boutons radio
- sur le composant Numéro de téléphone, il y avait un `label` rattaché au champ texte. La liste déroulante de pays n'avait donc pas d'étiquette.

## Changements apportés
* Ajout de nouvelles étiquettes sur les deux écrans spécifiques
* Remplacement du `label` du numéro de téléphone par un fieldset qui entoure les champs `select` et `input`

## Pré-requis
`npm run build / watch`

## Tests
- [ ] Vérifier l'étiquette sur l'écran de choix de profil
- [ ] Vérifier l'étiquette sur les écrans de choix de zone (les différents profils sont concernés)
- [ ] Vérifier le fonctionnement toujours ok des champs de numéro de téléphone (affichage d'erreur, enregistrement de données, ...)
- [ ] Faire un tour du formulaire si jamais un champ ou l'autre aurait échappé à ma vigilance...
