### PR TITLE
[FO - Fiche suivi usager - Accessibilité - 11.12] Ajout des documents uploadés par l'usager dans la fiche usager

### DIFF
--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -338,7 +338,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 			<br>
 		{% endfor %}
 	{% else %}
-		Aucun document à afficher, si vous avez ajouté des documents dans votre signalement, rafraîchissez la page pour les voir apparaître.
+		Aucun document à afficher. Si vous avez ajouté des documents dans votre signalement, rafraîchissez la page pour les voir apparaître.
 	{% endif %}
 </div>
 

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -306,6 +306,22 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 	{% endif %}
 </div>
 
+<h4 class="fr-mb-2v">Documents</h4>
+<div class="fr-mb-4v">
+	{% if signalement.files|filter(photo => photo.fileType == 'document')|length %}
+		Cliquez sur le document pour l'ouvrir dans un nouvel onglet.
+		<br>
+		{% for doc in signalement.files|filter(doc => doc.fileType == 'document' and doc.isUsagerFile) %}
+			<a href="{{ path('show_file', {uuid: doc.uuid}) }}" target="_blank" class="fr-link" rel="noopener">
+				{{doc.title}}
+			</a>
+			<br>
+		{% endfor %}
+	{% else %}
+		Aucune photo à afficher, si vous avez ajouté des photos dans votre signalement, rafraîchissez la page pour les voir apparaître.
+	{% endif %}
+</div>
+
 <div class="fr-mb-4v">
 	<h4 class="fr-mb-2v">Procédures et démarches</h4>
 	<section class="fr-accordion fr-mb-4v">

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -294,29 +294,31 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 <h4 class="fr-mb-2v">Vos photos</h4>
 <div class="fr-mb-4v">
 	{% if signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile)|length %}
-		Les photos que vous avez ajoutées
+		Les photos que vous avez ajoutées.
 	<br>
 		Cliquez sur la photo pour l'ouvrir dans un nouvel onglet.
 		<br>
 		{% for photo in signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile) %}
-			<a href="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize" class="photo-preview" target="_blank" rel="noopener">
+			<a href="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize" class="photo-preview" target="_blank" rel="noopener"
+				title="Voir la photo {{photo.title}} - ouvre une nouvelle fenêtre">
 				<img src="{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb" alt="{{photo.title}}">
 			</a>
 		{% endfor %}
 	{% else %}
-		Aucune photo à afficher, si vous avez ajouté des photos dans votre signalement, rafraîchissez la page pour les voir apparaître.
+		Aucune photo à afficher. Si vous avez ajouté des photos dans votre signalement, rafraîchissez la page pour les voir apparaître.
 	{% endif %}
 </div>
 
 {% if signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile is same as(false))|length %}
 	<h4 class="fr-mb-2v">Photos supplémentaires</h4>
 	<div class="fr-mb-4v">
-		Les photos ajoutées à votre dossier par l'administration
+		Les photos ajoutées à votre dossier par l'administration.
 		<br>
 		Cliquez sur la photo pour l'ouvrir dans un nouvel onglet.
 		<br>
 		{% for photo in signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile is same as(false)) %}
-			<a href="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize" class="photo-preview" target="_blank" rel="noopener">
+			<a href="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize" class="photo-preview" target="_blank" rel="noopener" 
+               title="Voir la photo {{photo.title}} - ouvre une nouvelle fenêtre">
 				<img src="{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb" alt="{{photo.title}}">
 			</a>
 		{% endfor %}
@@ -329,7 +331,8 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 		Cliquez sur le document pour l'ouvrir dans un nouvel onglet.
 		<br>
 		{% for doc in signalement.files|filter(doc => doc.fileType == 'document' and doc.isUsagerFile) %}
-			<a href="{{ path('show_file', {uuid: doc.uuid}) }}" target="_blank" class="fr-link" rel="noopener">
+			<a href="{{ path('show_file', {uuid: doc.uuid}) }}" target="_blank" class="fr-link" rel="noopener"
+				title="Voir le document {{doc.title}} - ouvre une nouvelle fenêtre">
 				{{doc.title}}
 			</a>
 			<br>

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -291,12 +291,14 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 	{% endif %}
 </div>
 
-<h4 class="fr-mb-2v">Photos</h4>
+<h4 class="fr-mb-2v">Vos photos</h4>
 <div class="fr-mb-4v">
-	{% if signalement.files|filter(photo => photo.fileType == 'photo')|length %}
+	{% if signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile)|length %}
+		Les photos que vous avez ajoutées
+	<br>
 		Cliquez sur la photo pour l'ouvrir dans un nouvel onglet.
 		<br>
-		{% for photo in signalement.files|filter(photo => photo.fileType == 'photo') %}
+		{% for photo in signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile) %}
 			<a href="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize" class="photo-preview" target="_blank" rel="noopener">
 				<img src="{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb" alt="{{photo.title}}">
 			</a>
@@ -306,9 +308,24 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 	{% endif %}
 </div>
 
+{% if signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile is same as(false))|length %}
+	<h4 class="fr-mb-2v">Photos supplémentaires</h4>
+	<div class="fr-mb-4v">
+		Les photos ajoutées à votre dossier par l'administration
+		<br>
+		Cliquez sur la photo pour l'ouvrir dans un nouvel onglet.
+		<br>
+		{% for photo in signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile is same as(false)) %}
+			<a href="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize" class="photo-preview" target="_blank" rel="noopener">
+				<img src="{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb" alt="{{photo.title}}">
+			</a>
+		{% endfor %}
+	</div>
+{% endif %}
+
 <h4 class="fr-mb-2v">Documents</h4>
 <div class="fr-mb-4v">
-	{% if signalement.files|filter(photo => photo.fileType == 'document')|length %}
+	{% if signalement.files|filter(doc => doc.fileType == 'document' and doc.isUsagerFile)|length %}
 		Cliquez sur le document pour l'ouvrir dans un nouvel onglet.
 		<br>
 		{% for doc in signalement.files|filter(doc => doc.fileType == 'document' and doc.isUsagerFile) %}
@@ -318,7 +335,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 			<br>
 		{% endfor %}
 	{% else %}
-		Aucune photo à afficher, si vous avez ajouté des photos dans votre signalement, rafraîchissez la page pour les voir apparaître.
+		Aucun document à afficher, si vous avez ajouté des documents dans votre signalement, rafraîchissez la page pour les voir apparaître.
 	{% endif %}
 </div>
 


### PR DESCRIPTION
## Ticket

#3120    

## Description
Pour répondre au critère 11.12, il faut que l'usager puisse avoir accès également aux documents qu'il a envoyé dans le formulaire.

## Changements apportés
*Ajout des documents uploadés par l'usager sur la fiche usager

## Pré-requis

## Tests
- [ ] Faire un signalement avec des photos et des documents, et vérifier dans la fiche usager qu'ils apparaissent
- [ ] En tant qu'agent, RT, ou SA, ajouter des photos et des documents sur un signalement
- [ ] Vérifier que les documents ajoutés par un agent n'apparaissent pas dans la fiche usager
- [ ] Supprimer des photos agents, et vérifier qu'elles n'apparaissent plus dans la fiche de suivi
