### PR TITLE
[BO] Erreurs liste des signalements

### DIFF
--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -25,10 +25,7 @@ class ExportSignalementController extends AbstractController
     ): Response {
         /** @var User $user */
         $user = $this->getUser();
-
-        $filters = $options = json_decode($request->cookies->get('filters'), true)
-            ?? $request->getSession()->get('filters', ['isImported' => '1']);
-
+        $filters = $options = $request->getSession()->get('filters', ['isImported' => '1']);
         $count_signalements = $signalementManager->findSignalementAffectationList($user, $options, true);
         $textFilters = $signalementExportFiltersDisplay->filtersToText($filters);
 

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -7,7 +7,6 @@ use App\Entity\User;
 use App\Manager\SignalementManager;
 use App\Service\Signalement\SearchFilter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -45,19 +44,11 @@ class SignalementListController extends AbstractController
         $session->set('signalementSearchQuery', $signalementQuery);
         $signalements = $signalementManager->findSignalementAffectationList($user, $filters);
 
-        $response = $this->json(
+        return $this->json(
             $signalements,
             Response::HTTP_OK,
             ['content-type' => 'application/json'],
             ['groups' => ['signalements:read']]
         );
-
-        $cookie = Cookie::create('filters')
-            ->withValue(json_encode($filters))
-            ->withExpires(strtotime('+1 hour'));
-
-        $response->headers->setCookie($cookie);
-
-        return $response;
     }
 }


### PR DESCRIPTION
## Ticket

#3397    

## Description
[La solution appliqué sur cet PR](https://github.com/MTES-MCT/histologe/pull/3321) a introduit une régression dans l'affichage de la liste avec certains filtres, notamment sur le widget "nouveau suivi".

Le problème vient de la quantité d'information stockée dans le cookie. Contrairement à la session qui n'a pas de limite de taille intrinsèque, les cookies sont limités par la taille totale des en-têtes HTTP, ce qui peut causer des erreurs serveur lorsque trop d'informations sont envoyés.

`2024-12-04T17:22:55.237901707Z 2024/12/04 17:22:55 [error] 43#43: *94 upstream sent too big header while reading response header from upstream, client: 172.20.0.1, server: , request: "GET /bo/list/signalements/?sortBy=lastSuiviAt&direction=DESC&nouveauSuivi=oui HTTP/1.1", upstream: "fastcgi://172.20.0.8:9000", host: "localhost:8080"
`

## Changements apportés
* Suppression des modifications du ticket https://github.com/MTES-MCT/histologe/pull/3321

## Pré-requis

## Tests
- [ ] Afficher la liste 
- [ ] Tester les widgets du dashboard
