### PR TITLE
[BO - Tableaux] Template Twig pour les tableaux du BO

### DIFF
--- a/templates/_partials/back/table.html.twig
+++ b/templates/_partials/back/table.html.twig
@@ -2,7 +2,7 @@
 	<div class="fr-table__wrapper">
 		<div class="fr-table__container">
 			<div class="fr-table__content">
-				<table class="{{ cancelSortable is defined ? '' : 'sortable' }} fr-cell--multiline" aria-label="{{ tableLabel }}" aria-describedby="{{ tableDescId ?? 'desc-table' }}">
+				<table class="{{ cancelSortable is defined ? '' : 'sortable' }} {{ cancelMultiline is defined ? '' : 'fr-cell--multiline' }}" aria-label="{{ tableLabel }}" aria-describedby="{{ tableDescId ?? 'desc-table' }}">
 					<thead>
 						<tr>
 							{{tableHead}}

--- a/templates/_partials/back/table.html.twig
+++ b/templates/_partials/back/table.html.twig
@@ -1,0 +1,18 @@
+<div class="fr-table">
+	<div class="fr-table__wrapper">
+		<div class="fr-table__container">
+			<div class="fr-table__content">
+				<table class="{{ cancelSortable is defined ? '' : 'sortable' }} fr-cell--multiline" aria-label="{{ tableLabel }}" aria-describedby="{{ tableDescId ?? 'desc-table' }}">
+					<thead>
+						<tr>
+							{{tableHead}}
+						</tr>
+					</thead>
+					<tbody>
+						{{tableBody}}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/back/account/index.html.twig
+++ b/templates/back/account/index.html.twig
@@ -57,86 +57,82 @@
         </form>
     </section>
     {% endif %}
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <h1 class="fr-h2 fr-mb-0" id="desc-table">{{total}} comptes archivés ou sans territoires et/ou partenaires trouvés</h1>
+
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{total}} comptes archivés ou sans territoires et/ou partenaires trouvés</h2>
     </section>
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-        <div class="fr-table__wrapper">
-            <div class="fr-table__container">
-                <div class="fr-table__content">
-                    <table class="sortable" aria-label="Liste des comptes archivés ou sans territoires et/ou partenaires" aria-describedby="desc-table">
-                        <thead>
-                        <tr>
-                            <th scope="col">Partenaire</th>
-                            <th scope="col">Territoire</th>
-                            <th scope="col">Statut part.</th>
-                            <th scope="col">E-mail</th>
-                            <th scope="col">Nom</th>
-                            <th scope="col">Prénom</th>
-                            <th scope="col" class="fr-text--right"></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for user in users %}
-                            <tr class="user-row">
-                                <td>
-                                    {% if user.partners.isEmpty%}
-                                        aucun
-                                    {% else %}
-                                        {% for partner in user.partners %}
-                                            {{ partner.nom }}
-                                            {% if not loop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if user.partners.isEmpty %}
-                                        aucun
-                                    {% else %}
-                                        {% for partner in user.partners %}
-                                            {% if partner.territory %}
-                                                {{ partner.territory.zip ~ ' - ' ~ partner.territory.name }}
-                                            {% else %}
-                                                aucun
-                                            {% endif %}
-                                            {% if not loop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if user.partners.isEmpty %}
-                                        <span class="fr-badge fr-badge--info fr-badge--no-icon fr-ws-nowrap ">AUCUN</span>
-                                    {% else %}
-                                        {% for partner in user.partners %}
-                                            {% set classe = 'fr-badge--success' %}
-                                            {% set statut = 'actif' %}
-                                            {% if partner.isArchive %}
-                                                {% set classe = 'fr-badge--error' %}
-                                                {% set statut = 'archivé' %}
-                                            {% endif %}
-                                            <span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span>
-                                            {% if not loop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    {% endif %}
-                                </td>
-                                <td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
-                                <td>{{ user.nom}}</ail td>
-                                <td>{{ user.prenom}}</ail td>
-                                <td class="fr-text--right">
-                                    <a href="{{ path('back_account_reactiver', {'id': user.id}) }}"
-                                    class="fr-btn fr-icon-flashlight-fill fr-btn--sm" title="Réactiver le compte {{user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}}"></a>
-                                </td>
-                            </tr>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">Partenaire</th>
+            <th scope="col">Territoire</th>
+            <th scope="col">Statut part.</th>
+            <th scope="col">E-mail</th>
+            <th scope="col">Nom</th>
+            <th scope="col">Prénom</th>
+            <th scope="col" class="fr-text--right">Actions</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for user in users %}
+                <tr class="user-row">
+                    <td>
+                        {% if user.partners.isEmpty%}
+                            aucun
                         {% else %}
-                            <tr>
-                                <td colspan="7">Aucun utilisateur trouvé</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
+                            {% for partner in user.partners %}
+                                {{ partner.nom }}
+                                {% if not loop.last %}<br>{% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if user.partners.isEmpty %}
+                            aucun
+                        {% else %}
+                            {% for partner in user.partners %}
+                                {% if partner.territory %}
+                                    {{ partner.territory.zip ~ ' - ' ~ partner.territory.name }}
+                                {% else %}
+                                    aucun
+                                {% endif %}
+                                {% if not loop.last %}<br>{% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if user.partners.isEmpty %}
+                            <span class="fr-badge fr-badge--info fr-badge--no-icon fr-ws-nowrap ">AUCUN</span>
+                        {% else %}
+                            {% for partner in user.partners %}
+                                {% set classe = 'fr-badge--success' %}
+                                {% set statut = 'actif' %}
+                                {% if partner.isArchive %}
+                                    {% set classe = 'fr-badge--error' %}
+                                    {% set statut = 'archivé' %}
+                                {% endif %}
+                                <span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span>
+                                {% if not loop.last %}<br>{% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    </td>
+                    <td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
+                    <td>{{ user.nom}}</ail td>
+                    <td>{{ user.prenom}}</ail td>
+                    <td class="fr-text--right">
+                        <a href="{{ path('back_account_reactiver', {'id': user.id}) }}"
+                        class="fr-btn fr-icon-flashlight-fill fr-btn--sm" title="Réactiver le compte {{user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}}"></a>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="7">Aucun utilisateur trouvé</td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des comptes archivés ou sans territoires et/ou partenaires', 'tableHead': tableHead, 'tableBody': tableBody } %}
+
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, page, 'back_account_index', {territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partner: (currentPartner ? currentPartner.id : (isNonePartner ? 'none' : null)), userTerms: userTerms}) }}

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -39,93 +39,89 @@
             </div>
         </form>
     </section>
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <h2 class="fr-h2 fr-mb-0" id="desc-table">{{total}} règles d'auto-affectation</h2>
-    </section>    
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="fr-cell--multiline sortable" aria-label="Liste des règles d'auto-affectation">
-                        <thead>
-                        <tr>
-                            <th scope="col">Territoire</th>
-                            <th scope="col">Statut</th>
-                            <th scope="col">Type de partenaire</th>
-                            <th scope="col">Profil déclarant</th>
-                            <th scope="col">Parc</th>
-                            <th scope="col">Allocataire</th>
-                            <th scope="col">Code insee inclus</th>
-                            <th scope="col">Code insee exclus</th>
-                            <th scope="col">Id partenaires exclus</th>
-                            <th scope="col" class="fr-text--right">Actions</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                            {% for autoaffectationrule in autoaffectationrules %}
-                                <tr class="autoaffectationrule-row">
-                                    <td>{{ autoaffectationrule.territory.zip}} - {{ autoaffectationrule.territory.name}}</td>
-                                    <td>
-                                        {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
-                                            {% set classe = 'fr-badge--green-emeraude' %}
-                                        {% else %}
-                                            {% set classe = 'fr-badge--blue-ecume' %}
-                                        {% endif %}
-                                        <span class="fr-badge {{ classe }} fr-mb-1v">{{ autoaffectationrule.status  }}</span></td>
-                                    </td>
-                                    <td>{{ autoaffectationrule.partnerType.label }}</td>
-                                    <td>{{ autoaffectationrule.profileDeclarant }}</td>
-                                    <td>{{ autoaffectationrule.parc }}</td>
-                                    <td>{{ autoaffectationrule.allocataire }}</td>
-                                    <td>
-                                        {% if autoaffectationrule.inseeToInclude is same as('all') or autoaffectationrule.inseeToInclude is same as('partner_list') %}
-                                            {{ autoaffectationrule.inseeToInclude }}
-                                        {% else %}
-                                            {% for insee in autoaffectationrule.inseeToInclude|split(',') %}
-                                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
-                                            {% endfor %}
-                                        {% endif %}
-                                    </td>
-                                    <td>
-                                        {% if autoaffectationrule.inseeToExclude %}
-                                            {% for insee in autoaffectationrule.inseeToExclude %}
-                                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
-                                            {% endfor %}
-                                        {% else %}
-                                            /
-                                        {% endif %}
-                                    </td>
-                                    <td>
-                                        {% if autoaffectationrule.partnerToExclude %}
-                                            {% for idPartner in autoaffectationrule.partnerToExclude %}
-                                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ idPartner }}</div>
-                                            {% endfor %}
-                                        {% else %}
-                                            /
-                                        {% endif %}
-                                    </td>
-                                    <td class="fr-text--right">
-                                        <a class="fr-btn fr-btn--sm fr-fi-edit-line" href="{{ path('back_auto_affectation_rule_edit', {'id': autoaffectationrule.id}) }}"></a>
-                                        {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
-                                            <button class="fr-btn fr-btn--danger fr-btn--sm fr-fi-delete-line fr-mt-3v btn-delete-autoaffectationrule"
-                                            id="autoaffectationrule_delete_{{ autoaffectationrule.id }}" aria-controls="fr-modal-autoaffectationrule-delete"
-                                            data-fr-opened="false" data-autoaffectationrule-id="{{ autoaffectationrule.id }}" data-autoaffectationrule-description="{{ autoaffectationrule.description }}"></button>
-                                        {% else %}
-                                            <a href="{{ path('back_auto_affectation_rule_reactive', {'id': autoaffectationrule.id}) }}"
-                                                class="fr-btn fr-icon-flashlight-fill fr-btn--sm fr-mt-3v" title="Réactiver la règle {{autoaffectationrule.id}}"></a>
-                                        {% endif %}
-                                    </td>
-                                </tr>
-                            {% else %}
-                                <tr>
-                                    <td colspan="3">Aucune règle d'auto-affectation trouvée</td>
-                                </tr>
+
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{total}} règles d'auto-affectation</h2>
+    </section>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">Territoire</th>
+            <th scope="col">Statut</th>
+            <th scope="col">Type de partenaire</th>
+            <th scope="col">Profil déclarant</th>
+            <th scope="col">Parc</th>
+            <th scope="col">Allocataire</th>
+            <th scope="col">Code insee inclus</th>
+            <th scope="col">Code insee exclus</th>
+            <th scope="col">Id partenaires exclus</th>
+            <th scope="col" class="fr-text--right">Actions</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for autoaffectationrule in autoaffectationrules %}
+                <tr class="autoaffectationrule-row">
+                    <td>{{ autoaffectationrule.territory.zip}} - {{ autoaffectationrule.territory.name}}</td>
+                    <td>
+                        {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
+                            {% set classe = 'fr-badge--green-emeraude' %}
+                        {% else %}
+                            {% set classe = 'fr-badge--blue-ecume' %}
+                        {% endif %}
+                        <span class="fr-badge {{ classe }} fr-mb-1v">{{ autoaffectationrule.status  }}</span></td>
+                    </td>
+                    <td>{{ autoaffectationrule.partnerType.label }}</td>
+                    <td>{{ autoaffectationrule.profileDeclarant }}</td>
+                    <td>{{ autoaffectationrule.parc }}</td>
+                    <td>{{ autoaffectationrule.allocataire }}</td>
+                    <td>
+                        {% if autoaffectationrule.inseeToInclude is same as('all') or autoaffectationrule.inseeToInclude is same as('partner_list') %}
+                            {{ autoaffectationrule.inseeToInclude }}
+                        {% else %}
+                            {% for insee in autoaffectationrule.inseeToInclude|split(',') %}
+                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
                             {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if autoaffectationrule.inseeToExclude %}
+                            {% for insee in autoaffectationrule.inseeToExclude %}
+                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
+                            {% endfor %}
+                        {% else %}
+                            /
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if autoaffectationrule.partnerToExclude %}
+                            {% for idPartner in autoaffectationrule.partnerToExclude %}
+                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ idPartner }}</div>
+                            {% endfor %}
+                        {% else %}
+                            /
+                        {% endif %}
+                    </td>
+                    <td class="fr-text--right">
+                        <a class="fr-btn fr-btn--sm fr-fi-edit-line" href="{{ path('back_auto_affectation_rule_edit', {'id': autoaffectationrule.id}) }}"></a>
+                        {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
+                            <button class="fr-btn fr-btn--danger fr-btn--sm fr-fi-delete-line fr-mt-3v btn-delete-autoaffectationrule"
+                            id="autoaffectationrule_delete_{{ autoaffectationrule.id }}" aria-controls="fr-modal-autoaffectationrule-delete"
+                            data-fr-opened="false" data-autoaffectationrule-id="{{ autoaffectationrule.id }}" data-autoaffectationrule-description="{{ autoaffectationrule.description }}"></button>
+                        {% else %}
+                            <a href="{{ path('back_auto_affectation_rule_reactive', {'id': autoaffectationrule.id}) }}"
+                                class="fr-btn fr-icon-flashlight-fill fr-btn--sm fr-mt-3v" title="Réactiver la règle {{autoaffectationrule.id}}"></a>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="10">Aucune règle d'auto-affectation trouvée</td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des règles d\'auto-affectation', 'tableHead': tableHead, 'tableBody': tableBody } %}
+
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center" id="autoaffectation-rule-pagination">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, page, 'back_auto_affectation_rule_index', {territory: (currentTerritory ? currentTerritory.id :  null)}) }}

