### PR TITLE
[FO - Formulaire] Correction du blocage quand on renseigne des numéros de téléphones invalide pour le principal et le secondaire

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -172,9 +172,6 @@ export default defineComponent({
     },
     getSelectOptionLabel (countryCode:CountryCode) {
       return getCountryNameByCode(countryCode) + ' : +' + getCountryCallingCode(countryCode)
-    },
-    isHiddenSecond () {
-      return formStore.data[this.idSecond] === '' || formStore.data[this.idSecond] === undefined
     }
   },
   computed: {
@@ -206,6 +203,9 @@ export default defineComponent({
     },
     hasErrorSecond () {
       return formStore.validationErrors[this.idSecond] !== undefined
+    },
+    isHiddenSecond () {
+      return formStore.data[this.idSecond] === '' || formStore.data[this.idSecond] === undefined
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -60,9 +60,9 @@
 
     <fieldset
       :id=idSecondGroup
-      :class="[ 'fr-fieldset', isHiddenSecond ? 'fr-hidden' : '', hasErrorSecond ? 'fr-fieldset--error' : '']"
-      :aria-hidden="isHiddenSecond ? true : undefined"
-      :hidden="isHiddenSecond ? true : undefined"
+      :class="[ 'fr-fieldset', isHiddenSecond && !hasErrorSecond ? 'fr-hidden' : '', hasErrorSecond ? 'fr-fieldset--error' : '']"
+      :aria-hidden="isHiddenSecond && !hasErrorSecond ? true : undefined"
+      :hidden="isHiddenSecond && !hasErrorSecond ? true : undefined"
       :aria-labelledby="id + '-legend-second'"
       >
       <legend class="fr-fieldset__legend--regular fr-fieldset__legend fr-col-12" :id="id + '-legend-second'">


### PR DESCRIPTION
## Ticket

#3191    

## Description
Sur le formulaire, quand on affichait et remplissait un numéro de téléphone secondaire au format invalide (par exemple "banane"), le champ secondaire disparaissait, et on ne pouvait pas corriger le numéro, et donc pas passer à la page suivante (sans comprendre pourquoi car l'erreur était cachée aussi)

## Changements apportés
* On affiche le champ de téléphone secondaire dès qu'il est en erreur pour voir le feedback et pouvoir le corriger

## Pré-requis
`npm run watch`
## Tests
- [ ] Faire un signalement, afficher le numéro de téléphone secondaire et mettre quelque-chose d'invalide
- [ ] Vérifier qu'il reste affiché, qu'il est en erreur et qu'on peut corriger (ou supprimer) sa saisie pour passer à la suite
