### PR TITLE
[BO - Signalement - Historique affectation] Affichage de partenaire N/A

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -222,8 +222,7 @@ document?.getElementById('fr-modal-historique-affectation')?.addEventListener('d
             tableHeader.innerHTML = `
                             <tr>
                                 <th class="fr-w-15">Date</th>
-                                <th class="fr-w-80">Action</th>
-                                <th>Id</th>
+                                <th>Action</th>
                             </tr>
                         `
             tableContentTable.appendChild(tableHeader)
@@ -241,10 +240,6 @@ document?.getElementById('fr-modal-historique-affectation')?.addEventListener('d
               const actionCell = document.createElement('td')
               actionCell.textContent = event.Action
               row.appendChild(actionCell)
-
-              const idCell = document.createElement('td')
-              idCell.textContent = event.Id
-              row.appendChild(idCell)
 
               tableBody.appendChild(row)
             })

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -67,9 +67,6 @@ pre {
 .fr-w-15{
     width: 15%;
 }
-.fr-w-80{
-    width: 80%;
-}
 
 @media (max-width: 48em) {
     .fr-w-100--sm {

--- a/src/Form/TerritoryType.php
+++ b/src/Form/TerritoryType.php
@@ -80,9 +80,11 @@ class TerritoryType extends AbstractType
         ]);
         $builder->get('authorizedCodesInsee')->addModelTransformer(new CallbackTransformer(
             function ($tagsAsArray) {
+                $tagsAsArray = $tagsAsArray ?? [];
+
                 return implode(',', $tagsAsArray);
             },
-            function ($tagsAsString) {
+            function ($tagsAsString): array {
                 return explode(',', $tagsAsString);
             }
         ));

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -165,8 +165,8 @@ class PartnerRepository extends ServiceEntityRepository
             $params = [
                 'territory' => $signalement->getTerritory()->getId(),
                 'insee' => '%'.$signalement->getInseeOccupant().'%',
-                'lng' => $signalement->getGeoloc()['lng'],
-                'lat' => $signalement->getGeoloc()['lat'],
+                'lng' => $signalement->getGeoloc()['lng'] ?? 'notInZone',
+                'lat' => $signalement->getGeoloc()['lat'] ?? 'notInZone',
             ];
             $clauseSubquery = '';
             if (\count($affectedPartners) || 'IN' == $operator) {

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -39,7 +39,7 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserList(): iterable
     {
-        yield 'Search without params' => [[], 49];
+        yield 'Search without params' => [[], 51];
         yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 18];
         yield 'Search with territory 13' => [['territory' => 13], 9];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];

--- a/tests/Functional/Controller/Back/HistoryEntryControllerTest.php
+++ b/tests/Functional/Controller/Back/HistoryEntryControllerTest.php
@@ -57,7 +57,7 @@ class HistoryEntryControllerTest extends WebTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('historyEntries', $response);
-        $this->assertEmpty($response['historyEntries']);
+        $this->assertArrayHasKey('Partenaire 13-01', $response['historyEntries']);
     }
 
     public function testListHistoryAffectationWithoutSignalementId()

--- a/tests/Functional/Controller/Back/HistoryEntryControllerTest.php
+++ b/tests/Functional/Controller/Back/HistoryEntryControllerTest.php
@@ -57,7 +57,7 @@ class HistoryEntryControllerTest extends WebTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('historyEntries', $response);
-        $this->assertNotEmpty($response['historyEntries']);
+        $this->assertEmpty($response['historyEntries']);
     }
 
     public function testListHistoryAffectationWithoutSignalementId()

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -156,15 +156,47 @@ class HistoryEntryManagerTest extends WebTestCase
         $historyEntries = $this->historyEntryManager->getAffectationHistory($signalementId);
 
         $this->assertIsArray($historyEntries);
-        $this->assertArrayHasKey('N/A', $historyEntries); // on est sur les fixtures, on ne sait donc pas qui a créé l'entrée
+        $this->assertEmpty($historyEntries);
+    }
 
-        $this->assertNotEmpty($historyEntries['N/A']);
-        $this->assertEquals(3, \count($historyEntries['N/A']));
+    public function testGetAffectationHistoryWithAffectation()
+    {
+        $featureHistoriqueAffectations = static::getContainer()->getParameter('feature_historique_affectations');
+        if (!$featureHistoriqueAffectations) {
+            $this->markTestSkipped('La fonctionnalité "feature_historique_affectations" est désactivée.');
+        }
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => 'user-01-01@histologe.fr']);
+        $this->client->loginUser($user);
 