--- a/templates/back/expired-account/index.html.twig
+++ b/templates/back/expired-account/index.html.twig
@@ -35,7 +35,7 @@
 				<th scope="col">E-mail</th>
 			{% endset %}
 
-        	{% set tableBody %}
+			{% set tableBody %}
 				{% for user in expiredUsagers %}
 					<tr class="user-row">
 						<td>{{ user.nom}}</td>

--- a/templates/back/expired-account/index.html.twig
+++ b/templates/back/expired-account/index.html.twig
@@ -28,32 +28,24 @@
 		</div>
 	</h2>
 	{% if expiredUsagers|length %}
-		<div class="fr-col-12 fr-table fr-table--no-caption">
-			<div class="fr-table__wrapper">
-				<div class="fr-table__container">
-					<div class="fr-table__content">
-						<table class="fr-cell--multiline" aria-label="Liste des comptes expirés" aria-describedby="desc-table-expired">
-						<caption>Liste des comptes usagers expirés</caption>
-							<thead>
-								<tr>
-									<th scope="col">Nom</th>
-									<th scope="col">Prénom</th>
-									<th scope="col">E-mail</th>
-								</tr>
-							</thead>
-							<tbody>
-								{% for user in expiredUsagers %}
-									<tr class="user-row">
-										<td>{{ user.nom}}</td>
-										<td>{{ user.prenom}}</td>
-										<td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}}</td>
-									</tr>
-								{% endfor %}
-							</tbody>
-						</table>
-					</div>
-				</div>
-			</div>
+		<div class="fr-col-12">
+			{% set tableHead %}
+				<th scope="col">Nom</th>
+				<th scope="col">Prénom</th>
+				<th scope="col">E-mail</th>
+			{% endset %}
+
+        	{% set tableBody %}
+				{% for user in expiredUsagers %}
+					<tr class="user-row">
+						<td>{{ user.nom}}</td>
+						<td>{{ user.prenom}}</td>
+						<td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}}</td>
+					</tr>
+				{% endfor %}
+			{% endset %}
+
+        	{% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des comptes usagers expirés', 'tableDescId': 'desc-table-expired', 'tableHead': tableHead, 'tableBody': tableBody } %}
 		</div>
 	{% endif %}
 </section>
@@ -66,58 +58,50 @@
 		</div>
 	</h2>
     {% if expiredUsers|length %}
-	<div class="fr-col-12 fr-table fr-table--no-caption">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-					<table class="fr-cell--multiline" aria-label="Liste des comptes inactifs" aria-describedby="desc-table-inactive">
-					<caption>Liste des comptes agents expirés</caption>
-						<thead>
-							<tr>
-								<th scope="col">Nom</th>
-								<th scope="col">Prénom</th>
-								<th scope="col">E-mail</th>
-								<th scope="col">Role</th>
-								<th scope="col">Statut</th>
-								<th scope="col">Date de connexion</th>
-								<th scope="col">Territoire</th>
-								<th scope="col">Partenaire</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for user in expiredUsers %}
-								<tr class="user-row">
-									<td>{{ user.nom}}</td>
-									<td>{{ user.prenom}}</td>
-									<td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}}</td>
-									<td>{{ user.roles[0]}}</td>
-									<td>{{ user.statutLabel}}</td>
-									<td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y H:i')}}</td>
-									<td>
-										{% if  user.partnersTerritories|length > 0 %}
-											{% for territory in user.partnersTerritories %}
-												{{ territory.zip ~ ' - ' ~ territory.name }}
-											{% endfor %}
-										{% else %}
-											aucun
-										{% endif %}
-									</td>
-									<td>
-										{% if user.partners|length > 0 %}
-											{% for partner in user.partners %}
-												{{ partner.nom }}
-											{% endfor %}
-										{% else %}
-											aucun
-										{% endif %}
-									</td>
-								</tr>
+	<div class="fr-col-12">
+		{% set tableHead %}
+			<th scope="col">Nom</th>
+			<th scope="col">Prénom</th>
+			<th scope="col">E-mail</th>
+			<th scope="col">Role</th>
+			<th scope="col">Statut</th>
+			<th scope="col">Date de connexion</th>
+			<th scope="col">Territoire</th>
+			<th scope="col">Partenaire</th>
+		{% endset %}
+
+		{% set tableBody %}
+			{% for user in expiredUsers %}
+				<tr class="user-row">
+					<td>{{ user.nom}}</td>
+					<td>{{ user.prenom}}</td>
+					<td>{{ user.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left')}}</td>
+					<td>{{ user.roles[0]}}</td>
+					<td>{{ user.statutLabel}}</td>
+					<td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y H:i')}}</td>
+					<td>
+						{% if  user.partnersTerritories|length > 0 %}
+							{% for territory in user.partnersTerritories %}
+								{{ territory.zip ~ ' - ' ~ territory.name }}
 							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
-		</div>
+						{% else %}
+							aucun
+						{% endif %}
+					</td>
+					<td>
+						{% if user.partners|length > 0 %}
+							{% for partner in user.partners %}
+								{{ partner.nom }}
+							{% endfor %}
+						{% else %}
+							aucun
+						{% endif %}
+					</td>
+				</tr>
+			{% endfor %}
+		{% endset %}
+
+		{% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des comptes agents expirés', 'tableDescId': 'desc-table-inactive', 'tableHead': tableHead, 'tableBody': tableBody } %}
 	</div>
     {% endif %}
 </section>

--- a/templates/back/idoss/log.html.twig
+++ b/templates/back/idoss/log.html.twig
@@ -14,67 +14,56 @@
 </section>
 
 <section class="fr-grid-row fr-grid-row--middle fr-px-5v">
-	<div class="fr-col-12 fr-table fr-table--no-caption">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-					<table class="fr-cell--multiline"  aria-label="Liste des comptes inactifs" aria-describedby="desc-table-inactive">
-					<caption>Erreurs</caption>
-						<thead>
-							<tr>
-								<th scope="col">Signalement</th>
-								<th scope="col">Date</th>
-								<th scope="col">action</th>
-								<th scope="col">Réponse</th>
-								<th scope="col">Code</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for error in errors %}
-								<tr class="user-row">
-									<td><a href="{{path('back_signalement_view', {'uuid': error.uuid})}}">{{error.reference}}</a></td>
-									<td>{{error.createdAt|date('d/m/Y H:i:s')}}</td>
-									<td>{{error.action}}</td>
-									<td>{{error.response}}</td>
-									<td>{{error.codeStatus}}</td>
-								</tr>
-							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
-		</div>
+	<h2 id="table-desc-idoss-error">Erreurs IDOSS</h2>
+
+	<div class="fr-col-12">
+        {% set tableHead %}
+			<th scope="col">Signalement</th>
+			<th scope="col">Date</th>
+			<th scope="col">action</th>
+			<th scope="col">Réponse</th>
+			<th scope="col">Code</th>
+        {% endset %}
+
+        {% set tableBody %}
+			{% for error in errors %}
+				<tr class="user-row">
+					<td><a href="{{path('back_signalement_view', {'uuid': error.uuid})}}">{{error.reference}}</a></td>
+					<td>{{error.createdAt|date('d/m/Y H:i:s')}}</td>
+					<td>{{error.action}}</td>
+					<td>{{error.response}}</td>
+					<td>{{error.codeStatus}}</td>
+				</tr>
+			{% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Erreurs IDOSS', 'tableDescId': 'table-desc-idoss-error', 'tableHead': tableHead, 'tableBody': tableBody } %}
 	</div>
-		<div class="fr-col-12 fr-table fr-table--no-caption">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-					<table class="fr-cell--multiline"  aria-label="Liste des comptes inactifs" aria-describedby="desc-table-inactive">
-					<caption>Success</caption>
-						<thead>
-							<tr>
-								<th scope="col">Signalement</th>
-								<th scope="col">Date</th>
-								<th scope="col">action</th>
-								<th scope="col">Réponse</th>
-								<th scope="col">Code</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for item in success %}
-								<tr class="user-row">
-									<td><a href="{{path('back_signalement_view', {'uuid': item.uuid})}}">{{item.reference}}</a></td>
-									<td>{{item.createdAt|date('d/m/Y H:i:s')}}</td>
-									<td>{{item.action}}</td>
-									<td>{{item.response}}</td>
-									<td>{{item.codeStatus}}</td>
-								</tr>
-							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
-		</div>
+
+	<div class="fr-col-12">
+		<h2 id="table-desc-idoss-success">Succès IDOSS</h2>
+
+        {% set tableHead %}
+			<th scope="col">Signalement</th>
+			<th scope="col">Date</th>
+			<th scope="col">action</th>
+			<th scope="col">Réponse</th>
+			<th scope="col">Code</th>
+        {% endset %}
+
+        {% set tableBody %}
+			{% for item in success %}
+				<tr class="user-row">
+					<td><a href="{{path('back_signalement_view', {'uuid': item.uuid})}}">{{item.reference}}</a></td>
+					<td>{{item.createdAt|date('d/m/Y H:i:s')}}</td>
+					<td>{{item.action}}</td>
+					<td>{{item.response}}</td>
+					<td>{{item.codeStatus}}</td>
+				</tr>
+			{% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Succès IDOSS', 'tableDescId': 'table-desc-idoss-success', 'tableHead': tableHead, 'tableBody': tableBody } %}
 	</div>
 </section>
 {% endblock %}

--- a/templates/back/inactive-account/index.html.twig
+++ b/templates/back/inactive-account/index.html.twig
@@ -22,7 +22,7 @@
 </section>
 
 <section class="fr-grid-row fr-grid-row--middle fr-px-5v">
-	<h2 class="fr-mb-0" id="desc-table-inactive">
+	<h2 class="fr-mb-0" id="desc-table">
 		{{inactiveUsers|length}} comptes agents inactifs
 		<div class="fr-text--sm fr-text--light">
 			Les comptes inactifs sont les comptes des agents qui n'ont pas eu de connexion depuis plus de 11 mois et qui ne sont pas archivés. 
@@ -30,62 +30,55 @@
 			Un e-mail leur est envoyé 30 jours et 7 jours avant la suppression des comptes, puis ils sont archivés s'il n'y a toujours pas de connexion 30 jours après la première notification.
 		</div>
 	</h2>
+
     {% if inactiveUsers|length %}
-	<div class="fr-col-12 fr-table fr-table--no-caption">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-					<table class="fr-cell--multiline"  aria-label="Liste des comptes inactifs" aria-describedby="desc-table-inactive">
-					<caption>Liste des comptes agents inactifs</caption>
-						<thead>
-							<tr>
-								<th scope="col">Nom</th>
-								<th scope="col">Prénom</th>
-								<th scope="col">E-mail</th>
-								<th scope="col">Role</th>
-								<th scope="col">Status</th>
-								<th scope="col">Date de connexion</th>
-								<th scope="col">Territoire</th>
-								<th scope="col">Partenaire</th>
-								<th scope="col">Archivage prévu le</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for user in inactiveUsers %}
-								<tr class="user-row">
-									<td class="word-wrap-anywhere">{{ user.nom}}</td>
-									<td class="word-wrap-anywhere">{{ user.prenom}}</td>
-									<td class="word-wrap-anywhere">{{ user.email}}</td>
-									<td class="word-wrap-anywhere">{{ user.roles[0]}}</td>
-									<td>{{ user.statutLabel }}</td>
-									<td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y H:i')}}</td>
-									<td>
-										{% if  user.partnersTerritories|length > 0 %}
-											{% for territory in user.partnersTerritories %}
-												{{ territory.zip ~ ' - ' ~ territory.name }}
-											{% endfor %}
-										{% else %}
-											aucun
-										{% endif %}
-									</td>
-									<td>
-										{% if  user.partners|length > 0 %}
-											{% for partner in user.partners %}
-												{{ partner.nom }}
-											{% endfor %}
-										{% else %}
-											aucun
-										{% endif %}
-									</td>
-									<td>{{ user.archivingScheduledAt ? user.archivingScheduledAt|date('d/m/Y') }}</td>
-								</tr>
-							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
+		<div class="fr-col-12">
+			{% set tableHead %}
+				<th scope="col">Nom</th>
+				<th scope="col">Prénom</th>
+				<th scope="col">E-mail</th>
+				<th scope="col">Role</th>
+				<th scope="col">Status</th>
+				<th scope="col">Date de connexion</th>
+				<th scope="col">Territoire</th>
+				<th scope="col">Partenaire</th>
+				<th scope="col">Archivage prévu le</th>
+			{% endset %}
+			
+			{% set tableBody %}
+				{% for user in inactiveUsers %}
+					<tr class="user-row">
+						<td class="word-wrap-anywhere">{{ user.nom}}</td>
+						<td class="word-wrap-anywhere">{{ user.prenom}}</td>
+						<td class="word-wrap-anywhere">{{ user.email}}</td>
+						<td class="word-wrap-anywhere">{{ user.roles[0]}}</td>
+						<td>{{ user.statutLabel }}</td>
+						<td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y H:i')}}</td>
+						<td>
+							{% if  user.partnersTerritories|length > 0 %}
+								{% for territory in user.partnersTerritories %}
+									{{ territory.zip ~ ' - ' ~ territory.name }}
+								{% endfor %}
+							{% else %}
+								aucun
+							{% endif %}
+						</td>
+						<td>
+							{% if  user.partners|length > 0 %}
+								{% for partner in user.partners %}
+									{{ partner.nom }}
+								{% endfor %}
+							{% else %}
+								aucun
+							{% endif %}
+						</td>
+						<td>{{ user.archivingScheduledAt ? user.archivingScheduledAt|date('d/m/Y') }}</td>
+					</tr>
+				{% endfor %}
+			{% endset %}
+
+			{% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des comptes inactifs', 'tableHead': tableHead, 'tableBody': tableBody } %}
 		</div>
-	</div>
     {% endif %}
 </section>
 {% endblock %}

--- a/templates/back/notifications/index.html.twig
+++ b/templates/back/notifications/index.html.twig
@@ -36,63 +36,61 @@
             </div>
         </div>
     </section>
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="fr-cell--multiline">
-                    	<caption>{{ count_notification(app.user) }}  Nouveau(x) suivi(s)</caption>
-                        <thead>
-                        <tr>
-                            <th scope="col"></th>
-                            <th scope="col">Signalement</th>
-                            <th scope="col">Date</th>
-                            <th scope="col">Description</th>
-                            <th scope="col">Par</th>
-                            <th scope="col" class="fr-text--right">actions</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for notification in notifications %}
-                            <tr class="partner-row">
-                                <td>
-                                    <div class="fr-fieldset__element">
-                                        <div class="fr-checkbox-group">
-                                            <input name="check-notification-{{ notification.id }}" id="check-notification-{{ notification.id }}" type="checkbox" class="check-notification" data-notification-id="{{ notification.id }}">
-                                            <label class="fr-label" for="check-notification-{{ notification.id }}">&nbsp;</label>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td>
-                                    {{ notification.suivi.signalement.reference }}
-                                    <br>
-                                    ({{notification.suivi.signalement.villeOccupant}})
-                                </td>
-                                <td>{{ notification.suivi.createdAt|format_datetime(locale='fr', timezone=territory_timezone, pattern='d MMMM yyyy à HH:mm:ss') }}</td>
-                                <td class="word-wrap-anywhere">{{ notification.suivi.description
-                                    |replace({'&t=___TOKEN___':'/'~notification.signalement.uuid})
-                                    |replace({'?t=___TOKEN___':'/'~notification.signalement.uuid})
-                                    |replace({'?folder=_up':'/'~notification.signalement.uuid~'?variant=resize'})
-                                    |sanitize_html('app.message_sanitizer') }}
-                                </td>
-                                <td>{{ notification.suivi.createdBy ? notification.suivi.createdBy.nomComplet : notification.signalement.nomOccupant|upper~' '~notification.signalement.prenomOccupant|capitalize }}</td>
-                                <td class="fr-text--right fr-ws-nowrap">
-                                    <a href="{{ path('back_signalement_view',{uuid:notification.suivi.signalement.uuid}) }}#suivis"
-                                    class="fr-btn fr-btn--sm {{ notification.isSeen ? 'fr-fi-check-line fr-btn--success':'fr-fi-eye-fill' }}"></a>
-                                    <a href="{{ path('back_notifications_delete_notification',{id:notification.id}) }}?_token={{ csrf_token('back_delete_notification_'~notification.id) }}"
-                                    class="fr-btn fr-btn--sm fr-btn--danger fr-fi-delete-line"></a>
-                                </td>
-                            </tr>
-                        {% else %}
-                            <tr>
-                                <td colspan="6" class="fr-text--center">Aucun suivi non lu</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+
+    <section class="fr-col-12 fr-px-5v">
+        <h2 class="fr-h6 fr-mb-0" id="desc-table">{{ count_notification(app.user) }} nouveau(x) suivi(s)</h2>
+    </section>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col"></th>
+            <th scope="col">Signalement</th>
+            <th scope="col">Date</th>
+            <th scope="col">Description</th>
+            <th scope="col">Par</th>
+            <th scope="col" class="fr-text--right">actions</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for notification in notifications %}
+                <tr class="partner-row">
+                    <td>
+                        <div class="fr-fieldset__element">
+                            <div class="fr-checkbox-group">
+                                <input name="check-notification-{{ notification.id }}" id="check-notification-{{ notification.id }}" type="checkbox" class="check-notification" data-notification-id="{{ notification.id }}">
+                                <label class="fr-label" for="check-notification-{{ notification.id }}">&nbsp;</label>
+                            </div>
+                        </div>
+                    </td>
+                    <td>
+                        {{ notification.suivi.signalement.reference }}
+                        <br>
+                        ({{notification.suivi.signalement.villeOccupant}})
+                    </td>
+                    <td>{{ notification.suivi.createdAt|format_datetime(locale='fr', timezone=territory_timezone, pattern='d MMMM yyyy à HH:mm:ss') }}</td>
+                    <td class="word-wrap-anywhere">{{ notification.suivi.description
+                        |replace({'&t=___TOKEN___':'/'~notification.signalement.uuid})
+                        |replace({'?t=___TOKEN___':'/'~notification.signalement.uuid})
+                        |replace({'?folder=_up':'/'~notification.signalement.uuid~'?variant=resize'})
+                        |sanitize_html('app.message_sanitizer') }}
+                    </td>
+                    <td>{{ notification.suivi.createdBy ? notification.suivi.createdBy.nomComplet : notification.signalement.nomOccupant|upper~' '~notification.signalement.prenomOccupant|capitalize }}</td>
+                    <td class="fr-text--right fr-ws-nowrap">
+                        <a href="{{ path('back_signalement_view',{uuid:notification.suivi.signalement.uuid}) }}#suivis"
+                        class="fr-btn fr-btn--sm {{ notification.isSeen ? 'fr-fi-check-line fr-btn--success':'fr-fi-eye-fill' }}"></a>
+                        <a href="{{ path('back_notifications_delete_notification',{id:notification.id}) }}?_token={{ csrf_token('back_delete_notification_'~notification.id) }}"
+                        class="fr-btn fr-btn--sm fr-btn--danger fr-fi-delete-line"></a>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="6" class="fr-text--center">Aucun suivi non lu</td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des notifications', 'tableHead': tableHead, 'tableBody': tableBody, cancelSortable: true } %}
+        
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">    
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, page, 'back_notifications_list', {}) }}

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -57,92 +57,86 @@
             <a href="{{ path('back_partner_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser</a>
         </div>
     </form>
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v ">
-        <div class="fr-col-6">
-            <h1 class="fr-h2 fr-mb-0" id="desc-table">{{total}} partenaires trouvés</h1>
-        </div>
+
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{total}} partenaires trouvés</h2>
     </section>
