### PR TITLE
[BO - Signalement] Régression sur l'affichage des partenaires affectés sur les signalements fermés

### DIFF
--- a/src/Controller/Back/HistoryEntryController.php
+++ b/src/Controller/Back/HistoryEntryController.php
@@ -19,7 +19,11 @@ class HistoryEntryController extends AbstractController
         SignalementRepository $signalementRepository,
     ): Response {
         $signalement = $signalementRepository->find($request->get('id'));
-        if (!$signalement || !$this->isGranted('SIGN_VIEW', $signalement) || !$this->isGranted('ASSIGN_TOGGLE', $signalement)) {
+        if (
+            !$signalement
+            || !$this->isGranted('SIGN_VIEW', $signalement)
+            || !$this->isGranted('ASSIGN_SEE', $signalement)
+        ) {
             return $this->json(['response' => 'error'], Response::HTTP_FORBIDDEN);
         }
 

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -214,7 +214,8 @@ class SignalementController extends AbstractController
             'partnersCanVisite' => $partnerVisite,
             'pendingVisites' => $interventionRepository->getPendingVisitesForSignalement($signalement),
             'allPhotosOrdered' => $allPhotosOrdered,
-            'canPartnerAffectation' => $this->isGranted('ASSIGN_TOGGLE', $signalement),
+            'canTogglePartnerAffectation' => $this->isGranted('ASSIGN_TOGGLE', $signalement),
+            'canSeePartnerAffectation' => $this->isGranted('ASSIGN_SEE', $signalement),
         ];
 
         return $this->render('back/signalement/view.html.twig', $twigParams);

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -4,7 +4,7 @@
 {% set static_picto_no = '<p class="fr-badge fr-badge--error">Non</p>' %}
 
 {% block content %}
-    {% if canTogglePartnerAffectation %}
+    {% if canSeePartnerAffectation and canTogglePartnerAffectation %}
         {% include '_partials/_modal_affectation.html.twig' %}
     {% endif %}
     {% if canSeePartnerAffectation %}        

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -4,8 +4,10 @@
 {% set static_picto_no = '<p class="fr-badge fr-badge--error">Non</p>' %}
 
 {% block content %}
-    {% if not needValidation and canPartnerAffectation %}
+    {% if canTogglePartnerAffectation %}
         {% include '_partials/_modal_affectation.html.twig' %}
+    {% endif %}
+    {% if canSeePartnerAffectation %}        
         {% include '_partials/_modal_historique_affectation.html.twig' %}
     {% endif %}
     {% include '_partials/_modal_dpe.html.twig' %}

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -1,4 +1,4 @@
-{% if canPartnerAffectation %}
+{% if canSeePartnerAffectation %}
     <div class="fr-grid-row">
         <div class="fr-col-9 fr-col-md-6">
             <h3 class="fr-h5">Partenaires affectés</h3>
@@ -12,7 +12,7 @@
                 >
                     Voir l'historique des affectations
                 </button>
-                {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
+                 {% if canTogglePartnerAffectation %}
                     <button class="fr-btn fr-fi-add-line fr-btn--icon-left" data-fr-opened="false" aria-controls="fr-modal-affectation">
                         Affecter des partenaires
                     </button>


### PR DESCRIPTION
## Ticket

#3337    

## Description
la liste des partenaires affectes/affectations/ historique des affectations n est pas/plus accessible sur les signalements fermés

## Changements apportés
* Création d'un nouveau droit `ASSIGN_SEE` qui permet de voir les partenaires affectés et l'historique des affectation
* Renommage de `canPartnerAffectation` en `canSeePartnerAffectation` pour éclaircir ce que ça fait

## Pré-requis

## Tests
- [ ] Tester l'affichage de l'onglet `Activités PDLHI` pour les 4 statuts de signalement et pour les différents rôles
