### PR TITLE
[BO - Modale] Uniformiser les modales

### DIFF
--- a/assets/scripts/vanilla/controllers/back_profil_edit_email/back_profil_edit_email.js
+++ b/assets/scripts/vanilla/controllers/back_profil_edit_email/back_profil_edit_email.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser'
 
 const modalEditEmail = document?.querySelector('#fr-modal-profil-edit-email');
-const modalEditEmailTitle = document?.querySelector('#fr-modal-profil-edit-email-title');
+const modalEditEmailTitle = document?.querySelector('#fr-profil-edit-email-title');
 const modalAlert = document?.querySelector('#fr-modal-profil-edit-email-alert');
 const modalEmailInput = document?.querySelector('#fr-modal-profil-edit-email-email-input');
 const modalCodeText = document?.querySelector('#fr-modal-profil-edit-email-code-text');

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -5,7 +5,7 @@
         <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
           <div class="fr-modal__body">
             <div class="fr-modal__header">
-              <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-already-exists" id="fr-modal-already-exists-close">Fermer</button>
+              <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-already-exists" id="fr-modal-already-exists-close">Fermer</button>
             </div>
             <div class="fr-modal__content" v-if="formStore.alreadyExists.type==='signalement'">
               <h1 id="fr-modal-title-modal-already-exists" class="fr-modal__title"><span v-if="formStore.alreadyExists.signalements?.length === 1">Ce signalement existe déjà</span><span v-else>Ces signalements existent déjà</span></h1>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormModalBackHome.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormModalBackHome.vue
@@ -5,7 +5,7 @@
         <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
           <div class="fr-modal__body">
             <div class="fr-modal__header">
-              <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-back-home">Fermer</button>
+              <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-back-home">Fermer</button>
             </div>
             <div class="fr-modal__content">
               <h1 id="fr-modal-title-modal-back-home" class="fr-modal__title">Retour à l'accueil</h1>
@@ -20,12 +20,12 @@
             <div class="fr-modal__footer">
               <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                 <li>
-                  <a class="fr-btn" href="/">
+                  <a class="fr-btn fr-icon-check-line" href="/">
                     Quitter le signalement
                   </a>
                 </li>
                 <li>
-                  <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-back-home">
+                  <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-back-home" type="button">
                     Continuer ma saisie
                   </button>
                 </li>

--- a/assets/scripts/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListCards.vue
@@ -82,17 +82,16 @@
       </div>
     </div>
   </div>
-  <dialog aria-labelledby="modal-delete-signalement-title" id="modal-delete-signalement" class="fr-modal" role="dialog" >
+  <dialog aria-labelledby="modal-delete-signalement-title" id="modal-delete-signalement" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-lg">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-btn--close fr-btn" aria-controls="modal-delete-signalement">Fermer</button>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="modal-delete-signalement">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="modal-delete-signalement-title" class="fr-modal__title">
-                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
                             Supprimer le signalement {{ selectedItem?.reference }}
                         </h1>
                         <div class="fr-alert fr-alert--warning fr-mb-1w">
@@ -112,10 +111,10 @@
                     </div>
                     <div class="fr-modal__footer">
                         <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" @click="emitDeleteSignalementItem(selectedItem)">
+                            <button class="fr-btn fr-btn--secondary fr-icon-check-line" @click="emitDeleteSignalementItem(selectedItem)">
                               Oui, supprimer
                             </button>
-                            <button class="fr-btn fr-icon-check-line" aria-controls="modal-delete-signalement">
+                            <button class="fr-btn fr-icon-close-line" aria-controls="modal-delete-signalement">
                               Non, annuler
                             </button>
                         </div>

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -835,6 +835,10 @@ a.photo-preview {
     z-index: 1;
 }
 
+.fr-modal__footer-shadow {
+    filter: drop-shadow(var(--raised-shadow));
+}
+
 .signalement-tag-add, .signalement-tag-remove {
     cursor: pointer;
 }

--- a/templates/_partials/_modal_affectation.html.twig
+++ b/templates/_partials/_modal_affectation.html.twig
@@ -1,16 +1,15 @@
-<dialog aria-labelledby="fr-modal-affectation-title" id="fr-modal-affectation" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-modal-affectation-title" id="fr-modal-affectation" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-10 fr-col-lg-10">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="fr-modal-affectation-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line"></span>
-                            Affectation de partenaires
-                        </h1>
-                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-affectation">Fermer</button>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-affectation">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-modal-affectation-title" class="fr-modal__title">
+                            Affectation de partenaires
+                        </h1>
                         <div class="fr-grid-row fr-grid-row--center fr-grid-row--middle fr-h-100 fr-hidden fr-mt-5w"
                              id="signalement-affectation-loader-row">
                             <div class="fr-col-12 fr-text--center">
@@ -75,7 +74,7 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-icon-checkbox-line" type="submit"
+                                <button class="fr-btn fr-icon-check-line" type="submit"
                                         form="signalement-affectation-form" id="signalement-affectation-form-submit"
                                         formaction="{{ path('back_signalement_toggle_affectation',{uuid:signalement.uuid}) }}">
                                     Affecter partenaire(s)
@@ -83,7 +82,7 @@
                             </li>
                             <li>
                                 <button class="fr-btn fr-btn--secondary fr-icon-close-line"
-                                        aria-controls="fr-modal-affectation">
+                                        aria-controls="fr-modal-affectation" type="button">
                                     Annuler
                                 </button>
                             </li>

--- a/templates/_partials/_modal_closed_territory.html.twig
+++ b/templates/_partials/_modal_closed_territory.html.twig
@@ -9,7 +9,9 @@
                         <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-closed-territory">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="fr-modal-title-modal-closed-territory" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Avertissement</h1>
+                        <h1 id="fr-modal-title-modal-closed-territory" class="fr-modal__title">
+                            Avertissement
+                        </h1>
                         <div id="fr-modal-closed-territory-content">
                             <p>
                                 Nous ne pouvons malheureusement pas traiter votre demande.<br>

--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -1,16 +1,15 @@
-<dialog aria-labelledby="cloture-modal-title" id="cloture-modal" class="fr-modal" role="dialog">
+<dialog aria-labelledby="cloture-modal-title" id="cloture-modal" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="cloture-modal-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
-                            Clôture signalement #{{ signalement.reference }}
-                        </h1>
-                        <a href="#" class="fr-link--close fr-link" aria-controls="cloture-modal">Fermer</a>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="cloture-modal">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="cloture-modal-title" class="fr-modal__title">
+                            Clôture signalement #{{ signalement.reference }}
+                        </h1>
                         {{ form_start(clotureForm,{attr:{
                             'class': 'tinyCheck'
                         }}) }}
@@ -63,7 +62,7 @@
                         {% endif %}
                     </div>
                     <div class="fr-modal__footer">
-                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                                 <li>
                                     <button class="fr-btn fr-btn--danger fr-w-100"
@@ -79,6 +78,11 @@
                                     </button>
                                 </li>
                             {% endif %}
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line " aria-controls="cloture-modal" type="button">
+                                        Annuler
+                                    </button>
+                                </li>
                         </ul>
                     </div>
                 </div>

--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -65,24 +65,24 @@
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                                 <li>
-                                    <button class="fr-btn fr-btn--danger fr-w-100"
+                                    <button class="fr-btn fr-icon-check-line"
                                             form="cloture_form" name="cloture[type]" value="all" type="submit" disabled>
                                         Cloturer pour tous les partenaires
                                     </button>
                                 </li>
                             {% else %}
                                 <li>
-                                    <button class="fr-btn fr-w-100" form="cloture_form"
+                                    <button class="fr-btn fr-icon-check-line" form="cloture_form"
                                             name="cloture[type]" value="partner" type="submit" disabled>
                                         Cloturer pour {{ app.user.partner ? app.user.partner.nom }}
                                     </button>
                                 </li>
                             {% endif %}
-                                <li>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line " aria-controls="cloture-modal" type="button">
-                                        Annuler
-                                    </button>
-                                </li>
+                            <li>
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line " aria-controls="cloture-modal" type="button">
+                                    Annuler
+                                </button>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/templates/_partials/_modal_dpe.html.twig
+++ b/templates/_partials/_modal_dpe.html.twig
@@ -1,16 +1,15 @@
-<dialog aria-labelledby="modal-dpe-title" id="modal-dpe" class="fr-modal" role="dialog">
+<dialog aria-labelledby="modal-dpe-title" id="modal-dpe" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8 fr-col-lg-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="modal-dpe-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
-                            Consulter le(s) DPE
-                        </h1>
-                        <button class="fr-btn--close fr-btn" aria-controls="modal-dpe">Fermer</button>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="modal-dpe">Fermer</button>
                     </div>
                     <div class="fr-modal__content" id="modal-dpe-content">
+                        <h1 id="modal-dpe-title" class="fr-modal__title">
+                            Consulter le(s) DPE
+                        </h1>
                         <h4>Aucun DPE connu pour ce logement</h4>
                     </div>
                 </div>

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -1,15 +1,15 @@
-<dialog aria-labelledby="fr-modal-edit-nde-title" id="fr-modal-edit-nde" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-modal-edit-nde-title" id="fr-modal-edit-nde" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-10 fr-col-lg-10">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                            <h1 id="fr-modal-edit-nde-title" class="fr-modal__title">
-                                Non décence énergétique
-                            </h1>
-                            <button class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-nde">Fermer</button>
-                     </div>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-nde">Fermer</button>
+                    </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-modal-edit-nde-title" class="fr-modal__title">
+                            Non décence énergétique
+                        </h1>
                         <p>
                             Validez les informations pour savoir si le logement dépasse le seuil de non décence énergétique ou non.
                             <br>
