### PR TITLE
[TECH] Brevo utilise HttpClient pour les appels api - Ne pas décorer le service

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -119,23 +119,17 @@ services:
     App\Service\DashboardWidget\WidgetDataManagerCache:
         decorates: App\Service\DashboardWidget\WidgetDataManager
 
-    App\Service\Interconnection\JobEventHttpClient:
-        decorates: http_client
-
-    http_client.default:
-        alias: 'App\Service\Interconnection\JobEventHttpClient.inner'
-
-    App\Service\DataGouv\AddressService:
+    App\Service\Interconnection\Esabora\EsaboraSCHSService:
         arguments:
-            - '@http_client.default'
+            - '@App\Service\Interconnection\JobEventHttpClient'
 
-    App\Command\LoadEpciCommand:
+    App\Service\Interconnection\Esabora\EsaboraSISHService:
         arguments:
-            - '@http_client.default'
+            - '@App\Service\Interconnection\JobEventHttpClient'
 
-    App\Service\Interconnection\Idoss\IdossService:
+    App\Service\Interconnection\Oilhi\HookZapierService:
         arguments:
-            - '@http_client.default'
+            - '@App\Service\Interconnection\JobEventHttpClient'
 
     App\Serializer\SignalementDraftRequestNormalizer:
         tags: [ 'serializer.normalizer' ]


### PR DESCRIPTION
## Ticket

#3161   

## Description
Erreur d'envoi de call http sur l'envoi de mail

## Changements apportés
* Suppression de la décoration 
* Déclarer les services utilisant le service http custom de manière explicite

## Pré-requis

## Tests
- [ ] `make console app="sync-esabora-sish"` OK
- [ ] `make console app="sync-esabora-schs"` OK
- [ ] Affecter un partenaire au signalement du 62 et vérifier la création de l'enregistrement dans la table job_event
(Ex : http://localhost:8080/bo/signalements/00000000-0000-0000-2024-000000000003) OK
- [ ] make console app="load-epci" OK