### PR TITLE
[OILHI] Activation connexion commune Beaudricourt

### DIFF
--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -458,6 +458,20 @@ partners:
       - 'VISITES'
       - 'RSD'
   -
+    nom: "Partenaire 62-02 (BEAUDRICOURT)"
+    email: "partenaire-62-02@histologe.fr"
+    is_archive: 0
+    insee: "[\"62091\"]"
+    territory: "Pas-de-Calais"
+    type: "COMMUNE_SCHS"
+    competence:
+      - 'ACCOMPAGNEMENT_SOCIAL'
+      - 'ACCOMPAGNEMENT_TRAVAUX'
+      - 'FSL'
+      - 'VISITES'
+      - 'RSD'
+
+  -
     nom: "Mairie de Saint-Denis"
     email: "partenaire-93-01@histologe.fr"
     is_archive: 0

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -24,8 +24,8 @@ class Partner implements EntityHistoryInterface
 
     public const string DEFAULT_PARTNER = 'Administrateurs Histologe ALL';
     public const int MAX_LIST_PAGINATION = 50;
-    public const array TERRITORY_ZIP_ALLOWED = [62]; // Should be replaced by CODE_INSEE_ALLOWED
-    public const array CODE_INSEE_ALLOWED = [62091]; // for testing production
+    public const array OILHI_TERRITORY_ZIP_ALLOWED = [62]; // Should be replaced by CODE_INSEE_ALLOWED
+    public const array OILHI_CODE_INSEE_ALLOWED = [62091]; // for testing production
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -324,16 +324,16 @@ class Partner implements EntityHistoryInterface
 
     public function canSyncWithOilhi(Signalement $signalement): bool
     {
-        $inseeAllowed = !empty(array_intersect($this->getInsee(), self::CODE_INSEE_ALLOWED));
+        $inseeAllowed = !empty(array_intersect($this->getInsee(), self::OILHI_CODE_INSEE_ALLOWED));
 
         return $this->hasCompetence(Qualification::RSD)
             && PartnerType::COMMUNE_SCHS === $this->type
             && \in_array(
                 $this->territory->getZip(),
-                self::TERRITORY_ZIP_ALLOWED
+                self::OILHI_TERRITORY_ZIP_ALLOWED
             )
             && $inseeAllowed
-            && in_array($signalement->getInseeOccupant(), self::CODE_INSEE_ALLOWED);
+            && in_array($signalement->getInseeOccupant(), self::OILHI_CODE_INSEE_ALLOWED);
     }
 
     public function canSyncWithIdoss(): bool

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -24,7 +24,7 @@ class Partner implements EntityHistoryInterface
 
     public const string DEFAULT_PARTNER = 'Administrateurs Histologe ALL';
     public const int MAX_LIST_PAGINATION = 50;
-    public const array OILHI_TERRITORY_ZIP_ALLOWED = [62]; // Should be replaced by CODE_INSEE_ALLOWED
+    public const array OILHI_TERRITORY_ZIP_ALLOWED = [62]; // Should be replaced by OILHI_CODE_INSEE_ALLOWED
     public const array OILHI_CODE_INSEE_ALLOWED = [62091]; // for testing production
 
     #[ORM\Id]

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -25,7 +25,7 @@ class Partner implements EntityHistoryInterface
     public const string DEFAULT_PARTNER = 'Administrateurs Histologe ALL';
     public const int MAX_LIST_PAGINATION = 50;
     public const array TERRITORY_ZIP_ALLOWED = [62]; // Should be replaced by CODE_INSEE_ALLOWED
-    public const array CODE_INSEE_ZIP_ALLOWED = [62091]; // for testing production
+    public const array CODE_INSEE_ALLOWED = [62091]; // for testing production
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -324,7 +324,7 @@ class Partner implements EntityHistoryInterface
 
     public function canSyncWithOilhi(Signalement $signalement): bool
     {
-        $inseeAllowed = !empty(array_intersect($this->getInsee(), self::CODE_INSEE_ZIP_ALLOWED));
+        $inseeAllowed = !empty(array_intersect($this->getInsee(), self::CODE_INSEE_ALLOWED));
 
         return $this->hasCompetence(Qualification::RSD)
             && PartnerType::COMMUNE_SCHS === $this->type
@@ -333,7 +333,7 @@ class Partner implements EntityHistoryInterface
                 self::TERRITORY_ZIP_ALLOWED
             )
             && $inseeAllowed
-            && in_array($signalement->getInseeOccupant(), self::CODE_INSEE_ZIP_ALLOWED);
+            && in_array($signalement->getInseeOccupant(), self::CODE_INSEE_ALLOWED);
     }
 
     public function canSyncWithIdoss(): bool

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -22,9 +22,10 @@ class Partner implements EntityHistoryInterface
 {
     use TimestampableTrait;
 
-    public const DEFAULT_PARTNER = 'Administrateurs Histologe ALL';
-    public const MAX_LIST_PAGINATION = 50;
-    public const TERRITORY_ZIP_ALLOWED = [62]; // Should be replaced by CODE_INSEE_ALLOWED
+    public const string DEFAULT_PARTNER = 'Administrateurs Histologe ALL';
+    public const int MAX_LIST_PAGINATION = 50;
+    public const array TERRITORY_ZIP_ALLOWED = [62]; // Should be replaced by CODE_INSEE_ALLOWED
+    public const array CODE_INSEE_ZIP_ALLOWED = [62091]; // for testing production
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -321,14 +322,18 @@ class Partner implements EntityHistoryInterface
             && $this->isEsaboraActive;
     }
 
