### PR TITLE
[BO - Fiche signalement] Modifier l'intitulé du bouton "Enregistrer" sur la modale d'ajout de suivi

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -158,3 +158,11 @@ document?.querySelector('#signalement-affectation-form-submit')?.addEventListene
         }
     })
 })
+
+document?.getElementById('signalement-add-suivi-notify-usager')?.addEventListeners('change', (e) => {
+    if (e.target.checked) {
+        document.getElementById('signalement-add-suivi-submit').textContent = 'Envoyer le suivi à l\'usager';
+    } else {
+        document.getElementById('signalement-add-suivi-submit').textContent = 'Enregistrer le suivi interne';
+    }
+})

--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -160,9 +160,5 @@ document?.querySelector('#signalement-affectation-form-submit')?.addEventListene
 })
 
 document?.getElementById('signalement-add-suivi-notify-usager')?.addEventListeners('change', (e) => {
-    if (e.target.checked) {
-        document.getElementById('signalement-add-suivi-submit').textContent = 'Envoyer le suivi à l\'usager';
-    } else {
-        document.getElementById('signalement-add-suivi-submit').textContent = 'Enregistrer le suivi interne';
-    }
+    document.getElementById('signalement-add-suivi-submit').textContent = (e.target.checked) ? 'Envoyer le suivi à l\'usager' : 'Enregistrer le suivi interne';
 })

--- a/templates/_partials/signalement/add_suivi.html.twig
+++ b/templates/_partials/signalement/add_suivi.html.twig
@@ -47,8 +47,8 @@
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
                                 <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-check-line"
-                                        form="signalement-add-suivi-form" disabled>
-                                    Enregistrer
+                                        form="signalement-add-suivi-form" disabled id="signalement-add-suivi-submit">
+                                    Enregistrer le suivi interne
                                 </button>
                             </li>
                             <li>


### PR DESCRIPTION
## Ticket

#3158    

## Description
Suite au constat que certains suivis restent en "suivi interne" alors qu'ils sont de toute évidence destinés à l'usager, il a été décidé de modifier l'intitulé du bouton "enregistrer" sur la modale d'ajout de suivi.

Si l'interrupteur "En cochant cette case, le suivi sera envoyé à l'usager"  est activé, le bouton doit s'appeler `Envoyer le suivi à l'usager` 
s'il n'est pas activé, alors le bouton doit s'appeler `Enregistrer le suivi interne` 

## Changements apportés
* Ajout d'un événement js

## Pré-requis
`npm run watch`

## Tests
- [ ] Ajouter un suivi interne, vérifier l'intitulé du bouton
- [ ] idem avec un suivi envoyé à l'usager
