### PR TITLE
[BO] Renommer le rôle "utilisateur" en "agent" (et unifier les noms de responsable territoire et admin partenaire)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ S3_URL_BUCKET=
 Territoire             | Partenaire                | Email                               | Rôle       
 -----------------------|---------------------------|-------------------------------------|----------------------
 N/A                    | Admin Histologe           | admin-01@histologe.fr               | ROLE_ADMIN 
-Bouches-du-Rhône       | Admin Territoire 13       | admin-territoire-13-01@histologe.fr | ROLE_ADMIN_TERRITORY
-Ain                    | Admin Territoire 01       | admin-territoire-01-01@histologe.fr | ROLE_ADMIN_TERRITORY
-Bouches-du-Rhône       | Admin Partenaire 13       | admin-partenaire-13-01@histologe.fr | ROLE_ADMIN_PARTNER
-Ain                    | Admin Partenaire 01       | admin-partenaire-01-01@histologe.fr | ROLE_ADMIN_PARTNER
-Bouches-du-Rhône       | Utilisateur Partenaire 13 | user-13-01@histologe.fr             | ROLE_USER_PARTNER
-Ain                    | Utilisateur Partenaire 01 | user-01-01@histologe.fr             | ROLE_USER_PARTNER
+Bouches-du-Rhône       | Resp. Territoire 13       | admin-territoire-13-01@histologe.fr | ROLE_ADMIN_TERRITORY
+Ain                    | Resp. Territoire 01       | admin-territoire-01-01@histologe.fr | ROLE_ADMIN_TERRITORY
+Bouches-du-Rhône       | Admin. partenaire 13       | admin-partenaire-13-01@histologe.fr | ROLE_ADMIN_PARTNER
+Ain                    | Admin. partenaire 01       | admin-partenaire-01-01@histologe.fr | ROLE_ADMIN_PARTNER
+Bouches-du-Rhône       | Agent Partenaire 13 | user-13-01@histologe.fr             | ROLE_USER_PARTNER
+Ain                    | Agent Partenaire 01 | user-01-01@histologe.fr             | ROLE_USER_PARTNER
 
 > Pour les mails générique partenaire, la nomenclature est la suivante: partenaire-[zip]-[index]
 

