### PR TITLE
[FO - Formulaire - Accessibilité - 12.8] Dans chaque page web, le focus est-il mis sur le premier élément en erreur lors de la validation ?

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-input-group" :id="id" :ref="id">
+  <div :class="['fr-input-group', {'fr-input-group--error' : hasError}]" :id="id" :ref="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">
       {{ variablesReplacer.replace(label) }}
       <span class="fr-hint-text">{{ description }}</span>
@@ -12,7 +12,7 @@
         :ref="idRef"
         :name="id"
         :value="internalValue"
-        :class="[ customCss, 'fr-input' ]"
+        :class="[ customCss, 'fr-input', {'fr-input--error' : hasError} ]"
         @input="updateValue($event)"
         :aria-describedby="hasError ? id + 'text-input-error-desc-error' : undefined"
         >

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-input-group" :id="id" :ref="id">
+  <div :class="['fr-input-group', {'fr-input-group--error' : hasError}]" :id="id" :ref="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">{{ label }}</label>
     <span v-if="hint !== ''" class="fr-hint-text">{{ hint }}</span>
     <input
@@ -8,7 +8,7 @@
       :ref="idRef"
       :name="id"
       :value="internalValue"
-      :class="[ customCss, 'fr-input' ]"
+      :class="[ customCss, 'fr-input', {'fr-input--error' : hasError} ]"
       @input="updateValue($event)"
       :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
       >

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderCategoryItem.vue
@@ -102,9 +102,11 @@ export default defineComponent({
 }
 .signalement-form-disorder-category-item.is-selected-batiment {
   border: 1px solid var(--border-default-orange-terre-battue);
+  background-color: rgb(228, 121, 74, 0.25);
 }
 .signalement-form-disorder-category-item.is-selected-logement {
   border: 1px solid var(--border-default-blue-france);
+  background-color: var(--blue-france-850-200);
 }
 .signalement-form-disorder-category-item input[type=checkbox] {
   position: absolute;

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id">
+  <div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }, {'fr-input-group--error' : hasError}]" :id="id">
     <label class='fr-label' :for="id + '_input'">
       {{ label }}
       <span class="fr-hint-text">{{ description }}</span>
@@ -12,7 +12,7 @@
         :name="access_name"
         :autocomplete="access_autocomplete"
         :value="internalValue"
-        :class="[ customCss, 'fr-input' ]"
+        :class="[ customCss, 'fr-input', {'fr-input--error' : hasError} ]"
         @input="updateValue($event)"
         :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
         :disabled="disabled"

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -1,7 +1,7 @@
 <template>
   <fieldset
     :id="id"
