### PR TITLE
[BO - Fiche signalement] Affichage des numéros de téléphone avec des espaces

### DIFF
--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -136,7 +136,7 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
             return '';
         }
 
-        if (strpos($phoneNumber, '+33') === 0) {
+        if (str_starts_with($phoneNumber, '+33')) {
             return preg_replace("/(\d{2})(\d{1})(\d{2})(\d{2})(\d{2})(\d{2})/i", '$1 $2 $3 $4 $5 $6', $phoneNumber);
         }
 

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -40,6 +40,7 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('image64', [ImageBase64Encoder::class, 'encode']),
             new TwigFilter('truncate_filename', [$this, 'getTruncatedFilename']),
             new TwigFilter('clean_tagged_text', [$this, 'cleanTaggedText']),
+            new TwigFilter('phone', [$this, 'formatPhone']),
         ];
     }
 
@@ -127,6 +128,19 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
             default:
                 return $taggedText;
         }
+    }
+
+    public function formatPhone(?string $phoneNumber): string
+    {
+        if (null === $phoneNumber) {
+            return '';
+        }
+
+        if (strpos($phoneNumber, '+33') === 0) {
+            return preg_replace("/(\d{2})(\d{1})(\d{2})(\d{2})(\d{2})(\d{2})/i", '$1 $2 $3 $4 $5 $6', $phoneNumber);
+        }
+
+        return $phoneNumber;
     }
 
     public function getFunctions(): array

--- a/templates/back/signalement/view/information/information-bailleur.html.twig
+++ b/templates/back/signalement/view/information/information-bailleur.html.twig
@@ -29,13 +29,13 @@
     <div class="fr-col-12 fr-col-md-6">
         <strong>Tél. :</strong>
         {% if signalement.telProprio %}
-            <a href="mailto:{{ signalement.telProprioDecoded }}">{{ signalement.telProprioDecoded }}</a>
+            <a href="mailto:{{ signalement.telProprioDecoded }}">{{ signalement.telProprioDecoded|phone }}</a>
         {% endif %}
     </div>
     <div class="fr-col-12 fr-col-md-6">
         <strong>Tél. sec. :</strong>
         {% if signalement.telProprioSecondaire %}
-            <a href="mailto:{{ signalement.telProprioSecondaireDecoded }}">{{ signalement.telProprioSecondaireDecoded }}</a>
+            <a href="mailto:{{ signalement.telProprioSecondaireDecoded }}">{{ signalement.telProprioSecondaireDecoded|phone }}</a>
         {% endif %}
     </div>
     <div class="fr-col-12">

--- a/templates/back/signalement/view/information/information-foyer.html.twig
+++ b/templates/back/signalement/view/information/information-foyer.html.twig
@@ -46,10 +46,10 @@
     </div>
     <div class="fr-col-12 fr-col-md-6">
         <strong>Tél. :</strong>
-        <a href="tel:{{ signalement.telOccupantDecoded }}">{{ signalement.telOccupantDecoded }}</a>
+        <a href="tel:{{ signalement.telOccupantDecoded }}">{{ signalement.telOccupantDecoded|phone }}</a>
     </div>
     <div class="fr-col-12 fr-col-md-6">
         <strong>Tél. sec. :</strong>
-        <a href="tel:{{ signalement.telOccupantBisDecoded }}">{{ signalement.telOccupantBisDecoded }}</a>
+        <a href="tel:{{ signalement.telOccupantBisDecoded }}">{{ signalement.telOccupantBisDecoded|phone }}</a>
     </div>
 </div>

--- a/templates/back/signalement/view/information/information-tiers.html.twig
+++ b/templates/back/signalement/view/information/information-tiers.html.twig
@@ -51,6 +51,6 @@
         {% endif %}
     </div>
     <div class="fr-col-12">
-        <strong>Tél. :</strong> {{ signalement.telDeclarantDecoded }}
+        <strong>Tél. :</strong> {{ signalement.telDeclarantDecoded|phone }}
     </div>
 </div>

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -24,11 +24,11 @@
 {% endif %}
 {% if signalement.telOccupant %}
 	<br>
-	{{ signalement.telOccupant }}
+	{{ signalement.telOccupantDecoded|phone }}
 {% endif %}
 {% if signalement.telOccupantBis %}
 	<br>
-	{{ signalement.telOccupantBis }}
+	{{ signalement.telOccupantBisDecoded|phone }}
 {% endif %}
 </div>
 
@@ -57,11 +57,11 @@
 {% endif %}
 {% if signalement.telProprio %}
 	<br>
-	{{ signalement.telProprio }}
+	{{ signalement.telProprioDecoded|phone }}
 {% endif %}
 {% if signalement.telProprioSecondaire %}
 	<br>
-	{{ signalement.telProprioSecondaire }}
+	{{ signalement.telProprioSecondaireDecoded|phone }}
 {% endif %}
 </div>
 {% if 

--- a/tests/Unit/Twig/AppExtensionTest.php
+++ b/tests/Unit/Twig/AppExtensionTest.php
@@ -91,4 +91,41 @@ class AppExtensionTest extends WebTestCase
             'UTC',
         ];
     }
+
+    /**
+     * @dataProvider provideDataPhone
+     */
+    public function testFormatPhone($inputPhone, $expectedOutputPhone): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $appExtension = $container->get(AppExtension::class);
+
+        $outputPhone = $appExtension->formatPhone($inputPhone);
+
+        $this->assertEquals($expectedOutputPhone, $outputPhone);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function provideDataPhone(): \Generator
+    {
+        yield 'No phone' => [
+            null,
+            '',
+        ];
+        yield 'French decoded phone' => [
+            '+33612345678',
+            '+33 6 12 34 56 78',
+        ];
+        yield 'French phone' => [
+            '0612345678',
+            '0612345678',
+        ];
+        yield 'Other phone' => [
+            '+31612345678',
+            '+31612345678',
+        ];
+    }
 }


### PR DESCRIPTION
## Ticket

#3317   

## Description
Pour faciliter la lecture, on ajoute des espaces dans les numéros de téléphone de la fiche signalement et la fiche de suivi usager

## Tests
- [ ] Vérifier que ça s'affiche correctement dans la fiche signalement
- [ ] L'édition est toujours correcte
- [ ] La fiche usager présente ce type d'affichage aussi
