### PR TITLE
[FO - Signalement] Ajout d'attributs hidden sur certains éléments

### DIFF
--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -33,7 +33,7 @@
                 :customCss="formStore.currentScreen.customCss"
                 :changeEvent="saveAndChangeScreenBySlug"
                 />
-              <button type="submit" class="hidden-submit">Submit</button>
+              <button type="submit" class="fr-hidden" hidden aria-hidden="true">Submit</button>
             </form>
           </div>
           <SignalementFormModal
@@ -320,8 +320,5 @@ export default defineComponent({
   }
   .signalement-form {
     background-color: white;
-  }
-  .hidden-submit {
-    display: none;
   }
 </style>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -126,7 +126,7 @@
       </div>
     </div>
   </dialog>
-  <button class="fr-btn fr-hidden" id="fr-modal-already-exists-button" data-fr-opened="false" aria-controls="fr-modal-already-exists"></button>
+  <button class="fr-btn fr-hidden" id="fr-modal-already-exists-button" data-fr-opened="false" aria-controls="fr-modal-already-exists" hidden aria-hidden="true"></button>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## Ticket

#3112   

## Description
Reprise du ticket sur la désactivation des feuilles de style.
Après lectures, ce critère est surtout important pour bien vérifier que la structure et l'ordre de lecture du site est logique.
Il n'est donc pas utile de travailler sur l'ergonomie de cet affichage (taille des images notamment).
Par contre, il est important de mettre des attributs `hidden` quand les éléments sont cachés via css (`fr-hidden`) pour qu'ils ne soient pas interprétés par les lecteurs d'écran.

## Changements apportés
* Ajout d'attribut `hidden` sur 2 boutons

## Pré-requis
`npm run watch`

## Tests
- [ ] Le formulaire fonctionne sans feuille de style jusqu'à la fin
