### PR TITLE
[QA - Performance] Optimisation requête widget connexion esabora

### DIFF
--- a/migrations/Version20241009143155.php
+++ b/migrations/Version20241009143155.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241009143155 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove useless indexes on job_event.service';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_job_event_service ON job_event');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20241009143155.php
+++ b/migrations/Version20241009143155.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use App\Entity\JobEvent;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -17,6 +18,9 @@ final class Version20241009143155 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('DROP INDEX idx_job_event_service ON job_event');
+        $this->addSql("UPDATE job_event SET status = :status_failed WHERE status = 'failure'", [
+            'status_failed' => JobEvent::STATUS_FAILED,
+        ]);
     }
 
     public function down(Schema $schema): void

--- a/src/Entity/JobEvent.php
+++ b/src/Entity/JobEvent.php
@@ -16,8 +16,8 @@ class JobEvent
 {
     use TimestampableTrait;
 
-    public const STATUS_SUCCESS = 'success';
-    public const STATUS_FAILED = 'failed';
+    public const string STATUS_SUCCESS = 'success';
+    public const string STATUS_FAILED = 'failed';
     public const string EXPIRATION_PERIOD = '- 6 months';
 
     #[ORM\Id]

--- a/src/Entity/JobEvent.php
+++ b/src/Entity/JobEvent.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: JobEventRepository::class)]
 #[ORM\HasLifecycleCallbacks()]
 #[ORM\Index(columns: ['created_at'], name: 'idx_job_event_created_at')]
-#[ORM\Index(columns: ['service'], name: 'idx_job_event_service')]
 #[ORM\Index(columns: ['partner_id'], name: 'idx_job_event_partner_id')]
 class JobEvent
 {

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -29,6 +29,9 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
         parent::__construct($registry, JobEvent::class);
     }
 
+    /**
+     * @throws \DateMalformedStringException
+     */
     public function findLastJobEventByInterfacageType(
         string $type,
         int $dayPeriod,
@@ -38,15 +41,15 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
             ->select('MAX(j.createdAt) AS last_event, p.id, p.nom, s.reference, j.status, j.action, j.codeStatus, j.response')
             ->innerJoin(Signalement::class, 's', 'WITH', 's.id = j.signalementId')
             ->innerJoin(Partner::class, 'p', 'WITH', 'p.id = j.partnerId')
-            ->where('j.service LIKE :service')
-            ->andWhere('DATEDIFF(NOW(),j.createdAt) <= :day_period');
+            ->where('j.service = :service')
+            ->andWhere('j.createdAt >= :date_limit');
 
         if (null !== $territory) {
             $qb->andWhere('p.territory = :territory')->setParameter('territory', $territory);
         }
 
-        $qb->setParameter('service', '%'.$type.'%')
-            ->setParameter('day_period', $dayPeriod)
+        $qb->setParameter('service', $type)
+            ->setParameter('date_limit', new \DateTimeImmutable('-'.$dayPeriod.' days'))
             ->groupBy('p.id, p.nom, s.reference, j.action, j.status, j.codeStatus, j.response')
             ->orderBy('last_event', 'DESC');
 
@@ -62,8 +65,8 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
             ->select('MAX(j.createdAt) AS last_event')
             ->innerJoin(Partner::class, 'p', 'WITH', 'p.id = j.partnerId')
             ->where('p.id = :partner')->setParameter('partner', $partner->getId())
-            ->andWhere('j.service LIKE :service')
-            ->setParameter('service', '%'.InterfacageType::ESABORA->value.'%')
+            ->andWhere('j.service = :service')
+            ->setParameter('service', InterfacageType::ESABORA->value)
             ->getQuery()
             ->getOneOrNullResult();
     }
@@ -84,8 +87,8 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
 
         $qb->where('j.status = :statusFailed')
             ->setParameter('statusFailed', JobEvent::STATUS_FAILED)
