### PR TITLE
[oilhi] Ajout nombre d'occupant

### DIFF
--- a/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
+++ b/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
@@ -87,7 +87,8 @@ class DossierMessageFactory implements DossierMessageFactoryInterface
             ->setRapportVisite($interventionData['rapport_visite'] ?? null)
             ->setDateVisite($interventionData['date_visite'] ?? null)
             ->setOperateurVisite($interventionData['operateur_visite'] ?? null)
-            ->setDesordres($this->buildDesordres($signalement));
+            ->setDesordres($this->buildDesordres($signalement))
+            ->setNbOccupants($signalement->getNbOccupantsLogement());
     }
 
     /**

--- a/src/Messenger/Message/Oilhi/DossierMessage.php
+++ b/src/Messenger/Message/Oilhi/DossierMessage.php
@@ -38,6 +38,7 @@ final class DossierMessage implements DossierMessageInterface
     private ?string $dateVisite = null;
     private ?string $operateurVisite = null;
     private array $desordres = [];
+    private ?int $nbOccupants = null;
 
     public function __construct()
     {
@@ -412,6 +413,18 @@ final class DossierMessage implements DossierMessageInterface
     public function setDesordres(array $desordres): self
     {
         $this->desordres = $desordres;
+
+        return $this;
+    }
+
+    public function getNbOccupants(): ?int
+    {
+        return $this->nbOccupants;
+    }
+
+    public function setNbOccupants(?int $nbOccupants): self
+    {
+        $this->nbOccupants = $nbOccupants;
 
         return $this;
     }

--- a/tests/Functional/Factory/Oilhi/DossierMessageFactoryTest.php
+++ b/tests/Functional/Factory/Oilhi/DossierMessageFactoryTest.php
@@ -80,6 +80,7 @@ class DossierMessageFactoryTest extends KernelTestCase
         $this->assertNotEmpty($dossierMessage->getTypeDeclarant());
         $this->assertNotEmpty($dossierMessage->getTelephoneDeclarant());
         $this->assertNotEmpty($dossierMessage->getCourrielDeclarant());
+        $this->assertNotEmpty($dossierMessage->getNbOccupants());
 
         $this->assertEquals('⌛️ Procédure en cours', $dossierMessage->getStatut());
 


### PR DESCRIPTION
## Ticket

#3192   

## Description
Demande d'ajout d'une nouvelle donnée à envoyer  (nombre de personnes occupant le foyer)

## Changements apportés
* Ajout d'une nouvelle propriété dans le DTO

## Pré-requis
> [!WARNING]  
> Ne pas mettre les bon identifiants pour Oilhi pour éviter d'avoir des données de test

```
FEATURE_OILHI_ENABLE=1 
ZAPIER_HOOK_URL=https://hooks.zapier.com/
ZAPIER_OILHI_TOKEN=xxxxxxxxx
ZAPIER_OILHI_USER_ID=xxxxxxxxxx
ZAPIER_OILHI_CREATE_AIRTABLE_RECORD_ZAP_ID=xxxxxx
```

```
make worker-stop && make worker-start
```
## Tests
- [ ] Aller sur ce [signalement du 62](http://localhost:8080/bo/signalements/00000000-0000-0000-2024-000000000003#foyer
) et changer l'adresse sur **Beaudricourt** pour autoriser l'envoi vers oilhi   
- [ ] Affecter le signalement au partenaire `Partenaire 62-02 (BEAUDRICOURT)
- [ ] Vérifier dans la table `job_event` que le champs est dans la payload correspond bien à ce qui est mentionné sur la fiche. 

![image](https://github.com/user-attachments/assets/cd1b2b91-2c4b-4e08-918f-c769d2011802)