-    <section class="fr-col-12 fr-pt-0 fr-px-5v fr-table">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="sortable fr-cell--multiline">
-                        <thead>
-                        <tr>
-                            <th scope="col" class="number">Id</th>
-                            {% if is_granted('ROLE_ADMIN') %}
-                                <th scope="col">Territoire</th>
-                            {% endif %}
-                            <th scope="col">Nom</th>
-                            <th scope="col">Type</th>
-                            <th scope="col">Compétences</th>
-                            <th scope="col">Codes INSEE</th>
-                            {% if platform.feature_zonage %}
-                                <th scope="col">Zones</th>
-                            {% endif %}
-                            <th scope="col" class="fr-text--right">Actions</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for partner in partners %}
-                            <tr class="partner-row">
-                                <td>{{ partner.id }}</td>
-                                {% if is_granted('ROLE_ADMIN') %}
-                                    <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
-                                {% endif %}
-                                <td>{{ partner.nom }}</td>
-                                <td>{{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'N/A') }}</td>
-                                <td>
-                                    {% if partner.competence %}
-                                        <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ partner.competence|length }}</div>
-                                    {% else %}
-                                        /
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if partner.insee %}
-                                        {% for insee in partner.insee|slice(0, 4) %}
-                                            <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
-                                        {% endfor %}
-                                        {% if partner.insee|length > 4 %}
-                                            + {{partner.insee|length - 4}}
-                                        {% endif %}
-                                    {% else %}
-                                        /
-                                    {% endif %}
-                                </td>
-                                {% if platform.feature_zonage %}
-                                    <td>
-                                        {% if partner.zones or partner.excludedZones %}
-                                            {% for zone in partner.zones %}
-                                                <div class="fr-badge fr-badge--success fr-badge--no-icon fr-mb-1v">{{ zone.name }}</div>
-                                            {% endfor %}
-                                            {% for zone in partner.excludedZones %}
-                                                <div class="fr-badge fr-badge--error fr-badge--no-icon fr-mb-1v">{{ zone.name }}</div>
-                                            {% endfor %}
-                                        {% else %}
-                                            /
-                                        {% endif %}
-                                    </td>
-                                {% endif %}
-                                <td class="fr-text--right fr-ws-nowrap">
-                                    <a href="{{ path('back_partner_view', {'id': partner.id}) }}"
-                                    class="fr-btn fr-fi-arrow-right-line fr-btn--sm"></a>
-                                    <a href="#" class="fr-btn fr-btn--danger fr-fi-delete-line fr-btn--sm btn-delete-partner"
-                                        id="partners_delete_{{ partner.id }}" aria-controls="fr-modal-partner-delete"
-                                        data-fr-opened="false" data-partnername="{{ partner.nom }}" data-partnerid="{{ partner.id }}"></a>
-                                </td>
-                            </tr>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col" class="number">Id</th>
+            {% if is_granted('ROLE_ADMIN') %}
+                <th scope="col">Territoire</th>
+            {% endif %}
+            <th scope="col">Nom</th>
+            <th scope="col">Type</th>
+            <th scope="col">Compétences</th>
+            <th scope="col">Codes INSEE</th>
+            {% if platform.feature_zonage %}
+                <th scope="col">Zones</th>
+            {% endif %}
+            <th scope="col" class="fr-text--right">Actions</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for partner in partners %}
+                <tr class="partner-row">
+                    <td>{{ partner.id }}</td>
+                    {% if is_granted('ROLE_ADMIN') %}
+                        <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
+                    {% endif %}
+                    <td>{{ partner.nom }}</td>
+                    <td>{{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'N/A') }}</td>
+                    <td>
+                        {% if partner.competence %}
+                            <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ partner.competence|length }}</div>
                         {% else %}
