### PR TITLE
[BO - Signalement] Correction de la possibilité d'éditer une visite si pas assigné

### DIFF
--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -142,7 +142,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
+        $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
 
         if ($intervention->hasScheduledDatePassed()) {
             $this->addFlash('error', 'Cette visite est déja passée et ne peut pas être annulée, merci de la noter comme non-effectuée.');
@@ -196,7 +196,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
+        $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
 
         $errorRedirect = $this->getSecurityRedirect(
             $signalement,
@@ -264,7 +264,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
+        $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
 
         $errorRedirect = $this->getSecurityRedirect(
             $signalement,
@@ -317,7 +317,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
+        $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
 
         $errorRedirect = $this->getSecurityRedirect(
             $signalement,
@@ -358,7 +358,7 @@ class SignalementVisitesController extends AbstractController
         EntityManagerInterface $entityManager,
         UploadHandlerService $uploadHandlerService,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
+        $this->denyAccessUnlessGranted('INTERVENTION_EDIT_VISITE', $intervention);
         if (!$this->isCsrfTokenValid('delete_rapport', $request->get('_token')) || $intervention->getSignalement()->getId() !== $signalement->getId() || $intervention->getFiles()->isEmpty()) {
             return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
         }

--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -142,7 +142,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_ADD_VISITE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
 
         if ($intervention->hasScheduledDatePassed()) {
             $this->addFlash('error', 'Cette visite est déja passée et ne peut pas être annulée, merci de la noter comme non-effectuée.');
@@ -196,7 +196,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_ADD_VISITE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
 
         $errorRedirect = $this->getSecurityRedirect(
             $signalement,
@@ -264,7 +264,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_ADD_VISITE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
 
         $errorRedirect = $this->getSecurityRedirect(
             $signalement,
@@ -317,7 +317,7 @@ class SignalementVisitesController extends AbstractController
 
             return $this->redirectToRoute('back_index');
         }
-        $this->denyAccessUnlessGranted('SIGN_ADD_VISITE', $signalement);
+        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
 
         $errorRedirect = $this->getSecurityRedirect(
             $signalement,
@@ -358,7 +358,7 @@ class SignalementVisitesController extends AbstractController
         EntityManagerInterface $entityManager,
         UploadHandlerService $uploadHandlerService,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_ADD_VISITE', $intervention->getSignalement());
+        $this->denyAccessUnlessGranted('SIGN_EDIT_VISITE', $intervention);
         if (!$this->isCsrfTokenValid('delete_rapport', $request->get('_token')) || $intervention->getSignalement()->getId() !== $signalement->getId() || $intervention->getFiles()->isEmpty()) {
             return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
         }

--- a/src/Security/Voter/InterventionVoter.php
+++ b/src/Security/Voter/InterventionVoter.php
@@ -26,9 +26,10 @@ class InterventionVoter extends Voter
             return false;
         }
 
-        if (self::EDIT_VISITE == $attribute) {
-            return $this->canEditVisite($subject, $user);
-        }
+        return match ($attribute) {
+            self::EDIT_VISITE => $this->canEditVisite($subject, $user),
+            default => false,
+        };
     }
 
     private function canEditVisite(Intervention $intervention, User $user): bool

--- a/src/Security/Voter/InterventionVoter.php
+++ b/src/Security/Voter/InterventionVoter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Intervention;
+use App\Entity\Signalement;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class InterventionVoter extends Voter
+{
+    public const EDIT_VISITE = 'INTERVENTION_EDIT_VISITE';
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return \in_array($attribute, [self::EDIT_VISITE]) && ($subject instanceof Intervention);
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    {
+        /** @var User $user */
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        if (self::EDIT_VISITE == $attribute) {
+            return $this->canEditVisite($subject, $user);
+        }
+    }
+
+    private function canEditVisite(Intervention $intervention, User $user): bool
+    {
+        $signalement = $intervention->getSignalement();
+        if (Signalement::STATUS_ACTIVE !== $signalement->getStatut()) {
+            return false;
+        }
+
+        $isUserInPartnerAffectedToVisite = $user->getPartner() === $intervention->getPartner();
+        $isUserTerritoryAdminOfSignalementTerritory = $user->isTerritoryAdmin() && $user->getTerritory() === $signalement->getTerritory();
+
+        return $user->isSuperAdmin() || $isUserInPartnerAffectedToVisite || $isUserTerritoryAdminOfSignalementTerritory;
+    }
+}

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -5,7 +5,6 @@ namespace App\Security\Voter;
 use App\Entity\Affectation;
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\QualificationStatus;
-use App\Entity\Intervention;
 use App\Entity\Signalement;
 use App\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -21,7 +20,6 @@ class SignalementVoter extends Voter
     public const EDIT = 'SIGN_EDIT';
     public const VIEW = 'SIGN_VIEW';
     public const ADD_VISITE = 'SIGN_ADD_VISITE';
-    public const EDIT_VISITE = 'SIGN_EDIT_VISITE';
     public const USAGER_EDIT = 'SIGN_USAGER_EDIT';
     public const EDIT_NDE = 'SIGN_EDIT_NDE';
 
@@ -31,9 +29,8 @@ class SignalementVoter extends Voter
 
     protected function supports(string $attribute, $subject): bool
     {
-        return (\in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::VALIDATE, self::CLOSE, self::ADD_VISITE, self::USAGER_EDIT, self::EDIT_NDE])
-            && ($subject instanceof Signalement))
-            || (\in_array($attribute, [self::EDIT_VISITE]) && ($subject instanceof Intervention));
+        return \in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::VALIDATE, self::CLOSE, self::ADD_VISITE, self::USAGER_EDIT, self::EDIT_NDE])
+            && ($subject instanceof Signalement);
     }
 
     protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
@@ -50,10 +47,6 @@ class SignalementVoter extends Voter
 
         if (self::ADD_VISITE == $attribute) {
             return $this->canAddVisite($subject, $user);
-        }
-
-        if (self::EDIT_VISITE == $attribute) {
-            return $this->canEditVisite($subject, $user);
         }
 
         if (self::EDIT_NDE == $attribute) {
@@ -155,19 +148,6 @@ class SignalementVoter extends Voter
         $isUserTerritoryAdminOfSignalementTerritory = $user->isTerritoryAdmin() && $user->getTerritory() === $signalement->getTerritory();
 
         return $user->isSuperAdmin() || $isUserInAffectedPartnerWithQualificationVisite || $isUserTerritoryAdminOfSignalementTerritory;
-    }
-
-    public function canEditVisite(Intervention $intervention, User $user): bool
-    {
-        $signalement = $intervention->getSignalement();
-        if (Signalement::STATUS_ACTIVE !== $signalement->getStatut()) {
-            return false;
-        }
-
-        $isUserInPartnerAffectedToVisite = $user->getPartner() === $intervention->getPartner();
-        $isUserTerritoryAdminOfSignalementTerritory = $user->isTerritoryAdmin() && $user->getTerritory() === $signalement->getTerritory();
-
-        return $user->isSuperAdmin() || $isUserInPartnerAffectedToVisite || $isUserTerritoryAdminOfSignalementTerritory;
     }
 
     private function canEditNDE(Signalement $signalement, User $user): bool

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -5,6 +5,7 @@ namespace App\Security\Voter;
 use App\Entity\Affectation;
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\QualificationStatus;
+use App\Entity\Intervention;
 use App\Entity\Signalement;
 use App\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -20,6 +21,7 @@ class SignalementVoter extends Voter
     public const EDIT = 'SIGN_EDIT';
     public const VIEW = 'SIGN_VIEW';
     public const ADD_VISITE = 'SIGN_ADD_VISITE';
+    public const EDIT_VISITE = 'SIGN_EDIT_VISITE';
     public const USAGER_EDIT = 'SIGN_USAGER_EDIT';
     public const EDIT_NDE = 'SIGN_EDIT_NDE';
 
@@ -29,8 +31,9 @@ class SignalementVoter extends Voter
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::VALIDATE, self::CLOSE, self::ADD_VISITE, self::USAGER_EDIT, self::EDIT_NDE])
-            && ($subject instanceof Signalement);
+        return (\in_array($attribute, [self::EDIT, self::VIEW, self::DELETE, self::VALIDATE, self::CLOSE, self::ADD_VISITE, self::USAGER_EDIT, self::EDIT_NDE])
+            && ($subject instanceof Signalement))
+            || (\in_array($attribute, [self::EDIT_VISITE]) && ($subject instanceof Intervention));
     }
 
     protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
