### PR TITLE
Enregistrer la géoloc uniquement sur les adresse exacte

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -186,7 +186,6 @@ class SignalementManager extends AbstractManager
     public function updateAddressOccupantFromAddress(Signalement $signalement, Address $address): void
     {
         $signalement->setInseeOccupant($address->getInseeCode());
-        $signalement->setGeoloc($address->getGeoloc());
 
         if (empty($signalement->getCpOccupant())) {
             $signalement->setCpOccupant($address->getZipCode());

--- a/src/Service/Signalement/SignalementAddressUpdater.php
+++ b/src/Service/Signalement/SignalementAddressUpdater.php
@@ -38,16 +38,13 @@ class SignalementAddressUpdater
             return;
         } elseif ($updateGeolocAndRnbId && !empty($signalement->getCpOccupant()) && !empty($signalement->getVilleOccupant())) {
             $inseeResult = $this->addressService->getAddress($signalement->getCpOccupant().' '.$signalement->getVilleOccupant());
-            $signalement->setRnbIdOccupant(null);
             if (!empty($inseeResult->getCity())) {
                 $signalement
                     ->setBanIdOccupant(0)
+                    ->setRnbIdOccupant(null)
                     ->setVilleOccupant($inseeResult->getCity())
                     ->setInseeOccupant($inseeResult->getInseeCode())
-                    ->setGeoloc([
-                        'lat' => $inseeResult->getLatitude(),
-                        'lng' => $inseeResult->getLongitude(),
-                    ]);
+                    ->setGeoloc([]);
 
                 return;
             }

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -95,15 +95,21 @@
                     </div>
                 {% endif %}
 
-                {% if signalement.geoloc.lat is defined and signalement.geoloc.lng is defined %}
                     <div class="fr-mt-3v">
-                        <a target="_blank" rel="noreferrer noopener" class="force-link-color"
-                            href="http://www.openstreetmap.org/?mlat={{ signalement.geoloc.lat }}&mlon={{ signalement.geoloc.lng }}#map=18/{{ signalement.geoloc.lat }}/{{ signalement.geoloc.lng }}"
-                            title="Voir sur la carte - Ouvre une nouvelle fenêtre">
-                            Voir sur la carte
-                        </a>
+                        {% if signalement.geoloc.lat is defined and signalement.geoloc.lng is defined %}
+                            <a target="_blank" rel="noreferrer noopener" class="force-link-color"
+                                href="http://www.openstreetmap.org/?mlat={{ signalement.geoloc.lat }}&mlon={{ signalement.geoloc.lng }}#map=18/{{ signalement.geoloc.lat }}/{{ signalement.geoloc.lng }}"
+                                title="Voir sur la carte - Ouvre une nouvelle fenêtre">
+                                Voir sur la carte
+                            </a>
+                        {% else %}
+                            <a target="_blank" rel="noreferrer noopener" class="force-link-color"
+                                href="http://www.openstreetmap.org/?search?query={{signalement.addressCompleteOccupant}}"
+                                title="Voir sur la carte - Ouvre une nouvelle fenêtre">
+                                Voir sur la carte
+                            </a>
+                        {% endif %}
                     </div>
-                {% endif %}
             </div>
             
             {% if not needValidation %}

--- a/tests/Functional/EventSubscriber/SignalementViewedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementViewedSubscriberTest.php
@@ -69,8 +69,7 @@ class SignalementViewedSubscriberTest extends KernelTestCase
         $this->assertTrue($isSeenAfter);
 
         $this->assertEquals('13203', $signalement->getInseeOccupant());
-        $this->assertArrayHasKey('lat', $signalement->getGeoloc());
-        $this->assertArrayHasKey('lng', $signalement->getGeoloc());
+        $this->assertEquals([], $signalement->getGeoloc());
         $this->assertEquals('13003', $signalement->getCpOccupant());
     }
 }


### PR DESCRIPTION
## Ticket

#3456

## Description
Les coordonnées géographique d'un signalement sont désormais uniquement sauvés quand l'adresse est précise (connu dans la BAN avec uns core > 0.9)

## Tests
- [ ] Déposer un signalement sur une adresse non précise et s'assurer que les coordonnée géographique restent vierge