--- a/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -109,8 +109,8 @@ export default defineComponent({
   methods: {
     handleInitSettings (requestResponse: any) {
       this.sharedState.user.isAdmin = requestResponse.roleLabel === 'Super Admin'
-      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
-      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin partenaire'
+      this.sharedState.user.isResponsableTerritoire = ['Responsable Territoire', 'Resp. Territoire'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isAdministrateurPartenaire = ['Administrateur', 'Admin. partenaire'].includes(requestResponse.roleLabel)
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       this.sharedState.user.prenom = requestResponse.firstname
       this.sharedState.user.avatarOrPlaceHolder = requestResponse.avatarOrPlaceHolder

--- a/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -109,8 +109,8 @@ export default defineComponent({
   methods: {
     handleInitSettings (requestResponse: any) {
       this.sharedState.user.isAdmin = requestResponse.roleLabel === 'Super Admin'
-      this.sharedState.user.isResponsableTerritoire = ['Responsable Territoire', 'Resp. Territoire'].includes(requestResponse.roleLabel)
-      this.sharedState.user.isAdministrateurPartenaire = ['Administrateur', 'Admin. partenaire'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
+      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin. partenaire'
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       this.sharedState.user.prenom = requestResponse.firstname
       this.sharedState.user.avatarOrPlaceHolder = requestResponse.avatarOrPlaceHolder

--- a/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -109,8 +109,8 @@ export default defineComponent({
   methods: {
     handleInitSettings (requestResponse: any) {
       this.sharedState.user.isAdmin = requestResponse.roleLabel === 'Super Admin'
-      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Responsable Territoire'
-      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Administrateur'
+      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
+      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin partenaire'
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       this.sharedState.user.prenom = requestResponse.firstname
       this.sharedState.user.avatarOrPlaceHolder = requestResponse.avatarOrPlaceHolder

--- a/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
@@ -145,9 +145,9 @@ export default defineComponent({
     },
     handleSettings (requestResponse: any) {
       this.sharedState.user.isAdmin = requestResponse.roleLabel === 'Super Admin'
-      this.sharedState.user.isResponsableTerritoire = ['Responsable Territoire', 'Resp. Territoire'].includes(requestResponse.roleLabel)
-      this.sharedState.user.isAdministrateurPartenaire = ['Administrateur', 'Admin. partenaire'].includes(requestResponse.roleLabel)
-      this.sharedState.user.isAgent = ['Administrateur', 'Admin. partenaire', 'Utilisateur', 'Agent'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
+      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin. partenaire'
+      this.sharedState.user.isAgent = ['Admin. partenaire', 'Agent'].includes(requestResponse.roleLabel)
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       const isAdminOrAdminTerritoire = this.sharedState.user.isAdmin || this.sharedState.user.isResponsableTerritoire
       this.sharedState.user.canSeeStatusAffectation = isAdminOrAdminTerritoire

--- a/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
@@ -145,9 +145,9 @@ export default defineComponent({
     },
     handleSettings (requestResponse: any) {
       this.sharedState.user.isAdmin = requestResponse.roleLabel === 'Super Admin'
-      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
-      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin partenaire'
-      this.sharedState.user.isAgent = ['Administrateur', 'Admin partenaire', 'Utilisateur', 'Agent'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isResponsableTerritoire = ['Responsable Territoire', 'Resp. Territoire'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isAdministrateurPartenaire = ['Administrateur', 'Admin. partenaire'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isAgent = ['Administrateur', 'Admin. partenaire', 'Utilisateur', 'Agent'].includes(requestResponse.roleLabel)
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       const isAdminOrAdminTerritoire = this.sharedState.user.isAdmin || this.sharedState.user.isResponsableTerritoire
       this.sharedState.user.canSeeStatusAffectation = isAdminOrAdminTerritoire

--- a/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
@@ -145,9 +145,9 @@ export default defineComponent({
     },
     handleSettings (requestResponse: any) {
       this.sharedState.user.isAdmin = requestResponse.roleLabel === 'Super Admin'
-      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Responsable Territoire'
-      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Administrateur'
-      this.sharedState.user.isAgent = ['Administrateur', 'Utilisateur'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
+      this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin partenaire'
+      this.sharedState.user.isAgent = ['Administrateur', 'Admin partenaire', 'Utilisateur', 'Agent'].includes(requestResponse.roleLabel)
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       const isAdminOrAdminTerritoire = this.sharedState.user.isAdmin || this.sharedState.user.isResponsableTerritoire
       this.sharedState.user.canSeeStatusAffectation = isAdminOrAdminTerritoire

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -39,7 +39,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
 
     public const ROLE_USAGER = self::ROLES['Usager'];
     public const ROLE_USER_PARTNER = self::ROLES['Agent'];
-    public const ROLE_ADMIN_PARTNER = self::ROLES['Admin partenaire'];
+    public const ROLE_ADMIN_PARTNER = self::ROLES['Admin. partenaire'];
     public const ROLE_ADMIN_TERRITORY = self::ROLES['Resp. Territoire'];
     public const ROLE_ADMIN = self::ROLES['Super Admin'];
 
@@ -51,7 +51,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     public const ROLES = [
         'Usager' => 'ROLE_USAGER',
         'Agent' => 'ROLE_USER_PARTNER',
-        'Admin partenaire' => 'ROLE_ADMIN_PARTNER',
+        'Admin. partenaire' => 'ROLE_ADMIN_PARTNER',
         'Resp. Territoire' => 'ROLE_ADMIN_TERRITORY',
         'Super Admin' => 'ROLE_ADMIN',
     ];

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -38,9 +38,9 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     public const MAX_LIST_PAGINATION = 20;
 
     public const ROLE_USAGER = self::ROLES['Usager'];
-    public const ROLE_USER_PARTNER = self::ROLES['Utilisateur'];
-    public const ROLE_ADMIN_PARTNER = self::ROLES['Administrateur'];
-    public const ROLE_ADMIN_TERRITORY = self::ROLES['Responsable Territoire'];
+    public const ROLE_USER_PARTNER = self::ROLES['Agent'];
+    public const ROLE_ADMIN_PARTNER = self::ROLES['Admin partenaire'];
+    public const ROLE_ADMIN_TERRITORY = self::ROLES['Resp. Territoire'];
     public const ROLE_ADMIN = self::ROLES['Super Admin'];
 
     public const SUFFIXE_ARCHIVED = '.archived@';
@@ -49,13 +49,6 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     public const ANONYMIZED_NOM = 'Anonymisé';
 
     public const ROLES = [
-        'Usager' => 'ROLE_USAGER',
-        'Utilisateur' => 'ROLE_USER_PARTNER',
-        'Administrateur' => 'ROLE_ADMIN_PARTNER',
-        'Responsable Territoire' => 'ROLE_ADMIN_TERRITORY',
-        'Super Admin' => 'ROLE_ADMIN',
-    ];
-    public const ROLESV2 = [
         'Usager' => 'ROLE_USAGER',
         'Agent' => 'ROLE_USER_PARTNER',
         'Admin partenaire' => 'ROLE_ADMIN_PARTNER',
@@ -427,13 +420,9 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         return array_unique($roles);
     }
 
-    public function getRoleLabel($v2 = false): string
+    public function getRoleLabel(): string
     {
-        if ($v2) {
-            $roleLabel = array_flip(self::ROLESV2);
-        } else {
-            $roleLabel = array_flip(self::ROLES);
-        }
+        $roleLabel = array_flip(self::ROLES);
         $role = array_shift($this->roles);
 
         return $roleLabel[$role];

--- a/src/Form/SearchUserType.php
+++ b/src/Form/SearchUserType.php
@@ -28,7 +28,7 @@ class SearchUserType extends AbstractType
     public function __construct(
         private readonly Security $security
     ) {
-        $this->roleChoices = User::ROLESV2;
+        $this->roleChoices = User::ROLES;
         unset($this->roleChoices['Usager']);
         if ($this->security->isGranted('ROLE_ADMIN')) {
             $this->isAdmin = true;

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -29,6 +29,14 @@ class GridAffectationLoader
         'errors' => [],
     ];
 
+    public const OLD_ROLES = [
+        'Usager' => 'ROLE_USAGER',
+        'Utilisateur' => 'ROLE_USER_PARTNER',
+        'Administrateur' => 'ROLE_ADMIN_PARTNER',
+        'Responsable Territoire' => 'ROLE_ADMIN_TERRITORY',
+        'Super Admin' => 'ROLE_ADMIN',
+    ];
+
     public function __construct(
         private PartnerFactory $partnerFactory,
         private PartnerManager $partnerManager,
@@ -134,7 +142,9 @@ class GridAffectationLoader
                     }
                 }
                 if (!empty($item[GridAffectationHeader::USER_ROLE])
-                    && !\in_array($item[GridAffectationHeader::USER_ROLE], array_keys(User::ROLES))) {
+                    && !\in_array($item[GridAffectationHeader::USER_ROLE], array_keys(User::ROLES))
+                    && !\in_array($item[GridAffectationHeader::USER_ROLE], array_keys(self::OLD_ROLES))
+                ) {
                     $errors[] = \sprintf(
                         'line %d : Rôle incorrect pour %s --> %s',
                         $numLine,
@@ -209,6 +219,14 @@ class GridAffectationLoader
                 }
 
                 $roleLabel = $item[GridAffectationHeader::USER_ROLE];
+                if ('Utilisateur' === $roleLabel) {
+                    $roleLabel = 'Agent';
+                } elseif ('Administrateur' === $roleLabel) {
+                    $roleLabel = 'Admin partenaire';
+                } elseif ('Responsable Territoire' === $roleLabel) {
+                    $roleLabel = 'Resp. Territoire';
+                }
+
                 $email = trim($item[GridAffectationHeader::USER_EMAIL]);
                 if (!empty($roleLabel) && !empty($email)) {
                     ++$countUsers;

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -222,7 +222,7 @@ class GridAffectationLoader
                 if ('Utilisateur' === $roleLabel) {
                     $roleLabel = 'Agent';
                 } elseif ('Administrateur' === $roleLabel) {
-                    $roleLabel = 'Admin partenaire';
+                    $roleLabel = 'Admin. partenaire';
                 } elseif ('Responsable Territoire' === $roleLabel) {
                     $roleLabel = 'Resp. Territoire';
                 }

--- a/src/Service/SearchUser.php
+++ b/src/Service/SearchUser.php
@@ -143,7 +143,7 @@ class SearchUser
             $filters['Statut'] = User::STATUS_LABELS[$this->statut];
         }
         if ($this->role) {
-            $filters['Rôle'] = array_search($this->role, User::ROLESV2);
+            $filters['Rôle'] = array_search($this->role, User::ROLES);
         }
 
         return $filters;

--- a/src/Service/UserExportLoader.php
+++ b/src/Service/UserExportLoader.php
@@ -46,7 +46,7 @@ readonly class UserExportLoader
                     'createdAt' => $user->getCreatedAt()->format('d/m/Y'),
                     'statut' => User::STATUS_ACTIVE === $user->getStatut() ? 'Activé' : 'Non activé',
                     'lastLoginAt' => $user->getLastLoginAt() ? $user->getLastLoginAt()->format('d/m/Y') : '',
-                    'role' => $user->getRoleLabel(true),
+                    'role' => $user->getRoleLabel(),
                     default => '',
                 };
             }

--- a/src/Service/UserExportLoader.php
+++ b/src/Service/UserExportLoader.php
@@ -18,7 +18,7 @@ readonly class UserExportLoader
         'createdAt' => ['label' => 'Date de création', 'desc' => 'la date de création du compte'],
         'statut' => ['label' => 'Statut', 'desc' => 'le statut du compte (s\'il est activé ou non)'],
         'lastLoginAt' => ['label' => 'Dernière connexion', 'desc' => 'la date de dernière connexion au compte'],
-        'role' => ['label' => 'Rôle', 'desc' => 's\'il s\'agit d\'un compte agent, admin partenaire ou responsable de territoire'],
+        'role' => ['label' => 'Rôle', 'desc' => 's\'il s\'agit d\'un compte agent, Admin. partenaire ou responsable de territoire'],
     ];
 
     public function __construct(

--- a/templates/_partials/_modal_user_create.html.twig
+++ b/templates/_partials/_modal_user_create.html.twig
@@ -45,11 +45,11 @@
                                             {% endif %}
                                             {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                                                 <option value="ROLE_ADMIN_TERRITORY">
-                                                    Responsable Territoire
+                                                    Resp. Territoire
                                                 </option>
                                             {% endif %}
-                                            <option value="ROLE_ADMIN_PARTNER">Administrateur</option>
-                                            <option value="ROLE_USER_PARTNER">Utilisateur</option>
+                                            <option value="ROLE_ADMIN_PARTNER">Admin partenaire</option>
+                                            <option value="ROLE_USER_PARTNER">Agent</option>
                                         </select>
                                         <p class="fr-error-text fr-hidden">
                                             Vous devez sélectionner le rôle de l'utilisateur

--- a/templates/_partials/_modal_user_create.html.twig
+++ b/templates/_partials/_modal_user_create.html.twig
@@ -48,7 +48,7 @@
                                                     Resp. Territoire
                                                 </option>
                                             {% endif %}
-                                            <option value="ROLE_ADMIN_PARTNER">Admin partenaire</option>
+                                            <option value="ROLE_ADMIN_PARTNER">Admin. partenaire</option>
                                             <option value="ROLE_USER_PARTNER">Agent</option>
                                         </select>
                                         <p class="fr-error-text fr-hidden">

--- a/templates/_partials/_modal_user_edit.html.twig
+++ b/templates/_partials/_modal_user_edit.html.twig
@@ -44,11 +44,11 @@
                                             {% endif %}
                                             {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                                                 <option value="ROLE_ADMIN_TERRITORY">
-                                                    Responsable Territoire
+                                                    Resp. Territoire
                                                 </option>
                                             {% endif %}
-                                            <option value="ROLE_ADMIN_PARTNER">Administrateur</option>
-                                            <option value="ROLE_USER_PARTNER">Utilisateur</option>                           
+                                            <option value="ROLE_ADMIN_PARTNER">Admin partenaire</option>
+                                            <option value="ROLE_USER_PARTNER">Agent</option>                           
                                         </select>
                                         <p class="fr-error-text fr-hidden">
                                             Vous devez sélectionner le rôle de l'utilisateur

--- a/templates/_partials/_modal_user_edit.html.twig
+++ b/templates/_partials/_modal_user_edit.html.twig
@@ -47,7 +47,7 @@
                                                     Resp. Territoire
                                                 </option>
                                             {% endif %}
-                                            <option value="ROLE_ADMIN_PARTNER">Admin partenaire</option>
+                                            <option value="ROLE_ADMIN_PARTNER">Admin. partenaire</option>
                                             <option value="ROLE_USER_PARTNER">Agent</option>                           
                                         </select>
                                         <p class="fr-error-text fr-hidden">

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -174,11 +174,11 @@
                                     <td>{% if 'ROLE_ADMIN' in user.roles %}
                                             Super Admin
                                         {% elseif 'ROLE_ADMIN_TERRITORY' in user.roles %}
-                                            Responsable Territoire
+                                            Resp. Territoire
                                         {% elseif 'ROLE_ADMIN_PARTNER' in user.roles %}
-                                            Administrateur
+                                            Admin partenaire
                                         {% elseif 'ROLE_USER_PARTNER' in user.roles %}
-                                            Utilisateur
+                                            Agent
                                         {% endif %}
                                     </td>
                                     <td class="fr-text--right">

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -176,7 +176,7 @@
                                         {% elseif 'ROLE_ADMIN_TERRITORY' in user.roles %}
                                             Resp. Territoire
                                         {% elseif 'ROLE_ADMIN_PARTNER' in user.roles %}
-                                            Admin partenaire
+                                            Admin. partenaire
                                         {% elseif 'ROLE_USER_PARTNER' in user.roles %}
                                             Agent
                                         {% endif %}

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -102,7 +102,7 @@
                                         {% endif %}
                                     </td>
                                     <td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}</td>
-                                    <td>{{ user.roleLabel(true) }}</td>
+                                    <td>{{ user.roleLabel() }}</td>
                                 </tr>
                             {% endfor %}
                         </tbody>

--- a/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
+++ b/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
@@ -32,7 +32,7 @@ class GridAffectationLoaderTest extends KernelTestCase
 
     public const FIXTURE_USER_EMAIL_DUPLICATE = 'user-ddt@histologe.fr';
     public const FIXTURE_ROLE_RT = 'Resp. Territoire';
-    public const FIXTURE_ROLE_PARTNER = 'Admin partenaire';
+    public const FIXTURE_ROLE_PARTNER = 'Admin. partenaire';
     public const FIXTURE_ROLE_USER = 'Agent';
 
     private GridAffectationLoader $gridAffectationLoader;

--- a/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
+++ b/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
@@ -31,9 +31,9 @@ class GridAffectationLoaderTest extends KernelTestCase
     public const FIXTURE_PARTNER_ARS_EMAIL = 'ars@histologe.fr';
 
     public const FIXTURE_USER_EMAIL_DUPLICATE = 'user-ddt@histologe.fr';
-    public const FIXTURE_ROLE_RT = 'Responsable Territoire';
-    public const FIXTURE_ROLE_PARTNER = 'Administrateur';
-    public const FIXTURE_ROLE_USER = 'Utilisateur';
+    public const FIXTURE_ROLE_RT = 'Resp. Territoire';
+    public const FIXTURE_ROLE_PARTNER = 'Admin partenaire';
+    public const FIXTURE_ROLE_USER = 'Agent';
 
     private GridAffectationLoader $gridAffectationLoader;
     private EntityManagerInterface $entityManager;
@@ -129,7 +129,7 @@ class GridAffectationLoaderTest extends KernelTestCase
             'line 7 : Partenaire déjà existant avec (partenaire-13-01@histologe.fr) dans Bouches-du-Rhône, nom : Partenaire 13-01',
             'line 8 : E-mail manquant pour Margaretta Borer, partenaire ADIL',
             'line 9 : Nom de partenaire manquant',
-            'line 10 : Utilisateur déjà existant avec (user-13-06@histologe.fr) dans Bouches-du-Rhône, partenaire : Partenaire 13-06 ESABORA ARS, rôle : Utilisateur',
+            'line 10 : Utilisateur déjà existant avec (user-13-06@histologe.fr) dans Bouches-du-Rhône, partenaire : Partenaire 13-06 ESABORA ARS, rôle : Agent',
             'Certains partenaires ont un e-mail en commun ddt-m@histologe.fr',
             'Certains utilisateurs ont un e-mail en commun user-ddt@histologe.fr',
             'Certains utilisateurs ont un e-mail en commun avec un partenaire ddt-m@histologe.fr,user-ddt@histologe.fr',

--- a/tests/Unit/Entity/PartnerTest.php
+++ b/tests/Unit/Entity/PartnerTest.php
@@ -25,7 +25,7 @@ class PartnerTest extends KernelTestCase
             ->setEmail($faker->email())
             ->setNom($faker->lastName())
             ->setPrenom($faker->firstName())
-            ->setRoles([User::ROLES['Utilisateur']])
+            ->setRoles([User::ROLES['Agent']])
             ->setIsMailingActive(true)
             ->setPassword($faker->password());
 
@@ -43,7 +43,7 @@ class PartnerTest extends KernelTestCase
                 ->setEmail($faker->email())
                 ->setNom($faker->lastName())
                 ->setPrenom($faker->firstName())
-                ->setRoles([User::ROLES['Utilisateur']])
+                ->setRoles([User::ROLES['Agent']])
                 ->setIsMailingActive(true)
                 ->setPassword($faker->password(8));
             $partner->addUser($user);

--- a/tests/Unit/Factory/UserFactoryTest.php
+++ b/tests/Unit/Factory/UserFactoryTest.php
@@ -31,7 +31,7 @@ class UserFactoryTest extends KernelTestCase
         $partner = new Partner();
 
         $user = (new UserFactory())->createInstanceFrom(
-            roleLabel: 'Utilisateur',
+            roleLabel: 'Agent',
             territory: $territory,
             partner: $partner,
             firstname: 'John',

--- a/tests/Unit/Service/DashboardWidget/WidgetSettingsTest.php
+++ b/tests/Unit/Service/DashboardWidget/WidgetSettingsTest.php
@@ -26,7 +26,7 @@ class WidgetSettingsTest extends TestCase
 
         $this->assertEquals('John', $widgetSettings->getFirstname());
         $this->assertEquals('Doe', $widgetSettings->getLastname());
-        $this->assertEquals('Utilisateur', $widgetSettings->getRoleLabel());
+        $this->assertEquals('Agent', $widgetSettings->getRoleLabel());
         $this->assertEquals('Partner', $widgetSettings->getPartnerName());
         $this->assertEquals('01-Ain', $widgetSettings->getTerritoryName());
         $this->assertCount(2, $widgetSettings->getTerritories());

--- a/tests/Unit/Service/UserAvatarTest.php
+++ b/tests/Unit/Service/UserAvatarTest.php
@@ -28,7 +28,7 @@ class UserAvatarTest extends WebTestCase
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user, 80);
         $this->assertEquals('<span class="avatar-histologe avatar-placeholder avatar-80">SA</span>', $outputSpan);
 
-        $user->setRoles([User::ROLES['Administrateur']]);
+        $user->setRoles([User::ROLES['Admin partenaire']]);
         $user->setTerritory((new Territory())->setZip('44'));
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user);
         $this->assertEquals('<span class="avatar-histologe avatar-placeholder avatar-74">44</span>', $outputSpan);

--- a/tests/Unit/Service/UserAvatarTest.php
+++ b/tests/Unit/Service/UserAvatarTest.php
@@ -28,7 +28,7 @@ class UserAvatarTest extends WebTestCase
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user, 80);
         $this->assertEquals('<span class="avatar-histologe avatar-placeholder avatar-80">SA</span>', $outputSpan);
 
-        $user->setRoles([User::ROLES['Admin partenaire']]);
+        $user->setRoles([User::ROLES['Admin. partenaire']]);
         $user->setTerritory((new Territory())->setZip('44'));
         $outputSpan = $userAvatar->userAvatarOrPlaceHolder($user);
         $this->assertEquals('<span class="avatar-histologe avatar-placeholder avatar-74">44</span>', $outputSpan);


### PR DESCRIPTION
## Ticket

#3110    

## Description
Pour plus de compréhension de la part des utilisateurs, il faut enommer le rôle "utilisateur" en "agent"
et "Administrateur" en "administrateur partenaire".
Ces nouveaux noms avaient été introduits dans un tableau User::ROLESV2 pour la liste des utilisateurs

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis
`npm run  watch` 

## Tests
- [ ] Parcourir toutes les pages du BO et vérifier qu'il n'y a plus d''`utilisateur` ou d'`administrateur` qui traînent
- [ ] Avec une grille d'affectation existante, ouvrir un territoire ayant les 3 rôles, et sans changer la grille vérifier que les utilisateurs sont créés avec les bons rôles
- [ ] Aller dans un partenaire, et créer et modifier des utilisateurs de chaque rôle, vérifier que tout se passe bien
- [ ] Aller sur la liste des utilisateurs et vérifier l'affichage des rôles sur le BO et dans l'export
- [ ] Sur le dashboard et la liste de signalements, vérifier l'affichage des filtres en fonction des rôles (TNR)
