### PR TITLE
[BO - Signalement] Fil d'Ariane fixé quand on scrolle dans la page

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -1,5 +1,14 @@
 import { loadWindowWithLocalStorage } from '../../services/list_filter_helper'
 
+window.onscroll = function () {
+  const yPos = window.scrollY
+  if (yPos > 150) {
+    document?.querySelector('.fr-breadcrumb').classList.add('fixed')
+  } else {
+    document?.querySelector('.fr-breadcrumb').classList.remove('fixed')
+  }
+}
+
 /* global histoPhotoIds */
 
 document?.querySelector('#btn-display-all-suivis')?.addEventListeners('click touchdown', (e) => {
@@ -173,12 +182,12 @@ modalsElement.forEach(modalElement => {
 
 document.querySelectorAll('button[data-cloture-type]').forEach(button => {
   button.addEventListener('click', (e) => {
-    const element = e.target;
+    const element = e.target
     if (element && element?.dataset) {
       document.getElementById('cloture_type').value = element.dataset.clotureType
     }
-  });
-});
+  })
+})
 
 document?.getElementById('signalement-add-suivi-notify-usager')?.addEventListeners('change', (e) => {
   document.getElementById('signalement-add-suivi-submit').textContent = (e.target.checked) ? 'Envoyer le suivi à l\'usager' : 'Enregistrer le suivi interne'

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -216,10 +216,6 @@ legend.required::after, label.required::after {
     display: inline-flex !important;
 }
 
-.fr-display-block {
-    display: block;
-}
-
 *, :after, :before {
     box-sizing: inherit;
 }
@@ -968,4 +964,29 @@ a.photo-preview {
     margin: 0 auto;
     padding-left: 1.5rem;
     padding-right: 1.5rem;
+}
+
+.fr-breadcrumb.can-fix {
+    padding-top: 15px;
+}
+
+@media (min-width: 992px) {
+    .fr-breadcrumb.can-fix.fixed {
+        position: fixed;
+        z-index: 1000;
+        top: 0px;
+        left: 0px;
+        width: 100%;
+        height: 40px;
+        padding-top: 5px;
+        background: white;
+        box-shadow: inset 0 -2px 0 0 var(--border-disabled-grey);
+
+        #breadcrumb {
+            margin: 0 auto;
+            width: 100%;
+            max-width: 95rem;
+            padding: 0 1.5rem;
+        }
+    }
 }

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -189,7 +189,7 @@ class SignalementController extends AbstractController
 
         $allPhotosOrdered = PhotoHelper::getSortedPhotos($signalement);
         $twigParams = [
-            'title' => 'Signalement',
+            'title' => '#'.$signalement->getReference().' Signalement',
             'createdFromDraft' => $signalement->getCreatedFrom(),
             'situations' => $infoDesordres['criticitesArranged'],
             'photos' => $infoDesordres['photos'],

--- a/templates/back/breadcrumb_bo.html.twig
+++ b/templates/back/breadcrumb_bo.html.twig
@@ -1,4 +1,4 @@
-<nav role="navigation" class="fr-breadcrumb fr-my-0" aria-label="vous êtes ici :">
+<nav role="navigation" class="fr-breadcrumb fr-my-0 {{ canFix is defined ? 'can-fix' : '' }}" aria-label="vous êtes ici :">
     <button class="fr-breadcrumb__button" aria-expanded="false" aria-controls="breadcrumb">Voir le fil d’Ariane</button>
     <div class="fr-collapse" id="breadcrumb">
         <ol class="fr-breadcrumb__list">

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -4,6 +4,15 @@
 {% set static_picto_no = '<p class="fr-badge fr-badge--error">Non</p>' %}
 
 {% block content %}
+    {% include 'back/breadcrumb_bo.html.twig' with {
+        'canFix': true,
+        'level2Title': 'Liste des signalements',
+        'level2Link': path('back_signalement_index'),
+        'level2Label': 'Retour à la liste des signalements',
+        'level3Title': 'Signalement #'~signalement.reference,
+        'level3Link': '',
+    } %}
+
     {% if canSeePartnerAffectation and canTogglePartnerAffectation %}
         {% include '_partials/_modal_affectation.html.twig' %}
     {% endif %}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -1,12 +1,4 @@
 <header>
-    {% include 'back/breadcrumb_bo.html.twig' with {
-        'level2Title': 'Liste des signalements',
-        'level2Link': path('back_signalement_index'),
-        'level2Label': 'Retour à la liste des signalements',
-        'level3Title': 'Signalement #'~signalement.reference,
-        'level3Link': '',
-    } %}
-
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-7">
             <div class="fr-mb-4v">      


### PR DESCRIPTION
## Ticket

#3396   

## Description
Depuis le nouveau menu, les partenaires n'ont plus accès à la référence du signalement en permanence comme avant.
On leur remet à disposition.

## Changements apportés
* Ajout de la référence dans le `title` de la page
* Fix du fil d'Ariane en haut de page lorsqu'on scrolle la page (uniquement en version desktop)

## Pré-requis
`npm run watch`

## Tests
- [ ] Tester le fonctionnement voulu sur la fiche signalement
- [ ] Vérifier qu'il n'y a pas de changement sur les autres pages
- [ ] Vérifier que le fonctionnement n'est pas appliqué en responsive
