### PR TITLE
[API RNB] Integrer le BatID quand l'adresse retourne un seul résultat

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -27,6 +27,7 @@ framework:
             App\Messenger\Message\UserExportMessage: async_priority_high
             App\Messenger\Message\PdfExportMessage: async_priority_high
             App\Messenger\Message\SignalementDraftFileMessage: async_priority_high
+            App\Messenger\Message\SignalementUpdateFromAddressMessage: async_priority_high
 
 
 

--- a/migrations/Version20241209082922.php
+++ b/migrations/Version20241209082922.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241209082922 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add rnb_id_occupant column to signalement table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP INDEX UNIQ_F4B551143EA4CB4D, ADD INDEX IDX_F4B551143EA4CB4D (created_from_id)');
+        $this->addSql('ALTER TABLE signalement ADD rnb_id_occupant VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP INDEX IDX_F4B551143EA4CB4D, ADD UNIQUE INDEX UNIQ_F4B551143EA4CB4D (created_from_id)');
+        $this->addSql('ALTER TABLE signalement DROP rnb_id_occupant');
+    }
+}

--- a/src/Command/InitIdBanCommand.php
+++ b/src/Command/InitIdBanCommand.php
@@ -57,7 +57,7 @@ class InitIdBanCommand extends Command
             foreach ($listSignalementBanIdNull as $signalement) {
                 $this->signalementAddressUpdater->updateAddressOccupantFromBanData(
                     signalement: $signalement,
-                    updateGeolocAndBatId: false,
+                    updateGeolocAndRnbId: false,
                 );
                 if (!empty($signalement->getBanIdOccupant())) {
                     ++$nb;

--- a/src/Command/InitIdBanCommand.php
+++ b/src/Command/InitIdBanCommand.php
@@ -4,8 +4,8 @@ namespace App\Command;
 
 use App\Entity\Signalement;
 use App\Manager\HistoryEntryManager;
-use App\Manager\SignalementManager;
 use App\Repository\SignalementRepository;
+use App\Service\Signalement\SignalementAddressUpdater;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -23,7 +23,7 @@ class InitIdBanCommand extends Command
     private const int BATCH_SIZE = 20;
 
     public function __construct(
-        private readonly SignalementManager $signalementManager,
+        private readonly SignalementAddressUpdater $signalementAddressUpdater,
         private readonly SignalementRepository $signalementRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly HistoryEntryManager $historyEntryManager,
@@ -55,9 +55,9 @@ class InitIdBanCommand extends Command
 
             /** @var Signalement $signalement */
             foreach ($listSignalementBanIdNull as $signalement) {
-                $this->signalementManager->updateAddressOccupantFromBanData(
+                $this->signalementAddressUpdater->updateAddressOccupantFromBanData(
                     signalement: $signalement,
-                    updateGeoloc: false,
+                    updateGeolocAndBatId: false,
                 );
                 if (!empty($signalement->getBanIdOccupant())) {
                     ++$nb;

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -423,6 +423,9 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Column(nullable: true)]
     private ?array $synchroData = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $rnb_id_occupant = null;
+
     public function __construct()
     {
         $this->situations = new ArrayCollection();
@@ -2442,5 +2445,17 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function getManyToManyFieldsToTrack(): array
     {
         return ['tags'];
+    }
+
+    public function getRnbIdOccupant(): ?string
+    {
+        return $this->rnb_id_occupant;
+    }
+
+    public function setRnbIdOccupant(?string $rnb_id_occupant): static
+    {
+        $this->rnb_id_occupant = $rnb_id_occupant;
+
+        return $this;
     }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -424,7 +424,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     private ?array $synchroData = null;
 
     #[ORM\Column(length: 255, nullable: true)]
-    private ?string $rnb_id_occupant = null;
+    private ?string $rnbIdOccupant = null;
 
     public function __construct()
     {
@@ -2449,12 +2449,12 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function getRnbIdOccupant(): ?string
     {
-        return $this->rnb_id_occupant;
+        return $this->rnbIdOccupant;
     }
 
-    public function setRnbIdOccupant(?string $rnb_id_occupant): static
+    public function setRnbIdOccupant(?string $rnbIdOccupant): static
     {
-        $this->rnb_id_occupant = $rnb_id_occupant;
+        $this->rnbIdOccupant = $rnbIdOccupant;
 
         return $this;
     }

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -8,6 +8,7 @@ use App\Event\SignalementDraftCompletedEvent;
 use App\Manager\SignalementManager;
 use App\Messenger\Message\NewSignalementCheckFileMessage;
 use App\Messenger\Message\SignalementDraftFileMessage;
+use App\Messenger\Message\SignalementUpdateFromAddressMessage;
 use App\Service\Files\DocumentProvider;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
@@ -69,6 +70,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                 $this->sendNotifications($signalement);
                 $this->processFiles($signalementDraft, $signalement);
                 $this->dispatchCheckFiles($signalement);
+                $this->dispatchUpdateFromAddress($signalement);
                 $this->autoAssigner->assign($signalement);
                 $this->entityManager->commit();
             } else {
@@ -114,5 +116,12 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                 new DelayStamp($delayInMs),
             ]
         );
+    }
+
+    public function dispatchUpdateFromAddress(Signalement $signalement): void
+    {
+        $this->messageBus->dispatch(new SignalementUpdateFromAddressMessage(
+            $signalement->getId()
+        ));
     }
 }

--- a/src/Messenger/Message/SignalementUpdateFromAddressMessage.php
+++ b/src/Messenger/Message/SignalementUpdateFromAddressMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Messenger\Message;
+
+class SignalementUpdateFromAddressMessage
+{
+    public function __construct(private ?int $signalementId)
+    {
+    }
+
+    public function getSignalementId(): ?int
+    {
+        return $this->signalementId;
+    }
+}

--- a/src/Messenger/MessageHandler/SignalementUpdateFromAddressMessageHandler.php
+++ b/src/Messenger/MessageHandler/SignalementUpdateFromAddressMessageHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Messenger\MessageHandler;
+
+use App\Messenger\Message\SignalementUpdateFromAddressMessage;
+use App\Repository\SignalementRepository;
+use App\Service\Signalement\SignalementAddressUpdater;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class SignalementUpdateFromAddressMessageHandler
+{
+    public function __construct(
+        private readonly SignalementRepository $signalementRepository,
+        private readonly SignalementAddressUpdater $signalementAddressUpdater,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(SignalementUpdateFromAddressMessage $signalementUpdateFromAddressMessage): void
+    {
+        try {
+            $signalement = $this->signalementRepository->find($signalementUpdateFromAddressMessage->getSignalementId());
+            $this->signalementAddressUpdater->updateAddressOccupantFromBanData($signalement);
+            $this->entityManager->flush();
+        } catch (\Throwable $exception) {
+            $this->logger->error(
+                sprintf(
+                    'The update from address of the signalement (%s) failed for the following reason : %s',
+                    $signalementUpdateFromAddressMessage->getSignalementId(),
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+}

--- a/src/Service/BetaGouv/Response/RnbBuilding.php
+++ b/src/Service/BetaGouv/Response/RnbBuilding.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Service\BetaGouv\Response;
+
+class RnbBuilding
+{
+    private ?string $rnbId = null;
+
+    public function __construct(?array $building = null)
+    {
+        $this->rnbId = $building['rnb_id'];
+    }
+
+    public function getRnbId(): ?string
+    {
+        return $this->rnbId;
+    }
+}

--- a/src/Service/BetaGouv/RnbService.php
+++ b/src/Service/BetaGouv/RnbService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Service\BetaGouv;
+
+use App\Service\BetaGouv\Response\RnbBuilding;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class RnbService
+{
+    private const string API_URL = 'https://rnb-api.beta.gouv.fr/api/alpha/buildings/';
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    private function searchBuildings(array $queryParams): ?array
+    {
+        try {
+            $url = self::API_URL.'?'.http_build_query($queryParams);
+            $response = $this->httpClient->request('GET', $url);
+
+            if (Response::HTTP_OK === $response->getStatusCode()) {
+                return $response->toArray();
+            }
+        } catch (\Throwable $exception) {
+            $this->logger->error($exception->getMessage());
+        }
+
+        return null;
+    }
+
+    public function getBuildings(string $cleInteropBan): array
+    {
+        $buildings = [];
+        $results = $this->searchBuildings(['cle_interop_ban' => $cleInteropBan]);
+        if (null !== $results && !empty($results['results'])) {
+            foreach ($results['results'] as $item) {
+                $buildings[] = new RnbBuilding($item);
+            }
+        }
+
+        return $buildings;
+    }
+}

--- a/src/Service/Signalement/SignalementAddressUpdater.php
+++ b/src/Service/Signalement/SignalementAddressUpdater.php
@@ -16,12 +16,12 @@ class SignalementAddressUpdater
     ) {
     }
 
-    public function updateAddressOccupantFromBanData(Signalement $signalement, bool $updateGeolocAndBatId = true): void
+    public function updateAddressOccupantFromBanData(Signalement $signalement, bool $updateGeolocAndRnbId = true): void
     {
         $addressResult = $this->addressService->getAddress($signalement->getAddressCompleteOccupant());
         if ($addressResult->getScore() > self::SCORE_IF_BAN_ID_ACCEPTED) {
             $signalement->setBanIdOccupant($addressResult->getBanId());
-            if ($updateGeolocAndBatId) {
+            if ($updateGeolocAndRnbId) {
                 $signalement
                     ->setInseeOccupant($addressResult->getInseeCode())
                     ->setGeoloc([
@@ -36,7 +36,7 @@ class SignalementAddressUpdater
             }
 
             return;
-        } elseif ($updateGeolocAndBatId && !empty($signalement->getCpOccupant()) && !empty($signalement->getVilleOccupant())) {
+        } elseif ($updateGeolocAndRnbId && !empty($signalement->getCpOccupant()) && !empty($signalement->getVilleOccupant())) {
             $inseeResult = $this->addressService->getAddress($signalement->getCpOccupant().' '.$signalement->getVilleOccupant());
             $signalement->setRnbIdOccupant(null);
             if (!empty($inseeResult->getCity())) {
@@ -55,7 +55,7 @@ class SignalementAddressUpdater
 
         $signalement->setBanIdOccupant(0);
         $signalement->setRnbIdOccupant(null);
-        if ($updateGeolocAndBatId) {
+        if ($updateGeolocAndRnbId) {
             $signalement
                 ->setInseeOccupant(null)
                 ->setGeoloc([]);

--- a/src/Service/Signalement/SignalementAddressUpdater.php
+++ b/src/Service/Signalement/SignalementAddressUpdater.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Service\Signalement;
+
+use App\Entity\Signalement;
+use App\Service\BetaGouv\RnbService;
+use App\Service\DataGouv\AddressService;
+
+class SignalementAddressUpdater
+{
+    private const float SCORE_IF_BAN_ID_ACCEPTED = 0.9;
+
+    public function __construct(
+        private readonly AddressService $addressService,
+        private readonly RnbService $rnbService,
+    ) {
+    }
+
+    public function updateAddressOccupantFromBanData(Signalement $signalement, bool $updateGeolocAndBatId = true): void
+    {
+        $addressResult = $this->addressService->getAddress($signalement->getAddressCompleteOccupant());
+        if ($addressResult->getScore() > self::SCORE_IF_BAN_ID_ACCEPTED) {
+            $signalement->setBanIdOccupant($addressResult->getBanId());
+            if ($updateGeolocAndBatId) {
+                $signalement
+                    ->setInseeOccupant($addressResult->getInseeCode())
+                    ->setGeoloc([
+                        'lat' => $addressResult->getLatitude(),
+                        'lng' => $addressResult->getLongitude(),
+                    ]);
+                $buildings = $this->rnbService->getBuildings($signalement->getBanIdOccupant());
+                $signalement->setRnbIdOccupant('');
+                if (1 === count($buildings)) {
+                    $signalement->setRnbIdOccupant($buildings[0]->getRnbId());
+                }
+            }
+
+            return;
+        } elseif ($updateGeolocAndBatId && !empty($signalement->getCpOccupant()) && !empty($signalement->getVilleOccupant())) {
+            $inseeResult = $this->addressService->getAddress($signalement->getCpOccupant().' '.$signalement->getVilleOccupant());
+            if (!empty($inseeResult->getCity())) {
+                $signalement
+                    ->setBanIdOccupant(0)
+                    ->setVilleOccupant($inseeResult->getCity())
+                    ->setInseeOccupant($inseeResult->getInseeCode())
+                    ->setGeoloc([
+                        'lat' => $inseeResult->getLatitude(),
+                        'lng' => $inseeResult->getLongitude(),
+                    ]);
+
+                return;
+            }
+        }
+
+        $signalement->setBanIdOccupant(0);
+        if ($updateGeolocAndBatId) {
+            $signalement
+                ->setInseeOccupant(null)
+                ->setGeoloc([]);
+        }
+    }
+}

--- a/src/Service/Signalement/SignalementAddressUpdater.php
+++ b/src/Service/Signalement/SignalementAddressUpdater.php
@@ -38,6 +38,7 @@ class SignalementAddressUpdater
             return;
         } elseif ($updateGeolocAndBatId && !empty($signalement->getCpOccupant()) && !empty($signalement->getVilleOccupant())) {
             $inseeResult = $this->addressService->getAddress($signalement->getCpOccupant().' '.$signalement->getVilleOccupant());
+            $signalement->setRnbIdOccupant(null);
             if (!empty($inseeResult->getCity())) {
                 $signalement
                     ->setBanIdOccupant(0)
@@ -53,6 +54,7 @@ class SignalementAddressUpdater
         }
 
         $signalement->setBanIdOccupant(0);
+        $signalement->setRnbIdOccupant(null);
         if ($updateGeolocAndBatId) {
             $signalement
                 ->setInseeOccupant(null)

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -19,7 +19,6 @@ use App\Factory\Signalement\InformationProcedureFactory;
 use App\Factory\Signalement\SituationFoyerFactory;
 use App\Factory\Signalement\TypeCompositionLogementFactory;
 use App\Manager\DesordreCritereManager;
-use App\Manager\SignalementManager;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordreCritereRepository;
 use App\Repository\DesordrePrecisionRepository;
@@ -55,7 +54,6 @@ class SignalementBuilder
         private CriticiteCalculator $criticiteCalculator,
         private SignalementQualificationUpdater $signalementQualificationUpdater,
         private DesordreCompositionLogementLoader $desordreCompositionLogementLoader,
-        private SignalementManager $signalementManager,
     ) {
     }
 
@@ -327,10 +325,6 @@ class SignalementBuilder
             )
             ->setAdresseAutreOccupant($this->signalementDraftRequest->getAdresseLogementComplementAdresseAutre())
             ->setManualAddressOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailManual());
-
-        $this->signalementManager->updateAddressOccupantFromBanData(
-            signalement: $this->signalement,
-        );
     }
 
     private function setOccupantDeclarantData(): void

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -18,11 +18,11 @@ use App\Manager\SuiviManager;
 use App\Repository\AffectationRepository;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordrePrecisionRepository;
-use App\Service\DataGouv\AddressService;
 use App\Service\Signalement\CriticiteCalculator;
 use App\Service\Signalement\DesordreTraitement\DesordreCompositionLogementLoader;
 use App\Service\Signalement\Qualification\QualificationStatusService;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
+use App\Service\Signalement\SignalementAddressUpdater;
 use App\Specification\Signalement\SuroccupationSpecification;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -55,7 +55,7 @@ class SignalementManagerTest extends WebTestCase
     private DesordreCompositionLogementLoader $desordreCompositionLogementLoader;
     private SuiviManager $suiviManager;
     private BailleurRepository $bailleurRepository;
-    private AddressService $addressService;
+    private SignalementAddressUpdater $signalementAddressUpdater;
     private AffectationRepository $affectationRepository;
 
     protected function setUp(): void
@@ -80,7 +80,7 @@ class SignalementManagerTest extends WebTestCase
         $this->desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
         $this->suiviManager = static::getContainer()->get(SuiviManager::class);
         $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
-        $this->addressService = static::getContainer()->get(AddressService::class);
+        $this->signalementAddressUpdater = static::getContainer()->get(SignalementAddressUpdater::class);
         $this->affectationRepository = static::getContainer()->get(AffectationRepository::class);
 
         $this->signalementManager = new SignalementManager(
@@ -99,8 +99,8 @@ class SignalementManagerTest extends WebTestCase
             $this->desordreCompositionLogementLoader,
             $this->suiviManager,
             $this->bailleurRepository,
-            $this->addressService,
-            $this->affectationRepository
+            $this->affectationRepository,
+            $this->signalementAddressUpdater,
         );
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
         $client->loginUser($user);

--- a/tests/Functional/Service/Signalement/PhotoHelperTest.php
+++ b/tests/Functional/Service/Signalement/PhotoHelperTest.php
@@ -11,12 +11,12 @@ use App\Manager\SuiviManager;
 use App\Repository\AffectationRepository;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordrePrecisionRepository;
-use App\Service\DataGouv\AddressService;
 use App\Service\Signalement\CriticiteCalculator;
 use App\Service\Signalement\DesordreTraitement\DesordreCompositionLogementLoader;
 use App\Service\Signalement\PhotoHelper;
 use App\Service\Signalement\Qualification\QualificationStatusService;
 use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
+use App\Service\Signalement\SignalementAddressUpdater;
 use App\Specification\Signalement\SuroccupationSpecification;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -42,7 +42,7 @@ class PhotoHelperTest extends KernelTestCase
     private DesordreCompositionLogementLoader $desordreCompositionLogementLoader;
     private SuiviManager $suiviManager;
     private BailleurRepository $bailleurRepository;
-    private AddressService $addressService;
+    private SignalementAddressUpdater $signalementAddressUpdater;
     private AffectationRepository $affectationRepository;
 
     protected function setUp(): void
@@ -65,7 +65,7 @@ class PhotoHelperTest extends KernelTestCase
         $this->desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
         $this->suiviManager = static::getContainer()->get(SuiviManager::class);
         $this->bailleurRepository = static::getContainer()->get(BailleurRepository::class);
-        $this->addressService = static::getContainer()->get(AddressService::class);
+        $this->signalementAddressUpdater = static::getContainer()->get(SignalementAddressUpdater::class);
         $this->affectationRepository = static::getContainer()->get(AffectationRepository::class);
 
         $this->signalementManager = new SignalementManager(
@@ -84,8 +84,8 @@ class PhotoHelperTest extends KernelTestCase
             $this->desordreCompositionLogementLoader,
             $this->suiviManager,
             $this->bailleurRepository,
-            $this->addressService,
-            $this->affectationRepository
+            $this->affectationRepository,
+            $this->signalementAddressUpdater
         );
     }
 

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -10,7 +10,6 @@ use App\Factory\Signalement\InformationProcedureFactory;
 use App\Factory\Signalement\SituationFoyerFactory;
 use App\Factory\Signalement\TypeCompositionLogementFactory;
 use App\Manager\DesordreCritereManager;
-use App\Manager\SignalementManager;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordreCritereRepository;
 use App\Repository\DesordrePrecisionRepository;
@@ -56,7 +55,6 @@ class SignalementBuilderTest extends KernelTestCase
         $criticiteCalculator = static::getContainer()->get(CriticiteCalculator::class);
         $signalementQualificationUpdater = static::getContainer()->get(SignalementQualificationUpdater::class);
         $desordreCompositionLogementLoader = static::getContainer()->get(DesordreCompositionLogementLoader::class);
-        $signalementManager = static::getContainer()->get(SignalementManager::class);
 
         $this->signalementBuilder = new SignalementBuilder(
             $territoryRepository,
@@ -74,7 +72,6 @@ class SignalementBuilderTest extends KernelTestCase
             $criticiteCalculator,
             $signalementQualificationUpdater,
             $desordreCompositionLogementLoader,
-            $signalementManager,
         );
     }
 
@@ -102,7 +99,8 @@ class SignalementBuilderTest extends KernelTestCase
             ->withProcedure()
             ->withInformationComplementaire()
             ->withDesordres()
-            ->build();
+            ->build()
+        ;
 
         $this->assertNotEmpty($signalement->getUuid());
         $this->assertNotEmpty($signalement->getReference());
@@ -142,11 +140,8 @@ class SignalementBuilderTest extends KernelTestCase
         $this->assertEquals('33 Rue des phoceens', $signalement->getAdresseOccupant());
         $this->assertEquals('13002', $signalement->getCpOccupant());
         $this->assertEquals('Marseille', $signalement->getVilleOccupant());
-        $this->assertEquals('13202', $signalement->getInseeOccupant());
         $this->assertEquals('5', $signalement->getEtageOccupant());
         $this->assertEquals('A', $signalement->getEscalierOccupant());
-        $this->assertArrayHasKey('lat', $signalement->getGeoloc());
-        $this->assertArrayHasKey('lng', $signalement->getGeoloc());
 
         $this->assertEquals('13 HABITAT', $signalement->getNomProprio());
         $this->assertEquals('Sandrine', $signalement->getPrenomProprio());

--- a/tests/Unit/Service/BetaGouv/RnbServiceTest.php
+++ b/tests/Unit/Service/BetaGouv/RnbServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Unit\Service\BetaGouv;
+
+use App\Service\BetaGouv\RnbService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class RnbServiceTest extends TestCase
+{
+    private const BAN_ID = '30348_0430_00015';
+    private const RNB_ID = 'FQYN6F6WPEJ8';
+    private RnbService $rnbService;
+
+    protected function setUp(): void
+    {
+        $mockResponse = new MockResponse(
+            file_get_contents(__DIR__.'/../../../files/betagouv/get_api_rnb_buildings_response.json')
+        );
+        $mockHttpClient = new MockHttpClient($mockResponse);
+        $this->rnbService = new RnbService($mockHttpClient, $this->createMock(LoggerInterface::class));
+    }
+
+    public function testGetBuildinds(): void
+    {
+        $buildings = $this->rnbService->getBuildings(self::BAN_ID);
+        $this->assertIsArray($buildings);
+        $this->assertCount(1, $buildings);
+        $this->assertSame(self::RNB_ID, $buildings[0]->getRnbId());
+    }
+}

--- a/tests/files/betagouv/get_api_rnb_buildings_response.json
+++ b/tests/files/betagouv/get_api_rnb_buildings_response.json
@@ -1,0 +1,73 @@
+{
+  "next": null,
+  "previous": null,
+  "results": [
+      {
+          "rnb_id": "FQYN6F6WPEJ8",
+          "status": "constructed",
+          "point": {
+              "type": "Point",
+              "coordinates": [
+                  4.141756415466935,
+                  44.05309187516625
+              ]
+          },
+          "shape": {
+              "type": "MultiPolygon",
+              "coordinates": [
+                  [
+                      [
+                          [
+                              4.14166820068322,
+                              44.05308064363605
+                          ],
+                          [
+                              4.141787016824452,
+                              44.05303079850556
+                          ],
+                          [
+                              4.141844630274239,
+                              44.053103106696454
+                          ],
+                          [
+                              4.14172581403257,
+                              44.05315295189149
+                          ],
+                          [
+                              4.14166820068322,
+                              44.05308064363605
+                          ]
+                      ]
+                  ]
+              ]
+          },
+          "addresses": [
+              {
+                  "id": "30348_0430_00015",
+                  "source": "bdnb",
+                  "street_number": "15",
+                  "street_rep": "",
+                  "street": "rue montfaucon",
+                  "city_name": "Vézénobres",
+                  "city_zipcode": "30360",
+                  "city_insee_code": "30348"
+              }
+          ],
+          "ext_ids": [
+              {
+                  "id": "bdnb-bc-D58V-9J29-VZ9B",
+                  "source": "bdnb",
+                  "created_at": "2023-12-09T19:37:21.915219+00:00",
+                  "source_version": "2023_01"
+              },
+              {
+                  "id": "BATIMENT0000000314481721",
+                  "source": "bdtopo",
+                  "created_at": "2023-12-21T23:51:00.180152+00:00",
+                  "source_version": "bdtopo_2023_09"
+              }
+          ],
+          "is_active": true
+      }
+  ]
+}


### PR DESCRIPTION
## Ticket

#3359

## Description
Enregistrement du `rnb_id` lors de la soumission / édition d'un signalement sous les conditions suivantes : 
- L'adresse correspond a une adresse BAN avec un score > 0.9
- La clé de l'adresse correspond a un seul bâtiment coté RNB

## Changements apportés
* Ajout d'un champ `rnb_id_occupant` sur la table signalement
* A la soumission d'un signalement traitement des appels API sur l'adresse en asynchrone via le worker à travers `dispatchUpdateFromAddress`
* Traitement des appels API de l'adresse mis dans un service à part `SignalementAddressUpdater`

## Pré-requis
`make execute-migration name=Version20241209082922 direction=up`
`make worker-stop`
`make worker-start`

## Tests
Déposer un signalement sur une adresse connue de la BAN (le worker doit être activé)
- [ ] S'assurer que le code INSEE, la clé BAN sont bien mis à jour sur le signalement 
- [ ] S'assurer que le champ rnb_id_occupant contient une valeur non nulle (clé ou '' si plusieurs bâtiments pour la clé)
- [ ] S'assurer que la mise à jour de l'adresse via le BO met à jour les valeurs géoloc, clé ban, rnb id
