### PR TITLE
[FO - Form] Ajouter un champ "classe énergétique"

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1003,6 +1003,52 @@
           "validate": {
             "required": false
           }
+        },
+        {
+          "type": "SignalementFormSelect",
+          "slug": "bail_dpe_classe_energetique",
+          "label": "Quelle est la classe énergétique du logement ?",
+          "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
+          "values": [
+            {
+              "label": "A",
+              "value": "A"
+            },
+            {
+              "label": "B",
+              "value": "B"
+            },
+            {
+              "label": "C",
+              "value": "C"
+            },
+            {
+              "label": "D",
+              "value": "D"
+            },
+            {
+              "label": "E",
+              "value": "E"
+            },
+            {
+              "label": "F",
+              "value": "F"
+            },
+            {
+              "label": "G",
+              "value": "G"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ],
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer la classe énergétique pour le logement."
+          }
         }
       ],
       "footer": [
@@ -1127,7 +1173,7 @@
           "type": "SignalementFormDate",
           "label": "Quelle est la date de naissance de l'allocataire ?",
           "slug": "logement_social_date_naissance",
-          "hint": "Format attendu : JJ/MM/AAAA",
+          "description": "Format attendu : JJ/MM/AAAA",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },
@@ -1643,7 +1689,7 @@
                 "type": "SignalementFormDate",
                 "label": "Quelle est votre date de naissance ?",
                 "slug": "informations_complementaires_situation_bailleur_date_naissance",
-                "hint": "Format attendu : JJ/MM/AAAA",
+                "description": "Format attendu : JJ/MM/AAAA",
                 "validate": {
                   "required": false
                 }

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -813,7 +813,7 @@
         {
           "type": "SignalementFormDate",
           "label": "A quelle date avez-vous emménagé dans le logement ?",
-          "hint": "Format attendu : JJ/MM/AAAA. Si vous ne connaissez pas la date exacte, sélectionnez un jour du mois d'emménagement",
+          "description": "Format attendu : JJ/MM/AAAA. Si vous ne connaissez pas la date exacte, sélectionnez un jour du mois d'emménagement",
           "slug": "bail_dpe_date_emmenagement",
           "validate": {
             "message": "Veuillez renseigner une date d'emménagement."
@@ -861,6 +861,52 @@
           },
           "validate": {
             "required": false
+          }
+        },
+        {
+          "type": "SignalementFormSelect",
+          "slug": "bail_dpe_classe_energetique",
+          "label": "Quelle est la classe énergétique de votre logement ?",
+          "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
+          "values": [
+            {
+              "label": "A",
+              "value": "A"
+            },
+            {
+              "label": "B",
+              "value": "B"
+            },
+            {
+              "label": "C",
+              "value": "C"
+            },
+            {
+              "label": "D",
+              "value": "D"
+            },
+            {
+              "label": "E",
+              "value": "E"
+            },
+            {
+              "label": "F",
+              "value": "F"
+            },
+            {
+              "label": "G",
+              "value": "G"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ],
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer la classe énergétique pour le logement."
           }
         }
       ],
@@ -1032,7 +1078,7 @@
           "type": "SignalementFormDate",
           "label": "Quelle est votre date de naissance ?",
           "slug": "logement_social_date_naissance",
-          "hint": "Format attendu : JJ/MM/AAAA",
+          "description": "Format attendu : JJ/MM/AAAA",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -925,7 +925,7 @@
         {
           "type": "SignalementFormDate",
           "label": "A quelle date avez-vous emménagé dans le logement ?",
-          "hint": "Format attendu : JJ/MM/AAAA. Si vous ne connaissez pas la date exacte, sélectionnez un jour du mois d'emménagement",
+          "description": "Format attendu : JJ/MM/AAAA. Si vous ne connaissez pas la date exacte, sélectionnez un jour du mois d'emménagement",
           "slug": "bail_dpe_date_emmenagement",
           "validate": {
             "message": "Veuillez renseigner une date d'emménagement."
@@ -1055,6 +1055,52 @@
           },
           "validate": {
             "required": false
+          }
+        },
+        {
+          "type": "SignalementFormSelect",
+          "slug": "bail_dpe_classe_energetique",
+          "label": "Quelle est la classe énergétique de votre logement ?",
+          "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
+          "values": [
+            {
+              "label": "A",
+              "value": "A"
+            },
+            {
+              "label": "B",
+              "value": "B"
+            },
+            {
+              "label": "C",
+              "value": "C"
+            },
+            {
+              "label": "D",
+              "value": "D"
+            },
+            {
+              "label": "E",
+              "value": "E"
+            },
+            {
+              "label": "F",
+              "value": "F"
+            },
+            {
+              "label": "G",
+              "value": "G"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ],
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer la classe énergétique pour le logement."
           }
         }
       ],
