### PR TITLE
[FO - Signalement] Champs détails des désordres facultatif pour tiers (hors tiers particulier)

### DIFF
--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -2899,6 +2899,24 @@
           },
           "validate": {
             "message": "Veuillez détailler la situation."
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'tiers_particulier'"
+          }
+        },
+        {
+          "type": "SignalementFormTextarea",
+          "slug": "message_administration",
+          "customCss": "fr-mt-5v",
+          "label": "Votre message ici (facultatif) :",
+          "accessibility": {
+            "focus": true
+          },
+          "validate": {
+            "required": false
+          },
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers !== 'tiers_particulier'"
           }
         }
       ],


### PR DESCRIPTION
## Ticket

#3282    

## Description
Le champ de texte libre qui permet de saisir des informations complémentaires sur les désordres devient facultatif pour les tiers, sauf pour les tiers particuliers.

## Changements apportés
* Champ dédoublé dans le fichier tiers

## Tests
- [ ] En tiers particulier : le champ est toujours obligatoire
- [ ] Autre tiers : le champ est facultatif
