### PR TITLE
[BO - Export] Effet de bord session sur les filtres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - .:/home/wiremock
 
   histologe_redis:
-    image: redis:7.0-alpine
+    image: redis:7.2.5-alpine
     container_name: histologe_redis
 
   histologe_clamav:

--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -25,7 +25,10 @@ class ExportSignalementController extends AbstractController
     ): Response {
         /** @var User $user */
         $user = $this->getUser();
-        $filters = $options = $request->getSession()->get('filters') ?? ['isImported' => '1'];
+
+        $filters = $options = json_decode($request->cookies->get('filters'), true)
+            ?? $request->getSession()->get('filters', ['isImported' => '1']);
+
         $count_signalements = $signalementManager->findSignalementAffectationList($user, $options, true);
         $textFilters = $signalementExportFiltersDisplay->filtersToText($filters);
 

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -6,7 +6,9 @@ use App\Dto\Request\Signalement\SignalementSearchQuery;
 use App\Entity\User;
 use App\Manager\SignalementManager;
 use App\Service\Signalement\SearchFilter;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -44,11 +46,19 @@ class SignalementListController extends AbstractController
         $session->set('signalementSearchQuery', $signalementQuery);
         $signalements = $signalementManager->findSignalementAffectationList($user, $filters);
 
-        return $this->json(
+        $response = $this->json(
             $signalements,
             Response::HTTP_OK,
             ['content-type' => 'application/json'],
             ['groups' => ['signalements:read']]
         );
+
+        $cookie = Cookie::create('filters')
+            ->withValue(json_encode($filters))
+            ->withExpires(strtotime('+1 hour'));
+
+        $response->headers->setCookie($cookie);
+
+        return $response;
     }
 }

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -6,7 +6,6 @@ use App\Dto\Request\Signalement\SignalementSearchQuery;
 use App\Entity\User;
 use App\Manager\SignalementManager;
 use App\Service\Signalement\SearchFilter;
-use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;


### PR DESCRIPTION
## Ticket

#3314    

## Description
Un effet de bord que je n'arrive pas à expliquer, quand on passe sur la liste des étiquettes pour faire un export, on se retrouve avec la session précédente. (Faut vraiment rafraîchir plusieurs fois la liste pour pour avoir la session à jour) 

Pour rappel, la session est mise à jour via la requête ajax

## Changements apportés
* Stocker la session des filtre coté front via un cookie 
* Vérifier lors de l'export le cookie dans un premier temps puis la session

## Pré-requis

## Tests
- [ ] Faire une recherche
- [ ] J'affiche la page `Etiquettes`
- [ ] Je clique sur `Voir sur la liste des signalements avec étiquettes` 
- [ ] Je clique sur le bouton `Exporter les résultats` le nombre doit correspondre à la liste filtré
