### PR TITLE
[FO - Formulaire - Accessibilité - 12.7] Lien d'évitement

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -621,6 +621,10 @@ a.force-link-color {
     overflow: visible;
 }
 
+.overflow-x-hidden {
+    overflow-x: hidden;
+}
+
 .bloc-list .fr-grid-row .fr-grid-row .fr-col-12 {
     padding: 0 0.75rem;
 }

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -6,7 +6,7 @@
     <main class="fr-container-fluid">
         <div class="fr-grid-row">
             {% include 'back/nav_bo.html.twig' %}
-            <div class="fr-col-12 fr-col-md-9 fr-col-lg-10" style="overflow-x:hidden " id="contenu">
+            <div class="fr-col-12 fr-col-md-9 fr-col-lg-10 overflow-x-hidden" id="content">
                 {% for label, messages in app.flashes %}
                     {% for message in messages %}
                         <div role="alert" class="fr-alert fr-alert--{{ label }} fr-alert--sm">

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -6,7 +6,7 @@
     <main class="fr-container-fluid">
         <div class="fr-grid-row">
             {% include 'back/nav_bo.html.twig' %}
-            <div class="fr-col-12 fr-col-md-9 fr-col-lg-10" style="overflow-x:hidden ">
+            <div class="fr-col-12 fr-col-md-9 fr-col-lg-10" style="overflow-x:hidden " id="contenu">
                 {% for label, messages in app.flashes %}
                     {% for message in messages %}
                         <div role="alert" class="fr-alert fr-alert--{{ label }} fr-alert--sm">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -105,6 +105,7 @@
 } %}
 <body {% if bodyClass is defined %}class="{{ bodyClass }}"{% endif %}
       data-mode-maintenance="{{ maintenance.enable }}">
+{% include "skiplink.html.twig" %}
 {% include 'maintenance/banner.html.twig' %}
 {% if 'back_' not in app.request.get('_route') %}
     {% include "header.html.twig" %}
@@ -125,7 +126,10 @@
 {% else %}
     {% include "consent_banner/banner.html.twig" %}
 {% endif %}
