### PR TITLE
[BO - signalements] Commande pour corriger les scores et qualifications des signalements créés entre le 14 février et le 8 mars

### DIFF
--- a/src/Command/FixScoreQualificationsCommand.php
+++ b/src/Command/FixScoreQualificationsCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class FixScoreQualificationsCommand extends Command
 {
-    private const BATCH_SIZE = 200;
+    private const BATCH_SIZE = 20;
     private SymfonyStyle $io;
 
     public function __construct(

--- a/src/Command/FixScoreQualificationsCommand.php
+++ b/src/Command/FixScoreQualificationsCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class FixScoreQualificationsCommand extends Command
 {
+    private const BATCH_SIZE = 200;
     private SymfonyStyle $io;
 
     public function __construct(
@@ -72,6 +73,9 @@ class FixScoreQualificationsCommand extends Command
                 $this->io->info(\sprintf('Number of qualifications of signalement %s changed %s to %s.',
                     $signalement->getUuid(), $oldQualifications->count(), $newQualifications->count()));
                 ++$countQualifChanged;
+            }
+            if (0 === $count % self::BATCH_SIZE) {
+                $this->signalementManager->flush();
             }
 
             ++$count;

--- a/src/Command/FixScoreQualificationsCommand.php
+++ b/src/Command/FixScoreQualificationsCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Signalement;
+use App\Manager\SignalementManager;
+use App\Repository\SignalementRepository;
+use App\Service\Signalement\CriticiteCalculator;
+use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:fix-score-qualifications',
+    description: 'Fix scores and qualifications of signalements created between 14th of february and 8th of march'
+)]
+class FixScoreQualificationsCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private SignalementRepository $signalementRepository,
+        private SignalementManager $signalementManager,
+        private CriticiteCalculator $criticiteCalculator,
+        private SignalementQualificationUpdater $signalementQualificationUpdater,
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        // See https://symfony.com/doc/current/console/style.html
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $count = 0;
+        $countScoreChanged = 0;
+        $countQualifChanged = 0;
+
+        $startDate = new \DateTimeImmutable('2024-02-14');
+        $endDate = new \DateTimeImmutable('2024-03-08');
+
+        /** @var Signalement[] $signalements */
+        $signalements = $this->signalementRepository->findSignalementsBetweenDates($startDate, $endDate);
+
+        $this->io->info(\sprintf('%s signalements à parcourir.', \count($signalements)));
+
+        /** @var Signalement $signalement */
+        foreach ($signalements as $signalement) {
+            $oldScore = $signalement->getScore();
+            /** @var ArrayCollection $oldQualifications */
+            $oldQualifications = new ArrayCollection($signalement->getSignalementQualifications()->toArray());
+
+            $newScore = $this->criticiteCalculator->calculate($signalement);
+            $signalement->setScore($newScore);
+            $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
+            $newQualifications = $signalement->getSignalementQualifications();
+            $this->signalementManager->save($signalement, false);
+
+            if (abs($oldScore - $newScore) > 0.00001) {
+                $this->io->info(\sprintf('Score of signalement %s changed from %s to %s.',
+                    $signalement->getUuid(), $oldScore, $newScore));
+                ++$countScoreChanged;
+            }
+            if ($oldQualifications->count() !== $newQualifications->count()) {
+                $this->io->info(\sprintf('Number of qualifications of signalement %s changed %s to %s.',
+                    $signalement->getUuid(), $oldQualifications->count(), $newQualifications->count()));
+                ++$countQualifChanged;
+            }
+
+            ++$count;
+        }
+        $this->signalementManager->flush();
+
+        $this->io->success(\sprintf(
+            '%s signalements were analyzed. %s scores changed. %s number of qualifications changed',
+            $count,
+            $countScoreChanged,
+            $countQualifChanged
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1375,4 +1375,17 @@ class SignalementRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function findSignalementsBetweenDates(\DateTimeImmutable $startDate, \DateTimeImmutable $endDate): array
+    {
+        $qb = $this->createQueryBuilder('s');
+
+        return $qb
+            ->where('s.createdAt BETWEEN :startDate AND :endDate')
+            ->setParameter('startDate', $startDate)
+            ->setParameter('endDate', $endDate)
+            ->orderBy('s.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
 }


### PR DESCRIPTION
## Ticket

#3328   

## Description
Il y a eu un bug entre la mise en prod du formulaire (14 février, 2.0.0) et la correcction ci-dessus  (8 mars, 2.0.3) : 

> Après analyse, pour le problème des désordres liés à la composition du logement, on affectait les désordres au signalement si la réponse à certaines questions était différente de "oui".
> Par exemple "la hauteur sous le plafond du logement est supérieur à 2 mètres". Si on ne répond pas oui, on a le désordre. Donc les Tiers déclarant qui ont répondu "je ne sais pas" ont un siignalement avec ce désordre.

La correction faite le 8 mars a permis de corriger ce pb, et a corrigé les signalements créés entre le 14 février et le 8 mars en enlevant ces désordres superflus, **mais sans recalculer les qualifications ni le score**.

## Changements apportés
* commande temporaire pour recalculer le score et les qualifications sur tous les signalements créés entre le 14 février et le 8 mars 

## Pré-requis
se mettre sur une base de prod

## Tests
- [ ] Jouer la commande `make console app="fix-score-qualifications"`et vérifier qu'elle s'execute correctement

