### PR TITLE
[FO - page de suivi usager] Afficher les infos saisies dans le champ "précisions"

### DIFF
--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -291,6 +291,15 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 	{% endif %}
 </div>
 
+<div class="fr-mb-4v">
+	<h4 class="fr-mb-2v">Précisions sur votre situation</h4>
+	{% if signalement.details and signalement.details != 'N/C' %}
+		{{ signalement.details }}
+	{% else %}
+		Aucun commentaire
+	{% endif %}
+</div>
+
 <h4 class="fr-mb-2v">Vos photos</h4>
 <div class="fr-mb-4v">
 	{% if signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile)|length %}

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -294,7 +294,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 <div class="fr-mb-4v">
 	<h4 class="fr-mb-2v">Précisions sur votre situation</h4>
 	{% if signalement.details and signalement.details != 'N/C' %}
-		{{ signalement.details }}
+		{{ signalement.details|nl2br }}
 	{% else %}
 		Aucun commentaire
 	{% endif %}


### PR DESCRIPTION
## Ticket

#3273   

## Description
En complément du https://github.com/MTES-MCT/histologe/issues/3223 , il faudrait afficher dans la page de suivi usager le contenu du champ Précisions sur votre situation, à la suite des désordres
Si pas de précisions on met `Aucun commentaire`

## Changements apportés
* Changement du twig

## Pré-requis

## Tests
- [ ] Parcourir plusieurs pages de suivis usagers, (avec et sans texte de détails) et vérifier l'afficchage de la page de suivi