-{% block body %}{% endblock %}
+
+{# <div id="contenu"> #}
+    {% block body %}{% endblock %}
+{# </div> #}
 {% include "footer.html.twig" %}
 
 <script type="module" src="{{ asset('build/dsfr/dsfr.module.min.js') }}"></script>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -127,9 +127,7 @@
     {% include "consent_banner/banner.html.twig" %}
 {% endif %}
 
-{# <div id="contenu"> #}
-    {% block body %}{% endblock %}
-{# </div> #}
+{% block body %}{% endblock %}
 {% include "footer.html.twig" %}
 
 <script type="module" src="{{ asset('build/dsfr/dsfr.module.min.js') }}"></script>

--- a/templates/bundles/SchebTwoFactorBundle/Authentication/form.html.twig
+++ b/templates/bundles/SchebTwoFactorBundle/Authentication/form.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Authentification à deux facteurs{% endblock %}
 
 {% block body %}
-	<main class="fr-container fr-py-5w">
+	<main class="fr-container fr-py-5w" id="contenu">
         <section class="fr-grid-row">
 
             <div class="fr-col-md-12">

--- a/templates/bundles/SchebTwoFactorBundle/Authentication/form.html.twig
+++ b/templates/bundles/SchebTwoFactorBundle/Authentication/form.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Authentification à deux facteurs{% endblock %}
 
 {% block body %}
-	<main class="fr-container fr-py-5w" id="contenu">
+	<main class="fr-container fr-py-5w" id="content">
         <section class="fr-grid-row">
 
             <div class="fr-col-md-12">

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Une erreur est survenue...{% endblock %}
 {% block body %}
 
-    <main class="fr-container--fluid" id="contenu">
+    <main class="fr-container--fluid" id="content">
         <section class="fr-container fr-py-5w">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Une erreur est survenue...{% endblock %}
 {% block body %}
 
-    <main class="fr-container--fluid">
+    <main class="fr-container--fluid" id="contenu">
         <section class="fr-container fr-py-5w">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Accès refusé{% endblock %}
 {% block body %}
 
-    <main class="fr-container--fluid">
+    <main class="fr-container--fluid" id="contenu">
         <section class="fr-container fr-py-5w">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Accès refusé{% endblock %}
 {% block body %}
 
-    <main class="fr-container--fluid" id="contenu">
+    <main class="fr-container--fluid" id="content">
         <section class="fr-container fr-py-5w">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Page introuvable{% endblock %}
 {% block body %}
 
-    <main class="fr-container--fluid">
+    <main class="fr-container--fluid" id="contenu">
         <section class="fr-container fr-py-5w">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Page introuvable{% endblock %}
 {% block body %}
 
-    <main class="fr-container--fluid" id="contenu">
+    <main class="fr-container--fluid" id="content">
         <section class="fr-container fr-py-5w">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--center">

--- a/templates/front/about.html.twig
+++ b/templates/front/about.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Qui sommes-nous ?{% endblock %}
 
 {% block body %}
-    <main class="fr-container--fluid">
+    <main class="fr-container--fluid" id="contenu">
         <header class="fr-background-contrast--blue-france fr-py-1v">
             {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Qui sommes-nous ?' } %}
             <div class="fr-container fr-grid-row fr-grid-row--middle">

--- a/templates/front/about.html.twig
+++ b/templates/front/about.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Qui sommes-nous ?{% endblock %}
 
 {% block body %}
-    <main class="fr-container--fluid" id="contenu">
+    <main class="fr-container--fluid" id="content">
         <header class="fr-background-contrast--blue-france fr-py-1v">
             {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Qui sommes-nous ?' } %}
             <div class="fr-container fr-grid-row fr-grid-row--middle">

--- a/templates/front/accessibilite.html.twig
+++ b/templates/front/accessibilite.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Accessibilité' } %}
 
-    <main class="fr-container fr-py-1w" id="contenu">
+    <main class="fr-container fr-py-1w" id="content">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Déclaration d’accessibilité</h1>

--- a/templates/front/accessibilite.html.twig
+++ b/templates/front/accessibilite.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Accessibilité' } %}
 
-    <main class="fr-container fr-py-1w">
+    <main class="fr-container fr-py-1w" id="contenu">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Déclaration d’accessibilité</h1>

--- a/templates/front/aides_travaux.html.twig
+++ b/templates/front/aides_travaux.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Les aides aux travaux pour le logement{% endblock %}
 
 {% block body %}
-    <main class="fr-container">
+    <main class="fr-container" id="contenu">
         {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Aides aux travaux' } %}
 
         <h1>Quelles aides pour faire des travaux dans mon logement ?</h1>

--- a/templates/front/aides_travaux.html.twig
+++ b/templates/front/aides_travaux.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Les aides aux travaux pour le logement{% endblock %}
 
 {% block body %}
-    <main class="fr-container" id="contenu">
+    <main class="fr-container" id="content">
         {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Aides aux travaux' } %}
 
         <h1>Quelles aides pour faire des travaux dans mon logement ?</h1>

--- a/templates/front/cgu_agents.html.twig
+++ b/templates/front/cgu_agents.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Conditions générales d\'utilisation de l\'espace pro' } %}
 
-    <main class="fr-container fr-py-1w" id="contenu">
+    <main class="fr-container fr-py-1w" id="content">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Conditions d’utilisation du site {{ platform.name }} - Espace PRO</h1>

--- a/templates/front/cgu_agents.html.twig
+++ b/templates/front/cgu_agents.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Conditions générales d\'utilisation de l\'espace pro' } %}
 
-    <main class="fr-container fr-py-1w">
+    <main class="fr-container fr-py-1w" id="contenu">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Conditions d’utilisation du site {{ platform.name }} - Espace PRO</h1>

--- a/templates/front/cgu_usagers.html.twig
+++ b/templates/front/cgu_usagers.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Conditions générales d\'utilisation' } %}
 
-    <main class="fr-container fr-py-1w">
+    <main class="fr-container fr-py-1w" id="contenu">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Conditions d’utilisation du site {{ platform.name }}</h1>

--- a/templates/front/cgu_usagers.html.twig
+++ b/templates/front/cgu_usagers.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Conditions générales d\'utilisation' } %}
 
-    <main class="fr-container fr-py-1w" id="contenu">
+    <main class="fr-container fr-py-1w" id="content">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Conditions d’utilisation du site {{ platform.name }}</h1>

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -3,8 +3,8 @@
 {% block title %}Contacter{% endblock %}
 
 {% block body %}