-        $entry = $historyEntries['N/A'][0];
+        /** @var Signalement $signalement */
+        $signalement = $this->managerRegistry->getRepository(Signalement::class)->findOneBy(
+            ['reference' => '2022-8']
+        );
+        $signalementId = $signalement->getId();
+        $affectations = $signalement->getAffectations();
+        $changes = [];
+        $changes['statut'] = [];
+        $changes['statut']['new'] = Affectation::STATUS_ACCEPTED;
+        $changes['statut']['old'] = $affectations[0]->getStatut();
+        $historyEntry =$this->historyEntryManager->create(HistoryEntryEvent::UPDATE, $affectations[0], $changes, true);
+        $source = $this->historyEntryManager->getSource();
+        $historyEntry->setSource($source);
+        $this->historyEntryManager->save($historyEntry);
+        $this->entityManager->persist($historyEntry);
+
+        $historyEntries = $this->historyEntryManager->getAffectationHistory($signalementId);
+
+        $this->assertIsArray($historyEntries);
+
+        $this->assertNotEmpty($historyEntries[$affectations[0]->getPartner()->getNom()]);
+        $this->assertEquals(1, \count($historyEntries[$affectations[0]->getPartner()->getNom()]));
+
+        $entry = $historyEntries[$affectations[0]->getPartner()->getNom()][0];
         $this->assertArrayHasKey('Date', $entry);
         $this->assertArrayHasKey('Action', $entry);
-        $this->assertEquals('Système a affecté le signalement au partenaire Partenaire 13-02', $entry['Action']);
+        $this->assertStringContainsString('réouvert son affectation', $entry['Action']);
         $this->assertArrayHasKey('Id', $entry);
         $this->assertEquals($affectations[0]->getId(), $entry['Id']);
     }

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -151,12 +151,11 @@ class HistoryEntryManagerTest extends WebTestCase
             ['reference' => '2022-8']
         );
         $signalementId = $signalement->getId();
-        $affectations = $signalement->getAffectations();
 
         $historyEntries = $this->historyEntryManager->getAffectationHistory($signalementId);
 
         $this->assertIsArray($historyEntries);
-        $this->assertEmpty($historyEntries);
+        $this->assertNotEmpty($historyEntries);
     }
 
     public function testGetAffectationHistoryWithAffectation()
@@ -191,7 +190,7 @@ class HistoryEntryManagerTest extends WebTestCase
         $this->assertIsArray($historyEntries);
 
         $this->assertNotEmpty($historyEntries[$affectations[0]->getPartner()->getNom()]);
-        $this->assertEquals(1, \count($historyEntries[$affectations[0]->getPartner()->getNom()]));
+        $this->assertEquals(2, \count($historyEntries[$affectations[0]->getPartner()->getNom()]));
 
         $entry = $historyEntries[$affectations[0]->getPartner()->getNom()][0];
         $this->assertArrayHasKey('Date', $entry);

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -180,7 +180,7 @@ class HistoryEntryManagerTest extends WebTestCase
         $changes['statut'] = [];
         $changes['statut']['new'] = Affectation::STATUS_ACCEPTED;
         $changes['statut']['old'] = $affectations[0]->getStatut();
-        $historyEntry =$this->historyEntryManager->create(HistoryEntryEvent::UPDATE, $affectations[0], $changes, true);
+        $historyEntry = $this->historyEntryManager->create(HistoryEntryEvent::UPDATE, $affectations[0], $changes, true);
         $source = $this->historyEntryManager->getSource();
         $historyEntry->setSource($source);
         $this->historyEntryManager->save($historyEntry);


### PR DESCRIPTION
## Ticket

#3230   

## Description

- Pour éviter d'avoir un affichage contenant des tableaux vide et Un tableau "N/A" on les ignore (les ligne "N/A" sont conservé via le libellé "Système (automatique)" dans les autres partenaires. On supprime aussi la colonne "Id" qui a peu d’intérêt
![avant](https://github.com/user-attachments/assets/3392c363-17b3-47f5-81f5-7f3b271545d3)
![aprés](https://github.com/user-attachments/assets/f4bf6965-9516-41d0-9446-7b4674bcb5b0)
- Correction d'un warning suite à la feature zonage sur les signalement n'ayant pas de latitude/longitude enregistré en base
- Correction d'un crash sur l'édition des territoire du fait que en prod les territoire on null dans le champ json `authorizedCodesInsee` contient `null` et non pas `[]`

## Prérequis
`make npm-build`

## Test
Se mettre sur une copie de base de prod sur le signalement http://localhost:8080/bo/signalements/b8468aea-bae1-468b-887b-6ac15bf0d6e7
- [ ] Il ne doit pas y'avoir de warning `Warning: Undefined array key "lng"`
- [ ] La modale historique d'afectation doit s'afficher comme dans la capture
- [ ] L'édition de grille de territoire doit être possible