@@ -47,6 +50,10 @@ class SignalementVoter extends Voter
 
         if (self::ADD_VISITE == $attribute) {
             return $this->canAddVisite($subject, $user);
+        }
+
+        if (self::EDIT_VISITE == $attribute) {
+            return $this->canEditVisite($subject, $user);
         }
 
         if (self::EDIT_NDE == $attribute) {
@@ -148,6 +155,19 @@ class SignalementVoter extends Voter
         $isUserTerritoryAdminOfSignalementTerritory = $user->isTerritoryAdmin() && $user->getTerritory() === $signalement->getTerritory();
 
         return $user->isSuperAdmin() || $isUserInAffectedPartnerWithQualificationVisite || $isUserTerritoryAdminOfSignalementTerritory;
+    }
+
+    public function canEditVisite(Intervention $intervention, User $user): bool
+    {
+        $signalement = $intervention->getSignalement();
+        if (Signalement::STATUS_ACTIVE !== $signalement->getStatut()) {
+            return false;
+        }
+
+        $isUserInPartnerAffectedToVisite = $user->getPartner() === $intervention->getPartner();
+        $isUserTerritoryAdminOfSignalementTerritory = $user->isTerritoryAdmin() && $user->getTerritory() === $signalement->getTerritory();
+
+        return $user->isSuperAdmin() || $isUserInPartnerAffectedToVisite || $isUserTerritoryAdminOfSignalementTerritory;
     }
 
     private function canEditNDE(Signalement $signalement, User $user): bool

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -1,8 +1,8 @@
 
 {% if signalement.interventions is not empty %}
     <div class="signalement-visites-buttons fr-text--right fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
