### PR TITLE
[QA - Sentry] Tableau envoyé au lieu de territoire

### DIFF
--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -88,7 +88,7 @@ class SuiviRepository extends ServiceEntityRepository
 
         $sql = 'SELECT COUNT(*) as count_signalement
                 FROM ('.
-                        $this->getSignalementsQuery($territory, $partner)
+                        $this->getSignalementsQuery($territory?->getId(), $partner?->getId())
                 .') as countSignalementSuivi';
         $statement = $connection->prepare($sql);
 
@@ -100,8 +100,8 @@ class SuiviRepository extends ServiceEntityRepository
      */
     public function findSignalementNoSuiviSince(
         int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
-        ?Territory $territory = null,
-        ?Partner $partner = null,
+        ?int $territory_id = null,
+        ?int $partner_id = null,
     ): array {
         $connection = $this->getEntityManager()->getConnection();
         $parameters = [
@@ -114,17 +114,17 @@ class SuiviRepository extends ServiceEntityRepository
             'status_refused' => Signalement::STATUS_REFUSED,
         ];
 
-        if (null !== $territory) {
-            $parameters['territory_id'] = $territory->getId();
+        if (null !== $territory_id) {
+            $parameters['territory_id'] = $territory_id;
         }
 
-        if (null != $partner) {
-            $parameters['partner_id'] = $partner->getId();
+        if (null != $partner_id) {
+            $parameters['partner_id'] = $partner_id;
             $parameters['status_wait'] = AffectationStatus::STATUS_WAIT->value;
             $parameters['status_accepted'] = AffectationStatus::STATUS_ACCEPTED->value;
         }
 
-        $sql = $this->getSignalementsQuery($territory, $partner);
+        $sql = $this->getSignalementsQuery($territory_id, $partner_id);
         $statement = $connection->prepare($sql);
 
         return $statement->executeQuery($parameters)->fetchFirstColumn();
@@ -174,16 +174,16 @@ class SuiviRepository extends ServiceEntityRepository
     }
 
     private function getSignalementsQuery(
-        ?Territory $territory = null,
-        ?Partner $partner = null,
+        ?int $territory_id = null,
+        ?int $partner_id = null,
     ): string {
         $whereTerritory = $wherePartner = $innerPartnerJoin = '';
 
-        if (null !== $territory) {
+        if (null !== $territory_id) {
             $whereTerritory = 'AND s.territory_id = :territory_id';
         }
 
-        if (null != $partner) {
+        if (null != $partner_id) {
             $wherePartner = 'AND a.partner_id = :partner_id';
             $innerPartnerJoin = 'INNER JOIN affectation a ON a.signalement_id = su.signalement_id AND a.statut IN (:status_wait, :status_accepted)';
         }

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -100,8 +100,8 @@ class SuiviRepository extends ServiceEntityRepository
      */
     public function findSignalementNoSuiviSince(
         int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
-        ?int $territory_id = null,
-        ?int $partner_id = null,
+        ?int $territoryId = null,
+        ?int $partnerId = null,
     ): array {
         $connection = $this->getEntityManager()->getConnection();
         $parameters = [
@@ -114,17 +114,17 @@ class SuiviRepository extends ServiceEntityRepository
             'status_refused' => Signalement::STATUS_REFUSED,
         ];
 
-        if (null !== $territory_id) {
-            $parameters['territory_id'] = $territory_id;
+        if (null !== $territoryId) {
+            $parameters['territory_id'] = $territoryId;
         }
 
-        if (null != $partner_id) {
-            $parameters['partner_id'] = $partner_id;
+        if (null != $partnerId) {
+            $parameters['partner_id'] = $partnerId;
             $parameters['status_wait'] = AffectationStatus::STATUS_WAIT->value;
             $parameters['status_accepted'] = AffectationStatus::STATUS_ACCEPTED->value;
         }
 
-        $sql = $this->getSignalementsQuery($territory_id, $partner_id);
+        $sql = $this->getSignalementsQuery($territoryId, $partnerId);
         $statement = $connection->prepare($sql);
 
         return $statement->executeQuery($parameters)->fetchFirstColumn();
@@ -174,16 +174,16 @@ class SuiviRepository extends ServiceEntityRepository
     }
 
     private function getSignalementsQuery(
-        ?int $territory_id = null,
-        ?int $partner_id = null,
+        ?int $territoryId = null,
+        ?int $partnerId = null,
     ): string {
         $whereTerritory = $wherePartner = $innerPartnerJoin = '';
 
-        if (null !== $territory_id) {
+        if (null !== $territoryId) {
             $whereTerritory = 'AND s.territory_id = :territory_id';
         }
 
-        if (null != $partner_id) {
+        if (null != $partnerId) {
             $wherePartner = 'AND a.partner_id = :partner_id';
             $innerPartnerJoin = 'INNER JOIN affectation a ON a.signalement_id = su.signalement_id AND a.statut IN (:status_wait, :status_accepted)';
         }

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -107,8 +107,8 @@ class SearchFilter
         }
 
         if (isset($filters['delays'])) {
-            $filters['delays_partner'] = $partner;
-            $filters['delays_territory'] = $territory;
+            $filters['delays_partner'] = $partner?->getId();
+            $filters['delays_territory'] = $territory?->getId();
         }
 
         if (isset($filters['nouveau_suivi'])) {
@@ -217,8 +217,8 @@ class SearchFilter
             $period = $this->filters['delays'] ?? $request->query->get('sans_suivi_periode');
             $partner = \in_array(User::ROLE_USER_PARTNER, $user->getRoles()) ? $user->getPartner() : null;
             $this->filters['delays'] = (int) $period;
-            $this->filters['delays_territory'] = $territory;
-            $this->filters['delays_partner'] = $partner;
+            $this->filters['delays_territory'] = $territory?->getId();
+            $this->filters['delays_partner'] = $partner?->getId();
         }
 
         return $this;


### PR DESCRIPTION
## Ticket

#3380

## Description
Dans le traitement des filtres de signalements les clés "delays_partner" et "delays_territory" (traités hors du `SearchFilter`) était les seules qui recevait des instances d'objets. Cela provoquait des erreurs sur la page d'export car ces objet était transformés en tableau vide lors de la conversion des filtre en json pour les stocker dans le cookie.
- Les clés "delays_partner" et "delays_territory" recoivent à présent l'id des objets
- Les fonctions utilisé par ces filtres sont adaptés en conséquence, c'est même plus logique étant donnée qu'elles n'utilisaient que l'id pour construire les requêtes

## Tests
- [ ] Se connecter en admin-partenaire ou admin-territoire, cliquer sur la carte "signalements sans suivi" puis sur l'export et vérifier que tout fonctionne correctement
