### PR TITLE
 [BO - Auto-affectation] Transformer les règles "code insee" en règle "périmètre géographique"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
         "knplabs/knp-snappy-bundle": "^1.9",
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-bundle": "^3.0",
+        "longitude-one/wkt-parser": "^3.0",
+        "mjaschen/phpgeo": "^5.0",
         "nelmio/cors-bundle": "^2.2",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpoffice/phpspreadsheet": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5096f2ed35426df739daceb598708c81",
+    "content-hash": "727f9a63054c0e1f2b9ac17c5ca06b06",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3354,6 +3354,74 @@
             "time": "2024-03-23T07:42:40+00:00"
         },
         {
+            "name": "longitude-one/wkt-parser",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/longitude-one/wkt-parser.git",
+                "reference": "cb9ded868bfd0200e5134bf259b1e001b83ebaa2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/longitude-one/wkt-parser/zipball/cb9ded868bfd0200e5134bf259b1e001b83ebaa2",
+                "reference": "cb9ded868bfd0200e5134bf259b1e001b83ebaa2",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.1|^3.0",
+                "php": "^8.1"
+            },
+            "replace": {
+                "creof/wkt-parser": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LongitudeOne\\Geo\\WKT": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexandre Tranchant",
+                    "email": "alexandre.tranchant@gmail.com"
+                },
+                {
+                    "name": "axi"
+                },
+                {
+                    "name": "Derek J. Lambert",
+                    "email": "dlambert@dereklambert.com"
+                },
+                {
+                    "name": "ellisgl"
+                }
+            ],
+            "description": "Parser for well-known text (WKT) object strings",
+            "keywords": [
+                "ewkt",
+                "geography",
+                "geometry",
+                "lexer",
+                "parser",
+                "spatial",
+                "string",
+                "text",
+                "wkt"
+            ],
+            "support": {
+                "issues": "https://github.com/longitude-one/wkt-parser/issues",
+                "source": "https://github.com/longitude-one/wkt-parser/tree/3.0.0"
+            },
+            "time": "2024-04-27T07:44:31+00:00"
+        },
+        {
             "name": "lorenzo/pinky",
             "version": "1.1.0",
             "source": {
@@ -3656,6 +3724,89 @@
                 "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
             },
             "time": "2024-03-31T07:05:07+00:00"
+        },
+        {
+            "name": "mjaschen/phpgeo",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mjaschen/phpgeo.git",
+                "reference": "20524a47c8edc76364c7373911224a710aeb1cae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/20524a47c8edc76364c7373911224a710aeb1cae",
+                "reference": "20524a47c8edc76364c7373911224a710aeb1cae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "squizlabs/php_codesniffer": "^3.7",
+                "vimeo/psalm": "^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Location\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Jaschen",
+                    "email": "mjaschen@gmail.com",
+                    "homepage": "https://www.marcusjaschen.de/"
+                }
+            ],
+            "description": "Simple Yet Powerful Geo Library",
+            "homepage": "https://phpgeo.marcusjaschen.de/",
+            "keywords": [
+                "Polygon",
+                "area",
+                "bearing",
+                "bounds",
+                "calculation",
+                "coordinate",
+                "distance",
+                "earth",
+                "ellipsoid",
+                "geo",
+                "geofence",
+                "gis",
+                "gps",
+                "haversine",
+                "length",
+                "perpendicular",
+                "point",
+                "polyline",
+                "projection",
+                "simplify",
+                "track",
+                "vincenty"
+            ],
+            "support": {
+                "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
+                "email": "mjaschen@gmail.com",
+                "issues": "https://github.com/mjaschen/phpgeo/issues",
+                "source": "https://github.com/mjaschen/phpgeo/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/mjaschen",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/mjaschen",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-07T09:53:11+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -14997,12 +15148,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.3"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -116,12 +116,12 @@ class AutoAffectationRuleType extends AbstractType
                 ],
             ])
             ->add('inseeToInclude', TextType::class, [
-                'label' => 'Code insee à inclure',
+                'label' => 'Périmètre géographique à inclure',
                 'attr' => [
                     'class' => 'fr-input',
                 ],
                 'required' => true,
-                'help' => 'Valeurs possibles : "all", "partner_list" ou une liste de codes insee séparés par des virgules.',
+                'help' => 'Valeurs possibles : "all", "partner_list" (codes insee, et zones) ou une liste de codes insee séparés par des virgules.',
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],

--- a/src/Specification/Affectation/CodeInseeSpecification.php
+++ b/src/Specification/Affectation/CodeInseeSpecification.php
@@ -92,7 +92,8 @@ class CodeInseeSpecification implements SpecificationInterface
 
     private function isInseeIncludeInPartnerList(Partner $partner, string $insee)
     {
-        return !empty($partner->getInsee()) && \in_array($insee, $partner->getInsee());
+        return (!empty($partner->getInsee()) && \in_array($insee, $partner->getInsee()))
+        || (empty($partner->getInsee()) && $partner->getZones()->count() > 0);
     }
 
     private function isInseeIncluded(string $insee): bool

--- a/src/Specification/Affectation/CodeInseeSpecification.php
+++ b/src/Specification/Affectation/CodeInseeSpecification.php
@@ -4,9 +4,13 @@ namespace App\Specification\Affectation;
 
 use App\Entity\Partner;
 use App\Entity\Signalement;
+use App\Entity\Zone;
 use App\Specification\Context\PartnerSignalementContext;
 use App\Specification\Context\SpecificationContextInterface;
 use App\Specification\SpecificationInterface;
+use Location\Coordinate;
+use Location\Polygon;
+use LongitudeOne\Geo\WKT\Parser;
 
 class CodeInseeSpecification implements SpecificationInterface
 {
@@ -45,8 +49,34 @@ class CodeInseeSpecification implements SpecificationInterface
                 $result = true;
                 break;
             case 'partner_list':
-                $result = !empty($partner->getInsee())
+                $isZoneOK = true;
+                $isZoneExcludedOK = true;
+                $isInseeOK = !empty($partner->getInsee())
                     && \in_array($signalement->getInseeOccupant(), $partner->getInsee());
+                // var_dump($isInseeOK);
+                if ($isInseeOK) {
+                    if (!empty($partner->getZones()) && $partner->getZones()->count() > 0) {
+                        $isZoneOK = false;
+                        foreach ($partner->getZones() as $zone) {
+                            $isZoneOK = $this->isSignalementInZone($signalement, $zone);
+                            if ($isZoneOK) {
+                                break;
+                            }
+                        }
+                    }
+                    // var_dump($isZoneOK);
+                    if ($isZoneOK && !empty($partner->getExcludedZones()) && $partner->getExcludedZones()->count() > 0) {
+                        foreach ($partner->getExcludedZones() as $zoneExcluded) {
+                            $isZoneExcludedOK = !$this->isSignalementInZone($signalement, $zoneExcluded);
+                            if (!$isZoneExcludedOK) {
+                                break;
+                            }
+                        }
+                    }
+                    // var_dump($isZoneExcludedOK);
+                }
+
+                $result = $isInseeOK && $isZoneOK && $isZoneExcludedOK;
                 break;
             default:
                 $result = !empty($this->inseeToInclude)
@@ -55,5 +85,64 @@ class CodeInseeSpecification implements SpecificationInterface
         }
 
         return $result;
+    }
+
+    private function isSignalementInZone(Signalement $signalement, Zone $zone): bool
+    {
+        $parser = new Parser($zone->getArea());
+        $zoneArea = $parser->parse();
+        $signalementCoordinate = new Coordinate($signalement->getGeoloc()['lat'], $signalement->getGeoloc()['lng']);
+        // var_dump($signalement->getGeoloc());
+        if ('POLYGON' === $zoneArea['type']) {
+            $polygon = $this->buildPolygon($zoneArea['value']);
+            // var_dump($polygon->contains($signalementCoordinate));
+            if ($polygon->contains($signalementCoordinate)) {
+                return true;
+            }
+        }
+        if ('MULTIPOLYGON' === $zoneArea['type']) {
+            foreach ($zoneArea['value'] as $value) {
+                $polygon = $this->buildPolygon($value);
+                if ($polygon->contains($signalementCoordinate)) {
+                    return true;
+                }
+            }
+        }
+        if ('GEOMETRYCOLLECTION' === $zoneArea['type']) {
+            foreach ($zoneArea['value'] as $value) {
+                if ('POLYGON' === $value['type']) {
+                    $polygon = $this->buildPolygon($value['value']);
+                    if ($polygon->contains($signalementCoordinate)) {
+                        return true;
+                    }
+                }
+                if ('MULTIPOLYGON' === $value['type']) {
+                    foreach ($value['value'] as $val) {
+                        $polygon = $this->buildPolygon($val);
+                        if ($polygon->contains($signalementCoordinate)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function buildPolygon(array $points): Polygon
+    {
+        $geofence = new Polygon();
+        // var_dump($points);
+        if (1 === \count($points) && \count($points[0]) > 2) {
+            $points = $points[0];
+        }
+        // var_dump($points);
+        foreach ($points as $point) {
+            $geofence->addPoint(new Coordinate($point[1], $point[0]));
+        }
+
+        // var_dump($geofence->getPoints());
+        return $geofence;
     }
 }

--- a/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
+++ b/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
@@ -29,6 +29,9 @@ class CodeInseeSpecificationTest extends KernelTestCase
         'lng' => -1.455196,
     ];
 
+    private const string INSEE_STMARS = '44179';
+    private const string INSEE_CELLIER = '44028';
+
     /**
      * @dataProvider provideRulesAndSignalementWithZone
      */
@@ -75,98 +78,98 @@ class CodeInseeSpecificationTest extends KernelTestCase
 
     public function provideRulesAndSignalementWithZone(): \Generator
     {
-        yield 'same insee as partner - no excluded insee - same zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'same insee as partner - no excluded insee - same zone as geoloc, same zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'same insee as partner - no excluded insee - same zone as geoloc, different zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - no excluded insee - no zone - no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, null, null, true];
-        yield 'same insee as partner - no excluded insee - no zone - same zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'same insee as partner - no excluded insee - no zone - different zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - no excluded insee - different zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'same insee as partner - no excluded insee - different zone as geoloc, same zone as excluded' => ['44179', ['44179'], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - no excluded insee - different zone as geoloc, different zone as excluded' => ['44179', ['44179'], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
+        yield 'same insee as partner - no excluded insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'same insee as partner - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - no excluded insee - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, null, null, true];
+        yield 'same insee as partner - no excluded insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'same insee as partner - no excluded insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - no excluded insee - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'same insee as partner - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
         // tout cela est illogique, et doit renvoyer false
-        yield 'same insee as partner - but excluded - same zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'same insee as partner - but excluded - same zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'same insee as partner - but excluded - same zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - but excluded - no zone - no zone excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, null, null, false];
-        yield 'same insee as partner - but excluded - no zone - same zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'same insee as partner - but excluded - no zone - different zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - but excluded - different zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'same insee as partner - but excluded - different zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - but excluded - different zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'same insee as partner - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'same insee as partner - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - but excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, null, false];
+        yield 'same insee as partner - but excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'same insee as partner - but excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - but excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'same insee as partner - but excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - but excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
-        yield 'same insee as partner - another insee - same zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'same insee as partner - another insee - same zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'same insee as partner - another insee - same zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - another insee - no zone - no zone excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, null, null, true];
-        yield 'same insee as partner - another insee - no zone - same zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'same insee as partner - another insee - no zone - different zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - another insee - different zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'same insee as partner - another insee - different zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - another insee - different zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - another insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
+        yield 'same insee as partner - another insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'same insee as partner - another insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - another insee - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, null, true];
+        yield 'same insee as partner - another insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'same insee as partner - another insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - another insee - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'same insee as partner - another insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - another insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
-        yield 'different insee than partner - no excluded insee - same zone as geoloc, no zone excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'different insee than partner - no excluded insee - same zone as geoloc, same zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'different insee than partner - no excluded insee - same zone as geoloc, different zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - no excluded insee - no zone - no zone excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, null, null, false];
-        yield 'different insee than partner - no excluded insee - no zone - same zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'different insee than partner - no excluded insee - no zone - different zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - no excluded insee - different zone as geoloc, no zone excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'different insee than partner - no excluded insee - different zone as geoloc, same zone as excluded' => ['44179', ['44028'], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - no excluded insee - different zone as geoloc, different zone as excluded' => ['44179', ['44028'], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        // tout cela est illogique, et doit renvoyer false
-        yield 'different insee than partner - but excluded - same zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'different insee than partner - but excluded - same zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'different insee than partner - but excluded - same zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - but excluded - no zone - no zone excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, null, null, false];
-        yield 'different insee than partner - but excluded - no zone - same zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'different insee than partner - but excluded - no zone - different zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - but excluded - different zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'different insee than partner - but excluded - different zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - but excluded - different zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'different insee than partner - another insee excluded - same zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'different insee than partner - another insee excluded - same zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'different insee than partner - another insee excluded - same zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - another insee excluded - no zone - no zone excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, null, null, false];
-        yield 'different insee than partner - another insee excluded - no zone - same zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'different insee than partner - another insee excluded - no zone - different zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - another insee excluded - different zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'different insee than partner - another insee excluded - different zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - another insee excluded - different zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'partner without insee - no excluded insee - same zone as geoloc, no zone excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'partner without insee - no excluded insee - same zone as geoloc, same zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - no excluded insee - same zone as geoloc, different zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'partner without insee - no excluded insee - no zone - no zone excluded' => ['44179', [], null, $this->geolocLaBodiniere, null, null, false];
-        yield 'partner without insee - no excluded insee - no zone - same zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'partner without insee - no excluded insee - no zone - different zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'partner without insee - no excluded insee - different zone as geoloc, no zone excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'partner without insee - no excluded insee - different zone as geoloc, same zone as excluded' => ['44179', [], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'partner without insee - no excluded insee - different zone as geoloc, different zone as excluded' => ['44179', [], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'different insee than partner - no excluded insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'different insee than partner - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - no excluded insee - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, null, null, false];
+        yield 'different insee than partner - no excluded insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'different insee than partner - no excluded insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - no excluded insee - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'different insee than partner - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
         // tout cela est illogique, et doit renvoyer false
-        yield 'partner without insee - but excluded - same zone as geoloc, no zone excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'partner without insee - but excluded - same zone as geoloc, same zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - but excluded - same zone as geoloc, different zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'partner without insee - but excluded - no zone - no zone excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, null, null, false];
-        yield 'partner without insee - but excluded - no zone - same zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'partner without insee - but excluded - no zone - different zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'partner without insee - but excluded - different zone as geoloc, no zone excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'partner without insee - but excluded - different zone as geoloc, same zone as excluded' => ['44179', [], ['44179'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'partner without insee - but excluded - different zone as geoloc, different zone as excluded' => ['44179', [], ['44179'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'different insee than partner - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'different insee than partner - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - but excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, null, false];
+        yield 'different insee than partner - but excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'different insee than partner - but excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - but excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'different insee than partner - but excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - but excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
-        yield 'partner without insee - another insee excluded - same zone as geoloc, no zone excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'partner without insee - another insee excluded - same zone as geoloc, same zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - another insee excluded - same zone as geoloc, different zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'partner without insee - another insee excluded - no zone - no zone excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, null, null, false];
-        yield 'partner without insee - another insee excluded - no zone - same zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'partner without insee - another insee excluded - no zone - different zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'partner without insee - another insee excluded - different zone as geoloc, no zone excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'partner without insee - another insee excluded - different zone as geoloc, same zone as excluded' => ['44179', [], ['44028'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'partner without insee - another insee excluded - different zone as geoloc, different zone as excluded' => ['44179', [], ['44028'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - another insee excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'different insee than partner - another insee excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'different insee than partner - another insee excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - another insee excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, null, false];
+        yield 'different insee than partner - another insee excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'different insee than partner - another insee excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - another insee excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'different insee than partner - another insee excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - another insee excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        yield 'partner without insee - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - no excluded insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'partner without insee - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - no excluded insee - no zone - no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, null, false];
+        yield 'partner without insee - no excluded insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'partner without insee - no excluded insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'partner without insee - no excluded insee - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'partner without insee - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'partner without insee - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        // tout cela est illogique, et doit renvoyer false
+        yield 'partner without insee - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'partner without insee - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - but excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, null, false];
+        yield 'partner without insee - but excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'partner without insee - but excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'partner without insee - but excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'partner without insee - but excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'partner without insee - but excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        yield 'partner without insee - another insee excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - another insee excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'partner without insee - another insee excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - another insee excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, null, false];
+        yield 'partner without insee - another insee excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'partner without insee - another insee excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'partner without insee - another insee excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'partner without insee - another insee excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'partner without insee - another insee excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
     }
 
     /**
@@ -198,49 +201,49 @@ class CodeInseeSpecificationTest extends KernelTestCase
 
     public function provideRulesAndSignalementWithoutZone(): \Generator
     {
-        yield 'all - same insee as partner - no exclude' => ['44179', ['44179'], 'all', null, true];
-        yield 'all - same insee as partner - but excluded' => ['44179', ['44179'], 'all', ['44179'], false];
-        yield 'all - same insee as partner - another excluded' => ['44179', ['44179'], 'all', ['44028'], true];
-        yield 'all - different insee than partner - no exclude' => ['44179', ['44028'], 'all', null, true];
-        yield 'all - different insee than partner - but excluded' => ['44179', ['44028'], 'all', ['44179'], false];
-        yield 'all - different insee than partner - another excluded' => ['44179', ['44028'], 'all', ['44028'], true];
-        yield 'all - partner without insee - no exclude' => ['44179', [], 'all', null, true];
-        yield 'all - partner without insee - but excluded' => ['44179', [], 'all', ['44179'], false];
-        yield 'all - partner without insee - another excluded' => ['44179', [], 'all', ['44028'], true];
+        yield 'all - same insee as partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'all', null, true];
+        yield 'all - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'all', [self::INSEE_STMARS], false];
+        yield 'all - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'all', [self::INSEE_CELLIER], true];
+        yield 'all - different insee than partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'all', null, true];
+        yield 'all - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'all', [self::INSEE_STMARS], false];
+        yield 'all - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'all', [self::INSEE_CELLIER], true];
+        yield 'all - partner without insee - no exclude' => [self::INSEE_STMARS, [], 'all', null, true];
+        yield 'all - partner without insee - but excluded' => [self::INSEE_STMARS, [], 'all', [self::INSEE_STMARS], false];
+        yield 'all - partner without insee - another excluded' => [self::INSEE_STMARS, [], 'all', [self::INSEE_CELLIER], true];
 
-        yield 'partner_list - same insee as partner - no exclusion' => ['44179', ['44179'], 'partner_list', null, true];
-        yield 'partner_list - same insee as partner - but excluded' => ['44179', ['44179'], 'partner_list', ['44179'], false];
-        yield 'partner_list - same insee as partner - another excluded' => ['44179', ['44179'], 'partner_list', ['44028'], true];
-        yield 'partner_list - different insee than partner - no exclusion' => ['44179', ['44028'], 'partner_list', null, false];
-        yield 'partner_list - different insee than partner - but excluded' => ['44179', ['44028'], 'partner_list', ['44179'], false];
-        yield 'partner_list - different insee than partner - another excluded' => ['44179', ['44028'], 'partner_list', ['44028'], false];
-        yield 'partner_list - partner without insee - no exclusion' => ['44179', [], 'partner_list', null, false];
-        yield 'partner_list - partner without insee - but excluded' => ['44179', [], 'partner_list', ['44179'], false];
-        yield 'partner_list - partner without insee - another excluded' => ['44179', [], 'partner_list', ['44028'], false];
+        yield 'partner_list - same insee as partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'partner_list', null, true];
+        yield 'partner_list - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'partner_list', [self::INSEE_STMARS], false];
+        yield 'partner_list - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'partner_list', [self::INSEE_CELLIER], true];
+        yield 'partner_list - different insee than partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'partner_list', null, false];
+        yield 'partner_list - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'partner_list', [self::INSEE_STMARS], false];
+        yield 'partner_list - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'partner_list', [self::INSEE_CELLIER], false];
+        yield 'partner_list - partner without insee - no exclusion' => [self::INSEE_STMARS, [], 'partner_list', null, false];
+        yield 'partner_list - partner without insee - but excluded' => [self::INSEE_STMARS, [], 'partner_list', [self::INSEE_STMARS], false];
+        yield 'partner_list - partner without insee - another excluded' => [self::INSEE_STMARS, [], 'partner_list', [self::INSEE_CELLIER], false];
 
-        yield 'array of insee with this one - same insee as partner - no exclusion' => ['44179', ['44179'], '44179', null, true];
-        yield 'array of insee with this one - same insee as partner - but excluded' => ['44179', ['44179'], '44179', ['44179'], false];
-        yield 'array of insee with this one - same insee as partner - another excluded' => ['44179', ['44179'], '44179', ['44028'], true];
-        yield 'array of insee with this one - different insee than partner - no exclusion' => ['44179', ['44028'], '44179', null, true];
-        yield 'array of insee with this one - different insee than partner - but excluded' => ['44179', ['44028'], '44179', ['44179'], false];
-        yield 'array of insee with this one - different insee than partner - another excluded' => ['44179', ['44028'], '44179', ['44028'], true];
-        yield 'array of insee with this one - partner without insee - no exclusion' => ['44179', [], '44179', null, true];
-        yield 'array of insee with this one - partner without insee - but excluded' => ['44179', [], '44179', ['44179'], false];
-        yield 'array of insee with this one - partner without insee - another excluded' => ['44179', [], '44179', ['44028'], true];
+        yield 'array of insee with this one - same insee as partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_STMARS, null, true];
+        yield 'array of insee with this one - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_STMARS, [self::INSEE_STMARS], false];
+        yield 'array of insee with this one - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_STMARS, [self::INSEE_CELLIER], true];
+        yield 'array of insee with this one - different insee than partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_CELLIER], self::INSEE_STMARS, null, true];
+        yield 'array of insee with this one - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], self::INSEE_STMARS, [self::INSEE_STMARS], false];
+        yield 'array of insee with this one - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], self::INSEE_STMARS, [self::INSEE_CELLIER], true];
+        yield 'array of insee with this one - partner without insee - no exclusion' => [self::INSEE_STMARS, [], self::INSEE_STMARS, null, true];
+        yield 'array of insee with this one - partner without insee - but excluded' => [self::INSEE_STMARS, [], self::INSEE_STMARS, [self::INSEE_STMARS], false];
+        yield 'array of insee with this one - partner without insee - another excluded' => [self::INSEE_STMARS, [], self::INSEE_STMARS, [self::INSEE_CELLIER], true];
 
-        yield 'array of insee without this one - same insee as partner - no exclusion' => ['44179', ['44179'], '44028', null, false];
-        yield 'array of insee without this one - same insee as partner - but excluded' => ['44179', ['44179'], '44028', ['44179'], false];
-        yield 'array of insee without this one - same insee as partner - another excluded' => ['44179', ['44179'], '44028', ['44028'], false];
-        yield 'array of insee without this one - different insee than partner - no exclusion' => ['44179', ['44028'], '44028', null, false];
-        yield 'array of insee without this one - different insee than partner - but excluded' => ['44179', ['44028'], '44028', ['44179'], false];
-        yield 'array of insee without this one - different insee than partner - another excluded' => ['44179', ['44028'], '44028', ['44028'], false];
-        yield 'array of insee without this one - partner without insee - no exclusion' => ['44179', [], '44028', null, false];
-        yield 'array of insee without this one - partner without insee - but excluded' => ['44179', [], '44028', ['44179'], false];
-        yield 'array of insee without this one - partner without insee - another excluded' => ['44179', [], '44028', ['44028'], false];
+        yield 'array of insee without this one - same insee as partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_CELLIER, null, false];
+        yield 'array of insee without this one - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_CELLIER, [self::INSEE_STMARS], false];
+        yield 'array of insee without this one - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_CELLIER, [self::INSEE_CELLIER], false];
+        yield 'array of insee without this one - different insee than partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_CELLIER], self::INSEE_CELLIER, null, false];
+        yield 'array of insee without this one - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], self::INSEE_CELLIER, [self::INSEE_STMARS], false];
+        yield 'array of insee without this one - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], self::INSEE_CELLIER, [self::INSEE_CELLIER], false];
+        yield 'array of insee without this one - partner without insee - no exclusion' => [self::INSEE_STMARS, [], self::INSEE_CELLIER, null, false];
+        yield 'array of insee without this one - partner without insee - but excluded' => [self::INSEE_STMARS, [], self::INSEE_CELLIER, [self::INSEE_STMARS], false];
+        yield 'array of insee without this one - partner without insee - another excluded' => [self::INSEE_STMARS, [], self::INSEE_CELLIER, [self::INSEE_CELLIER], false];
 
         // tous les cas ne sont pas testés en cas d'absence d'insee sur le signalement, car ça renvoie toujours false
-        yield 'all - no insee signalement' => [null, ['44028'], 'all', ['44028'], false];
-        yield 'partner_list - no insee signalement - another excluded' => [null, [], 'partner_list', ['44028'], false];
-        yield 'array of insee - no insee signalement - another excluded' => [null, [], '44179', ['44028'], false];
+        yield 'all - no insee signalement' => [null, [self::INSEE_CELLIER], 'all', [self::INSEE_CELLIER], false];
+        yield 'partner_list - no insee signalement - another excluded' => [null, [], 'partner_list', [self::INSEE_CELLIER], false];
+        yield 'array of insee - no insee signalement - another excluded' => [null, [], self::INSEE_STMARS, [self::INSEE_CELLIER], false];
     }
 }

--- a/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
+++ b/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
@@ -4,20 +4,98 @@ namespace App\Tests\Functional\Specification\Affectation;
 
 use App\Entity\Partner;
 use App\Entity\Signalement;
+use App\Entity\Zone;
 use App\Specification\Affectation\CodeInseeSpecification;
 use App\Specification\Context\PartnerSignalementContext;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class CodeInseeSpecificationTest extends KernelTestCase
 {
+    private string $zoneBourgStMars = 'GEOMETRYCOLLECTION(POLYGON ((-1.403246 47.368071, -1.405563 47.369234, -1.409512 47.368652, -1.41346 47.369699, -1.41758 47.368478, -1.417408 47.365571, -1.41758 47.362316, -1.415176 47.359932, -1.410713 47.359583, -1.40625 47.358479, -1.401443 47.358188, -1.400757 47.362374, -1.40316 47.365339, -1.403246 47.368071)), POLYGON ((-1.423073 47.368304, -1.419983 47.369641, -1.420326 47.372024, -1.424017 47.372489, -1.426506 47.371036, -1.42642 47.369583, -1.423073 47.368304)))';
+    private string $zoneLaBodiniere = 'POLYGON ((-1.444273 47.350861, -1.448994 47.352024, -1.450453 47.350745, -1.44865 47.349059, -1.446505 47.348593, -1.444273 47.349, -1.444273 47.350861))';
+
+    private array $geolocLaBodiniere = [
+        'lat' => 47.349698,
+        'lng' => -1.446676,
+    ];
+
+    private array $geolocLaTourmentinerie = [
+        'lat' => 47.363934,
+        'lng' => -1.41422,
+    ];
+
     /**
-     * @dataProvider provideRulesAndSignalement
+     * @dataProvider provideRulesAndSignalementWithZone
      */
-    public function testIsSatisfiedBy(?string $inseeSignalement, array $inseePartenaire, string $inseeToIncludeRule, ?array $inseeToExcludeRule, bool $isSatisfied): void
-    {
+    public function testIsSatisfiedByWithZone(
+        ?string $inseeSignalement,
+        array $inseePartenaire,
+        ?array $inseeToExcludeRule,
+        array $geolocSignalement,
+        ?string $zoneToInclude,
+        ?string $zoneToExclude,
+        bool $isSatisfied,
+    ): void {
         $partner = new Partner();
         $partner->setInsee($inseePartenaire);
         $this->assertEquals($inseePartenaire, $partner->getInsee());
+        if (null !== $zoneToInclude) {
+            /** @var Zone $zone */
+            $zone = new Zone();
+            $zone->setArea($zoneToInclude);
+            $partner->addZone($zone);
+            $this->assertEquals($zoneToInclude, $partner->getZones()[0]->getArea());
+        }
+        if (null !== $zoneToExclude) {
+            /** @var Zone $zone */
+            $zone = new Zone();
+            $zone->setArea($zoneToExclude);
+            $partner->addExcludedZone($zone);
+            $this->assertEquals($zoneToInclude, $partner->getExcludedZones()[0]->getArea());
+        }
+
+        $signalement = new Signalement();
+        $signalement->setInseeOccupant($inseeSignalement);
+        $signalement->setGeoloc($geolocSignalement);
+        $this->assertEquals($inseeSignalement, $signalement->getInseeOccupant());
+
+        $specification = new CodeInseeSpecification('partner_list', $inseeToExcludeRule);
+        $context = new PartnerSignalementContext($partner, $signalement);
+        if ($isSatisfied) {
+            $this->assertTrue($specification->isSatisfiedBy($context));
+        } else {
+            $this->assertFalse($specification->isSatisfiedBy($context));
+        }
+    }
+
+    public function provideRulesAndSignalementWithZone(): \Generator
+    {
+        yield 'same insee as partner - no exclusion - same zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
+        yield 'same insee as partner - no exclusion - different zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        // yield 'same insee as partner - but excluded' => ['44179', ['44179'], ['44179'], false];
+        // yield 'same insee as partner - another excluded' => ['44179', ['44179'], ['44028'], true];
+        // yield 'different insee than partner - no exclusion' => ['44179', ['44028'], null, false];
+        // yield 'different insee than partner - but excluded' => ['44179', ['44028'], ['44179'], false];
+        // yield 'different insee than partner - another excluded' => ['44179', ['44028'], ['44028'], false];
+        // yield 'partner without insee - no exclusion' => ['44179', [], null, false];
+        // yield 'partner without insee - but excluded' => ['44179', [], ['44179'], false];
+        // yield 'partner without insee - another excluded' => ['44179', [], ['44028'], false];
+    }
+
+    /**
+     * @dataProvider provideRulesAndSignalementWithoutZone
+     */
+    public function testIsSatisfiedByWithoutZone(
+        ?string $inseeSignalement,
+        array $inseePartenaire,
+        string $inseeToIncludeRule,
+        ?array $inseeToExcludeRule,
+        bool $isSatisfied,
+    ): void {
+        $partner = new Partner();
+        $partner->setInsee($inseePartenaire);
+        $this->assertEquals($inseePartenaire, $partner->getInsee());
+
         $signalement = new Signalement();
         $signalement->setInseeOccupant($inseeSignalement);
         $this->assertEquals($inseeSignalement, $signalement->getInseeOccupant());
@@ -31,7 +109,7 @@ class CodeInseeSpecificationTest extends KernelTestCase
         }
     }
 
-    public function provideRulesAndSignalement(): \Generator
+    public function provideRulesAndSignalementWithoutZone(): \Generator
     {
         yield 'all - same insee as partner - no exclude' => ['44179', ['44179'], 'all', null, true];
         yield 'all - same insee as partner - but excluded' => ['44179', ['44179'], 'all', ['44179'], false];

--- a/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
+++ b/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
@@ -119,7 +119,6 @@ class CodeInseeSpecificationTest extends KernelTestCase
         yield 'different insee than partner - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
         yield 'different insee than partner - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
-        // tout cela est illogique, et doit renvoyer false
         yield 'different insee than partner - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
         yield 'different insee than partner - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
         yield 'different insee than partner - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
@@ -140,9 +139,9 @@ class CodeInseeSpecificationTest extends KernelTestCase
         yield 'different insee than partner - another insee excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
         yield 'different insee than partner - another insee excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
-        yield 'partner without insee - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
         yield 'partner without insee - no excluded insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
         yield 'partner without insee - no excluded insee - no zone - no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, null, false];
         yield 'partner without insee - no excluded insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
         yield 'partner without insee - no excluded insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
@@ -150,7 +149,6 @@ class CodeInseeSpecificationTest extends KernelTestCase
         yield 'partner without insee - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
         yield 'partner without insee - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
-        // tout cela est illogique, et doit renvoyer false
         yield 'partner without insee - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
         yield 'partner without insee - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
         yield 'partner without insee - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
@@ -161,9 +159,9 @@ class CodeInseeSpecificationTest extends KernelTestCase
         yield 'partner without insee - but excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
         yield 'partner without insee - but excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
 
-        yield 'partner without insee - another insee excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - another insee excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
         yield 'partner without insee - another insee excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - another insee excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - another insee excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
         yield 'partner without insee - another insee excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, null, false];
         yield 'partner without insee - another insee excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
         yield 'partner without insee - another insee excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];

--- a/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
+++ b/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
@@ -24,6 +24,11 @@ class CodeInseeSpecificationTest extends KernelTestCase
         'lng' => -1.41422,
     ];
 
+    private array $geolocLaGree = [
+        'lat' => 47.37025,
+        'lng' => -1.455196,
+    ];
+
     /**
      * @dataProvider provideRulesAndSignalementWithZone
      */
@@ -51,7 +56,7 @@ class CodeInseeSpecificationTest extends KernelTestCase
             $zone = new Zone();
             $zone->setArea($zoneToExclude);
             $partner->addExcludedZone($zone);
-            $this->assertEquals($zoneToInclude, $partner->getExcludedZones()[0]->getArea());
+            $this->assertEquals($zoneToExclude, $partner->getExcludedZones()[0]->getArea());
         }
 
         $signalement = new Signalement();
@@ -70,16 +75,98 @@ class CodeInseeSpecificationTest extends KernelTestCase
 
     public function provideRulesAndSignalementWithZone(): \Generator
     {
-        yield 'same insee as partner - no exclusion - same zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'same insee as partner - no exclusion - different zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        // yield 'same insee as partner - but excluded' => ['44179', ['44179'], ['44179'], false];
-        // yield 'same insee as partner - another excluded' => ['44179', ['44179'], ['44028'], true];
-        // yield 'different insee than partner - no exclusion' => ['44179', ['44028'], null, false];
-        // yield 'different insee than partner - but excluded' => ['44179', ['44028'], ['44179'], false];
-        // yield 'different insee than partner - another excluded' => ['44179', ['44028'], ['44028'], false];
-        // yield 'partner without insee - no exclusion' => ['44179', [], null, false];
-        // yield 'partner without insee - but excluded' => ['44179', [], ['44179'], false];
-        // yield 'partner without insee - another excluded' => ['44179', [], ['44028'], false];
+        yield 'same insee as partner - no excluded insee - same zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
+        yield 'same insee as partner - no excluded insee - same zone as geoloc, same zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'same insee as partner - no excluded insee - same zone as geoloc, different zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - no excluded insee - no zone - no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, null, null, true];
+        yield 'same insee as partner - no excluded insee - no zone - same zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'same insee as partner - no excluded insee - no zone - different zone as excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - no excluded insee - different zone as geoloc, no zone excluded' => ['44179', ['44179'], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'same insee as partner - no excluded insee - different zone as geoloc, same zone as excluded' => ['44179', ['44179'], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - no excluded insee - different zone as geoloc, different zone as excluded' => ['44179', ['44179'], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        // tout cela est illogique, et doit renvoyer false
+        yield 'same insee as partner - but excluded - same zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'same insee as partner - but excluded - same zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'same insee as partner - but excluded - same zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - but excluded - no zone - no zone excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, null, null, false];
+        yield 'same insee as partner - but excluded - no zone - same zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'same insee as partner - but excluded - no zone - different zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - but excluded - different zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'same insee as partner - but excluded - different zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - but excluded - different zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44179'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        yield 'same insee as partner - another insee - same zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
+        yield 'same insee as partner - another insee - same zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'same insee as partner - another insee - same zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - another insee - no zone - no zone excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, null, null, true];
+        yield 'same insee as partner - another insee - no zone - same zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'same insee as partner - another insee - no zone - different zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
+        yield 'same insee as partner - another insee - different zone as geoloc, no zone excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'same insee as partner - another insee - different zone as geoloc, same zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'same insee as partner - another insee - different zone as geoloc, different zone as excluded' => ['44179', ['44179'], ['44028'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        yield 'different insee than partner - no excluded insee - same zone as geoloc, no zone excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'different insee than partner - no excluded insee - same zone as geoloc, same zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'different insee than partner - no excluded insee - same zone as geoloc, different zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - no excluded insee - no zone - no zone excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, null, null, false];
+        yield 'different insee than partner - no excluded insee - no zone - same zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'different insee than partner - no excluded insee - no zone - different zone as excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - no excluded insee - different zone as geoloc, no zone excluded' => ['44179', ['44028'], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'different insee than partner - no excluded insee - different zone as geoloc, same zone as excluded' => ['44179', ['44028'], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - no excluded insee - different zone as geoloc, different zone as excluded' => ['44179', ['44028'], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        // tout cela est illogique, et doit renvoyer false
+        yield 'different insee than partner - but excluded - same zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'different insee than partner - but excluded - same zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'different insee than partner - but excluded - same zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - but excluded - no zone - no zone excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, null, null, false];
+        yield 'different insee than partner - but excluded - no zone - same zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'different insee than partner - but excluded - no zone - different zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - but excluded - different zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'different insee than partner - but excluded - different zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - but excluded - different zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44179'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        yield 'different insee than partner - another insee excluded - same zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'different insee than partner - another insee excluded - same zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'different insee than partner - another insee excluded - same zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - another insee excluded - no zone - no zone excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, null, null, false];
+        yield 'different insee than partner - another insee excluded - no zone - same zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'different insee than partner - another insee excluded - no zone - different zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - another insee excluded - different zone as geoloc, no zone excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'different insee than partner - another insee excluded - different zone as geoloc, same zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'different insee than partner - another insee excluded - different zone as geoloc, different zone as excluded' => ['44179', ['44028'], ['44028'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        yield 'partner without insee - no excluded insee - same zone as geoloc, no zone excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - no excluded insee - same zone as geoloc, same zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'partner without insee - no excluded insee - same zone as geoloc, different zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - no excluded insee - no zone - no zone excluded' => ['44179', [], null, $this->geolocLaBodiniere, null, null, false];
+        yield 'partner without insee - no excluded insee - no zone - same zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'partner without insee - no excluded insee - no zone - different zone as excluded' => ['44179', [], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'partner without insee - no excluded insee - different zone as geoloc, no zone excluded' => ['44179', [], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'partner without insee - no excluded insee - different zone as geoloc, same zone as excluded' => ['44179', [], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'partner without insee - no excluded insee - different zone as geoloc, different zone as excluded' => ['44179', [], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        // tout cela est illogique, et doit renvoyer false
+        yield 'partner without insee - but excluded - same zone as geoloc, no zone excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - but excluded - same zone as geoloc, same zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'partner without insee - but excluded - same zone as geoloc, different zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - but excluded - no zone - no zone excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, null, null, false];
+        yield 'partner without insee - but excluded - no zone - same zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'partner without insee - but excluded - no zone - different zone as excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'partner without insee - but excluded - different zone as geoloc, no zone excluded' => ['44179', [], ['44179'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'partner without insee - but excluded - different zone as geoloc, same zone as excluded' => ['44179', [], ['44179'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'partner without insee - but excluded - different zone as geoloc, different zone as excluded' => ['44179', [], ['44179'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+
+        yield 'partner without insee - another insee excluded - same zone as geoloc, no zone excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
+        yield 'partner without insee - another insee excluded - same zone as geoloc, same zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
+        yield 'partner without insee - another insee excluded - same zone as geoloc, different zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
+        yield 'partner without insee - another insee excluded - no zone - no zone excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, null, null, false];
+        yield 'partner without insee - another insee excluded - no zone - same zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
+        yield 'partner without insee - another insee excluded - no zone - different zone as excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
+        yield 'partner without insee - another insee excluded - different zone as geoloc, no zone excluded' => ['44179', [], ['44028'], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
+        yield 'partner without insee - another insee excluded - different zone as geoloc, same zone as excluded' => ['44179', [], ['44028'], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
+        yield 'partner without insee - another insee excluded - different zone as geoloc, different zone as excluded' => ['44179', [], ['44028'], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
     }
 
     /**


### PR DESCRIPTION
## Ticket

#3286   

## Description
Actuellement nous avons :
```
Code insee à inclure
Valeurs possibles : "all", "partner_list" ou une liste de codes insee séparés par des virgules.

Codes insee à exclure (facultatif)
Une liste de codes insee séparés par des virgules.

```
Il faudrait les renommer car quand on choisit "partner_list" cela doit prendre en comptes à la fois les codes insee du partenaire et les zones (geoloc)

## Changements apportés
* Ajout de la librairie `mjaschen/phpgeo` pour vérifier si un point se trouve dans un polygon
* Ajout de la librairie `longitude-one/wkt-parser` pour transformer un text wkt an tableaux lisibles
* Modification du formType pour renommer le paramètre `Code insee à inclure` en `Périmètre géographique à inclure`
* Adaptation de la spécification `CodeInseeSpecification` pour prendre en compte les zones
* Ajout de tests sur la spécification

## Pré-requis
`make build`

## Tests
- [ ] CI ok
- [ ] Créer des règles d'affectation dans un territoire avec des zones et des partners ayant des zones et des zones d'exclusion
- [ ] Créer une règle avec `partner_list` pour le périmètre géographique
- [ ] Créer un signalement, et en fonction de sa géolocalisation, vérifier qu'il est affecté aux bon partenaires
