### PR TITLE
[Tech] Mise à jour commande pour recalculer les geolocs des signalements depuis une date

### DIFF
--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -84,7 +84,7 @@ trait FixturesHelper
     /**
      * @return Signalement[]
      */
-    public function getSignalementsWithoutGeolocation($count = 1): array
+    public function getSignalements($count = 1): array
     {
         $faker = Factory::create('fr_FR');
 


### PR DESCRIPTION
## Ticket

#3448    

## Description
Ajout d'une option pour recalculer les geoloc depuis une date quelconque

## Changements apportés
* Mise à jour de la commande

## Pré-requis

## Tests
- [ ] Exécuter la commande `make console app="update-signalement-geolocalisation --from_created_at=2024-01-01`
