### PR TITLE
[BO - Fiche signalement] Onglet Documents - Ordre Descendant

### DIFF
--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -134,7 +134,7 @@
             (filesFilter is same as 'procedure' 
             and doc.documentType.label() in  DocumentType.getOrderedProcedureList)
         )
-    ) %}
+    )|reverse %}
     <div class="fr-grid-row fr-grid-row--middle fr-background-alt--grey fr-rounded fr-p-3v signalement-file-item">
         <div class="fr-col-9">
             <div class="fr-grid-row">


### PR DESCRIPTION
## Ticket

#3228 

## Description
Inversion de l'ordre d'affichage des documents de l'onglet document de la fiche signalement
