### PR TITLE
[BO - SISH] MAJ la qualification quand on récupère des arrêtés

### DIFF
--- a/src/Command/UpdateSishArreteProcedureCommand.php
+++ b/src/Command/UpdateSishArreteProcedureCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Enum\ProcedureType;
+use App\Entity\Intervention;
+use App\Repository\InterventionRepository;
+use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:update-sish-arrete-procedure',
+    description: 'Add a short description for your command',
+)]
+class UpdateSishArreteProcedureCommand extends Command
+{
+    public function __construct(
+        private readonly InterventionRepository $interventionRepository,
+        private readonly SignalementQualificationUpdater $qualificationUpdater,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $arreteInterventions = $this->interventionRepository->getArreteToApplyProcedureInsalubrite();
+        $countArreteInterventions = count($arreteInterventions);
+        $progressBar = new ProgressBar($output, $countArreteInterventions);
+        $progressBar->start();
+        foreach ($arreteInterventions as $arreteIntervention) {
+            /* @var Intervention $arreteIntervention */
+            $arreteIntervention->setConcludeProcedure([ProcedureType::INSALUBRITE]);
+            $signalement = $arreteIntervention->getSignalement();
+            $this->qualificationUpdater->updateQualificationFromVisiteProcedureList(
+                $signalement,
+                [ProcedureType::INSALUBRITE]
+            );
+            $progressBar->advance();
+        }
+        $progressBar->finish();
+        $io->success(sprintf('%s interventions de type arrếtés processed', $countArreteInterventions));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/UpdateSishArreteProcedureCommand.php
+++ b/src/Command/UpdateSishArreteProcedureCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:update-sish-arrete-procedure',
-    description: 'Add a short description for your command',
+    description: 'Update intervention with arrete procedure insalubrite',
 )]
 class UpdateSishArreteProcedureCommand extends Command
 {

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -232,3 +232,12 @@ affectations:
     affected_by: "admin-territoire-13-01@histologe.fr"
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
+  -
+    signalement: 2024-10
+    partner: "partenaire-13-06@histologe.fr"
+    statut: 1
+    answered_by: ""
+    affected_by: "admin-territoire-13-01@histologe.fr"
+    motif_cloture: ""
+    territory: "Bouches-du-Rhône"
+    is_synchronized: true

--- a/src/DataFixtures/Files/Intervention.yml
+++ b/src/DataFixtures/Files/Intervention.yml
@@ -74,3 +74,11 @@ interventions:
     user: "admin-partenaire-13-01@histologe.fr"
     scheduled_at: '-2 days'
     status: 'PLANNED'
+  -
+    signalement: "2024-10"
+    partner: "partenaire-13-06@histologe.fr"
+    user: "user-13-06@histologe.fr"
+    scheduled_at: '2024-06-20 10:00:00'
+    status: 'DONE'
+    occupant_present: 1
+    proprietaire_present: 0

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -613,3 +613,58 @@ signalements:
       - "desordres_batiment_securite_murs_fissures_details_mur_porteur_oui"
       - "desordres_batiment_securite_balcons"
       - "desordres_batiment_incendie_odeur_gaz"
+  -
+    territory: "Bouches-du-Rhône"
+    uuid: "00000000-0000-0000-2024-000000000010"
+    reference: "2024-10"
+    details: "Je crois que ma maison risque de s'envoler."
+    is_proprio_averti: 1
+    is_allocataire: "0"
+    nature_logement: "maison"
+    superficie: 67
+    loyer: null
+    date_entree: "2022-12-01"
+    nom_proprio: "13 Habitat"
+    type_proprio: "ORGANISME_SOCIETE"
+    is_logement_social: 0
+    nom_occupant: "Coco"
+    prenom_occupant: "Second"
+    tel_occupant: "+330240556676"
+    phone_number: "+330240556676"
+    mail_occupant: "coco.second@yopmail.com"
+    adresse_occupant: "25 Rue desiree clary"
+    cp_occupant: "13002"
+    ville_occupant: "Marseille"
+    statut: 2
+    geoloc: "{\"lat\": 43.3085624, \"lng\": 5.3705315}"
+    insee_occupant: "13202"
+    nb_pieces_logement: 5
+    nb_occupants_logement: 4
+    score: 35.194711538462
+    created_from_uuid: '00000000-0000-0000-2024-000000000010'
+    profile_declarant: "LOCATAIRE"
+    civilite_occupant: "mme"
+    type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"oui\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"
+    situation_foyer: "{\"logement_social_allocation\": \"non\", \"logement_social_date_naissance\": null, \"logement_social_allocation_caisse\": null, \"travailleur_social_accompagnement\": \"non\", \"logement_social_demande_relogement\": \"non\", \"logement_social_montant_allocation\": null, \"logement_social_numero_allocataire\": null, \"travailleur_social_quitte_logement\": \"non\", \"travailleur_social_accompagnement_declarant\": null}"
+    information_procedure: "{\"utilisation_service_ok_visite\": true, \"utilisation_service_ok_cgu\": true, \"info_procedure_bailleur_prevenu\": \"oui\", \"info_procedure_reponse_assurance\": null, \"info_procedure_assurance_contactee\": \"non\", \"info_procedure_depart_apres_travaux\": \"oui\", \"utilisation_service_ok_demande_logement\": true, \"utilisation_service_ok_prevenir_bailleur\": true}"
+    information_complementaire: "{\"informations_complementaires_logement_montant_loyer\": null, \"informations_complementaires_logement_nombre_etages\": null, \"informations_complementaires_logement_annee_construction\": null, \"informations_complementaires_situation_bailleur_revenu_fiscal\": null, \"informations_complementaires_situation_occupants_loyers_payes\": null, \"informations_complementaires_situation_bailleur_date_naissance\": null, \"informations_complementaires_situation_occupants_date_naissance\": null, \"informations_complementaires_situation_bailleur_beneficiaire_fsl\": null, \"informations_complementaires_situation_bailleur_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_beneficiaire_fsl\": null, \"informations_complementaires_situation_occupants_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_date_emmenagement\": null, \"informations_complementaires_situation_occupants_demande_relogement\": null}"
+    score_logement: 13.990384615385
+    score_batiment: 50
+    qualifications:
+      - "RSD"
+      - "NON_DECENCE"
+    desordre_categorie:
+      - "Sécurite risques particuliers"
+      - "Structure du bâti"
+    desordre_critere:
+      - "desordres_batiment_securite_elements_toit"
+      - "desordres_batiment_securite_toit"
+      - "desordres_batiment_securite_murs_fissures"
+      - "desordres_batiment_securite_balcons"
+      - "desordres_batiment_incendie_odeur_gaz"
+    desordre_precision:
+      - "desordres_batiment_securite_elements_toit"
+      - "desordres_batiment_securite_toit"
+      - "desordres_batiment_securite_murs_fissures_details_mur_porteur_oui"
+      - "desordres_batiment_securite_balcons"
+      - "desordres_batiment_incendie_odeur_gaz"

--- a/src/Factory/InterventionFactory.php
+++ b/src/Factory/InterventionFactory.php
@@ -19,8 +19,9 @@ class InterventionFactory
         ?string $doneBy = null,
         ?string $details = null,
         ?array $additionalInformation = null,
+        ?array $concludeProcedures = [],
     ): Intervention {
-        return (new Intervention())
+        $intervention = (new Intervention())
             ->setPartner($affectation->getPartner())
             ->setSignalement($affectation->getSignalement())
             ->setType($type)
@@ -31,7 +32,12 @@ class InterventionFactory
             ->setProviderId($providerId)
             ->setDoneBy($doneBy)
             ->setDetails($details)
-            ->setAdditionalInformation($additionalInformation)
-        ;
+            ->setAdditionalInformation($additionalInformation);
+
+        if (!empty($concludeProcedures)) {
+            $intervention->setConcludeProcedure($concludeProcedures);
+        }
+
+        return $intervention;
     }
 }

