### PR TITLE
[BO - Signalement] Droits de clôture pour RT

### DIFF
--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -62,7 +62,7 @@
                         {% endif %}
                     </div>
                     <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group-reverse fr-btns-group--icon-left">
                             {% if is_granted('ROLE_ADMIN_TERRITORY') %}
                                 <li>
                                     <button class="fr-btn fr-icon-check-line"
@@ -70,6 +70,14 @@
                                         Cloturer pour tous les partenaires
                                     </button>
                                 </li>
+                                {% if isAffected and isAccepted %}
+                                    <li>
+                                        <button class="fr-btn fr-icon-check-line" form="cloture_form"
+                                                name="cloture[type]" value="partner" type="submit" disabled>
+                                            Cloturer pour {{ app.user.partner ? app.user.partner.nom }}
+                                        </button>
+                                    </li>
+                                {% endif %}
                             {% else %}
                                 <li>
                                     <button class="fr-btn fr-icon-check-line" form="cloture_form"

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -218,7 +218,7 @@
                             </button>
                         {% endif %}
                     {% endif %}
-                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') %}
+                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or (is_granted('ROLE_ADMIN_TERRITORY') and isAffected) %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                                 aria-controls="reopen-signalement-modal" data-fr-opened="false">
                             Rouvrir pour {{ app.user.partner.nom }}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -136,7 +136,7 @@
                 %}</p>
             </div>
 
-            <div class="fr-mb-4v fr-text--right">
+            <div class="fr-mb-4v fr-text--right">                        
                 {% if isAffected and not isAccepted and not isRefused and not needValidation and not isClosed and not isClosedForMe %}
                     <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isAffected.id}) }}"
                             class="tinyCheck" id="signalement-affectation-response-form"
@@ -205,11 +205,18 @@
                     </div>
 
                 {% elseif isClosedForMe or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') %}
-                    {% if isClosed and is_granted('ROLE_ADMIN_TERRITORY') %}
-                        <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
-                                aria-controls="reopen-all-signalement-modal" data-fr-opened="false">
-                            Rouvrir pour tous
-                        </button>
+                    {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+                        {% if isClosed %}
+                            <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
+                                    aria-controls="reopen-all-signalement-modal" data-fr-opened="false">
+                                Rouvrir pour tous
+                            </button>
+                        {% else %}
+                            <button aria-controls="cloture-modal" data-fr-opened="false"
+                                class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left keep-when-signalement-closed" id="test-bouton-cloturer">
+                                Clôturer
+                            </button>
+                        {% endif %}
                     {% endif %}
                     {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"


### PR DESCRIPTION
## Ticket

#3194    

## Description
Un RT qui est affecté à un ticket pouvait seulement "cloturer pour tous" et pas "cloturer son affectation".
On a remis le bouton "cloturer pour partenaire" dans la modale s'il est affecté au signalement, et remis le bouton "cloturer" dans la fiche si seule son affectation est fermée, mais pas le signalement.

## Changements apportés
* Modification de bouton sur la modale
* Modification de bouton dans le header du signalement

## Pré-requis
Faire un utilisateur avec un rôle agent dans le `partenaire 13-01`

## Tests
- [ ] En tant que RT, aller sur un signalement qui n'est pas affecté au `partenaire 13-01`, vérifier qu'on peut seulement le "cloturer pour tous", et qu'une fois fermé, on ne peut rien faire, sauf le `rouvrir pour tous`
- [ ] En tant que RT, aller sur un signalement qui est affecté au `partenaire 13-01`, vérifier qu'on peut le `cloturer pour tous`, ou le `cloturer pour le partenaire` . Le cloturer pour le partenaire, vérifier qu'on peut toujours faire des actions sur le signalement
- [ ] Vérifier qu'on peut toujours le `cloturer pour tous` ou le `rouvrir pour le partenaire`
- [ ] Le `cloturer pour tous`, et vérifier qu'on peut à présent le `rouvrir pour tous` ou le `rouvrir pour le partenaire`
- [ ] Le rouvrir pour tous, vérifier qu'on doit à nouveau accepter l'affectation
- [ ] Se connecter en agent et retourner sur ce signalement
- [ ] Vérifier qu'on peut `cloturer pour le partenaire` seulement (et pas `cloturer pour tous`)
- [ ] Cloturer pour le partenaire, vérifier qu'on ne peut plus rien faire mais qu'on peut rouvrir pour le partenaire
- [ ] Se reconnecter à ce signalement en tant que RT, vérifier qu'on peut soit le `cloturer pour tous`, soit le `rouvrir pour le partenaire`

Si vous pensez à d'autres tests...