### PR TITLE
[FO - formulaire] Correction d'un bug sur la suppression doc sur formulaire dépot de signalement

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -147,7 +147,18 @@ export default defineComponent({
       }
     }
   },
+  created () {
+    this.initializeUploadedFiles()
+  },
   methods: {
+    initializeUploadedFiles () {
+      const files = this.formStore.data[this.id]
+      if (files && Array.isArray(files)) {
+        this.uploadedFiles = files
+      } else {
+        this.uploadedFiles = []
+      }
+    },
     getFileTitle (file: any) {
       if (typeof file === 'string') {
         return file


### PR DESCRIPTION
## Ticket

#3145   

## Description
Sur le formulaire de dépôt de signalement, la suppression de fichier uploadé ne fonctionnait que si on venait de mettre le fichier. Elle ne fonctionnait pas en reprise de brouillon, ou au retour sur l'écran après navigation. Cela venait du fait que la suppression s'effectuait sur le tableau local des fichiers (uploadedFiles) et que ce tableau n'était pas initialisé au moment de l'affichage de l'écran.

## Changements apportés
* Initialisation de uploadedFiles avec les données du formStore au moment de la création du composant

## Pré-requis

## Tests
- [ ] Faire un signalement, ajouter plusieurs fichiers, en supprimer vérifier que c'est ok
- [ ] Changer d'écran et puis revenir dessus, vérifier que la suppression de fichier fonctionne (et l'ajout)
- [ ] Revenir sur le signalement via la route signalement-draft, et faire les mêmes vérifications