--- a/src/Factory/SignalementAffectationListViewFactory.php
+++ b/src/Factory/SignalementAffectationListViewFactory.php
@@ -27,7 +27,8 @@ class SignalementAffectationListViewFactory
 
         /** @var ?ProfileDeclarant $profileDeclarant */
         $profileDeclarant = $data['profileDeclarant'];
-        $signalementAffectationListView = new SignalementAffectationListView(
+
+        return new SignalementAffectationListView(
             id: $data['id'],
             uuid: $data['uuid'],
             reference: $data['reference'],
@@ -48,10 +49,8 @@ class SignalementAffectationListViewFactory
             qualifications: SignalementAffectationHelper::getQualificationFrom($data),
             qualificationsStatuses: SignalementAffectationHelper::getQualificationStatusesFrom($data),
             conclusionsProcedure: SignalementAffectationHelper::parseConclusionProcedure($data['conclusionsProcedure']),
-            canDeleteSignalement: $canDeleteSignalement,
             csrfToken: $canDeleteSignalement ? $this->csrfTokenManager->getToken('signalement_delete_'.$data['id']) : null,
+            canDeleteSignalement: $canDeleteSignalement,
         );
-
-        return $signalementAffectationListView;
     }
 }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -774,7 +774,6 @@ class SignalementManager extends AbstractManager
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = $this->getRepository();
 
