### PR TITLE
[BO - Export signalements] Correction limite de taille pour liste de visites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ worker-exec-failed: ## Consume failed queue
 	@echo -e '\e[1;32mConsume failed queue\032'
 	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker php bin/console messenger:consume failed -vvv'
 
+worker-consume: ## Consume local queue for debug
+	@echo -e '\e[1;32mConsume queue\032'
+	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker php bin/console messenger:consume async_priority_high -vvv'
+
 mock-start: ## Start Mock server
 	@${DOCKER_COMP} start histologe_wiremock && sleep 5
 	@${DOCKER_COMP} exec -it histologe_phpfpm sh -c "cd tools/wiremock/src/Mock && php AppMock.php"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@
 services:
   histologe_mysql:
     image: 'mysql:8.0.35'
-    command:
-      --max_allowed_packet=32505856
-      --group_concat_max_len=32505856
+    command: --max_allowed_packet=32505856
     container_name: histologe_mysql
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@
 services:
   histologe_mysql:
     image: 'mysql:8.0.35'
-    command: --max_allowed_packet=32505856
+    command:
+      --max_allowed_packet=32505856
+      --group_concat_max_len=32505856
     container_name: histologe_mysql
     restart: always
     environment:

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -100,7 +100,7 @@ class SignalementExportFactory
             lienDeclarantOccupant: $data['lienDeclarantOccupant'] ?? '-',
             nbVisites: $lastIntervention['nbVisites'],
             dateVisite: $dateVisite,
-            isOccupantPresentVisite: $isOccupantPresentVisite ? self::OUI : ('0' === $isOccupantPresentVisite ? self::NON : ''),
+            isOccupantPresentVisite: ($isOccupantPresentVisite && '-' !== $isOccupantPresentVisite) ? self::OUI : ('0' === $isOccupantPresentVisite ? self::NON : ''),
             interventionStatus: $lastIntervention['status'],
             interventionConcludeProcedure: $lastIntervention['conclude'],
             interventionDetails: strip_tags($lastIntervention['details']),

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -162,11 +162,9 @@ class SignalementExportFactory
         $lastIntervention['details'] = $interventionDetailsExploded[count($interventionDetailsExploded) - 1];
 
         $interventionsExploded = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $interventionData);
