### PR TITLE
[FO] Ajout d'un écran pour le champ précisions sur les désordres et fix

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -2864,6 +2864,54 @@
   },
   {
     "type": "SignalementFormScreen",
+    "label": "Précisions sur votre situation",
+    "description": "Détaillez ici votre situation, les démarches déjà engagées et toutes les informations que vous jugez utiles au traitement de votre dossier.",
+    "slug": "desordres_precisions",
+    "screenCategory": "Désordres",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormTextarea",
+          "slug": "message_administration",
+          "customCss": "fr-mt-5v",
+          "label": "Votre message ici",
+          "accessibility": {
+            "focus": true
+          },
+          "validate": {
+            "message": "Veuillez détailler votre situation."
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_precisions_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_precisions_next",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_precisions_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
     "label": "Les désordres renseignés",
     "slug": "desordres_renseignes",
     "screenCategory": "Désordres",

--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -2874,7 +2874,7 @@
           "type": "SignalementFormTextarea",
           "slug": "message_administration",
           "customCss": "fr-mt-5v",
-          "label": "Votre message ici",
+          "label": "Votre message ici :",
           "accessibility": {
             "focus": true
           },
@@ -2894,7 +2894,7 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "desordres_precisions_next",
-                "action": "goto:desordres_renseignes",
+                "action": "goto.save:desordres_renseignes",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -1629,7 +1629,7 @@
         },
         {
           "type": "SignalementFormSubscreen",
-          "label": "Le type de chauffage est : {{formStore.data.desordres_logement_chauffage_type}}",
+          "label": "Le type de chauffage est : {{dictionaryStore::formStore.data.desordres_logement_chauffage_type}}",
           "slug": "desordres_logement_chauffage_details",
           "description": "Sélectionnez le ou les problèmes rencontrés",
           "conditional": {
@@ -2872,6 +2872,54 @@
                 "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_proprete_previous",
+                "action": "resolve:findPreviousScreen",
+                "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "SignalementFormScreen",
+    "label": "Précisions sur la situation",
+    "description": "Détaillez ici la situation, les démarches déjà engagées et toutes les informations que vous jugez utiles au traitement de votre dossier.",
+    "slug": "desordres_precisions",
+    "screenCategory": "Désordres",
+    "components": {
+      "body": [
+        {
+          "type": "SignalementFormTextarea",
+          "slug": "message_administration",
+          "customCss": "fr-mt-5v",
+          "label": "Votre message ici",
+          "accessibility": {
+            "focus": true
+          },
+          "validate": {
+            "message": "Veuillez détailler la situation."
+          }
+        }
+      ],
+      "footer": [
+        {
+          "type": "SignalementFormSubscreen",
+          "slug": "desordres_precisions_footer",
+          "customCss": "button-group-responsive-inverted",
+          "components": {
+            "body": [
+              {
+                "type": "SignalementFormButton",
+                "label": "Suivant",
+                "slug": "desordres_precisions_next",
+                "action": "goto:desordres_renseignes",
+                "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Précédent",
+                "slug": "desordres_precisions_previous",
                 "action": "resolve:findPreviousScreen",
                 "customCss": "fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
               }

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -2893,7 +2893,7 @@
           "type": "SignalementFormTextarea",
           "slug": "message_administration",
           "customCss": "fr-mt-5v",
-          "label": "Votre message ici",
+          "label": "Votre message ici :",
           "accessibility": {
             "focus": true
           },
@@ -2913,7 +2913,7 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "desordres_precisions_next",
-                "action": "goto:desordres_renseignes",
+                "action": "goto.save:desordres_renseignes",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {

--- a/assets/json/Signalement/dictionary.json
+++ b/assets/json/Signalement/dictionary.json
@@ -244,7 +244,12 @@
   "desordres_logement_electricite_pas_compteur": { "default": "Il n'y a pas de compteur électrique pour le logement" },
   "desordres_logement_electricite_installation_dangereuse": { "default": "L'installation est dangereuse : les fils sont dénudés, les prises ne tiennent pas dans les murs, etc." },
   "desordres_logement_electricite_manque_prises": { "default": "Il n'y a pas de prises, ou il en manque" },
-  "desordres_logement_electricite_manque_prises_details_multiprises": { "default": "Des multi-prises sont branchées les unes sur les autres : {{dictionaryStore::formStore.data.desordres_logement_electricite_manque_prises_details_multiprises}}" },
+  "desordres_logement_electricite_manque_prises_details_multiprises": {
+    "default": "Des multi-prises doivent-elles être branchées les unes sur les autres ?",
+    "disorderOverview": {
+      "default": "Des multi-prises sont branchées les unes sur les autres : {{dictionaryStore::formStore.data.desordres_logement_electricite_manque_prises_details_multiprises}}" 
+    }
+  },
   "desordres_logement_nuisibles_cafards": { "default": "Il y a des cafards ou blattes" },
   "desordres_logement_nuisibles_rongeurs": { "default": "Il y a des rongeurs (rats, souris…)" },
   "desordres_logement_nuisibles_punaises": { "default": "Il y a des punaises de lit" },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -185,8 +185,8 @@ export default defineComponent({
         formStore.data[this.id + '_detail_need_refresh_insee'] = true
       }
       if (
-        variableTester.isEmpty(this.formStore.data[this.id + '_detail_numero']) ||
-        variableTester.isEmpty(this.formStore.data[this.id + '_detail_code_postal']) ||
+        variableTester.isEmpty(this.formStore.data[this.id + '_detail_numero']) &&
+        variableTester.isEmpty(this.formStore.data[this.id + '_detail_code_postal']) &&
         variableTester.isEmpty(this.formStore.data[this.id + '_detail_commune'])
       ) {
         if (this.validate !== null && this.validate.required === false) {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -61,6 +61,7 @@
 import { defineComponent, watch } from 'vue'
 import formStore from './../store'
 import { requests } from './../requests'
+import { variableTester } from './../services/variableTester'
 import { subscreenManager } from './../services/subscreenManager'
 import subscreenData from './../address_subscreen.json'
 import SignalementFormTextfield from './SignalementFormTextfield.vue'
@@ -134,23 +135,21 @@ export default defineComponent({
       }
     )
     watch(
+      () => this.formStore.data[this.id + '_detail_numero'],
+      async () => {
+        this.handleAddressFieldsEdited(false)
+      }
+    )
+    watch(
       () => this.formStore.data[this.id + '_detail_code_postal'],
       async () => {
-        this.handleAddressFieldsEdited()
+        this.handleAddressFieldsEdited(true)
       }
     )
     watch(
       () => this.formStore.data[this.id + '_detail_commune'],
       async () => {
-        this.handleAddressFieldsEdited()
-      }
-    )
-    watch(
-      () => this.subscreenCss,
-      (newValue, oldValue) => {
-        if (newValue === 'fr-hidden') {
-          this.formStore.data[this.id + '_detail_manual'] = 0
-        }
+        this.handleAddressFieldsEdited(true)
       }
     )
   },
@@ -167,7 +166,11 @@ export default defineComponent({
       return ''
     },
     subscreenCss () {
-      if (this.buttonCss === '') {
+      if (this.buttonCss === '' &&
+        variableTester.isEmpty(this.formStore.validationErrors[this.id + '_detail_numero']) &&
+        variableTester.isEmpty(this.formStore.validationErrors[this.id + '_detail_code_postal']) &&
+        variableTester.isEmpty(this.formStore.validationErrors[this.id + '_detail_commune'])
+      ) {
         return 'fr-hidden'
       }
       return ''
@@ -177,8 +180,19 @@ export default defineComponent({
     updateValue (value: any) {
       this.$emit('update:modelValue', value)
     },
-    handleAddressFieldsEdited () {
-      formStore.data[this.id + '_detail_need_refresh_insee'] = true
+    handleAddressFieldsEdited (changeCommune:Boolean) {
+      if (changeCommune) {
+        formStore.data[this.id + '_detail_need_refresh_insee'] = true
+      }
+      if (
+        variableTester.isEmpty(this.formStore.data[this.id + '_detail_numero']) ||
+        variableTester.isEmpty(this.formStore.data[this.id + '_detail_code_postal']) ||
+        variableTester.isEmpty(this.formStore.data[this.id + '_detail_commune'])
+      ) {
+        if (this.validate !== null && this.validate.required === false) {
+          this.formStore.data[this.id + '_detail_manual'] = 0
+        }
+      }
     },
     handleClickButton (type:string, param:string, slugButton:string) {
       this.formStore.data[this.idShow] = 1

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -145,6 +145,14 @@ export default defineComponent({
         this.handleAddressFieldsEdited()
       }
     )
+    watch(
+      () => this.subscreenCss,
+      (newValue, oldValue) => {
+        if (newValue === 'fr-hidden') {
+          this.formStore.data[this.id + '_detail_manual'] = 0
+        }
+      }
+    )
   },
   computed: {
     buttonCss () {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -100,20 +100,9 @@
       Aucun désordre sélectionné
     </div>
     <!-- MESSAGE A L'ADMINISTRATION -->
-    <div v-if="formStore.currentScreen?.slug === 'desordres_renseignes'">
+    <div v-if="formStore.currentScreen?.slug !== 'desordres_renseignes_batiment'">
       <br>
-      <h3>Précisions sur les désordres (facultatif)</h3>
-      <p>Vous pouvez apporter des précisions sur votre situation.</p>
-      <SignalementFormTextarea
-        :id="idMessageAdministration"
-        description="Votre message ici"
-        @input="updateValue($event)"
-        :modelValue="formStore.data[idMessageAdministration]"
-        />
-    </div>
-    <div v-else-if="formStore.currentScreen?.slug === 'validation_signalement' && formStore.data[idMessageAdministration] !== undefined">
-      <br>
-      <h5 class="fr-h6">Précisions sur les désordres</h5>
+      <h5 class="fr-h6">Précisions sur la situation</h5>
       <p class="white-space-pre-line">{{ formStore.data[idMessageAdministration] }}</p>
     </div>
   </div>
@@ -124,13 +113,9 @@ import { defineComponent } from 'vue'
 import formStore from './../store'
 import dictionaryStore from './../dictionary-store'
 import { dictionaryManager } from './../services/dictionaryManager'
-import SignalementFormTextarea from './SignalementFormTextarea.vue'
 
 export default defineComponent({
   name: 'SignalementFormDisorderOverview',
-  components: {
-    SignalementFormTextarea
-  },
   props: {
     id: { type: String, default: null },
     icons: { type: Object },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -1,10 +1,10 @@
 <template>
-<div :class="['fr-input-group', { 'fr-input-group--disabled': disabled }, {'fr-input-group--error' : hasError}]" :id="id">
+<div :class="[customCss, 'fr-input-group', { 'fr-input-group--disabled': disabled }, {'fr-input-group--error' : hasError}]" :id="id">
   <label class='fr-label' :for="id + '_input'">
     {{ label }}
     <span class="fr-hint-text">{{ description }}</span>
   </label>
-    <div :class="[ customCss, 'fr-input-wrap' ]">
+    <div class="fr-input-wrap">
       <textarea
         :id="id + '_input'"
         :name="id"

--- a/assets/scripts/vue/components/signalement-form/matomo.ts
+++ b/assets/scripts/vue/components/signalement-form/matomo.ts
@@ -1,6 +1,6 @@
 export const matomo = {
   pushEvent (eventAction: string, eventName: string) {
-    const _paq = Object(window)._paq = Object(window)._paq || []
+    const _paq = Array.isArray(Object(window)._paq) ? Object(window)._paq : []
     const eventCategory = 'Signaler un problème de logement'
     _paq.push(['trackEvent', eventCategory, eventAction, eventName])
   }

--- a/assets/scripts/vue/components/signalement-form/services/disorderScreenNavigator.ts
+++ b/assets/scripts/vue/components/signalement-form/services/disorderScreenNavigator.ts
@@ -19,8 +19,11 @@ export function findPreviousScreen (
       case 'desordres_batiment':
         previousScreenSlug = (formStore.data.zone_concernee_zone === 'batiment_logement') ? 'ecran_intermediaire_les_desordres' : 'desordres_logement'
         break
-      case 'desordres_renseignes':
+      case 'desordres_precisions':
         previousScreenSlug = (formStore.data.zone_concernee_zone === 'batiment') ? 'desordres_batiment' : 'desordres_logement'
+        break
+      case 'desordres_renseignes':
+        previousScreenSlug = 'desordres_precisions'
         break
       default:
         previousScreenSlug = (['logement', 'batiment_logement'].includes(formStore.data.zone_concernee_zone) && currentStep.includes('logement'))
@@ -58,7 +61,7 @@ export function findNextScreen (
         if (formStore.data.zone_concernee_zone === 'batiment_logement') {
           nextScreenSlug = 'desordres_renseignes_batiment'
         } else if (formStore.data.zone_concernee_zone === 'batiment') {
-          nextScreenSlug = 'desordres_renseignes'
+          nextScreenSlug = 'desordres_precisions'
         }
       } else {
         nextScreenSlug = formStore.data.categorieDisorders.batiment[0]
@@ -66,7 +69,7 @@ export function findNextScreen (
       break
     case 'desordres_logement':
       if (slugButton === 'desordres_logement_ras') {
-        nextScreenSlug = 'desordres_renseignes'
+        nextScreenSlug = 'desordres_precisions'
       } else {
         nextScreenSlug = formStore.data.categorieDisorders.logement[0]
       }
@@ -89,10 +92,10 @@ export function findNextScreen (
       switch (formStore.data.zone_concernee_zone) {
         case 'batiment':
         case 'logement':
-          nextScreenSlug = 'desordres_renseignes'
+          nextScreenSlug = 'desordres_precisions'
           break
         case 'batiment_logement':
-          nextScreenSlug = slugButton.includes('batiment') ? 'desordres_renseignes_batiment' : 'desordres_renseignes'
+          nextScreenSlug = slugButton.includes('batiment') ? 'desordres_renseignes_batiment' : 'desordres_precisions'
           break
       }
       incrementIndex = 0

--- a/assets/scripts/vue/components/signalement-form/services/variableTester.ts
+++ b/assets/scripts/vue/components/signalement-form/services/variableTester.ts
@@ -1,6 +1,6 @@
 export const variableTester = {
   isNotEmpty (value: any): boolean {
-    return value !== undefined && value !== null && value !== ''
+    return !this.isEmpty(value)
   },
   isEmpty (value: any): boolean {
     return value === undefined || value === null || value === ''

--- a/assets/scripts/vue/components/signalement-form/services/variableTester.ts
+++ b/assets/scripts/vue/components/signalement-form/services/variableTester.ts
@@ -1,5 +1,8 @@
 export const variableTester = {
   isNotEmpty (value: any): boolean {
     return value !== undefined && value !== null && value !== ''
+  },
+  isEmpty (value: any): boolean {
+    return value === undefined || value === null || value === ''
   }
 }


### PR DESCRIPTION
## Ticket

#3219 
#3233
#3223

## Description
Le champ `Précisions sur les désordres` est déplacé dans un écran dédié avant l'écran de récap sur tous les désordres et devient obligatoire
Correction de 2 problèmes de dictionnaire dans le désordre "logement -électricité", et "logement - chauffage"
Correction d'un problème de validation sur le composant SignalementFormAddress

## Changements apportés
* Ajout d'un nouvel écran dans les 2 json de désordres
* Retrait du `SignalementFormTextarea` dans le composant `SignalementFormDisorderOverview` (car maintenant dans un écran séparé)
* Correction de la css custom dans le composant  `SignalementFormTextarea`
* Modification de `disorderScreenNavigator.ts` pour prendre en compte le nouvel écran
* Correction d'un label dans le json de désordres tiers (il manquait `dictionaryStore::` )
* Correction d'une entrée pour les multiprises dans le json dictionnaire
* Dans le composant SignalementFormAddress, on guette le désaffichage du subscreen pour remettre `_detail_manual` à 0 (et ainsi les champs ne sont plus testés dans la validation du composant)
* lint fix dans matomo.ts

## Pré-requis
`npm run watch`

## Tests
Tests à faire en occupant ET en tiers
- [ ] Déposer un signalement, en choisissant les 2 zones (ou seulement la zone logement pour un des 2 tests)
- [ ] Dans un écran avec une adresse facultative, modifier l'adresse à la main pour faire apparaitre le subscreen, puis supprimer les contenus de tous les champs de cette adresse facultative -> vérifier qu'on peut passer à l'écran suivant et qu'on n'a pas d'erreur sur les champs vides
- [ ] En logement, choisir les désordres électricité et chauffage
- [ ] Pour le chauffage, vérifier que le choix du type de chauffage est bien traduit dans le subscreen (`Ne sait pas` plutôt que `nsp`, `électricité` plutôt que `electricite`,` gaz, bois, ethanol ou fioul` plutôt que `gaz`)
- [ ] Pour le désordre électricité, choisir `il n'y a pas de prise ou il en manque`, et vérifier qu'on a un label correctement traduit à la question qui apparait en subscreen
- [ ] Vérifier qu'on a bien un écran pour ajouter un texte avant le récap, qu'il est obligatoire, et que la navigation précédent / suivant se fait bien entre les désordres, les précisions et le récap, et dans l'autre sens aussi
- [ ] Aller au bout du tépôt et vérifier l'affichage du texte de précisions dans le récap final
- [ ] Valider le signalement, et vérifier que le texte de précisions est bien enregistré et visible dans le BO et sur la fiche de signalement