-        /* @var Paginator $paginator */
         $paginator = $signalementRepository->findSignalementAffectationListPaginator($user, $options);
         $total = $paginator->count();
         if ($count) {

--- a/src/Repository/InterventionRepository.php
+++ b/src/Repository/InterventionRepository.php
@@ -83,4 +83,14 @@ class InterventionRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function getArreteToApplyProcedureInsalubrite(): array
+    {
+        return $this->createQueryBuilder('i')
+            ->andWhere('i.type = :arrete')
+            ->andWhere('i.concludeProcedure IS NULL')
+            ->setParameter('arrete', InterventionType::ARRETE_PREFECTORAL->name)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -467,7 +467,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->leftJoin('s.affectations', 'a')
             ->leftJoin('a.partner', 'p')
             ->leftJoin('s.signalementQualifications', 'sq', 'WITH', 'sq.status LIKE \'%AVEREE%\' OR sq.status LIKE \'%CHECK%\'')
-            ->leftJoin('s.interventions', 'i', 'WITH', 'i.type LIKE \'VISITE\'')
+            ->leftJoin('s.interventions', 'i', 'WITH', 'i.type LIKE \'VISITE\' OR i.type LIKE \'ARRETE_PREFECTORAL\'')
             ->leftJoin('s.territory', 'territory')
             ->where('s.statut != :status')
             ->groupBy('s.id')

--- a/src/Service/Interconnection/Esabora/DateParser.php
+++ b/src/Service/Interconnection/Esabora/DateParser.php
@@ -18,7 +18,8 @@ class DateParser
         ) {
             return $dateLocaleParsed->setTimezone($toTimezone);
         }
+        $dateParsed = \DateTimeImmutable::createFromFormat(AbstractEsaboraService::FORMAT_DATE, $date);
 
-        return \DateTimeImmutable::createFromFormat(AbstractEsaboraService::FORMAT_DATE, $date);
+        return $dateParsed->setTime(0, 0);
     }
 }