-                            <tr>
-                                <td colspan="3">Aucun partenaire trouvé</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+                            /
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if partner.insee %}
+                            {% for insee in partner.insee|slice(0, 4) %}
+                                <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
+                            {% endfor %}
+                            {% if partner.insee|length > 4 %}
+                                + {{partner.insee|length - 4}}
+                            {% endif %}
+                        {% else %}
+                            /
+                        {% endif %}
+                    </td>
+                    {% if platform.feature_zonage %}
+                        <td>
+                            {% if partner.zones or partner.excludedZones %}
+                                {% for zone in partner.zones %}
+                                    <div class="fr-badge fr-badge--success fr-badge--no-icon fr-mb-1v">{{ zone.name }}</div>
+                                {% endfor %}
+                                {% for zone in partner.excludedZones %}
+                                    <div class="fr-badge fr-badge--error fr-badge--no-icon fr-mb-1v">{{ zone.name }}</div>
+                                {% endfor %}
+                            {% else %}
+                                /
+                            {% endif %}
+                        </td>
+                    {% endif %}
+                    <td class="fr-text--right fr-ws-nowrap">
+                        <a href="{{ path('back_partner_view', {'id': partner.id}) }}"
+                        class="fr-btn fr-fi-arrow-right-line fr-btn--sm"></a>
+                        <a href="#" class="fr-btn fr-btn--danger fr-fi-delete-line fr-btn--sm btn-delete-partner"
+                            id="partners_delete_{{ partner.id }}" aria-controls="fr-modal-partner-delete"
+                            data-fr-opened="false" data-partnername="{{ partner.nom }}" data-partnerid="{{ partner.id }}"></a>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="3">Aucun partenaire trouvé</td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des partenaires', 'tableHead': tableHead, 'tableBody': tableBody } %}
+
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center" id="partner-pagination">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, page, 'back_partner_index', {territory: (currentTerritory ? currentTerritory.id : null), type: (currentType ? currentType : null), userTerms: userTerms}) }}

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -191,7 +191,7 @@
         <div id="tabpanel-agents-panel" class="fr-tabs__panel fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-agents" tabindex="0">
             <div class="fr-grid-row fr-grid-row--gutters">
                 <div class="fr-col-6">
-                    <h2>Agents du partenaire</h2>
+                    <h2 id="desc-table">Agents du partenaire</h2>
                 </div>
                 <div class="fr-col-6 fr-text--right">
                     <a href="#" class="fr-btn fr-btn--success fr-btn--icon-left fr-btn--md fr-fi-add-line fr-btn-add-user"
@@ -200,90 +200,82 @@
                         un utilisateur</a>
                 </div>
             </div>
