### PR TITLE
[Sécurité] Correction des feedback codeQL

### DIFF
--- a/assets/scripts/vanilla/controllers/back_auto_affectation_rule/form_auto_affectation_rule.js
+++ b/assets/scripts/vanilla/controllers/back_auto_affectation_rule/form_auto_affectation_rule.js
@@ -3,10 +3,10 @@ import { loadWindowWithLocalStorage, updateLocalStorageWithPaginationParams, upd
 document.querySelectorAll('.btn-delete-autoaffectationrule').forEach(swbtn => {
     swbtn.addEventListener('click', evt => {
         const target = evt.target
-        document.querySelector('.fr-modal-autoaffectationrule-delete-description').innerHTML = target.getAttribute('data-autoaffectationrule-description')
+        document.querySelector('.fr-modal-autoaffectationrule-delete-description').textContent = target.getAttribute('data-autoaffectationrule-description')
         document.querySelector('#fr-modal-autoaffectationrule-delete-id').value = target.getAttribute('data-autoaffectationrule-id')
         document.querySelector('#autoaffectationrule_delete_form').addEventListener('submit', (e) => {
-            document.querySelector('#autoaffectationrule_delete_form_submit').innerHTML = 'Suppression en cours...'
+            document.querySelector('#autoaffectationrule_delete_form_submit').textContent = 'Suppression en cours...'
             document.querySelector('#autoaffectationrule_delete_form_submit').disabled = true
         })
     })

--- a/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
+++ b/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
@@ -41,7 +41,7 @@ function histoUpdateValueFromData(elementName, elementData, target) {
 document.querySelectorAll('.btn-transfer-partner-user').forEach(swbtn => {
   swbtn.addEventListener('click', evt => {
     const target = evt.target
-    document.querySelector('#fr-modal-user-transfer_username').innerHTML = target.getAttribute('data-username')
+    document.querySelector('#fr-modal-user-transfer_username').textContent = target.getAttribute('data-username')
     histoUpdateValueFromData('#fr-modal-user-transfer_userid', 'data-userid', target)
     document.querySelector('#user_transfer_form').addEventListener('submit', (e) => {
       histoUpdateSubmitButton('#user_transfer_form_submit', 'Transfert en cours...')
@@ -52,10 +52,10 @@ document.querySelectorAll('.btn-delete-partner-user').forEach(swbtn => {
   swbtn.addEventListener('click', evt => {
     const target = evt.target
     document.querySelectorAll('.fr-modal-user-delete_username').forEach(userItem => {
-      userItem.innerHTML = target.getAttribute('data-username')
+      userItem.textContent = target.getAttribute('data-username')
     })
     document.querySelectorAll('.fr-modal-user-delete_useremail').forEach(userItem => {
-      userItem.innerHTML = target.getAttribute('data-useremail')
+      userItem.textContent = target.getAttribute('data-useremail')
     })
     histoUpdateValueFromData('#fr-modal-user-delete_userid', 'data-userid', target)
     document.querySelector('#user_delete_form').addEventListener('submit', (e) => {
@@ -68,7 +68,7 @@ document.querySelectorAll('.btn-delete-partner').forEach(swbtn => {
   swbtn.addEventListener('click', evt => {
     const target = evt.target
     document.querySelectorAll('.fr-modal-partner-delete_name').forEach(userItem => {
-      userItem.innerHTML = target.getAttribute('data-partnername')
+      userItem.textContent = target.getAttribute('data-partnername')
     })
     histoUpdateValueFromData('#fr-modal-partner-delete_partnerid', 'data-partnerid', target)
     document.querySelector('#partner_delete_form').addEventListener('submit', (e) => {
@@ -93,7 +93,7 @@ document.querySelectorAll('.btn-edit-partner-user').forEach(swbtn => {
     clearErrors() 
     const target = evt.target
     document.querySelectorAll('.fr-modal-user-edit_useremail').forEach(userItem => {
-      userItem.innerHTML = target.getAttribute('data-useremail')
+      userItem.textContent = target.getAttribute('data-useremail')
     })
     userEditedId = target.getAttribute('data-userid')
     histoUpdateValueFromData('#user_edit_userid', 'data-userid', target)

--- a/assets/scripts/vanilla/controllers/back_signalement_delete_file/back_signalement_delete_file.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_delete_file/back_signalement_delete_file.js
@@ -4,14 +4,14 @@ document.querySelectorAll('.btn-signalement-file-delete').forEach(swbtn => {
     const target = evt.target
     if (target.getAttribute('data-type') === 'photo') {
       document.querySelectorAll('.fr-modal-file-delete-type').forEach(typeItem => {
-        typeItem.innerHTML = 'la photo'
+        typeItem.textContent = 'la photo'
       })
     } else {
       document.querySelectorAll('.fr-modal-file-delete-type').forEach(typeItem => {
-        typeItem.innerHTML = 'le document'
+        typeItem.textContent = 'le document'
       })
     }
-    document.querySelector('.fr-modal-file-delete-filename').innerHTML = target.getAttribute('data-filename')
+    document.querySelector('.fr-modal-file-delete-filename').textContent = target.getAttribute('data-filename')
     document.querySelector('#file-delete-fileid').value = target.getAttribute('data-file-id')
   })
 })

--- a/assets/scripts/vanilla/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 function histoUpdateDesordreSelect(target, selectedDocumentType) {
   let desordreSelectBox = document.querySelector('#desordre-slug-select');
   let desordres = JSON.parse(target.getAttribute('data-signalement-desordres'))
@@ -29,8 +31,9 @@ function histoUpdateDesordreSelect(target, selectedDocumentType) {
 function histoCreateMiniatureImage(target) {
   histoDeleteMiniatureImage()
   const url = target.getAttribute('data-file-path');
+  const sanitizedUrl = DOMPurify.sanitize(url);
   const modalFileEditType = document.querySelector('#fr-modal-edit-file-miniature');
-  const newDiv = '<div id="fr-modal-edit-file-miniature-image" class="fr-col-6 fr-col-offset-3 fr-col-md-2 fr-col-offset-md-5 fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center" style="background: url(\'' + url + '\') no-repeat center center/cover;"></div>';
+  const newDiv = '<div id="fr-modal-edit-file-miniature-image" class="fr-col-6 fr-col-offset-3 fr-col-md-2 fr-col-offset-md-5 fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center" style="background: url(\'' + sanitizedUrl + '\') no-repeat center center/cover;"></div>';
   modalFileEditType.insertAdjacentHTML('afterbegin', newDiv);
 }
 function histoDeleteMiniatureImage() {
@@ -47,14 +50,14 @@ document.querySelectorAll('.btn-signalement-file-edit').forEach(swbtn => {
     const target = evt.target
 
     if ( target.getAttribute('data-type') === 'photo') {
-      document.querySelector('.fr-modal-file-edit-type').innerHTML = ' la photo'
+      document.querySelector('.fr-modal-file-edit-type').textContent = ' la photo'
       histoCreateMiniatureImage(target)
     } else {
-      document.querySelector('.fr-modal-file-edit-type').innerHTML = ' le document'
+      document.querySelector('.fr-modal-file-edit-type').textContent = ' le document'
       histoDeleteMiniatureImage()
     }
-    document.querySelector('.fr-modal-file-edit-filename').innerHTML = target.getAttribute('data-filename')
-    document.querySelector('.fr-modal-file-edit-infos').innerHTML = 'Ajouté le '+target.getAttribute('data-createdAt')
+    document.querySelector('.fr-modal-file-edit-filename').textContent = target.getAttribute('data-filename')
+    document.querySelector('.fr-modal-file-edit-infos').textContent = 'Ajouté le '+target.getAttribute('data-createdAt')
     + ' par '+ target.getAttribute('data-partner-name')+target.getAttribute('data-user-name')
     document.querySelector('#file-edit-fileid').value = target.getAttribute('data-file-id')
 

--- a/assets/scripts/vanilla/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -1,5 +1,3 @@
-import DOMPurify from 'dompurify';
-
 function histoUpdateDesordreSelect(target, selectedDocumentType) {
   let desordreSelectBox = document.querySelector('#desordre-slug-select');
   let desordres = JSON.parse(target.getAttribute('data-signalement-desordres'))
@@ -31,9 +29,8 @@ function histoUpdateDesordreSelect(target, selectedDocumentType) {
 function histoCreateMiniatureImage(target) {
   histoDeleteMiniatureImage()
   const url = target.getAttribute('data-file-path');
-  const sanitizedUrl = DOMPurify.sanitize(url);
   const modalFileEditType = document.querySelector('#fr-modal-edit-file-miniature');
-  const newDiv = '<div id="fr-modal-edit-file-miniature-image" class="fr-col-6 fr-col-offset-3 fr-col-md-2 fr-col-offset-md-5 fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center" style="background: url(\'' + sanitizedUrl + '\') no-repeat center center/cover;"></div>';
+  const newDiv = '<div id="fr-modal-edit-file-miniature-image" class="fr-col-6 fr-col-offset-3 fr-col-md-2 fr-col-offset-md-5 fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center" style="background: url(\'' + url + '\') no-repeat center center/cover;"></div>';
   modalFileEditType.insertAdjacentHTML('afterbegin', newDiv);
 }
 function histoDeleteMiniatureImage() {

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -1,5 +1,3 @@
-import DOMPurify from 'dompurify';
-
 initializeUploadModal(
     '#fr-modal-upload-files',
     '#select-type-situation-to-clone',
@@ -106,7 +104,7 @@ function initializeUploadModal(
     function uploadFile(file) {
         let div = document.createElement('div')
         div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w', 'modal-upload-list-item')
-        div.innerHTML = DOMPurify.sanitize(initInnerHtml(file))
+        div.innerHTML = initInnerHtml(file)
         let btnDeleteTmpFile = div.querySelector('a.delete-tmp-file')
         addEventListenerDeleteTmpFile(btnDeleteTmpFile)
         listContainer.prepend(div)

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 initializeUploadModal(
     '#fr-modal-upload-files',
     '#select-type-situation-to-clone',
@@ -95,7 +97,8 @@ function initializeUploadModal(
         }
         let div = document.createElement('div')
         div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
-        div.innerHTML = 'Impossible d\'ajouter le fichier ' +file.name +' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' +modal.dataset.acceptedExtensions+'.';
+        const message = document.createTextNode('Impossible d\'ajouter le fichier ' +file.name +' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' +modal.dataset.acceptedExtensions+'.');
+        div.appendChild(message);
         listContainer.prepend(div)
         return false;
     }
@@ -103,7 +106,7 @@ function initializeUploadModal(
     function uploadFile(file) {
         let div = document.createElement('div')
         div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w', 'modal-upload-list-item')
-        div.innerHTML = initInnerHtml(file)
+        div.innerHTML = DOMPurify.sanitize(initInnerHtml(file))
         let btnDeleteTmpFile = div.querySelector('a.delete-tmp-file')
         addEventListenerDeleteTmpFile(btnDeleteTmpFile)
         listContainer.prepend(div)

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -1,5 +1,3 @@
-import DOMPurify from 'dompurify';
-
 const modalUploadFiles = document?.querySelector('#fr-modal-upload-files-usager')
 if (modalUploadFiles) {
 
@@ -81,7 +79,7 @@ if (modalUploadFiles) {
     function uploadFile(file) {
         let div = document.createElement('div')
         div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w', 'modal-upload-list-item')
-        div.innerHTML = DOMPurify.sanitize(initInnerHtml(file))
+        div.innerHTML = initInnerHtml(file)
         let btnDeleteTmpFile = div.querySelector('a.delete-tmp-file')
         addEventListenerDeleteTmpFile(btnDeleteTmpFile)
         listContainer.prepend(div)

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 const modalUploadFiles = document?.querySelector('#fr-modal-upload-files-usager')
 if (modalUploadFiles) {
 

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -70,7 +70,8 @@ if (modalUploadFiles) {
         let div = document.createElement('div')
         div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
 
-        div.innerHTML = 'Impossible d\'ajouter le fichier ' +file.name +' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' +modalUploadFiles.dataset.acceptedExtensions+'.';
+        const message = document.createTextNode('Impossible d\'ajouter le fichier ' +file.name +' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' +modalUploadFiles.dataset.acceptedExtensions+'.');
+        div.appendChild(message);
         listContainer.prepend(div)
         return false;
     }
@@ -78,7 +79,7 @@ if (modalUploadFiles) {
     function uploadFile(file) {
         let div = document.createElement('div')
         div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w', 'modal-upload-list-item')
-        div.innerHTML = initInnerHtml(file)
+        div.innerHTML = DOMPurify.sanitize(initInnerHtml(file))
         let btnDeleteTmpFile = div.querySelector('a.delete-tmp-file')
         addEventListenerDeleteTmpFile(btnDeleteTmpFile)
         listContainer.prepend(div)
@@ -135,7 +136,8 @@ if (modalUploadFiles) {
         let div = document.createElement('div')
         div.id = 'uploaded-file-' + response.response
         div.classList.add('fr-mb-2v')
-        div.innerHTML = file.name
+        let textNode = document.createTextNode(file.name)
+        div.appendChild(textNode)
         let deleteFileLink = document.createElement('a')
         deleteFileLink.href = deleteTmpFileRoute + '?file_id=' + response.response
         deleteFileLink.classList.add('uploaded-file-delete', 'fr-ml-2v', 'fr-btn', 'fr-btn--tertiary', 'fr-btn--icon-left', 'fr-icon-delete-line')

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "axios": "^1.7.4",
         "datatables.net-dt": "^1.12.1",
         "datatables.net-vue3": "^1.0.0",
-        "dompurify": "^3.1.7",
         "libphonenumber-js": "^1.10.44",
         "vue": "^3.2.37",
         "vue-chartjs": "^4.1.1",
@@ -4992,11 +4991,6 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
-    },
-    "node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -14838,11 +14832,6 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
-    },
-    "dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "domutils": {
       "version": "2.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "histologe",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -14,6 +14,7 @@
         "axios": "^1.7.4",
         "datatables.net-dt": "^1.12.1",
         "datatables.net-vue3": "^1.0.0",
+        "dompurify": "^3.1.7",
         "libphonenumber-js": "^1.10.44",
         "vue": "^3.2.37",
         "vue-chartjs": "^4.1.1",
@@ -4991,6 +4992,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -14832,6 +14838,11 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
+    },
+    "dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "domutils": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "vue": "^3.2.37",
     "vue-chartjs": "^4.1.1",
     "vue-loader": "^17.0.0",
-    "vue-template-compiler": "^2.7.8"
+    "vue-template-compiler": "^2.7.8",
+    "dompurify": "^3.1.7"
   },
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "vue": "^3.2.37",
     "vue-chartjs": "^4.1.1",
     "vue-loader": "^17.0.0",
-    "vue-template-compiler": "^2.7.8",
-    "dompurify": "^3.1.7"
+    "vue-template-compiler": "^2.7.8"
   },
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",


### PR DESCRIPTION
## Ticket

#3167    

## Description
Il y a sur GitHub un nouveau module qui scanne d'éventuelles erreurs : https://github.com/MTES-MCT/histologe/security/code-scanning

## Changements apportés
* Modification de quelques fichiers javascript pour éviter des failles XSS, principalement en remplaçant `innerHTML` par `textContent` ou en utilisant `DOMPurify`
`Extracting text from a DOM node and interpreting it as HTML can lead to a cross-site scripting vulnerability.`

## Pré-requis
```
npm install
npm run watch
```

## Tests
Dans tous les tests suivants, il faut vérifier que les textes remplacés en js dans les modales sont cohérents
- [ ] Tester la suppression de règle d'auto-affectation
- [ ] Tester la suppression de partenaire, l'édition d'utilisateur dans un partenaire, le transfert d'utilisateur à un autre partenaire, et la suppression d'utilisateur
- [ ] Tester l'upload de doc/photo dans la fiche BO d'un signalement (bon format, et mauvais format), puis leur édition et leur suppression
- [ ] Tester l'upload de doc/photo  dans la fiche de suivi usager (bon format, et mauvais format)