### PR TITLE
[BO - Utilisateurs] La recherche par nom / email ne fonctionne pas

### DIFF
--- a/src/Form/SearchUserType.php
+++ b/src/Form/SearchUserType.php
@@ -141,14 +141,9 @@ class SearchUserType extends AbstractType
             'choice_label' => function ($choice) {
                 return $choice->label();
             },
-            'row_attr' => [
-                'class' => 'fr-select-group',
-            ],
             'placeholder' => 'Type de partenaire',
-            'attr' => [
-                'class' => 'fr-select',
-                'disabled' => isset($partners) && !empty($partners) && \count($partners) > 0,
-            ],
+            'required' => false,
+            'disabled' => isset($partners) && !empty($partners) && \count($partners) > 0,
             'label' => false,
         ];
 


### PR DESCRIPTION
## Ticket

#3417

## Description
Correction du champ "Type de partenaire" sur la page liste des utilisateurs qui était par défaut obligatoire alors qu'il ne le devait pas.

## Tests
- [ ] Sur la page BO liste ds utilisateurs : faire une recherche par nom d'utilisateur et vérifier que la soumission du formulaire de recherche fonctionne
