### PR TITLE
[BO - Statistiques] Correction d'initialisation du graphique avec les motifs de refus depuis l'ajout de DOUBLON

### DIFF
--- a/assets/scripts/vue/components/common/external/chartjs/HistoChartDoughnut.vue
+++ b/assets/scripts/vue/components/common/external/chartjs/HistoChartDoughnut.vue
@@ -54,7 +54,7 @@ export default defineComponent({
     },
     height: {
       type: Number,
-      default: 400
+      default: 550
     },
     cssClasses: {
       type: String,

--- a/src/Service/Statistics/MotifClotureStatisticProvider.php
+++ b/src/Service/Statistics/MotifClotureStatisticProvider.php
@@ -123,6 +123,11 @@ class MotifClotureStatisticProvider
                 'color' => '#FC5D00',
                 'count' => 0,
             ],
+            'DOUBLON' => [
+                'label' => 'Doublon',
+                'color' => '#CECE00',
+                'count' => 0,
+            ],
             'AUTRE' => [
                 'label' => 'Autre',
                 'color' => '#CECECE',

--- a/tests/Functional/Service/Statistics/MotifClotureStatisticProviderTest.php
+++ b/tests/Functional/Service/Statistics/MotifClotureStatisticProviderTest.php
@@ -15,7 +15,7 @@ class MotifClotureStatisticProviderTest extends KernelTestCase
         $signalementRepository = self::getContainer()->get(SignalementRepository::class);
         $data = (new MotifClotureStatisticProvider($signalementRepository))->getData(null, null);
 
-        $this->assertEquals(14, \count($data));
+        $this->assertEquals(15, \count($data));
         $this->assertArrayHasKey('TRAVAUX_FAITS_OU_EN_COURS', $data);
         $this->assertArrayHasKey('color', $data['TRAVAUX_FAITS_OU_EN_COURS']);
         $this->assertArrayHasKey('label', $data['TRAVAUX_FAITS_OU_EN_COURS']);


### PR DESCRIPTION
## Ticket

#3412   

## Description
Correction d'initialisation du graphique avec les motifs de refus depuis l'ajout de DOUBLON

## Changements apportés
* J'ai aussi augmenté la hauteur des graphiques de type doughnuts pour pouvoir afficher la légende de ce graphique (qui est un peu grosse quand même...)

## Tests
- [ ] Vérifier que les stats BO s'affichent bien