@@ -1226,7 +1272,7 @@
           "type": "SignalementFormDate",
           "label": "Quelle est votre date de naissance ?",
           "slug": "logement_social_date_naissance",
-          "hint": "Format attendu : JJ/MM/AAAA",
+          "description": "Format attendu : JJ/MM/AAAA",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },
@@ -1690,7 +1736,7 @@
                 "type": "SignalementFormDate",
                 "label": "Quelle est votre date de naissance ?",
                 "slug": "informations_complementaires_situation_occupants_date_naissance",
-                "hint": "Format attendu : JJ/MM/AAAA",
+                "description": "Format attendu : JJ/MM/AAAA",
                 "conditional": {
                   "show": "formStore.data.logement_social_allocation === 'non'"
                 },

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1107,6 +1107,52 @@
           "validate": {
             "required": false
           }
+        },
+        {
+          "type": "SignalementFormSelect",
+          "slug": "bail_dpe_classe_energetique",
+          "label": "Quelle est la classe énergétique du logement ?",
+          "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
+          "values": [
+            {
+              "label": "A",
+              "value": "A"
+            },
+            {
+              "label": "B",
+              "value": "B"
+            },
+            {
+              "label": "C",
+              "value": "C"
+            },
+            {
+              "label": "D",
+              "value": "D"
+            },
+            {
+              "label": "E",
+              "value": "E"
+            },
+            {
+              "label": "F",
+              "value": "F"
+            },
+            {
+              "label": "G",
+              "value": "G"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ],
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer la classe énergétique pour le logement."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1134,6 +1134,52 @@
           "validate": {
             "required": false
           }
+        },
+        {
+          "type": "SignalementFormSelect",
+          "slug": "bail_dpe_classe_energetique",
+          "label": "Quelle est la classe énergétique du logement ?",
+          "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
+          "values": [
+            {
+              "label": "A",
+              "value": "A"
+            },
+            {
+              "label": "B",
+              "value": "B"
+            },
+            {
+              "label": "C",
+              "value": "C"
+            },
+            {
+              "label": "D",
+              "value": "D"
+            },
+            {
+              "label": "E",
+              "value": "E"
+            },
+            {
+              "label": "F",
+              "value": "F"
+            },
+            {
+              "label": "G",
+              "value": "G"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ],
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer la classe énergétique pour le logement."
+          }
         }
       ],
       "footer": [
@@ -1258,7 +1304,7 @@
           "type": "SignalementFormDate",
           "label": "Quelle est la date de naissance de l'allocataire ?",
           "slug": "logement_social_date_naissance",
-          "hint": "Format attendu : JJ/MM/AAAA",
+          "description": "Format attendu : JJ/MM/AAAA",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1118,6 +1118,52 @@
           "validate": {
             "required": false
           }
+        },
+        {
+          "type": "SignalementFormSelect",
+          "slug": "bail_dpe_classe_energetique",
+          "label": "Quelle est la classe énergétique du logement ?",
+          "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
+          "values": [
+            {
+              "label": "A",
+              "value": "A"
+            },
+            {
+              "label": "B",
+              "value": "B"
+            },
+            {
+              "label": "C",
+              "value": "C"
+            },
+            {
+              "label": "D",
+              "value": "D"
+            },
+            {
+              "label": "E",
+              "value": "E"
+            },
+            {
+              "label": "F",
+              "value": "F"
+            },
+            {
+              "label": "G",
+              "value": "G"
+            },
+            {
+              "label": "Je ne sais pas",
+              "value": "nsp"
+            }
+          ],
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
+          "validate": {
+            "message": "Veuillez indiquer la classe énergétique pour le logement."
+          }
         }
       ],
       "footer": [
@@ -1242,7 +1288,7 @@
           "type": "SignalementFormDate",
           "label": "Quelle est la date de naissance de l'allocataire ?",
           "slug": "logement_social_date_naissance",
-          "hint": "Format attendu : JJ/MM/AAAA",
+          "description": "Format attendu : JJ/MM/AAAA",
           "conditional": {
             "show": "formStore.data.logement_social_allocation === 'oui'"
           },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormComponentGenerator.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormComponentGenerator.vue
@@ -5,7 +5,6 @@
       v-bind:key="component.slug"
       :id="component.slug"
       :label="component.label"
-      :hint="component.hint"
       :labelInfo="component.labelInfo"
       :labelUpload="component.labelUpload"
       :description="component.description"
@@ -46,6 +45,7 @@ import SignalementFormTextarea from './SignalementFormTextarea.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormLink from './SignalementFormLink.vue'
 import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
+import SignalementFormSelect from './SignalementFormSelect.vue'
 import SignalementFormDate from './SignalementFormDate.vue'
 import SignalementFormYear from './SignalementFormYear.vue'
 import SignalementFormTime from './SignalementFormTime.vue'
@@ -77,6 +77,7 @@ export default defineComponent({
     SignalementFormButton,
     SignalementFormLink,
     SignalementFormOnlyChoice,
+    SignalementFormSelect,
     SignalementFormDate,
     SignalementFormYear,
     SignalementFormTime,

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDate.vue
@@ -1,7 +1,9 @@
 <template>
   <div :class="['fr-input-group', {'fr-input-group--error' : hasError}]" :id="id" :ref="id">
-    <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">{{ label }}</label>
-    <span v-if="hint !== ''" class="fr-hint-text">{{ hint }}</span>
+    <label :class="[ customCss, 'fr-label' ]" :for="id + '_input'">
+      {{ label }}
+      <span v-if="description !== ''" class="fr-hint-text">{{ description }}</span>
+    </label>
     <input
       type="date"
       :id="id + '_input'"
@@ -31,7 +33,7 @@ export default defineComponent({
   props: {
     id: { type: String, default: null },
     label: { type: String, default: null },
-    hint: { type: String, default: null },
+    description: { type: String, default: null },
     modelValue: { type: String, default: null },
     customCss: { type: String, default: '' },
     hasError: { type: Boolean, default: false },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -364,6 +364,12 @@ export default defineComponent({
       }
       result += this.addLineIfNeeded('composition_logement_nombre_personnes', 'Nombre de personnes : ')
       result += this.addLineIfNeeded('composition_logement_enfants', 'Enfants de moins de 6 ans ? ')
+      result += this.addLineIfNeeded('bail_dpe_bail', 'Bail établi ? ')
+      result += this.addLineIfNeeded('bail_dpe_etat_des_lieux', 'Etat des lieux réalisé ? ')
+      result += this.addLineIfNeeded('bail_dpe_dpe', 'DPE réalisé ? ')
+      if (this.formStore.data.bail_dpe_dpe === 'oui') {
+        result += this.addLineIfNeeded('bail_dpe_classe_energetique', 'Classe énergétique du logement : ')
+      }
       return result
     },
     getFormDataSituationOccupant (): string {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSelect.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSelect.vue
@@ -1,0 +1,90 @@
+<template>
+  <div
+    :id="id"
+    :class="[customCss, 'fr-select-group', { 'fr-select-group--error': hasError }]"
+    :aria-labelledby="id + '-select-label'"
+  >
+    <label
+      :for="id + '-select'"
+      class="fr-label"
+      :id="id + '-select-label'"
+    >
+      {{ variablesReplacer.replace(label) }}
+      <span class="fr-hint-text">{{ description }}</span>
+    </label>
+    <select
+      :id="id + '-select'"
+      :class="['fr-select', { 'fr-select--error': hasError }]"
+      :aria-describedby="id + '-select-hint-messages'"
+      v-model="formStore.data[id]"
+      @change="updateValue"
+    >
+      <option
+        key=""
+        value=""
+      ></option>
+      <option
+        v-for="option in values"
+        :key="option.value"
+        :value="option.value"
+      >
+        {{ variablesReplacer.replace(option.label) }}
+      </option>
+    </select>
+    <div class="fr-messages-group" :id="id + '-select-hint-messages'" aria-live="assertive">
+      <p
+        class="fr-message fr-message--error fr-error-text"
+        role="alert"
+        v-if="hasError"
+      >
+        {{ error }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { variablesReplacer } from '../services/variableReplacer'
+import formStore from './../store'
+
+export default defineComponent({
+  name: 'SignalementFormSelect',
+  props: {
+    id: { type: String, default: null },
+    label: { type: String, default: null },
+    modelValue: { type: String as () => null | string, default: null },
+    values: { type: Array as () => Array<{ label: string; value: string }>, default: null },
+    description: { type: String, default: null },
+    customCss: { type: String, default: '' },
+    validate: { type: Object, default: null },
+    hasError: { type: Boolean, default: false },
+    error: { type: String, default: '' },
+    access_focus: { type: Boolean, default: false },
+    // les propriétés suivantes ne sont pas utilisées,
+    // mais si on ne les met pas, elles apparaissent dans le DOM
+    // et ça soulève des erreurs W3C
+    clickEvent: Function,
+    handleClickComponent: Function,
+    access_name: { type: String, default: undefined },
+    access_autocomplete: { type: String, default: undefined }
+  },
+  data () {
+    return {
+      variablesReplacer,
+      formStore
+    }
+  },
+  methods: {
+    updateValue (event: Event) {
+      const value = (event.target as HTMLSelectElement).value
+      console.log(value)
+      this.$emit('update:modelValue', value)
+    }
+  },
+  emits: ['update:modelValue']
+})
+</script>
+
+<style>
+</style>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSelect.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSelect.vue
@@ -78,7 +78,6 @@ export default defineComponent({
   methods: {
     updateValue (event: Event) {
       const value = (event.target as HTMLSelectElement).value
-      console.log(value)
       this.$emit('update:modelValue', value)
     }
   },

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -16,7 +16,6 @@
             :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
             :access_focus="component.accessibility?.focus ?? false"
             :label="component.label"
-            :hint="component.hint"
             :labelInfo="component.labelInfo"
             :labelUpload="component.labelUpload"
             :description="component.description"
@@ -52,7 +51,6 @@
           :access_autocomplete="component.accessibility?.autocomplete ?? 'off'"
           :access_focus="component.accessibility?.focus ?? false"
           :label="component.label"
-          :hint="component.hint"
           :labelInfo="component.labelInfo"
           :labelUpload="component.labelUpload"
           :description="component.description"
@@ -90,6 +88,7 @@ import SignalementFormTextarea from './SignalementFormTextarea.vue'
 import SignalementFormButton from './SignalementFormButton.vue'
 import SignalementFormLink from './SignalementFormLink.vue'
 import SignalementFormOnlyChoice from './SignalementFormOnlyChoice.vue'
+import SignalementFormSelect from './SignalementFormSelect.vue'
 import SignalementFormDate from './SignalementFormDate.vue'
 import SignalementFormYear from './SignalementFormYear.vue'
 import SignalementFormTime from './SignalementFormTime.vue'
@@ -114,6 +113,7 @@ export default defineComponent({
     SignalementFormButton,
     SignalementFormLink,
     SignalementFormOnlyChoice,
+    SignalementFormSelect,
     SignalementFormDate,
     SignalementFormYear,
     SignalementFormTime,

--- a/assets/scripts/vue/components/signalement-form/interfaces/interfaceComponent.ts
+++ b/assets/scripts/vue/components/signalement-form/interfaces/interfaceComponent.ts
@@ -23,7 +23,6 @@ export interface Component {
   disabled?: string
   multiple?: string
   conditional?: any
-  hint?: string
   placeholder?: string
   ariaControls?: string
   tagWhenEdit?: string

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -105,6 +105,7 @@ const formStore: FormStore = reactive({
     'SignalementFormTextfield',
     'SignalementFormTextarea',
     'SignalementFormOnlyChoice',
+    'SignalementFormSelect',
     'SignalementFormRoomList',
     'SignalementFormAddress',
     'SignalementFormAutocomplete',

--- a/src/DataFixtures/Files/signalement_draft_payload/bailleur_occupant.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/bailleur_occupant.json
@@ -2,6 +2,7 @@
   "profil": "bailleur_occupant",
   "currentStep": "desordres_batiment_eau",
   "bail_dpe_dpe": "oui",
+  "bail_dpe_classe_energetique": "C",
   "type_logement_rdc": "non",
   "categorieDisorders": {
     "batiment": [

--- a/src/DataFixtures/Files/signalement_draft_payload/locataire.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/locataire.json
@@ -2,6 +2,7 @@
   "profil": "locataire",
   "currentStep": "informations_complementaires",
   "bail_dpe_dpe": "oui",
+  "bail_dpe_classe_energetique": "E",
   "bail_dpe_bail": "oui",
   "type_logement_rdc": "non",
   "categorieDisorders": {

--- a/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/bailleur.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/bailleur.json
@@ -2,6 +2,7 @@
   "profil": "bailleur",
   "currentStep": "validation_signalement",
   "bail_dpe_dpe": "oui",
+  "bail_dpe_classe_energetique": "F",
   "bail_dpe_bail": "oui",
   "type_logement_rdc": "non",
   "categorieDisorders": {

--- a/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/bailleur_occupant.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/bailleur_occupant.json
@@ -40,6 +40,7 @@
   "type_logement_commodites_wc_cuisine": "non",
   "bail_dpe_date_emmenagement": "2020-12-10",
   "bail_dpe_dpe": "oui",
+  "bail_dpe_classe_energetique": "B",
   "logement_social_montant_allocation": null,
   "logement_social_demande_relogement": "non",
   "logement_social_allocation": "non",

--- a/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/locataire.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/step/validation_signalement/locataire.json
@@ -60,6 +60,7 @@
   "bail_dpe_bail": "oui",
   "bail_dpe_etat_des_lieux": "oui",
   "bail_dpe_dpe": "oui",
+  "bail_dpe_classe_energetique": "F",
   "logement_social_montant_allocation": "250",
   "logement_social_demande_relogement": "oui",
   "logement_social_allocation": "oui",

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -30,6 +30,8 @@ class InformationsLogementRequest implements RequestInterface
         #[Assert\NotBlank(message: 'Merci d\'indiquer si un DPE existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR', 'BAILLEUR_OCCUPANT'])]
         #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "DPE" est incorrect.')]
         private readonly ?string $bailDpeDpe = null,
+        #[Assert\Choice(choices: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'nsp'], message: 'Le champ "Classe énergétique" est incorrect.')]
+        private readonly ?string $bailDpeClasseEnergetique = null,
         #[Assert\Type(type: 'numeric', message: 'Le loyer doit être un nombre.')]
         #[Assert\Length(max: 20, maxMessage: 'Le loyer ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $loyer = null,
@@ -73,6 +75,11 @@ class InformationsLogementRequest implements RequestInterface
     public function getBailDpeDpe(): ?string
     {
         return $this->bailDpeDpe;
+    }
+
+    public function getBailDpeClasseEnergetique(): ?string
+    {
+        return $this->bailDpeClasseEnergetique;
     }
 
     public function getLoyer(): ?string

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -370,6 +370,8 @@ class SignalementDraftRequest
     #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "bailDpeDpe" est incorrect.')]
     private ?string $bailDpeDpe = null;
     private ?array $bailDpeDpeUpload = null;
+    #[Assert\Choice(choices: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'nsp'], message: 'Le champ "Classe énergétique" est incorrect.')]
+    private ?string $bailDpeClasseEnergetique = null;
     #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "logementSocialDemandeRelogement" est incorrect.')]
     private ?string $logementSocialDemandeRelogement = null;
     #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "logementSocialAllocation" est incorrect.')]
@@ -1346,6 +1348,18 @@ class SignalementDraftRequest
     public function setBailDpeDpe(?string $bailDpeDpe): self
     {
         $this->bailDpeDpe = $bailDpeDpe;
+
+        return $this;
+    }
+
+    public function getBailDpeClasseEnergetique(): ?string
+    {
+        return $this->bailDpeClasseEnergetique;
+    }
+
+    public function setBailDpeClasseEnergetique(?string $bailDpeClasseEnergetique): self
+    {
+        $this->bailDpeClasseEnergetique = $bailDpeClasseEnergetique;
 
         return $this;
     }

--- a/src/Entity/Model/TypeCompositionLogement.php
+++ b/src/Entity/Model/TypeCompositionLogement.php
@@ -27,6 +27,7 @@ class TypeCompositionLogement
         private ?string $typeLogementCommoditesPieceAVivre9m = null,
         private ?string $bailDpeBail = null,
         private ?string $bailDpeDpe = null,
+        private ?string $bailDpeClasseEnergetique = null,
         private ?string $bailDpeEtatDesLieux = null,
         private ?string $bailDpeDateEmmenagement = null,
         private ?string $desordresLogementChauffageDetailsDpeConsoFinale = null,
@@ -296,6 +297,18 @@ class TypeCompositionLogement
         return $this;
     }
 
+    public function getBailDpeClasseEnergetique(bool $raw = true): ?string
+    {
+        return (!$raw && 'nsp' === $this->bailDpeClasseEnergetique) ? 'Ne sait pas' : $this->bailDpeClasseEnergetique;
+    }
+
+    public function setBailDpeClasseEnergetique(?string $bailDpeClasseEnergetique): self
+    {
+        $this->bailDpeClasseEnergetique = $bailDpeClasseEnergetique;
+
+        return $this;
+    }
+
     public function getBailDpeEtatDesLieux(bool $raw = true): ?string
     {
         return (!$raw && 'nsp' === $this->bailDpeEtatDesLieux) ? 'Ne sait pas' : $this->bailDpeEtatDesLieux;
@@ -405,6 +418,7 @@ class TypeCompositionLogement
             'composition_logement_enfants' => $this->compositionLogementEnfants,
             'bail_dpe_bail' => $this->bailDpeBail,
             'bail_dpe_dpe' => $this->bailDpeDpe,
+            'bail_dpe_classe_energetique' => $this->bailDpeClasseEnergetique,
             'bail_dpe_etat_des_lieux' => $this->bailDpeEtatDesLieux,
             'bail_dpe_date_emmenagement' => $this->bailDpeDateEmmenagement,
             'desordres_logement_chauffage_details_dpe_conso_finale' => $this->desordresLogementChauffageDetailsDpeConsoFinale,

--- a/src/Factory/Signalement/TypeCompositionLogementFactory.php
+++ b/src/Factory/Signalement/TypeCompositionLogementFactory.php
@@ -48,6 +48,7 @@ class TypeCompositionLogementFactory
             compositionLogementEnfants: $data['composition_logement_enfants'] ?? null,
             bailDpeBail: $data['bail_dpe_bail'] ?? null,
             bailDpeDpe: $data['bail_dpe_dpe'] ?? null,
+            bailDpeClasseEnergetique: $data['bail_dpe_classe_energetique'] ?? null,
             bailDpeEtatDesLieux: $data['bail_dpe_etat_des_lieux'] ?? null,
             bailDpeDateEmmenagement: $data['bail_dpe_date_emmenagement'] ?? null,
             desordresLogementChauffageDetailsDpeConsoFinale: $data['desordres_logement_chauffage_details_dpe_conso_finale'] ?? null,

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -504,7 +504,8 @@ class SignalementManager extends AbstractManager
             ->setCompositionLogementEnfants($informationsLogementRequest->getCompositionLogementEnfants())
             ->setBailDpeBail($informationsLogementRequest->getBailDpeBail())
             ->setBailDpeEtatDesLieux($informationsLogementRequest->getBailDpeEtatDesLieux())
-            ->setBailDpeDpe($informationsLogementRequest->getBailDpeDpe());
+            ->setBailDpeDpe($informationsLogementRequest->getBailDpeDpe())
+            ->setBailDpeClasseEnergetique($informationsLogementRequest->getBailDpeClasseEnergetique());
         $signalement->setTypeCompositionLogement($typeCompositionLogement);
 
         $informationComplementaire = new InformationComplementaire();

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -134,6 +134,29 @@
                                 </select>
                             </div>
 
+                            <div class="fr-select-group">
+                                {% set bailDpeClasseEnergetique = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeClasseEnergetique : null %}
+                                <label class="fr-label" for="informationLogementBailDpeClasseEnergetique">Classe énergétique
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'bailDpeClasseEnergetique',
+                                        signalement.profileDeclarant,
+                                        null != signalement.createdFrom)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="informationLogementBailDpeClasseEnergetique" name="bailDpeClasseEnergetique">
+                                    <option value="" {{ bailDpeClasseEnergetique not in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'nsp'] ? 'selected' : '' }}></option>
+                                    <option value="A" {{ bailDpeClasseEnergetique is same as 'A' ? 'selected' : '' }}>A</option>
+                                    <option value="B" {{ bailDpeClasseEnergetique is same as 'B' ? 'selected' : '' }}>B</option>
+                                    <option value="C" {{ bailDpeClasseEnergetique is same as 'C' ? 'selected' : '' }}>C</option>
+                                    <option value="D" {{ bailDpeClasseEnergetique is same as 'D' ? 'selected' : '' }}>D</option>
+                                    <option value="E" {{ bailDpeClasseEnergetique is same as 'E' ? 'selected' : '' }}>E</option>
+                                    <option value="F" {{ bailDpeClasseEnergetique is same as 'F' ? 'selected' : '' }}>F</option>
+                                    <option value="G" {{ bailDpeClasseEnergetique is same as 'G' ? 'selected' : '' }}>G</option>
+                                    <option value="nsp" {{ bailDpeClasseEnergetique is same as 'nsp' ? 'selected' : '' }}>Je ne sais pas</option>
+                                </select>
+                            </div>
+
                             <div class="fr-input-group">
                                 <label class="fr-label" for="informationLogementLoyer">Montant du loyer (facultatif)</label>
                                 <input class="fr-input" type="number" id="informationLogementLoyer" name="loyer" value="{{ signalement.loyer }}">

--- a/templates/back/signalement/view/information/information-logement.html.twig
+++ b/templates/back/signalement/view/information/information-logement.html.twig
@@ -94,6 +94,12 @@
         {% endif %}
     </div>
     <div class="fr-col-12 fr-col-md-6">
+        <strong>Classe énergétique :</strong>
+        {% if signalement.typeCompositionLogement %}
+            {{signalement.typeCompositionLogement.bailDpeClasseEnergetique(false)}}
+        {% endif %}
+    </div>
+    <div class="fr-col-12 fr-col-md-6">
         <strong>Montant du loyer :</strong> {{ signalement.loyer ? signalement.loyer ~ ' €'}}
     </div>
     <div class="fr-col-12 fr-col-md-6">

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -198,6 +198,7 @@
                                     {{ picto_no|raw }}
                                 {% endif %}
                             </li>
+                            <li><b>Classe énergétique :</b> {{ signalement.typeCompositionLogement.bailDpeClasseEnergetique(false) ?? 'N/R' }}
                         </ul>
                     </td>
                 </tr>

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -198,7 +198,9 @@
                                     {{ picto_no|raw }}
                                 {% endif %}
                             </li>
-                            <li><b>Classe énergétique :</b> {{ signalement.typeCompositionLogement.bailDpeClasseEnergetique(false) ?? 'N/R' }}
+                            <li>
+                                <b>Classe énergétique :</b> {{ signalement.typeCompositionLogement.bailDpeClasseEnergetique(false) ?? 'N/R' }}
+                            </li>
                         </ul>
                     </td>
                 </tr>

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -431,6 +431,7 @@ trait FixturesHelper
     {
         $typeCompostion = [
             'bail_dpe_dpe' => 'oui',
+            'bail_dpe_classe_energetique' => 'E',
             'bail_dpe_bail' => 'oui',
             'type_logement_rdc' => 'non',
             'type_logement_nature' => 'appartement',

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -158,6 +158,7 @@ class SignalementEditControllerTest extends WebTestCase
             'bailDpeBail' => 'oui',
             'bailDpeEtatDesLieux' => 'oui',
             'bailDpeDpe' => 'oui',
+            'bailDpeClasseEnergetique' => 'F',
             'loyer' => '494',
             'loyersPayes' => 'oui',
             'anneeConstruction' => '1994',

--- a/tests/Unit/Dto/Request/Signalement/InformationsLogementRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/InformationsLogementRequestTest.php
@@ -26,6 +26,7 @@ class InformationsLogementRequestTest extends KernelTestCase
             bailDpeBail: 'oui',
             bailDpeEtatDesLieux: 'oui',
             bailDpeDpe: 'oui',
+            bailDpeClasseEnergetique: 'C',
             loyer: '750',
             loyersPayes: 'oui',
             anneeConstruction: '2000'
@@ -38,6 +39,7 @@ class InformationsLogementRequestTest extends KernelTestCase
         $this->assertSame('oui', $informationsLogementRequest->getBailDpeBail());
         $this->assertSame('oui', $informationsLogementRequest->getBailDpeEtatDesLieux());
         $this->assertSame('oui', $informationsLogementRequest->getBailDpeDpe());
+        $this->assertSame('C', $informationsLogementRequest->getBailDpeClasseEnergetique());
         $this->assertSame('750', $informationsLogementRequest->getLoyer());
         $this->assertSame('oui', $informationsLogementRequest->getLoyersPayes());
         $this->assertSame('2000', $informationsLogementRequest->getAnneeConstruction());
@@ -56,12 +58,13 @@ class InformationsLogementRequestTest extends KernelTestCase
             bailDpeBail: 'unknown',
             bailDpeEtatDesLieux: 'unknown',
             bailDpeDpe: 'unknown',
+            bailDpeClasseEnergetique: 'unknown',
             loyer: 'invalid-loyer',
             loyersPayes: 'unknown',
             anneeConstruction: '20'
         );
 
         $errors = $this->validator->validate($informationsLogementRequest);
-        $this->assertCount(10, $errors);
+        $this->assertCount(11, $errors);
     }
 }

--- a/tests/Unit/Dto/Request/Signalement/SignalementDraftRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SignalementDraftRequestTest.php
@@ -91,6 +91,7 @@ class SignalementDraftRequestTest extends WebTestCase
             ->setBailDpeBail('oui')
             ->setBailDpeEtatDesLieux('oui')
             ->setBailDpeDpe('oui')
+            ->setBailDpeClasseEnergetique('D')
             ->setLogementSocialDemandeRelogement('oui')
             ->setLogementSocialAllocation('oui')
             ->setLogementSocialAllocationCaisse('caf')
@@ -147,6 +148,7 @@ class SignalementDraftRequestTest extends WebTestCase
         $this->assertSame('non', $signalementDraftRequest->getTypeLogementCommoditesWcCuisine());
         $this->assertSame('oui', $signalementDraftRequest->getBailDpeEtatDesLieux());
         $this->assertSame('oui', $signalementDraftRequest->getBailDpeDpe());
+        $this->assertSame('D', $signalementDraftRequest->getBailDpeClasseEnergetique());
         $this->assertSame('oui', $signalementDraftRequest->getTravailleurSocialAccompagnement());
         $this->assertSame('1', $signalementDraftRequest->getTravailleurSocialAccompagnementDeclarant());
         $this->assertSame('oui', $signalementDraftRequest->getInfoProcedureAssuranceContactee());
@@ -258,6 +260,7 @@ class SignalementDraftRequestTest extends WebTestCase
             ->setBailDpeBail('invalid_bail')
             ->setBailDpeEtatDesLieux('invalid_etat_des_lieux')
             ->setBailDpeDpe('invalid_dpe')
+            ->setBailDpeClasseEnergetique('invalid_classe_energetique')
             ->setLogementSocialDemandeRelogement('invalid_demande_relogement')
             ->setLogementSocialAllocation('invalid_allocation')
             ->setLogementSocialAllocationCaisse('invalid_caisse')
@@ -290,6 +293,6 @@ class SignalementDraftRequestTest extends WebTestCase
             ->setMessageAdministration('Message administration');
 
         $errors = $this->validator->validate($signalementDraftRequest);
-        $this->assertCount(97, $errors);
+        $this->assertCount(98, $errors);
     }
 }


### PR DESCRIPTION
## Ticket

#3295   

## Description
Dans le FO, dans l'écran bail-dpe, on pourrait ajouter un champ obligatoire Quelle est la classe énergétique de votre logement ? avec un dropdown avec les lettres de A à G + une option "je ne sais pas"
:warning: on n'a pas ajouté la classe énergétique dans la fiche de suivi signalement, car il manque beaucoup de données, et un ticket spécial va être créé pour ça

## Changements apportés
* Ajout d'un composant `SignalementFormSelect` dans le formulaire
* Ajout de la question dans les 6 profils
* Retrait de la propriété `hint` dans le formulaire qui n'était utilisée que dans le composant `SignalementFormDate` et remplacement par la propriété `description`
* Ajout de la classe énergétique dans les fixtures
* Ajout de la classe énergétique dans le BO et dans l'export pdf
* Mise à jour des tests

## Pré-requis
```
make composer
npm run watch

```
## Tests
- [ ] Dans le BO, aller sur un signalement existant, vérifier l'affichage (vide) de la classe énergétique, vérifier l'export pdf
- [ ] Modifier la classe énergétique dans la fiche signalement, vérifier son bon enregistrement, et vérifier l'export pdf
- [ ] Créer un signalement, vérifier qu'en choisissant "oui" au DPE, on a bien le nouveau champ et qu'il est obligatoire d'y répondre
- [ ] Valider le dépot du signalement et vérifier que la classe énergétique est bien prise en compte
