### PR TITLE
[BUG] erreur upload synchro IDOSS (nb files limit)

### DIFF
--- a/src/Service/ImageManipulationHandler.php
+++ b/src/Service/ImageManipulationHandler.php
@@ -115,12 +115,10 @@ class ImageManipulationHandler
     public function getFilePath(File $file): string
     {
         $filename = $file->getFilename();
-        if ($this->isImage($filename)) {
-            $variantNames = self::getVariantNames($file->getFilename());
-            $filename = $variantNames[self::SUFFIX_RESIZE];
-        }
+        $variantNames = self::getVariantNames($file->getFilename());
+        $filename = $variantNames[self::SUFFIX_RESIZE];
         if (!$this->fileStorage->fileExists($filename) && !$this->fileStorage->fileExists($file->getFilename())) {
-            throw new FileNotFoundException('File "'.$filename.'" not found');
+            throw new FileNotFoundException($filename);
         }
         if (!$this->fileStorage->fileExists($filename)) {
             $filename = $file->getFilename();
@@ -150,12 +148,5 @@ class ImageManipulationHandler
         $thumb = $pathInfo['filename'].self::SUFFIX_THUMB.$ext;
 
         return [self::SUFFIX_RESIZE => $resize, self::SUFFIX_THUMB => $thumb];
-    }
-
-    public function isImage(string $filename): bool
-    {
-        $extension = strtolower(pathinfo($filename, \PATHINFO_EXTENSION));
-
-        return in_array($extension, File::IMAGE_EXTENSION);
     }
 }

--- a/src/Service/Interconnection/Idoss/IdossService.php
+++ b/src/Service/Interconnection/Idoss/IdossService.php
@@ -38,6 +38,7 @@ class IdossService
     private const CREATE_DOSSIER_ENDPOINT = '/api/EtatCivil/creatDossHistologe';
     private const UPLOAD_FILES_ENDPOINT = '/api/EtatCivil/uploadFileRepoHistologe';
     private const LIST_STATUTS_ENDPOINT = '/api/EtatCivil/listStatutsHistologe';
+    private const NB_MAX_FILES = 20;
 
     public function __construct(
         private readonly HttpClientInterface $client,
@@ -88,6 +89,9 @@ class IdossService
             }
             $files[] = $file;
             $filesJson[] = ['id' => $file->getId(), 'filename' => $file->getFilename()];
+            if (count($files) >= self::NB_MAX_FILES) {
+                break;
+            }
         }
         if (!\count($files)) {
             return false;

--- a/tests/Unit/Service/ImageInterventionHandlerTest.php
+++ b/tests/Unit/Service/ImageInterventionHandlerTest.php
@@ -113,20 +113,6 @@ class ImageInterventionHandlerTest extends TestCase
         $this->assertInstanceOf(ImageManipulationHandler::class, $result);
     }
 
-    /**
-     * @dataProvider provideFile
-     */
-    public function testIsImage(string $filepath, bool $result): void
-    {
-        $imageManipulationHandler = new ImageManipulationHandler(
-            $this->parameterBag,
-            $this->fileStorage,
-            $this->imageManager
-        );
-
-        $this->assertEquals($result, $imageManipulationHandler->isImage($filepath));
-    }
-
     public function provideFile(): \Generator
     {
         yield 'sample.jpg is image' => [__DIR__.'/../../files/sample.jpg', true];


### PR DESCRIPTION
## Ticket

#3279

## Description
Les 4 dossiers en erreurs concerne des synchronisation ou l'on tente d'envoyer plus de 20 fichiers en un seul appel. Je n'ai pas retrouvé la trace dans la doc mais de mémoire c'était une limite IDOSS.

## Changements apportés
* Ajout d'une limite du nombre fichiers par appel idoss (les suivant se feront à la synchro suivante, par lot de 20)
* Retrait du check isImage de la #3285 car déja vérifié et ok 
![Capture d’écran 2024-11-14 140333](https://github.com/user-attachments/assets/bffed5eb-ecb0-409b-9281-f38148a68868)

## Tests
- [ ] Lancer la commande `app:synchronize-idoss` et s'assurer que le nombre de fichiers est limité à 20
