### PR TITLE
[BUG - Historique des affectations] masquer le bouton quand feature désactivée

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -4,9 +4,9 @@
 {% set static_picto_no = '<p class="fr-badge fr-badge--error">Non</p>' %}
 
 {% block content %}
-    {% if not needValidation and (is_granted('ROLE_ADMIN_TERRITORY') or canPartnerAffectation) %}
+    {% if not needValidation and canPartnerAffectation %}
         {% include '_partials/_modal_affectation.html.twig' %}
-        {% if (platform.feature_historique_affectations and is_granted('ROLE_ADMIN_TERRITORY')) or canPartnerAffectation %}
+        {% if platform.feature_historique_affectations and canPartnerAffectation %}
             {% include '_partials/_modal_historique_affectation.html.twig' %}
         {% endif %}
     {% endif %}

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -5,7 +5,7 @@
         </div>
         <div class="fr-col-3 fr-col-md-6">
             <div class="fr-text--right fr-btns-group fr-btns-group--sm fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
-                {% if (platform.feature_historique_affectations and is_granted('ROLE_ADMIN_TERRITORY')) or canPartnerAffectation %}
+                {% if platform.feature_historique_affectations %}
                     <button 
                         class="fr-btn fr-btn--secondary fr-btn--icon-left"
                         data-fr-opened="false"


### PR DESCRIPTION
## Ticket

#3248

## Description
- Correction (et simplification) des conditions d'affichage du bouton historique des affectations

## Tests
- [ ] Désactiver la feature et vérifier que le bouton ne s'affiche pas en SA/RT
