### PR TITLE
[BO - Albert] Non réception de l'email selon le type de signalement choisi

### DIFF
--- a/src/Controller/Back/SuiviSummariesController.php
+++ b/src/Controller/Back/SuiviSummariesController.php
@@ -2,12 +2,14 @@
 
 namespace App\Controller\Back;
 
+use App\Entity\Territory;
 use App\Entity\User;
 use App\Form\SuiviSummariesType;
 use App\Messenger\Message\SuiviSummariesMessage;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -15,6 +17,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[Route('/bo/resumes-suivi')]
 class SuiviSummariesController extends AbstractController
 {
+    /**
+     * @throws ExceptionInterface
+     */
     #[Route('/', name: 'back_suivi_summaries_index', methods: ['GET', 'POST'])]
     #[IsGranted('ROLE_ADMIN')]
     public function index(
@@ -26,13 +31,21 @@ class SuiviSummariesController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             /** @var User $user */
             $user = $this->getUser();
+            /** @var Territory $territory */
             $territory = $form->get('territory')->getData();
             $count = $form->get('count')->getData();
             $prompt = $form->get('prompt')->getData();
             $model = $form->get('model')->getData();
             $querySignalement = $form->get('querySignalement')->getData();
 
-            $messageBus->dispatch(new SuiviSummariesMessage($user, $territory, $count, $prompt, $model, $querySignalement));
+            $messageBus->dispatch(new SuiviSummariesMessage(
+                $user->getId(),
+                $territory->getId(),
+                $count,
+                $prompt,
+                $model,
+                $querySignalement)
+            );
             $this->addFlash(
                 'success',
                 \sprintf(

--- a/src/Messenger/Message/SuiviSummariesMessage.php
+++ b/src/Messenger/Message/SuiviSummariesMessage.php
@@ -2,14 +2,11 @@
 
 namespace App\Messenger\Message;
 
-use App\Entity\Territory;
-use App\Entity\User;
-
-class SuiviSummariesMessage
+readonly class SuiviSummariesMessage
 {
     public function __construct(
-        private User $user,
-        private Territory $territory,
+        private int $userId,
+        private int $territoryId,
         private int $count,
         private string $prompt,
         private string $model,
@@ -17,14 +14,14 @@ class SuiviSummariesMessage
     ) {
     }
 
-    public function getUser(): User
+    public function getUserId(): int
     {
-        return $this->user;
+        return $this->userId;
     }
 
-    public function getTerritory(): Territory
+    public function getTerritoryId(): int
     {
-        return $this->territory;
+        return $this->territoryId;
     }
 
     public function getCount(): int


### PR DESCRIPTION
## Ticket

#3423    

## Description
https://sentry.incubateur.net/organizations/betagouv/issues/137846
> The export of suivi summaries failed for the following reason : The identifier id is missing for a query of App\Entity\User

Le dernier suivi de type usager peut ne pas avoir d'utilisateur dans la table user, ce qui fait planter la demande de résumé pour le type `Relancés automatiquement, dernier suivi de type usager`

## Changements apportés
* Ajout d'un contrôle pour éviter d'aller faire une requête sur la table user s'il n'existe pas
* Travailler avec type primitifs au lieu d'objet d'entités (peut avoir des effets de bord sur la serialization/désérialisation du messsage) 

## Pré-requis
```
make load-data
make worker-stop && make worker-consume
```
## Tests
- [ ] Demander un résumé pour le type `Relancés automatiquement, dernier suivi de type usager`  et vérifier l'export avec la mention `Occupant ou déclarant`
![image](https://github.com/user-attachments/assets/a3973ef9-a128-4796-a23d-72ab7f205197)

- [ ] TNR, faire une demande de le type `Dernier suivi partenaire, sans autre suivi depuis +20 jours`
