### PR TITLE
[BUG] erreur upload synchro IDOSS

### DIFF
--- a/src/Command/Cron/SynchronizeIdossCommand.php
+++ b/src/Command/Cron/SynchronizeIdossCommand.php
@@ -15,6 +15,7 @@ use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -160,6 +161,9 @@ class SynchronizeIdossCommand extends AbstractCronCommand
         return $nbStatusUpdated;
     }
 
+    /**
+     * @throws FilesystemException
+     */
     private function uploadFilesOnIdoss(): int
     {
         $nbFilesUploaded = 0;

--- a/src/Service/ImageManipulationHandler.php
+++ b/src/Service/ImageManipulationHandler.php
@@ -114,17 +114,17 @@ class ImageManipulationHandler
      */
     public function getFilePath(File $file): string
     {
-        $filename = $file->getFilename();
         $variantNames = self::getVariantNames($file->getFilename());
         $filename = $variantNames[self::SUFFIX_RESIZE];
-        if (!$this->fileStorage->fileExists($filename) && !$this->fileStorage->fileExists($file->getFilename())) {
-            throw new FileNotFoundException($filename);
+        $originalFilename = $file->getFilename();
+        if ($this->fileStorage->fileExists($filename)) {
+            return $this->parameterBag->get('url_bucket').'/'.$filename;
         }
-        if (!$this->fileStorage->fileExists($filename)) {
-            $filename = $file->getFilename();
+        if ($this->fileStorage->fileExists($originalFilename)) {
+            return $this->parameterBag->get('url_bucket').'/'.$originalFilename;
         }
 
-        return $this->parameterBag->get('url_bucket').'/'.$filename;
+        throw new FileNotFoundException($filename);
     }
 
     private function getNewPath(string $suffix): string

--- a/tests/MockableResizeImage.php
+++ b/tests/MockableResizeImage.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Tests;
+
+use Intervention\Image\Image;
+use Psr\Http\Message\StreamInterface;
+
+class MockableResizeImage extends Image
+{
+    public function resize($width, $height, $callback = null): Image
+    {
+        return static::resize($width, $height, $callback);
+    }
+
+    public function stream(?string $format = null, int $quality = 90): StreamInterface
+    {
+        return static::stream($format, $quality);
+    }
+}

--- a/tests/MockableThumbnailImage.php
+++ b/tests/MockableThumbnailImage.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Tests;
+
+use Intervention\Image\Image;
+use Psr\Http\Message\StreamInterface;
+
+class MockableThumbnailImage extends Image
+{
+    public function fit(int $width, ?int $height = null): Image
+    {
+        return static::fit($width, $height);
+    }
+
+    public function stream(?string $format = null, int $quality = 90): StreamInterface
+    {
+        return static::stream($format, $quality);
+    }
+}

--- a/tests/Unit/Service/ImageInterventionHandlerTest.php
+++ b/tests/Unit/Service/ImageInterventionHandlerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\ImageManipulationHandler;
+use App\Tests\MockableResizeImage;
+use App\Tests\MockableThumbnailImage;
+use Intervention\Image\ImageManager;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+class ImageInterventionHandlerTest extends TestCase
+{
+    private MockObject|ParameterBagInterface $parameterBag;
+    private MockObject|FilesystemOperator $fileStorage;
+    private MockObject|ImageManager $imageManager;
+
+    protected function setUp(): void
+    {
+        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
+        $this->fileStorage = $this->createMock(FilesystemOperator::class);
+        $this->fileStorage
+            ->expects($this->atLeast(0))
+            ->method('writeStream');
+
+        $this->fileStorage
+            ->expects($this->atLeast(0))
+            ->method('readStream')
+            ->willReturn(__DIR__.'/../../files/sample.jpg');
+
+        $this->imageManager = $this->createMock(ImageManager::class);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testResize(): void
+    {
+        $manager = new ImageManager();
+        $image = $manager->make(__DIR__.'/../../files/sample.jpg');
+
+        $imageMock = $this->createMock(MockableResizeImage::class);
+        $imageMock->expects($this->once())
+            ->method('resize')
+            ->with(1000, 1000, $this->isType('callable'))
+            ->willReturn($image);
+
+        $streamMock = $this->createMock(StreamInterface::class);
+        $imageMock
+            ->expects($this->once())
+            ->method('stream')->willReturn($streamMock);
+
+        $this->imageManager
+            ->expects($this->once())
+            ->method('make')
+            ->with(__DIR__.'/../../files/sample.jpg')
+            ->willReturn($imageMock);
+
+        $imageManipulationHandler = new ImageManipulationHandler(
+            $this->parameterBag,
+            $this->fileStorage,
+            $this->imageManager
+        );
+
+        $result = $imageManipulationHandler->resize(__DIR__.'/../../files/sample.jpg');
+
+        $this->assertInstanceOf(ImageManipulationHandler::class, $result);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testThumbnail(): void
+    {
+        $manager = new ImageManager();
+        $image = $manager->make(__DIR__.'/../../files/sample.jpg');
+
+        $imageMock = $this->createMock(MockableThumbnailImage::class);
+        $imageMock->expects($this->once())
+            ->method('fit')
+            ->with(400, 400)
+            ->willReturn($image);
+
+        $streamMock = $this->createMock(StreamInterface::class);
+        $imageMock
+            ->expects($this->once())
+            ->method('stream')
+            ->willReturn($streamMock);
+
+        $this->parameterBag
+            ->expects($this->once())
+            ->method('get')
+            ->with('bucket_tmp_dir')
+            ->willReturn('/tmp');
+
+        $this->imageManager
+            ->expects($this->once())
+            ->method('make')
+            ->with(__DIR__.'/../../files/sample.jpg')
+            ->willReturn($imageMock);
+
+        $imageManipulationHandler = new ImageManipulationHandler(
+            $this->parameterBag,
+            $this->fileStorage,
+            $this->imageManager
+        );
+
+        $result = $imageManipulationHandler->thumbnail(__DIR__.'/../../files/sample.jpg');
+
+        $this->assertInstanceOf(ImageManipulationHandler::class, $result);
+    }
+
+    /**
+     * @dataProvider provideFile
+     */
+    public function testIsImage(string $filepath, bool $result): void
+    {
+        $imageManipulationHandler = new ImageManipulationHandler(
+            $this->parameterBag,
+            $this->fileStorage,
+            $this->imageManager
+        );
+
+        $this->assertEquals($result, $imageManipulationHandler->isImage($filepath));
+    }
+
+    public function provideFile(): \Generator
+    {
+        yield 'sample.jpg is image' => [__DIR__.'/../../files/sample.jpg', true];
+        yield 'sample.pdf is not image ' => [__DIR__.'/../../files/sample.pdf', false];
+    }
+}


### PR DESCRIPTION
## Ticket

#3279    

## Description
Voici les deux types d'erreur trouvé en base

* `The value of the form field "id" can only be a string, an array, or an instance of TextPart, "null" given. `

* `{"message":"Erreur lors du transfère de fichiers ! Dossier :","uuid":"xxx","id":"xxx","xxx":"MulterError: Unexpected field"}`

Toutes les payload se ressemblent (succès comme échec) donc difficile de voir d'ou vient le problème cependant j'ai remarqué qu'on essaie de récupérer un fichier de resize pour les documents (pdf)

Surement cette erreur, `The value of the form field "id" can only be a string, an array, or an instance of TextPart, "null" given. `
fichier xxx_resize.pdf n’existe pas et au moment de construire le data_part le fichier est null

Il faudrait avoir la vrai structure de la payload loggé dans la table pour avancer dans les investigations.

* `{"message":"Erreur lors du transfère de fichiers ! Dossier :","uuid":"xxx","id":"xxx","xxx":"MulterError: Unexpected field"}`
Pas de piste pour celle ci pour le moment, voyons voir ce que donne cette PR


## Changements apportés
* Ajout d'une fonction afin de déterminer s'il s'agit d'une image
* Sauvegarde de la payload avec la structure du datapart (pas sérialisable) mais la structure est suffisante
* Ajout d'un TU sur le service `ImageManipulationHandler`

## Pré-requis
```
make mock-stop
make mock-start
```

Partir sur une base vierge
```
make create-db
```

## Tests
- [ ] Exécuter la commande `make console app=synchronize-idoss` et vérifier que tout est OK au niveau des appels dans la table job_event

Si un fichier du dossier est absent, pousser le sur le bucket de dev et re-exécuter la commande
`aws s3 cp scripts/local/blank.pdf  s3://XXXXXXXXXXXXXXXXXXXXXXXXXX/test1.pdf`

`aws s3 cp scripts/local/blank.png  s3://XXXXXXXXXXXXXXXXXXXXXXXXXX/test1.png`

`aws s3 cp scripts/local/blank.jpg  s3://XXXXXXXXXXXXXXXXXXXXXXXXXX/test1.jpg`
