### PR TITLE
[QA] Comparaison des valeurs JSON indépendamment de l'ordre des clés

### DIFF
--- a/src/EventListener/EntityHistoryListener.php
+++ b/src/EventListener/EntityHistoryListener.php
@@ -95,8 +95,6 @@ readonly class EntityHistoryListener
                 $originalValue = $this->entityComparator->processValue($originalValue);
                 $newValue = $this->entityComparator->processValue($newValue);
 
-
-
                 $fieldChanges = $this->entityComparator->compareValues($originalValue, $newValue, $field);
                 if (!empty($fieldChanges)) {
                     $changes[$field] = $fieldChanges;

--- a/src/EventListener/EntityHistoryListener.php
+++ b/src/EventListener/EntityHistoryListener.php
@@ -87,8 +87,15 @@ readonly class EntityHistoryListener
                 $originalValue = $changed[0] ?? null;
                 $newValue = $changed[1] ?? null;
 
+                if (is_array($originalValue) && is_array($newValue)) {
+                    $originalValue = $this->sortKey($originalValue);
+                    $newValue = $this->sortKey($newValue);
+                }
+
                 $originalValue = $this->entityComparator->processValue($originalValue);
                 $newValue = $this->entityComparator->processValue($newValue);
+
+
 
                 $fieldChanges = $this->entityComparator->compareValues($originalValue, $newValue, $field);
                 if (!empty($fieldChanges)) {
@@ -145,5 +152,12 @@ readonly class EntityHistoryListener
         } catch (\Throwable $exception) {
             $this->logger->error($exception->getMessage());
         }
+    }
+
+    private function sortKey(array $data): array
+    {
+        ksort($data);
+
+        return $data;
     }
 }


### PR DESCRIPTION
## Ticket

#3455    

## Description
Les valeurs JSON avec un contenu identique mais un ordre de clés différent sont actuellement considérées comme différentes dans la logique de comparaison.

Ancienne valeurs
```
{
    "arrete_type": "Arrêté L.511-19 - Insalubrité",
    "arrete_numero": "2024/DD13/00664",
    "arrete_mainlevee_date": "01/08/2024",
    "arrete_mainlevee_numero": "2024-DD13-00173"
}
```
Nouvelles valeurs
```
{
    "arrete_numero": "2024/DD13/00664",
    "arrete_type": "Arrêté L.511-19 - Insalubrité",
    "arrete_mainlevee_date": "01/08/2024",
    "arrete_mainlevee_numero": "2024-DD13-00173"
}
```
Les valeurs sont identiques mais l'ordre est différent. 
N'ayant pas la main sur ce que UnitOfWork de doctrine renvoie, il serait plus sur de trier les clés de tableau avant de comparer. 
## Changements apportés
* Ajout d'un tri de tableau

## Pré-requis
```
make worker-stop && make worker-start
make mock-stop && make mock-start
```
## Tests
- [ ] Lancer plusieurs fois la commande  make sync-sish et vérifier l'absence d'historique sur la table intervention

## TNR
- [ ] Modifier la superficie et vérifier que l'objet typeCompositionLogement a bien été historisé
- [ ] Modifier allocataire et vérifier que l'objet SituationFoyer a bien été historisé
- [ ] Modifier assurance contacté et vérifier que l'objet informationProcedure a bien été historisé
- [ ] Modifier nombre étage et vérifier que l'objet informationComplementaire a bien été historisé
