### PR TITLE
[QA - Sentry] Suivi créés plusieurs fois, erreur d'execution de requête

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -161,7 +161,7 @@ document?.querySelector('#signalement-affectation-form-submit')?.addEventListene
   })
 })
 
-const modalsElement = document?.querySelectorAll('.fr-modal')
+const modalsElement = document?.querySelectorAll('#cloture-modal, #fr-modal-add-suivi, #refus-signalement-modal, #refus-affectation-modal')
 modalsElement.forEach(modalElement => {
   modalElement.addEventListener('submit', (e) => {
     const submitButton = modalElement.querySelector('.fr-modal--opened [type=submit]')

--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -161,6 +161,16 @@ document?.querySelector('#signalement-affectation-form-submit')?.addEventListene
   })
 })
 
+const modalsElement = document?.querySelectorAll('.fr-modal')
+modalsElement.forEach(modalElement => {
+  modalElement.addEventListener('submit', (e) => {
+    const submitButton = modalElement.querySelector('.fr-modal--opened [type=submit]')
+    if (submitButton) {
+      submitButton.disabled = true
+    }
+  })
+})
+
 document?.getElementById('signalement-add-suivi-notify-usager')?.addEventListeners('change', (e) => {
   document.getElementById('signalement-add-suivi-submit').textContent = (e.target.checked) ? 'Envoyer le suivi à l\'usager' : 'Enregistrer le suivi interne'
 })

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -7,7 +7,7 @@ doctrine:
                 # IMPORTANT: You MUST configure your server version,
                 # either here or in the DATABASE_URL env var (see .env file)
                 server_version: '8.0.35'
-                use_savepoints: true
+                use_savepoints: false
                 charset: utf8mb4
                 default_table_options:
                     charset: utf8mb4
@@ -49,3 +49,9 @@ doctrine:
                 GROUP_CONCAT: DoctrineExtensions\Query\Mysql\GroupConcat
                 REGEXP: DoctrineExtensions\Query\Mysql\Regexp
 
+when@test:
+    doctrine:
+        dbal:
+            connections:
+                default:
+                    use_savepoints: true

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -104,7 +104,7 @@ class SignalementActionController extends AbstractController
     public function addSuiviSignalement(
         Signalement $signalement,
         Request $request,
-        SuiviRepository $suiviRepository,
+        EntityManagerInterface $entityManager,
         LoggerInterface $logger,
     ): Response {
         $this->denyAccessUnlessGranted('COMMENT_CREATE', $signalement);
@@ -126,9 +126,10 @@ class SignalementActionController extends AbstractController
                 ->setType(Suivi::TYPE_PARTNER);
 
             try {
-                $suiviRepository->save($suivi, true);
+                $entityManager->persist($suivi);
+                $entityManager->flush();
             } catch (\Throwable $exception) {
-                $this->addFlash('error', 'Une erreur est survenu lors de la publication');
+                $this->addFlash('error', 'Une erreur est survenue lors de la publication.');
                 $logger->error($exception->getMessage());
 
                 return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
@@ -136,7 +137,7 @@ class SignalementActionController extends AbstractController
 
             $this->addFlash('success', 'Suivi publié avec succès !');
         } else {
-            $this->addFlash('error', 'Une erreur est survenu lors de la publication');
+            $this->addFlash('error', 'Une erreur est survenue lors de la publication.');
         }
 
         return $this->redirect(

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -30,6 +30,15 @@ class SuiviRepository extends ServiceEntityRepository
         parent::__construct($registry, Suivi::class);
     }
 
+    public function save(Suivi $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
     /**
      * @throws Exception
      */

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -30,15 +30,6 @@ class SuiviRepository extends ServiceEntityRepository
         parent::__construct($registry, Suivi::class);
     }
 
-    public function save(Suivi $entity, bool $flush = false): void
-    {
-        $this->getEntityManager()->persist($entity);
-
-        if ($flush) {
-            $this->getEntityManager()->flush();
-        }
-    }
-
     /**
      * @throws Exception
      */


### PR DESCRIPTION
## Ticket

#3338  

## Description
L'option doctrine `use_savepoints` à true (transactions imbriquées) était obligatoire pour la montée de version vers Symfony 7 en raison de la mise à jour du bundle dama/doctrine-test-bundle en version 8.2.*.

Ce bundle est utilisé uniquement en environnement de test et peut donc être désactivé en prod.

L'erreur de "savepoint" signalée sur Sentry n'est pas liée à la création multiple d'un même suivi, mais plutôt à une utilisation répétée du bouton de soumission. Ça date de plusieurs année, la désactivation à la soumission de création de suivi n'a jamais été implémenté. 

Voir ce signalement de 2023 par exemple : 
https://histologe.beta.gouv.fr/bo/signalements/e3dab9ba-43c6-4e37-a0e5-4f5f046b44e1

La liste ici 
https://histologe-metabase.osc-fr1.scalingo.io/question/1351-doublon-de-suivi-partenaire

## Changements apportés
* Désactivation du savepoint en prod
* Activation du savepoint en test
* Désactivation du bouton de soumission sur les modales
* Ajout d'un try/catch au flush

## Pré-requis

## Tests
- [ ] Essayer de soumettre un suivi plusieurs fois. 
