### PR TITLE
[QA] Upgrade MySQL 8.0.40

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -6,7 +6,7 @@ doctrine:
                 url: '%env(resolve:DATABASE_URL)%'
                 # IMPORTANT: You MUST configure your server version,
                 # either here or in the DATABASE_URL env var (see .env file)
-                server_version: '8.0.35'
+                server_version: '8.0.40'
                 use_savepoints: false
                 charset: utf8mb4
                 default_table_options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # docker-compose.yml
 services:
   histologe_mysql:
-    image: 'mysql:8.0.35'
+    image: 'mysql:8.0.40'
     command: --max_allowed_packet=32505856
     container_name: histologe_mysql
     restart: always

--- a/tests/Unit/Messenger/MessageHandler/NewSignalementCheckFileMessageHandlerTest.php
+++ b/tests/Unit/Messenger/MessageHandler/NewSignalementCheckFileMessageHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Unit\Messenger\MessageHandler\Esabora;
+namespace App\Tests\Unit\Messenger\MessageHandler;
 
 use App\Entity\DesordreCritere;
 use App\Entity\Signalement;


### PR DESCRIPTION
## Ticket

#3447    

## Description
Mise à jour de la version de mysql afin de la faire sur scalingo

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-40.html
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-39.html
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-38.html
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-37.html
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-36.html

Aujourd'hui les logs mysql sont pourries par ce warning en continue
`
[Server] Plugin mysql_native_password reported: ''mysql_native_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'
`
Ça devrait être corrigé avec l'upgrade 
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-38.html#:~:text=104121%2C%20Bug%20%2333057164)-,Pluggable%20Authentication,-The%20deprecation%20warning

## Changements apportés
* Mise à jour de l'environnement locale
* Mise à jour de la conf doctrine

## Pré-requis

## Tests
- [ ] Faire quelques actions, ça reste une maj mineure. La CI OK devrait garantir que tout est OK
