### PR TITLE
[FO - Formulaire] Réenregistrer en synchrone la geoloc et le code insee du signalement

### DIFF
--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -212,6 +212,8 @@ export default defineComponent({
         if (suggestions[0] !== undefined) {
           formStore.data.adresse_logement_adresse_detail_commune = suggestions[0].properties.city
           formStore.data.adresse_logement_adresse_detail_insee = suggestions[0].properties.citycode
+          formStore.data.adresse_logement_adresse_detail_geoloc_lng = suggestions[0].geometry.coordinates[0]
+          formStore.data.adresse_logement_adresse_detail_geoloc_lat = suggestions[0].geometry.coordinates[1]
           formStore.data.adresse_logement_adresse = formStore.data.adresse_logement_adresse_detail_numero + ' ' + formStore.data.adresse_logement_adresse_detail_code_postal + ' ' + formStore.data.adresse_logement_adresse_detail_commune
           formStore.data.adresse_logement_adresse_suggestion = formStore.data.adresse_logement_adresse_detail_numero + ' ' + formStore.data.adresse_logement_adresse_detail_code_postal + ' ' + formStore.data.adresse_logement_adresse_detail_commune
 

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -222,6 +222,8 @@ export default defineComponent({
         this.formStore.data[this.id + '_detail_code_postal'] = this.suggestions[index].properties.postcode
         this.formStore.data[this.id + '_detail_commune'] = this.suggestions[index].properties.city
         this.formStore.data[this.id + '_detail_insee'] = this.suggestions[index].properties.citycode
+        this.formStore.data[this.id + '_detail_geoloc_lng'] = this.suggestions[index].geometry.coordinates[0]
+        this.formStore.data[this.id + '_detail_geoloc_lat'] = this.suggestions[index].geometry.coordinates[1]
         this.formStore.data[this.id + '_detail_manual'] = 0
         this.suggestions.length = 0
         setTimeout(() => {

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -54,6 +54,18 @@ class SignalementDraftRequest
     #[Assert\NotBlank(message: 'Merci de saisir un code INSEE.')]
     #[Assert\Regex(pattern: '/^[0-9][0-9A-Za-z][0-9]{3}$/', message: 'Le code insee doit être composé de 5 caractères.')]
     private ?string $adresseLogementAdresseDetailInsee = null;
+    #[Assert\Length(max: 50, maxMessage: 'La latitude ne peut pas dépasser {{ limit }} caractères.')]
+    #[Assert\Regex(
+        pattern: '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/',
+        message: 'La latitude doit être un nombre décimal.'
+    )]
+    private ?float $adresseLogementAdresseDetailGeolocLat = null;
+    #[Assert\Length(max: 50, maxMessage: 'La longitude ne peut pas dépasser {{ limit }} caractères.')]
+    #[Assert\Regex(
+        pattern: '/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/',
+        message: 'La longitude doit être un nombre décimal.'
+    )]
+    private ?float $adresseLogementAdresseDetailGeolocLng = null;
     private ?bool $adresseLogementAdresseDetailManual = null;
     #[Assert\Length(max: 3, maxMessage: 'L\'escalier ne doit pas dépasser {{ limit }} caractères')]
     private ?string $adresseLogementComplementAdresseEscalier = null;
@@ -548,6 +560,30 @@ class SignalementDraftRequest
     public function setAdresseLogementAdresseDetailInsee(?string $adresseLogementAdresseDetailInsee): self
     {
         $this->adresseLogementAdresseDetailInsee = $adresseLogementAdresseDetailInsee;
+
+        return $this;
+    }
+
+    public function getAdresseLogementAdresseDetailGeolocLat(): ?float
+    {
+        return $this->adresseLogementAdresseDetailGeolocLat;
+    }
+
+    public function setAdresseLogementAdresseDetailGeolocLat(?float $adresseLogementAdresseDetailGeolocLat): self
+    {
+        $this->adresseLogementAdresseDetailGeolocLat = $adresseLogementAdresseDetailGeolocLat;
+
+        return $this;
+    }
+
+    public function getAdresseLogementAdresseDetailGeolocLng(): ?float
+    {
+        return $this->adresseLogementAdresseDetailGeolocLng;
+    }
+
+    public function setAdresseLogementAdresseDetailGeolocLng(?float $adresseLogementAdresseDetailGeolocLng): self
+    {
+        $this->adresseLogementAdresseDetailGeolocLng = $adresseLogementAdresseDetailGeolocLng;
 
         return $this;
     }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -324,7 +324,12 @@ class SignalementBuilder
                 $this->signalementDraftRequest->getAdresseLogementComplementAdresseNumeroAppartement()
             )
             ->setAdresseAutreOccupant($this->signalementDraftRequest->getAdresseLogementComplementAdresseAutre())
-            ->setManualAddressOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailManual());
+            ->setManualAddressOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailManual())
+            ->setInseeOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailInsee())
+            ->setGeoloc([
+                'lat' => $this->signalementDraftRequest->getAdresseLogementAdresseDetailGeolocLat(),
+                'lng' => $this->signalementDraftRequest->getAdresseLogementAdresseDetailGeolocLng(),
+            ]);
     }
 
     private function setOccupantDeclarantData(): void


### PR DESCRIPTION
## Ticket

#3433   

## Description
L'appel au service d'adresse updater étant fait en asynchrone, les règles d'affectation automatiques ne s'appliquaient plus car ni code insee ni geoloc sur le signalement au moment où on les appelle

## Changements apportés
* Réenregistrement du code insee et de la geoloc dans le formulaire et le SignalementBuilder

## Pré-requis
`npm run watch`

## Tests
- [ ] Déposer un signalement et s'assurer que les codes insee et geoloc sont bien enregistrées (soit en désactivant le worker, soit, et c'est mieux, en créant des règles d'auto-affectation sur code insee et zone)
- [ ] Editer l'adresse d'un signalement, et vérifier que geoloc et insee sont bien mis à jour (TNR)