-    :class="[customCss, 'signalement-form-only-choice fr-fieldset']"
+    :class="[customCss, 'signalement-form-only-choice fr-fieldset', {'fr-fieldset--error' : hasError} ]"
     :aria-labelledby="id + '-radio-hint-legend'"
     :ref="id"
     >

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -101,17 +101,17 @@ export default defineComponent({
 </script>
 
 <style>
-  .signalement-form-only-choice .fr-radio-group {
+  .signalement-form-only-choice .fr-fieldset__element {
     width: 100%;
     max-width: 500px;
     padding: 1rem;
     border: 1px solid var(--border-disabled-grey);
     background-color: var(--grey-1000-50);
   }
-  .signalement-form-only-choice .fr-radio-group:hover {
+  .signalement-form-only-choice .fr-fieldset__element:hover {
     background-color: var(--grey-1000-50-hover);
   }
-  .signalement-form-only-choice .fr-radio-group.is-checked {
+  .signalement-form-only-choice .fr-fieldset__element.is-checked {
     border: 1px solid rgb(0, 0, 145);
   }
 

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -1,17 +1,17 @@
 <template>
   <div>
-    <fieldset class="fr-fieldset" :aria-labelledby="id + '-legend'">
+    <fieldset :class="['fr-fieldset', hasErrorFirst ? 'fr-fieldset--error' : '']" :aria-labelledby="id + '-legend'">
       <legend class="fr-fieldset__legend--regular fr-fieldset__legend fr-col-12" :id="id + '-legend'">
         {{ variablesReplacer.replace(label) }}
       </legend>
       <div class="fr-fieldset__element fr-col-12 fr-col-md-4">
         <select
-          class="fr-select"
+          :class="['fr-select', hasErrorFirst ? 'fr-select--error' : '']"
           :id="idCountryCode"
           :name="idCountryCode"
           v-model="formStore.data[idCountryCode]"
           title="Indicatif national"
-          :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
+          :aria-describedby="hasErrorFirst ? id + '-text-input-error-desc-error' : undefined"
           >
           <option
             v-for="countryItem in countryList"
@@ -31,15 +31,15 @@
             :name="access_name"
             :autocomplete="access_autocomplete"
             v-model="formStore.data[id]"
-            class="fr-input"
-            :aria-describedby="formStore.validationErrors[id] !== undefined ? id + '-text-input-error-desc-error' : undefined"
+            :class="[ 'fr-input', hasErrorFirst ? 'fr-input--error' : '' ]"
+            :aria-describedby="hasErrorFirst ? id + '-text-input-error-desc-error' : undefined"
             >
         </div>
       </div>
       <div
         :id="id + '-text-input-error-desc-error'"
         class="fr-error-text fr-mt-0 fr-mb-3v fr-ml-2v"
-        v-if="formStore.validationErrors[id] !== undefined"
+        v-if="hasErrorFirst"
         >
         {{ formStore.validationErrors[id] }}
       </div>
@@ -55,7 +55,7 @@
 
     <fieldset
       :id=idSecondGroup
-      :class="[ 'fr-fieldset', formStore.data[idSecond] === undefined ? 'fr-hidden' : '' ]"
+      :class="[ 'fr-fieldset', formStore.data[idSecond] === undefined ? 'fr-hidden' : '' , hasErrorSecond ? 'fr-fieldset--error' : '']"
       :aria-labelledby="id + '-legend-second'"
       >
       <legend class="fr-fieldset__legend--regular fr-fieldset__legend fr-col-12" :id="id + '-legend-second'">
@@ -63,12 +63,12 @@
       </legend>
       <div class="fr-fieldset__element fr-col-12 fr-col-md-4">
         <select
-          class="fr-select"
+          :class="['fr-select', hasErrorSecond ? 'fr-select--error' : '']"
           :id="idCountryCodeSecond"
           :name="idCountryCodeSecond"
           v-model="formStore.data[idCountryCodeSecond]"
           title="Indicatif national"
-          :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
+          :aria-describedby="hasErrorSecond ? idSecond + '-text-input-error-desc-error' : undefined"
           >
           <option
             v-for="countryItem in countryList"
@@ -86,8 +86,8 @@
             :id="idSecond"
             :name="idSecond"
             v-model="formStore.data[idSecond]"
-            class="fr-input"
-            :aria-describedby="formStore.validationErrors[idSecond] !== undefined ? idSecond + '-text-input-error-desc-error' : undefined"
+            :class="[ 'fr-input', hasErrorSecond ? 'fr-input--error' : '' ]"
+            :aria-describedby="hasErrorSecond ? idSecond + '-text-input-error-desc-error' : undefined"
             :autocomplete="access_autocomplete"
             >
         </div>
@@ -95,7 +95,7 @@
       <div
         :id="idSecond + '-text-input-error-desc-error'"
         class="fr-error-text fr-mt-0 fr-mb-3v fr-ml-2v"
-        v-if="formStore.validationErrors[idSecond] !== undefined"
+        v-if="hasErrorSecond"
         >
         {{ formStore.validationErrors[idSecond] }}
       </div>
@@ -186,6 +186,12 @@ export default defineComponent({
       countryList.unshift({ code: 'FR' + ':' + getCountryCallingCode('FR'), label: this.getSelectOptionLabel('FR') })
 
       return countryList
+    },
+    hasErrorFirst () {
+      return formStore.validationErrors[this.id] !== undefined
+    },
+    hasErrorSecond () {
+      return formStore.validationErrors[this.idSecond] !== undefined
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -1,13 +1,6 @@
 <template>
-  <div :class="[ customCss, 'signalement-form-roomlist' ]" :id="id">
+  <div :class="[ customCss, 'signalement-form-roomlist', { 'signalement-form-roomlist-error': hasError } ]" :id="id">
     <label class="fr-label" :for="idPieceAVivre+'_check'">{{ label }}</label>
-    <div
-      id="text-input-error-desc-error"
-      class="fr-error-text"
-      v-if="hasError"
-      >
-      {{ error }}
-    </div>
     <div class="signalement-form-roomlist-rooms">
       <SignalementFormCheckbox
         :key="idPieceAVivre"
@@ -42,6 +35,13 @@
         :error="formStore.validationErrors[idSalleDeBain]"
         @update:modelValue="handleCheckBox(idSalleDeBain)"
       />
+    </div>
+    <div
+      id="text-input-error-desc-error"
+      class="fr-error-text"
+      v-if="hasError"
+      >
+      {{ error }}
     </div>
   </div>
 </template>
@@ -101,6 +101,17 @@ export default defineComponent({
   border-left: 3px solid var(--border-action-high-blue-france);
   margin-left: 10px;
   padding-left: 18px;
+}
+.signalement-form-roomlist-error {
+  border-left: 3px solid var(--text-default-error);
+  margin-left: 10px;
+  padding-left: 18px;
+}
+.signalement-form-roomlist-error .fr-label {
+  color: var(--text-default-error);
+}
+.signalement-form-roomlist-error .fr-checkbox-group input[type="checkbox"] + label::before {
+  background-image: radial-gradient(at 5px 4px,transparent 4px,var(--border-plain-error) 4px,var(--border-plain-error) 5px,transparent 6px),linear-gradient(var(--border-plain-error),var(--border-plain-error)),radial-gradient(at calc(100% - 5px) 4px,transparent 4px,var(--border-plain-error) 4px,var(--border-plain-error) 5px,transparent 6px),linear-gradient(var(--border-plain-error),var(--border-plain-error)),radial-gradient(at calc(100% - 5px) calc(100% - 4px),transparent 4px,var(--border-plain-error) 4px,var(--border-plain-error) 5px,transparent 6px),linear-gradient(var(--border-plain-error),var(--border-plain-error)),radial-gradient(at 5px calc(100% - 4px),transparent 4px,var(--border-plain-error) 4px,var(--border-plain-error) 5px,transparent 6px),linear-gradient(var(--border-plain-error),var(--border-plain-error)),var(--data-uri-svg);
 }
 .signalement-form-roomlist-rooms {
   margin-left: 20px;

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -253,7 +253,33 @@ export default defineComponent({
         if (this.components && this.components.body) {
           this.validateComponents(this.components.body)
           if (Object.keys(formStore.validationErrors).length > 0) {
-            window.scrollTo(0, 0)
+            this.$nextTick(() => {
+              // Tableau contenant toutes les classes d'erreur possibles
+              const errorClasses = [
+                'signalement-form-roomlist-error',
+                'fr-fieldset--error',
+                'fr-input--error',
+                'fr-select--error',
+                'fr-checkbox-group--error',
+                'fr-input-group--error',
+                'custom-file-input-error'
+              ]
+              // Construire dynamiquement le sélecteur pour toutes les classes d'erreur
+              const selectors = errorClasses.map(errorClass => `.${errorClass}`).join(', ')
+
+              // Sélectionner tous les éléments correspondant aux classes d'erreur pour tester
+              const ancestorsWithError = document.querySelectorAll(selectors)
+              if (ancestorsWithError.length > 0) {
+                // Sélectionner le premier input ou textarea dans le premier élément trouvé
+                const firstAncestorWithError = ancestorsWithError[0]
+                const inputElement = firstAncestorWithError.querySelector('input, textarea') as HTMLElement
+                // Si un élément input/textarea est trouvé, mettre le focus dessus
+                if (inputElement) {
+                  inputElement.focus()
+                  inputElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                }
+              }
+            })
             return
           }
         }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -1,5 +1,5 @@
 <template>
-<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id">
+<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }, {'fr-input-group--error' : hasError}]" :id="id">
   <label class='fr-label' :for="id + '_input'">
     {{ label }}
     <span class="fr-hint-text">{{ description }}</span>
@@ -10,7 +10,7 @@
         :name="id"
         :value="internalValue"
         :placeholder="placeholder"
-        :class="[ customCss, 'fr-input' ]"
+        :class="[ customCss, 'fr-input', {'fr-input--error' : hasError} ]"
         @input="updateValue($event)"
         :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
         :disabled="disabled"

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -1,5 +1,5 @@
 <template>
-<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }]" :id="id" :ref="id">
+<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }, {'fr-input-group--error' : hasError}]" :id="id" :ref="id">
   <label class='fr-label' :for="id + '_input'">
     {{ variablesReplacer.replace(label) }}
     <span class="fr-hint-text">{{ description }}</span>
@@ -13,7 +13,7 @@
         :autocomplete="access_autocomplete"
         :value="internalValue"
         :placeholder="placeholder"
-        :class="[ customCss, 'fr-input' ]"
+        :class="[ customCss, 'fr-input', {'fr-input--error' : hasError} ]"
         @input="updateValue($event)"
         :aria-describedby="hasError ? id + '-text-input-error-desc-error' : undefined"
         :disabled="disabled"

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTime.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTime.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="fr-input-group" :id="id">
+  <div :class="['fr-input-group', {'fr-input-group--error' : hasError}]" :id="id">
   <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">{{ label }}</label>
   <input
       type="time"
       :id="id + '_input'"
       :name="id"
       :value="internalValue"
-      :class="[ customCss, 'fr-input' ]"
+      :class="[ customCss, 'fr-input', {'fr-input--error' : hasError} ]"
       @input="updateValue($event)"
       aria-describedby="text-input-error-desc-error"
       >

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -1,11 +1,11 @@
 <template>
-<div :class="['fr-mb-6w fr-upload-group', { 'fr-upload-group--disabled': disabled }]" :id="id">
+<div :class="['fr-mb-6w fr-upload-group', { 'fr-upload-group--disabled': disabled }, {'custom-file-input-error' : hasError}]" :id="id">
   <div :class="[ customCss, 'fr-upload-wrap', 'fr-py-3v' ]">
     <input
       type="file"
       :id="id + '_input'"
       :name="id"
-      class="custom-file-input"
+      :class="['custom-file-input']"
       :aria-describedby="hasError ? id + '-text-upload-error-desc-error' : undefined"
       :disabled="disabled"
       :multiple="multiple"
@@ -242,6 +242,11 @@ export default defineComponent({
   outline-offset: 2px;
   outline-style: solid;
   outline-width: 2px;
+}
+.custom-file-input-error{
+  border-left: 3px solid var(--text-default-error);
+  margin-left: 10px;
+  padding-left: 18px;
 }
 .fr-link--error {
   color: var(--text-default-error);

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormYear.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormYear.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-input-group" :id="id">
+  <div :class="['fr-input-group', {'fr-input-group--error' : hasError}]" :id="id">
     <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">{{ label }}</label>
     <input
       :id="id + '_input'"
@@ -10,7 +10,7 @@
       max="2099"
       step="1"
       :value="internalValue"
-      :class="[ customCss, 'fr-input' ]"
+      :class="[ customCss, 'fr-input', {'fr-input--error' : hasError} ]"
       @input="updateValue($event)"
       />
     <div


### PR DESCRIPTION
## Ticket

#3091    

## Description
Mise à jour des classes css pour coller au dsfr lors d'erreur
Mise du focus sur le premier élément en erreur lors de la validation de l'écran

## Changements apportés
* Mise à jour des css sur tous les composants pouvant être en erreur
* Algo "vanilla" pour sélectionner le premier élément en erreur et mettre le focus dessus (en "VueJS" avec les `ref` c'était une usine à gaz)

## Pré-requis
`npm run watch`
## Tests
- [ ] Parcourir le formulaire au clavier (ou pas) en faisant des erreurs et vérifier l'aspect des champs en erreur et la mise du focus
