### PR TITLE
[QA - BUG] crash export signalements

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -563,6 +563,7 @@ class SignalementRepository extends ServiceEntityRepository
 
     public function findSignalementAffectationIterable(User $user, array $options): \Generator
     {
+        ini_set('memory_limit', '4096M');
         // temporary increase the group_concat_max_len to a higher value, for texts in GROUP_CONCAT
         $connection = $this->getEntityManager()->getConnection();
         $sql = 'SET SESSION group_concat_max_len=32505856';


### PR DESCRIPTION
## Ticket

#3429

## Description
L'export de signalement de l'oise provoquait un crash, les causes étant : 
- Utilisation massive de `GROUP_CONCAT` dans la requête
- Augmentation `SET SESSION group_concat_max_len=32505856` provenant de #3149 (plus de crash sans l'option)
- Champ problématique : conclusion de visite (contenant du html et potentiellement très long)

Solution rapide : 
-  Augmentation du `memory_limit` sur la requête d'export de signalement

Défaut : 
- Ne règle pas le problème de concaténation : le champs conclusion de visites reste tronqué

Analyse : 
- La requête étant standard, on charge toutes les données même si l'on n'exporte pas les colonnes correspondante
- On fait une concaténation des informations de visite alors que seul leur nombre et les donnés de la dernière visite nous intéresse 
- Problème difficile à régler (requête complexe)


## Pré-requis
* Se mettre sur une base de prod
* Facultatif : commenter `App\Messenger\Message\ListExportMessage: async_priority_high`

## Tests
- [ ] Tester l'import de tous le signalement de l'oise et vérifier qu'on à pas de crash mémoire
