### PR TITLE
[BO - dashboard] Mettre la même marge sur le bandeau stats que pour le reste de la page

### DIFF
--- a/assets/scripts/vue/components/dashboard/TheHistoDashboardHeader.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoDashboardHeader.vue
@@ -107,7 +107,7 @@ export default defineComponent({
   .histo-dashboard-header div.header-list div.header-item {
     display: table-cell;
     background-color: #FFF;
-    padding: 6px 12px;
+    padding: 6px 1.95rem;
   }
   .histo-dashboard-header div.header-list div.border-left {
     display: table-cell;
@@ -115,7 +115,7 @@ export default defineComponent({
     margin-right: 5px;
   }
 
-  @media (max-width: 1200px) {
+  @media (max-width: 1550px) {
     .histo-dashboard-header div.header-list {
       display: block;
       cursor: pointer;


### PR DESCRIPTION
## Ticket

#3284   
![image](https://github.com/user-attachments/assets/198073c7-7fd7-4436-bca5-1696e1643885)

## Description
## Changements apportés
* Augmentation de la marge interne sur l'axe x
* Mise à jour de la média query 

## Pré-requis

```
make npm-watch
```
## Tests
- [ ] Afficher le dashboard
