### PR TITLE
[BUG] crash affichage page d'une zone quand WKT mal formaté

### DIFF
--- a/migrations/Version20241213110913.php
+++ b/migrations/Version20241213110913.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241213110913 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix invalid zone area';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $zones = $this->connection->fetchAllAssociative('SELECT id, area FROM zone');
+        foreach ($zones as $zone) {
+            try {
+                $testSQL = 'SELECT ST_GeomFromText(:area)';
+                $this->connection->executeQuery($testSQL, ['area' => $zone['area']]);
+            } catch (\Exception $e) {
+                $this->addSql('UPDATE zone SET area = "POINT (3.880363 43.608965)" WHERE id = :id', ['id' => $zone['id']]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#3443

## Description
- Ajout d'un contrainte de validation à la soumission du formulaire d'ajout/édition de zone afin de s'assurer que le WKT à un format valide et ne provoquera pas d'exception lors de son utilisation dans les requêtes
- Ajout d'une migration remplaçant les zones mal formaté existants (par un point arbitrairement situé sur la place de la comédie de Montpellier)

## Tests
- [ ] Essayer d'enregistrer une zone contenant un WKT mal formaté
