### PR TITLE
[BUG] crash export

### DIFF
--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -103,7 +103,7 @@ class SignalementExportFactory
             isOccupantPresentVisite: ($isOccupantPresentVisite && '-' !== $isOccupantPresentVisite) ? self::OUI : ('0' === $isOccupantPresentVisite ? self::NON : ''),
             interventionStatus: $lastIntervention['status'],
             interventionConcludeProcedure: $lastIntervention['conclude'],
-            interventionDetails: strip_tags($lastIntervention['details']),
+            interventionDetails: 'colonne temporairement désactivée',
             modifiedAt: $modifiedAt,
             closedAt: $closedAt,
             motifCloture: $motifCloture,

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -563,7 +563,6 @@ class SignalementRepository extends ServiceEntityRepository
 
     public function findSignalementAffectationIterable(User $user, array $options): \Generator
     {
-        ini_set('memory_limit', '4096M');
         // temporary increase the group_concat_max_len to a higher value, for texts in GROUP_CONCAT
         $connection = $this->getEntityManager()->getConnection();
         $sql = 'SET SESSION group_concat_max_len=32505856';
@@ -609,7 +608,7 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(DISTINCT tags.label SEPARATOR :group_concat_separator_1) as etiquettes,
             GROUP_CONCAT(IFNULL(i.occupantPresent, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionOccupantPresent,
             GROUP_CONCAT(IFNULL(i.concludeProcedure, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionConcludeProcedure,
-            GROUP_CONCAT(IFNULL(i.details, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionDetails,
+            \'-désactivation temporaire-\' as interventionDetails,
             GROUP_CONCAT(
                 DISTINCT
                 CONCAT(

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -113,6 +113,6 @@ class SignalementExportFactoryTest extends TestCase
         $this->assertEquals(SignalementExportFactory::NON, $signalementExportFactory->isNotOccupant);
         $this->assertEquals(VisiteStatus::TERMINEE->value, $signalementExportFactory->interventionStatus);
         $this->assertEquals('RSD,INSALUBRITE', $signalementExportFactory->interventionConcludeProcedure);
-        $this->assertEquals('dossier envoyé pour manquement sanitaire', $signalementExportFactory->interventionDetails);
+        $this->assertEquals('colonne temporairement désactivée', $signalementExportFactory->interventionDetails);
     }
 }


### PR DESCRIPTION
## Ticket

#3436

## Description
Désactivation de la colonne "Comm. de la dernière visite" pour éviter crash mémoire et DB

## Tests
- [ ] Exporter tous les signalements de l'Oise