--- a/src/Service/Signalement/Qualification/SignalementQualificationUpdater.php
+++ b/src/Service/Signalement/Qualification/SignalementQualificationUpdater.php
@@ -543,6 +543,7 @@ class SignalementQualificationUpdater
         if ($procedureTypes) {
             foreach ($procedureTypes as $procedureType) {
                 $signalementQualification = null;
+                /** @var ProcedureType $procedureType */
                 switch ($procedureType->name) {
                     case ProcedureType::NON_DECENCE->name:
                         $signalementQualification = $this->signalementQualificationFactory->createInstanceFrom(

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -173,35 +173,35 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search Terms with Firstname Occupant' => [['searchTerms' => 'Mapaire', 'isImported' => 'oui'], 1];
         yield 'Search Terms with Lastname Occupant' => [['searchTerms' => 'Nawell', 'isImported' => 'oui'], 2];
         yield 'Search Terms with Email Occupant' => [['searchTerms' => 'nawell.mapaire@yopmail.com', 'isImported' => 'oui'], 1];
-        yield 'Search by Territory 13' => [['territoire' => '13', 'isImported' => 'oui'], 25];
-        yield 'Search by Commune' => [['communes' => ['gex', 'marseille'], 'isImported' => 'oui'], 30];
-        yield 'Search by Commune code postal' => [['communes' => ['13002'], 'isImported' => 'oui'], 1];
+        yield 'Search by Territory 13' => [['territoire' => '13', 'isImported' => 'oui'], 26];
+        yield 'Search by Commune' => [['communes' => ['gex', 'marseille'], 'isImported' => 'oui'], 31];
+        yield 'Search by Commune code postal' => [['communes' => ['13002'], 'isImported' => 'oui'], 2];
         yield 'Search by EPCIS' => [['epcis' => ['244400503'], 'isImported' => 'oui'], 2];
         yield 'Search by Partner' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
         yield 'Search by Etiquettes' => [['etiquettes' => ['5'], 'isImported' => 'oui'], 4];
         yield 'Search by Parc public' => [['natureParc' => 'public', 'isImported' => 'oui'], 5];
         yield 'Search by Parc public/prive non renseigné' => [['natureParc' => 'non_renseigne', 'isImported' => 'oui'], 1];
         yield 'Search by Enfant moins de 6ans (non)' => [['enfantsM6' => 'non', 'isImported' => 'oui'], 2];
-        yield 'Search by Enfant moins de 6ans (oui)' => [['enfantsM6' => 'oui', 'isImported' => 'oui'], 47];
+        yield 'Search by Enfant moins de 6ans (oui)' => [['enfantsM6' => 'oui', 'isImported' => 'oui'], 48];
         yield 'Search by Enfant moins de 6ans (non_renseignee)' => [['enfantsM6' => 'non_renseigne', 'isImported' => 'oui'], 0];
         yield 'Search by Date de depot' => [['dateDepotDebut' => '2023-03-08', 'dateDepotFin' => '2023-03-16', 'isImported' => 'oui'], 2];
-        yield 'Search by Procédure estimée' => [['procedure' => 'rsd', 'isImported' => 'oui'], 6];
+        yield 'Search by Procédure estimée' => [['procedure' => 'rsd', 'isImported' => 'oui'], 7];
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
         yield 'Search by Statut de la visite' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 5];
-        yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 32];
+        yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 33];
         yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18', 'isImported' => 'oui'], 3];
         yield 'Search by Statut de l\'affectation' => [['statusAffectation' => 'refuse', 'isImported' => 'oui'], 1];
         yield 'Search by Score criticite' => [['criticiteScoreMin' => 5, 'criticiteScoreMax' => 6, 'isImported' => 'oui'], 9];
-        yield 'Search by Declarant' => [['typeDeclarant' => 'locataire', 'isImported' => 'oui'], 44];
+        yield 'Search by Declarant' => [['typeDeclarant' => 'locataire', 'isImported' => 'oui'], 45];
         yield 'Search by Nature du parc' => [['natureParc' => 'public', 'isImported' => 'oui'], 5];
         yield 'Search by Allocataire CAF' => [['allocataire' => 'caf', 'isImported' => 'oui'], 16];
         yield 'Search by Allocataire MSA' => [['allocataire' => 'msa', 'isImported' => 'oui'], 1];
         yield 'Search by Allocataire Oui (CAF+MSA+1)' => [['allocataire' => 'oui', 'isImported' => 'oui'], 17];
-        yield 'Search by Allocataire Non (null+empty)' => [['allocataire' => 'non', 'isImported' => 'oui'], 5];
-        yield 'Search by Situation Bail en cours' => [['situation' => 'bail_en_cours', 'isImported' => 'oui'], 8];
+        yield 'Search by Allocataire Non (null+empty)' => [['allocataire' => 'non', 'isImported' => 'oui'], 6];
+        yield 'Search by Situation Bail en cours' => [['situation' => 'bail_en_cours', 'isImported' => 'oui'], 9];
         yield 'Search by Situation Prévis de départ' => [['situation' => 'preavis_de_depart', 'isImported' => 'oui'], 1];
         yield 'Search by Situation Attente de relogement' => [['situation' => 'attente_relogement', 'isImported' => 'oui'], 2];
-        yield 'Search by Signalement Imported' => [['isImported' => 'oui'], 49];
+        yield 'Search by Signalement Imported' => [['isImported' => 'oui'], 50];
     }
 
     /**
@@ -245,8 +245,8 @@ class SignalementListControllerTest extends WebTestCase
 
         if (\count($result['list']) > 0) {
             $this->assertGreaterThanOrEqual(1, \count($result['list']));
+        } else {
+            $this->assertEmpty($result['list']);
         }
-
-        $this->assertEquals($result['pagination']['total_items'], \count($result['list']));
     }
 }

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -48,20 +48,20 @@ class BackStatistiquesControllerTest extends WebTestCase
     public function provideRoutesStatistiquesDatas(): \Generator
     {
         yield 'Super Admin' => ['back_statistiques_filter', [], self::USER_SUPER_ADMIN, [
-            ['result' => 45, 'label' => 'count_signalement'],
-            ['result' => 59.4, 'label' => 'average_criticite'],
+            ['result' => 46, 'label' => 'count_signalement'],
+            ['result' => 58.9, 'label' => 'average_criticite'],
         ]];
         yield 'Responsable Territoire' => ['back_statistiques_filter', [], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 25, 'label' => 'count_signalement'],
-            ['result' => 90.6, 'label' => 'average_criticite'],
+            ['result' => 26, 'label' => 'count_signalement'],
+            ['result' => 88.4, 'label' => 'average_criticite'],
         ]];
         yield 'Partner' => ['back_statistiques_filter', [], self::USER_PARTNER, [
             ['result' => 3, 'label' => 'count_signalement'],
             ['result' => 100, 'label' => 'average_criticite'],
         ]];
         yield 'RT - filtered with commune Arles' => ['back_statistiques_filter', ['communes' => '["Arles"]'], self::USER_ADMIN_TERRITOIRE, [
-            ['result' => 25, 'label' => 'count_signalement'],
-            ['result' => 90.6, 'label' => 'average_criticite'],
+            ['result' => 26, 'label' => 'count_signalement'],
+            ['result' => 88.4, 'label' => 'average_criticite'],
             ['result' => 0, 'label' => 'count_signalement_filtered'],
             ['result' => 0, 'label' => 'average_criticite_filtered'],
         ]];

--- a/tests/Functional/Controller/StatistiquesControllerTest.php
+++ b/tests/Functional/Controller/StatistiquesControllerTest.php
@@ -25,7 +25,7 @@ class StatistiquesControllerTest extends WebTestCase
 
         $expectedResponses = [
             ['result' => 1, 'label' => 'count_signalement_resolus'],
-            ['result' => 43, 'label' => 'count_signalement'],
+            ['result' => 44, 'label' => 'count_signalement'],
         ];
 
         foreach ($expectedResponses as $expectedResponse) {

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -18,6 +18,7 @@ use App\Service\Interconnection\Esabora\EsaboraManager;
 use App\Service\Interconnection\Esabora\Response\DossierStateSCHSResponse;
 use App\Service\Interconnection\Esabora\Response\DossierStateSISHResponse;
 use App\Service\Security\FileScanner;
+use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use App\Service\UploadHandlerService;
 use App\Tests\FixturesHelper;
 use Doctrine\ORM\EntityManagerInterface;
@@ -45,6 +46,7 @@ class EsaboraManagerTest extends KernelTestCase
     private ImageManipulationHandler $imageManipulationHandler;
     private UrlGeneratorInterface $UrlGeneratorInterface;
     private FileFactory $fileFactory;
+    private SignalementQualificationUpdater $signalementQualificationUpdater;
 
     protected function setUp(): void
     {
@@ -63,6 +65,7 @@ class EsaboraManagerTest extends KernelTestCase
         $this->imageManipulationHandler = self::getContainer()->get(ImageManipulationHandler::class);
         $this->UrlGeneratorInterface = self::getContainer()->get('router');
         $this->fileFactory = self::getContainer()->get(FileFactory::class);
+        $this->signalementQualificationUpdater = self::getContainer()->get(SignalementQualificationUpdater::class);
     }
 
     /**
@@ -107,6 +110,7 @@ class EsaboraManagerTest extends KernelTestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
+            $this->signalementQualificationUpdater
         );
 
         $esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);
@@ -224,6 +228,7 @@ class EsaboraManagerTest extends KernelTestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
+            $this->signalementQualificationUpdater
         );
 
         $esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -25,7 +25,7 @@ class AffectationRepositoryTest extends KernelTestCase
         /** @var AffectationRepository $affectationRepository */
         $affectationRepository = $this->entityManager->getRepository(Affectation::class);
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::ARS);
-        $this->assertCount(1, $affectationsSubscribedToEsabora);
+        $this->assertCount(2, $affectationsSubscribedToEsabora);
         foreach ($affectationsSubscribedToEsabora as $affectationSubscribedToEsabora) {
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }

