### PR TITLE
[BO - optimisation] mettre un filtre par defaut sur liste de signalement SA

### DIFF
--- a/src/Service/Menu/MenuBuilder.php
+++ b/src/Service/Menu/MenuBuilder.php
@@ -19,7 +19,7 @@ readonly class MenuBuilder
         /** @var User $user */
         $user = $this->currentRoute->getUser();
         $signalementsSubMenu = (new MenuItem(label: 'Signalements', roleGranted: User::ROLE_USER))
-            ->addChild(new MenuItem(label: 'Liste', route: 'back_signalement_index', roleGranted: User::ROLE_USER))
+            ->addChild(new MenuItem(label: 'Liste', route: 'back_signalement_index', roleGranted: User::ROLE_USER, routeParameters: $this->currentRoute->isGranted(User::ROLE_ADMIN) ? ['status' => 'nouveau', 'isImported' => 'oui'] : []))
             ->addChild(new MenuItem(label: 'Créer un signalement', route: 'front_signalement', roleGranted: User::ROLE_USER))
             ->addChild(new MenuItem(route: 'back_signalement_view'))
         ;


### PR DESCRIPTION
## Ticket

#3402

## Description
Petit hack pour éviter de lancer la grosse requête sur tous les signalements quand un SA clique sur le menu `Signalements ->Liste`
Test temps de réponse sans le filtre ou avec sur la prod : 9300 -> 300 ms 

## Tests
- [ ] Vérifier que les filtres sont bien ajouté uniquement pour les SA