-            ->andWhere('j.service LIKE :service')
-            ->setParameter('service', '%'.InterfacageType::ESABORA->value.'%')
+            ->andWhere('j.service = :service')
+            ->setParameter('service', InterfacageType::ESABORA->value)
             ->andWhere('j.partnerType LIKE :partnerType')
             ->setParameter('partnerType', $partnerType->value)
             ->andWhere('j.action = :action')

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -38,7 +38,7 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
         ?Territory $territory,
     ): array {
         $qb = $this->createQueryBuilder('j')
-            ->select('MAX(j.createdAt) AS last_event, p.id, p.nom, s.reference, j.status, j.action, j.codeStatus, j.response')
+            ->select('j.createdAt, p.id, p.nom, s.reference, j.status, j.action, j.codeStatus, j.response')
             ->innerJoin(Signalement::class, 's', 'WITH', 's.id = j.signalementId')
             ->innerJoin(Partner::class, 'p', 'WITH', 'p.id = j.partnerId')
             ->where('j.service = :service')
@@ -50,8 +50,7 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
 
         $qb->setParameter('service', $type)
             ->setParameter('date_limit', new \DateTimeImmutable('-'.$dayPeriod.' days'))
-            ->groupBy('p.id, p.nom, s.reference, j.action, j.status, j.codeStatus, j.response')
-            ->orderBy('last_event', 'DESC');
+            ->orderBy('j.createdAt', 'DESC');
 
         $qb->setMaxResults(1000);
 

--- a/src/Service/DashboardWidget/WidgetDataManager.php
+++ b/src/Service/DashboardWidget/WidgetDataManager.php
@@ -56,6 +56,10 @@ class WidgetDataManager implements WidgetDataManagerInterface
         }, $countAffectationPartnerList);
     }
 
+    /**
+     * @throws \DateMalformedStringException
+     * @throws \DateInvalidTimeZoneException
+     */
     public function findLastJobEventByInterfacageType(string $type, array $params, ?Territory $territory = null): array
     {
         $jobEvents = $this->jobEventRepository->findLastJobEventByInterfacageType($type, $params['period'], $territory);
@@ -63,7 +67,9 @@ class WidgetDataManager implements WidgetDataManagerInterface
         return array_map(/**
          * @throws \Exception
          */ function ($jobEvent) use ($territory) {
-            $jobEvent['last_event'] = (new \DateTimeImmutable($jobEvent['last_event']))
+            /** @var \DateTimeImmutable $createdAt */
+            $createdAt = $jobEvent['createdAt'];
+            $jobEvent['last_event'] = $createdAt
                 ->setTimezone(
                     new \DateTimeZone($territory ? $territory->getTimezone() : TimezoneProvider::TIMEZONE_EUROPE_PARIS)
                 )

--- a/src/Service/Interconnection/JobEventHttpClient.php
+++ b/src/Service/Interconnection/JobEventHttpClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Interconnection;
 
+use App\Entity\JobEvent;
 use App\Manager\JobEventManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\HttpClientTrait;
@@ -92,7 +93,7 @@ class JobEventHttpClient implements HttpClientInterface
             action: $jobEventMetaData->getAction(),
             message: json_encode($payload),
             response: $responseContent,
-            status: Response::HTTP_OK === $statusCode ? 'success' : 'failure',
+            status: Response::HTTP_OK === $statusCode ? JobEvent::STATUS_SUCCESS : JobEvent::STATUS_FAILED,
             codeStatus: $statusCode,
             signalementId: $jobEventMetaData->getSignalementId(),
             partnerId: $jobEventMetaData->getPartnerId(),

--- a/tests/Functional/Repository/JobEventRepositoryTest.php
+++ b/tests/Functional/Repository/JobEventRepositoryTest.php
@@ -41,7 +41,7 @@ class JobEventRepositoryTest extends KernelTestCase
             null
         );
 
-        $this->assertCount(2, $jobEvents);
+        $this->assertCount(7, $jobEvents);
     }
 
     public function testFindFailedEsaboraDossierByPartnerTypeByAction(): void


### PR DESCRIPTION
## Ticket

#3136    

## Description
La requête des événements n'est pas complexe, malgré tout elle dépssait les 2 sec pour environ ~ 10000 enregistrement.
Des index ont été ajouté sur la table job_event il y'a quelques mois mais la requête n'en profite pas vraiment 

## Changements apportés
* Remplacement des LIKE ` %%` par `=` 
* Remplacement de `DATE_DIFF` par une comparaison classique de date 

|              | Avant Optimisation | Après Optimisation |
|-----------------------|--------------------|--------------------|
| Temps d'exécution     | > 2 s             | < 0.5 s              |

## Pré-requis
* Travailler avec la base de prod `make load-data`

## Tests

> [!NOTE]  
> Rappel : Seul le premier appel fait une requête en base, les résultats des requêtes suivantes proviennent du cache

Supprimer le cache`make clear-pool pool="--all"`

- [ ] Se rendre du le dashboard et vérifier via le profiler le résultat au premier appel
![Capture d’écran du 2024-10-07 16-35-33](https://github.com/user-attachments/assets/53df1856-cb2c-47a5-95cc-ffefaf41c389)