-	<main>
-        {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Contact' } %}
+    {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Contact' } %}
+	<main id="contenu">
 		<section class="fr-container">
 			<h1 class="fr-mt-5w">Contacter {{ platform.name }}</h1>
 		</section>

--- a/templates/front/contact.html.twig
+++ b/templates/front/contact.html.twig
@@ -4,7 +4,7 @@
 
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Contact' } %}
-	<main id="contenu">
+	<main id="content">
 		<section class="fr-container">
 			<h1 class="fr-mt-5w">Contacter {{ platform.name }}</h1>
 		</section>

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -7,7 +7,7 @@
     {% if display_modal != '' %}
         {% include '_partials/_modal_closed_territory.html.twig' with { 'autoopen': '1' } %}
     {% endif %}
-    <main id="contenu">
+    <main id="content">
         <section class="fr-background-contrast--blue-france fr-pt-3w">
             <div class="fr-container fr-grid-row">
                 <div class="fr-col-12 fr-col-md-8 fr-mt-5w">

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -7,7 +7,7 @@
     {% if display_modal != '' %}
         {% include '_partials/_modal_closed_territory.html.twig' with { 'autoopen': '1' } %}
     {% endif %}
-    <main>
+    <main id="contenu">
         <section class="fr-background-contrast--blue-france fr-pt-3w">
             <div class="fr-container fr-grid-row">
                 <div class="fr-col-12 fr-col-md-8 fr-mt-5w">

--- a/templates/front/mentions_legales.html.twig
+++ b/templates/front/mentions_legales.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Mentions légales' } %}
 
-    <main class="fr-container fr-py-1w">
+    <main class="fr-container fr-py-1w" id="contenu">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Mentions légales de la Plateforme {{ platform.name }}</h1>

--- a/templates/front/mentions_legales.html.twig
+++ b/templates/front/mentions_legales.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Mentions légales' } %}
 
-    <main class="fr-container fr-py-1w" id="contenu">
+    <main class="fr-container fr-py-1w" id="content">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Mentions légales de la Plateforme {{ platform.name }}</h1>

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block body %}
-  <main class="fr-my-5v" id="contenu">
+  <main class="fr-my-5v" id="content">
     <div id="app-signalement-form-container"
         data-ajaxurl="{{ path('front_signalement') }}"
         data-ajaxurl-dictionary="{{ path('api_dictionary') }}"

--- a/templates/front/nouveau_formulaire.html.twig
+++ b/templates/front/nouveau_formulaire.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block body %}
-  <main class="fr-my-5v">
+  <main class="fr-my-5v" id="contenu">
     <div id="app-signalement-form-container"
         data-ajaxurl="{{ path('front_signalement') }}"
         data-ajaxurl-dictionary="{{ path('api_dictionary') }}"

--- a/templates/front/obligations_entretien.html.twig
+++ b/templates/front/obligations_entretien.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Logement : les obligations des propriétaires et locataire{% endblock %}
 
 {% block body %}
