### PR TITLE
[FO - Form] Ajouter un champ "classe énergétique"

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1043,9 +1043,6 @@
               "value": "nsp"
             }
           ],
-          "conditional": {
-            "show": "formStore.data.bail_dpe_dpe === 'oui'"
-          },
           "validate": {
             "message": "Veuillez indiquer la classe énergétique pour le logement."
           }

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -866,7 +866,7 @@
         {
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
-          "label": "Quelle est la classe énergétique de votre logement ?",
+          "label": "Quelle est la classe énergétique du logement ?",
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -902,9 +902,6 @@
               "value": "nsp"
             }
           ],
-          "conditional": {
-            "show": "formStore.data.bail_dpe_dpe === 'oui'"
-          },
           "validate": {
             "message": "Veuillez indiquer la classe énergétique pour le logement."
           }

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1060,7 +1060,7 @@
         {
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
-          "label": "Quelle est la classe énergétique de votre logement ?",
+          "label": "Quelle est la classe énergétique du logement ?",
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -1096,9 +1096,6 @@
               "value": "nsp"
             }
           ],
-          "conditional": {
-            "show": "formStore.data.bail_dpe_dpe === 'oui'"
-          },
           "validate": {
             "message": "Veuillez indiquer la classe énergétique pour le logement."
           }

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1147,9 +1147,6 @@
               "value": "nsp"
             }
           ],
-          "conditional": {
-            "show": "formStore.data.bail_dpe_dpe === 'oui'"
-          },
           "validate": {
             "message": "Veuillez indiquer la classe énergétique pour le logement."
           }

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1174,9 +1174,6 @@
               "value": "nsp"
             }
           ],
-          "conditional": {
-            "show": "formStore.data.bail_dpe_dpe === 'oui'"
-          },
           "validate": {
             "message": "Veuillez indiquer la classe énergétique pour le logement."
           }

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1158,9 +1158,6 @@
               "value": "nsp"
             }
           ],
-          "conditional": {
-            "show": "formStore.data.bail_dpe_dpe === 'oui'"
-          },
           "validate": {
             "message": "Veuillez indiquer la classe énergétique pour le logement."
           }

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -367,9 +367,7 @@ export default defineComponent({
       result += this.addLineIfNeeded('bail_dpe_bail', 'Bail établi ? ')
       result += this.addLineIfNeeded('bail_dpe_etat_des_lieux', 'Etat des lieux réalisé ? ')
       result += this.addLineIfNeeded('bail_dpe_dpe', 'DPE réalisé ? ')
-      if (this.formStore.data.bail_dpe_dpe === 'oui') {
-        result += this.addLineIfNeeded('bail_dpe_classe_energetique', 'Classe énergétique du logement : ')
-      }
+      result += this.addLineIfNeeded('bail_dpe_classe_energetique', 'Classe énergétique du logement : ')
       return result
     },
     getFormDataSituationOccupant (): string {


### PR DESCRIPTION
## Ticket

#3295   

## Description
Dans le FO, dans l'écran bail-dpe, le champ `Quelle est la classe énergétique de votre logement ?` doit être visible même si le déclarant n'a pas mis oui à DPE

## Changements apportés
* Modification de la question dans les 6 profils
* Mise à jour du récap du signalement

## Pré-requis
```
make composer
npm run watch

```
## Tests
- [ ] Créer un signalement, vérifier qu'en choisissant "non" ou "je ne sais pas" au DPE, on a bien le nouveau champ et qu'il est obligatoire d'y répondre
- [ ] Valider le dépot du signalement et vérifier que la classe énergétique est bien prise en compte
