### PR TITLE
[BO - Signalement] Affichage historique d'affectation

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -221,8 +221,8 @@ document?.getElementById('fr-modal-historique-affectation')?.addEventListener('d
             const tableHeader = document.createElement('thead')
             tableHeader.innerHTML = `
                             <tr>
-                                <th>Date</th>
-                                <th>Action</th>
+                                <th class="fr-w-15">Date</th>
+                                <th class="fr-w-80">Action</th>
                                 <th>Id</th>
                             </tr>
                         `

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -64,6 +64,12 @@ pre {
     width: 100%;
     justify-content: center;
 }
+.fr-w-15{
+    width: 15%;
+}
+.fr-w-80{
+    width: 80%;
+}
 
 @media (max-width: 48em) {
     .fr-w-100--sm {

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -5,11 +5,6 @@
         </div>
         <div class="fr-col-3 fr-col-md-6">
             <div class="fr-text--right fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
-                {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
-                    <button class="fr-btn fr-fi-add-line fr-btn--icon-left" data-fr-opened="false" aria-controls="fr-modal-affectation">
-                        Affecter des partenaires
-                    </button>
-                {% endif %}
                 {% if platform.feature_historique_affectations and is_granted('ROLE_ADMIN_TERRITORY') %}
                     <button 
                         class="fr-btn fr-btn--secondary fr-btn--icon-left"
@@ -17,6 +12,11 @@
                         aria-controls="fr-modal-historique-affectation"
                     >
                         Voir l'historique des affectations
+                    </button>
+                {% endif %}
+                {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
+                    <button class="fr-btn fr-fi-add-line fr-btn--icon-left" data-fr-opened="false" aria-controls="fr-modal-affectation">
+                        Affecter des partenaires
                     </button>
                 {% endif %}
             </div>


### PR DESCRIPTION
## Ticket

#3229

## Description
- Inversion de l'ordre des boutons "Affecter des partenaires" "Voir l'historique des affectations"
- Ajout de taille sur les colonne du tableau historique afin qu'il soit toujours alligné

## Pré-requis
`make npm-build`

## Tests
- [ ] Vérifier l'affichage des boutons
![Screenshot 2024-10-29 at 17-30-11 Signalement - Histologe](https://github.com/user-attachments/assets/8cd70291-a930-4d42-8658-bf9512e71b5e)
- [ ] Vérifier l'affichage du tableau
![Screenshot 2024-10-29 at 17-30-43 Signalement - Histologe](https://github.com/user-attachments/assets/2202b6e9-a07e-4110-99a7-69bc747720e1)
