### PR TITLE
[BO - Liste des signalements] Ajouter "assurantiel" dans le filtre procédure

### DIFF
--- a/assets/scripts/vue/components/signalement-list/store.ts
+++ b/assets/scripts/vue/components/signalement-list/store.ts
@@ -92,7 +92,8 @@ export const store = {
       { Id: 'danger', Text: 'Danger occupant' },
       { Id: 'insalubrite', Text: 'Insalubrité' },
       { Id: 'mise_en_securite_peril', Text: 'Péril' },
-      { Id: 'suroccupation', Text: 'Suroccupation' }
+      { Id: 'suroccupation', Text: 'Suroccupation' },
+      { Id: 'assurantiel', Text: 'Assurantiel' }
     ],
     typeDernierSuiviList: [
       { Id: 'partenaire', Text: 'Suivi Partenaire' },

--- a/src/Dto/Request/Signalement/SignalementSearchQuery.php
+++ b/src/Dto/Request/Signalement/SignalementSearchQuery.php
@@ -62,7 +62,8 @@ class SignalementSearchQuery
             'danger',
             'insalubrite',
             'mise_en_securite_peril',
-            'suroccupation', ])]
+            'suroccupation',
+            'assurantiel', ])]
         private readonly ?string $procedure = null,
         private readonly ?int $page = 1,
         #[Assert\Choice(['oui'])]


### PR DESCRIPTION
## Ticket

#3316   

## Description
Il serait utile d'ajouter le tag "Assurantiel" dans le filtre Procédure suspectée de la liste des signalements

## Changements apportés
* Ajout d'assurantiel dans la liste du filtre procédure

## Pré-requis

## Tests
- [ ] Faire un signalement avec la procédure assurantiel (logement > Humidité > oui il y a eu une fuite)
- [ ] Vérifier que le signalement possède bien la qualification
- [ ] Vérifier la liste des filtres, et choisir la procédure suspectée Assurantiel -> la liste est bien filtrée
- [ ] Faire un export de la liste et vérifier que ça fonctionne
