### PR TITLE
[API Albert] test en envoyant le prompt en role "system"

### DIFF
--- a/src/Controller/Back/SuiviSummariesController.php
+++ b/src/Controller/Back/SuiviSummariesController.php
@@ -35,6 +35,8 @@ class SuiviSummariesController extends AbstractController
             $territory = $form->get('territory')->getData();
             $count = $form->get('count')->getData();
             $prompt = $form->get('prompt')->getData();
+            $promptRole = $form->get('promptRole')->getData();
+            $temperature = $form->get('temperature')->getData();
             $model = $form->get('model')->getData();
             $querySignalement = $form->get('querySignalement')->getData();
 
@@ -43,6 +45,8 @@ class SuiviSummariesController extends AbstractController
                 $territory->getId(),
                 $count,
                 $prompt,
+                $promptRole,
+                $temperature,
                 $model,
                 $querySignalement)
             );

--- a/src/Form/SuiviSummariesType.php
+++ b/src/Form/SuiviSummariesType.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class SuiviSummariesType extends AbstractType
 {
@@ -43,6 +44,24 @@ class SuiviSummariesType extends AbstractType
                 ],
                 'label' => 'Prompt',
                 'required' => true,
+            ])
+            ->add('promptRole', ChoiceType::class, [
+                'choices' => [
+                    'System' => 'system',
+                    'User' => 'user',
+                ],
+                'label' => 'Rôle du prompt',
+            ])
+            ->add('temperature', NumberType::class, [
+                'data' => 0.7,
+                'label' => 'Température (0.0 - 2.0)',
+                'required' => true,
+                'constraints' => [
+                    new Assert\Range([
+                        'min' => 0,
+                        'max' => 2,
+                    ]),
+                ],
             ])
 
             // Commented languages are listed in Albert doc, but don't work when used

--- a/src/Messenger/Message/SuiviSummariesMessage.php
+++ b/src/Messenger/Message/SuiviSummariesMessage.php
@@ -9,6 +9,8 @@ readonly class SuiviSummariesMessage
         private int $territoryId,
         private int $count,
         private string $prompt,
+        private string $promptRole,
+        private float $temperature,
         private string $model,
         private string $querySignalement,
     ) {
@@ -32,6 +34,16 @@ readonly class SuiviSummariesMessage
     public function getPrompt(): string
     {
         return $this->prompt;
+    }
+
+    public function getPromptRole(): string
+    {
+        return $this->promptRole;
+    }
+
+    public function getTemperature(): float
+    {
+        return $this->temperature;
     }
 
     public function getModel(): string

--- a/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
+++ b/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
@@ -131,7 +131,7 @@ class SuiviSummariesMessageHandler
         $messages = [];
 
         if (!empty($cleanLastSuiviDescription)) {
-            $messages[] = $this->getAlbertMessage($suiviSummariesMessage->getPrompt());
+            $messages[] = $this->getAlbertMessage($suiviSummariesMessage->getPrompt(), $suiviSummariesMessage->getPromptRole());
             $messages[] = $this->getAlbertMessage($cleanLastSuiviDescription);
         } else {
             return null;
@@ -139,6 +139,7 @@ class SuiviSummariesMessageHandler
 
         $payload = [
             'messages' => $messages,
+            'temperature' => $suiviSummariesMessage->getTemperature(),
             'model' => $suiviSummariesMessage->getModel(),
             'stream' => false,
             'n' => 1,
@@ -157,8 +158,8 @@ class SuiviSummariesMessageHandler
         return $content->choices[0]->message->content;
     }
 
-    private function getAlbertMessage(string $message): array
+    private function getAlbertMessage(string $message, string $role = 'user'): array
     {
-        return ['role' => 'user', 'content' => $message];
+        return ['role' => $role, 'content' => $message];
     }
 }


### PR DESCRIPTION
## Ticket

#3457

## Description
- Ajout dun paramètre "Role du prompt" (user ou system) pour les appel API Albert
- Ajout d'un paramètre "Température" (valeur de 0 a 2) censé données plus ou moins de liberté d'interprétation à l'IA

Note : Je n'ai vu aucune différence, j'ai l'impression que les paramètres ne sont pas pris en compte (à part peut être sur le modèle `AgentPublic/llama3-instruct-8b`)

## Tests
- [ ] Générer des export de résumé de suivi et voir que tout fonctionne comme avant
