### PR TITLE
[BO - Signalement - Historique affectation] Afficher le bouton pour tous les users avec les droits d'affectation

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -7,7 +7,7 @@
       "command": "0 0 * * * sh /app/scripts/clean.sh"
     },
     {
-      "command": "15 1-5 * * * php bin/console app:clear-storage-original-file"
+      "command": "0 2 */5 * * php bin/console app:clear-storage-original-file"
     },
     {
       "command": "0 6 * * * php bin/console app:ask-feedback-usager"

--- a/src/Controller/Back/HistoryEntryController.php
+++ b/src/Controller/Back/HistoryEntryController.php
@@ -9,7 +9,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route('/bo/history')]
 class HistoryEntryController extends AbstractController
@@ -24,19 +23,18 @@ class HistoryEntryController extends AbstractController
     }
 
     #[Route('/signalement/{id}/affectations', name: 'history_affectation', methods: ['GET'])]
-    #[IsGranted('ROLE_ADMIN_TERRITORY')]
     public function listHistoryAffectation(
         Request $request,
         HistoryEntryManager $historyEntryManager,
         SignalementRepository $signalementRepository,
     ): Response {
         $signalement = $signalementRepository->find($request->get('id'));
-        if ($signalement && $this->isGranted('SIGN_VIEW', $signalement)) {
-            $historyEntries = $historyEntryManager->getAffectationHistory($signalement->getId());
-
-            return $this->json(['historyEntries' => $historyEntries]);
+        if (!$signalement || !$this->isGranted('SIGN_VIEW', $signalement) || !$this->isGranted('ASSIGN_TOGGLE', $signalement)) {
+            return $this->json(['response' => 'error'], Response::HTTP_FORBIDDEN);
         }
 
-        return $this->json(['response' => 'error'], 400);
+        $historyEntries = $historyEntryManager->getAffectationHistory($signalement->getId());
+
+        return $this->json(['historyEntries' => $historyEntries]);
     }
 }

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -6,7 +6,7 @@
 {% block content %}
     {% if not needValidation and (is_granted('ROLE_ADMIN_TERRITORY') or canPartnerAffectation) %}
         {% include '_partials/_modal_affectation.html.twig' %}
-        {% if platform.feature_historique_affectations and is_granted('ROLE_ADMIN_TERRITORY') %}
+        {% if (platform.feature_historique_affectations and is_granted('ROLE_ADMIN_TERRITORY')) or canPartnerAffectation %}
             {% include '_partials/_modal_historique_affectation.html.twig' %}
         {% endif %}
     {% endif %}

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -5,7 +5,7 @@
         </div>
         <div class="fr-col-3 fr-col-md-6">
             <div class="fr-text--right fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
-                {% if platform.feature_historique_affectations and is_granted('ROLE_ADMIN_TERRITORY') %}
+                {% if (platform.feature_historique_affectations and is_granted('ROLE_ADMIN_TERRITORY')) or canPartnerAffectation %}
                     <button 
                         class="fr-btn fr-btn--secondary fr-btn--icon-left"
                         data-fr-opened="false"

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -39,7 +39,7 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserList(): iterable
     {
-        yield 'Search without params' => [[], 49];
+        yield 'Search without params' => [[], 51];
         yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 18];
         yield 'Search with territory 13' => [['territory' => 13], 9];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];

--- a/tests/Functional/Controller/Back/HistoryEntryControllerTest.php
+++ b/tests/Functional/Controller/Back/HistoryEntryControllerTest.php
@@ -74,7 +74,7 @@ class HistoryEntryControllerTest extends WebTestCase
         ]);
         $this->client->request('GET', $route);
 
-        $this->assertResponseStatusCodeSame(400);
+        $this->assertResponseStatusCodeSame(403);
 
         $this->assertJson($this->client->getResponse()->getContent());
         $response = json_decode($this->client->getResponse()->getContent(), true);


### PR DESCRIPTION
## Ticket

#3236
#3238

## Description
- Autorisation d'accès à la modale d'historique des affectations pour tous les utilisateurs ayant les droits d'affectations pour le signalement (en lien avec la nouvelle feature `FEATURE_PERMISSION_AFFECTATION`)
- Modification de fréquence du cron de suppression des images originale. Maintenant que le gros a été traité une fois tous les 5 jours semble ok selon les dernières métriques 

## Tests
- [ ] S'assurer qu'un utilisateur a qui ont à ajouté la permission d'affectation à bien accès à l'historique des affectations
