### PR TITLE
[BO - Liste signalements] Je n'ai plus le bouton "supprimer" en tant que RT

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -363,7 +363,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     public function getPartnerInTerritory(Territory $territory): ?Partner
     {
         foreach ($this->userPartners as $userPartner) {
-            if ($userPartner->getPartner()->getTerritory() === $territory) {
+            if ($userPartner->getPartner()->getTerritory()?->getId() === $territory->getId()) {
                 return $userPartner->getPartner();
             }
         }
@@ -379,7 +379,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     public function hasPartnerInTerritory(Territory $territory): bool
     {
         foreach ($this->userPartners as $userPartner) {
-            if ($userPartner->getPartner()->getTerritory() === $territory) {
+            if ($userPartner->getPartner()->getTerritory()?->getId() === $territory->getId()) {
                 return true;
             }
         }


### PR DESCRIPTION
## Ticket

#3416

## Description
Suite au modification multi-territoire, le voter `SIGN_DELETE` n'avait pas une comparaison assez fine face au cas particulier de son utilisation dans `SignalementAffectationListViewFactory`

## Changements apportés
* Correction via une comparaison sur l'id des objets plutôt que sur les objets

## Tests
- [ ] Se connecter en tant que RT et vérifier sur la lite de signalement que le bouton de suppression est présent (pour les signalement fermé/refusé)
