### PR TITLE
[BO - Utilisateurs] Amélioration modale de création / édition d'utilisateur

### DIFF
--- a/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
+++ b/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
@@ -37,18 +37,27 @@ function histoUpdateFieldsVisibility () {
 function histoUpdateValueFromData (elementName, elementData, target) {
   document.querySelector(elementName).value = target.getAttribute(elementData)
 }
-function histoUpdatePermissionsFromRole(editOrCreate) {
-  const elementTogglePermissionAffectation = document.querySelector('#user_'+editOrCreate+'_permission_affectation_toggle')
-  const elementTextPermissionAffectation = document.querySelector('#user_'+editOrCreate+'_permission_affectation_text')
+function histoUpdatePermissionsFromRole (editOrCreate, toggleValue) {
+  const elementTogglePermissionAffectation = document.querySelector('#user_' + editOrCreate + '_permission_affectation_toggle input')
+  const elementTextPermissionAffectation = document.querySelector('#user_' + editOrCreate + '_permission_affectation_text')
   if (!elementTogglePermissionAffectation || !elementTextPermissionAffectation) {
     return
   }
-  const rolesSelect = document.querySelector('#user_'+editOrCreate+'_roles')
+  const rolesSelect = document.querySelector('#user_' + editOrCreate + '_roles')
   if (rolesSelect.value === 'ROLE_ADMIN' || rolesSelect.value === 'ROLE_ADMIN_TERRITORY') {
-    elementTogglePermissionAffectation.classList.add('fr-hidden')
+    if (!elementTogglePermissionAffectation.checked) {
+      elementTogglePermissionAffectation.click()
+    }
+    elementTogglePermissionAffectation.setAttribute('disabled', 'disabled')
     elementTextPermissionAffectation.classList.remove('fr-hidden')
   } else {
-    elementTogglePermissionAffectation.classList.remove('fr-hidden')
+    elementTogglePermissionAffectation.removeAttribute('disabled')
+    if (toggleValue === false && elementTogglePermissionAffectation.checked) {
+      elementTogglePermissionAffectation.click()
+    }
+    if (editOrCreate === 'edit' && toggleValue === true && !elementTogglePermissionAffectation.checked) {
+      elementTogglePermissionAffectation.click()
+    }
     elementTextPermissionAffectation.classList.add('fr-hidden')
   }
 }
@@ -121,16 +130,16 @@ document.querySelectorAll('.btn-edit-partner-user').forEach(swbtn => {
     } else {
       document.querySelector('#user_edit_is_mailing_active-2').checked = true
     }
-    
+
     const elementPermissionAffectation = document.querySelector('#user_edit_permission_affectation')
     if (elementPermissionAffectation) {
-      elementPermissionAffectation.checked = target.getAttribute('data-userpermissionaffectation') === '1'
+      elementPermissionAffectation.removeAttribute('disabled')
     }
 
     const userRole = target.getAttribute('data-userrole')
     const rolesSelect = document.querySelector('#user_edit_roles')
     rolesSelect.value = userRole
-    histoUpdatePermissionsFromRole('edit')
+    histoUpdatePermissionsFromRole('edit', target.getAttribute('data-userpermissionaffectation') === '1')
 
     document.querySelector('#user_edit_form').addEventListener('submit', (e) => {
       histoUpdateSubmitButton('#user_edit_form_submit', 'Edition en cours...')
@@ -153,16 +162,18 @@ if (document.querySelector('#partner_type')) {
 
 if (document.querySelector('#user_create_roles')) {
   document.querySelector('#user_create_roles').addEventListener('change', () => {
-    histoUpdatePermissionsFromRole('create')
+    histoUpdatePermissionsFromRole('create', null)
   })
+  histoUpdatePermissionsFromRole('create', null)
 }
 if (document.querySelector('#user_edit_roles')) {
   document.querySelector('#user_edit_roles').addEventListener('change', () => {
-    histoUpdatePermissionsFromRole('edit')
+    histoUpdatePermissionsFromRole('edit', null)
   })
+  histoUpdatePermissionsFromRole('edit', null)
 }
 
-const deletePartnerForm = document.querySelectorAll('form[name="deletePartner"]');
+const deletePartnerForm = document.querySelectorAll('form[name="deletePartner"]')
 deletePartnerForm.forEach(form => {
   form.addEventListener('submit', function (event) {
     if (!confirm('Êtes-vous sûr de vouloir supprimer ce partenaire ?')) {

--- a/templates/_partials/_modal_user_create.html.twig
+++ b/templates/_partials/_modal_user_create.html.twig
@@ -10,102 +10,112 @@
                         <h1 id="fr-user-create-title" class="fr-modal__title">
                             Ajouter un utilisateur
                         </h1>   
-                        <span class="fr-grid-row fr-grid-row--gutters">Tous les champs sont obligatoires</span><br>
+                        <span class="fr-mb-3v">Tous les champs sont obligatoires</span>
+                        <br>
                         <form action="{{ path('back_partner_user_add', {'id': partner.id}) }}" name="user_create"
-                              id="user_create_form" method="POST"  class='needs-validation' novalidate="novalidate">
-                            <div class="fr-col-12 fr-mb-5v">
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_create_nom" class="fr-label">Nom</label>
-                                        <input type="text" id="user_create_nom" name="user_create[nom]"
-                                            required="required" class="fr-input">
-                                        <p class="fr-error-text fr-hidden">
-                                            Vous devez renseigner le nom du nouvel utilisateur.
-                                        </p>
-                                    </div>
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_create_prenom" class="fr-label">Prénom</label>
-                                        <input type="text" id="user_create_prenom" name="user_create[prenom]"
-                                            required="required" class="fr-input">
-                                        <p class="fr-error-text fr-hidden">
-                                            Vous devez renseigner le prénom de l'utilisateur
-                                        </p>
-                                    </div>
+                                id="user_create_form" method="POST" class='needs-validation' novalidate="novalidate">
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_create_nom" class="fr-label">Nom</label>
+                                    <input type="text" id="user_create_nom" name="user_create[nom]"
+                                        required="required" class="fr-input">
+                                    <p class="fr-error-text fr-hidden">
+                                        Vous devez renseigner le nom du nouvel utilisateur.
+                                    </p>
                                 </div>
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_create_roles" class="fr-label">Rôle</label>
-                                        <select id="user_create_roles" name="user_create[roles]" required="required"
-                                                class="fr-select">
-                                            <option value="" selected="selected">--- Selectionnez ---</option>
-                                            {% if is_granted('ROLE_ADMIN') %}
-                                                <option value="ROLE_ADMIN">
-                                                    Super Admin
-                                                </option>
-                                            {% endif %}
-                                            {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                                                <option value="ROLE_ADMIN_TERRITORY">
-                                                    Resp. Territoire
-                                                </option>
-                                            {% endif %}
-                                            <option value="ROLE_ADMIN_PARTNER">Admin. partenaire</option>
-                                            <option value="ROLE_USER_PARTNER">Agent</option>
-                                        </select>
-                                        <p class="fr-error-text fr-hidden">
-                                            Vous devez sélectionner le rôle de l'utilisateur
-                                        </p>
-                                    </div>
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_create_email" class="fr-label">Courriel</label>
-                                        <input type="email" id="user_create_email" name="user_create[email]"
-                                            required="required" class="fr-input fr-input-email"
-                                            data-token="{{ csrf_token('partner_checkmail') }}">
-                                        <span class="fr-hint-text">Un e-mail d'activation du compte sera envoyé à cette adresse e-mail.</span>
-                                        <p class="fr-error-text fr-hidden">
-                                            Courriel invalide
-                                        </p>
-                                    </div>
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_create_prenom" class="fr-label">Prénom</label>
+                                    <input type="text" id="user_create_prenom" name="user_create[prenom]"
+                                        required="required" class="fr-input">
+                                    <p class="fr-error-text fr-hidden">
+                                        Vous devez renseigner le prénom de l'utilisateur
+                                    </p>
                                 </div>
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <fieldset class="fr-fieldset fr-fieldset--inline fr-input-group fr-col-12 fr-col-md-6">
-                                        <legend class="fr-fieldset__legend fr-text--regular">
-                                            <label class="fr-label">Recevoir les e-mails ?</label>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_create_roles" class="fr-label">Rôle</label>
+                                    <select id="user_create_roles" name="user_create[roles]" required="required"
+                                            class="fr-select">
+                                        <option value="" selected="selected">--- Selectionnez ---</option>
+                                        {% if is_granted('ROLE_ADMIN') %}
+                                            <option value="ROLE_ADMIN">
+                                                Super Admin
+                                            </option>
+                                        {% endif %}
+                                        {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+                                            <option value="ROLE_ADMIN_TERRITORY">
+                                                Resp. Territoire
+                                            </option>
+                                        {% endif %}
+                                        <option value="ROLE_ADMIN_PARTNER">Admin. partenaire</option>
+                                        <option value="ROLE_USER_PARTNER">Agent</option>
+                                    </select>
+                                    <p class="fr-error-text fr-hidden">
+                                        Vous devez sélectionner le rôle de l'utilisateur
+                                    </p>
+                                </div>
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_create_email" class="fr-label">Courriel</label>
+                                    <input type="email" id="user_create_email" name="user_create[email]"
+                                        required="required" class="fr-input fr-input-email"
+                                        data-token="{{ csrf_token('partner_checkmail') }}">
+                                    <span class="fr-hint-text">Un e-mail d'activation du compte sera envoyé à cette adresse e-mail.</span>
+                                    <p class="fr-error-text fr-hidden">
+                                        Courriel invalide
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-12">
+                                    <fieldset class="fr-fieldset">
+                                        <legend class="fr-fieldset__legend fr-fieldset__legend--regular">
+                                            Recevoir les e-mails ?
+                                            <span class="fr-hint-text">Si vous cochez oui, des e-mails concernant les signalements seront envoyés à cette adresse.</span>
                                         </legend>
-                                        <div class="fr-fieldset__content">
-                                            <div class="fr-fieldset__element fr-fieldset__element--inline">
-                                                <div class="fr-radio-group">
-                                                    <input type="radio" id="user_create_is_mailing_active-1" value='1' name="user_create[isMailingActive]" checked>
-                                                    <label class="fr-label" for="user_create_is_mailing_active-1">
-                                                        Oui
-                                                    </label>
-                                                </div>
-                                            </div>
-                                            <div class="fr-fieldset__element fr-fieldset__element--inline fr-ml-2w">
-                                                <div class="fr-radio-group">
-                                                    <input type="radio" id="user_create_is_mailing_active-2" value='0' name="user_create[isMailingActive]">
-                                                    <label class="fr-label" for="user_create_is_mailing_active-2">
-                                                        Non
-                                                    </label>
-                                                </div>
+                                        <div class="fr-fieldset__element fr-fieldset__element--inline">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="user_create_is_mailing_active-1" value='1' name="user_create[isMailingActive]" checked>
+                                                <label class="fr-label" for="user_create_is_mailing_active-1">
+                                                    Oui
+                                                </label>
                                             </div>
                                         </div>
-                                        <span class="fr-hint-text fr-mt-inf-3v">Si vous cochez oui, des e-mails concernant les signalements seront envoyés à cette adresse.</span>
+                                        <div class="fr-fieldset__element fr-fieldset__element--inline">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="user_create_is_mailing_active-2" value='0' name="user_create[isMailingActive]">
+                                                <label class="fr-label" for="user_create_is_mailing_active-2">
+                                                    Non
+                                                </label>
+                                            </div>
+                                        </div>
                                     </fieldset>
                                 </div>
-                                {% if platform.feature_permission_affectation and is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-col-12">
-                                        <div id="user_create_permission_affectation_toggle" class="fr-toggle">
-                                            <input type="checkbox" class="fr-toggle__input" id="user_create_permission_affectation" name="user_create[hasPermissionAffectation]" value="1">
-                                            <label class="fr-toggle__label" for="user_create_permission_affectation">Cet utilisateur peut affecter d'autres partenaires à ses signalements</label>
-                                        </div>
-                                        <div id="user_create_permission_affectation_text" class="fr-hidden">
-                                            Un administrateur de territoire peut affecter d'autres partenaires à ses signalements.
-                                        </div>
-                                    </div>
-                                </div>
-                                {% endif %}
                             </div>
+                            {% if platform.feature_permission_affectation and is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-12">
+                                    <fieldset id="user_create_permission_affectation_toggle" class="fr-fieldset" aria-labelledby="user-create-permissions-legend">
+                                        <legend class="fr-mb-3v" id="user-create-permissions-legend">
+                                            Droits d'affectation
+                                        </legend>
+                                        <div class="fr-fieldset__element">
+                                            <ul class="fr-toggle__list">
+                                                <li>
+                                                    <div class="fr-toggle">
+                                                        <input type="checkbox" class="fr-toggle__input" id="user_create_permission_affectation" name="user_create[hasPermissionAffectation]" value="1">
+                                                        <label class="fr-toggle__label" for="user_create_permission_affectation" data-fr-checked-label="Activé" data-fr-unchecked-label="Désactivé">Cet utilisateur peut affecter d'autres partenaires à ses signalements</label>
+                                                    </div>
+                                                    <div id="user_create_permission_affectation_text" class="fr-alert fr-alert--info fr-alert--sm fr-mt-2v" class="fr-hidden">
+                                                        <p>Les responsables de territoire ont le droit d'affecter des partenaires aux signalements du territoire. Ce droit ne peut pas leur être retiré.</p>
+                                                    </div>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </fieldset>
+                                </div>
+                            </div>
+                            {% endif %}
                             <input type="hidden" name="_token" value="{{ csrf_token('partner_user_create') }}">
                         </form>
                     </div>

--- a/templates/_partials/_modal_user_edit.html.twig
+++ b/templates/_partials/_modal_user_edit.html.twig
@@ -10,101 +10,111 @@
                         <h1 id="fr-user-edit-title" class="fr-modal__title">
                             Modifier le compte de :  <span class="fr-modal-user-edit_useremail"></span>
                         </h1>   
-                        <span class="fr-grid-row fr-grid-row--gutters">Tous les champs sont obligatoires</span><br>
+                        <span class="fr-mb-3v">Tous les champs sont obligatoires</span>
+                        <br>
                         <form action="{{ path('back_partner_user_edit') }}" name="user_edit"
-                              id="user_edit_form" method="POST" class='needs-validation' novalidate="novalidate">
-                            <div class="fr-col-12 fr-mb-5v">
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_edit_nom" class="fr-label">Nom</label>
-                                        <input type="text" id="user_edit_nom" name="user_edit[nom]"
-                                            required="required" class="fr-input">
-                                        <p class="fr-error-text fr-hidden">
-                                            Vous devez renseigner le nom du nouvel utilisateur.
-                                        </p>
-                                    </div>
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_edit_prenom" class="fr-label">Prénom</label>
-                                        <input type="text" id="user_edit_prenom" name="user_edit[prenom]"
-                                            required="required" class="fr-input">
-                                        <p class="fr-error-text fr-hidden">
-                                            Vous devez renseigner le prénom de l'utilisateur
-                                        </p>
-                                    </div>
+                                id="user_edit_form" method="POST" class='needs-validation' novalidate="novalidate">
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_edit_nom" class="fr-label">Nom</label>
+                                    <input type="text" id="user_edit_nom" name="user_edit[nom]"
+                                        required="required" class="fr-input">
+                                    <p class="fr-error-text fr-hidden">
+                                        Vous devez renseigner le nom du nouvel utilisateur.
+                                    </p>
                                 </div>
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_edit_roles" class="fr-label">Rôle</label>
-                                        <select id="user_edit_roles" name="user_edit[roles]" required="required" class="fr-select"> 
-                                            <option value="" selected="selected">--- Selectionnez ---</option>
-                                            {% if is_granted('ROLE_ADMIN') %}
-                                                <option value="ROLE_ADMIN">
-                                                    Super Admin
-                                                </option>
-                                            {% endif %}
-                                            {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                                                <option value="ROLE_ADMIN_TERRITORY">
-                                                    Resp. Territoire
-                                                </option>
-                                            {% endif %}
-                                            <option value="ROLE_ADMIN_PARTNER">Admin. partenaire</option>
-                                            <option value="ROLE_USER_PARTNER">Agent</option>                           
-                                        </select>
-                                        <p class="fr-error-text fr-hidden">
-                                            Vous devez sélectionner le rôle de l'utilisateur
-                                        </p>
-                                    </div>
-                                    <div class="fr-input-group fr-col-12 fr-col-md-6 fr-pl-0 fr-pl-md-0">
-                                        <label for="user_edit_email" class="fr-label">Courriel</label>
-                                        <input type="email" id="user_edit_email" name="user_edit[email]"
-                                            required="required" class="fr-input fr-input-email"
-                                            data-token="{{ csrf_token('partner_checkmail') }}">
-                                        <span class="fr-hint-text">Un e-mail d'activation du compte sera envoyé à cette adresse e-mail.</span>
-                                        <p class="fr-error-text fr-hidden">
-                                            Courriel invalide
-                                        </p>
-                                    </div>
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_edit_prenom" class="fr-label">Prénom</label>
+                                    <input type="text" id="user_edit_prenom" name="user_edit[prenom]"
+                                        required="required" class="fr-input">
+                                    <p class="fr-error-text fr-hidden">
+                                        Vous devez renseigner le prénom de l'utilisateur
+                                    </p>
                                 </div>
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <fieldset class="fr-fieldset fr-fieldset--inline fr-input-group fr-col-12 fr-col-md-6">
-                                        <legend class="fr-fieldset__legend fr-text--regular">
-                                            <label class="fr-label">Recevoir les e-mails ?</label>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_edit_roles" class="fr-label">Rôle</label>
+                                    <select id="user_edit_roles" name="user_edit[roles]" required="required" class="fr-select"> 
+                                        <option value="" selected="selected">--- Selectionnez ---</option>
+                                        {% if is_granted('ROLE_ADMIN') %}
+                                            <option value="ROLE_ADMIN">
+                                                Super Admin
+                                            </option>
+                                        {% endif %}
+                                        {% if is_granted('ROLE_ADMIN_TERRITORY') %}
+                                            <option value="ROLE_ADMIN_TERRITORY">
+                                                Resp. Territoire
+                                            </option>
+                                        {% endif %}
+                                        <option value="ROLE_ADMIN_PARTNER">Admin. partenaire</option>
+                                        <option value="ROLE_USER_PARTNER">Agent</option>                           
+                                    </select>
+                                    <p class="fr-error-text fr-hidden">
+                                        Vous devez sélectionner le rôle de l'utilisateur
+                                    </p>
+                                </div>
+                                <div class="fr-input-group fr-col-12 fr-col-md-6">
+                                    <label for="user_edit_email" class="fr-label">Courriel</label>
+                                    <input type="email" id="user_edit_email" name="user_edit[email]"
+                                        required="required" class="fr-input fr-input-email"
+                                        data-token="{{ csrf_token('partner_checkmail') }}">
+                                    <span class="fr-hint-text">Un e-mail d'activation du compte sera envoyé à cette adresse e-mail.</span>
+                                    <p class="fr-error-text fr-hidden">
+                                        Courriel invalide
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-12">
+                                    <fieldset class="fr-fieldset">
+                                        <legend class="fr-fieldset__legend fr-fieldset__legend--regular">
+                                            Recevoir les e-mails ?
+                                            <span class="fr-hint-text">Si vous cochez oui, des e-mails concernant les signalements seront envoyés à cette adresse.</span>
                                         </legend>
-                                        <div class="fr-fieldset__content">
-                                            <div class="fr-fieldset__element fr-fieldset__element--inline">
-                                                <div class="fr-radio-group">
-                                                    <input type="radio" id="user_edit_is_mailing_active-1" value='1' name="user_edit[isMailingActive]">
-                                                    <label class="fr-label" for="user_edit_is_mailing_active-1">
-                                                        Oui
-                                                    </label>
-                                                </div>
-                                            </div>
-                                            <div class="fr-fieldset__element fr-fieldset__element--inline fr-ml-2w">
-                                                <div class="fr-radio-group">
-                                                    <input type="radio" id="user_edit_is_mailing_active-2" value='0' name="user_edit[isMailingActive]">
-                                                    <label class="fr-label" for="user_edit_is_mailing_active-2">
-                                                        Non
-                                                    </label>
-                                                </div>
+                                        <div class="fr-fieldset__element fr-fieldset__element--inline">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="user_edit_is_mailing_active-1" value='1' name="user_edit[isMailingActive]">
+                                                <label class="fr-label" for="user_edit_is_mailing_active-1">
+                                                    Oui
+                                                </label>
                                             </div>
                                         </div>
-                                        <span class="fr-hint-text fr-mt-inf-3v">Si vous cochez oui, des e-mails concernant les signalements seront envoyés à cette adresse.</span>
+                                        <div class="fr-fieldset__element fr-fieldset__element--inline">
+                                            <div class="fr-radio-group">
+                                                <input type="radio" id="user_edit_is_mailing_active-2" value='0' name="user_edit[isMailingActive]">
+                                                <label class="fr-label" for="user_edit_is_mailing_active-2">
+                                                    Non
+                                                </label>
+                                            </div>
+                                        </div>
                                     </fieldset>
                                 </div>
-                                {% if platform.feature_permission_affectation and is_granted('ROLE_ADMIN_TERRITORY') %}
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-col-12">
-                                        <div id="user_edit_permission_affectation_toggle" class="fr-toggle">
-                                            <input type="checkbox" class="fr-toggle__input" id="user_edit_permission_affectation" name="user_edit[hasPermissionAffectation]" value="1">
-                                            <label class="fr-toggle__label" for="user_edit_permission_affectation">Cet utilisateur peut affecter d'autres partenaires à ses signalements</label>
-                                        </div>
-                                        <div id="user_edit_permission_affectation_text">
-                                            Un administrateur de territoire peut affecter d'autres partenaires à ses signalements.
-                                        </div>
-                                    </div>
-                                </div>
-                                {% endif %}
                             </div>
+                            {% if platform.feature_permission_affectation and is_granted('ROLE_ADMIN_TERRITORY') %}
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-12">
+                                    <fieldset id="user_edit_permission_affectation_toggle" class="fr-fieldset" aria-labelledby="user-edit-permissions-legend">
+                                        <legend class="fr-mb-3v" id="user-edit-permissions-legend">
+                                            Droits d'affectation
+                                        </legend>
+                                        <div class="fr-fieldset__element">
+                                            <ul class="fr-toggle__list">
+                                                <li>
+                                                    <div class="fr-toggle">
+                                                        <input type="checkbox" class="fr-toggle__input" id="user_edit_permission_affectation" name="user_edit[hasPermissionAffectation]" value="1">
+                                                        <label class="fr-toggle__label" for="user_edit_permission_affectation" data-fr-checked-label="Activé" data-fr-unchecked-label="Désactivé">Cet utilisateur peut affecter d'autres partenaires à ses signalements</label>
+                                                    </div>
+                                                    <div id="user_edit_permission_affectation_text" class="fr-alert fr-alert--info fr-alert--sm fr-mt-2v" class="fr-hidden">
+                                                        <p>Les responsables de territoire ont le droit d'affecter des partenaires aux signalements du territoire. Ce droit ne peut pas leur être retiré.</p>
+                                                    </div>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </fieldset>
+                                </div>
+                            </div>
+                            {% endif %}
                             <input type="hidden" name="user_id" id="user_edit_userid">
                             <input type="hidden" name="redirect_to" value="{{ currentPage }}">
                             <input type="hidden" name="_token" value="{{ csrf_token('partner_user_edit') }}">


### PR DESCRIPTION
## Ticket

#3235   

## Description
Quelques améliorations apportées aux fenêtres pour créer et éditer les utilisateurs 
- Passage des notifs mails en pleine largeur
- Ajout d'une légende pour les droits d'affectation
- Ajout du toggle grisé et d'une info pour les utilisateurs Admin

J'en ai profité pour revoir quelques classes d'affichage des champs dans ces modale, pour correspondre aux classes dsfr actuelles, et aux marges correctes.

## Pré-requis
`npm run watch`

## Tests
- [ ] Avoir un partenaire avec des utilisateurs admin, des utilisateurs sans droit et des utilisateurs avec droits d'affectation
- [ ] Passer de l'édition de l'un à l'autre et vérifier que l'affichage dans la modale est correcte