--- a/tests/Unit/Service/Esabora/DateParserTest.php
+++ b/tests/Unit/Service/Esabora/DateParserTest.php
@@ -17,7 +17,9 @@ class DateParserTest extends TestCase
     public function testParseWithDateFormat(): void
     {
         $date = '04/05/2023';
-        $expected = \DateTimeImmutable::createFromFormat('d/m/Y', $date);
-        $this->assertEquals($expected, DateParser::parse($date));
+        $parsedDate = DateParser::parse($date);
+        $expected = \DateTimeImmutable::createFromFormat('d/m/Y H:i:s', $date.' 00:00:00');
+        $this->assertEquals($expected, $parsedDate);
+        $this->assertSame('00:00:00', $parsedDate->format('H:i:s'));
     }
 }

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -15,6 +15,7 @@ use App\Service\Files\ZipHelper;
 use App\Service\ImageManipulationHandler;
 use App\Service\Interconnection\Esabora\EsaboraManager;
 use App\Service\Security\FileScanner;
+use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use App\Service\UploadHandlerService;
 use App\Tests\FixturesHelper;
 use Doctrine\ORM\EntityManager;
@@ -47,6 +48,7 @@ class EsaboraManagerTest extends TestCase
     private MockObject|ImageManipulationHandler $imageManipulationHandler;
     private MockObject|UrlGeneratorInterface $UrlGeneratorInterface;
     private MockObject|FileFactory $fileFactory;