-        $lastIntervention['nbVisites'] = count($interventionsExploded);
-        $lastInterventionItem = $interventionsExploded[count($interventionsExploded) - 1];
-        $lastInterventionItemExploded = explode(SignalementExport::SEPARATOR_GROUP_CONCAT, $lastInterventionItem);
-        $lastIntervention['scheduledAt'] = $lastInterventionItemExploded[count($lastInterventionItemExploded) - 1];
-        $status = $lastInterventionItemExploded[count($lastInterventionItemExploded) - 2];
+        $lastIntervention['nbVisites'] = count($interventionsExploded) / 2;
+        $lastIntervention['scheduledAt'] = $interventionsExploded[count($interventionsExploded) - 1];
+        $status = $interventionsExploded[count($interventionsExploded) - 2];
         if (Intervention::STATUS_PLANNED === $status) {
             $todayDatetime = new \DateTime();
             if ($lastIntervention['scheduledAt'] > $todayDatetime->format('Y-m-d')) {

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -2,6 +2,7 @@
 
 namespace App\Factory;
 
+use App\Dto\SignalementAffectationListView;
 use App\Dto\SignalementExport;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\ProfileDeclarant;
@@ -39,7 +40,12 @@ class SignalementExportFactory
         $status = SignalementAffectationHelper::getStatusLabelFrom($user, $data);
 
         $geoloc = $data['geoloc'];
-        $lastIntervention = $this->getLastVisiteData($data['interventionsData']);
+        $lastIntervention = $this->getLastVisiteData(
+            $data['interventionsData'],
+            $data['interventionOccupantPresent'],
+            $data['interventionConcludeProcedure'],
+            $data['interventionDetails'],
+        );
         $dateVisite = $lastIntervention['scheduledAt'];
         $dateVisite = (!empty($dateVisite) && DateHelper::isValidDate($dateVisite)) ? (new \DateTime($dateVisite))->format(self::DATE_FORMAT) : '';
         $isOccupantPresentVisite = $lastIntervention['occupantPresent'];
@@ -130,8 +136,12 @@ class SignalementExportFactory
         return $value;
     }
 
-    private function getLastVisiteData(?string $interventionData): array
-    {
+    private function getLastVisiteData(
+        ?string $interventionData,
+        ?string $interventionOccupantPresent,
+        ?string $interventionConcludeProcedure,
+        ?string $interventionDetails
+    ): array {
         $lastIntervention = [
             'status' => VisiteStatus::NON_PLANIFIEE->value,
             'conclude' => '-',
@@ -143,13 +153,20 @@ class SignalementExportFactory
         if (null === $interventionData) {
             return $lastIntervention;
         }
-        $interventionsExploded = explode(SignalementExport::SEPARATOR_GROUP_CONCAT, $interventionData);
-        $status = $interventionsExploded[count($interventionsExploded) - 5];
-        $lastIntervention['scheduledAt'] = $interventionsExploded[count($interventionsExploded) - 4];
-        $lastIntervention['occupantPresent'] = $interventionsExploded[count($interventionsExploded) - 3];
-        $lastIntervention['conclude'] = $interventionsExploded[count($interventionsExploded) - 2] ?? '-';
-        $lastIntervention['details'] = $interventionsExploded[count($interventionsExploded) - 1] ?? '-';
-        $lastIntervention['nbVisites'] = count($interventionsExploded) / 5;
+
+        $interventionOccupantPresentExploded = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $interventionOccupantPresent);
+        $lastIntervention['occupantPresent'] = $interventionOccupantPresentExploded[count($interventionOccupantPresentExploded) - 1];
+        $interventionConcludeProcedureExploded = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $interventionConcludeProcedure);
+        $lastIntervention['conclude'] = $interventionConcludeProcedureExploded[count($interventionConcludeProcedureExploded) - 1];
+        $interventionDetailsExploded = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $interventionDetails);
+        $lastIntervention['details'] = $interventionDetailsExploded[count($interventionDetailsExploded) - 1];
+
+        $interventionsExploded = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $interventionData);
+        $lastIntervention['nbVisites'] = count($interventionsExploded);
+        $lastInterventionItem = $interventionsExploded[count($interventionsExploded) - 1];
+        $lastInterventionItemExploded = explode(SignalementExport::SEPARATOR_GROUP_CONCAT, $lastInterventionItem);
+        $lastIntervention['scheduledAt'] = $lastInterventionItemExploded[count($lastInterventionItemExploded) - 1];
+        $status = $lastInterventionItemExploded[count($lastInterventionItemExploded) - 2];
         if (Intervention::STATUS_PLANNED === $status) {
             $todayDatetime = new \DateTime();
             if ($lastIntervention['scheduledAt'] > $todayDatetime->format('Y-m-d')) {

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -597,15 +597,16 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(DISTINCT desordreCategories.label SEPARATOR :group_concat_separator_1) as listDesordreCategories,
             GROUP_CONCAT(DISTINCT desordreCriteres.labelCritere SEPARATOR :group_concat_separator_1) as listDesordreCriteres,
             GROUP_CONCAT(DISTINCT tags.label SEPARATOR :group_concat_separator_1) as etiquettes,
-            GROUP_CONCAT(DISTINCT IFNULL(i.occupantPresent, \'\') SEPARATOR :concat_separator) as interventionOccupantPresent,
-            GROUP_CONCAT(DISTINCT IFNULL(i.concludeProcedure, \'\') SEPARATOR :concat_separator) as interventionConcludeProcedure,
-            GROUP_CONCAT(DISTINCT IFNULL(i.details, \'\') SEPARATOR :concat_separator) as interventionDetails,
-            GROUP_CONCAT(DISTINCT
+            GROUP_CONCAT(IFNULL(i.occupantPresent, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionOccupantPresent,
+            GROUP_CONCAT(IFNULL(i.concludeProcedure, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionConcludeProcedure,
+            GROUP_CONCAT(IFNULL(i.details, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionDetails,
+            GROUP_CONCAT(
                 CONCAT(
                     i.status,
                     :concat_separator,
                     i.scheduledAt
                 )
+                ORDER BY i.scheduledAt ASC
                 SEPARATOR :concat_separator
             ) as interventionsData
             '

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -592,15 +592,15 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(DISTINCT desordreCategories.label SEPARATOR :group_concat_separator_1) as listDesordreCategories,
             GROUP_CONCAT(DISTINCT desordreCriteres.labelCritere SEPARATOR :group_concat_separator_1) as listDesordreCriteres,
             GROUP_CONCAT(DISTINCT tags.label SEPARATOR :group_concat_separator_1) as etiquettes,
+            GROUP_CONCAT(DISTINCT IFNULL(i.occupantPresent, \'\') SEPARATOR :concat_separator) as interventionOccupantPresent,
+            GROUP_CONCAT(DISTINCT IFNULL(i.concludeProcedure, \'\') SEPARATOR :concat_separator) as interventionConcludeProcedure,
+            GROUP_CONCAT(DISTINCT IFNULL(i.details, \'\') SEPARATOR :concat_separator) as interventionDetails,
             GROUP_CONCAT(DISTINCT
                 CONCAT(
                     i.status, :group_concat_separator_1,
-                    i.scheduledAt, :group_concat_separator_1,
-                    IFNULL(i.occupantPresent, \'\'), :group_concat_separator_1,
-                    IFNULL(i.concludeProcedure, \'\'), :group_concat_separator_1,
-                    IFNULL(i.details, \'\')
+                    i.scheduledAt, :group_concat_separator_1
                 )
-                SEPARATOR :group_concat_separator_1
+                SEPARATOR :concat_separator
             ) as interventionsData
             '
         )->leftJoin('s.situations', 'situations')

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -601,6 +601,7 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(IFNULL(i.concludeProcedure, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionConcludeProcedure,
             GROUP_CONCAT(IFNULL(i.details, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionDetails,
             GROUP_CONCAT(
+                DISTINCT
                 CONCAT(
                     i.status,
                     :concat_separator,

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -597,8 +597,9 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(DISTINCT IFNULL(i.details, \'\') SEPARATOR :concat_separator) as interventionDetails,
             GROUP_CONCAT(DISTINCT
                 CONCAT(
-                    i.status, :group_concat_separator_1,
-                    i.scheduledAt, :group_concat_separator_1
+                    i.status,
+                    :concat_separator,
+                    i.scheduledAt
                 )
                 SEPARATOR :concat_separator
             ) as interventionsData

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -554,6 +554,11 @@ class SignalementRepository extends ServiceEntityRepository
 
     public function findSignalementAffectationIterable(User $user, array $options): \Generator
     {
+        // temporary increase the group_concat_max_len to a higher value, for texts in GROUP_CONCAT
+        $connection = $this->getEntityManager()->getConnection();
+        $sql = 'SET SESSION group_concat_max_len=32505856';
+        $connection->prepare($sql)->executeQuery();
+
         $qb = $this->findSignalementAffectationQuery($user, $options);
 
         $qb->addSelect(

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -71,7 +71,10 @@ class SignalementExportFactoryTest extends TestCase
                 Les murs ont des fissures.|De l'eau s’infiltre dans mon logement.|Il y a des trace ",
             'etiquettes' => null,
             'geoloc' => '{"lat": "43.3426152", "lng": "5.3711848"}',
-            'interventionsData' => 'PLANNED|2023-07-13 13:41:15||||DONE|2024-06-09 10:00:00|1|RSD,INSALUBRITE|dossier envoyé pour manquement sanitaire',
+            'interventionsData' => 'PLANNED|2023-07-13 13:41:15||DONE|2024-06-09 10:00:00',
+            'interventionOccupantPresent' => '||1',
+            'interventionConcludeProcedure' => '||RSD,INSALUBRITE',
+            'interventionDetails' => '||dossier envoyé pour manquement sanitaire',
         ];
 
         $user = $this->getUserFromRole(User::ROLE_ADMIN);
@@ -88,6 +91,7 @@ class SignalementExportFactoryTest extends TestCase
         $this->assertEquals($dateFormatted, $signalementExportFactory->closedAt);
         $this->assertEquals('09/06/2024', $signalementExportFactory->dateVisite);
         $this->assertEquals('Oui', $signalementExportFactory->isOccupantPresentVisite);
+        $this->assertEquals(2, $signalementExportFactory->nbVisites);
 
         $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->telephoneOccupantBis);
         $this->assertEquals(SignalementExportFactory::NON_RENSEIGNE, $signalementExportFactory->etageOccupant);

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -71,7 +71,7 @@ class SignalementExportFactoryTest extends TestCase
                 Les murs ont des fissures.|De l'eau s’infiltre dans mon logement.|Il y a des trace ",
             'etiquettes' => null,
             'geoloc' => '{"lat": "43.3426152", "lng": "5.3711848"}',
-            'interventionsData' => 'PLANNED|2023-07-13 13:41:15||DONE|2024-06-09 10:00:00',
+            'interventionsData' => 'PLANNED||2023-07-13 13:41:15||DONE||2024-06-09 10:00:00',
             'interventionOccupantPresent' => '||1',
             'interventionConcludeProcedure' => '||RSD,INSALUBRITE',
             'interventionDetails' => '||dossier envoyé pour manquement sanitaire',


### PR DESCRIPTION
## Ticket

#3133   

## Description
Problème signalé de départ : le nombre de visite était retourné sous la forme d'un float, ce qui n'avait pas trop de sens.
Après analyse, on découvre que la fonction MySQL `GROUP_CONCAT` possède une limite de taille.
Quand on fournit les détails d'une visite, on peut facilement dépasser cette limite.

## Changements apportés
* Augmentation de la limite
* Séparation des différents champs de visite en 4 éléments différents au sein du select
* Modification du séparateur des éléments

## Tests
- [ ] Idéalement avec les données de prod, faire des exports de signalements et vérifier que les données de signalement sont toujours bonnes
