### PR TITLE
[BO - Signalement] Pleine largeur pour le fond gris sur les signalements refusés et clôturés

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -41,7 +41,17 @@ html, body {
 }
 img.huechange { filter: hue-rotate(120deg); }
 
-main:has(.signalement-invalid) {
+main#container-horizontal:has(.signalement-invalid) {
+    background: rgba(0, 0, 0, 0.1);
+}
+main#container-vertical .signalement-invalid::before {
+    content: '';
+    position: absolute;
+    line-height: 100vh;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     background: rgba(0, 0, 0, 0.1);
 }
 .fr-background--white.signalement-invalid {

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -40,15 +40,12 @@ html, body {
     margin: 0;
 }
 img.huechange { filter: hue-rotate(120deg); }
-.signalement-invalid::before {
-    content: '';
-    position: absolute;
-    line-height: 100vh;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+
+main:has(.signalement-invalid) {
     background: rgba(0, 0, 0, 0.1);
+}
+.fr-background--white.signalement-invalid {
+    background-color: inherit;
 }
 
 pre {

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -5,27 +5,30 @@
 {% block body %}
     {% if platform.feature_enable_menu_horizontale %}
         {% include 'back/nav_bo.html.twig' %}
-        <main class="{{ app.request.get('_route') in ['back_cartographie', 'back_signalement_index', 'back_dashboard'] ? 'fr-container-fluid' : container_class }}">
-            <div class="fr-grid-row">
-                <div class="fr-col-12" id="content">
+        <main>
+            <div class="{{ app.request.get('_route') in ['back_cartographie', 'back_signalement_index', 'back_dashboard'] ? 'fr-container-fluid' : container_class }}">
+                <div class="fr-grid-row">
+                    <div class="fr-col-12" id="content">
     {% else %}
-                    <main class="fr-container-fluid">
-                        <div class="fr-grid-row">
-                            {% include 'back/nav_bo.html.twig' %}
-                            <div class="fr-col-12 fr-col-md-9 fr-col-lg-10 overflow-x-hidden" id="content">
+        <main>
+            <div class="fr-container-fluid">
+                <div class="fr-grid-row">
+                    {% include 'back/nav_bo.html.twig' %}
+                    <div class="fr-col-12 fr-col-md-9 fr-col-lg-10 overflow-x-hidden" id="content">
     {% endif %}
-                    {% for label, messages in app.flashes %}
-                        {% for message in messages %}
-                            <div role="alert" class="fr-alert fr-alert--{{ label }} fr-alert--sm">
-                                {% if label is same as('error error-raw')  %}
-                                    <p>{{ message|raw }}</p>
-                                {% else %}
-                                    <p>{{ message }}</p>
-                                {% endif %}
-                            </div>
+                        {% for label, messages in app.flashes %}
+                            {% for message in messages %}
+                                <div role="alert" class="fr-alert fr-alert--{{ label }} fr-alert--sm">
+                                    {% if label is same as('error error-raw')  %}
+                                        <p>{{ message|raw }}</p>
+                                    {% else %}
+                                        <p>{{ message }}</p>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
                         {% endfor %}
-                    {% endfor %}
-                    {% block content %}{% endblock %}
+                        {% block content %}{% endblock %}
+                    </div>
                 </div>
             </div>
         </main>

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -5,12 +5,12 @@
 {% block body %}
     {% if platform.feature_enable_menu_horizontale %}
         {% include 'back/nav_bo.html.twig' %}
-        <main>
+        <main id="container-horizontal">
             <div class="{{ app.request.get('_route') in ['back_cartographie', 'back_signalement_index', 'back_dashboard'] ? 'fr-container-fluid' : container_class }}">
                 <div class="fr-grid-row">
                     <div class="fr-col-12" id="content">
     {% else %}
-        <main>
+        <main id="container-vertical">
             <div class="fr-container-fluid">
                 <div class="fr-grid-row">
                     {% include 'back/nav_bo.html.twig' %}


### PR DESCRIPTION
## Ticket

#3331 
#3332

## Description
- Pleine largeur pour le fond gris sur les signalements refusés et clôturés
- Ajout de marge en bas dans le BO

## Tests
- [ ] `FEATURE_ENABLE_MENU_HORIZONTALE=0` vérifier affichage avec menu vertical
- [ ] `FEATURE_ENABLE_MENU_HORIZONTALE=1` Vérifier affichage avec menu horizontal
