### PR TITLE
[Tech - email] Configuration sur l'injection par setter des mailer via l'héritage

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -68,6 +68,8 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
             - '../src/Tests/'
+            - '../src/Service/Mailer/Mail/AbstractNotificationMailer.php'
+
 
     App\EventListener\ContentSecurityPolicyListener:
         tags:
@@ -206,6 +208,17 @@ services:
         App\Service\Signalement\DesordreTraitement\DesordreTraitementProcessor:
             tags: ['desordre_traitement']
 
+
+    App\Service\Mailer\Mail\AbstractNotificationMailer:
+        abstract: true
+        autoconfigure: false
+        calls:
+            - setFailedEmailManager: [ '@App\Manager\FailedEmailManager' ]
+
+    App\Service\Mailer\Mail\:
+        resource: '../src/Service/Mailer/Mail/*'
+        parent: App\Service\Mailer\Mail\AbstractNotificationMailer
+
 when@test:
     parameters:
         uploads_tmp_dir: '%kernel.project_dir%/tmp/'
@@ -219,7 +232,6 @@ when@test:
                 $parameterBag: '@Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface'
                 $logger: '@Psr\Log\LoggerInterface'
                 $urlGenerator: '@Symfony\Component\Routing\Generator\UrlGeneratorInterface'
-                $failedEmailManager: '@App\Manager\FailedEmailManager'
                 $userManager: '@App\Manager\UserManager'
             tags:
                 - name: 'app.notification_mailer'

--- a/src/Entity/FailedEmail.php
+++ b/src/Entity/FailedEmail.php
@@ -2,9 +2,10 @@
 
 namespace App\Entity;
 
+use App\Repository\FailedEmailRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: FailedEmailRepository::class)]
 class FailedEmail
 {
     #[ORM\Id]

--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -24,13 +24,13 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
     protected ?string $mailerTemplate = null;
     protected ?string $tagHeader = null;
     protected array $mailerParams = [];
+    private ?FailedEmailManager $failedEmailManager = null;
 
     public function __construct(
         protected MailerInterface $mailer,
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
     }
 
@@ -128,7 +128,7 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
         ));
         if ($saveFailedMail && NotificationMailerType::TYPE_ERROR_SIGNALEMENT !== $notificationMail->getType()) {
             try {
-                $this->failedEmailManager->create(
+                $this->getFailedEmailManager()->create(
                     $message, $notificationMail, $exception, $this->parameterBag->get('reply_to_email'), $notifyUsager);
             } catch (\Exception $e) {
                 $this->logger->error('Failed to save FailedEmail: '.$e->getMessage());
@@ -186,5 +186,19 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
                 .' - '.
                 str_replace('%param.platform_name%', $this->parameterBag->get('platform_name'), $this->mailerSubject)
             );
+    }
+
+    public function setFailedEmailManager(FailedEmailManager $failedEmailManager): void
+    {
+        $this->failedEmailManager = $failedEmailManager;
+    }
+
+    public function getFailedEmailManager(): FailedEmailManager
+    {
+        if (!$this->failedEmailManager) {
+            throw new \LogicException('FailedEmailManager has not been initialized.');
+        }
+
+        return $this->failedEmailManager;
     }
 }

--- a/src/Service/Mailer/Mail/Account/AccountActivationBoMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountActivationBoMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
-use App\Manager\FailedEmailManager;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
@@ -24,10 +23,10 @@ class AccountActivationBoMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
+
         private readonly UserManager $userManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Account/AccountActivationFoMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountActivationFoMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
-use App\Manager\FailedEmailManager;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
@@ -24,10 +23,10 @@ class AccountActivationFoMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
+
         private readonly UserManager $userManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Account/AccountActivationReminderMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountActivationReminderMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
-use App\Manager\FailedEmailManager;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
@@ -25,10 +24,10 @@ class AccountActivationReminderMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
+
         private readonly UserManager $userManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Account/AccountDeleteMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountDeleteMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -22,9 +21,8 @@ class AccountDeleteMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Account/AccountLostPasswordMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountLostPasswordMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
-use App\Manager\FailedEmailManager;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
@@ -24,10 +23,10 @@ class AccountLostPasswordMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
+
         private readonly UserManager $userManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Account/AccountReactivationMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountReactivationMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
-use App\Manager\FailedEmailManager;
 use App\Security\FormLoginAuthenticator;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
@@ -24,9 +23,8 @@ class AccountReactivationMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Account/AccountSoonArchivedMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountSoonArchivedMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class AccountSoonArchivedMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
@@ -3,7 +3,6 @@
 namespace App\Service\Mailer\Mail\Account;
 
 use App\Entity\User;
-use App\Manager\FailedEmailManager;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
@@ -24,10 +23,10 @@ class AccountTransferMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
+
         private UserManager $userManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Contact/ContactFormMailer.php