-            <div class="fr-table">
-                <div class="fr-table__wrapper">
-                    <div class="fr-table__container">
-                        <div class="fr-table__content">
-                            <table class="fr-cell--multiline" aria-label="Liste des utilisateurs du partenaire">
-                                <thead>
-                                <tr>
-                                    <th scope="col">Dernière connexion</th>
-                                    <th scope="col">Nom</th>
-                                    <th scope="col">Prénom</th>
-                                    <th scope="col">Courriel</th>
-                                    <th scope="col">Notif. e-mails</th>
-                                    <th scope="col">Statut</th>
-                                    <th scope="col">Rôle</th>
+
+            {% set tableHead %}
+                <th scope="col">Dernière connexion</th>
+                <th scope="col">Nom</th>
+                <th scope="col">Prénom</th>
+                <th scope="col">Courriel</th>
+                <th scope="col">Notif. e-mails</th>
+                <th scope="col">Statut</th>
+                <th scope="col">Rôle</th>
+                {% if platform.feature_permission_affectation and is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
+                <th scope="col">Droits d'affectation</th>
+                {% endif %}
+                <th scope="col" class="fr-text--right">Actions</th>
+            {% endset %}
+
+			{% set tableBody %}
+                {% for user in partner.users|filter(user => user.id is not null) %}
+                    <tr class="user-row">
+                        <td>{{ user.getLastLoginAtStr('d/m/Y') }}</td>
+                        <td>{{ user.nom }}</td>
+                        <td>{{ user.prenom }}</td>
+                        <td>{{ user.email }}</td>
+                        <td><span class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ user.isMailingActive ? 'OUI' : 'NON' }}</span></td>
+                        <td>{% if user.statut == 0 %}
+                                {% set classe = 'fr-badge--orange-terre-battue' %}
+                                {% set label = 'INACTIF' %}
+                            {% elseif user.statut == 1 %}
+                                {% set classe = 'fr-badge--green-emeraude' %}
+                                {% set label = 'ACTIF' %}
+                            {% elseif user.statut == 2 %}
+                                {% set classe = 'fr-badge--blue-ecume' %}
+                                {% set label = 'ARCHIVE' %}
+                            {% endif %}
+                            <span class="fr-badge {{ classe }} fr-mb-1v">{{ label }}</span></td>
+                        <td>
+                            {{ user.roleLabel() }}
+                        </td>
+                        {% if platform.feature_permission_affectation and is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
+                        <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
+                        {% endif %}
+                        <td class="fr-text--right">
+                            {% if is_granted('USER_EDIT', user) %}
+                                <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"
+                                    id="partner_users_edit_{{ user.id }}" aria-controls="fr-modal-user-edit"
+                                    data-fr-opened="false"
+                                    data-usernom="{{ user.nom }}"
+                                    data-userprenom="{{ user.prenom }}"
+                                    data-userrole="{{ user.roles[0] }}"
                                     {% if platform.feature_permission_affectation and is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
-                                    <th scope="col">Droits d'affectation</th>
+                                    data-userpermissionaffectation="{{ user.hasPermissionAffectation() ? '1' : '0' }}"
                                     {% endif %}
-                                    <th scope="col" class="fr-text--right">Actions</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                    {% for user in partner.users|filter(user => user.id is not null) %}
-                                        <tr class="user-row">
-                                            <td>{{ user.getLastLoginAtStr('d/m/Y') }}</td>
-                                            <td>{{ user.nom }}</td>
-                                            <td>{{ user.prenom }}</td>
-                                            <td>{{ user.email }}</td>
-                                            <td><span class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ user.isMailingActive ? 'OUI' : 'NON' }}</span></td>
-                                            <td>{% if user.statut == 0 %}
-                                                    {% set classe = 'fr-badge--orange-terre-battue' %}
-                                                    {% set label = 'INACTIF' %}
-                                                {% elseif user.statut == 1 %}
-                                                    {% set classe = 'fr-badge--green-emeraude' %}
-                                                    {% set label = 'ACTIF' %}
-                                                {% elseif user.statut == 2 %}
-                                                    {% set classe = 'fr-badge--blue-ecume' %}
-                                                    {% set label = 'ARCHIVE' %}
-                                                {% endif %}
-                                                <span class="fr-badge {{ classe }} fr-mb-1v">{{ label }}</span></td>
-                                            <td>
-                                                {{ user.roleLabel() }}
-                                            </td>
-                                            {% if platform.feature_permission_affectation and is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
-                                            <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
-                                            {% endif %}
-                                            <td class="fr-text--right">
-                                                {% if is_granted('USER_EDIT', user) %}
-                                                    <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"
-                                                        id="partner_users_edit_{{ user.id }}" aria-controls="fr-modal-user-edit"
-                                                        data-fr-opened="false"
-                                                        data-usernom="{{ user.nom }}"
-                                                        data-userprenom="{{ user.prenom }}"
-                                                        data-userrole="{{ user.roles[0] }}"
-                                                        {% if platform.feature_permission_affectation and is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
-                                                        data-userpermissionaffectation="{{ user.hasPermissionAffectation() ? '1' : '0' }}"
-                                                        {% endif %}
-                                                        data-userismailingactive="{{ user.isMailingActive }}"
-                                                        data-userid="{{ user.id }}"
-                                                        data-useremail="{{ user.email }}">
-                                                    </a>
-                                                {% endif %}
-                                                {% if is_granted('USER_TRANSFER', user) and app.request.get('_route') is not same as('back_partner_new') %}
-                                                    <a href="#" class="fr-btn fr-btn--orange fr-fi-upload-2-fill fr-mt-3v btn-transfer-partner-user"
-                                                    id="partner_users_transfer_{{ user.id }}" aria-controls="fr-modal-user-transfer"
-                                                    data-fr-opened="false" data-username="{{ user.nomComplet }}" data-userid="{{ user.id }}"></a>
-                                                {% endif %}
-                                                {% if is_granted('USER_DELETE', user) and app.request.get('_route') is not same as('back_partner_new') %}
-                                                    <a href="#" class="fr-btn fr-btn--danger fr-fi-delete-line fr-mt-3v btn-delete-partner-user"
-                                                    id="partner_users_delete_{{ user.id }}" aria-controls="fr-modal-user-delete"
-                                                    data-fr-opened="false" data-username="{{ user.nomComplet }}" data-userid="{{ user.id }}" data-useremail="{{ user.email }}"></a>
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                    {% else %}
-                                        <tr>
-                                            <td colspan="3">Aucun agent trouvé</td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                                    data-userismailingactive="{{ user.isMailingActive }}"
+                                    data-userid="{{ user.id }}"
+                                    data-useremail="{{ user.email }}">
+                                </a>
+                            {% endif %}
+                            {% if is_granted('USER_TRANSFER', user) and app.request.get('_route') is not same as('back_partner_new') %}
+                                <a href="#" class="fr-btn fr-btn--orange fr-fi-upload-2-fill fr-mt-3v btn-transfer-partner-user"
+                                id="partner_users_transfer_{{ user.id }}" aria-controls="fr-modal-user-transfer"
+                                data-fr-opened="false" data-username="{{ user.nomComplet }}" data-userid="{{ user.id }}"></a>
+                            {% endif %}
+                            {% if is_granted('USER_DELETE', user) and app.request.get('_route') is not same as('back_partner_new') %}
+                                <a href="#" class="fr-btn fr-btn--danger fr-fi-delete-line fr-mt-3v btn-delete-partner-user"
+                                id="partner_users_delete_{{ user.id }}" aria-controls="fr-modal-user-delete"
+                                data-fr-opened="false" data-username="{{ user.nomComplet }}" data-userid="{{ user.id }}" data-useremail="{{ user.email }}"></a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="3">Aucun agent trouvé</td>
+                    </tr>
+                {% endfor %}
+			{% endset %}
+
+        	{% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des utilisateurs du partenaire', 'tableDescId': 'desc-table', 'tableHead': tableHead, 'tableBody': tableBody, 'cancelSortable': true } %}
         </div>
     </div>
     

--- a/templates/back/partner_archived/index.html.twig
+++ b/templates/back/partner_archived/index.html.twig
@@ -48,52 +48,48 @@
         </form>
     </section>
     {% endif %}
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <h1 class="fr-h2 fr-mb-0" id="desc-table">{{total}} partenaires archivés ou sans territoires trouvés</h1>
+
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{total}} partenaires archivés ou sans territoires trouvés</h2>
     </section>
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="sortable" aria-label="Liste des partenaires archivés ou sans territoires" aria-describedby="desc-table">
-                        <thead>
-                        <tr>
-                            <th scope="col">Territoire</th>
-                            <th scope="col">Statut</th>
-                            <th scope="col">E-mail</th>
-                            <th scope="col">Nom</th>
-                            <th scope="col">Type</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for partner in partners %}
-                            {% if partner is null %}
-                                {% set classe = 'fr-badge--info' %}
-                                {% set statut = 'aucun' %}
-                            {% elseif partner and partner.isArchive  %}
-                                {% set classe = 'fr-badge--error' %}
-                                {% set statut = 'archivé' %}
-                            {% else %}
-                                {% set classe = 'fr-badge--success' %}
-                                {% set statut = 'actif' %}
-                            {% endif %}
-                            <tr class="user-row">
-                                <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
-                                <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
-                                <td>{{ partner.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
-                                <td>{{ partner.nom}}</ail td>
-                                <td>{{ partner.type is null ? 'N/R' : partner.type.label}}</ail td>
-                            </tr>
-                        {% else %}
-                            <tr>
-                                <td colspan="4">Aucun partenaire trouvé</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">Territoire</th>
+            <th scope="col">Statut</th>
+            <th scope="col">E-mail</th>
+            <th scope="col">Nom</th>
+            <th scope="col">Type</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for partner in partners %}
+                {% if partner is null %}
+                    {% set classe = 'fr-badge--info' %}
+                    {% set statut = 'aucun' %}
+                {% elseif partner and partner.isArchive  %}
+                    {% set classe = 'fr-badge--error' %}
+                    {% set statut = 'archivé' %}
+                {% else %}
+                    {% set classe = 'fr-badge--success' %}
+                    {% set statut = 'actif' %}
+                {% endif %}
+                <tr class="user-row">
+                    <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
+                    <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
+                    <td>{{ partner.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</ail td>
+                    <td>{{ partner.nom}}</ail td>
+                    <td>{{ partner.type is null ? 'N/R' : partner.type.label}}</ail td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="5">Aucun partenaire trouvé</td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des partenaires archivés ou sans territoires', 'tableHead': tableHead, 'tableBody': tableBody } %}
+        
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">    
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, page, 'back_archived_partner_index', {territory: (currentTerritory ? currentTerritory.id : (isNoneTerritory ? 'none' : null)), partnerTerms: partnerTerms}) }}

--- a/templates/back/signalement_archived/index.html.twig
+++ b/templates/back/signalement_archived/index.html.twig
@@ -14,7 +14,7 @@
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-6 fr-text--left">
-                    <h1 class="fr-h1 fr-mb-0">Signalements archivés</h1>
+                    <h1 class="fr-mb-0">Signalements archivés</h1>
                 </div>
             </div>
         </header>
@@ -45,88 +45,84 @@
             </div>
         </form>
     </section>
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <h2 class="fr-h2 fr-mb-0" id="desc-table">{{total}} signalements archivés</h2>
+
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{total}} signalements archivés</h2>
     </section>
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="sortable fr-cell--multiline" aria-label="Liste des signalements archivés" aria-describedby="desc-table">
-                        <thead>
-                        <tr>
-                            <th scope="col">#Ref.</th>
-                            <th scope="col">Territoire</th>
-                            <th scope="col">Date</th>
-                            <th scope="col">Occupant</th>
-                            <th scope="col">Adresse</th>
-                            <th scope="col">Affectation</th>
-                            <th scope="col">Dernier suivi</th>
-                            <th scope="col" class="fr-text--right ">Actions</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                            {% for index,signalement in signalements %}
-                                <tr class="{% if signalement.statut is same as(1) or signalement.statut is same as(3) %}fr-background-contrast--orange-terre-battue{% endif %} signalement-row"
-                                    data-score="{{ signalement.score }}">
-                                    <td>
-                                        <a href="{{ path('back_signalement_view',{uuid:signalement.uuid}) }}"
-                                        class="fr-ws-nowrap">{{ signalement.reference }}</a>
-                                    </td>
-                                    <td>{{ signalement.territory.zip}} - {{ signalement.territory.name}} </td>
-                                    <td>{{ signalement.createdAt|date('d/m/Y') }}</td>
-                                    <td>
-                                        {{ signalement.nomOccupant|upper }}<br>{{ signalement.prenomOccupant|capitalize }}
-                                    </td>
-                                    <td>{{ signalement.villeOccupant|upper }} <br><small>[{{ signalement.adresseOccupant }}]</small></td>
-                                    <td>
-                                        {% for affectation in signalement.affectations %}
-                                            {% set classe = '' %}
-                                            {% if affectation.statut is same as (0) %}
-                                                {% set classe = 'fr-badge fr-badge--info' %}
-                                            {% elseif affectation.statut is same as (1) %}
-                                                {% set classe = 'fr-badge fr-badge--success' %}
-                                            {% elseif affectation.statut is same as (2) %}
-                                                {% set classe = 'fr-badge fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line' %}
-                                            {% elseif affectation.statut is same as (3) %}
-                                                {% set classe = 'fr-badge fr-fi-close-circle-fill' %}
-                                            {% endif %}
-                                            <small class="{{ classe }} fr-ws-nowrap fr-badge--sm fr-my-1v fr-text--bold fr-display-block fr-limit-chars"><span
-                                                > {{ affectation.partner.nom }}</span></small>
-                                        {% else %}
-                                            Aucune
-                                        {% endfor %}
-                                    </td>
-                                    <td>
-                                        {% if signalement.lastSuiviBy is not null %}
-                                            <strong>{{ signalement.lastSuiviAt|date('d.m.Y') }}</strong> <br>{% set classe = '' %}
-                                            {% if 'OCCUPANT' == signalement.lastSuiviBy or 'DECLARANT' == signalement.lastSuiviBy %}
-                                                {% set classe = 'fr-badge fr-badge--warning' %}
-                                            {% endif %}
-                                            <small class="{{ classe }}">                
-                                                {% if signalement.lastSuiviBy is same as 'Aucun' %}   
-                                                    Occupant ou déclarant         
-                                                {% else %}
-                                                    {{ signalement.lastSuiviBy }}
-                                                {% endif %}
-                                            </small> <br>
-                                        {% else %}
-                                            Aucun
-                                        {% endif %}
-                                    </td>
-                                    <td class="fr-text--right fr-ws-nowrap">
-                                        <button data-reactive="{{ path('back_archived_signalements_reactiver',{uuid:signalement.uuid}) }}"
-                                            data-token="{{ csrf_token('signalement_reactive_'~signalement.id) }}"
-                                            class="fr-btn fr-icon-flashlight-fill fr-btn--sm signalement-row-reactive">
-                                        </button>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">#Ref.</th>
+            <th scope="col">Territoire</th>
+            <th scope="col">Date</th>
+            <th scope="col">Occupant</th>
+            <th scope="col">Adresse</th>
+            <th scope="col">Affectation</th>
+            <th scope="col">Dernier suivi</th>
+            <th scope="col" class="fr-text--right">Actions</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for index,signalement in signalements %}
+                <tr class="{% if signalement.statut is same as(1) or signalement.statut is same as(3) %}fr-background-contrast--orange-terre-battue{% endif %} signalement-row"
+                    data-score="{{ signalement.score }}">
+                    <td>
+                        <a href="{{ path('back_signalement_view',{uuid:signalement.uuid}) }}"
+                        class="fr-ws-nowrap">{{ signalement.reference }}</a>
+                    </td>
+                    <td>{{ signalement.territory.zip}} - {{ signalement.territory.name}} </td>
+                    <td>{{ signalement.createdAt|date('d/m/Y') }}</td>
+                    <td>
+                        {{ signalement.nomOccupant|upper }}<br>{{ signalement.prenomOccupant|capitalize }}
+                    </td>
+                    <td>{{ signalement.villeOccupant|upper }} <br><small>[{{ signalement.adresseOccupant }}]</small></td>
+                    <td>
+                        {% for affectation in signalement.affectations %}
+                            {% set classe = '' %}
+                            {% if affectation.statut is same as (0) %}
+                                {% set classe = 'fr-badge fr-badge--info' %}
+                            {% elseif affectation.statut is same as (1) %}
+                                {% set classe = 'fr-badge fr-badge--success' %}
+                            {% elseif affectation.statut is same as (2) %}
+                                {% set classe = 'fr-badge fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line' %}
+                            {% elseif affectation.statut is same as (3) %}
+                                {% set classe = 'fr-badge fr-fi-close-circle-fill' %}
+                            {% endif %}
+                            <small class="{{ classe }} fr-ws-nowrap fr-badge--sm fr-my-1v fr-text--bold fr-display-block fr-limit-chars"><span
+                                > {{ affectation.partner.nom }}</span></small>
+                        {% else %}
+                            Aucune
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% if signalement.lastSuiviBy is not null %}
+                            <strong>{{ signalement.lastSuiviAt|date('d.m.Y') }}</strong> <br>{% set classe = '' %}
+                            {% if 'OCCUPANT' == signalement.lastSuiviBy or 'DECLARANT' == signalement.lastSuiviBy %}
+                                {% set classe = 'fr-badge fr-badge--warning' %}
+                            {% endif %}
+                            <small class="{{ classe }}">                
+                                {% if signalement.lastSuiviBy is same as 'Aucun' %}   
+                                    Occupant ou déclarant         
+                                {% else %}
+                                    {{ signalement.lastSuiviBy }}
+                                {% endif %}
+                            </small> <br>
+                        {% else %}
+                            Aucun
+                        {% endif %}
+                    </td>
+                    <td class="fr-text--right fr-ws-nowrap">
+                        <button data-reactive="{{ path('back_archived_signalements_reactiver',{uuid:signalement.uuid}) }}"
+                            data-token="{{ csrf_token('signalement_reactive_'~signalement.id) }}"
+                            class="fr-btn fr-icon-flashlight-fill fr-btn--sm signalement-row-reactive">
+                        </button>
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des signalements archivés', 'tableHead': tableHead, 'tableBody': tableBody } %}
+
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, page, 'back_archived_signalements_index', {territory: (currentTerritory ? currentTerritory.id :  null), referenceTerms: referenceTerms}) }}

