### PR TITLE
[BO - Signalements] Filtre Commune n agrege pas les données

### DIFF
--- a/migrations/Version20241024083100.php
+++ b/migrations/Version20241024083100.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241024083100 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set consistent ville_occupant values for Marseille and Lyon';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $mapping = [
+            // Marseille
+            'MARSEILLE' => 'Marseille',
+            'MARSEILLE 2EME' => 'Marseille 2e Arrondissement',
+            'MARSEILLE 02' => 'Marseille 2e Arrondissement',
+            'MARSEILLE 04' => 'Marseille 4e Arrondissement',
+            'MARSEILLE (13013)' => 'Marseille 13e Arrondissement',
+            'MARSEILLE 14' => 'Marseille 14e Arrondissement',
+            // Lyon
+            'LYON 05' => 'Lyon 5e Arrondissement',
+            'Lyon 6' => 'Lyon 6e Arrondissement',
+            'LYON 08' => 'Lyon 8e Arrondissement',
+            'LYON 9EME' => 'Lyon 9e Arrondissement',
+        ];
+        foreach ($mapping as $key => $value) {
+            $this->addSql("UPDATE signalement SET ville_occupant = '".$value."' WHERE ville_occupant = '".$key."'");
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -20,6 +20,7 @@ use App\Repository\NotificationRepository;
 use App\Repository\SignalementQualificationRepository;
 use App\Repository\SuiviRepository;
 use App\Repository\TerritoryRepository;
+use App\Utils\CommuneHelper;
 use App\Utils\ImportCommune;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityManagerInterface;
@@ -379,6 +380,11 @@ class SearchFilter
         }
 
         if (!empty($filters['cities'])) {
+            foreach ($filters['cities'] as $city) {
+                if (isset(CommuneHelper::COMMUNES_ARRONDISSEMENTS[$city])) {
+                    $filters['cities'] = array_merge($filters['cities'], CommuneHelper::COMMUNES_ARRONDISSEMENTS[$city]);
+                }
+            }
             $qb->andWhere('s.villeOccupant IN (:cities) OR s.cpOccupant IN (:cities)')
                 ->setParameter('cities', $filters['cities']);
         }

--- a/src/Utils/CommuneHelper.php
+++ b/src/Utils/CommuneHelper.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Utils;
+
+class CommuneHelper
+{
+    private const MARSEILLE_ARRONDISSEMENTS = [
+        'Marseille 1er Arrondissement',
+        'Marseille 2e Arrondissement',
+        'Marseille 3e Arrondissement',
+        'Marseille 4e Arrondissement',
+        'Marseille 5e Arrondissement',
+        'Marseille 6e Arrondissement',
+        'Marseille 7e Arrondissement',
+        'Marseille 8e Arrondissement',
+        'Marseille 9e Arrondissement',
+        'Marseille 10e Arrondissement',
+        'Marseille 11e Arrondissement',
+        'Marseille 12e Arrondissement',
+        'Marseille 13e Arrondissement',
+        'Marseille 14e Arrondissement',
+        'Marseille 15e Arrondissement',
+        'Marseille 16e Arrondissement',
+    ];
+
+    private const LYON_ARRONDISSEMENTS = [
+        'Lyon 1er Arrondissement',
+        'Lyon 2e Arrondissement',
+        'Lyon 3e Arrondissement',
+        'Lyon 4e Arrondissement',
+        'Lyon 5e Arrondissement',
+        'Lyon 6e Arrondissement',
+        'Lyon 7e Arrondissement',
+        'Lyon 8e Arrondissement',
+        'Lyon 9e Arrondissement',
+    ];
+
+    private const PARIS_ARRONDISSEMENTS = [
+        'Paris 1er Arrondissement',
+        'Paris 2e Arrondissement',
+        'Paris 3e Arrondissement',
+        'Paris 4e Arrondissement',
+        'Paris 5e Arrondissement',
+        'Paris 6e Arrondissement',
+        'Paris 7e Arrondissement',
+        'Paris 8e Arrondissement',
+        'Paris 9e Arrondissement',
+        'Paris 10e Arrondissement',
+        'Paris 11e Arrondissement',
+        'Paris 12e Arrondissement',
+        'Paris 13e Arrondissement',
+        'Paris 14e Arrondissement',
+        'Paris 15e Arrondissement',
+        'Paris 16e Arrondissement',
+        'Paris 17e Arrondissement',
+        'Paris 18e Arrondissement',
+        'Paris 19e Arrondissement',
+        'Paris 20e Arrondissement',
+    ];
+
+    public const COMMUNES_ARRONDISSEMENTS = [
+        'Marseille' => self::MARSEILLE_ARRONDISSEMENTS,
+        'Lyon' => self::LYON_ARRONDISSEMENTS,
+        'Paris' => self::PARIS_ARRONDISSEMENTS,
+    ];
+}


### PR DESCRIPTION
## Ticket

#3206

## Description
Description de la modification apportée

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis
Se mettre sur une copie de base de prod
`make load-migrations`
`make clear-pool pool=--all`

## Tests
- [ ] Se rendre sur le listing est filtrer sur le territoire 13 et commune "Marseille", le nombre de résultat doit correspondre à celui de cette requête `SELECT count(*) FROM signalement WHERE ville_occupant LIKE 'marseille%' and territory_id = 13 and statut != 7;`
