### PR TITLE
[BO - Export] Remplacer la pièce jointe de l'export par un lien téléchargeable en corps de mail

### DIFF
--- a/migrations/Version20241001125833.php
+++ b/migrations/Version20241001125833.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241001125833 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make signalement column nullable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file CHANGE signalement_id signalement_id INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file CHANGE signalement_id signalement_id INT NOT NULL');
+    }
+}

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -24,6 +24,7 @@ enum DocumentType: String
     case AUTRE_PROCEDURE = 'AUTRE_PROCEDURE';
     case PHOTO_SITUATION = 'PHOTO_SITUATION';
     case PHOTO_VISITE = 'PHOTO_VISITE';
+    case EXPORT = 'EXPORT';
 
     public static function getLabelList(): array
     {
@@ -90,7 +91,7 @@ enum DocumentType: String
             self::PROCEDURE_SAISINE, self::BAILLEUR_DEVIS_POUR_TRAVAUX,
             self::BAILLEUR_REPONSE_BAILLEUR, => File::FILE_TYPE_DOCUMENT,
             self::PHOTO_SITUATION,self::PHOTO_VISITE => File::FILE_TYPE_PHOTO,
-            self::AUTRE, self::AUTRE_PROCEDURE => null,
+            self::AUTRE, self::AUTRE_PROCEDURE, self::EXPORT => null,
         };
     }
 }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -70,7 +70,7 @@ class File implements EntityHistoryInterface
     private ?User $uploadedBy = null;
 
     #[ORM\ManyToOne(inversedBy: 'files')]
-    #[ORM\JoinColumn(nullable: false)]
+    #[ORM\JoinColumn(nullable: true)]
     private ?Signalement $signalement = null;
 
     #[ORM\Column(length: 255)]

--- a/src/Messenger/MessageHandler/ListExportMessageHandler.php
+++ b/src/Messenger/MessageHandler/ListExportMessageHandler.php
@@ -2,6 +2,8 @@
 
 namespace App\Messenger\MessageHandler;
 
+use App\Entity\Enum\DocumentType;
+use App\Manager\FileManager;
 use App\Messenger\Message\ListExportMessage;
 use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMail;
@@ -9,11 +11,13 @@ use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\Export\SignalementExportLoader;
 use App\Service\TimezoneProvider;
+use App\Service\UploadHandlerService;
 use PhpOffice\PhpSpreadsheet\Writer\Csv;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
 
 #[AsMessageHandler]
 class ListExportMessageHandler
@@ -23,7 +27,9 @@ class ListExportMessageHandler
         private readonly LoggerInterface $logger,
         private readonly SignalementExportLoader $signalementExportLoader,
         private readonly UserRepository $userRepository,
-        private ParameterBagInterface $parameterBag,
+        private readonly ParameterBagInterface $parameterBag,
+        private readonly UploadHandlerService $uploadHandlerService,
+        private readonly FileManager $fileManager
     ) {
     }
 
@@ -44,16 +50,30 @@ class ListExportMessageHandler
 
             if (isset($writer)) {
                 $timezone = $user->getTerritory()?->getTimezone() ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
-                $datetimeStr = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone($timezone))->format('Ymd-Hi');
-                $filename = 'export-histologe-'.$listExportMessage->getUserId().'-'.$datetimeStr.'.'.$format;
+                $datetimeStr = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone($timezone))->format('Ymd-His');
+                $uuid = Uuid::v4();
+                $filename = 'export-histologe-'.$listExportMessage->getUserId().'-'.$datetimeStr.'-'.$uuid.'.'.$format;
                 $tmpFilepath = $this->parameterBag->get('uploads_tmp_dir').$filename;
                 $writer->save($tmpFilepath);
+
+                $filename = $this->uploadHandlerService->uploadFromFilename($filename);
+                $file = $this->fileManager->createOrUpdate(
+                    filename: $filename,
+                    title: $filename,
+                    type: 'document',
+                    user: $user,
+                    flush: true,
+                    documentType: DocumentType::EXPORT
+                );
 
                 $this->notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_LIST_EXPORT,
                         to: $user->getEmail(),
