### PR TITLE
[BO - Partenaire / périmètre] Mettre les erreurs sous les champs

### DIFF
--- a/src/Form/TerritoryType.php
+++ b/src/Form/TerritoryType.php
@@ -74,7 +74,7 @@ class TerritoryType extends AbstractType
             'required' => false,
         ]);
         $builder->add('submit', SubmitType::class, [
-            'label' => 'Modifier',
+            'label' => 'Valider',
             'attr' => ['class' => 'fr-btn fr-icon-check-line fr-btn--icon-left'],
             'row_attr' => ['class' => 'fr-text--right'],
         ]);

--- a/src/Form/ZoneType.php
+++ b/src/Form/ZoneType.php
@@ -65,7 +65,7 @@ class ZoneType extends AbstractType
                         ->orderBy('p.nom', 'ASC');
                 },
                 'choice_label' => 'nom',
-                'label' => 'Partenaires de la zone',
+                'label' => 'Partenaires de la zone (facultatitf)',
                 'help' => 'Sélectionnez dans la liste les partenaires qui pourront intervenir spécifiquement sur les dossiers situés dans la zone.',
                 'noselectionlabel' => 'Sélectionnez les partenaires',
                 'nochoiceslabel' => 'Aucun partenaire disponible',
@@ -81,7 +81,7 @@ class ZoneType extends AbstractType
                 },
                 'choice_label' => 'nom',
                 'help' => 'Sélectionnez dans la liste les partenaires à exclure de la zone. Ces partenaires ne pourront pas être affectés aux dossiers situés dans la zone.',
-                'label' => 'Partenaires exclus de la zone',
+                'label' => 'Partenaires exclus de la zone (facultatif)',
                 'noselectionlabel' => 'Sélectionnez les partenaires',
                 'nochoiceslabel' => 'Aucun partenaire disponible',
                 'by_reference' => false,
@@ -120,7 +120,7 @@ class ZoneType extends AbstractType
         ]);
         if ($zone->getId()) {
             $builder->add('save', SubmitType::class, [
-                'label' => 'Modifier',
+                'label' => 'Valider',
                 'attr' => ['class' => 'fr-btn fr-icon-check-line fr-btn--icon-left'],
                 'row_attr' => ['class' => 'fr-text--right'],
             ]);


### PR DESCRIPTION
## Ticket

#3362 #3363 #3364

## Description
- Sur l'édition du périmètre d'un partenaire les erreur de code insee s'affiche conformément au style du DSFR
![Screenshot 2024-12-03 at 09-11-32 Partenaire - Histologe](https://github.com/user-attachments/assets/dbc96c73-c05e-4948-b834-5130c5e65da2)
- Sur le formulaire d'ajout/édition d'une zone les champs "Partenaires" et "Partenaires exclus" sont indiqués comme facultatif
- Sur les formulaires d'édition du périmètre, d'édition d'une zone et d'édition d'un territoire le bouton "Modifier" est renommer "Valider"


## Tests
- [ ] Vérifier les 3 points
