### PR TITLE
[Signalement BO] Gérer les doublons côté backend

### DIFF
--- a/migrations/Version20241004142515.php
+++ b/migrations/Version20241004142515.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241004142515 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique index on created_from_id column in signalement table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $req_doublon = '
+            SELECT id, created_from_id, statut
+            FROM signalement
+            WHERE created_from_id IN (
+                SELECT created_from_id
+                FROM signalement
+                GROUP BY created_from_id
+                HAVING COUNT(*) > 1
+            )
+            ORDER BY created_from_id ASC, statut desc
+        ';
+        $list = $this->connection->fetchAllAssociative($req_doublon);
+        $createdFrom = 0;
+        $lastId = 0;
+        foreach ($list as $item) {
+            // lorsqu'on a parcouru tous les doublons pour un même draft on garde uniquement le dernier de la liste (correspondant au statut le plus bas)
+            if ($createdFrom !== $item['created_from_id']) {
+                $this->keepSingleSignalementWithCreatedFrom($createdFrom, $lastId);
+                $createdFrom = $item['created_from_id'];
+            }
+            $lastId = $item['id'];
+        }
+        $this->keepSingleSignalementWithCreatedFrom($createdFrom, $lastId);
+        $this->addSql('ALTER TABLE signalement DROP INDEX IDX_F4B551143EA4CB4D, ADD UNIQUE INDEX UNIQ_F4B551143EA4CB4D (created_from_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP INDEX UNIQ_F4B551143EA4CB4D, ADD INDEX IDX_F4B551143EA4CB4D (created_from_id)');
+    }
+
+    private function keepSingleSignalementWithCreatedFrom(int $createdFrom, int $lastId): void
+    {
+        $this->addSql('UPDATE signalement SET created_from_id = NULL WHERE created_from_id = :created_from_id AND id != :id', [
+            'created_from_id' => $createdFrom,
+            'id' => $lastId,
+        ]);
+    }
+}

--- a/migrations/Version20241004142515.php
+++ b/migrations/Version20241004142515.php
@@ -16,7 +16,7 @@ final class Version20241004142515 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $req_doublon = '
+        $queryDuplicates = '
             SELECT id, created_from_id, statut
             FROM signalement
             WHERE created_from_id IN (
@@ -27,7 +27,7 @@ final class Version20241004142515 extends AbstractMigration
             )
             ORDER BY created_from_id ASC, statut desc
         ';
-        $list = $this->connection->fetchAllAssociative($req_doublon);
+        $list = $this->connection->fetchAllAssociative($queryDuplicates);
         $createdFrom = 0;
         $lastId = 0;
         foreach ($list as $item) {

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -122,7 +122,7 @@ signalements:
     nb_pieces_logement: 5
     nb_occupants_logement: 4
     score: 35.194711538462
-    created_from_uuid: '00000000-0000-0000-2023-locataire003'
+    created_from_uuid: '00000000-0000-0000-2024-locataire001'
     profile_declarant: "LOCATAIRE"
     civilite_occupant: "mme"
     type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"oui\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"
@@ -295,7 +295,7 @@ signalements:
     nb_pieces_logement: 5
     nb_occupants_logement: 4
     score: 35.194711538462
-    created_from_uuid: '00000000-0000-0000-2024-locataire002'
+    created_from_uuid: '00000000-0000-0000-2023-locataire004'
     profile_declarant: "LOCATAIRE"
     civilite_occupant: "mme"
     type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"oui\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"
@@ -381,7 +381,7 @@ signalements:
     nb_pieces_logement: 5
     nb_occupants_logement: 4
     score: 35.194711538462
-    created_from_uuid: '00000000-0000-0000-2024-locataire002'
+    created_from_uuid: '00000000-0000-0000-2024-bailleuroc01'
     profile_declarant: "LOCATAIRE"
     civilite_occupant: "mme"
     type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"oui\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"
@@ -466,7 +466,7 @@ signalements:
     nb_pieces_logement: 5
     nb_occupants_logement: 4
     score: 35.194711538462
-    created_from_uuid: '00000000-0000-0000-2024-locataire002'
+    created_from_uuid: '00000000-0000-0000-2024-bailleuroc02'
     profile_declarant: "LOCATAIRE"
     civilite_occupant: "mme"
     type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"non\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"

--- a/src/DataFixtures/Files/SignalementDraft.yml
+++ b/src/DataFixtures/Files/SignalementDraft.yml
@@ -38,6 +38,7 @@ signalements_draft:
     profile_declarant: 'LOCATAIRE'
     email_declarant: 'tous-les-desordres-locataire@histologe.fr'
     payload: 'locataire_all_in.json'
+    status: 'EN_SIGNALEMENT'
   -
     uuid: '00000000-0000-0000-2023-bailleuroc01'
     profile_declarant: 'BAILLEUR_OCCUPANT'
@@ -79,3 +80,15 @@ signalements_draft:
     email_declarant: 'service_secours-02@histologe.fr'
     payload: 'step/validation_signalement/service_secours.json'
     created_at_period: '-7 months'
+  -
+    uuid: '00000000-0000-0000-2024-bailleuroc01'
+    profile_declarant: 'BAILLEUR_OCCUPANT'
+    email_declarant: 'bailleur_occupant-01@histologe.fr'
+    payload: 'bailleur_occupant.json'
+    status: 'EN_SIGNALEMENT'
+  -
+    uuid: '00000000-0000-0000-2024-bailleuroc02'
+    profile_declarant: 'BAILLEUR_OCCUPANT'
+    email_declarant: 'bailleur_occupant-01@histologe.fr'
+    payload: 'bailleur_occupant.json'
+    status: 'EN_SIGNALEMENT'

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -72,6 +72,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
         } catch (\Throwable $exception) {
             $this->logger->critical($exception->getMessage());
             $this->entityManager->rollback();
+            throw $exception;
         }
     }
 