-                        attachment: $tmpFilepath
+                        params: [
+                            'filename' => $filename,
+                            'file_uuid' => $file->getUuid(),
+                        ]
                     )
                 );
             }

--- a/src/Service/Mailer/Mail/Signalement/SignalementListExportMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementListExportMailer.php
@@ -14,6 +14,7 @@ class SignalementListExportMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_LIST_EXPORT;
     protected ?string $mailerSubject = 'Votre export de la liste des signalements';
+    protected ?string $mailerButtonText = 'Afficher l\'export';
     protected ?string $mailerTemplate = 'signalement_list_export';
 
     public function __construct(
@@ -27,10 +28,12 @@ class SignalementListExportMailer extends AbstractNotificationMailer
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
     {
-        $attachment = $notificationMail->getAttachment();
-
         return [
-            'attach' => $attachment,
+            'link' => $this->generateLink(
+                'show_file', [
+                    'uuid' => $notificationMail->getParams()['file_uuid'],
+                ]
+            ),
         ];
     }
 }

--- a/templates/emails/signalement_list_export.html.twig
+++ b/templates/emails/signalement_list_export.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}  
     <p>Bonjour,</p>
-    <p>Un export de la liste des signalements est disponible pour le signalement</p>
+    <p>Un export de la liste des signalements est disponible.</p>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
            style="text-align: center">
         <tbody>

--- a/templates/emails/signalement_list_export.html.twig
+++ b/templates/emails/signalement_list_export.html.twig
@@ -2,9 +2,24 @@
 
 {% block body %}  
     <p>Bonjour,</p>
-    <p>
-        Vous trouverez en pièce jointe de cet e-mail l'export de la liste des signalements.
-    </p>
+    <p>Un export de la liste des signalements est disponible pour le signalement</p>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
+           style="text-align: center">
+        <tbody>
+        <tr>
+            <td align="left">
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                    <tbody>
+                    <tr style="text-align: center;width: 100%">
+                        <td>
+                            <a href="{{ link|raw }}" target="_blank" rel="noopener">{{ btntext }}</a></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+        </tbody>
+    </table>
     <p>
         A bientôt sur Histologe !
     </p>

--- a/tests/Functional/Messenger/MessageHandler/ListExportMessageHandlerTest.php
+++ b/tests/Functional/Messenger/MessageHandler/ListExportMessageHandlerTest.php
@@ -3,41 +3,65 @@
 namespace App\Tests\Functional\Messenger\MessageHandler;
 
 use App\Entity\User;
+use App\Manager\FileManager;
 use App\Messenger\Message\ListExportMessage;
 use App\Messenger\MessageHandler\ListExportMessageHandler;
 use App\Repository\UserRepository;
