### PR TITLE
[QA - Sentry] Impossible d'enregistrer un événement SCHS

### DIFF
--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -228,7 +228,15 @@ class EsaboraManager
 
     public function createSuiviFromDossierEvent(DossierEventSCHS $event, Affectation $affectation): Suivi
     {
-        $description = "Message provenant d'esabora SCHS :\n".$event->getPresentation();
+        $description = 'Message provenant d\'esabora SCHS :'.\PHP_EOL;
+
+        if (!empty($event->getPresentation())) {
+            $description .= $event->getPresentation().\PHP_EOL;
+        }
+
+        if (!empty($event->getLibelle())) {
+            $description .= $event->getLibelle();
+        }
 
         $suivi = new Suivi();
         $suivi->setCreatedBy($this->userManager->getSystemUser());
@@ -236,7 +244,9 @@ class EsaboraManager
         $suivi->setType(Suivi::TYPE_PARTNER);
         $suivi->setContext(Suivi::CONTEXT_SCHS);
         $suivi->setDescription(nl2br($description));
-        $suivi->setCreatedAt(\DateTimeImmutable::createFromFormat('d/m/Y', $event->getDate()));
+        if (!empty($event->getDate())) {
+            $suivi->setCreatedAt(\DateTimeImmutable::createFromFormat('d/m/Y', $event->getDate()));
+        }
         $suivi->setOriginalData($event->getOriginalData());
         $this->entityManager->persist($suivi);
 

--- a/src/Service/Interconnection/Esabora/Response/Model/DossierEventSCHS.php
+++ b/src/Service/Interconnection/Esabora/Response/Model/DossierEventSCHS.php
@@ -48,12 +48,12 @@ class DossierEventSCHS
         return $this->originalData;
     }
 
-    public function getDate(): string
+    public function getDate(): ?string
     {
         return $this->date;
     }
 
-    public function getPresentation(): string
+    public function getPresentation(): ?string
     {
         return $this->presentation;
     }

--- a/tools/wiremock/src/Resources/Esabora/schs/ws_get_dossier_events.json
+++ b/tools/wiremock/src/Resources/Esabora/schs/ws_get_dossier_events.json
@@ -67,6 +67,19 @@
         "28",
         "30414"
       ]
+    },
+    {
+      "columnDataList": [
+        "HISTOO0013",
+        null,
+        null,
+        null,
+        "Visite Hygi\u00e8ne de l'habitat"
+      ],
+      "keyDataList": [
+        "28",
+        "30414"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Ticket

#3408    

## Description
Les premiers événements sont arrivés mais avec certaines propriétés null qui empeche l'enregistrement de suivi. il faut donc ajouter plus de contrôle. 

```json
{
  "searchId": 27453,
  "nbResults": 1,
  "columnList": [
    "SAS_R\u00e9f\u00e9rence",
    "Evt_Date",
    "Evt_Pr\u00e9sentation",
    "Evt_Documents",
    "Evty_Libell\u00e9"
  ],
  "documentTypeList": {
    "3": "e6_t1.evt_nomdoc"
  },
  "keyList": [
    "i1.iaff_id",
    "e6_t1.evt_id"
  ],
  "rowList": [
    {
      "columnDataList": [
        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
        null,
        null,
        null,
        "Visite Hygi\u00e8ne de l'habitat"
      ],
      "keyDataList": [
        4,
        925
      ]
    }
  ]
}
```
 
## Changements apportés
* Rendre toutes les propriétés nullable `DossierEventSCHS`
* Ajout d'une réponse dans le mock pour simuler la prod

## Pré-requis
```
make mock-stop && make mock-start
```

## Tests
- [ ] Exécuter la commande `make console app="sync-esabora-schs"`  et vérifier que le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012 a bien le suivi suivant 

![image](https://github.com/user-attachments/assets/d3978004-dfa1-4bd5-9713-5cc422aef9a7)