@@ -156,14 +156,14 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-icon-checkbox-line" type="submit"
+                                <button class="fr-btn fr-icon-check-line" type="submit"
                                         id="signalement-edit-nde-form-submit">
                                     Valider
                                 </button>
                             </li>
                             <li>
                                 <button class="fr-btn fr-btn--secondary fr-icon-close-line"
-                                        aria-controls="fr-modal-edit-nde">
+                                        aria-controls="fr-modal-edit-nde" type="button">
                                     Annuler
                                 </button>
                             </li>

--- a/templates/_partials/_modal_file_delete.html.twig
+++ b/templates/_partials/_modal_file_delete.html.twig
@@ -1,9 +1,9 @@
-<dialog aria-labelledby="fr-modal-title-modal-delete-file" role="dialog" id="fr-modal-delete-file" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-delete-file" id="fr-modal-delete-file" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md  fr-text--left">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-delete-file" enctype="application/json" action="{{ path('back_signalement_delete_file',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-delete-file" enctype="application/json" action="{{ path('back_signalement_delete_file',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-delete-file">Fermer</button>
                         </div>
@@ -20,29 +20,28 @@
                             <div class="fr-alert fr-alert--info">
                                 <p>Voulez-vous vraiment supprimer <span class="fr-modal-file-delete-type"></span> ?</p>
                             </div>
-
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
+                            <input type="hidden" name="file_id" id="file-delete-fileid">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit" form="form-delete-file"
+                                        id="form-delete-file-submit">
+                                        Oui, supprimer
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-delete-file">
                                         Non, annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit" form="form-delete-file"
-                                        id="form-delete-file-submit">
-                                        Oui, supprimer
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
-                    <input type="hidden" name="file_id" id="file-delete-fileid">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/_partials/_modal_partner_delete.html.twig
+++ b/templates/_partials/_modal_partner_delete.html.twig
@@ -1,16 +1,15 @@
-<dialog aria-labelledby="fr-partner-delete-title" id="fr-modal-partner-delete" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-partner-delete-title" id="fr-modal-partner-delete" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="fr-modal-partner-delete-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line" aria-hidden="true"></span>
-                            Suppression du partenaire <span class="fr-modal-partner-delete_name"></span> 
-                        </h1>   
-                       <button class="fr-link--close fr-link" aria-controls="fr-modal-partner-delete">Fermer</button>
+                       <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-partner-delete">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-partner-delete-title" class="fr-modal__title">
+                            Suppression du partenaire <span class="fr-modal-partner-delete_name"></span> 
+                        </h1>   
                         <form action="{{ path('back_partner_delete') }}" name="partner_delete"
                               id="partner_delete_form" method="POST">
                             <div class="fr-select-group">
@@ -32,13 +31,13 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn" form="partner_delete_form"
+                                <button class="fr-btn fr-icon-check-line" form="partner_delete_form"
                                         id="partner_delete_form_submit">
                                     Oui, supprimer
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
                                         aria-controls="fr-modal-partner-delete">
                                     Non, annuler
                                 </button>

--- a/templates/_partials/_modal_refus_affectation.html.twig
+++ b/templates/_partials/_modal_refus_affectation.html.twig
@@ -42,11 +42,17 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button class="fr-btn fr-btn--danger fr-w-100"
+                                    <button class="fr-btn fr-icon-check-line"
                                             form="signalement-affectation-response-deny-form" type="submit"
                                             name="signalement-affectation-response[deny]" value="1" disabled
                                         >
                                         Refuser l'affectation
+                                    </button>
+                                </li>
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                            aria-controls="refus-signalement-modal">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>

--- a/templates/_partials/_modal_refus_affectation.html.twig
+++ b/templates/_partials/_modal_refus_affectation.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="refus-affectation-modal-title" id="refus-affectation-modal" class="fr-modal" role="dialog">
+<dialog aria-labelledby="refus-affectation-modal-title" id="refus-affectation-modal" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
@@ -7,13 +7,12 @@
                             class="tinyCheck fr-mb-3v" id="signalement-affectation-response-deny-form"
                             name="signalement-affectation-response-form" method="POST">
                         <div class="fr-modal__header">
-                            <h1 id="refus-affectation-modal-title" class="fr-modal__title">
-                                <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
-                                Refus signalement #{{ signalement.reference }}
-                            </h1>
-                            <a href="#" class="fr-link--close fr-link" aria-controls="refus-affectation-modal">Fermer</a>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="refus-affectation-modal">Fermer</button>
                         </div>
                         <div class="fr-modal__content fr-text--left">
+                            <h1 id="refus-affectation-modal-title" class="fr-modal__title">
+                                Refus signalement #{{ signalement.reference }}
+                            </h1>
                             <div class="fr-select-group">
                                 <label class="fr-label required" for="signalement-affectation-response[motifRefus]">
                                     Veuillez sélectionner le motif de refus
@@ -37,9 +36,11 @@
                                         id="refus_affectation_suivi"></textarea>
                                 <p class="fr-error-text fr-hidden">Vous devez saisir un message pour les partenaires.</p>
                             </div>
+                            <input type="hidden" name="_token"
+                                    value="{{ csrf_token('signalement_affectation_response_'~signalement.id) }}">
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
                                     <button class="fr-btn fr-btn--danger fr-w-100"
                                             form="signalement-affectation-response-deny-form" type="submit"
@@ -50,8 +51,6 @@
                                 </li>
                             </ul>
                         </div>
-                        <input type="hidden" name="_token"
-                                value="{{ csrf_token('signalement_affectation_response_'~signalement.id) }}">
                     </form>
                 </div>
             </div>

--- a/templates/_partials/_modal_refus_signalement.html.twig
+++ b/templates/_partials/_modal_refus_signalement.html.twig
@@ -1,4 +1,4 @@
-<dialog aria-labelledby="refus-signalement-modal-title" id="refus-signalement-modal" class="fr-modal" role="dialog">
+<dialog aria-labelledby="refus-signalement-modal-title" id="refus-signalement-modal" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
@@ -6,13 +6,12 @@
                     <form id="signalement-validation-response-deny-form" class="tinyCheck"
                             action="{{ path('back_signalement_validation_response',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
-                            <h1 id="refus-signalement-modal-title" class="fr-modal__title">
-                                <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
-                                Refus signalement #{{ signalement.reference }}
-                            </h1>
-                            <a href="#" class="fr-link--close fr-link" aria-controls="refus-signalement-modal">Fermer</a>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="refus-signalement-modal">Fermer</button>
                         </div>
                         <div class="fr-modal__content fr-text--left">
+                            <h1 id="refus-signalement-modal-title" class="fr-modal__title">
+                                Refus signalement #{{ signalement.reference }}
+                            </h1>
                             <div class="fr-select-group">
                                 <label class="fr-label required" for="signalement-validation-response[motifRefus]">
                                     Veuillez sélectionner le motif de refus
@@ -35,10 +34,12 @@
                                 <p class="fr-error-text fr-hidden">Vous devez indiquer le motif de ce refus. (10 caractères
                                     minimum)</p>
                             </div>
+                            <input type="hidden" name="_token"
+                                    value="{{ csrf_token('signalement_validation_response_'~signalement.id) }}">
                         </div>
 
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
                                     <button class="fr-btn fr-btn--danger fr-w-100"
                                             form="signalement-validation-response-deny-form" type="submit"
@@ -49,8 +50,6 @@
                                 </li>
                             </ul>
                         </div>
-                        <input type="hidden" name="_token"
-                                value="{{ csrf_token('signalement_validation_response_'~signalement.id) }}">
                     </form>
                 </div>
             </div>

--- a/templates/_partials/_modal_refus_signalement.html.twig
+++ b/templates/_partials/_modal_refus_signalement.html.twig
@@ -41,11 +41,17 @@
                         <div class="fr-modal__footer">
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button class="fr-btn fr-btn--danger fr-w-100"
+                                    <button class="fr-btn fr-icon-check-line"
                                             form="signalement-validation-response-deny-form" type="submit"
                                             name="signalement-validation-response[deny]" value="1" disabled
                                         >
                                         Refuser le signalement
+                                    </button>
+                                </li>
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                            aria-controls="refus-signalement-modal">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>

--- a/templates/_partials/_modal_reopen_signalement.html.twig
+++ b/templates/_partials/_modal_reopen_signalement.html.twig
@@ -47,13 +47,19 @@
                             <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
                                     <button type="submit"
-                                        class="fr-btn fr-btn--success fr-icon-lock-fill fr-btn--icon-left fr-w-100 reopen"
+                                        class="fr-btn fr-icon-check-line reopen"
                                         name="signalement-action[{% if all == '1' %}reopenAll{% else %}reopen{% endif %}]" value="1">
                                         {% if all == '1' %}
                                         Rouvrir le signalement pour tous
                                         {% else %}
                                         Rouvrir le signalement pour {{ app.user.partner.nom }}
                                         {% endif %}
+                                    </button>
+                                </li>
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                            aria-controls="reopen{% if all == '1' %}-all{% endif %}-signalement-modal">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>

--- a/templates/_partials/_modal_reopen_signalement.html.twig
+++ b/templates/_partials/_modal_reopen_signalement.html.twig
@@ -1,10 +1,14 @@
-<dialog aria-labelledby="reopen{% if all == '1' %}-all{% endif %}-signalement-modal-title" id="reopen{% if all == '1' %}-all{% endif %}-signalement-modal" class="fr-modal" role="dialog">
+<dialog aria-labelledby="reopen{% if all == '1' %}-all{% endif %}-signalement-modal-title" id="reopen{% if all == '1' %}-all{% endif %}-signalement-modal" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <form action="{{ path('back_signalement_reopen',{uuid:signalement.uuid}) }}" class="fr-mb-3v fr-w-100">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="reopen{% if all == '1' %}-all{% endif %}-signalement-modal">Fermer</button>
+                        </div>
+
+                        <div class="fr-modal__content fr-text--left">
                             <h1 id="reopen{% if all == '1' %}-all{% endif %}-signalement-modal-title" class="fr-modal__title">
                                 {% if all == '1' %}
                                 Rouvrir le signalement pour tous
@@ -12,10 +16,6 @@
                                 Rouvrir pour {{ app.user.partner.nom }}
                                 {% endif %}
                             </h1>
-                            <a href="#" class="fr-link--close fr-link" aria-controls="reopen{% if all == '1' %}-all{% endif %}-signalement-modal">Fermer</a>
-                        </div>
-
-                        <div class="fr-modal__content fr-text--left">
                             <fieldset class="fr-fieldset" id="radio-hint{% if all == '1' %}-all{% endif %}" aria-labelledby="radio-hint-legend{% if all == '1' %}-all{% endif %} radio-hint-messages">
                                 <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="radio-hint-legend{% if all == '1' %}-all{% endif %}">
                                     Un suivi de ré-ouverture va être créé.
@@ -39,20 +39,24 @@
                                     </div>
                                 </div>
                             </fieldset>
+                            <input type="hidden" name="_token"
+                                value="{{ csrf_token('signalement_reopen_'~signalement.id) }}">
                         </div>
 
                         <div class="fr-modal__footer">
-                            <button type="submit"
-                                class="fr-btn fr-btn--success fr-icon-lock-fill fr-btn--icon-left fr-w-100 reopen"
-                                name="signalement-action[{% if all == '1' %}reopenAll{% else %}reopen{% endif %}]" value="1">
-                                {% if all == '1' %}
-                                Rouvrir le signalement pour tous
-                                {% else %}
-                                Rouvrir le signalement pour {{ app.user.partner.nom }}
-                                {% endif %}
-                            </button>
-                            <input type="hidden" name="_token"
-                                value="{{ csrf_token('signalement_reopen_'~signalement.id) }}">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button type="submit"
+                                        class="fr-btn fr-btn--success fr-icon-lock-fill fr-btn--icon-left fr-w-100 reopen"
+                                        name="signalement-action[{% if all == '1' %}reopenAll{% else %}reopen{% endif %}]" value="1">
+                                        {% if all == '1' %}
+                                        Rouvrir le signalement pour tous
+                                        {% else %}
+                                        Rouvrir le signalement pour {{ app.user.partner.nom }}
+                                        {% endif %}
+                                    </button>
+                                </li>
+                            </ul>
                         </div>
                     </div>
                 </form>

--- a/templates/_partials/_modal_send_lien_suivi.html.twig
+++ b/templates/_partials/_modal_send_lien_suivi.html.twig
@@ -1,14 +1,10 @@
-<dialog aria-labelledby="send-lien-suivi-modal-title" id="send-lien-suivi-modal" class="fr-modal" role="dialog">
+<dialog aria-labelledby="send-lien-suivi-modal-title" id="send-lien-suivi-modal" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="send-lien-suivi-modal-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line fr-fi--sm"></span>
-                            Envoyer le lien de suivi pour le signalement #{{ signalement.reference }}
-                        </h1>
-                        <a href="#" class="fr-link--close fr-link" aria-controls="send-lien-suivi-modal">Fermer</a>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="send-lien-suivi-modal">Fermer</button>
                     </div>
                     {% set lienSuivi = platform.url ~ path('front_suivi_signalement',{code:signalement.codeSuivi}) %}
                     {% set hasMail = '' %}
@@ -23,6 +19,9 @@
                     <form action="{{ path('send_mail_get_lien_suivi',{uuid:signalement.uuid}) }}" name="send_lien_suivi"
                             id="send_lien_suivi" method="POST"  class='needs-validation' novalidate="novalidate">
                         <div class="fr-modal__content">
+                            <h1 id="send-lien-suivi-modal-title" class="fr-modal__title">
+                                Envoyer le lien de suivi pour le signalement #{{ signalement.reference }}
+                            </h1>
                             Vous êtes sur le point d'envoyer le lien de la page de suivi du signalement <strong>#{{ signalement.reference }}</strong> 
                             {% if hasMail is same as 'declarant' %}
                                 au tiers déclarant <strong>{{signalement.nomDeclarant}} {{signalement.prenomDeclarant}} ({{signalement.mailDeclarant}})</strong>.<br>
@@ -58,15 +57,9 @@
                             <input type="hidden" name="preferedResponse" value="redirection">
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary"
-                                            aria-controls="send-lien-suivi-modal">
-                                        Annuler
-                                    </button>
-                                </li>
-                                <li>
-                                    <button class="fr-btn fr-w-100" form="send_lien_suivi" type="submit">                                            
+                                    <button class="fr-btn fr-w-100 fr-icon-check-line" form="send_lien_suivi" type="submit">                                            
                                         {% if hasMail is same as 'declarant' %}
                                             Envoyer le lien au tiers déclarant
                                         {% elseif hasMail is same as 'occupant' %}
@@ -74,6 +67,12 @@
                                         {% elseif hasMail is same as 'both' %}
                                             Envoyer le lien de suivi
                                         {% endif %}
+                                    </button>
+                                </li>
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                            aria-controls="send-lien-suivi-modal" type="button">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -1,8 +1,7 @@
 <dialog 
-    aria-labelledby="fr-modal-upload-files" 
+    aria-labelledby="fr-modal-upload-files-title" 
     id="fr-modal-upload-files" 
     class="fr-modal" 
-    role="dialog" 
     data-file-type="document"
     data-has-changes="false"
     data-validated="false"
@@ -15,15 +14,15 @@
     >
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-upload-files">Fermer</button>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-upload-files">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <div class="type-conditional type-document">
                             <div class="filter-conditional filter-procedure">
-                                <h1 class="fr-modal__title">
+                                <h1 id="fr-modal-upload-files-title" class="fr-modal__title">
                                     Ajouter des documents liés à la procédure
                                 </h1>
                                 <div>
@@ -34,7 +33,7 @@
                                 </div>
                             </div>
                             <div class="filter-conditional filter-situation">
-                                <h1 class="fr-modal__title">
+                                <h1  id="fr-modal-upload-files-title" class="fr-modal__title">
                                     Ajouter des documents liés à la situation
                                 </h1>
                                 <div>
@@ -49,7 +48,7 @@
                             </div>
                         </div>
                         <div class="type-conditional type-photo">
-                            <h1 class="fr-modal__title">
+                            <h1 id="fr-modal-upload-files-title"  class="fr-modal__title">
                                 Ajouter des photos de la situation
                             </h1>
                             <div>
@@ -96,14 +95,18 @@
                         </div>
                     </div>
                     <div class="fr-modal__footer">
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-upload-files">
-                                Annuler
-                            </button>
-                            <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files" id="btn-validate-modal-upload-files">
-                                Valider
-                            </button>
-                        </div>
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files" id="btn-validate-modal-upload-files">
+                                    Valider
+                                </button>
+                            </li>
+                            <li>
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-upload-files" type="button">
+                                    Annuler
+                                </button>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/templates/_partials/_modal_upload_files_usager.html.twig
+++ b/templates/_partials/_modal_upload_files_usager.html.twig
@@ -1,8 +1,7 @@
 <dialog 
-    aria-labelledby="fr-modal-upload-files-usager" 
+    aria-labelledby="fr-modal-upload-files-usager-title" 
     id="fr-modal-upload-files-usager" 
     class="fr-modal" 
-    role="dialog" 
     data-file-type="document"
     data-has-changes="false"
     data-validated="false"
@@ -14,14 +13,14 @@
     >
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-upload-files-usager">Fermer</button>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-upload-files-usager">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <div class="type-conditional type-document">
-                            <h1 class="fr-modal__title">
+                            <h1 id="fr-modal-upload-files-usager-title" class="fr-modal__title">
                                 Ajouter des documents liés à la situation
                             </h1>
                             <div>
@@ -29,7 +28,7 @@
                             </div>
                         </div>
                         <div class="type-conditional type-photo">
-                            <h1 class="fr-modal__title">
+                            <h1 id="fr-modal-upload-files-usager-title" class="fr-modal__title">
                                 Ajouter des photos de la situation
                             </h1>
                             <div>
@@ -110,14 +109,18 @@
                         </div>
                     </div>
                     <div class="fr-modal__footer">
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-upload-files-usager">
-                                Annuler
-                            </button>
-                            <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files-usager" id="btn-validate-modal-upload-files">
-                                Valider
-                            </button>
-                        </div>
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files-usager" id="btn-validate-modal-upload-files">
+                                    Valider
+                                </button>
+                            </li>
+                            <li>
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-upload-files-usager" type="button">
+                                    Annuler
+                                </button>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/templates/_partials/_modal_user_create.html.twig
+++ b/templates/_partials/_modal_user_create.html.twig
@@ -1,16 +1,15 @@
-<dialog aria-labelledby="fr-user-create-title" id="fr-modal-user-create" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-user-create-title" id="fr-modal-user-create" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="fr-modal-user-create-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line" aria-hidden="true"></span>
-                            Ajouter un utilisateur
-                        </h1>   
-                       <button class="fr-link--close fr-link" aria-controls="fr-modal-user-create">Fermer</button>
+                       <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-user-create">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-user-create-title" class="fr-modal__title">
+                            Ajouter un utilisateur
+                        </h1>   
                         <span class="fr-grid-row fr-grid-row--gutters">Tous les champs sont obligatoires</span><br>
                         <form action="{{ path('back_partner_user_add', {'id': partner.id}) }}" name="user_create"
                               id="user_create_form" method="POST"  class='needs-validation' novalidate="novalidate">
@@ -98,17 +97,17 @@
                         </form>
                     </div>
                     <div class="fr-modal__footer">
-                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
-                                        aria-controls="fr-modal-user-create">
-                                    Annuler
+                                <button class="fr-btn fr-icon-check-line" form="user_create_form"
+                                        id="user_create_form_submit">
+                                    Créer le compte
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn" form="user_create_form"
-                                        id="user_create_form_submit">
-                                    Créer le compte
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                        aria-controls="fr-modal-user-create" type="button">
+                                    Annuler
                                 </button>
                             </li>
                         </ul>

--- a/templates/_partials/_modal_user_delete.html.twig
+++ b/templates/_partials/_modal_user_delete.html.twig
@@ -1,16 +1,15 @@
-<dialog aria-labelledby="fr-user-delete-title" id="fr-modal-user-delete" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-user-delete-title" id="fr-modal-user-delete" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="fr-modal-user-delete-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line" aria-hidden="true"></span>
-                            Suppression du compte de <span class="fr-modal-user-delete_username"></span> 
-                        </h1>   
-                       <button class="fr-link--close fr-link" aria-controls="fr-modal-user-delete">Fermer</button>
+                       <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-user-delete">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-user-delete-title" class="fr-modal__title">
+                            Suppression du compte de <span class="fr-modal-user-delete_username"></span> 
+                        </h1>   
                         <form action="{{ path('back_partner_user_delete') }}" name="user_delete"
                               id="user_delete_form" method="POST">
                             <div class="fr-select-group">
@@ -31,14 +30,14 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn" form="user_delete_form"
+                                <button class="fr-btn fr-icon-check-line" form="user_delete_form"
                                         id="user_delete_form_submit">
                                     Oui, supprimer
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
-                                        aria-controls="fr-modal-user-delete">
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                        aria-controls="fr-modal-user-delete" type="button">
                                     Non, annuler
                                 </button>
                             </li>

--- a/templates/_partials/_modal_user_edit.html.twig
+++ b/templates/_partials/_modal_user_edit.html.twig
@@ -1,16 +1,15 @@
-<dialog aria-labelledby="fr-user-edit-title" id="fr-modal-user-edit" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-user-edit-title" id="fr-modal-user-edit" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="fr-modal-user-edit-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line" aria-hidden="true"></span>
-                            Modifier le compte de :  <span class="fr-modal-user-edit_useremail"></span>
-                        </h1>   
-                       <button class="fr-link--close fr-link" aria-controls="fr-modal-user-edit">Fermer</button>
+                       <button class="fr-btn--close fr-btn" aria-controls="fr-modal-user-edit">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-user-edit-title" class="fr-modal__title">
+                            Modifier le compte de :  <span class="fr-modal-user-edit_useremail"></span>
+                        </h1>   
                         <span class="fr-grid-row fr-grid-row--gutters">Tous les champs sont obligatoires</span><br>
                         <form action="{{ path('back_partner_user_edit') }}" name="user_edit"
                               id="user_edit_form" method="POST" class='needs-validation' novalidate="novalidate">
@@ -100,14 +99,14 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn" form="user_edit_form"
+                                <button class="fr-btn fr-icon-check-line" form="user_edit_form"
                                         id="user_edit_form_submit">
                                     Enregistrer
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
-                                        aria-controls="fr-modal-user-edit">
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                        aria-controls="fr-modal-user-edit" type="button">
                                     Annuler
                                 </button>
                             </li>

--- a/templates/_partials/_modal_user_transfer.html.twig
+++ b/templates/_partials/_modal_user_transfer.html.twig
@@ -1,15 +1,15 @@
-<dialog aria-labelledby="fr-user-transfer-title" id="fr-modal-user-transfer" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-user-transfer-title" id="fr-modal-user-transfer" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="fr-modal-user-transfer-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line" aria-hidden="true"></span>
-                            Transférer <span id="fr-modal-user-transfer_username"></span>
-                        </h1>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-user-transfer">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-user-transfer-title" class="fr-modal__title">
+                            Transférer <span id="fr-modal-user-transfer_username"></span>
+                        </h1>
                         <form action="{{ path('back_partner_user_transfer') }}" name="user_transfer"
                               id="user_transfer_form" method="POST">
                             <div class="fr-select-group">
@@ -29,13 +29,13 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn" form="user_transfer_form"
+                                <button class="fr-btn fr-icon-check-line" form="user_transfer_form"
                                         id="user_transfer_form_submit">
                                     Transférer
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
                                         aria-controls="fr-modal-user-transfer">
                                     Annuler
                                 </button>

--- a/templates/_partials/_search_filter_form.html.twig
+++ b/templates/_partials/_search_filter_form.html.twig
@@ -38,18 +38,18 @@
             </div>
         </div>
     </div>
-    <dialog aria-labelledby="fr-modal-2-title" id="bo-modal-filters" class="fr-modal" role="dialog" >
+    <dialog aria-labelledby="fr-modal-2-title" id="bo-modal-filters" class="fr-modal">
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
-                <div class="fr-col-12 fr-col-md-8">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <h1 id="fr-modal-2-title" class="fr-modal__title">
-                                <span class="fr-fi-search-line fr-fi--sm" aria-hidden="true"></span>
-                                Filtres
-                            </h1>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="bo-modal-filters">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
+                            <h1 id="fr-modal-2-title" class="fr-modal__title">
+                                Filtres
+                            </h1>
                             <div class="fr-grid-row fr-grid-row--gutters fr-p-3v">
                                 {% if is_granted('ROLE_ADMIN') %}
                                     <div class="fr-col-12 fr-col-md-6">
@@ -546,14 +546,14 @@
 
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button class="fr-btn" >
+                                    <button class="fr-btn fr-icon-check-line">
                                         Rechercher
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary " aria-controls="bo-modal-filters">
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line " aria-controls="bo-modal-filters" type="button">
                                         Annuler
                                     </button>
                                 </li>

--- a/templates/_partials/signalement/add_suivi.html.twig
+++ b/templates/_partials/signalement/add_suivi.html.twig
@@ -1,15 +1,15 @@
-<dialog aria-labelledby="fr-modal-add-suivi-title" id="fr-modal-add-suivi" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-modal-add-suivi-title" id="fr-modal-add-suivi" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-10 fr-col-lg-10">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-add-suivi">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
                         <h1 id="fr-modal-add-suivi-title" class="fr-modal__title">
                             Ajouter un suivi
                         </h1>
-                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-add-suivi">Fermer</button>
-                    </div>
-                    <div class="fr-modal__content">
                         <form method="POST" name="signalement-add-suivi" id="signalement-add-suivi-form" class="tinyCheck"
                                 action="{{ path('back_signalement_add_suivi',{uuid:signalement.uuid}) }}">
                             <div class="fr-fieldset fr-fieldset--inline fr-mb-5v">
@@ -46,13 +46,13 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-checkbox-line"
+                                <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line"
                                         form="signalement-add-suivi-form" disabled>
                                     Enregistrer
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-add-suivi">
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-add-suivi" type="button">
                                     Annuler
                                 </button>
                             </li>

--- a/templates/back/auto-affectation-rule/_modal_autoaffectationrule_delete.html.twig
+++ b/templates/back/auto-affectation-rule/_modal_autoaffectationrule_delete.html.twig
@@ -4,13 +4,12 @@
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <h1 id="fr-modal-autoaffectationrule-delete-title" class="fr-modal__title">
-                            <span class="fr-fi-arrow-right-line" aria-hidden="true"></span>
-                            Suppression d'une règle d'auto-affectation 
-                        </h1>   
-                       <button class="fr-link--close fr-link" aria-controls="fr-modal-autoaffectationrule-delete">Fermer</button>
+                       <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-autoaffectationrule-delete">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
+                        <h1 id="fr-autoaffectationrule-delete-title" class="fr-modal__title">
+                            Suppression d'une règle d'auto-affectation 
+                        </h1>   
                         <form action="{{ path('back_auto_affectation_rule_delete') }}" name="autoaffectationrule_delete"
                               id="autoaffectationrule_delete_form" method="POST">
                             <div>
@@ -23,13 +22,13 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn" form="autoaffectationrule_delete_form"
+                                <button class="fr-btn fr-icon-check-line" form="autoaffectationrule_delete_form"
                                         id="autoaffectationrule_delete_form_submit">
                                     Oui, supprimer
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
                                         aria-controls="fr-modal-autoaffectationrule-delete">
                                     Non, annuler
                                 </button>

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -44,18 +44,17 @@
 {% block cgumodale %}
     {% if platform.cgu_current_version is not same as app.user.cguVersionChecked %}
         <button class="fr-hidden" data-fr-opened="true" aria-controls="fr-modal-cgu-bo"></button>
-        <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-cgu-bo" class="fr-modal" role="dialog" open="true">
+        <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-cgu-bo" class="fr-modal" open="true">
             <div class="fr-container fr-container--fluid fr-container-md">
                 <div class="fr-grid-row fr-grid-row--center">
                     <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                         <div class="fr-modal__body">
                             <div class="fr-modal__header">
-                                <h1 id="fr-modal-cgu-bo-title" class="fr-modal__title">
-                                    <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
-                                    Mise à jour des conditions d'utilisation
-                                </h1>
                             </div>
                             <div class="fr-modal__content">
+                                <h1 id="fr-modal-cgu-bo-title" class="fr-modal__title">
+                                    Mise à jour des conditions d'utilisation
+                                </h1>
                                 <div>
                                     <p>
                                         Les conditions générales d'utilisation du service ont été mises à jour le {{platform.cgu_current_version}}.

--- a/templates/back/profil/_modal_profil_email.html.twig
+++ b/templates/back/profil/_modal_profil_email.html.twig
@@ -1,13 +1,13 @@
 <dialog aria-labelledby="fr-profil-edit-email-title" id="fr-modal-profil-edit-email" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-profil-edit-email">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="fr-modal-profil-edit-email-title" class="fr-modal__title">
+                        <h1 id="fr-profil-edit-email-title" class="fr-modal__title">
                             Modifier mon adresse e-mail
                         </h1>                                   
                         <div id="fr-modal-profil-edit-email-alert" class="fr-alert fr-alert--info">
@@ -32,17 +32,17 @@
                         </form>
                     </div>
                     <div class="fr-modal__footer">
-                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
-                                        aria-controls="fr-modal-profil-edit-email">
-                                    Annuler
+                                <button class="fr-btn fr-icon-check-line" form="profil_edit_email_form"
+                                        id="profil_edit_email_form_submit" type="submit">
+                                    Valider
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn" form="profil_edit_email_form"
-                                        id="profil_edit_email_form_submit" type="submit">
-                                    Valider
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                        aria-controls="fr-modal-profil-edit-email">
+                                    Annuler
                                 </button>
                             </li>
                         </ul>

--- a/templates/back/profil/_modal_profil_infos.html.twig
+++ b/templates/back/profil/_modal_profil_infos.html.twig
@@ -1,13 +1,13 @@
 <dialog aria-labelledby="fr-profil-edit-infos-title" id="fr-modal-profil-edit-infos" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-profil-edit-infos">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="fr-modal-profil-edit-infos-title" class="fr-modal__title">
+                        <h1 id="fr-profil-edit-infos-title" class="fr-modal__title">
                             Modifier mes infos
                         </h1>   
                         <form action="{{ path('back_profil_edit_infos') }}" name="profil_edit_infos"
@@ -43,17 +43,17 @@
                         </form>
                     </div>
                     <div class="fr-modal__footer">
-                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-btn--secondary"
-                                        aria-controls="fr-modal-profil-edit-infos">
-                                    Annuler
+                                <button class="fr-btn fr-icon-check-line" form="profil_edit_infos_form"
+                                        id="profil_edit_infos_form_submit" type="submit">
+                                    Valider
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn" form="profil_edit_infos_form"
-                                        id="profil_edit_infos_form_submit" type="submit">
-                                    Valider
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                        aria-controls="fr-modal-profil-edit-infos">
+                                    Annuler
                                 </button>
                             </li>
                         </ul>

--- a/templates/back/profil/_modal_profil_password.html.twig
+++ b/templates/back/profil/_modal_profil_password.html.twig
@@ -1,57 +1,57 @@
-<dialog aria-labelledby="fr-profil-edit-password-title" id="fr-modal-profil-edit-password" class="fr-modal">
+<dialog aria-labelledby="fr-modal-profil-edit-password-title" id="fr-modal-profil-edit-password" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <form action="{{ path('back_profil_edit_password') }}" name="login-creation-mdp-form"
                         id="profil_edit_password_form" method="POST">
                         <div class="fr-modal__header">
-                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-profil-edit-password">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-profil-edit-password">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-profil-edit-password-title" class="fr-modal__title">
                                 Modifier mon mot de passe
                             </h1>    
                             Pour votre sécurité, choisissez un mot de passe unique pour votre compte Histologe.
-                                <div class="fr-input-group fr-input-group-password fr-grid-row fr-grid-row--middle fr-mt-5v">
-                                    <label class="fr-label fr-col-12" for="login-password">
-                                        Nouveau mot de passe
-                                    </label>
-                                    <input class="fr-input fr-col-11" type="password" id="login-password" name="password" required minlength="12" autocomplete="new-password">
-                                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
-                                    <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
-                                        <p class="fr-message">Votre mot de passe doit contenir :</p>
-                                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">12 caractères minimum</p>
-                                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-maj">1 caractère majuscule minimum</p>
-                                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-min">1 caractère minuscule minimum</p>
-                                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-nb">1 chiffre minimum</p>
-                                        <p class="message-password fr-message fr-message--info" id="password-input-message-info-special">1 caractère spécial minimum</p>
-                                    </div>
+                            <div class="fr-input-group fr-input-group-password fr-grid-row fr-grid-row--middle fr-mt-5v">
+                                <label class="fr-label fr-col-12" for="login-password">
+                                    Nouveau mot de passe
+                                </label>
+                                <input class="fr-input fr-col-11" type="password" id="login-password" name="password" required minlength="12" autocomplete="new-password">
+                                <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                                <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
+                                    <p class="fr-message">Votre mot de passe doit contenir :</p>
+                                    <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">12 caractères minimum</p>
+                                    <p class="message-password fr-message fr-message--info" id="password-input-message-info-maj">1 caractère majuscule minimum</p>
+                                    <p class="message-password fr-message fr-message--info" id="password-input-message-info-min">1 caractère minuscule minimum</p>
+                                    <p class="message-password fr-message fr-message--info" id="password-input-message-info-nb">1 chiffre minimum</p>
+                                    <p class="message-password fr-message fr-message--info" id="password-input-message-info-special">1 caractère spécial minimum</p>
                                 </div>
-                                <div class="fr-input-group fr-input-group-password-repeat fr-grid-row fr-grid-row--middle">
-                                    <label class="fr-label fr-col-12" for="login-password-repeat">
-                                        Confirmer le nouveau mot de passe
-                                    </label>
-                                    <input class="fr-input fr-col-11" type="password" id="login-password-repeat" name="password-repeat" required minlength="12" autocomplete="new-password">
-                                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
-                                    <p id="password-match-error" class="fr-error-text fr-hidden fr-col-12">
-                                        Les mots de passe ne correspondent pas.
-                                    </p>
-                                </div>
-                                <input type="hidden" name="_token" value="{{ csrf_token('profil_edit_password') }}">
+                            </div>
+                            <div class="fr-input-group fr-input-group-password-repeat fr-grid-row fr-grid-row--middle">
+                                <label class="fr-label fr-col-12" for="login-password-repeat">
+                                    Confirmer le nouveau mot de passe
+                                </label>
+                                <input class="fr-input fr-col-11" type="password" id="login-password-repeat" name="password-repeat" required minlength="12" autocomplete="new-password">
+                                <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                                <p id="password-match-error" class="fr-error-text fr-hidden fr-col-12">
+                                    Les mots de passe ne correspondent pas.
+                                </p>
+                            </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('profil_edit_password') }}">
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary"
-                                            aria-controls="fr-modal-profil-edit-password">
-                                        Annuler
+                                    <button class="fr-btn fr-icon-check-line" form="profil_edit_password_form"
+                                            id="submitter" type="submit">
+                                        Valider
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn" form="profil_edit_password_form"
-                                            id="submitter" type="submit">
-                                        Valider
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                            aria-controls="fr-modal-profil-edit-password" type="button">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>

--- a/templates/back/profil/index.html.twig
+++ b/templates/back/profil/index.html.twig
@@ -101,19 +101,18 @@
     </section>
     <hr>
     <section class="fr-px-5v fr-my-5v">
-        <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-profil-cgu-bo" class="fr-modal" role="dialog">
+        <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-profil-cgu-bo" class="fr-modal">
             <div class="fr-container fr-container--fluid fr-container-md">
                 <div class="fr-grid-row fr-grid-row--center">
-                    <div class="fr-col-12 fr-col-md-8">
+                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                         <div class="fr-modal__body">
                             <div class="fr-modal__header">
+                                <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-profil-cgu-bo">Fermer</button>
+                            </div>
+                            <div class="fr-modal__content">
                                 <h1 id="fr-modal-cgu-bo-title" class="fr-modal__title">
                                     Conditions Générales d'Utilisation
                                 </h1>
-                                <button class="fr-link--close fr-link" aria-controls="fr-modal-profil-cgu-bo">Fermer
-                                </button>
-                            </div>
-                            <div class="fr-modal__content">
                                 {{ include('back/cgu_bo.html.twig') }}
                             </div>
                         </div>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -21,6 +21,16 @@
     {% include '_partials/_modal_file_delete.html.twig' %}
     {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
 
+    {% if isClosedForMe or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED')  %}
+        {% if isClosed and is_granted('ROLE_ADMIN_TERRITORY') %}
+            {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
+        {% endif %}
+        
+        {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') %}
+            {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
+        {% endif %}
+    {% endif %}
+
     <div class="fr-background--white
             {{ (isClosedForMe and not is_granted('ROLE_ADMIN_TERRITORY'))
                 or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED')

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -1,9 +1,9 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-address" role="dialog" id="fr-modal-edit-address" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-address" id="fr-modal-edit-address" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-address" enctype="application/json" action="{{ path('back_signalement_edit_address',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-edit-address" enctype="application/json" action="{{ path('back_signalement_edit_address',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-address">Fermer</button>
                         </div>
@@ -85,26 +85,26 @@
                                     </div>
                                 </div>
                             </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_address_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn  fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-address">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_address_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-composition-logement.html.twig
@@ -1,9 +1,9 @@
 <dialog aria-labelledby="fr-modal-title-modal-edit-composition-logement" id="fr-modal-edit-composition-logement" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-composition-logement" enctype="application/json" action="{{ path('back_signalement_edit_composition_logement',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-edit-composition-logement" enctype="application/json" action="{{ path('back_signalement_edit_composition_logement',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-composition-logement">Fermer</button>
                         </div>
@@ -225,26 +225,26 @@
                                     <option value="non" {{ typeLogementCommoditesWcCuisine is same as 'non' ? 'selected' : '' }}>Non</option>
                                 </select>
                             </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_composition_logement_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn  fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-composition-logement">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_composition_logement_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -1,9 +1,9 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-coordonnees-bailleur" role="dialog" id="fr-modal-edit-coordonnees-bailleur" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-coordonnees-bailleur" id="fr-modal-edit-coordonnees-bailleur" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-coordonnees-bailleur" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_bailleur',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">                
+                    <form method="POST" id="form-edit-coordonnees-bailleur" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_bailleur',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-bailleur">Fermer</button>
                         </div>
@@ -136,26 +136,26 @@
                                 <label class="fr-label" for="coordonneesBailleurDateNaissance">Date de naissance (facultatif)</label>
                                 <input class="fr-input" type="date" id="coordonneesBailleurDateNaissance" name="dateNaissance" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? '' }}">
                             </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_bailleur_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-coordonnees-bailleur">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_bailleur_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-foyer.html.twig
@@ -1,12 +1,12 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-coordonnees-foyer" role="dialog" id="fr-modal-edit-coordonnees-foyer" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-coordonnees-foyer" id="fr-modal-edit-coordonnees-foyer" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST"
-                      id="form-edit-coordonnees-foyer"
-                      enctype="application/json"
-                      action="{{ path('back_signalement_edit_coordonnees_foyer',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form method="POST"
+                        id="form-edit-coordonnees-foyer"
+                        enctype="application/json"
+                        action="{{ path('back_signalement_edit_coordonnees_foyer',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-foyer">Fermer</button>
                         </div>
@@ -86,26 +86,26 @@
                                 <label class="fr-label" for="coordonneesFoyerTelephoneBis">Téléphone sec. (facultatif)</label>
                                 <input class="fr-input" type="text" id="coordonneesFoyerTelephoneBis" name="telephoneBis" value="{{ signalement.telOccupantBisDecoded }}">
                             </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_foyer_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-coordonnees-foyer">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_foyer_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -1,9 +1,9 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-coordonnees-tiers" role="dialog" id="fr-modal-edit-coordonnees-tiers" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-coordonnees-tiers" id="fr-modal-edit-coordonnees-tiers" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-coordonnees-tiers" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_tiers',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-edit-coordonnees-tiers" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_tiers',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-tiers">Fermer</button>
                         </div>
@@ -62,26 +62,26 @@
                                 <label class="fr-label" for="coordonneesTiersStructure">Structure (si lien avec l'occupant: professionnel(le) ou service de secours)</label>
                                 <input class="fr-input" type="text" id="coordonneesTiersStructure" name="structure" value="{{ signalement.structureDeclarant }}">
                             </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_tiers_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-coordonnees-tiers">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_tiers_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-file.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-file.html.twig
@@ -1,9 +1,9 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-file" role="dialog" id="fr-modal-edit-file" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-file" id="fr-modal-edit-file" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md  fr-text--left">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-file" enctype="application/json" action="{{ path('back_signalement_edit_file',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-edit-file" enctype="application/json" action="{{ path('back_signalement_edit_file',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-file">Fermer</button>
                         </div>
@@ -37,28 +37,28 @@
                                 <textarea class="fr-input" type="text" id="fileDescription" name="description" maxlength=250>
                                 </textarea>
                             </div>    
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_file_'~signalement.id) }}">
+                            <input type="hidden" name="file_id" id="file-edit-fileid">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn  fr-icon-check-line" type="submit" form="form-edit-file"
+                                        id="form-edit-file-submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-file">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit" form="form-edit-file"
-                                        id="form-edit-file-submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_file_'~signalement.id) }}">
-                    <input type="hidden" name="file_id" id="file-edit-fileid">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -1,9 +1,9 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-informations-logement" role="dialog" id="fr-modal-edit-informations-logement" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-informations-logement" id="fr-modal-edit-informations-logement" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-informations-logement" enctype="application/json" action="{{ path('back_signalement_edit_informations_logement',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-edit-informations-logement" enctype="application/json" action="{{ path('back_signalement_edit_informations_logement',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-informations-logement">Fermer</button>
                         </div>
@@ -157,26 +157,26 @@
                                 <label class="fr-label" for="informationLogementAnneeConstruction">Année de construction (facultatif)</label>
                                 <input class="fr-input" type="number" id="informationLogementAnneeConstruction" name="anneeConstruction" value="{{ anneeConstruction }}">
                             </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_informations_logement_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-informations-logement">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_informations_logement_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-procedure-demarches.html.twig
@@ -1,9 +1,9 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-procedure-demarches" role="dialog" id="fr-modal-edit-procedure-demarches" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-procedure-demarches" id="fr-modal-edit-procedure-demarches" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-procedure-demarches" enctype="application/json" action="{{ path('back_signalement_edit_procedure_demarches',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-edit-procedure-demarches" enctype="application/json" action="{{ path('back_signalement_edit_procedure_demarches',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-procedure-demarches">Fermer</button>
                         </div>
@@ -71,26 +71,26 @@
                                     <option value="nsp" {{ infoProcedureDepartApresTravaux is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
                                 </select>
                             </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_procedure_demarches_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-procedure-demarches">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn  fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_procedure_demarches_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -1,9 +1,10 @@
-<dialog aria-labelledby="fr-modal-title-modal-edit-situation-foyer" role="dialog" id="fr-modal-edit-situation-foyer" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-edit-situation-foyer" id="fr-modal-edit-situation-foyer" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8">
-                <form method="POST" id="form-edit-situation-foyer" enctype="application/json" action="{{ path('back_signalement_edit_situation_foyer',{uuid:signalement.uuid}) }}">
-                    <div class="fr-modal__body">
+                <div class="fr-modal__body">
+                    <form method="POST" id="form-edit-situation-foyer" enctype="application/json" action="{{ path('back_signalement_edit_situation_foyer',{uuid:signalement.uuid}) }}">
+
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-situation-foyer">Fermer</button>
                         </div>
@@ -157,26 +158,26 @@
                                 <input class="fr-input" type="text" id="situationFoyerRevenuFiscal" name="revenuFiscal" value="{{ signalement.informationComplementaire.informationsComplementairesSituationOccupantsRevenuFiscal ?? '0' }}">
                             </div>
                             {% endif %}
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_situation_foyer_'~signalement.id) }}">
                         </div>
                         
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="fr-modal-edit-situation-foyer">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button class="fr-btn fr-icon-checkbox-line" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                    <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_situation_foyer_'~signalement.id) }}">
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -206,14 +206,12 @@
 
                 {% elseif isClosedForMe or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') %}
                     {% if isClosed and is_granted('ROLE_ADMIN_TERRITORY') %}
-                        {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                                 aria-controls="reopen-all-signalement-modal" data-fr-opened="false">
                             Rouvrir pour tous
                         </button>
                     {% endif %}
                     {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') %}
-                        {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                                 aria-controls="reopen-signalement-modal" data-fr-opened="false">
                             Rouvrir pour {{ app.user.partner.nom }}

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -4,18 +4,18 @@
     <div class="fr-col-9 fr-col-md-6">
         <h3 class="fr-h5">Suivis</h3>
     </div>
-    <div class="fr-col-3 fr-col-md-6 fr-text--right">
-        {% if 
-            is_granted('COMMENT_CREATE', signalement)
-            and not isClosedForMe
-            %}
+    {% if 
+        is_granted('COMMENT_CREATE', signalement)
+        and not isClosedForMe
+        %}
+        {% include '_partials/signalement/add_suivi.html.twig' %}
+        <div class="fr-col-3 fr-col-md-6 fr-text--right">
             <button class="fr-btn fr-btn--icon-left fr-icon-quote-line" data-fr-opened="false"
                     aria-controls="fr-modal-add-suivi">
                 Ajouter un suivi
             </button>
-            {% include '_partials/signalement/add_suivi.html.twig' %}
-        {% endif %}
-    </div>
+        </div>
+    {% endif %}
 </div>
 
 {% for suivi in signalement.suivis|reverse %}

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -16,17 +16,17 @@
     </div>
 </div>
 
-<dialog aria-labelledby="fr-modal-title-modal-etiquettes" role="dialog" id="fr-modal-etiquettes" class="fr-modal">
+<dialog aria-labelledby="fr-modal-title-modal-etiquettes" id="fr-modal-etiquettes" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
                         <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etiquettes">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-title-modal-etiquettes" class="fr-modal__title">
-                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>Gérer les étiquettes du signalement
+                            Gérer les étiquettes du signalement
                         </h1>
                         <p>
                             Sélectionnez les étiquettes à attribuer au signalement en cliquant dessus.
@@ -89,12 +89,18 @@
                         </form>
                     </div>
                     <div class="fr-modal__footer">
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn" form="form-signalement-save-tags" type="submit"
-                                >Valider</button>
-                            <button class="fr-btn fr-btn--secondary" type="button" aria-controls="fr-modal-etiquettes"
-                                >Annuler</button>
-                        </div>
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button class="fr-btn fr-icon-check-line" form="form-signalement-save-tags" type="submit">
+                                    Valider
+                                </button>
+                            </li>
+                            <li>
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-etiquettes">
+                                    Annuler
+                                </button>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
@@ -1,14 +1,13 @@
-<dialog aria-labelledby="fr-modal-add-visite-modal" role="dialog" id="add-visite-modal" class="fr-modal">
+<dialog aria-labelledby="fr-modal-add-visite-modal" id="add-visite-modal" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                <form method="POST" name="signalement-add-visite"
-                      class="signalement-add-visite"
-                      enctype="multipart/form-data"
-                      action="{{ path('back_signalement_visite_add',{uuid:signalement.uuid}) }}"
-                >
-
-                    <div class="fr-modal__body">
+                <div class="fr-modal__body">
+                    <form method="POST" name="signalement-add-visite"
+                        class="signalement-add-visite"
+                        enctype="multipart/form-data"
+                        action="{{ path('back_signalement_visite_add',{uuid:signalement.uuid}) }}"
+                    >
                         <div class="fr-modal__header">
                             <button type="button" class="fr-btn--close fr-btn" aria-controls="add-visite-modal">Fermer</button>
                         </div>
@@ -94,21 +93,21 @@
                             <input type="hidden" name="_token" value="{{ csrf_token('signalement_add_visit_'~signalement.id) }}">
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button type="submit" class="fr-btn fr-icon-check-line" id="form-signalement-add-visite-submit">
+                                        Valider
+                                    </button>
+                                </li>
                                 <li>
                                     <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="add-visite-modal">
                                         Annuler
                                     </button>
                                 </li>
-                                <li>
-                                    <button type="submit" class="fr-btn fr-icon-checkbox-line" id="form-signalement-add-visite-submit">
-                                        Valider
-                                    </button>
-                                </li>
                             </ul>
                         </div>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/visites/modals/visites-modal-cancel.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-cancel.html.twig
@@ -1,15 +1,14 @@
-<dialog aria-labelledby="fr-modal-cancel-visite-modal-{{intervention.id}}" role="dialog" id="cancel-visite-modal-{{intervention.id}}" class="fr-modal">
+<dialog aria-labelledby="fr-modal-cancel-visite-modal-{{intervention.id}}" id="cancel-visite-modal-{{intervention.id}}" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                <form method="POST"
-                    name="signalement-cancel-visite" class="signalement-cancel-visite"
-                    data-intervention-id="{{intervention.id}}" enctype="application/json"
-                    action="{{ path('back_signalement_visite_cancel',{uuid:signalement.uuid}) }}">
-
-                    <div class="fr-modal__body">
+                <div class="fr-modal__body">
+                    <form method="POST"
+                        name="signalement-cancel-visite" class="signalement-cancel-visite"
+                        data-intervention-id="{{intervention.id}}" enctype="application/json"
+                        action="{{ path('back_signalement_visite_cancel',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="cancel-visite-modal-{{intervention.id}}">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="cancel-visite-modal-{{intervention.id}}">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-cancel-visite-modal-{{intervention.id}}" class="fr-modal__title">
@@ -40,21 +39,21 @@
                             <input type="hidden" name="_token" value="{{ csrf_token('signalement_cancel_visit_'~intervention.id) }}">
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary" aria-controls="cancel-visite-modal-{{intervention.id}}">
-                                        Annuler
+                                    <button type="submit" class="fr-btn fr-icon-check-line">
+                                        Valider
                                     </button>
                                 </li>
                                 <li>
-                                    <button type="submit" class="fr-btn">
-                                        Valider
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="cancel-visite-modal-{{intervention.id}}">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>
                         </div>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/visites/modals/visites-modal-confirm.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-confirm.html.twig
@@ -1,12 +1,11 @@
-<dialog aria-labelledby="fr-modal-confirm-visite-modal-{{intervention.id}}" role="dialog" id="confirm-visite-modal-{{intervention.id}}" class="fr-modal">
+<dialog aria-labelledby="fr-modal-confirm-visite-modal-{{intervention.id}}" id="confirm-visite-modal-{{intervention.id}}" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                <form method="POST" name="signalement-confirm-visite" class="signalement-confirm-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_confirm',{uuid:signalement.uuid}) }}">
-                        
-                    <div class="fr-modal__body">
+                <div class="fr-modal__body">
+                    <form method="POST" name="signalement-confirm-visite" class="signalement-confirm-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_confirm',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="confirm-visite-modal-{{intervention.id}}">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="confirm-visite-modal-{{intervention.id}}">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-confirm-visite-modal-{{intervention.id}}" class="fr-modal__title">
@@ -29,21 +28,21 @@
                             <input type="hidden" name="_token" value="{{ csrf_token('signalement_confirm_visit_'~intervention.id) }}">
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary" aria-controls="confirm-visite-modal-{{intervention.id}}">
-                                        Annuler
+                                    <button type="submit" class="fr-btn fr-icon-check-line">
+                                        Valider
                                     </button>
                                 </li>
                                 <li>
-                                    <button type="submit" class="fr-btn">
-                                        Valider
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="confirm-visite-modal-{{intervention.id}}">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>
                         </div>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/visites/modals/visites-modal-edit.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-edit.html.twig
@@ -1,13 +1,12 @@
 {% if intervention.scheduledAt is not empty %}
-    <dialog aria-labelledby="fr-modal-edit-visite-modal-{{intervention.id}}" role="dialog" id="edit-visite-modal-{{intervention.id}}" class="fr-modal">
+    <dialog aria-labelledby="fr-modal-edit-visite-modal-{{intervention.id}}" id="edit-visite-modal-{{intervention.id}}" class="fr-modal">
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                    <form method="POST" name="signalement-edit-visite" class="signalement-edit-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_edit',{uuid:signalement.uuid}) }}">
-
-                        <div class="fr-modal__body">
+                    <div class="fr-modal__body">
+                        <form method="POST" name="signalement-edit-visite" class="signalement-edit-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_edit',{uuid:signalement.uuid}) }}">
                             <div class="fr-modal__header">
-                                <button type="button" class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="edit-visite-modal-{{intervention.id}}">Fermer</button>
+                                <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="edit-visite-modal-{{intervention.id}}">Fermer</button>
                             </div>
                             <div class="fr-modal__content">
                                 <h1 id="fr-modal-edit-visite-modal-{{intervention.id}}" class="fr-modal__title">
@@ -25,21 +24,21 @@
                                 <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_visit_'~intervention.id) }}">
                             </div>
                             <div class="fr-modal__footer">
-                                <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                     <li>
-                                        <button type="button" class="fr-btn fr-btn--secondary" aria-controls="edit-visite-modal-{{intervention.id}}">
-                                            Annuler
+                                        <button type="submit" class="fr-btn fr-icon-check-line">
+                                            Valider
                                         </button>
                                     </li>
                                     <li>
-                                        <button type="submit" class="fr-btn">
-                                            Valider
+                                        <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="edit-visite-modal-{{intervention.id}}">
+                                            Annuler
                                         </button>
                                     </li>
                                 </ul>
                             </div>
-                        </div>
-                    </form>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
@@ -1,12 +1,11 @@
-<dialog aria-labelledby="fr-modal-reschedule-visite-modal-{{intervention.id}}" role="dialog" id="reschedule-visite-modal-{{intervention.id}}" class="fr-modal">
+<dialog aria-labelledby="fr-modal-reschedule-visite-modal-{{intervention.id}}" id="reschedule-visite-modal-{{intervention.id}}" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                <form method="POST" name="signalement-reschedule-visite" class="signalement-reschedule-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_reschedule',{uuid:signalement.uuid}) }}">
-
-                    <div class="fr-modal__body">
+                <div class="fr-modal__body">
+                    <form method="POST" name="signalement-reschedule-visite" class="signalement-reschedule-visite" enctype="multipart/form-data" action="{{ path('back_signalement_visite_reschedule',{uuid:signalement.uuid}) }}">
                         <div class="fr-modal__header">
-                            <button type="button" class="fr-link--close fr-link" title="Fermer la fenêtre modale" aria-controls="reschedule-visite-modal-{{intervention.id}}">Fermer</button>
+                            <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="reschedule-visite-modal-{{intervention.id}}">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-reschedule-visite-modal-{{intervention.id}}" class="fr-modal__title">
@@ -92,21 +91,21 @@
                             <input type="hidden" name="_token" value="{{ csrf_token('signalement_reschedule_visit_'~intervention.id) }}">
                         </div>
                         <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <li>
-                                    <button type="button" class="fr-btn fr-btn--secondary" aria-controls="reschedule-visite-modal-{{intervention.id}}">
-                                        Annuler
+                                    <button type="submit" class="fr-btn fr-icon-check-line">
+                                        Valider
                                     </button>
                                 </li>
                                 <li>
-                                    <button type="submit" class="fr-btn">
-                                        Valider
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="reschedule-visite-modal-{{intervention.id}}">
+                                        Annuler
                                     </button>
                                 </li>
                             </ul>
                         </div>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-upload-files.html.twig
@@ -2,7 +2,6 @@
     aria-labelledby="fr-modal-visites-upload-files-{{intervention.id}}" 
     id="visites-upload-files-{{intervention.id}}" 
     class="fr-modal fr-modal-visites-upload-files" 
-    role="dialog" 
     data-file-type="document"
     data-intervention-id="{{intervention.id}}"
     data-has-changes="false"
@@ -19,11 +18,11 @@
             <div class="fr-col-12 fr-col-md-8">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-btn--close fr-btn" aria-controls="visites-upload-files-{{intervention.id}}">Fermer</button>
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="visites-upload-files-{{intervention.id}}">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
                         <div class="type-conditional type-photo">
-                            <h1 class="fr-modal__title">
+                            <h1 class="fr-modal__title" id="fr-modal-visites-upload-files-{{intervention.id}}">
                                 Ajout des photos de la visite
                             </h1>
                             <div>
@@ -49,12 +48,12 @@
                         </div>
                     </div>
                     <div class="fr-modal__footer">
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="visites-upload-files-{{intervention.id}}">
-                                Annuler
-                            </button>
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <button class="fr-btn fr-icon-check-line" aria-controls="visites-upload-files-{{intervention.id}}" id="btn-validate-modal-upload-files">
                                 Valider
+                            </button>
+                            <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="visites-upload-files-{{intervention.id}}" type="button">
+                                Annuler
                             </button>
                         </div>
                     </div>

--- a/templates/back/tags/index.html.twig
+++ b/templates/back/tags/index.html.twig
@@ -71,8 +71,8 @@
                                 <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etiquette-add">Fermer</button>
                             </div>
                             <div class="fr-modal__content">
-                                <h1 id="fr-modal-title-modal-etiquette-add" class="fr-modal__title">
-                                    <span class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter une étiquette
+                                <h1 id="fr-modal-title-etiquette-add" class="fr-modal__title">
+                                    Ajouter une étiquette
                                 </h1>
                                 <p>Une fois créée, les agents pourront ajouter ou retirer l'étiquette aux signalements et l'utiliser pour filtrer la liste des signalements.</p>
                                 {% form_theme addForm 'form/dsfr_theme.html.twig' %}
@@ -80,9 +80,9 @@
                             </div>
                             <div class="fr-modal__footer">
                                 <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                    <button class="fr-btn" form="form-add-tag" type="submit"
+                                    <button class="fr-btn fr-icon-check-line" form="form-add-tag" type="submit"
                                         >Valider</button>
-                                    <button class="fr-btn fr-btn--secondary" type="button" aria-controls="fr-modal-etiquette-add"
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-etiquette-add"
                                         >Annuler</button>
                                 </div>
                             </div>
@@ -105,8 +105,8 @@
                                     <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etiquette-edit-{{ tag.id }}">Fermer</button>
                                 </div>
                                 <div class="fr-modal__content">
-                                    <h1 id="fr-modal-title-modal-etiquette-edit-{{ tag.id }}" class="fr-modal__title">
-                                        <span class="fr-icon-arrow-right-line fr-icon--lg"></span>Modifier l'étiquette : {{ tag.label }}
+                                    <h1 id="fr-modal-title-etiquette-edit-{{ tag.id }}" class="fr-modal__title">
+                                        Modifier l'étiquette : {{ tag.label }}
                                     </h1>
                                     <p>L'étiquette sera mise à jour sur tous les signalements dans lesquelles elle est utilisée.</p>
                                     <form method="POST" action="{{ path('back_tags_edit', {tag:tag.id}) }}" id="form-edit-tag-{{ tag.id }}">
@@ -119,9 +119,9 @@
                                 </div>
                                 <div class="fr-modal__footer">
                                     <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                        <button class="fr-btn" form="form-edit-tag-{{ tag.id }}" type="submit"
+                                        <button class="fr-btn fr-icon-check-line" form="form-edit-tag-{{ tag.id }}" type="submit"
                                             >Modifier</button>
-                                        <button class="fr-btn fr-btn--secondary" type="button" aria-controls="fr-modal-etiquette-edit-{{ tag.id }}"
+                                        <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-etiquette-edit-{{ tag.id }}"
                                             >Annuler</button>
                                     </div>
                                 </div>
@@ -141,8 +141,8 @@
                                 <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etiquette-delete-{{ tag.id }}">Fermer</button>
                             </div>
                             <div class="fr-modal__content">
-                                <h1 id="fr-modal-title-modal-etiquette-delete-{{ tag.id }}" class="fr-modal__title">
-                                    <span class="fr-icon-arrow-right-line fr-icon--lg"></span>Supprimer l'étiquette : {{ tag.label }}
+                                <h1 id="fr-modal-title-etiquette-delete-{{ tag.id }}" class="fr-modal__title">
+                                    Supprimer l'étiquette : {{ tag.label }}
                                 </h1>
                                 <p>Vous êtes sur le point de supprimer une étiquette.</p>
                                 <p>Une fois l'étiquette supprimée :</p>
@@ -162,9 +162,9 @@
                             </div>
                             <div class="fr-modal__footer">
                                 <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                    <button class="fr-btn" form="form-delete-tag-{{ tag.id }}" type="submit"
+                                    <button class="fr-btn fr-icon-check-line" form="form-delete-tag-{{ tag.id }}" type="submit"
                                         >Oui, supprimer</button>
-                                    <button class="fr-btn fr-btn--secondary" type="button" aria-controls="fr-modal-etiquette-delete-{{ tag.id }}"
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-etiquette-delete-{{ tag.id }}"
                                         >Non, annuler</button>
                                 </div>
                             </div>

--- a/templates/consent_banner/_modal_consent.html.twig
+++ b/templates/consent_banner/_modal_consent.html.twig
@@ -1,7 +1,7 @@
 <dialog id="fr-consent-modal" class="fr-modal" aria-labelledby="fr-consent-modal-title">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+            <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
                         <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-consent-modal" title="Fermer"> Fermer

--- a/templates/consent_banner/_modal_consent.html.twig
+++ b/templates/consent_banner/_modal_consent.html.twig
@@ -1,14 +1,16 @@
-<dialog id="fr-consent-modal" class="fr-modal" role="dialog" aria-labelledby="fr-consent-modal-title">
+<dialog id="fr-consent-modal" class="fr-modal" aria-labelledby="fr-consent-modal-title">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
-            <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-btn--close fr-btn" aria-controls="fr-consent-modal" title="Fermer"> Fermer
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-consent-modal" title="Fermer"> Fermer
                         </button>
                     </div>
-                    <div class="fr-modal__content"><h1 id="fr-consent-modal-title" class="fr-modal__title"> Panneau de
-                            gestion des cookies </h1>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-consent-modal-title" class="fr-modal__title"> Panneau de
+                            gestion des cookies 
+                        </h1>
                         <div class="fr-consent-manager">                            <!-- Finalités -->
                             <div class="fr-consent-service fr-consent-manager__header">
                                 <fieldset class="fr-fieldset fr-fieldset--inline">

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -32,8 +32,6 @@
                             <div class="fr-col-12 fr-col-md-8">
                                 <div class="fr-modal__body">
                                     <div class="fr-modal__header">
-                                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-cgu-bo">Fermer
-                                        </button>
                                     </div>
                                     <div class="fr-modal__content">
                                         <h1 id="fr-modal-cgu-bo-title" class="fr-modal__title">

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -26,26 +26,26 @@
             </header>
             <form class="fr-mt-5v fr-col-md-6" name="login-creation-mdp-form" method="POST"
                   novalidate="">
-                <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-cgu-bo" class="fr-modal" role="dialog">
+                <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-cgu-bo" class="fr-modal">
                     <div class="fr-container fr-container--fluid fr-container-md">
                         <div class="fr-grid-row fr-grid-row--center">
                             <div class="fr-col-12 fr-col-md-8">
                                 <div class="fr-modal__body">
                                     <div class="fr-modal__header">
+                                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-cgu-bo">Fermer
+                                        </button>
+                                    </div>
+                                    <div class="fr-modal__content">
                                         <h1 id="fr-modal-cgu-bo-title" class="fr-modal__title">
                                             <span class="fr-fi-arrow-right-line fr-icon--sm" aria-hidden="true"></span>
                                             Conditions Générales d'Utilisation
                                         </h1>
-                                        <button class="fr-link--close fr-link" aria-controls="fr-modal-cgu-bo">Fermer
-                                        </button>
-                                    </div>
-                                    <div class="fr-modal__content">
                                         {{ include('back/cgu_bo.html.twig') }}
                                     </div>
                                     <div class="fr-modal__footer">
                                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                             <li>
-                                                <button class="fr-btn">
+                                                <button class="fr-btn fr-icon-check-line">
                                                     Accepter et continuer
                                                 </button>
                                             </li>


### PR DESCRIPTION
## Ticket

#2960    

## Description
Pour les modales, le mieux est de regarder celles sur la maquette la plus récente : [le profil utilisateur]

    Pas de flèche avant le titre
    Bouton fermer en haut à droite
    Zone d'action en bas de modale avec une ombre portée (edit Hélène : non pas d'ombre, ce n'est plus dans le dsfr). La zone d'action contient 2 boutons alignés à droite
        Principal : bouton valider à droite
        Secondaire : annuler à gauche


## Changements apportés
* Changement des twigs et des Vue

## Pré-requis
`npm run watch`

## Tests
- [ ] Ouvrir chaque modale
- [ ] Vérifier la cohérence de l'UI
- [ ] Vérifier que les actions fonctionnent toujours
