### PR TITLE
[TECH] Option pour désactiver EntityHistoryListener

### DIFF
--- a/src/EventListener/Behaviour/DoctrineListenerRemoverTrait.php
+++ b/src/EventListener/Behaviour/DoctrineListenerRemoverTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\EventListener\Behaviour;
+
+use Doctrine\Common\EventManager;
+
+trait DoctrineListenerRemoverTrait
+{
+    public function removeListener(EventManager $eventManager, string $listenerClass, string $event): void
+    {
+        foreach ($eventManager->getListeners($event) as $listener) {
+            if ($listener instanceof $listenerClass) {
+                $eventManager->removeEventListener([$event], $listener);
+            }
+        }
+    }
+
+    public function removeListeners(EventManager $eventManager, string $listenerClass, array $events): void
+    {
+        foreach ($events as $event) {
+            $this->removeListener($eventManager, $listenerClass, $event);
+        }
+    }
+}

--- a/tests/Unit/EventListener/Behaviour/DoctrineListenerRemoverTraitTest.php
+++ b/tests/Unit/EventListener/Behaviour/DoctrineListenerRemoverTraitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Tests\Unit\EventListener\Behaviour;
+
+use App\EventListener\Behaviour\DoctrineListenerRemoverTrait;
+use Doctrine\Common\EventManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DoctrineListenerRemoverTraitTest extends TestCase
+{
+    private MockObject|EventManager $eventManagerMock;
+
+    protected function setUp(): void
+    {
+        $this->eventManagerMock = $this->createMock(EventManager::class);
+    }
+
+    public function testRemoveListenerWhenClassUsingTrait(): void
+    {
+        $listener = $this->createMock(ListenerToRemove::class);
+
+        $this->eventManagerMock
+            ->expects($this->once())
+            ->method('getListeners')
+            ->with('postPersist')
+            ->willReturn([$listener]);
+
+        $this->eventManagerMock
+            ->expects($this->once())
+            ->method('removeEventListener')
+            ->with(['postPersist'], $listener);
+
+        $classUsingTrait = new class {
+            use DoctrineListenerRemoverTrait;
+        };
+
+        $classUsingTrait->removeListener(
+            $this->eventManagerMock,
+            ListenerToRemove::class,
+            'postPersist'
+        );
+    }
+
+    public function testDoNotRemoveListenerWhenClassNotUsingTrait(): void
+    {
+        $listener = $this->createMock(Listener::class);
+
+        $this->eventManagerMock
+            ->expects($this->once())
+            ->method('getListeners')
+            ->with('postPersist')
+            ->willReturn([$listener]);
+
+        $this->eventManagerMock
+            ->expects($this->never())
+            ->method('removeEventListener');
+
+        $classUsingTrait = new class {
+            use DoctrineListenerRemoverTrait;
+        };
+
+        $classUsingTrait->removeListener(
+            $this->eventManagerMock,
+            ListenerToRemove::class,
+            'postPersist'
+        );
+    }
+}
+
+class ListenerToRemove // As EntityHistoryListener
+{
+}
+
+class Listener
+{
+}


### PR DESCRIPTION
## Ticket

#3346    

## Description
https://mattermost.incubateur.net/betagouv/pl/id3yw41jwjnd5rphe9w59gk8ce

Pour éviter les limitations liées au traitement de gros volumes de données, notamment en mode batch, ajout d’un trait permettant de désactiver les listeners et événements au choix.

## Changements apportés
* Ajout d'un trait 

## Pré-requis
### Exemple d'usage

#### Rendre l'entité Epci historisable

```php
class Epci implements EntityHistoryInterface
{
    /* .... */
    public function getHistoryRegisteredEvent(): array
    {
        return [HistoryEntryEvent::CREATE];
    }
}
```

#### Appel de la méthode de suppression des event dédié à l'historisation via HistoryEntryManager
![image](https://github.com/user-attachments/assets/c9767758-7a83-491a-9a41-f29158a076ac)


## Tests
- [ ] Exécuter la commande de chargement des EPCI `make console app="load-epci"` et vérifier l'absence d'historique d'epci dans la table. 