-    public function canSyncWithOilhi(): bool
+    public function canSyncWithOilhi(Signalement $signalement): bool
     {
+        $inseeAllowed = !empty(array_intersect($this->getInsee(), self::CODE_INSEE_ZIP_ALLOWED));
+
         return $this->hasCompetence(Qualification::RSD)
             && PartnerType::COMMUNE_SCHS === $this->type
             && \in_array(
                 $this->territory->getZip(),
                 self::TERRITORY_ZIP_ALLOWED
-            );
+            )
+            && $inseeAllowed
+            && in_array($signalement->getInseeOccupant(), self::CODE_INSEE_ZIP_ALLOWED);
     }
 
     public function canSyncWithIdoss(): bool

--- a/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
+++ b/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
@@ -34,7 +34,7 @@ class DossierMessageFactory implements DossierMessageFactoryInterface
 
         return $this->featureEnable
         && $signalement->hasQualificaton(Qualification::RSD)
-        && $partner->canSyncWithOilhi();
+        && $partner->canSyncWithOilhi($signalement);
     }
 
     public function createInstance(Affectation $affectation): DossierMessage

--- a/src/Messenger/InterconnectionBus.php
+++ b/src/Messenger/InterconnectionBus.php
@@ -20,7 +20,9 @@ class InterconnectionBus
 
     public function dispatch(Affectation $affectation): void
     {
-        if (!$affectation->getPartner()->canSyncWithEsabora() && !$affectation->getPartner()->canSyncWithOilhi()) {
+        if (!$affectation->getPartner()->canSyncWithEsabora()
+            && !$affectation->getPartner()->canSyncWithOilhi($affectation->getSignalement())
+        ) {
             return;
         }
         /** @var DossierMessageFactoryInterface $dossierMessageFactory */

--- a/tests/Functional/Factory/Oilhi/DossierMessageFactoryTest.php
+++ b/tests/Functional/Factory/Oilhi/DossierMessageFactoryTest.php
@@ -66,7 +66,7 @@ class DossierMessageFactoryTest extends KernelTestCase
 
         $dossierMessageFactory = new DossierMessageFactory($urlGenerator, true);
 
-        $this->assertTrue($dossierMessageFactory->supports($affectation));
+        $this->assertFalse($dossierMessageFactory->supports($affectation));
 
         $dossierMessage = $dossierMessageFactory->createInstance($affectation);
 

--- a/tests/Unit/Entity/PartnerTest.php
+++ b/tests/Unit/Entity/PartnerTest.php
@@ -3,15 +3,19 @@
 namespace App\Tests\Unit\Entity;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\Qualification;
 use App\Entity\Partner;
 use App\Entity\Territory;
 use App\Entity\User;
+use App\Tests\FixturesHelper;
 use Faker\Factory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Validator\ConstraintViolationList;
 
 class PartnerTest extends KernelTestCase
 {
+    use FixturesHelper;
+
     public function testPartnerWithUserIsValid(): void
     {
         self::bootKernel();
@@ -52,5 +56,20 @@ class PartnerTest extends KernelTestCase
         /** @var ConstraintViolationList $errors */
         $errors = $validator->validate($partner);
         $this->assertEquals(0, $errors->count());
+    }
+
+    public function testPartnerSCHSCompetenceRSDWithSpecificInseeCanSyncWithOilhi(): void
+    {
+        $territory = $this->getTerritory('Pas-de-calais')->setZip('62');
+        $signalement = $this->getSignalement($territory);
+        $signalement->setInseeOccupant('62091');
+        $partner = (new Partner())
+            ->setNom('BEAUDRICOURT')
+            ->setType(PartnerType::COMMUNE_SCHS)
+            ->setCompetence([Qualification::RSD])
+            ->setInsee([62091])
+            ->setTerritory($territory);
+
+        $this->assertTrue($partner->canSyncWithOilhi($signalement));
     }
 }


### PR DESCRIPTION
## Ticket

#3160   

## Description
A la base ça devait être déployé dans tous le 62 mais ajout prise en charge code insee 

## Changements apportés
* Mise à jour méthode `canSyncWithOilhi` pour prise en compte de code insee

## Pré-requis
make worker-stop & make worker-start


## Tests
- [ ] Créer un signalement dans la commune de Beaudricourt et l'affecter au partenaire `Partenaire 62-02 (BEAUDRICOURT)` et  vérifier l'envoi via la table `job_event`
- [ ] Affecter un signalement lambda du 62 à un partenaire et vérifier que rien est loggé dans la table job_event
 
