### PR TITLE
[BO-Signalement] Suivi auto Document manquant

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -151,6 +151,7 @@ class AffectationController extends AbstractController
                         'type' => Suivi::TYPE_AUTO,
                     ],
                     isPublic: true,
+                    context: Suivi::CONTEXT_NOTIFY_USAGER_ONLY,
                     flush: true
                 );
             }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -17,7 +17,7 @@ class Suivi implements EntityHistoryInterface
     public const TYPE_PARTNER = 3;
     public const TYPE_TECHNICAL = 4;
     public const TYPE_USAGER_POST_CLOTURE = 5;
-
+    public const string CONTEXT_NOTIFY_USAGER_ONLY = 'notifyUsagerOnly';
     public const CONTEXT_INTERVENTION = 'intervention';
     public const CONTEXT_SCHS = 'schs';
 

--- a/src/EventListener/ActivityListener.php
+++ b/src/EventListener/ActivityListener.php
@@ -69,7 +69,7 @@ class ActivityListener
                         continue;
                     }
 
-                    $notifyAdminsAndPartners = $entity->getDescription() != $this->parameterBag->get('suivi_message')['first_accepted_affectation'];
+                    $notifyAdminsAndPartners = Suivi::CONTEXT_NOTIFY_USAGER_ONLY !== $entity->getContext();
                     if ($notifyAdminsAndPartners) {
                         $this->tos->clear();
                         $this->notifyAdmins($entity, Notification::TYPE_SUIVI, $entity->getSignalement()->getTerritory());

--- a/src/Messenger/MessageHandler/NewSignalementCheckFileMessageHandler.php
+++ b/src/Messenger/MessageHandler/NewSignalementCheckFileMessageHandler.php
@@ -208,7 +208,8 @@ class NewSignalementCheckFileMessageHandler
                 'description' => $this->description,
             ],
             isPublic: true,
-            flush: true
+            context: Suivi::CONTEXT_NOTIFY_USAGER_ONLY,
+            flush: true,
         );
     }
 }


### PR DESCRIPTION
## Ticket

#3358

## Description
Le nouveau message de suivi automatique demandant les documents manquant suite au dépôt d'un signalement notifiait (interne et email) les agents sans que cela ai un intérêt pour eux. Retrait de ces notifications.

## Changements apportés
Ajout d'un contexte "notifyUsagerOnly" sur les suivis pour lesquels seul les usagers doivent être notifié, il s'agit des suivi 
- Demande de document manquant suite au dépôt du signalement
- Première acceptation d'une affectation sur un signalement (ne change rien par rapport à l'existant)

## Pré-requis
`make worker-stop`
`make worker-start`

## Tests
- [ ] Déposer un signalement avec des document manquant, attendre que le suivi demandant les doc soit généré et s'assurer qu'aucune notification interne n'a été créee, et que seul l'usager/déclarant sont notifié par mail