--- a/templates/back/signalement_export/index.html.twig
+++ b/templates/back/signalement_export/index.html.twig
@@ -68,65 +68,57 @@
             <li><strong>Logement social :</strong> s'il s'agit d'un logement social ou non</li>
         </ul>
 
-        <div class="fr-table fr-table--bordered" id="table-select-export-col">
-            <div class="fr-table__wrapper">
-                <div class="fr-table__container">
-                    <div class="fr-table__content">
-                        <table id="table-selectable">
-                            <caption>
-                                Infos à sélectionner
-                                <div class="fr-table__caption__desc">
-                                    Dans le tableau ci-dessous, sélectionnez les colonnes à ajouter à votre fichier.
-                                    <br>
-                                    Cliquez sur la case dans l'en-tête pour tout sélectionner.
-                                    <br>
-                                    Si vous ne cochez aucune case, seule les informations obligatoires vous seront transmises.
-                                </div>
-                            </caption>
-                            <thead>
-                                <tr>
-                                    <th class="fr-cell--fixed" role="columnheader">
-                                        <div class="fr-checkbox-group fr-checkbox-group--sm">
-                                            <input id="table-select-checkbox-all" type="checkbox">
-                                            <label class="fr-label" for="table-select-checkbox-all">
-                                                Nom de la colonne
-                                            </label>
-                                        </div>
-                                    </th>
-                                    <th scope="col">
-                                        Nom de la colonne
-                                    </th>
-                                    <th scope="col">
-                                        Détails
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for colId, col in selectable_cols %}
-                                <tr data-row-key="{{ loop.index }}">
-                                    <th class="fr-cell--fixed" scope="row">
-                                        <div class="fr-checkbox-group fr-checkbox-group--sm">
-                                            <input name="cols[]" value="{{ colId }}" id="table-select-checkbox-{{ colId }}" type="checkbox" class="checkbox-column"
-                                                {% if colId in selected_cols %}checked="checked"{% endif %}>
-                                            <label class="fr-label" for="table-select-checkbox-{{ colId }}">
-                                                {{ col.name }}
-                                            </label>
-                                        </div>
-                                    </th>
-                                    <td>
-                                        {{ col.name }}
-                                    </td>
-                                    <td>
-                                        {{ col.description }}
-                                    </td>
-                                </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+        <h2 class="fr-mb-0" id="desc-table">
+            Infos à sélectionner
+            <div class="fr-text--sm fr-text--light">
+                Dans le tableau ci-dessous, sélectionnez les colonnes à ajouter à votre fichier.
+                <br>
+                Cliquez sur la case dans l'en-tête pour tout sélectionner.
+                <br>
+                Si vous ne cochez aucune case, seule les informations obligatoires vous seront transmises.
             </div>
-        </div>
+        </h2>
+        
+        {% set tableHead %}
+            <th class="fr-cell--fixed" role="columnheader">
+                <div class="fr-checkbox-group fr-checkbox-group--sm">
+                    <input id="table-select-checkbox-all" type="checkbox">
+                    <label class="fr-label" for="table-select-checkbox-all">
+                        Nom de la colonne
+                    </label>
+                </div>
+            </th>
+            <th scope="col">
+                Nom de la colonne
+            </th>
+            <th scope="col">
+                Détails
+            </th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for colId, col in selectable_cols %}
+            <tr data-row-key="{{ loop.index }}">
+                <th class="fr-cell--fixed" scope="row">
+                    <div class="fr-checkbox-group fr-checkbox-group--sm">
+                        <input name="cols[]" value="{{ colId }}" id="table-select-checkbox-{{ colId }}" type="checkbox" class="checkbox-column"
+                            {% if colId in selected_cols %}checked="checked"{% endif %}>
+                        <label class="fr-label" for="table-select-checkbox-{{ colId }}">
+                            {{ col.name }}
+                        </label>
+                    </div>
+                </th>
+                <td>
+                    {{ col.name }}
+                </td>
+                <td>
+                    {{ col.description }}
+                </td>
+            </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des colonnes à exporter', 'tableDescId': 'desc-table-expired', 'tableHead': tableHead, 'tableBody': tableBody, 'cancelSortable': true, 'cancelMultiline': true } %}
 
         <ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--right fr-btns-group--icon-left">
             <li>

--- a/templates/back/tags/index.html.twig
+++ b/templates/back/tags/index.html.twig
@@ -175,56 +175,50 @@
         </dialog>
     {% endfor %}
 
