### PR TITLE
[BO] Marge du bas avant footer

### DIFF
--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -5,7 +5,7 @@
 {% block body %}
     {% if platform.feature_enable_menu_horizontale %}
         {% include 'back/nav_bo.html.twig' %}
-        <main id="container-horizontal">
+        <main id="container-horizontal" class="fr-mb-5v">
             <div class="{{ app.request.get('_route') in ['back_cartographie', 'back_signalement_index', 'back_dashboard'] ? 'fr-container-fluid' : container_class }}">
                 <div class="fr-grid-row">
                     <div class="fr-col-12" id="content">


### PR DESCRIPTION
## Ticket

#3332   

## Description
Erreur dans la PR ici : https://github.com/MTES-MCT/histologe/pull/3333
La marge du bas avant footer n'a pas été mise en ligne au moment de la PR.
Erreur de ma part, probablement, qui n'a pas été aperçue.

## Tests
- [ ] Vérifier qu'il y a bien la marge juste avant le footer
