### PR TITLE
[QA - Performance] Optimisation requête widget KPI

### DIFF
--- a/src/Controller/Back/WidgetController.php
+++ b/src/Controller/Back/WidgetController.php
@@ -11,7 +11,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Serializer\SerializerInterface;
 
 #[Route('/bo')]
 class WidgetController extends AbstractController
@@ -20,7 +19,6 @@ class WidgetController extends AbstractController
     public function index(
         Request $request,
         WidgetLoaderCollection $widgetLoaderCollection,
-        SerializerInterface $serializer,
         TerritoryManager $territoryManager,
         LoggerInterface $logger,
         string $widgetType

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -152,7 +152,7 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
             ->setParameter('is_seen', 0)
             ->setParameter('type_notification', Notification::TYPE_SUIVI)
             ->setParameter('statut', Signalement::STATUS_CLOSED)
-            ->setParameter('description', '%'.Suivi::DESCRIPTION_MOTIF_CLOTURE_ALL.'%')
+            ->setParameter('description', Suivi::DESCRIPTION_MOTIF_CLOTURE_ALL.'%')
             ->setParameter('user', $user);
 
         if (null !== $territory) {
@@ -180,8 +180,8 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
             ->andWhere('su.description NOT LIKE :description_all AND su.description LIKE :description_partner')
             ->setParameter('is_seen', 0)
             ->setParameter('type_notification', Notification::TYPE_SUIVI)
-            ->setParameter('description_all', '%'.Suivi::DESCRIPTION_MOTIF_CLOTURE_ALL.'%')
-            ->setParameter('description_partner', '%'.Suivi::DESCRIPTION_MOTIF_CLOTURE_PARTNER.'%')
+            ->setParameter('description_all', Suivi::DESCRIPTION_MOTIF_CLOTURE_ALL.'%')
+            ->setParameter('description_partner', Suivi::DESCRIPTION_MOTIF_CLOTURE_PARTNER.'%')
             ->setParameter('status_closed', SignalementStatus::CLOSED)
             ->setParameter('user', $user);
 

--- a/tests/Functional/Repository/SuiviRepositoryTest.php
+++ b/tests/Functional/Repository/SuiviRepositoryTest.php
@@ -34,4 +34,19 @@ class SuiviRepositoryTest extends KernelTestCase
 
         $this->assertStringContainsString('le premier suivi de partenaire 13-01', $firstSuivi->getDescription());
     }
+
+    public function testFindSignalementsForThirdRelance(): void
+    {
+        $result = $this->suiviRepository->findSignalementsForThirdRelance();
+        $this->assertCount(1, $result);
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $signalement = $signalementRepository->findOneBy(['id' => $result[0]]);
+        $this->assertEquals('2023-15', $signalement->getReference());
+    }
+
+    public function testCountSignalementNoSuiviAfter3Relances(): void
+    {
+        $result = $this->suiviRepository->countSignalementNoSuiviAfter3Relances();
+        $this->assertEquals(0, $result);
+    }
 }


### PR DESCRIPTION
## Ticket

#3135

## Description
- Réduction du temps de chargement du widget KPI via l'optimisation de plusieurs requête
Différence d'exécution des requetes avant/aprés en SA (aucune requete sup a 3 secondes)
![SA_total_v1](https://github.com/user-attachments/assets/af814dcd-84e1-4459-a075-1a02e8ecb69e)
![SA_total_v2](https://github.com/user-attachments/assets/409c50a3-09cd-449d-9424-1f661b83e76b)

- Différence d'exécution des requetes avant/aprés en RT Marseille (aucune requête sup a 1 seconde)
![RT_total_v1](https://github.com/user-attachments/assets/7bdaf01a-d2eb-4246-8a12-d6d6b23134fb)
![RT_total_v2](https://github.com/user-attachments/assets/9afceb05-3675-4a82-93bc-b3b9e5d69814)


## Changements apportés
* Passage de requete `LIKE '%term%'` en `LIKE 'term%'`
* Simplification et conditionnalité d'ajout de clause sur la requête la plus lente (qui remonte sur sentry) 

## Tests
- [ ] S'assurer que le tableau de bord s'affiche correctement pour les différent rôles
