### PR TITLE
[BO - Signalements] Filtre Commune "quasi vide"

### DIFF
--- a/src/Service/Signalement/SearchFilterOptionDataProvider.php
+++ b/src/Service/Signalement/SearchFilterOptionDataProvider.php
@@ -76,6 +76,6 @@ class SearchFilterOptionDataProvider
         }
         $role = $user->getRoles();
 
-        return $className.array_shift($role).'-territory-'.$territory?->getZip();
+        return $className.array_shift($role).'-territory-'.$territory?->getZip().'-'.$user->getId();
     }
 }


### PR DESCRIPTION
## Ticket

#3475    

## Description
Régression sur la clé de cache pour les filtres de la liste

## Changements apportés
* Ajout du user-ud

## Pré-requis
`make load-data`

## Tests
- [ ] Se connecter avec 2 agents (2 navigateurs différents) du même territoires, de partenaires différents dont un partenaire limité à un code insee
- [ ] Aller sur le premier utilisateur limité au code insee, chercher une ville et vérifier que c'est cohérent avec la ville du ou des partenaires.
- [ ] Aller sur le deuxième, faite la même recherche et vérifier que c'est cohérent et qu'il n'est pas limité au cache de l'utilisateur précédent. 