+use App\Service\Mailer\NotificationMailerRegistry;
+use App\Service\Signalement\Export\SignalementExportLoader;
+use App\Service\UploadHandlerService;
+use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Twig\Mime\NotificationEmail;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
 
 class ListExportMessageHandlerTest extends WebTestCase
 {
-    public function testHandleGenerateListCsv()
+    private MessageBusInterface $messageBus;
+    private UserRepository $userRepository;
+    private TransportInterface $transport;
+
+    protected function setUp(): void
     {
         self::bootKernel();
+        $this->userRepository = static::getContainer()->get(UserRepository::class);
+        $this->transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $this->messageBus = static::getContainer()->get(MessageBusInterface::class);
+    }
 
-        $container = static::getContainer();
-
-        $messageBus = $container->get(MessageBusInterface::class);
-
+    public function testHandleGenerateListCsv()
+    {
         $userEmail = 'admin-01@histologe.fr';
-
-        $userRepository = static::getContainer()->get(UserRepository::class);
         /** @var User $user */
-        $user = $userRepository->findOneBy(['email' => $userEmail]);
+        $user = $this->userRepository->findOneBy(['email' => $userEmail]);
         $message = (new ListExportMessage())
             ->setUserId($user->getId())
             ->setFormat('csv')
             ->setFilters([])
             ->setSelectedColumns([]);
 
-        $messageBus->dispatch($message);
-
-        $transport = $container->get('messenger.transport.async_priority_high');
-        $envelopes = $transport->get();
+        $this->messageBus->dispatch($message);
+        $envelopes = $this->transport->get();
         $this->assertCount(1, $envelopes);
 
-        $handler = $container->get(ListExportMessageHandler::class);
+        $uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
+        $uploadHandlerServiceMock
+            ->expects($this->once())
+            ->method('uploadFromFilename')
+            ->willReturn('sample.csv');
+
+        $handler = new ListExportMessageHandler(
+            static::getContainer()->get(NotificationMailerRegistry::class),
+            static::getContainer()->get(LoggerInterface::class),
+            static::getContainer()->get(SignalementExportLoader::class),
+            static::getContainer()->get(UserRepository::class),
+            static::getContainer()->get(ParameterBagInterface::class),
+            $uploadHandlerServiceMock,
+            static::getContainer()->get(FileManager::class)
+        );
+
         $handler($message);
         $this->assertEmailCount(1);
         /** @var NotificationEmail $email */
@@ -48,30 +72,35 @@ class ListExportMessageHandlerTest extends WebTestCase
 
     public function testHandleGenerateListXlsWithOptions()
     {
-        self::bootKernel();
-
-        $container = static::getContainer();
-
-        $messageBus = $container->get(MessageBusInterface::class);
-
         $userEmail = 'admin-territoire-13-01@histologe.fr';
-
-        $userRepository = static::getContainer()->get(UserRepository::class);
         /** @var User $user */
-        $user = $userRepository->findOneBy(['email' => $userEmail]);
+        $user = $this->userRepository->findOneBy(['email' => $userEmail]);
         $message = (new ListExportMessage())
             ->setUserId($user->getId())
             ->setFormat('xlsx')
             ->setFilters([])
             ->setSelectedColumns(['INSEE']);
 
-        $messageBus->dispatch($message);
-
-        $transport = $container->get('messenger.transport.async_priority_high');
-        $envelopes = $transport->get();
+        $this->messageBus->dispatch($message);
+        $envelopes = $this->transport->get();
         $this->assertCount(1, $envelopes);
 
-        $handler = $container->get(ListExportMessageHandler::class);
+        $uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
+        $uploadHandlerServiceMock
+            ->expects($this->once())
+            ->method('uploadFromFilename')
+            ->willReturn('sample.xlsx');
+
+        $handler = new ListExportMessageHandler(
+            static::getContainer()->get(NotificationMailerRegistry::class),
+            static::getContainer()->get(LoggerInterface::class),
+            static::getContainer()->get(SignalementExportLoader::class),
+            static::getContainer()->get(UserRepository::class),
+            static::getContainer()->get(ParameterBagInterface::class),
+            $uploadHandlerServiceMock,
+            static::getContainer()->get(FileManager::class)
+        );
+
         $handler($message);
         $this->assertEmailCount(1);
         /** @var NotificationEmail $email */


### PR DESCRIPTION
## Ticket

#3111    

## Description
Contrainte de poids des fichiers pour les pièces jointes : Remplacer la pièce jointe par un lien de téléchargement.
![image](https://github.com/user-attachments/assets/90259f76-7a0a-4853-9677-de19cbcbaa19)

## Changements apportés
* Ajout d'une migration afin de rendre la colonne signalement optionnel
* Ajout d'un nouveau type de document
* Mise à jour handler
* Mise à jour template

## Pré-requis
```
make worker-stop
make worker-start
```
## Tests
- [ ] Lancer un export csv et vérifier que l'export est téléchargeable depuis un lien
- [ ] Lancer un export xls et vérifier que l'export est téléchargeable depuis un lien
