### PR TITLE
[QA] Ignorer les erreurs 404 dans les alertes email

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 
@@ -37,7 +38,7 @@ readonly class ExceptionListener
             $event->setResponse($response);
         }
 
-        if (!$exception instanceof MethodNotAllowedException) {
+        if (!$exception instanceof MethodNotAllowedException && !$exception instanceof NotFoundHttpException) {
             $this->notificationMailerRegistry->send(
                 new NotificationMail(
                     type: NotificationMailerType::TYPE_ERROR_SIGNALEMENT,

--- a/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
+++ b/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class ErrorSignalementMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_ERROR_SIGNALEMENT;
-    protected ?string $mailerSubject = 'Une erreur est survenue lors de la création d\'un signalement !';
+    protected ?string $mailerSubject = 'Une erreur est survenue !';
     protected ?string $mailerTemplate = 'erreur_signalement_email';
 
     public function __construct(


### PR DESCRIPTION
## Ticket

#3101    

## Description
Ignorer les erreurs 404 dans les alertes mail comme sur Sentry

## Changements apportés
* Mise à jour exceptionListener
* Mise à jour de l'objet du mail

## Pré-requis

## Tests
- [ ] Simuler une erreur 404 et vérifier que vous ne recevez d'email