-    <main class="fr-container">
+    <main class="fr-container" id="contenu">
         {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Entretien du logement : les obligations' } %}
 
         <h1>Entretien du logement : quelles obligations pour les propriétaires et les locataires ?</h1>

--- a/templates/front/obligations_entretien.html.twig
+++ b/templates/front/obligations_entretien.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Logement : les obligations des propriétaires et locataire{% endblock %}
 
 {% block body %}
-    <main class="fr-container" id="contenu">
+    <main class="fr-container" id="content">
         {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Entretien du logement : les obligations' } %}
 
         <h1>Entretien du logement : quelles obligations pour les propriétaires et les locataires ?</h1>

--- a/templates/front/plan_du_site.html.twig
+++ b/templates/front/plan_du_site.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Plan du site{% endblock %}
 
 {% block body %}
-    <div class="fr-container fr-py-16v plan-du-site-header" id="contenu">
+    <div class="fr-container fr-py-16v plan-du-site-header" id="content">
         <div class="fr-grid-row">
             <div class="fr-col-12 fr-col-md-8">
                 <h1>Plan du site</h1>

--- a/templates/front/plan_du_site.html.twig
+++ b/templates/front/plan_du_site.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Plan du site{% endblock %}
 
 {% block body %}
-    <div class="fr-container fr-py-16v plan-du-site-header">
+    <div class="fr-container fr-py-16v plan-du-site-header" id="contenu">
         <div class="fr-grid-row">
             <div class="fr-col-12 fr-col-md-8">
                 <h1>Plan du site</h1>

--- a/templates/front/politique_de_confidentialite.html.twig
+++ b/templates/front/politique_de_confidentialite.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Politique de confidentialité' } %}
 
-    <main class="fr-container fr-py-1w" id="contenu">
+    <main class="fr-container fr-py-1w" id="content">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Politique de confidentialité {{ platform.name }}</h1>

--- a/templates/front/politique_de_confidentialite.html.twig
+++ b/templates/front/politique_de_confidentialite.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Politique de confidentialité' } %}
 
-    <main class="fr-container fr-py-1w">
+    <main class="fr-container fr-py-1w" id="contenu">
         <section class="cgu fr-grid-row">
             <div class="fr-col-12 fr-col-lg-8">
                 <h1>Politique de confidentialité {{ platform.name }}</h1>

--- a/templates/front/statistiques.html.twig
+++ b/templates/front/statistiques.html.twig
@@ -10,5 +10,7 @@
 {% endblock %}
 
 {% block body %}
-    <main id="app-front-stats" data-ajaxurl="{{ path('front_statistiques_filter') }}"></main>
+    <main id="contenu">
+        <div id="app-front-stats" data-ajaxurl="{{ path('front_statistiques_filter') }}"></div>
+    </main>
 {% endblock %}

--- a/templates/front/statistiques.html.twig
+++ b/templates/front/statistiques.html.twig
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block body %}
-    <main id="contenu">
+    <main id="content">
         <div id="app-front-stats" data-ajaxurl="{{ path('front_statistiques_filter') }}"></div>
     </main>
 {% endblock %}

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -9,7 +9,7 @@
 		{% include '_partials/_modal_upload_files_usager.html.twig' with {'criteres': infoDesordres['criteres']} %}
 	{% endif %}
 
-<main class="fr-container">
+<main class="fr-container" id="contenu">
 	<header>
 		<div class="fr-grid-row fr-grid fr-mt-2v">
 			<div class="fr-col-12 fr-col-lg-6">

--- a/templates/front/suivi_signalement.html.twig
+++ b/templates/front/suivi_signalement.html.twig
@@ -9,7 +9,7 @@
 		{% include '_partials/_modal_upload_files_usager.html.twig' with {'criteres': infoDesordres['criteres']} %}
 	{% endif %}
 
-<main class="fr-container" id="contenu">
+<main class="fr-container" id="content">
 	<header>
 		<div class="fr-grid-row fr-grid fr-mt-2v">
 			<div class="fr-col-12 fr-col-lg-6">

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w" id="contenu">
+    <main class="fr-container fr-py-5w" id="content">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">Connexion</p>

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w">
+    <main class="fr-container fr-py-5w" id="contenu">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">Connexion</p>

--- a/templates/security/login_activation.html.twig
+++ b/templates/security/login_activation.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Activation de votre compte{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w" id="contenu">
+    <main class="fr-container fr-py-5w" id="content">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">Activation de votre compte</p>

--- a/templates/security/login_activation.html.twig
+++ b/templates/security/login_activation.html.twig
@@ -3,7 +3,7 @@
 {% block title %}Activation de votre compte{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w">
+    <main class="fr-container fr-py-5w" id="contenu">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">Activation de votre compte</p>

--- a/templates/security/login_link_sent.html.twig
+++ b/templates/security/login_link_sent.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w">
+    <main class="fr-container fr-py-5w" id="contenu">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">{{title}}</p>

--- a/templates/security/login_link_sent.html.twig
+++ b/templates/security/login_link_sent.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w" id="contenu">
+    <main class="fr-container fr-py-5w" id="content">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">{{title}}</p>

--- a/templates/security/reset_password.html.twig
+++ b/templates/security/reset_password.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w">
+    <main class="fr-container fr-py-5w" id="contenu">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">{{title}}</p>

--- a/templates/security/reset_password.html.twig
+++ b/templates/security/reset_password.html.twig
@@ -3,7 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block body %}
-    <main class="fr-container fr-py-5w" id="contenu">
+    <main class="fr-container fr-py-5w" id="content">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">{{title}}</p>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -4,7 +4,7 @@
 
 {% block body %}
 
-    <main class="fr-container fr-py-5w" id="contenu">
+    <main class="fr-container fr-py-5w" id="content">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">Création de votre mot de passe</p>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -4,7 +4,7 @@
 
 {% block body %}
 
-    <main class="fr-container fr-py-5w">
+    <main class="fr-container fr-py-5w" id="contenu">
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">Création de votre mot de passe</p>

--- a/templates/skiplink.html.twig
+++ b/templates/skiplink.html.twig
@@ -1,0 +1,12 @@
+<div class="fr-skiplinks">
+    <nav class="fr-container" role="navigation" aria-label="Accès rapide">
+        <ul class="fr-skiplinks__list">
+            <li>
+                <a class="fr-link" href="#contenu">Contenu</a>
+            </li>
+            <li>
+                <a class="fr-link" href="#footer">Pied de page</a>
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/templates/skiplink.html.twig
+++ b/templates/skiplink.html.twig
@@ -2,7 +2,7 @@
     <nav class="fr-container" role="navigation" aria-label="Accès rapide">
         <ul class="fr-skiplinks__list">
             <li>
-                <a class="fr-link" href="#contenu">Contenu</a>
+                <a class="fr-link" href="#content">Contenu</a>
             </li>
             <li>
                 <a class="fr-link" href="#footer">Pied de page</a>


### PR DESCRIPTION
## Ticket

#3184   

## Description
Ajout du lien d'évitement du DSFR.
Suite à l'audit accessibilité punaises, nous avions du enlever les liens d'évitement vers le menu et le menu secondaire.
Du coup je n'ai mis que des liens d'évitement vers le contenu et le footer.

## Changements apportés
* twig

## Pré-requis

## Tests
- [ ] Se promener sur les pages du FO et du BO et vérifier que le contenu et le footer peuvent être atteints au clavier