-
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <h2 class="fr-h2 fr-mb-0" id="desc-table">{{total}} étiquette{% if total > 1%}s{% endif %}</h2>
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{total}} étiquette{% if total > 1%}s{% endif %}</h2>
     </section>
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="sortable fr-cell--multiline" aria-label="Liste des étiquettes" aria-describedby="desc-table">
-                        <thead>
-                        <tr>
-                            <th scope="col" class="number">ID</th>
-                            <th scope="col">Etiquette</th>
-                            <th scope="col" class="number">Nombre d'utilisation</th>
-                            <th scope="col">Territoire</th>
-                            <th scope="col" class="fr-text--right">Actions</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                            {% for index,tag in tags %}
-                                <tr class="signalement-row">
-                                    <td>{{ tag.id }}</td>
-                                    <td><span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon">{{ tag.label }}</span></td>
-                                    <td>{{ tag.signalements|length }}</td>
-                                    <td>{{ tag.territory.name }}</td>
-                                    <td class="fr-text--right fr-ws-nowrap">
-                                        <button class="fr-btn fr-icon-edit-line"
-                                            title="Editer l'étiquette {{ tag.label }}"
-                                            data-fr-opened="false" aria-controls="fr-modal-etiquette-edit-{{ tag.id }}"
-                                            >Editer l'étiquette {{ tag.label }}</button>
-                                        <a class="fr-btn fr-icon-list-unordered"
-                                            title="Voir la liste des signalements avec l'étiquette {{ tag.label }}"
-                                            {% if is_granted('ROLE_ADMIN') %}
-                                                href="{{ path('back_signalement_index', { 'etiquettes[]': tag.id, 'isImported': 'oui', 'territoire': tag.territory.id }) }}"
-                                            {% else %}
-                                                href="{{ path('back_signalement_index', { 'etiquettes[]': tag.id, 'isImported': 'oui' }) }}"
-                                            {% endif %}
-                                            >Voir la liste des signalements avec l'étiquette {{ tag.label }}</a>
-                                        <button class="fr-btn fr-btn--secondary fr-icon-delete-line"
-                                            title="Supprimer l'étiquette {{ tag.label }}"
-                                            data-fr-opened="false" aria-controls="fr-modal-etiquette-delete-{{ tag.id }}"
-                                            >Supprimer l'étiquette {{ tag.label }}</button>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col" class="number">ID</th>
+            <th scope="col">Etiquette</th>
+            <th scope="col" class="number">Nombre d'utilisation</th>
+            <th scope="col">Territoire</th>
+            <th scope="col" class="fr-text--right">Actions</th>
+        {% endset %}
+        
+        {% set tableBody %}
+            {% for index,tag in tags %}
+                <tr class="signalement-row">
+                    <td>{{ tag.id }}</td>
+                    <td><span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon">{{ tag.label }}</span></td>
+                    <td>{{ tag.signalements|length }}</td>
+                    <td>{{ tag.territory.name }}</td>
+                    <td class="fr-text--right fr-ws-nowrap">
+                        <button class="fr-btn fr-icon-edit-line"
+                            title="Editer l'étiquette {{ tag.label }}"
+                            data-fr-opened="false" aria-controls="fr-modal-etiquette-edit-{{ tag.id }}"
+                            >Editer l'étiquette {{ tag.label }}</button>
+                        <a class="fr-btn fr-icon-list-unordered"
+                            title="Voir la liste des signalements avec l'étiquette {{ tag.label }}"
+                            {% if is_granted('ROLE_ADMIN') %}
+                                href="{{ path('back_signalement_index', { 'etiquettes[]': tag.id, 'isImported': 'oui', 'territoire': tag.territory.id }) }}"
+                            {% else %}
+                                href="{{ path('back_signalement_index', { 'etiquettes[]': tag.id, 'isImported': 'oui' }) }}"
+                            {% endif %}
+                            >Voir la liste des signalements avec l'étiquette {{ tag.label }}</a>
+                        <button class="fr-btn fr-btn--secondary fr-icon-delete-line"
+                            title="Supprimer l'étiquette {{ tag.label }}"
+                            data-fr-opened="false" aria-controls="fr-modal-etiquette-delete-{{ tag.id }}"
+                            >Supprimer l'étiquette {{ tag.label }}</button>
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des étiquettes', 'tableHead': tableHead, 'tableBody': tableBody } %}
+
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, page, 'back_tags_index', {territory: (currentTerritory ? currentTerritory.id :  null), search: search}) }}

--- a/templates/back/territory/index.html.twig
+++ b/templates/back/territory/index.html.twig
@@ -38,70 +38,62 @@
         {{ form_end(form) }}
     </section>
 
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <div class="fr-col">
-            <h2 class="fr-h2 fr-mb-0" id="desc-table">{{territories|length}} territoire{% if territories|length > 1%}s{% endif %}</h2>
-        </div>
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{territories|length}} territoire{% if territories|length > 1%}s{% endif %}</h2>
     </section>
 
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="sortable fr-cell--multiline" aria-label="Liste des territoires" aria-describedby="desc-table">
-                        <thead>
-                            <tr>
-                                <th scope="col">ID</th>
-                                <th scope="col">Code</th>
-                                <th scope="col">Nom</th>
-                                <th scope="col">Statut</th>
-                                <th scope="col">Codes Insee ouverts</th>
-                                <th scope="col">Timezone</th>
-                                <th scope="col">Grille de visite</th>
-                                <th scope="col">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for territory in territories %}
-                                <tr class="signalement-row">
-                                    <td>{{ territory.id }}</td>
-                                    <td>{{ territory.zip }}</td>
-                                    <td>{{ territory.name }}</td>
-                                    <td>
-                                        {% if territory.isActive %}
-                                            <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
-                                        {% else %}
-                                            <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>
-                                        {% endif %}
-                                    </td>
-                                    <td>
-                                        {% for code in territory.authorizedCodesInsee %}
-                                            <span class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ code }}</span>
-                                        {% endfor %}
-                                    </td>
-                                    <td>{{ territory.timezone}}</td>
-                                    <td>
-                                        {% if territory.isGrilleVisiteDisabled %}
-                                            <span class="fr-badge fr-badge--error">Désactivée</span>
-                                        {% elseif territory.grilleVisiteFilename is not null %}
-                                            <a class="fr-link" target="_blank" rel="noreferrer noopener" href="{{ path('back_territory_grille_visite', {territory:territory.id}) }}">
-                                                Grille spécifique
-                                            </a>
-                                        {% else %}
-                                            <a target="_blank" rel="noreferrer noopener" href="{{ path('back_territory_grille_visite', {territory:territory.id}) }}">
-                                                Grille par défaut
-                                            </a>
-                                        {% endif %}
-                                    <td>
-                                        <a class="fr-btn fr-btn--sm fr-fi-edit-line" href="{{path('back_territory_edit', {territory:territory.id})}}"></a>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">ID</th>
+            <th scope="col">Code</th>
+            <th scope="col">Nom</th>
+            <th scope="col">Statut</th>
+            <th scope="col">Codes Insee ouverts</th>
+            <th scope="col">Timezone</th>
+            <th scope="col">Grille de visite</th>
+            <th scope="col">Actions</th>
+        {% endset %}
+        
+        {% set tableBody %}
+            {% for territory in territories %}
+                <tr class="signalement-row">
+                    <td>{{ territory.id }}</td>
+                    <td>{{ territory.zip }}</td>
+                    <td>{{ territory.name }}</td>
+                    <td>
+                        {% if territory.isActive %}
+                            <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
+                        {% else %}
+                            <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% for code in territory.authorizedCodesInsee %}
+                            <span class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ code }}</span>
+                        {% endfor %}
+                    </td>
+                    <td>{{ territory.timezone}}</td>
+                    <td>
+                        {% if territory.isGrilleVisiteDisabled %}
+                            <span class="fr-badge fr-badge--error">Désactivée</span>
+                        {% elseif territory.grilleVisiteFilename is not null %}
+                            <a class="fr-link" target="_blank" rel="noreferrer noopener" href="{{ path('back_territory_grille_visite', {territory:territory.id}) }}">
+                                Grille spécifique
+                            </a>
+                        {% else %}
+                            <a target="_blank" rel="noreferrer noopener" href="{{ path('back_territory_grille_visite', {territory:territory.id}) }}">
+                                Grille par défaut
+                            </a>
+                        {% endif %}
+                    <td>
+                        <a class="fr-btn fr-btn--sm fr-fi-edit-line" href="{{path('back_territory_edit', {territory:territory.id})}}"></a>
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des territoires', 'tableHead': tableHead, 'tableBody': tableBody } %}
+
         <div id="territory-pagination" class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, searchTerritory.page, 'back_territory_index', searchTerritory.urlParams) }}

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -61,110 +61,104 @@
         {{ form_end(form) }}
     </section>
 
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <div class="fr-col">
-            <h2 class="fr-h2 fr-mb-0" id="desc-table">{{users|length}} utilisateur{% if users|length > 1%}s{% endif %}</h2>
+    <section class="fr-col-12 fr-grid-row fr-grid-row--middle fr-p-5v">
+        <div class="fr-col-12 fr-col-md-6">
+            <h2 class="fr-mb-0" id="desc-table">{{users|length}} utilisateur{% if users|length > 1%}s{% endif %}</h2>
         </div>
-        <div class="fr-col fr-text--right">
+        <div class="fr-col-12 fr-col-md-6 fr-text--right">
             <a href="{{path('back_user_export', searchUser.urlParams)}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-fill"> Exporter les résultats </a>
         </div>
     </section>
 
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="sortable fr-cell--multiline" aria-label="Liste des utilisateurs" aria-describedby="desc-table">
-                        <thead>
-                            <tr>
-                                {% if is_granted('ROLE_ADMIN') %}
-                                    <th scope="col">Territoire</th>
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            {% if is_granted('ROLE_ADMIN') %}
+                <th scope="col">Territoire</th>
+            {% endif %}
+            <th scope="col">Utilisateur</th>
+            <th scope="col">E-mail</th>
+            <th scope="col">Partenaire</th>
+            <th scope="col">Type de partenaire</th>
+            <th scope="col">Statut du compte</th>
+            <th scope="col">Dernière connexion</th>
+            <th scope="col">Rôle</th>
+            {% if platform.feature_permission_affectation %}
+            <th scope="col">Droits d'affectation</th>
+            {% endif %}
+            <th scope="col" class="fr-text--right">Actions</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for user in users %}
+                <tr class="signalement-row">
+                    {% if is_granted('ROLE_ADMIN') %}
+                        <td>
+                            {% for partner in user.partners %}
+                                {% if partner.territory %}
+                                    {{ partner.territory.zip ~ ' - ' ~ partner.territory.name }}
+                                {% else %}
+                                    N/A
                                 {% endif %}
