### PR TITLE
[FO - Formulaire] Bug quand on n'a choisi aucun désordre

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -254,7 +254,7 @@ export default defineComponent({
     },
     focusInput () {
       const focusableElement = (this.$refs[this.idRef]) as Array<HTMLElement>
-      if (focusableElement[0]) {
+      if (focusableElement && focusableElement[0]) {
         focusableElement[0].focus()
       }
     }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -83,7 +83,7 @@ export default defineComponent({
     },
     focusInput () {
       const focusableElement = (this.$refs[this.id + '_' + this.values[0].value + '_ref']) as Array<HTMLElement>
-      if (focusableElement[0]) {
+      if (focusableElement && focusableElement[0]) {
         focusableElement[0].focus()
       }
     }


### PR DESCRIPTION
## Ticket

#3125   

## Description
Quand on ne choisit aucun désordres, en arrivant sur le page "Les désordres renseignés" on a une erreur : 
![Image](https://github.com/user-attachments/assets/db218ccd-81d2-47f3-81fb-2a804302b809)

Et du coup on est coincés

## Changements apportés
* Dans deux composants vérification de l'existence de `focusableElement` avant de vérifier l'existence de `focusableElement[0]`

## Pré-requis
`npm run watch`
## Tests
- [ ] Faire un signalement sans renseigner aucun désordres, sur la page "Les désordres renseignés", vérifier qu'il n'y a pas d'erreur dans la console et que le clic sur le bouton "je renseigne les désordres" et "je passe à la suite" est fonctionnel
