### PR TITLE
[BO - Menu] Ajouter nb de notif non lues dans le menu

### DIFF
--- a/templates/back/nav_bo.html.twig
+++ b/templates/back/nav_bo.html.twig
@@ -1,4 +1,5 @@
 {% if platform.feature_enable_menu_horizontale %}
+    {% set notification_count = count_notification(app.user) %}
     <header class="fr-header">
         <div class="fr-header__body">
             <div class="{{ container_class }}">
@@ -28,7 +29,8 @@
                                 <li>
                                     <a class="fr-btn fr-icon-notification-3-fill notification-icon" href="{{ path('back_notifications_list') }}">
                                         Notifications
-                                        {% if count_notification(app.user) > 0 %}
+                                        {% if notification_count > 0 %}
+                                            ({{ notification_count }})
                                             <span class="notification-badge"></span>
                                         {% endif %}
                                     </a>


### PR DESCRIPTION
## Ticket

#3283    

## Description
Comme sur le menu actuel ajouter le nombre de notif après le libellé du menu notification

## Changements apportés
* Ajout du nombre entre parenthèse

## Pré-requis
```
FEATURE_ENABLE_MENU_HORIZONTALE=1
```
## Tests
- [ ] Vérifier que le libellé notifications est suivi d'un nombre 
- [ ] Vérifier que le nombre entre parenthèse disparaît si pas de notif à lire 
