### PR TITLE
[BO - Liste signalement] Correction quand le prénom de l'occupant est null, mais pas le nom

### DIFF
--- a/assets/scripts/vue/components/signalement-list/components/SignalementListCards.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListCards.vue
@@ -6,7 +6,7 @@
           <div class="fr-card__content">
             <div class="fr-grid-row">
               <div class="fr-col-xl-8 fr-col-lg-6 fr-col-12">
-                <h3 class="fr-card__title fr-my-1v">#{{ item.reference }} - {{ item.nomOccupant && item.nomOccupant.toUpperCase()  + ' ' + item.prenomOccupant }}</h3>
+                <h3 class="fr-card__title fr-my-1v">#{{ item.reference }} - {{ (item.nomOccupant ? item.nomOccupant.toUpperCase() : '') + ' ' + (item.prenomOccupant !== null ? item.prenomOccupant : '') }}</h3>
                 <p class="fr-my-1v fr-text--bold fr-text--lg">{{ item.adresseOccupant }}, {{ item.codepostalOccupant }} {{ item.villeOccupant }}</p>
               </div>
               <div class="fr-col-xl-4 fr-col-lg-6 fr-col-12">


### PR DESCRIPTION
## Ticket

#3350   

## Description
Quand le prénom de l'occupant est `null`, mais pas le nom de famille, la liste de signalements affiche "null" à la place du prénom

## Tests
- [ ] Modifier un signalement en mettant un nom de famille et null en prénom ; vérifier l'affichage dans la liste des signalements
