### PR TITLE
[BO - EXPORT] Réactiver la colonne "Comm. de la dernière visite" 

### DIFF
--- a/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
@@ -15,7 +15,14 @@
       />
     </div>
     <div class="fr-col-12 fr-col-lg-6 fr-col-xl-8 fr-text--right">
-      <a :href="`${sharedProps.ajaxurlExportCsv}`" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-fill">
+      <a :href="canExport ? `${sharedProps.ajaxurlExportCsv}` : null"
+          :class="[
+              'fr-btn',
+              'fr-btn--secondary',
+              'fr-btn--icon-left',
+              'fr-icon-download-fill',
+              { 'fr-label--disabled': !canExport }]"
+      >
         Exporter les résultats
       </a>
     </div>
@@ -65,6 +72,13 @@ export default defineComponent({
         { Id: 'villeOccupant-ASC', Text: 'Nom de commune (A -> Z)' },
         { Id: 'villeOccupant-DESC', Text: 'Nom de commune (Z -> A)' }
       ]
+    }
+  },
+  computed: {
+    canExport () {
+      return Object.entries(this.sharedState.input.filters).some(
+        ([key, value]) => key !== 'isImported' && (value !== null && !(Array.isArray(value) && value.length === 0))
+      )
     }
   }
 })

--- a/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListHeader.vue
@@ -14,15 +14,21 @@
           :option-items=orderList
       />
     </div>
-    <div class="fr-col-12 fr-col-lg-6 fr-col-xl-8 fr-text--right">
+    <div v-if="sharedState.user.isAdmin" class="fr-col-12 fr-col-lg-6 fr-col-xl-8 fr-text--right">
       <a :href="canExport ? `${sharedProps.ajaxurlExportCsv}` : null"
-          :class="[
+         :class="[
               'fr-btn',
               'fr-btn--secondary',
               'fr-btn--icon-left',
               'fr-icon-download-fill',
               { 'fr-label--disabled': !canExport }]"
       >
+        Exporter les résultats
+      </a>
+    </div>
+    <div v-if="!sharedState.user.isAdmin" class="fr-col-12 fr-col-lg-6 fr-col-xl-8 fr-text--right">
+      <a :href="`${sharedProps.ajaxurlExportCsv}`"
+         class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-fill">
         Exporter les résultats
       </a>
     </div>

--- a/assets/scripts/vue/components/signalement-list/store.ts
+++ b/assets/scripts/vue/components/signalement-list/store.ts
@@ -47,7 +47,7 @@ export const store = {
       canSeeBailleurSocial: false,
       canSeeScore: false,
       canSeeFilterPartner: false,
-      partnerIds: new Array<string>(),
+      partnerIds: new Array<string>()
     },
     showOptions: false,
     territories: new Array<HistoInterfaceSelectOption>(),

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,3 +1,4 @@
+# https://symfony.com/bundles/DoctrineBundle/current/configuration.html
 doctrine:
     dbal:
         default_connection: default
@@ -9,6 +10,7 @@ doctrine:
                 server_version: '8.0.40'
                 use_savepoints: false
                 charset: utf8mb4
+                # All view or table as well start by view will be ignored by the schema tool.
                 schema_filter: ~^(?!view_)~
                 default_table_options:
                     charset: utf8mb4

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -9,6 +9,7 @@ doctrine:
                 server_version: '8.0.40'
                 use_savepoints: false
                 charset: utf8mb4
+                schema_filter: ~^(?!view_)~
                 default_table_options:
                     charset: utf8mb4
                     collate: utf8mb4_unicode_ci

--- a/migrations/Version20241217195812.php
+++ b/migrations/Version20241217195812.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241217195812 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create view to get latest intervention';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('
+            CREATE OR REPLACE VIEW view_latest_intervention AS
+                SELECT
+                    i.signalement_id,
+                    i.conclude_procedure,
+                    i.details,
+                    i.occupant_present,
+                    i.scheduled_at,
+                    i.status,
+                    (
+                        SELECT COUNT(*)
+                        FROM intervention i2
+                        WHERE i2.signalement_id = i.signalement_id
+                          AND i2.type = \'VISITE\'
+                    ) AS nb_visites
+                FROM
+                    intervention i
+                WHERE
+                    i.type = \'VISITE\' AND
+                    i.scheduled_at = (
+                        SELECT
+                            MAX(i2.scheduled_at)
+                        FROM
+                            intervention i2
+                        WHERE
+                            i2.signalement_id = i.signalement_id
+                            AND i2.type = \'VISITE\'
+                    );'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP VIEW IF EXISTS view_latest_intervention');
+    }
+}

