### PR TITLE
[QA] Revoir type de retour en cas d'erreur de web-service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ worker-exec-failed: ## Consume failed queue
 
 worker-consume: ## Consume local queue for debug
 	@echo -e '\e[1;32mConsume queue\032'
-	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker php bin/console messenger:consume async_priority_high -vvv'
+	@bash -l -c '$(DOCKER_COMP) exec -it histologe_phpworker php bin/console messenger:consume async_priority_high async -vvv'
 
 mock-start: ## Start Mock server
 	@${DOCKER_COMP} start histologe_wiremock && sleep 5

--- a/src/Service/Interconnection/JobEventHttpClient.php
+++ b/src/Service/Interconnection/JobEventHttpClient.php
@@ -6,12 +6,10 @@ use App\Entity\JobEvent;
 use App\Manager\JobEventManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\HttpClientTrait;
-use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -28,7 +26,6 @@ class JobEventHttpClient implements HttpClientInterface
     }
 
     /**
-     * @throws TransportExceptionInterface
      * @throws ServerExceptionInterface
      * @throws RedirectionExceptionInterface
      * @throws ClientExceptionInterface
@@ -57,7 +54,7 @@ class JobEventHttpClient implements HttpClientInterface
             'url' => $url,
             'options' => $options,
         ]);
-
+        $response = null;
         try {
             $response = $this->httpClient->request($method, $url, $options);
             if ($response->getStatusCode() >= Response::HTTP_BAD_REQUEST) {
@@ -76,9 +73,6 @@ class JobEventHttpClient implements HttpClientInterface
             $this->logger->error('HTTP error occurred', [
                 'status_code' => $statusCode = Response::HTTP_INTERNAL_SERVER_ERROR,
                 'response_content' => $responseContent = $exception->getMessage(),
-            ]);
-            $response = new MockResponse($responseContent, [
-                'http_code' => $statusCode,
             ]);
         }
 


### PR DESCRIPTION
## Ticket

#3224    

## Description
Renvoyer la réponse HttpClient même en cas d'erreur 

## Changements apportés
* Suppression de MockResponse

## Pré-requis
_Couper le service de mock pour simuler des erreurs http_

```
make mock-stop
```

```
make worker-stop && make worker-start
```

## Tests
- [ ] Affecter un partenaire interfacé à un signalement et vérifier les erreurs sont toujours loggé dans la table job_event
