### PR TITLE
[Mails - Visites] Correction du décalage horaire envoyé par e-mail aux usagers

### DIFF
--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -107,17 +107,11 @@ class Intervention implements EntityHistoryInterface
 
     public function getScheduledAtFormated(): string
     {
-        if ($this->getScheduledAt()->format('H') > 0) {
-            if ($this->getPartner()) {
-                return $this->getScheduledAt()
-                            ->setTimezone(
-                                new \DateTimeZone($this->getPartner()->getTerritory() ? $this->getPartner()->getTerritory()->getTimezone() : TimezoneProvider::TIMEZONE_EUROPE_PARIS)
-                            )
-                            ->format('d/m/Y à H:i');
-            }
+        if ($this->getScheduledAt()->format('His') > 0) {
+            $timezone = $this->getPartner()?->getTerritory()?->getTimezone() ?? TimezoneProvider::TIMEZONE_EUROPE_PARIS;
 
             return $this->getScheduledAt()
-                        ->setTimezone(new \DateTimeZone(TimezoneProvider::TIMEZONE_EUROPE_PARIS))
+                        ->setTimezone(new \DateTimeZone($timezone))
                         ->format('d/m/Y à H:i');
         }
 

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -9,6 +9,7 @@ use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\ProcedureType;
 use App\Repository\InterventionRepository;
+use App\Service\TimezoneProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -102,6 +103,25 @@ class Intervention implements EntityHistoryInterface
         $this->scheduledAt = $scheduledAt;
 
         return $this;
+    }
+
+    public function getScheduledAtFormated(): string
+    {
+        if ($this->getScheduledAt()->format('H') > 0) {
+            if ($this->getPartner()) {
+                return $this->getScheduledAt()
+                            ->setTimezone(
+                                new \DateTimeZone($this->getPartner()->getTerritory() ? $this->getPartner()->getTerritory()->getTimezone() : TimezoneProvider::TIMEZONE_EUROPE_PARIS)
+                            )
+                            ->format('d/m/Y à H:i');
+            }
+
+            return $this->getScheduledAt()
+                        ->setTimezone(new \DateTimeZone(TimezoneProvider::TIMEZONE_EUROPE_PARIS))
+                        ->format('d/m/Y à H:i');
+        }
+
+        return $this->getScheduledAt()->format('d/m/Y');
     }
 
     public function getRegisteredAt(): ?\DateTimeImmutable

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToPartnerMailer.php
@@ -30,7 +30,7 @@ class SuiviVisiteAbortedToPartnerMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
 
         return [
             'intervention_scheduledAt' => $interventionScheduledAt,

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteAbortedToUsagerMailer.php
@@ -31,7 +31,7 @@ class SuiviVisiteAbortedToUsagerMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
 
         return [
             'intervention_scheduledAt' => $interventionScheduledAt,

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledMailer.php
@@ -31,7 +31,7 @@ class SuiviVisiteCanceledMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
 
         return [
             'intervention_scheduledAt' => $interventionScheduledAt,

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCanceledToUsagerMailer.php
@@ -31,7 +31,7 @@ class SuiviVisiteCanceledToUsagerMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
 
         return [
             'signalement_adresseOccupant' => $signalement->getAdresseOccupant(),

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteCreatedToUsagerMailer.php
@@ -31,7 +31,7 @@ class SuiviVisiteCreatedToUsagerMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
         $partnerName = $intervention->getPartner() ? $intervention->getPartner()->getNom() : 'Non renseigné';
 
         return [

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToPartnerMailer.php
@@ -31,7 +31,7 @@ class SuiviVisiteFutureReminderToPartnerMailer extends AbstractNotificationMaile
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
 
         return [
             'signalement_adresseOccupant' => $signalement->getAdresseOccupant(),

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteFutureReminderToUsagerMailer.php
@@ -30,7 +30,7 @@ class SuiviVisiteFutureReminderToUsagerMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
         $partnerName = $intervention->getPartner() ? $intervention->getPartner()->getNom() : 'Non renseigné';
 
         return [

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisitePastReminderToPartnerMailer.php
@@ -31,7 +31,7 @@ class SuiviVisitePastReminderToPartnerMailer extends AbstractNotificationMailer
     {
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
 
         return [
             'signalement_adresseOccupant' => $signalement->getAdresseOccupant(),

--- a/src/Service/Mailer/Mail/Suivi/SuiviVisiteRescheduledToUsagerMailer.php
+++ b/src/Service/Mailer/Mail/Suivi/SuiviVisiteRescheduledToUsagerMailer.php
@@ -32,7 +32,8 @@ class SuiviVisiteRescheduledToUsagerMailer extends AbstractNotificationMailer
         $signalement = $notificationMail->getSignalement();
         $intervention = $notificationMail->getIntervention();
         $previousDate = $notificationMail->getPreviousVisiteDate();
-        $interventionScheduledAt = $intervention->getScheduledAt()->format('H') > 0 ? $intervention->getScheduledAt()->format('d/m/Y à H:i') : $intervention->getScheduledAt()->format('d/m/Y');
+        $interventionScheduledAt = $intervention->getScheduledAtFormated();
+
         $partnerName = $intervention->getPartner() ? $intervention->getPartner()->getNom() : 'Non renseigné';
 
         return [


### PR DESCRIPTION
## Ticket

#3472   

## Description
Correction du décalage horaire envoyé par e-mail aux usagers dans les notifications de visites.

## Tests
- [ ] Créer une visite et vérifier la notification par mail
- [ ] Idem pour édition, annulation...