-                                <th scope="col">Utilisateur</th>
-                                <th scope="col">E-mail</th>
-                                <th scope="col">Partenaire</th>
-                                <th scope="col">Type de partenaire</th>
-                                <th scope="col">Statut du compte</th>
-                                <th scope="col">Dernière connexion</th>
-                                <th scope="col">Rôle</th>
-                                {% if platform.feature_permission_affectation %}
-                                <th scope="col">Droits d'affectation</th>
-                                {% endif %}
-                                <th scope="col" class="fr-text--right">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for user in users %}
-                                <tr class="signalement-row">
-                                    {% if is_granted('ROLE_ADMIN') %}
-                                        <td>
-                                            {% for partner in user.partners %}
-                                                {% if partner.territory %}
-                                                    {{ partner.territory.zip ~ ' - ' ~ partner.territory.name }}
-                                                {% else %}
-                                                    N/A
-                                                {% endif %}
-                                                {% if not loop.last %}<br>{% endif %}
-                                            {% endfor %}
-                                        </td>
-                                    {% endif %}
-                                    <td>{{ user.prenom }} {{ user.nom }}</td>
-                                    <td>{{ user.email }}</td>
-                                    <td>
-                                        {% for partner in user.partners %}
-                                            {{ partner.nom }}
-                                            {% if not loop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    </td>
-                                    <td>
-                                        {% for partner in user.partners %}
-                                             {% if partner.type %}
-                                                {{ partner.type.label }}
-                                             {% else %}
-                                                N/A
-                                             {% endif %}
-                                             {% if not loop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    </td>
-                                    <td>
-                                        {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE') %}
-                                            <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>
-                                        {% elseif user.statut is same as constant('App\\Entity\\User::STATUS_ACTIVE') %}
-                                            <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
-                                        {% else %}
-                                            {{ user.statutLabel }}
-                                        {% endif %}
-                                    </td>
-                                    <td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}</td>
-                                    <td>{{ user.roleLabel() }}</td>
-                                    {% if platform.feature_permission_affectation %}
-                                    <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
-                                    {% endif %}
-                                    <td class="fr-text--right">
-                                        {% if user.getPartners|length %}
-                                            <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"
-                                                id="partner_users_edit_{{ user.id }}" aria-controls="fr-modal-user-edit"
-                                                data-fr-opened="false"
-                                                data-submit-url="{{ path('back_partner_user_edit', {'id': user.getPartners.first.id}) }}"
-                                                data-usernom="{{ user.nom }}"
-                                                data-userprenom="{{ user.prenom }}"
-                                                data-userrole="{{ user.roles[0] }}"
-                                                {% if platform.feature_permission_affectation %}
-                                                data-userpermissionaffectation="{{ user.hasPermissionAffectation() ? '1' : '0' }}"
-                                                {% endif %}
-                                                data-userismailingactive="{{ user.isMailingActive }}"
-                                                data-userid="{{ user.id }}"
-                                                data-useremail="{{ user.email }}">
-                                            </a>
-                                        {% endif %}
-                                    </td>
-                                </tr>
+                                {% if not loop.last %}<br>{% endif %}
                             {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+                        </td>
+                    {% endif %}
+                    <td>{{ user.prenom }} {{ user.nom }}</td>
+                    <td>{{ user.email }}</td>
+                    <td>
+                        {% for partner in user.partners %}
+                            {{ partner.nom }}
+                            {% if not loop.last %}<br>{% endif %}
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% for partner in user.partners %}
+                                {% if partner.type %}
+                                {{ partner.type.label }}
+                                {% else %}
+                                N/A
+                                {% endif %}
+                                {% if not loop.last %}<br>{% endif %}
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE') %}
+                            <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>
+                        {% elseif user.statut is same as constant('App\\Entity\\User::STATUS_ACTIVE') %}
+                            <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
+                        {% else %}
+                            {{ user.statutLabel }}
+                        {% endif %}
+                    </td>
+                    <td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}</td>
+                    <td>{{ user.roleLabel() }}</td>
+                    {% if platform.feature_permission_affectation %}
+                    <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
+                    {% endif %}
+                    <td class="fr-text--right">
+                        {% if user.getPartners|length %}
+                            <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"
+                                id="partner_users_edit_{{ user.id }}" aria-controls="fr-modal-user-edit"
+                                data-fr-opened="false"
+                                data-submit-url="{{ path('back_partner_user_edit', {'id': user.getPartners.first.id}) }}"
+                                data-usernom="{{ user.nom }}"
+                                data-userprenom="{{ user.prenom }}"
+                                data-userrole="{{ user.roles[0] }}"
+                                {% if platform.feature_permission_affectation %}
+                                data-userpermissionaffectation="{{ user.hasPermissionAffectation() ? '1' : '0' }}"
+                                {% endif %}
+                                data-userismailingactive="{{ user.isMailingActive }}"
+                                data-userid="{{ user.id }}"
+                                data-useremail="{{ user.email }}">
+                            </a>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des utilisateurs', 'tableHead': tableHead, 'tableBody': tableBody } %}
+        
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, searchUser.page, 'back_user_index', searchUser.urlParams) }}

--- a/templates/back/zone/index.html.twig
+++ b/templates/back/zone/index.html.twig
@@ -53,72 +53,64 @@
         {{ form_end(form) }}
     </section>
 
-    <section class="fr-grid-row fr-grid-row--middle fr-p-5v">
-        <div class="fr-col">
-            <h2 class="fr-h2 fr-mb-0" id="desc-table">{{zones|length}} zone{% if zones|length > 1%}s{% endif %}</h2>
-        </div>
+    <section class="fr-col-12 fr-p-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{zones|length}} zone{% if zones|length > 1%}s{% endif %}</h2>
     </section>
 
-    <section class="fr-col-12 fr-table fr-pt-0 fr-px-5v">
-		<div class="fr-table__wrapper">
-			<div class="fr-table__container">
-				<div class="fr-table__content">
-                    <table class="sortable fr-cell--multiline" aria-label="Liste des utilisateurs" aria-describedby="desc-table">
-                        <thead>
-                            <tr>
-                                <th scope="col" class="number">ID</th>
-                                <th scope="col">Nom</th>
-                                <th scope="col">Partenaires</th>
-                                <th scope="col">Partenaires exclus</th>
-                                <th scope="col">Territoire</th>
-                                <th scope="col">Type</th>
-                                <th scope="col" class="fr-text--right">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for item in zones %}
-                                <tr class="signalement-row">
-                                    <td>{{ item.id }}</td>
-                                    <td>{{ item.name }}</td>
-                                    <td>
-                                        {% for partner in item.partners %}
-                                            <span class="fr-badge fr-badge--success fr-badge--no-icon">{{ partner.nom }}</span>
-                                        {% endfor %}
-                                    </td>
-                                    <td>
-                                        {% for partner in item.excludedPartners %}
-                                            <span class="fr-badge fr-badge--error fr-badge--no-icon">{{ partner.nom }}</span>
-                                        {% endfor %}
-                                    </td>
-                                    <td>
-                                        {% if item.territory %}
-                                            {{ item.territory.zip }} - {{ item.territory.name }}
-                                        {% endif %}
-                                    </td>
-                                    <td>{{ item.type.label }}</td>
-                                    <td class="fr-text--right fr-ws-nowrap">
-                                        <a href="{{path('back_zone_show', {zone: item.id})}}" class="fr-btn fr-icon-arrow-right-line" title="Visualiser la zone {{item.name}}">
-                                            Visualiser la zone {{ item.name }}
-                                        </a>
-                                        <a href="{{path('back_zone_edit', {zone: item.id})}}" class="fr-btn fr-icon-edit-line" title="Editer la zone {{item.name}}">
-                                            Editer la zone {{ item.name }}
-                                        </a>
-                                        <button 
-                                            class="fr-btn fr-btn--secondary fr-icon-delete-line open-modal-zone-delete" 
-                                            title="Supprimer la zone {{item.name}}" 
-                                            data-fr-opened="false" 
-                                            aria-controls="fr-modal-zone-delete"
-                                            data-url="{{path('back_zone_delete', {zone: item.id})}}?_token={{ csrf_token('zone_delete') }}"
-                                            data-name="{{item.name}}" >
-                                            Supprimer la zone {{ item.name }}</button>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-				</div>
-			</div>
-		</div>
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col" class="number">ID</th>
+            <th scope="col">Nom</th>
+            <th scope="col">Partenaires</th>
+            <th scope="col">Partenaires exclus</th>
+            <th scope="col">Territoire</th>
+            <th scope="col">Type</th>
+            <th scope="col" class="fr-text--right">Actions</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for item in zones %}
+                <tr class="signalement-row">
+                    <td>{{ item.id }}</td>
+                    <td>{{ item.name }}</td>
+                    <td>
+                        {% for partner in item.partners %}
+                            <span class="fr-badge fr-badge--success fr-badge--no-icon">{{ partner.nom }}</span>
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% for partner in item.excludedPartners %}
+                            <span class="fr-badge fr-badge--error fr-badge--no-icon">{{ partner.nom }}</span>
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% if item.territory %}
+                            {{ item.territory.zip }} - {{ item.territory.name }}
+                        {% endif %}
+                    </td>
+                    <td>{{ item.type.label }}</td>
+                    <td class="fr-text--right fr-ws-nowrap">
+                        <a href="{{path('back_zone_show', {zone: item.id})}}" class="fr-btn fr-icon-arrow-right-line" title="Visualiser la zone {{item.name}}">
+                            Visualiser la zone {{ item.name }}
+                        </a>
+                        <a href="{{path('back_zone_edit', {zone: item.id})}}" class="fr-btn fr-icon-edit-line" title="Editer la zone {{item.name}}">
+                            Editer la zone {{ item.name }}
+                        </a>
+                        <button 
+                            class="fr-btn fr-btn--secondary fr-icon-delete-line open-modal-zone-delete" 
+                            title="Supprimer la zone {{item.name}}" 
+                            data-fr-opened="false" 
+                            aria-controls="fr-modal-zone-delete"
+                            data-url="{{path('back_zone_delete', {zone: item.id})}}?_token={{ csrf_token('zone_delete') }}"
+                            data-name="{{item.name}}" >
+                            Supprimer la zone {{ item.name }}</button>
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des utilisateurs', 'tableHead': tableHead, 'tableBody': tableBody } %}
+
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
             {{ macros.customPagination(pages, searchZone.page, 'back_zone_index', searchZone.urlParams) }}

--- a/tests/Functional/Controller/BackArchivedAccountControllerTest.php
+++ b/tests/Functional/Controller/BackArchivedAccountControllerTest.php
@@ -35,7 +35,7 @@ class BackArchivedAccountControllerTest extends WebTestCase
             $client->getResponse()->getStatusCode(),
             \sprintf('Result value: %d', $client->getResponse()->getStatusCode())
         );
-        $this->assertEquals(1, $crawler->filter('h1:contains("9 comptes archivés ou sans territoires et/ou partenaires trouvés")')->count());
+        $this->assertEquals(1, $crawler->filter('h2:contains("9 comptes archivés ou sans territoires et/ou partenaires trouvés")')->count());
     }
 
     public function testAccountListWithTerritory(): void


### PR DESCRIPTION
## Ticket

#3377   

## Description
Création d'un fichier twig à inclure en BO lorsqu'on crée un tableau.
Premier pas vers une standardisation.

## Changements apportés
* J'en ai profité pour retoucher quelques titres / descriptions de tableaux... C'était secondaire mais bon...

## Tests
- [ ] Tester sur http://localhost:8080/bo/partenaires/
- [ ] Tester sur http://localhost:8080/bo/utilisateurs/
- [ ] Tester sur http://localhost:8080/bo/zone/
- [ ] Tester sur http://localhost:8080/bo/etiquettes/
- [ ] Tester sur http://localhost:8080/bo/partner-archives/
- [ ] Tester sur http://localhost:8080/bo/comptes-archives/
- [ ] Tester sur http://localhost:8080/bo/signalements-archives/
- [ ] Tester sur http://localhost:8080/bo/auto-affectation/
- [ ] Tester sur http://localhost:8080/bo/comptes-archives/
- [ ] Tester sur http://localhost:8080/bo/comptes-expires/
- [ ] Tester sur http://localhost:8080/bo/comptes-inactifs/
- [ ] Tester sur http://localhost:8080/bo/notifications/
- [ ] Tester sur http://localhost:8080/bo/territoire/
- [ ] Tester sur http://localhost:8080/bo/idoss/log
- [ ] Vérifier que je n'ai pas oublié de liste !
