### PR TITLE
[QA] optimisation requetes

### DIFF
--- a/migrations/Version20241206084748.php
+++ b/migrations/Version20241206084748.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241206084748 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add indexes';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_suivi_signalement_type_created_at ON suivi (signalement_id, type, created_at)');
+        $this->addSql('CREATE INDEX idx_signalement_code_suivi ON signalement (code_suivi)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_suivi_signalement_type_created_at ON suivi');
+        $this->addSql('DROP INDEX idx_signalement_code_suivi ON signalement');
+    }
+}

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -31,6 +31,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Index(columns: ['created_at'], name: 'idx_signalement_created_at')]
 #[ORM\Index(columns: ['is_imported'], name: 'idx_signalement_is_imported')]
 #[ORM\Index(columns: ['uuid'], name: 'idx_signalement_uuid')]
+#[ORM\Index(columns: ['code_suivi'], name: 'idx_signalement_code_suivi')]
 class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInterface
 {
     public const STATUS_NEED_VALIDATION = 1;

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: SuiviRepository::class)]
 #[ORM\Index(columns: ['type'], name: 'idx_suivi_type')]
 #[ORM\Index(columns: ['created_at'], name: 'idx_suivi_created_at')]
+#[ORM\Index(columns: ['signalement_id', 'type', 'created_at'], name: 'idx_suivi_signalement_type_created_at')]
 class Suivi implements EntityHistoryInterface
 {
     public const TYPE_AUTO = 1;


### PR DESCRIPTION
## Ticket

#3399

## Description
1
https://sentry.incubateur.net/organizations/betagouv/issues/127893/?environment=prod&project=61&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=1

https://sentry.incubateur.net/organizations/betagouv/issues/133207/?environment=prod&project=61&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=4

Ajout d'un index composé sur Suivi afin accélérer cette requête (chargement du tableau de bord) 
Durée de la requête avant/après lors de mes essaies : 
pour SA : 2500 -> 570 ms
pour RT 13 : 730 -> 480ms
pour Agent marseille : 3800 -> 540ms

2
https://sentry.incubateur.net/organizations/betagouv/issues/137000/?environment=prod&project=61&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=1
Affichage de la page signalement FO (cette requête remonte récemment bien que les temps restent acceptables)

Ajout d'un index sur Signalement sur code_suivi
Test avant après : 330 -> 2 ms

3
https://sentry.incubateur.net/organizations/betagouv/issues/121522/events/2bd3936928eb41ebbdb5cee1be42eab5/
C'est la grosse requête par défaut de la liste signalement pour les SA

J'ai essayé plein de truc sur la requête et les index sans réussir à baisser a moins de 3sec
Je propose de mettre un filtre par défaut pour les SA

## Pré-requis
Se mettre sur une copie base de prod
`make load-migrations`
`make clear-pool pool=--all`

## Tests
- [ ] Regarder le temps d'execution de la requête numéro 13 du tableau de bord (bo/widget/data-kpi)
- [ ] Regarder le temps d'exécution coté fiche signalement usager