--- a/tests/Functional/Manager/SignalementDraftManagerTest.php
+++ b/tests/Functional/Manager/SignalementDraftManagerTest.php
@@ -8,6 +8,7 @@ use App\Entity\User;
 use App\Factory\SignalementDraftFactory;
 use App\Manager\SignalementDraftManager;
 use App\Repository\SignalementDraftRepository;
+use App\Repository\SignalementRepository;
 use App\Serializer\SignalementDraftRequestSerializer;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -27,6 +28,7 @@ class SignalementDraftManagerTest extends WebTestCase
     private UrlGeneratorInterface $urlGenerator;
     private SignalementDraftRequestSerializer $signalementDraftRequestSerializer;
     private SignalementDraftRepository $signalementDraftRepository;
+    private SignalementRepository $signalementRepository;
 
     protected function setUp(): void
     {
@@ -38,6 +40,7 @@ class SignalementDraftManagerTest extends WebTestCase
         $this->urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
         $this->signalementDraftRequestSerializer = static::getContainer()->get(SignalementDraftRequestSerializer::class);
         $this->signalementDraftRepository = static::getContainer()->get(SignalementDraftRepository::class);
+        $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
 
         $this->signalementDraftManager = new SignalementDraftManager(
             $this->signalementDraftFactory,
@@ -46,6 +49,7 @@ class SignalementDraftManagerTest extends WebTestCase
             $this->urlGenerator,
             $this->signalementDraftRequestSerializer,
             $this->signalementDraftRepository,
+            $this->signalementRepository,
         );
 
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);


### PR DESCRIPTION
## Ticket

#3134

## Description
- Ajout d'une contrainte unique sur le champ `created_from_id` de la table `signalement` afin d'éviter qu'un draft puisse créer des doublon de signalement (ce qui arrive à la marge quand le même draft est soumis a quelque secondes d'intervalle)
- Gestion de l'erreur lorsque le cas se produit afin de retourner le signalement existant

## Changements apportés
* Ajout d'une migration gardant uniquement un signalement par draft (mise a null des doublon en fonction de leur statut) + ajout de la contrainte unique

## Pré-requis
`make execute-migration name=Version20241004142515 direction=up`

## Tests
Voila ce que j'ai fait pour tester le comportement (mais vous aurez peut être d'autre idée) :
- Remplacer dans `SignalementDraftManager` la ligne `if (SignalementDraftStatus::EN_SIGNALEMENT === $signalementDraft->getStatus()) {` par `if (SignalementDraftStatus::EN_SIGNALEMENT === 'test') {`
- [ ] Soumettre le même draft (via postman) à plusieurs reprise et s'assurer que l'app ne crash pas et qu'un seul signalement en provenance de ce draft est crée.
