### PR TITLE
[BO - Etiquettes] Correction du tri

### DIFF
--- a/assets/scripts/vanilla/services/table_sortable.js
+++ b/assets/scripts/vanilla/services/table_sortable.js
@@ -3,19 +3,40 @@ const siblingIndex=e=>{
     let t=0;for(;e=e.previousElementSibling;)t++;return t
 }
 
-const sortTableFunction=e=>function(t){
-    "a"==t.target.tagName.toLowerCase()&&(sortRows(e,siblingIndex(t.target.parentNode)),t.preventDefault())
+const sortTableFunction=table=>function(event){
+    if ("a"==event.target.tagName.toLowerCase()) {
+        sortRows(table,siblingIndex(event.target.parentNode));
+        event.preventDefault();
+    }
 }
-const sortRows=(e,t)=>{
-    let r,a,l,n=e.querySelectorAll("tbody tr"),o="thead th:nth-child("+(t+1)+")",d="td:nth-child("+(t+1)+")",s=e.querySelector(o).classList,i=[],c="",u=!0;
-    for(s&&(s.contains("date")?c="date":s.contains("number")&&(c="number")),a=0;a<n.length;a++)
+const sortRows=(table,index)=>{
+    let r,a,l;
+    let n=table.querySelectorAll("tbody tr");
+    let o="thead th:nth-child("+(index+1)+")";
+    let d="td:nth-child("+(index+1)+")";
+    let classList = table.querySelector(o).classList;
+    let isDesc = classList.contains('desc')
+    if (!isDesc) {
+        classList.add('desc')
+    } else {
+        classList.remove('desc')
+    }
+    let i=[],c="",u=!0;
+    for(classList&&(classList.contains("date")?c="date":classList.contains("number")&&(c="number")),a=0;a<n.length;a++)
         l=n[a].querySelector(d),r=l.innerText,isNaN(r)?u=!1:r=parseFloat(r),i.push({value:r,row:n[a]});
-    ""==c&&u&&(c="number"),"number"==c?(i.sort(sortNumberVal),i=i.reverse()):"date"==c?i.sort(sortDateVal):i.sort(sortTextVal);
-    for(let t=0;t<i.length;t++)e.querySelector("tbody").appendChild(i[t].row)
+    ""==c&&u&&(c="number"),
+    "number"==c?(i.sort(sortNumberVal),i=i.reverse()):"date"==c?i.sort(sortDateVal):i.sort(sortTextVal);
+
+    if (isDesc) {
+        i=i.reverse()
+    }
+    for(let t=0;t<i.length;t++) {
+        table.querySelector("tbody").appendChild(i[t].row)
+    }
 }
 
 const sortNumberVal=(e,t)=>sortNumber(e.value,t.value)
-const sortNumber=(e,t)=>{e-t}
+const sortNumber=(e,t)=>{ return t-e }
 const sortDateVal=(e,t)=>{let r=Date.parse(e.value),a=Date.parse(t.value);return sortNumber(r,a)}
 const sortTextVal=(e,t)=>{let r=(e.value+"").toUpperCase(),a=(t.value+"").toUpperCase();return r<a?-1:r>a?1:0}
 

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'back/base_bo.html.twig' %}
 
-{% block title %}Partenaire index{% endblock %}
+{% block title %}Partenaires du territoire{% endblock %}
 
 {% block content %}
     {% include '_partials/_modal_partner_delete.html.twig' %}
@@ -69,9 +69,9 @@
                     <table class="sortable fr-cell--multiline">
                         <thead>
                         <tr>
-                            <th scope="col">Id</th>
+                            <th scope="col" class="number">Id</th>
                             {% if is_granted('ROLE_ADMIN') %}
-                                <th scope="col" class="number">Territoire</th>
+                                <th scope="col">Territoire</th>
                             {% endif %}
                             <th scope="col">Nom</th>
                             <th scope="col">Type</th>

--- a/templates/back/tags/index.html.twig
+++ b/templates/back/tags/index.html.twig
@@ -186,9 +186,9 @@
                     <table class="sortable fr-cell--multiline" aria-label="Liste des étiquettes" aria-describedby="desc-table">
                         <thead>
                         <tr>
-                            <th scope="col">ID</th>
+                            <th scope="col" class="number">ID</th>
                             <th scope="col">Etiquette</th>
-                            <th scope="col">Nombre d'utilisation</th>
+                            <th scope="col" class="number">Nombre d'utilisation</th>
                             <th scope="col">Territoire</th>
                             <th scope="col" class="fr-text--right">Actions</th>
                         </tr>


### PR DESCRIPTION
## Ticket

#3083   

## Description
Le tri par colonne dans certains tableaux du BO ne fonctionnait pas bien.

## Changements apportés
* Correction du tri sur la page étiquettes. J'ai du toucher au js minifié, je l'ai un peu ajusté pour comprendre certaines parties, mais c'est encore minifié pour certains passages...
* Correction du tri au passage sur la colonne territoire de la page de partenaires
* Ajustement du titre de la page partenaire

## Tests
- [ ] Aller sur les différentes pages du BO avec tableaux et tester le tri par colonne
- [ ] http://localhost:8080/bo/etiquettes/
- [ ] http://localhost:8080/bo/partenaires/
- [ ] http://localhost:8080/bo/partner-archives/
- [ ] ...