+    private MockObject|SignalementQualificationUpdater $signalementQualificationUpdater;
 
     protected function setUp(): void
     {
@@ -65,6 +67,7 @@ class EsaboraManagerTest extends TestCase
         $this->imageManipulationHandler = $this->createMock(ImageManipulationHandler::class);
         $this->UrlGeneratorInterface = $this->createMock(UrlGeneratorInterface::class);
         $this->fileFactory = $this->createMock(FileFactory::class);
+        $this->signalementQualificationUpdater = $this->createMock(SignalementQualificationUpdater::class);
     }
 
     public function testCreateVisite(): void
@@ -111,7 +114,8 @@ class EsaboraManagerTest extends TestCase
             $this->uploadHander,
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
-            $this->fileFactory
+            $this->fileFactory,
+            $this->signalementQualificationUpdater
         );
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
@@ -177,7 +181,8 @@ class EsaboraManagerTest extends TestCase
             $this->uploadHander,
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
-            $this->fileFactory
+            $this->fileFactory,
+            $this->signalementQualificationUpdater
         );
     }
 }

--- a/tools/wiremock/src/Mock/Esabora/EsaboraSISHMock.php
+++ b/tools/wiremock/src/Mock/Esabora/EsaboraSISHMock.php
@@ -90,7 +90,15 @@ class EsaboraSISHMock extends AbstractEsaboraMock
         self::createMockIntervention(
             $wiremock,
             self::SISH_ARRETES_DOSSIER_SAS,
-            'ws_arretes_dossier_sas_termine.json'
+            'ws_arretes_dossier_sas_termine.json',
+            '00000000-0000-0000-2023-000000000010'
+        );
+
+        self::createMockIntervention(
+            $wiremock,
+            self::SISH_ARRETES_DOSSIER_SAS,
+            'ws_arretes_dossier_sas_termine_insalubrite.json',
+            '00000000-0000-0000-2024-000000000010'
         );
     }
 

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine.json
@@ -1,6 +1,6 @@
 {
   "searchId": "00000000-0000-0000-2023-000000000012",
-  "nbResults": 2,
+  "nbResults": 3,
   "columnList": [
     "Sas_LogicielProvenance",
     "Reference_Dossier",
@@ -51,7 +51,7 @@
     {
       "columnDataList": [
         "Histologe",
-        "00000000-0000-0000-2024-000000000012",
+        "00000000-0000-0000-2023-000000000012",
         "2024/DD13/0010",
         "14/07/2024",
         "2024/DD13/00664",

--- a/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine_insalubrite.json
+++ b/tools/wiremock/src/Resources/Esabora/sish/ws_arretes_dossier_sas_termine_insalubrite.json
@@ -1,0 +1,36 @@
+{
+  "searchId": "00000000-0000-0000-2024-000000000010",
+  "nbResults": 1,
+  "columnList": [
+    "Sas_LogicielProvenance",
+    "Reference_Dossier",
+    "SISH_DossNum",
+    "SISH_ArreteDate",
+    "SISH_ArreteNumero",
+    "SISH_ArreteType",
+    "SISH_ArreteMLDate",
+    "SISH_ArreteMLNumero"
+  ],
+  "keyList": [
+    "i1.imdo_id",
+    "a3_t2.arre_id"
+  ],
+  "rowList": [
+    {
+      "columnDataList": [
+        "Histologe",
+        "00000000-0000-0000-2024-000000000010",
+        "2024/DD13/0011",
+        "05/07/2024",
+        "2024/DD13/00664",
+        "Arrêté L.511-19 - Insalubrité",
+        "01/08/2024",
+        "2024-DD13-00173"
+      ],
+      "keyDataList": [
+        30,
+        601
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Ticket

#3366    

## Description
Mise à jour de la qualification aprés avoir enregistré un arrête. 

## Changements apportés
* Mise à jour du EsaboraManager pour enregistrer la procédure Insalubrité
* Ajouter de la procédure sur les arrêtés passés via une commande

## Pré-requis
1. 
```
make mock-stop && make mock-start
```
2. Ouvrir le signalement 2024-10 et vérifier l'absence de procédure constatée

## Tests
- [ ] Lancer la commande `make sync-sish` et vérifier que la procédure `INSALUBRITE` apparaît sur la liste et [sur la fiche](http://localhost:8080/bo/signalements/00000000-0000-0000-2024-000000000010) 
- [ ] Récupérer la base de prod et exécuter la commande de reprise `make console app="update-sish-arrete-procedure"`, vous rendre dans la table historique afin de récupérer les interventions mises à jour. 
