### PR TITLE
[FO - Formulaire - Accessibilité - 11.5 à 11.8] Champs de même nature

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCheckbox.vue
@@ -91,5 +91,6 @@ export default defineComponent({
 <style>
 .signalement-form-checkbox {
   margin-top: 1rem;
+  margin-left: -.5rem;
 }
 </style>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormComponentGenerator.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormComponentGenerator.vue
@@ -1,0 +1,119 @@
+<template>
+    <component
+      v-for="component in componentList"
+      :is="component.type"
+      v-bind:key="component.slug"
+      :id="component.slug"
+      :label="component.label"
+      :hint="component.hint"
+      :labelInfo="component.labelInfo"
+      :labelUpload="component.labelUpload"
+      :description="component.description"
+      :placeholder="component.placeholder"
+      :components="component.components"
+      :icons="component.icons"
+      :action="component.action"
+      :link="component.link"
+      :linktarget="component.linktarget"
+      :values="component.values"
+      :defaultValue="component.defaultValue"
+      :customCss="component.customCss"
+      :validate="component.validate"
+      :disabled="component.disabled"
+      :multiple="component.multiple"
+      :ariaControls="component.ariaControls"
+      :tagWhenEdit="component.tagWhenEdit"
+      v-model="formStore.data[component.slug]"
+      :hasError="formStore.validationErrors[component.slug] !== undefined"
+      :error="formStore.validationErrors[component.slug]"
+      :class="{ 'fr-hidden': !formStore.shouldShowField(component) }"
+      :aria-hidden="!formStore.shouldShowField(component) ? true : undefined"
+      :hidden="!formStore.shouldShowField(component) ? true : undefined"
+      :autocomplete="component.autocomplete"
+      :clickEvent="handleClickComponent"
+      :handleClickComponent="handleClickComponent"
+      :access_name="component.accessibility?.name ?? component.slug"
+      :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
+      :access_focus="component.accessibility?.focus ?? false"
+      />
+</template>
+<script lang="ts">
+import { defineComponent } from 'vue'
+import formStore from './../store'
+import { Component } from '../interfaces/interfaceComponent'
+import SignalementFormTextfield from './SignalementFormTextfield.vue'
+import SignalementFormTextarea from './SignalementFormTextarea.vue'
+import SignalementFormButton from './SignalementFormButton.vue'
+import SignalementFormLink from './SignalementFormLink.vue'
+import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
+import SignalementFormDate from './SignalementFormDate.vue'
+import SignalementFormYear from './SignalementFormYear.vue'
+import SignalementFormTime from './SignalementFormTime.vue'
+import SignalementFormCounter from './SignalementFormCounter.vue'
+import SignalementFormWarning from './SignalementFormWarning.vue'
+import SignalementFormInfo from './SignalementFormInfo.vue'
+import SignalementFormCheckbox from './SignalementFormCheckbox.vue'
+import SignalementFormPhonefield from './SignalementFormPhonefield.vue'
+import SignalementFormUpload from './SignalementFormUpload.vue'
+import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
+import SignalementFormOverview from './SignalementFormOverview.vue'
+import SignalementFormConfirmation from './SignalementFormConfirmation.vue'
+import SignalementFormRoomList from './SignalementFormRoomList.vue'
+import SignalementFormDisorderCategoryItem from './SignalementFormDisorderCategoryItem.vue'
+import SignalementFormDisorderCategoryList from './SignalementFormDisorderCategoryList.vue'
+import SignalementFormSubscreen from './SignalementFormSubscreen.vue'
+import SignalementFormAddress from './SignalementFormAddress.vue'
+import SignalementFormIcon from './SignalementFormIcon.vue'
+import SignalementFormEmailfield from './SignalementFormEmailfield.vue'
+import SignalementFormDisorderOverview from './SignalementFormDisorderOverview.vue'
+import SignalementFormModal from './SignalementFormModal.vue'
+import SignalementFormAutocomplete from './SignalementFormAutocomplete.vue'
+
+export default defineComponent({
+  name: 'SignalementFormComponentGenerator',
+  components: {
+    SignalementFormTextfield,
+    SignalementFormTextarea,
+    SignalementFormButton,
+    SignalementFormLink,
+    SignalementFormOnlyChoice,
+    SignalementFormDate,
+    SignalementFormYear,
+    SignalementFormTime,
+    SignalementFormCounter,
+    SignalementFormWarning,
+    SignalementFormInfo,
+    SignalementFormCheckbox,
+    SignalementFormPhonefield,
+    SignalementFormUpload,
+    SignalementFormUploadPhotos,
+    SignalementFormOverview,
+    SignalementFormConfirmation,
+    SignalementFormRoomList,
+    SignalementFormDisorderCategoryItem,
+    SignalementFormDisorderCategoryList,
+    SignalementFormAddress,
+    SignalementFormIcon,
+    SignalementFormEmailfield,
+    SignalementFormDisorderOverview,
+    SignalementFormModal,
+    SignalementFormAutocomplete,
+    SignalementFormSubscreen
+  },
+  props: {
+    componentList: {
+      type: Array as () => Array<Component>,
+      required: true
+    },
+    handleClickComponent: {
+      type: Function,
+      required: true
+    }
+  },
+  data () {
+    return {
+      formStore
+    }
+  }
+})
+</script>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -274,6 +274,8 @@ export default defineComponent({
     background-color: rgb(106, 106, 244, 0.25);
   }
   .form-screen-fieldset {
-    display: inherit
+    display: inherit;
+    margin: 0 0rem 1rem;
+    padding: 0 0rem;
   }
 </style>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -9,46 +9,21 @@
     <h1 v-if="formStore.currentScreen?.slug === 'introduction'" >{{ label }}</h1>
     <h2 v-else-if="label !== ''">{{ label }}</h2>
     <div v-html="variablesReplacer.replace(description)"></div>
-    <div
-      v-if="components != undefined"
-      >
-      <component
-        v-for="component in components.body"
-        :is="component.type"
-        v-bind:key="component.slug"
-        :id="component.slug"
-        :label="component.label"
-        :hint="component.hint"
-        :labelInfo="component.labelInfo"
-        :labelUpload="component.labelUpload"
-        :description="component.description"
-        :placeholder="component.placeholder"
-        :components="component.components"
-        :icons="component.icons"
-        :action="component.action"
-        :link="component.link"
-        :linktarget="component.linktarget"
-        :values="component.values"
-        :defaultValue="component.defaultValue"
-        :customCss="component.customCss"
-        :validate="component.validate"
-        :disabled="component.disabled"
-        :multiple="component.multiple"
-        :ariaControls="component.ariaControls"
-        :tagWhenEdit="component.tagWhenEdit"
-        v-model="formStore.data[component.slug]"
-        :hasError="formStore.validationErrors[component.slug] !== undefined"
-        :error="formStore.validationErrors[component.slug]"
-        :class="{ 'fr-hidden': !formStore.shouldShowField(component) }"
-        :aria-hidden="!formStore.shouldShowField(component) ? true : undefined"
-        :hidden="!formStore.shouldShowField(component) ? true : undefined"
-        :autocomplete="component.autocomplete"
-        :clickEvent="handleClickComponent"
-        :handleClickComponent="handleClickComponent"
-        :access_name="component.accessibility?.name ?? component.slug"
-        :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
-        :access_focus="component.accessibility?.focus ?? false"
+    <div v-if="components != undefined">
+      <template v-if="shouldAddFieldset()">
+        <fieldset class="fr-fieldset" id="checkboxes">
+          <SignalementFormComponentGenerator
+            :componentList="components.body"
+            :handleClickComponent="handleClickComponent"
+          />
+        </fieldset>
+      </template>
+      <template v-else>
+        <SignalementFormComponentGenerator
+          :componentList="components.body"
+          :handleClickComponent="handleClickComponent"
         />
+      </template>
     </div>
   </div>
   <div
@@ -56,36 +31,9 @@
     class="fr-container form-screen-footer"
     >
     <div>
-      <component
-        v-for="component in components.footer"
-        :is="component.type"
-        v-bind:key="component.slug"
-        :id="component.slug"
-        :label="component.label"
-        :labelInfo="component.labelInfo"
-        :labelUpload="component.labelUpload"
-        :description="component.description"
-        :placeholder="component.placeholder"
-        :components="component.components"
-        :icons="component.icons"
-        :action="component.action"
-        :link="component.link"
-        :linktarget="component.linktarget"
-        :values="component.values"
-        :defaultValue="component.defaultValue"
-        :customCss="component.customCss"
-        :validate="component.validate"
-        :disabled="component.disabled"
-        :multiple="component.multiple"
-        v-model="formStore.data[component.slug]"
-        :hasError="formStore.validationErrors[component.slug] !== undefined"
-        :error="formStore.validationErrors[component.slug]"
-        :class="{ 'fr-hidden': !formStore.shouldShowField(component) }"
-        :aria-hidden="!formStore.shouldShowField(component) ? true : undefined"
-        :hidden="!formStore.shouldShowField(component) ? true : undefined"
-        :clickEvent="handleClickComponent"
+      <SignalementFormComponentGenerator
+        :componentList="components.footer"
         :handleClickComponent="handleClickComponent"
-        :access_focus="component.accessibility?.focus ?? false"
       />
     </div>
   </div>
@@ -95,67 +43,15 @@
 import { defineComponent } from 'vue'
 import formStore from './../store'
 import { requests } from '../requests'
-import SignalementFormAddress from './SignalementFormAddress.vue'
-import SignalementFormButton from './SignalementFormButton.vue'
-import SignalementFormCheckbox from './SignalementFormCheckbox.vue'
-import SignalementFormConfirmation from './SignalementFormConfirmation.vue'
-import SignalementFormCounter from './SignalementFormCounter.vue'
-import SignalementFormDate from './SignalementFormDate.vue'
-import SignalementFormDisorderCategoryItem from './SignalementFormDisorderCategoryItem.vue'
-import SignalementFormDisorderCategoryList from './SignalementFormDisorderCategoryList.vue'
-import SignalementFormDisorderOverview from './SignalementFormDisorderOverview.vue'
-import SignalementFormEmailfield from './SignalementFormEmailfield.vue'
-import SignalementFormIcon from './SignalementFormIcon.vue'
-import SignalementFormInfo from './SignalementFormInfo.vue'
-import SignalementFormLink from './SignalementFormLink.vue'
-import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
-import SignalementFormOverview from './SignalementFormOverview.vue'
-import SignalementFormPhonefield from './SignalementFormPhonefield.vue'
-import SignalementFormRoomList from './SignalementFormRoomList.vue'
-import SignalementFormSubscreen from './SignalementFormSubscreen.vue'
-import SignalementFormTextfield from './SignalementFormTextfield.vue'
-import SignalementFormTextarea from './SignalementFormTextarea.vue'
-import SignalementFormTime from './SignalementFormTime.vue'
-import SignalementFormUpload from './SignalementFormUpload.vue'
-import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
-import SignalementFormWarning from './SignalementFormWarning.vue'
-import SignalementFormYear from './SignalementFormYear.vue'
-import SignalementFormModal from './SignalementFormModal.vue'
-import SignalementFormAutocomplete from './SignalementFormAutocomplete.vue'
 import { variablesReplacer } from './../services/variableReplacer'
 import { componentValidator } from './../services/componentValidator'
 import { findPreviousScreen, findNextScreen } from '../services/disorderScreenNavigator'
+import SignalementFormComponentGenerator from './SignalementFormComponentGenerator.vue'
 
 export default defineComponent({
   name: 'SignalementFormScreen',
   components: {
-    SignalementFormTextfield,
-    SignalementFormTextarea,
-    SignalementFormButton,
-    SignalementFormLink,
-    SignalementFormOnlyChoice,
-    SignalementFormSubscreen,
-    SignalementFormAddress,
-    SignalementFormDate,
-    SignalementFormYear,
-    SignalementFormTime,
-    SignalementFormCounter,
-    SignalementFormWarning,
-    SignalementFormInfo,
-    SignalementFormIcon,
-    SignalementFormCheckbox,
-    SignalementFormPhonefield,
-    SignalementFormUpload,
-    SignalementFormUploadPhotos,
-    SignalementFormEmailfield,
-    SignalementFormOverview,
-    SignalementFormConfirmation,
-    SignalementFormDisorderCategoryItem,
-    SignalementFormDisorderCategoryList,
-    SignalementFormDisorderOverview,
-    SignalementFormRoomList,
-    SignalementFormModal,
-    SignalementFormAutocomplete
+    SignalementFormComponentGenerator
   },
   props: {
     label: String,
@@ -319,6 +215,21 @@ export default defineComponent({
     },
     gotoHomepage () {
       window.location.href = '/'
+    },
+    shouldAddFieldset () {
+      if (formStore.currentScreen &&
+          formStore.currentScreen.components &&
+          formStore.currentScreen.components.body &&
+          formStore.currentScreen.components?.body?.length > 0
+      ) {
+        if (formStore.currentScreen.slug.startsWith('desordres_batiment_') ||
+            formStore.currentScreen.slug.startsWith('desordres_logement_') ||
+            formStore.currentScreen.slug === 'utilisation_service'
+        ) {
+          return true
+        }
+      }
+      return false
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -11,7 +11,7 @@
     <div v-html="variablesReplacer.replace(description)"></div>
     <div v-if="components != undefined">
       <template v-if="shouldAddFieldset()">
-        <fieldset class="fr-fieldset" id="checkboxes">
+        <fieldset class="fr-fieldset" id="screen_fieldset">
           <SignalementFormComponentGenerator
             :componentList="components.body"
             :handleClickComponent="handleClickComponent"

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -10,8 +10,8 @@
     <h2 v-else-if="label !== ''">{{ label }}</h2>
     <div v-html="variablesReplacer.replace(description)"></div>
     <div v-if="components != undefined">
-      <template v-if="shouldAddFieldset()">
-        <fieldset class="fr-fieldset" id="screen_fieldset">
+      <template v-if="formStore.shouldAddFieldset(formStore.currentScreen?.components?.body)">
+        <fieldset :id="formStore.currentScreen?.slug+'_screen_fieldset'" class="fr-fieldset form-screen-fieldset">
           <SignalementFormComponentGenerator
             :componentList="components.body"
             :handleClickComponent="handleClickComponent"
@@ -215,21 +215,6 @@ export default defineComponent({
     },
     gotoHomepage () {
       window.location.href = '/'
-    },
-    shouldAddFieldset () {
-      if (formStore.currentScreen &&
-          formStore.currentScreen.components &&
-          formStore.currentScreen.components.body &&
-          formStore.currentScreen.components?.body?.length > 0
-      ) {
-        if (formStore.currentScreen.slug.startsWith('desordres_batiment_') ||
-            formStore.currentScreen.slug.startsWith('desordres_logement_') ||
-            formStore.currentScreen.slug === 'utilisation_service'
-        ) {
-          return true
-        }
-      }
-      return false
     }
   }
 })
@@ -287,5 +272,8 @@ export default defineComponent({
   .fr-span-highlight-logement {
     /* équivalent de --blue-france-main-525 en rgb */
     background-color: rgb(106, 106, 244, 0.25);
+  }
+  .form-screen-fieldset {
+    display: inherit
   }
 </style>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -5,39 +5,78 @@
     <div
       v-if="components != undefined"
       >
-      <component
-        v-for="component in components.body"
-        :is="component.type"
-        v-bind:key="component.slug"
-        :id="component.slug"
-        :access_name="component.accessibility?.name ?? component.slug"
-        :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
-        :access_focus="component.accessibility?.focus ?? false"
-        :label="component.label"
-        :hint="component.hint"
-        :labelInfo="component.labelInfo"
-        :labelUpload="component.labelUpload"
-        :description="component.description"
-        :placeholder="component.placeholder"
-        :action="component.action"
-        :link="component.link"
-        :linktarget="component.linktarget"
-        :components="component.components"
-        :values="component.values"
-        :customCss="component.customCss"
-        :validate="component.validate"
-        :disabled="component.disabled"
-        :multiple="component.multiple"
-        :ariaControls="component.ariaControls"
-        :tagWhenEdit="component.tagWhenEdit"
-        v-model="formStore.data[component.slug]"
-        :hasError="formStore.validationErrors[component.slug] !== undefined"
-        :error="formStore.validationErrors[component.slug]"
-        :class="{ 'fr-hidden': !formStore.shouldShowField(component) }"
-        :aria-hidden="!formStore.shouldShowField(component) ? true : undefined"
-        :hidden="!formStore.shouldShowField(component) ? true : undefined"
-        :clickEvent="handleClickComponent"
-      />
+      <template v-if="formStore.shouldAddFieldset(components.body)">
+        <fieldset :id="id+'_subscreen_fieldset'" class="fr-fieldset form-subscreen-fieldset">
+          <component
+            v-for="component in components.body"
+            :is="component.type"
+            v-bind:key="component.slug"
+            :id="component.slug"
+            :access_name="component.accessibility?.name ?? component.slug"
+            :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
+            :access_focus="component.accessibility?.focus ?? false"
+            :label="component.label"
+            :hint="component.hint"
+            :labelInfo="component.labelInfo"
+            :labelUpload="component.labelUpload"
+            :description="component.description"
+            :placeholder="component.placeholder"
+            :action="component.action"
+            :link="component.link"
+            :linktarget="component.linktarget"
+            :components="component.components"
+            :values="component.values"
+            :customCss="component.customCss"
+            :validate="component.validate"
+            :disabled="component.disabled"
+            :multiple="component.multiple"
+            :ariaControls="component.ariaControls"
+            :tagWhenEdit="component.tagWhenEdit"
+            v-model="formStore.data[component.slug]"
+            :hasError="formStore.validationErrors[component.slug] !== undefined"
+            :error="formStore.validationErrors[component.slug]"
+            :class="{ 'fr-hidden': !formStore.shouldShowField(component) }"
+            :aria-hidden="!formStore.shouldShowField(component) ? true : undefined"
+            :hidden="!formStore.shouldShowField(component) ? true : undefined"
+            :clickEvent="handleClickComponent"
+          />
+        </fieldset>
+      </template>
+      <template v-else>
+        <component
+          v-for="component in components.body"
+          :is="component.type"
+          v-bind:key="component.slug"
+          :id="component.slug"
+          :access_name="component.accessibility?.name ?? component.slug"
+          :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
+          :access_focus="component.accessibility?.focus ?? false"
+          :label="component.label"
+          :hint="component.hint"
+          :labelInfo="component.labelInfo"
+          :labelUpload="component.labelUpload"
+          :description="component.description"
+          :placeholder="component.placeholder"
+          :action="component.action"
+          :link="component.link"
+          :linktarget="component.linktarget"
+          :components="component.components"
+          :values="component.values"
+          :customCss="component.customCss"
+          :validate="component.validate"
+          :disabled="component.disabled"
+          :multiple="component.multiple"
+          :ariaControls="component.ariaControls"
+          :tagWhenEdit="component.tagWhenEdit"
+          v-model="formStore.data[component.slug]"
+          :hasError="formStore.validationErrors[component.slug] !== undefined"
+          :error="formStore.validationErrors[component.slug]"
+          :class="{ 'fr-hidden': !formStore.shouldShowField(component) }"
+          :aria-hidden="!formStore.shouldShowField(component) ? true : undefined"
+          :hidden="!formStore.shouldShowField(component) ? true : undefined"
+          :clickEvent="handleClickComponent"
+        />
+      </template>
     </div>
   </div>
 </template>
@@ -126,5 +165,8 @@ export default defineComponent({
   border-left: 3px solid var(--border-action-high-blue-france);
   margin-left: 10px;
   padding-left: 18px;
+}
+.form-subscreen-fieldset {
+  display: inherit
 }
 </style>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -167,6 +167,8 @@ export default defineComponent({
   padding-left: 18px;
 }
 .form-subscreen-fieldset {
-  display: inherit
+  display: inherit ;
+  margin: 0 -0.25rem 1rem;
+  padding: 0 0rem;
 }
 </style>

--- a/assets/scripts/vue/components/signalement-form/interfaces/interfaceComponent.ts
+++ b/assets/scripts/vue/components/signalement-form/interfaces/interfaceComponent.ts
@@ -23,4 +23,10 @@ export interface Component {
   disabled?: string
   multiple?: string
   conditional?: any
+  hint?: string
+  placeholder?: string
+  ariaControls?: string
+  tagWhenEdit?: string
+  autocomplete?: string
+  accessibility?: any
 }

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -217,9 +217,10 @@ const formStore: FormStore = reactive({
         component.components !== undefined) {
         inputComponentsByScreen += this.countInputComponentsByScreen(component.components.body)
       }
+      if (inputComponentsByScreen > 1) {
+        return inputComponentsByScreen
+      }
     }
-    console.log('inputComponentsByScreen  = ')
-    console.log( inputComponentsByScreen)
     return inputComponentsByScreen
   }
 })

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -213,10 +213,13 @@ const formStore: FormStore = reactive({
       if (formStore.inputComponents.includes(component.type)) {
         inputComponentsByScreen++
       } else if ((component.type === 'SignalementFormSubscreen') &&
-        component.components !== null) {
+        component.components !== null &&
+        component.components !== undefined) {
         inputComponentsByScreen += this.countInputComponentsByScreen(component.components.body)
       }
     }
+    console.log('inputComponentsByScreen  = ')
+    console.log( inputComponentsByScreen)
     return inputComponentsByScreen
   }
 })

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -59,7 +59,7 @@ interface FormStore {
   validationErrors: FormData
   inputComponents: string[]
   updateData: (key: string, value: any) => void
-  shouldShowField: (conditional: string) => boolean
+  shouldShowField: (component: any) => boolean
   preprocessScreen: (screenBodyComponents: any) => Component[]
   hasDesordre: (categorieSlug: string) => boolean
 }
@@ -117,7 +117,7 @@ const formStore: FormStore = reactive({
     formStore.data[key] = value
   },
   shouldShowField (component: any) {
-    if (!component.conditional) {
+    if (component.conditional === undefined || component.conditional === '') {
       return true
     }
     return computed(() => eval(component.conditional.show)).value

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -62,6 +62,8 @@ interface FormStore {
   shouldShowField: (component: any) => boolean
   preprocessScreen: (screenBodyComponents: any) => Component[]
   hasDesordre: (categorieSlug: string) => boolean
+  shouldAddFieldset: (components: any) => boolean
+  countInputComponentsByScreen: (components: any) => number
 }
 
 const formStore: FormStore = reactive({
@@ -196,6 +198,26 @@ const formStore: FormStore = reactive({
     }
 
     return hasDesordre
+  },
+  shouldAddFieldset (components: any): boolean {
+    if (((components) != null) &&
+        this.countInputComponentsByScreen(components) > 1
+    ) {
+      return true
+    }
+    return false
+  },
+  countInputComponentsByScreen (components: any): number {
+    let inputComponentsByScreen = 0
+    for (const component of components) {
+      if (formStore.inputComponents.includes(component.type)) {
+        inputComponentsByScreen++
+      } else if ((component.type === 'SignalementFormSubscreen') &&
+        component.components !== null) {
+        inputComponentsByScreen += this.countInputComponentsByScreen(component.components.body)
+      }
+    }
+    return inputComponentsByScreen
   }
 })
 

--- a/src/DataFixtures/Files/signalement_draft_payload/locataire_all_in.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/locataire_all_in.json
@@ -168,7 +168,7 @@
     "informations_complementaires_logement_nombre_etages": "1",
     "vos_coordonnees_occupant_tel_secondaire_countrycode": "FR:33",
     "desordres_logement_chauffage_details_dpe_conso_finale": null,
-    "adresse_logement_complement_adresse_numero_appartement": "4-B3-1",
+    "adresse_logement_complement_adresse_numero_appartement": "4-B3",
     "desordres_batiment_securite_escalier_details_dangereux": "oui",
     "desordres_batiment_securite_sol_details_plancher_abime": "non",
     "desordres_logement_electricite_installation_dangereuse": 1,


### PR DESCRIPTION
## Ticket

#3115    

## Description
[Critère 11.5](https://accessibilite.public.lu/fr/rgaa4.1/criteres.html#crit-11-5) [A] : Dans chaque [formulaire](https://accessibilite.public.lu/fr/rgaa4.1/glossaire.html#formulaire), les [champs de même nature](https://accessibilite.public.lu/fr/rgaa4.1/glossaire.html#champs-de-meme-nature) sont-ils regroupés, si nécessaire ?
Regrouper les différents inputs des désordres et de l'utilisation du service en 1 fieldset

## Changements apportés
* Création d'un composant qui gère la boucle de création de composant à la volée
* Utilisation de ce composant dans le SignalementFormScreen pour le body et le footer (malheureusement pas dans le SignalementFormSubscreen, cf commentaire)
* Inclusion de cette boucle de composant dans un fieldset si besoin

## Pré-requis
`npm run watch`
## Tests
- [ ] Faire un signalement et vérifier que tout fonctionne comme avant
- [ ] Inspecter quelques pages, et vérifier la présence, ou l'absence de balise fieldset selon les écrans