--- a/src/Entity/View/ViewLatestIntervention.php
+++ b/src/Entity/View/ViewLatestIntervention.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Entity\View;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(readOnly: true)]
+#[ORM\Table(name: 'view_latest_intervention')]
+class ViewLatestIntervention
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private ?int $signalementId = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    private ?string $concludeProcedure = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $details = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?bool $occupantPresent = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $scheduledAt = null;
+
+    #[ORM\Column(type: 'string')]
+    private ?string $status = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $nbVisites = null;
+
+    public function getSignalementId(): int
+    {
+        return $this->signalementId;
+    }
+
+    public function getConcludeProcedure(): ?string
+    {
+        return $this->concludeProcedure;
+    }
+
+    public function getDetails(): ?string
+    {
+        return $this->details;
+    }
+
+    public function getOccupantPresent(): ?bool
+    {
+        return $this->occupantPresent;
+    }
+
+    public function getScheduledAt(): ?\DateTimeImmutable
+    {
+        return $this->scheduledAt;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function getNbVisites(): ?int
+    {
+        return $this->nbVisites;
+    }
+}

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -14,11 +14,11 @@ use App\Utils\DateHelper;
 
 class SignalementExportFactory
 {
-    public const OUI = 'Oui';
-    public const NON = 'Non';
-    public const NON_RENSEIGNE = 'Non renseigné';
-    public const ALLOCATAIRE = ['CAF', 'MSA', 'Oui', 1];
-    public const DATE_FORMAT = 'd/m/Y';
+    public const string OUI = 'Oui';
+    public const string NON = 'Non';
+    public const string NON_RENSEIGNE = 'Non renseigné';
+    public const array ALLOCATAIRE = ['CAF', 'MSA', 'Oui', 1];
+    public const string DATE_FORMAT = 'd/m/Y';
 
     public function createInstanceFrom(User $user, array $data): SignalementExport
     {
@@ -41,7 +41,7 @@ class SignalementExportFactory
         $geoloc = $data['geoloc'];
         $dateVisite = $data['interventionScheduledAt'];
         $dateVisite = (!empty($dateVisite) && DateHelper::isValidDate($dateVisite)) ? (new \DateTime($dateVisite))->format(self::DATE_FORMAT) : '';
-        $interventionStatus = $this->mapInterventionStatus($dateVisite ?? '', $data['interventionStatus']);
+        $interventionStatus = $this->mapInterventionStatus($dateVisite, $data['interventionStatus']);
         $isOccupantPresentVisite = $data['interventionOccupantPresent'];
 
         $enfantsM6 = null;
@@ -141,7 +141,7 @@ class SignalementExportFactory
 
     private function mapInterventionStatus(?string $scheduledAt = null, ?string $status = null): string
     {
-        if (null === $status) {
+        if (empty($status)) {
             return VisiteStatus::NON_PLANIFIEE->value;
         }
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -44,6 +44,7 @@ use App\Service\Signalement\SignalementAddressUpdater;
 use App\Service\Signalement\SignalementInputValueMapper;
 use App\Service\Signalement\ZipcodeProvider;
 use App\Specification\Signalement\SuroccupationSpecification;
+use Doctrine\DBAL\Exception;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -799,6 +800,9 @@ class SignalementManager extends AbstractManager
         ];
     }
 
+    /**
+     * @throws Exception
+     */
     public function findSignalementAffectationIterable(
         User|UserInterface $user,
         ?array $options = null,

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -16,6 +16,7 @@ use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\Territory;
 use App\Entity\User;
+use App\Entity\View\ViewLatestIntervention;
 use App\Service\Interconnection\Idoss\IdossService;
 use App\Service\Signalement\SearchFilter;
 use App\Service\Statistics\CriticitePercentStatisticProvider;
@@ -608,25 +609,19 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(DISTINCT desordreCategories.label SEPARATOR :group_concat_separator_1) as listDesordreCategories,
             GROUP_CONCAT(DISTINCT desordreCriteres.labelCritere SEPARATOR :group_concat_separator_1) as listDesordreCriteres,
             GROUP_CONCAT(DISTINCT tags.label SEPARATOR :group_concat_separator_1) as etiquettes,
-            GROUP_CONCAT(IFNULL(i.occupantPresent, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionOccupantPresent,
-            GROUP_CONCAT(IFNULL(i.concludeProcedure, \'-\') ORDER BY i.scheduledAt ASC SEPARATOR :concat_separator) as interventionConcludeProcedure,
-            \'-désactivation temporaire-\' as interventionDetails,
-            GROUP_CONCAT(
-                DISTINCT
-                CONCAT(
-                    i.status,
-                    :concat_separator,
-                    i.scheduledAt
-                )
-                ORDER BY i.scheduledAt ASC
-                SEPARATOR :concat_separator
-            ) as interventionsData
+            MAX(vli.occupantPresent) AS interventionOccupantPresent,
+            MAX(vli.concludeProcedure) AS interventionConcludeProcedure,
+            MAX(vli.details) AS interventionDetails,
+            MAX(vli.status) AS interventionStatus,
+            MAX(vli.scheduledAt) AS interventionScheduledAt,
+            MAX(vli.nbVisites) AS interventionNbVisites
             '
         )->leftJoin('s.situations', 'situations')
             ->leftJoin('s.criteres', 'criteres')
             ->leftJoin('s.desordreCategories', 'desordreCategories')
             ->leftJoin('s.desordreCriteres', 'desordreCriteres')
             ->leftJoin('s.tags', 'tags')
+            ->leftJoin(ViewLatestIntervention::class, 'vli', 'WITH', 'vli.signalementId = s.id')
             ->setParameter('concat_separator', SignalementAffectationListView::SEPARATOR_CONCAT)
             ->setParameter('group_concat_separator_1', SignalementExport::SEPARATOR_GROUP_CONCAT);
 

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -628,13 +628,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->setParameter('concat_separator', SignalementAffectationListView::SEPARATOR_CONCAT)
             ->setParameter('group_concat_separator_1', SignalementExport::SEPARATOR_GROUP_CONCAT);
 
-        $iterableResult = $qb->getQuery()->toIterable();
-        foreach ($iterableResult as $key => $row) {
-            yield $row;
-            if (($key % 100) === 0) {
-                gc_collect_cycles();
-            }
-        }
+        return $qb->getQuery()->toIterable();
     }
 
     public function findCities(?User $user = null, ?Territory $territory = null): array|int|string

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -563,6 +563,9 @@ class SignalementRepository extends ServiceEntityRepository
         return $qb;
     }
 
+    /**
+     * @throws Exception
+     */
     public function findSignalementAffectationIterable(User $user, array $options): \Generator
     {
         // temporary increase the group_concat_max_len to a higher value, for texts in GROUP_CONCAT
@@ -625,7 +628,13 @@ class SignalementRepository extends ServiceEntityRepository
             ->setParameter('concat_separator', SignalementAffectationListView::SEPARATOR_CONCAT)
             ->setParameter('group_concat_separator_1', SignalementExport::SEPARATOR_GROUP_CONCAT);
 
-        return $qb->getQuery()->toIterable();
+        $iterableResult = $qb->getQuery()->toIterable();
+        foreach ($iterableResult as $key => $row) {
+            yield $row;
+            if (($key % 100) === 0) {
+                gc_collect_cycles();
+            }
+        }
     }
 
     public function findCities(?User $user = null, ?Territory $territory = null): array|int|string

--- a/src/Service/Signalement/Export/SignalementExportLoader.php
+++ b/src/Service/Signalement/Export/SignalementExportLoader.php
@@ -4,18 +4,25 @@ namespace App\Service\Signalement\Export;
 
 use App\Entity\User;
 use App\Manager\SignalementManager;
+use Doctrine\DBAL\Exception;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 readonly class SignalementExportLoader
 {
+    public const int CHUNK_SIZE = 1000;
+
     public function __construct(
         private SignalementManager $signalementManager,
     ) {
     }
 
+    /**
+     * @throws Exception
+     */
     public function load(User $user, ?array $filters, ?array $selectedColumns = null): Spreadsheet
     {
         $spreadsheet = new Spreadsheet();
+        $spreadsheet->getCalculationEngine()->disableCalculationCache();
         $sheet = $spreadsheet->getActiveSheet();
 
         $keysToRemove = [];
@@ -24,17 +31,22 @@ readonly class SignalementExportLoader
             $selectedColumns = [];
         }
         $headers = $this->getHeadersWithSelectedColumns($headers, $keysToRemove, $selectedColumns);
-        $sheetData = [$headers];
+        $sheet->fromArray([$headers]);
 
-        foreach ($this->signalementManager->findSignalementAffectationIterable($user, $filters) as $signalementExportItem) {
-            $rowArray = get_object_vars($signalementExportItem);
-            foreach ($keysToRemove as $index) {
-                unset($rowArray[$index]);
+        $rowIndex = 2;
+        foreach ($this->getDataChunks($user, $filters) as $chunk) {
+            foreach ($chunk as $signalementExportItem) {
+                $rowArray = get_object_vars($signalementExportItem);
+
+                foreach ($keysToRemove as $index) {
+                    unset($rowArray[$index]);
+                }
+
+                $sheet->fromArray([$rowArray], null, 'A'.$rowIndex++);
             }
-            $sheetData[] = $rowArray;
-        }
 
-        $sheet->fromArray($sheetData);
+            $spreadsheet->garbageCollect();
+        }
 
         return $spreadsheet;
     }
@@ -66,6 +78,30 @@ readonly class SignalementExportLoader
         $indexToUnset = array_search($colName, $headers);
         if ($indexToUnset > 0 && isset($headers[$indexToUnset])) {
             unset($headers[$indexToUnset]);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getDataChunks(User $user, ?array $filters): \Generator
+    {
+        $data = [];
+        $counter = 0;
+
+        foreach ($this->signalementManager->findSignalementAffectationIterable($user, $filters) as $row) {
+            $data[] = $row;
+            ++$counter;
+
+            if ($counter >= self::CHUNK_SIZE) {
+                yield $data; // return chunk by chunk
+                $data = [];
+                $counter = 0;
+            }
+        }
+
+        if (!empty($data)) {
+            yield $data; // return the last chunk
         }
     }
 }

--- a/src/Service/Signalement/Export/SignalementExportLoader.php
+++ b/src/Service/Signalement/Export/SignalementExportLoader.php
@@ -22,7 +22,6 @@ readonly class SignalementExportLoader
     public function load(User $user, ?array $filters, ?array $selectedColumns = null): Spreadsheet
     {
         $spreadsheet = new Spreadsheet();
-        $spreadsheet->getCalculationEngine()->disableCalculationCache();
         $sheet = $spreadsheet->getActiveSheet();
 
         $keysToRemove = [];

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -73,10 +73,12 @@ class SignalementExportFactoryTest extends TestCase
             'debutDesordres' => DebutDesordres::YEARS_1_TO_2,
             'etiquettes' => null,
             'geoloc' => '{"lat": "43.3426152", "lng": "5.3711848"}',
-            'interventionsData' => 'PLANNED||2023-07-13 13:41:15||DONE||2024-06-09 10:00:00',
-            'interventionOccupantPresent' => '||1',
-            'interventionConcludeProcedure' => '||RSD,INSALUBRITE',
-            'interventionDetails' => '||dossier envoyé pour manquement sanitaire',
+            'interventionScheduledAt' => '2024-06-09 13:41:15',
+            'interventionStatus' => 'DONE',
+            'interventionNbVisites' => 2,
+            'interventionOccupantPresent' => 1,
+            'interventionConcludeProcedure' => 'RSD,INSALUBRITE',
+            'interventionDetails' => 'dossier envoyé pour manquement sanitaire',
         ];
 
         $user = $this->getUserFromRole(User::ROLE_ADMIN);
@@ -115,7 +117,7 @@ class SignalementExportFactoryTest extends TestCase
         $this->assertEquals(SignalementExportFactory::NON, $signalementExportFactory->isNotOccupant);
         $this->assertEquals(VisiteStatus::TERMINEE->value, $signalementExportFactory->interventionStatus);
         $this->assertEquals('RSD,INSALUBRITE', $signalementExportFactory->interventionConcludeProcedure);
-        $this->assertEquals('colonne temporairement désactivée', $signalementExportFactory->interventionDetails);
         $this->assertEquals('Entre 1 et 2 ans', $signalementExportFactory->debutDesordres);
+        $this->assertEquals('dossier envoyé pour manquement sanitaire', $signalementExportFactory->interventionDetails);
     }
 }


### PR DESCRIPTION
## Ticket

#3437    

## Description
La fonction `GROUP_CONCAT` utilisée sur le champ détail de la table intervention provoque un plantage lors de l'export sur l'oise. Si le contenu de ce champ est volumineux ce qui est le cas ici avec du code HTML stocké, la fonction `GROUP_CONCAT` peut atteindre la limite au niveau de la mémoire. 

**Rappel du besoin est de récupérer la dernière intervention**  
Les tentatives de modification de requête ont échoué, la solution la plus efficace est de passer par une vue

## Changements apportés
* Création d'une vue pour les dernières interventions par signalements afin de faire une jointure sur cette vue et éviter les group concat qui peuvent être gourmande en mémoire 
* Afficher le bouton export uniquement si un filtre existe
* Divers optimisations coté doctrine et coté loader pour les gestions de la mémoire 

## Pré-requis

## Tests
- [ ] Faire un export CSV et XLS quelconques
- [ ] Faire un export CSV et XLS sur l'Oise
- [ ] Faire un export CSV et XLS sur le 06 et le 13
- [ ] Vérifier qu'il est impossible de faire un export sur toute la base a moins d'avoir un filtre activé
- [ ] Vérifier qu'un responsable territoire peut exporter tout son territoire

