### PR TITLE
fixes and opti #3197

### DIFF
--- a/migrations/Version20241022073450.php
+++ b/migrations/Version20241022073450.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241022073450 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index on service column in job_event table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_job_event_service ON job_event (service)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_job_event_service ON job_event');
+    }
+}

--- a/src/Controller/Back/IdossController.php
+++ b/src/Controller/Back/IdossController.php
@@ -2,52 +2,26 @@
 
 namespace App\Controller\Back;
 
-use App\Entity\Affectation;
-use App\Entity\Partner;
-use App\Entity\Signalement;
-use App\Factory\Interconnection\Idoss\DossierMessageFactory;
-use App\Repository\AffectationRepository;
+use App\Entity\JobEvent;
 use App\Repository\SignalementRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\Attribute\When;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/idoss')]
-#[When('dev')]
-#[When('test')]
 class IdossController extends AbstractController
 {
     #[Route('/log', name: 'back_idoss_log')]
     #[IsGranted('ROLE_ADMIN')]
     public function log(SignalementRepository $signalementRepository): Response
     {
-        $errors = $signalementRepository->findSynchroIdossErrors();
+        $errors = $signalementRepository->findSynchroIdoss(JobEvent::STATUS_FAILED);
+        $success = $signalementRepository->findSynchroIdoss(JobEvent::STATUS_SUCCESS);
 
         return $this->render('back/idoss/log.html.twig', [
             'errors' => $errors,
+            'success' => $success,
         ]);
-    }
-
-    #[Route('/retry/{signalement}/{partner}', name: 'back_idoss_retry')]
-    #[IsGranted('ROLE_ADMIN')]
-    public function retry(
-        Signalement $signalement,
-        Partner $partner,
-        SignalementRepository $signalementRepository,
-        AffectationRepository $affectationRepository,
-        DossierMessageFactory $dossierMessageFactory,
-        MessageBusInterface $bus
-    ): Response {
-        $errors = $signalementRepository->findSynchroIdossErrors();
-        $affectation = $affectationRepository->findOneBy(['signalement' => $signalement, 'partner' => $partner, 'statut' => Affectation::STATUS_ACCEPTED]);
-        if (isset($errors[$signalement->getId()]) && $affectation && $dossierMessageFactory->supports($affectation)) {
-            $bus->dispatch($dossierMessageFactory->createInstance($affectation));
-            $this->addFlash('success', 'La synchronisation a été relancée');
-        }
-
-        return $this->redirectToRoute('back_idoss_log');
     }
 }

--- a/src/Entity/JobEvent.php
+++ b/src/Entity/JobEvent.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\HasLifecycleCallbacks()]
 #[ORM\Index(columns: ['created_at'], name: 'idx_job_event_created_at')]
 #[ORM\Index(columns: ['partner_id'], name: 'idx_job_event_partner_id')]
+#[ORM\Index(columns: ['service'], name: 'idx_job_event_service')]
 class JobEvent
 {
     use TimestampableTrait;

--- a/src/Service/Interconnection/Idoss/IdossService.php
+++ b/src/Service/Interconnection/Idoss/IdossService.php
@@ -204,7 +204,7 @@ class IdossService
     private function getFilesPayload(Signalement $signalement, array $files): array
     {
         $payload = [
-            'id' => $signalement->getSynchroData(self::TYPE_SERVICE)['id'] ?? null,
+            'id' => (string) $signalement->getSynchroData(self::TYPE_SERVICE)['id'],
             'uuid' => $signalement->getUuid(),
         ];
         $dataparts = [];

--- a/templates/back/idoss/log.html.twig
+++ b/templates/back/idoss/log.html.twig
@@ -24,9 +24,9 @@
 							<tr>
 								<th scope="col">Signalement</th>
 								<th scope="col">Date</th>
+								<th scope="col">action</th>
 								<th scope="col">Réponse</th>
 								<th scope="col">Code</th>
-								<th scope="col">Action</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -34,9 +34,40 @@
 								<tr class="user-row">
 									<td><a href="{{path('back_signalement_view', {'uuid': error.uuid})}}">{{error.reference}}</a></td>
 									<td>{{error.createdAt|date('d/m/Y H:i:s')}}</td>
+									<td>{{error.action}}</td>
 									<td>{{error.response}}</td>
 									<td>{{error.codeStatus}}</td>
-									<td><a href="{{path('back_idoss_retry', {'signalement':error.id, 'partner':error.partnerId})}}" class="fr-btn fr-btn--sm fr-btn--secondary">Relancer</a></td>
+								</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+		<div class="fr-col-12 fr-table fr-table--lg fr-table--no-caption">
+		<div class="fr-table__wrapper">
+			<div class="fr-table__container">
+				<div class="fr-table__content">
+					<table class="fr-cell--multiline"  aria-label="Liste des comptes inactifs" aria-describedby="desc-table-inactive">
+					<caption>Success</caption>
+						<thead>
+							<tr>
+								<th scope="col">Signalement</th>
+								<th scope="col">Date</th>
+								<th scope="col">action</th>
+								<th scope="col">Réponse</th>
+								<th scope="col">Code</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for item in success %}
+								<tr class="user-row">
+									<td><a href="{{path('back_signalement_view', {'uuid': item.uuid})}}">{{item.reference}}</a></td>
+									<td>{{item.createdAt|date('d/m/Y H:i:s')}}</td>
+									<td>{{item.action}}</td>
+									<td>{{item.response}}</td>
+									<td>{{item.codeStatus}}</td>
 								</tr>
 							{% endfor %}
 						</tbody>


### PR DESCRIPTION
## Ticket

#3197

## Description
La commande de synchronisation IDOSS contenait une erreur de requete : on tentait de synchoniser des signalement n'ayant jamais était envoyé sur IDOSS, c'est corrigé

## Changements apportés
* Ajout d'un index sur le champ `service` de la table `job_event` : sur la requête : 
`SELECT * FROM signalement s0_ INNER JOIN job_event j1_ ON (s0_.id = j1_.signalement_id) WHERE j1_.signalement_id = s0_.id AND j1_.service = 'idoss' AND j1_.status = 'failed' ORDER BY j1_.created_at; ` on passe de 3.8 sec a 0.0026 sec en prod.
* Réactivation de la page /bo/idoss/log qui contient à présent uniquement les 100 dernière erreur/success d'idoss (avec des requête légères)
* Correction de la requête de synchronisation des fichiers sur IDOSS

## Pré-requis
`make execute-migration name=Version20241022073450 direction=up`

## Tests
- [ ] Garder uniquement les image/doc existants des signalements (2023-13, 2023-14, 2023-15) afin de ne pas avoir l'erreur "File not found" et lancer la commande `app:synchronize-idoss` aucune erreur ne doit apparaitre
- [ ] Sur copie de prod vérifier que la page http://localhost:8080/bo/idoss/log ne provoque pas de ralentissement

