### PR TITLE
[FO/BO - Adresse] Application de la navigation clavier sur le composant d'adresse

### DIFF
--- a/assets/scripts/vanilla/controllers/front_demande_lien_signalement/front_demande_lien_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_demande_lien_signalement/front_demande_lien_signalement.js
@@ -24,6 +24,4 @@ function attachSubmitFormDemandeLienSignalementEvent () {
       })
     return true
   })
-  const inputAdresse = document?.querySelector('#demande_lien_signalement_adresseHelper')
-  attacheAutocompleteAddressEvent(inputAdresse)
 }

--- a/assets/scripts/vanilla/services/component_search_address.js
+++ b/assets/scripts/vanilla/services/component_search_address.js
@@ -24,8 +24,10 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
   if (!inputAdresse) {
     return false
   }
-  const apiAdresse = 'https://api-adresse.data.gouv.fr/search/?q='
+
+  let selectionIndex = -1
   const addressGroup = document?.querySelector(inputAdresse.dataset.autocompleteQuerySelector)
+  const apiAdresse = 'https://api-adresse.data.gouv.fr/search/?q='
   inputAdresse.addEventListener('input', (e) => {
     const adresse = e.target.value
     if (adresse.length > 8) {
@@ -78,6 +80,43 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
       if (document?.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]')) {
         document.querySelector('#' + idForm + ' [data-autocomplete-geoloclat]').value = ''
       }
+    }
+  })
+
+  inputAdresse.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' || e.key === 'Tab') {
+      addressGroup.innerHTML = ''
+      selectionIndex = -1
+    }
+    
+    if (e.key === 'ArrowDown') {
+      if (addressGroup.children.length > 0) {
+        selectionIndex = Math.min(selectionIndex + 1, addressGroup.children.length - 1)
+      } else {
+        selectionIndex = -1
+      }
+    }
+    if (e.key === 'ArrowUp') {
+      if (addressGroup.children.length > 0) {
+        selectionIndex = Math.max(selectionIndex - 1, 0)
+      } else {
+        selectionIndex = -1
+      }
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault() // avoids form submit
+      if (selectionIndex > -1) {
+        addressGroup.children[selectionIndex].click()
+      }
+      addressGroup.innerHTML = ''
+      selectionIndex = -1
+    }
+
+    document.querySelectorAll('.fr-adresse-suggestion').forEach((element) => {
+      element.classList.remove('fr-autocomplete-suggestion-highlighted')
+    })
+    if (selectionIndex > -1) {
+      addressGroup.children[selectionIndex].classList.add('fr-autocomplete-suggestion-highlighted')
     }
   })
 }

--- a/templates/back/signalement/view/edit-modals/edit-address.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-address.html.twig
@@ -22,6 +22,7 @@
                                             <span class="fr-hint-text">Tapez l'adresse et sélectionnez-la dans la liste</span>
                                         </label>
                                         <input class="fr-input search-address-autocomplete" type="text" id="edit-address-search"
+                                            autocomplete="off"
                                             data-fr-adresse-autocomplete="true" 
                                             data-autocomplete-query-selector="#form-edit-address .fr-address-group-bo"
                                             data-form-id="form-edit-address" 


### PR DESCRIPTION
## Ticket

#3256   

## Description
Application du même fonctionnement de navigation au clavier que pour le composant Vue dans le composant Vanilla

## Tests
- [ ] Front - Retrouver son lien de signalement : utiliser la recherche d'adresse au clavier
- [ ] Back - Edition d'adresse : utiliser la recherche d'adresse au clavier
