### PR TITLE
[BO - Menu horizontal] Mauvais lien de documentation (Remplacement documentation par faq)

### DIFF
--- a/templates/back/header_main_menu.html.twig
+++ b/templates/back/header_main_menu.html.twig
@@ -39,7 +39,7 @@
             {% endif %}
         {% endfor %}
         <li class="fr-nav__item fr-ml-auto">
-            <a class="fr-nav__link" href="{{ gitbook.faq }}" target="_blank" rel="noopener">
+            <a class="fr-nav__link" href="{{ gitbook.documentation }}" target="_blank" rel="noopener">
                 Documentation
             </a>
         </li>


### PR DESCRIPTION
## Ticket

#3368   

## Description
Mauvais lien sur le menu horizontal

## Changements apportés
* Remplacement du lien

## Pré-requis

## Tests
- [ ] Vérifier que le lien du BO renvoi bien vers la documentation 
