### PR TITLE
[FO - Formulaire - Accessibilité] Amélioration de la prise en compte des technologies d'assistance

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -15,6 +15,7 @@
       @keydown.down.prevent="handleDownSuggestion"
       @keydown.up.prevent="handleUpSuggestion"
       @keydown.enter.prevent="handleEnterSuggestion"
+      @keydown.escape.prevent="handleTabSuggestion"
       @keydown.tab="handleTabSuggestion"
     />
 

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormCounter.vue
@@ -19,6 +19,7 @@
     <div
       :id="id + 'text-input-error-desc-error'"
       class="fr-error-text"
+      role="alert"
       v-if="hasError"
       >
       {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -15,6 +15,7 @@
     <div
       :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
+      role="alert"
       v-if="hasError"
       >
       {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormEmailfield.vue
@@ -21,6 +21,7 @@
     <div
       :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
+      role="alert"
       v-if="hasError"
     >
       {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -35,7 +35,12 @@
           </div>
       </div>
       <div class="fr-messages-group" :id="id + '-radio-hint-messages'" aria-live="assertive">
-          <p class="fr-message fr-message--error fr-error-text" :id="id + '-messages-error'" v-if="hasError">{{ error }}</p>
+          <p
+            class="fr-message fr-message--error fr-error-text"
+            role="alert"
+            :id="id + '-messages-error'"
+            v-if="hasError"
+            >{{ error }}</p>
       </div>
   </fieldset>
 </template>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormPhonefield.vue
@@ -42,6 +42,7 @@
       <div
         :id="id + '-text-input-error-desc-error'"
         class="fr-error-text fr-mt-0 fr-mb-3v fr-ml-2v"
+        role="alert"
         v-if="hasErrorFirst"
         >
         {{ formStore.validationErrors[id] }}
@@ -105,6 +106,7 @@
       <div
         :id="idSecond + '-text-input-error-desc-error'"
         class="fr-error-text fr-mt-0 fr-mb-3v fr-ml-2v"
+        role="alert"
         v-if="hasErrorSecond"
         >
         {{ formStore.validationErrors[idSecond] }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormRoomList.vue
@@ -39,6 +39,7 @@
     <div
       id="text-input-error-desc-error"
       class="fr-error-text"
+      role="alert"
       v-if="hasError"
       >
       {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextarea.vue
@@ -20,6 +20,7 @@
     <div
       :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
+      role="alert"
       v-if="hasError"
       >
       {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTextfield.vue
@@ -23,6 +23,7 @@
     <div
       :id="id + '-text-input-error-desc-error'"
       class="fr-error-text"
+      role="alert"
       v-if="hasError"
       >
       {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormTime.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormTime.vue
@@ -13,6 +13,7 @@
   <div
     id="text-input-error-desc-error"
     class="fr-error-text"
+    role="alert"
     v-if="hasError"
     >
     {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -41,6 +41,7 @@
   <div
     :id="id + '-text-upload-error-desc-error'"
     class="fr-error-text"
+    role="alert"
     v-if="hasError"
     >
     {{ error }}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormYear.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormYear.vue
@@ -16,6 +16,7 @@
     <div
       id="text-input-error-desc-error"
       class="fr-error-text"
+      role="alert"
       v-if="hasError"
       >
       {{ error }}


### PR DESCRIPTION
## Ticket

#2547    

## Description
Reprise des retours que nous avons eues sur Stop Punaises. La plupart ont déjà été corrigés dans d'autres critères, ou n'étaient pas un souci.
Deux éléments ont été corrigés ici en complément :
- utilisation de la touche `Echap` pour masquer la liste de suggestion d'adresse (on le faisait avec la touche `TAB`, on réutilise le même événement)
- ajout d'un attribut `role=alert` sur les messages d'erreur

Plus tard : la liste déroulante de sélection multiple utilisée dans le BO devra sûrement être revue pour l'utilisation au clavier.

## Pré-requis
`npm run watch`

## Tests
- [ ] Vérifier qu'on peut fermer la liste des suggestions du composant Adresse si on appuie sur `Echap`
- [ ] Vérifier que les messages d'erreur des différents composants comportent bien un attribut `role=alert`
