### PR TITLE
[SEO] Ajout du fichier sitemap.xml

### DIFF
--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -81,7 +81,11 @@ class SecurityController extends AbstractController
         return $this->json(['success']);
     }
 
-    #[Route('/connexion', name: 'app_login')]
+    #[Route(
+        '/connexion',
+        name: 'app_login',
+        defaults: ['show_sitemap' => true]
+    )]
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         $title = 'Connexion';

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -21,7 +21,11 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class UserAccountController extends AbstractController
 {
-    #[Route('/activation', name: 'login_activation')]
+    #[Route(
+        '/activation',
+        name: 'login_activation',
+        defaults: ['show_sitemap' => true]
+    )]
     public function requestLoginLink(
         NotificationMailerRegistry $notificationMailerRegistry,
         UserRepository $userRepository,
@@ -62,7 +66,11 @@ class UserAccountController extends AbstractController
         return $this->render('security/login_activation.html.twig');
     }
 
-    #[Route('/mot-de-pass-perdu', name: 'login_mdp_perdu')]
+    #[Route(
+        '/mot-de-pass-perdu',
+        name: 'login_mdp_perdu',
+        defaults: ['show_sitemap' => true]
+    )]
     public function requestNewPass(
         UserRepository $userRepository,
         Request $request,

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -42,7 +42,11 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 #[Route('/')]
 class SignalementController extends AbstractController
 {
-    #[Route('/signalement', name: 'front_signalement')]
+    #[Route(
+        '/signalement',
+        name: 'front_signalement',
+        defaults: ['show_sitemap' => true]
+    )]
     public function index(
     ): Response {
         return $this->render('front/nouveau_formulaire.html.twig', [

--- a/src/Controller/StatistiquesController.php
+++ b/src/Controller/StatistiquesController.php
@@ -34,7 +34,11 @@ class StatistiquesController extends AbstractController
     ) {
     }
 
-    #[Route('/stats', name: 'front_statistiques')]
+    #[Route(
+        '/stats',
+        name: 'front_statistiques',
+        defaults: ['show_sitemap' => true]
+    )]
     public function statistiques(): Response
     {
         return $this->render('front/statistiques.html.twig');

--- a/templates/front/sitemap.xml.twig
+++ b/templates/front/sitemap.xml.twig
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {% for url in urls %}
+        <url>
+            <loc>{{ url.loc }}</loc>
+        </url>
+    {% endfor %}
+</urlset>


### PR DESCRIPTION
## Ticket

#3259   

## Description
On avait ajouté la page plan du site, mais pas le fichier `sitemap.xml`.

## Changements apportés
Comme pour Stop Punaises, on ajoute un paramètre `show_sitemap` dans les routes pour déterminer si la route doit apparaître dans le fichier ou non.

## Tests
- [ ] La sitemap s'affiche bien sur http://localhost:8080/sitemap.xml
- [ ] Les autres routes s'affichent toujours correctement
