### PR TITLE
[QA] Correction appel méthode label() quand le partenaire n'a pas de type

### DIFF
--- a/src/Service/UserExportLoader.php
+++ b/src/Service/UserExportLoader.php
@@ -47,7 +47,7 @@ readonly class UserExportLoader
                     'nom' => $user->getNom(),
                     'prenom' => $user->getPrenom(),
                     'partner' => $user->getPartner() ? $user->getPartner()->getNom() : '',
-                    'partnerType' => $user->getPartner() ? $user->getPartner()->getType()->label() : '',
+                    'partnerType' => $user->getPartner() && $user->getPartner()->getType() ? $user->getPartner()->getType()->label() : '',
                     'createdAt' => $user->getCreatedAt()->format('d/m/Y'),
                     'statut' => User::STATUS_ACTIVE === $user->getStatut() ? 'Activé' : 'Non activé',
                     'lastLoginAt' => $user->getLastLoginAt() ? $user->getLastLoginAt()->format('d/m/Y') : '',

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -91,7 +91,7 @@
                                     <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
                                 {% endif %}
                                 <td>{{ partner.nom }}</td>
-                                <td>{{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'Partenaire') }}</td>
+                                <td>{{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'N/A') }}</td>
                                 <td>
                                     {% if partner.competence %}
                                         <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ partner.competence|length }}</div>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -57,7 +57,7 @@
                 <div><b>E-mail générique :</b> {{ partner.email }}</div>
             </div>
             <div class="fr-col-6">
-                <div><b>Type :</b> {{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'Partenaire') }}</div>
+                <div><b>Type :</b> {{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'N/A') }}</div>
             </div>
         </div>
         <div class="fr-col-12 fr-grid-row fr-grid-row--gutters">

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -106,7 +106,7 @@
                                     <td>{{ user.prenom }} {{ user.nom }}</td>
                                     <td>{{ user.email }}</td>
                                     <td>{{ user.partner ? user.partner.nom }}</td>
-                                    <td>{{ user.partner ? user.partner.type.label }}</td>
+                                    <td>{{ user.partner and user.partner.type ? user.partner.type.label }}</td>
                                     <td>
                                         {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE') %}
                                             <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -106,7 +106,7 @@
                                     <td>{{ user.prenom }} {{ user.nom }}</td>
                                     <td>{{ user.email }}</td>
                                     <td>{{ user.partner ? user.partner.nom }}</td>
-                                    <td>{{ user.partner and user.partner.type ? user.partner.type.label }}</td>
+                                    <td>{{ user.partner and user.partner.type ? user.partner.type.label : 'N/A' }}</td>
                                     <td>
                                         {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE') %}
                                             <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>


### PR DESCRIPTION
## Ticket

#3251   

## Description
Pas mal de partenaires n'ont pas de type défini (à l'heure actuelle, environ 700 sur 6000).
Lors de l'export de la liste des utilisateurs, si le type de partenaire n'est pas défini, il y avait un plantage.

## Tests
- [ ] Dans la BDD, passer le type d'un ou plusieurs partenaires à NULL
- [ ] Afficher la liste des utilisateurs
- [ ] Exporter la liste des utlisateurs