-        {% if intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}    
-            {% if is_granted('SIGN_ADD_VISITE', intervention.signalement) %}
+        {% if intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}
+            {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
                 {% if workflow_can(intervention, 'cancel') %}
                     <button class="fr-btn fr-btn--danger fr-fi-close-line" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
                         Annuler la visite
@@ -19,20 +19,20 @@
             {% endif %}
         {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
             {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty %}
-                {% if is_granted('SIGN_ADD_VISITE', intervention.signalement) %}
-                    <button 
+                {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+                    <button
                         class="fr-btn fr-btn--secondary fr-fi-file-fill"
-                        aria-controls="edit-visite-modal-{{intervention.id}}"  
+                        aria-controls="edit-visite-modal-{{intervention.id}}"
                         data-fr-opened="false"
                         >
                         Ajouter un rapport de visite
                     </button>
                 {% endif %}
             {% else %}
-                {% if is_granted('SIGN_ADD_VISITE', intervention.signalement) %}
-                    <button 
-                        class="fr-btn fr-btn--secondary fr-fi-edit-line" 
-                        aria-controls="edit-visite-modal-{{intervention.id}}" 
+                {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+                    <button
+                        class="fr-btn fr-btn--secondary fr-fi-edit-line"
+                        aria-controls="edit-visite-modal-{{intervention.id}}"
                         data-fr-opened="false">
                         Editer le rapport
                     </button>
@@ -45,10 +45,10 @@
                     <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
                 </a>
             {% endif %}
-            {% if is_granted('SIGN_ADD_VISITE', intervention.signalement)%}
-                <button 
-                    class="fr-btn fr-btn--secondary fr-icon-camera-fill open-modal-upload-files-btn" 
-                    data-fr-opened="false" 
+            {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+                <button
+                    class="fr-btn fr-btn--secondary fr-icon-camera-fill open-modal-upload-files-btn"
+                    data-fr-opened="false"
                     aria-controls="visites-upload-files-{{intervention.id}}"
                     data-file-type="photo"
                     data-document-type="PHOTO_VISITE"

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -1,6 +1,6 @@
 <div class="signalement-visites-buttons fr-text--right fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
     {% if intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}
-        {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+        {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
             {% if workflow_can(intervention, 'cancel') %}
                 <button class="fr-btn fr-btn--danger fr-fi-close-line" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
                     Annuler la visite
@@ -17,7 +17,7 @@
         {% endif %}
     {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
         {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty %}
-            {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+            {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
                 <button
                     class="fr-btn fr-btn--secondary fr-fi-file-fill"
                     aria-controls="edit-visite-modal-{{intervention.id}}"
@@ -27,7 +27,7 @@
                 </button>
             {% endif %}
         {% else %}
-            {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+            {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
                 <button
                     class="fr-btn fr-btn--secondary fr-fi-edit-line"
                     aria-controls="edit-visite-modal-{{intervention.id}}"
@@ -43,7 +43,7 @@
                 <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
             </a>
         {% endif %}
-        {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+        {% if is_granted('INTERVENTION_EDIT_VISITE', intervention) %}
             <button
                 class="fr-btn fr-btn--secondary fr-icon-camera-fill open-modal-upload-files-btn"
                 data-fr-opened="false"

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -1,75 +1,72 @@
-
-{% if signalement.interventions is not empty %}
-    <div class="signalement-visites-buttons fr-text--right fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
-        {% if intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}
-            {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
-                {% if workflow_can(intervention, 'cancel') %}
-                    <button class="fr-btn fr-btn--danger fr-fi-close-line" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
-                        Annuler la visite
-                    </button>
-                {% endif %}
-                <button class="fr-btn fr-btn--secondary fr-fi-edit-line" aria-controls="reschedule-visite-modal-{{intervention.id}}" data-fr-opened="false">
-                    Modifier la date
+<div class="signalement-visites-buttons fr-text--right fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
+    {% if intervention.status is same as constant('App\\Entity\\Intervention::STATUS_PLANNED') %}
+        {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+            {% if workflow_can(intervention, 'cancel') %}
+                <button class="fr-btn fr-btn--danger fr-fi-close-line" aria-controls="cancel-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                    Annuler la visite
                 </button>
-                {% if workflow_can(intervention, 'confirm') %}
-                    <button class="fr-btn fr-fi-check-line" aria-controls="confirm-visite-modal-{{intervention.id}}" data-fr-opened="false">
-                        Confirmer la visite
-                    </button>
-                {% endif %}
             {% endif %}
-        {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
-            {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty %}
-                {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
-                    <button
-                        class="fr-btn fr-btn--secondary fr-fi-file-fill"
-                        aria-controls="edit-visite-modal-{{intervention.id}}"
-                        data-fr-opened="false"
-                        >
-                        Ajouter un rapport de visite
-                    </button>
-                {% endif %}
-            {% else %}
-                {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
-                    <button
-                        class="fr-btn fr-btn--secondary fr-fi-edit-line"
-                        aria-controls="edit-visite-modal-{{intervention.id}}"
-                        data-fr-opened="false">
-                        Editer le rapport
-                    </button>
-                {% endif %}
-                <a href="{{ path('show_file', {uuid: intervention.getRapportDeVisite.first.uuid}) }}"
-                    class="fr-btn fr-btn--secondary"
-                    title="Voir le rapport de visite"
-                    rel="noopener"
-                    target="_blank">
-                    <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
-                </a>
+            <button class="fr-btn fr-btn--secondary fr-fi-edit-line" aria-controls="reschedule-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                Modifier la date
+            </button>
+            {% if workflow_can(intervention, 'confirm') %}
+                <button class="fr-btn fr-fi-check-line" aria-controls="confirm-visite-modal-{{intervention.id}}" data-fr-opened="false">
+                    Confirmer la visite
+                </button>
             {% endif %}
+        {% endif %}
+    {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_DONE') %}
+        {% if signalement.interventions is empty or intervention.files is empty or intervention.getRapportDeVisite is empty %}
             {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
                 <button
-                    class="fr-btn fr-btn--secondary fr-icon-camera-fill open-modal-upload-files-btn"
+                    class="fr-btn fr-btn--secondary fr-fi-file-fill"
+                    aria-controls="edit-visite-modal-{{intervention.id}}"
                     data-fr-opened="false"
-                    aria-controls="visites-upload-files-{{intervention.id}}"
-                    data-file-type="photo"
-                    data-document-type="PHOTO_VISITE"
-                    data-accepted-type-mimes={{ get_accepted_mime_type('photo')}}
-                    data-accepted-extensions="{{ get_accepted_extensions('photo')}}"
-                    data-intervention-id="{{intervention.id}}">
-                    Ajouter les photos de la visite
+                    >
+                    Ajouter un rapport de visite
                 </button>
             {% endif %}
-        {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_NOT_DONE') %}
-            {% if intervention.getRapportDeVisite is not empty %}
-                <a href="{{ path('show_file', {uuid: intervention.getRapportDeVisite.first.uuid}) }}"
-                    class="fr-btn fr-btn--secondary"
-                    title="Voir le rapport de visite"
-                    rel="noopener"
-                    target="_blank">
-                    <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
-                </a>
-            {% endif %}
         {% else %}
-            &nbsp;
+            {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+                <button
+                    class="fr-btn fr-btn--secondary fr-fi-edit-line"
+                    aria-controls="edit-visite-modal-{{intervention.id}}"
+                    data-fr-opened="false">
+                    Editer le rapport
+                </button>
+            {% endif %}
+            <a href="{{ path('show_file', {uuid: intervention.getRapportDeVisite.first.uuid}) }}"
+                class="fr-btn fr-btn--secondary"
+                title="Voir le rapport de visite"
+                rel="noopener"
+                target="_blank">
+                <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
+            </a>
         {% endif %}
-    </div>
-{% endif %}
+        {% if is_granted('SIGN_EDIT_VISITE', intervention) %}
+            <button
+                class="fr-btn fr-btn--secondary fr-icon-camera-fill open-modal-upload-files-btn"
+                data-fr-opened="false"
+                aria-controls="visites-upload-files-{{intervention.id}}"
+                data-file-type="photo"
+                data-document-type="PHOTO_VISITE"
+                data-accepted-type-mimes={{ get_accepted_mime_type('photo')}}
+                data-accepted-extensions="{{ get_accepted_extensions('photo')}}"
+                data-intervention-id="{{intervention.id}}">
+                Ajouter les photos de la visite
+            </button>
+        {% endif %}
+    {% elseif intervention.status is same as constant('App\\Entity\\Intervention::STATUS_NOT_DONE') %}
+        {% if intervention.getRapportDeVisite is not empty %}
+            <a href="{{ path('show_file', {uuid: intervention.getRapportDeVisite.first.uuid}) }}"
+                class="fr-btn fr-btn--secondary"
+                title="Voir le rapport de visite"
+                rel="noopener"
+                target="_blank">
+                <span aria-hidden="true" class="fr-fi-file-line fr-icon--sm"></span> Voir le rapport de visite
+            </a>
+        {% endif %}
+    {% else %}
+        &nbsp;
+    {% endif %}
+</div>

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -30,9 +30,6 @@
 </div>
 
 {% if signalement.interventions is empty %}
-    {% if is_granted('SIGN_ADD_VISITE', signalement) %}
-        {% include 'back/signalement/view/visites/visites-buttons.html.twig' %}
-    {% endif %}
     {% include 'back/signalement/view/visites/visite-item.html.twig' %}
 {% else %}
     {% for intervention in signalement.interventions | filter(intervention => intervention.type != enum('App\\Entity\\Enum\\InterventionType').ARRETE_PREFECTORAL) %}


### PR DESCRIPTION
## Ticket

#3100   

## Description
Les personnes qui ont le droit d'éditer (et par conséquent : confirmer, annuler, ajouter/supprimer des docs) une visite sont les suivantes : Super Admin, Admin du territoire du signalement, Utilisateur du partenaire qui est affecté à la visite.
Avant correction, tous les partenaires affectés au signalement et avec la compétence visite pouvaient éditer la visite.

## Changements apportés
* Ajout d'un voter SIGN_EDIT_VISITE aux droits différents de l'ajout de visite

## Tests
- [ ] Si je suis super admin, je peux tout faire au niveau de la partie visite
- [ ] Si je suis admin territoire, aussi
- [ ] Si je suis dans un partenaire non-affecté, je ne peux rien faire
- [ ] Si je suis dans un partenaire dont l'affectation n'est pas acceptée, je ne peux rien faire
- [ ] Si je suis dans un partenaire avec affectation acceptée, qui a la compétence visite et que je suis assigné à la visite : je peux l'éditer
- [ ] Si je suis dans un partenaire avec affectation acceptée, qui a la compétence visite, mais pas assigné, je ne peux rien éditer
