### PR TITLE
[BUG - Rouvrir signalement] Un RT doit pouvoir rouvrir in signalement pour lui même

### DIFF
--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -218,7 +218,7 @@
                             </button>
                         {% endif %}
                     {% endif %}
-                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or (is_granted('ROLE_ADMIN_TERRITORY') and isAffected) %}
+                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or (is_granted('ROLE_ADMIN_TERRITORY') or isAffected) %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                                 aria-controls="reopen-signalement-modal" data-fr-opened="false">
                             Rouvrir pour {{ app.user.partner.nom }}


### PR DESCRIPTION
## Ticket

#3264

## Description
Possibilité pour un RT de rouvrir un signalement pour lui même (même sans y être affecté)

## Tests
- [ ] S'assurer qu'un RT peux toujours rouvrir pour lui même un signalement clôturé
- [ ] S'assurer que la modification n'as pas d'effet de bord 
