### PR TITLE
[BO] Désactiver la page de debug idoss

### DIFF
--- a/src/Controller/Back/IdossController.php
+++ b/src/Controller/Back/IdossController.php
@@ -9,12 +9,14 @@ use App\Factory\Interconnection\Idoss\DossierMessageFactory;
 use App\Repository\AffectationRepository;
 use App\Repository\SignalementRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\When;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/idoss')]
+#[When('dev')]
 class IdossController extends AbstractController
 {
     #[Route('/log', name: 'back_idoss_log')]

--- a/src/Controller/Back/IdossController.php
+++ b/src/Controller/Back/IdossController.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/idoss')]
 #[When('dev')]
+#[When('test')]
 class IdossController extends AbstractController
 {
     #[Route('/log', name: 'back_idoss_log')]


### PR DESCRIPTION
## Ticket

#3189    

## Description
Des optimisations sont à prévoir et observer si c'est utile

## Changements apportés
* Ajout d'un attribut pour rendre les routes innaccessible en prod

## Pré-requis
```
make cc env=prod
composer dump-env prod
```
## Tests
- [ ] Aller sur la route `http://localhost:8080/bo/idoss/log`
