### PR TITLE
[BO - Fiche signalement] Correction de l'enregistrement de la valeur du préavis de départ

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -687,7 +687,7 @@ class SignalementManager extends AbstractManager
 
         if ('non' === $situationFoyerRequest->getTravailleurSocialPreavisDepart()) {
             $signalement->setIsPreavisDepart(false);
-        } elseif ('oui' === $situationFoyerRequest->getIsAllocataire()) {
+        } elseif ('oui' === $situationFoyerRequest->getTravailleurSocialPreavisDepart()) {
             $signalement->setIsPreavisDepart(true);
         } else {
             $signalement->setIsPreavisDepart(null);

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -178,10 +178,20 @@
                             </li>
                             <li>
                                 <b>Preavis de départ :</b>
-                                {% if signalement.isPreavisDepart %}
+                                {% set travailleurSocialPreavisDepart = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialPreavisDepart : null %}
+                                {% if travailleurSocialPreavisDepart is same as null %}
+                                    {% if signalement.isPreavisDepart is same as true %}
+                                        {% set travailleurSocialPreavisDepart = 'oui' %}
+                                    {% elseif signalement.isPreavisDepart is same as false %}
+                                        {% set travailleurSocialPreavisDepart = 'non' %}
+                                    {% endif %}
+                                {% endif %}
+                                {% if travailleurSocialPreavisDepart is same as 'oui' %}
                                     {{ picto_yes|raw }}
-                                {% else %}
+                                {% elseif travailleurSocialPreavisDepart is same as 'non' %}
                                     {{ picto_no|raw }}
+                                {% elseif travailleurSocialPreavisDepart is same as 'nsp' %}
+                                    Ne sait pas
                                 {% endif %}
                             </li>
                             <li>


### PR DESCRIPTION
## Ticket

#3312   

## Description
Dans la fiche signalement du BO, l'enregistrement de données pour le préavis de départ était mal fait (prenait une autre valeur en compte)

## Pré-requis
`make worker-stop && make worker-start`

## Tests
- [ ] Dans le BO, enregistrer plusieurs valeurs et vérifier l'affichage puis l'export PDF