+++ b/src/Service/Mailer/Mail/Contact/ContactFormMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Contact;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class ContactFormMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Cron/CronMailer.php
+++ b/src/Service/Mailer/Mail/Cron/CronMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Cron;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -22,9 +21,8 @@ class CronMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
+++ b/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Error;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -22,9 +21,8 @@ class ErrorSignalementMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Profil/ProfilEditEmailMailer.php
+++ b/src/Service/Mailer/Mail/Profil/ProfilEditEmailMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Profil;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -22,9 +21,8 @@ class ProfilEditEmailMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Profil/ProfilEditPasswordMailer.php
+++ b/src/Service/Mailer/Mail/Profil/ProfilEditPasswordMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Profil;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -22,9 +21,8 @@ class ProfilEditPasswordMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/AssignementNewMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/AssignementNewMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class AssignementNewMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/ContinueFromDraftMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/ContinueFromDraftMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class ContinueFromDraftMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementAskBailDpeMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementAskBailDpeMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class SignalementAskBailDpeMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToAllPartnersMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToAllPartnersMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SignalementClosedToAllPartnersMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToOnePartnerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToOnePartnerMailer.php
@@ -3,7 +3,6 @@
 namespace App\Service\Mailer\Mail\Signalement;
 
 use App\Entity\User;
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -26,10 +25,10 @@ class SignalementClosedToOnePartnerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
+
         private readonly Security $security,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementClosedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementClosedToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SignalementClosedToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementConfirmReceptionMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementConfirmReceptionMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SignalementConfirmReceptionMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerThirdMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerThirdMailer.php
@@ -3,7 +3,6 @@
 namespace App\Service\Mailer\Mail\Signalement;
 
 use App\Entity\Suivi;
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SignalementFeedbackUsagerThirdMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerWithResponseMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerWithResponseMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -25,9 +24,8 @@ class SignalementFeedbackUsagerWithResponseMailer extends AbstractNotificationMa
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerWithoutResponseMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementFeedbackUsagerWithoutResponseMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -25,9 +24,8 @@ class SignalementFeedbackUsagerWithoutResponseMailer extends AbstractNotificatio
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementLienSuiviMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementLienSuiviMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class SignalementLienSuiviMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementListExportMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementListExportMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class SignalementListExportMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementNewMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementNewMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SignalementNewMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementPdfExportMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementPdfExportMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SignalementPdfExportMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementRefusalMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementRefusalMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class SignalementRefusalMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementUserExportMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementUserExportMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -22,9 +21,8 @@ class SignalementUserExportMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Signalement/SignalementValidationMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/SignalementValidationMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Signalement;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SignalementValidationMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentBackMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,16 +23,15 @@ class SuiviNewCommentBackMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
     {
         $signalement = $notificationMail->getSignalement();
         $suivi = $notificationMail->getSuivi();
-        if ($suivi->getCreatedBy()) {
+        if ($suivi && $suivi->getCreatedBy()) {
             $suiviCreator = $suivi->getCreatedBy()->getNom().' ('.$suivi->getCreatedBy()->getPartner()->getNom().')';
         } else {
             $suiviCreator = $signalement->getPrenomDeclarant().' '.$signalement->getNomDeclarant();

--- a/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviNewCommentFrontMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviNewCommentFrontMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class SuiviVisiteAbortedToPartnerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteAbortedToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteCanceledMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteCanceledToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToPartnerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteConfirmedToPartnerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteConfirmedToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class SuiviVisiteConfirmedToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToPartnerMailer.php
@@ -26,7 +26,7 @@ class SuiviVisiteCreatedToPartnerMailer extends AbstractNotificationMailer
     //     protected UrlGeneratorInterface $urlGenerator,
     //     protected FailedEmailManager $failedEmailManager,
     // ) {
-    //     parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+    //     parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     // }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteCreatedToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteEditedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteEditedToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteEditedToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteFutureReminderToPartnerMailer extends AbstractNotificationMaile
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -23,9 +22,8 @@ class SuiviVisiteFutureReminderToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteNeededMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteNeededMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteNeededMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisitePastReminderToPartnerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteRescheduledToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteRescheduledToUsagerMailer.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Mailer\Mail\Suivi;
 
-use App\Manager\FailedEmailManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerType;
@@ -24,9 +23,8 @@ class SuiviVisiteRescheduledToUsagerMailer extends AbstractNotificationMailer
         protected ParameterBagInterface $parameterBag,
         protected LoggerInterface $logger,
         protected UrlGeneratorInterface $urlGenerator,
-        protected FailedEmailManager $failedEmailManager,
     ) {
-        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator, $this->failedEmailManager);
+        parent::__construct($this->mailer, $this->parameterBag, $this->logger, $this->urlGenerator);
     }
 
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array


### PR DESCRIPTION
## Ticket

#3260 

## Description
Désolé @hmeneuvrier je t'ai donné la doc de base https://symfony.com/doc/current/service_container/calls.html

C'est plutôt cette doc qui est adapté (gestion de l'héritage) https://symfony.com/doc/current/service_container/parent_services.html + du rafistolage. 

## Changements apportés
* Suppression de l'injection via constructeur
* Mise à jour de la conf

## Pré-requis

## Tests
- [ ] Idem que la PR cible
