### PR TITLE
[BO -Tableau de bord] Problème chargement du tableau de bord

### DIFF
--- a/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -189,7 +189,9 @@ export default defineComponent({
       this.sharedState.noSuiviAfter3Relances.count = dataWidget.cardNoSuiviAfter3Relances?.count
       this.sharedState.noSuiviAfter3Relances.link = dataWidget.cardNoSuiviAfter3Relances?.link
 
-      if (callback) callback()
+      if (callback) {
+        callback()
+      }
     },
     handleAffectationPartner (requestResponse: any) {
       this.countTablesLoaded++

--- a/assets/scripts/vue/components/dashboard/requests.ts
+++ b/assets/scripts/vue/components/dashboard/requests.ts
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/browser'
 export const requests = {
   doRequest (ajaxUrl: string, functionReturn: Function) {
     axios
-      .get(ajaxUrl, { timeout: 15000 })
+      .get(ajaxUrl, { timeout: 30000 })
       .then(response => {
         const responseData = response.data
         functionReturn(responseData)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dev": "encore dev",
     "watch": "encore dev --watch",
     "build": "encore production --progress",
-    "es-vue-fix": "node_modules/.bin/eslint --config=.eslintrc.js assets/vue --fix"
+    "es-vue-fix": "node_modules/.bin/eslint --config=.eslintrc.js assets/scripts/vue --fix"
   },
   "engines": {
     "node": "18.14.2"


### PR DESCRIPTION
## Ticket

#3103    
![image](https://github.com/user-attachments/assets/b8eb642a-3fd4-4448-ac58-599272f0f9ee)


## Description
Augmentation du timeout pour les requêtes du dashboard dont une peut mettre plus de 15 secondes pour le super-admin

Correction d'un problème de chargement de widget entraînant des widgets non chargés correctement dans le tableau de bord ou `initKPI` peut répondre avant `initSettings`

![image](https://github.com/user-attachments/assets/d60cd40a-ec6a-4534-9288-7f6b9c0c75a6)

Les modifications apportées garantissent que les réponses des services réponde dans l'ordre voulu

## Changements apportés
* Surcharge des fonction callback initSettings et initKPI par des promesses initSettingsWithPromise et initKPIWithPromise
* Gestion des promesses lors de l'appel via async/await pour garantir l'ordre des réponses.
* Augmentation du timeout de 15 à 30s
* Mise à jour de la config eslint

## Pré-requis
Charger la base de prod
```
make load-data
```

Builder les assets
```
make npm-watch
```

## Tests
- [ ] Se connecter en super admin et vérifier que le tableau de bord affichent bien tous les widget et sans erreur
- [ ] Refaire un appel, vérifier que le tableau de bord profite  du cache et que tous les widgets s'affichent sans erreur
- [ ] Tester en tant que RT et agent