### PR TITLE
[Auto-Affectation] Ne pas affecter si la géolocalisation n'est pas définie

### DIFF
--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -50,6 +50,9 @@ class AutoAssigner
         if ($autoAffectationRules->isEmpty()) {
             return;
         }
+        if (empty($signalement->getGeoloc())) {
+            return;
+        }
         $adminEmail = $this->parameterBag->get('user_system_email');
         $adminUser = $this->userManager->findOneBy(['email' => $adminEmail]);
         $partners = $signalement->getTerritory()->getPartners();
@@ -57,10 +60,6 @@ class AutoAssigner
 
         /** @var AutoAffectationRule $rule */
         foreach ($autoAffectationRules as $rule) {
-            if (empty($signalement->getGeoloc()) && $rule->getInseeToInclude() === 'partner_list') {
-                continue;
-            }
-
             $specification = new AndSpecification(
                 new ProfilDeclarantSpecification($rule->getProfileDeclarant()),
                 new PartnerTypeSpecification($rule->getPartnerType()),

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -57,6 +57,10 @@ class AutoAssigner
 
         /** @var AutoAffectationRule $rule */
         foreach ($autoAffectationRules as $rule) {
+            if (empty($signalement->getGeoloc()) && $rule->getInseeToInclude() === 'partner_list') {
+                continue;
+            }
+
             $specification = new AndSpecification(
                 new ProfilDeclarantSpecification($rule->getProfileDeclarant()),
                 new PartnerTypeSpecification($rule->getPartnerType()),

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -23,6 +23,7 @@ use App\Specification\Affectation\ProcedureSuspecteeSpecification;
 use App\Specification\Affectation\ProfilDeclarantSpecification;
 use App\Specification\AndSpecification;
 use App\Specification\Context\PartnerSignalementContext;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class AutoAssigner
@@ -38,6 +39,7 @@ class AutoAssigner
         private UserManager $userManager,
         private ParameterBagInterface $parameterBag,
         private InterconnectionBus $interconnectionBus,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -51,6 +53,12 @@ class AutoAssigner
             return;
         }
         if (empty($signalement->getGeoloc())) {
+            $logMessage = \sprintf(
+                'No auto-affectation for signalement %s - Empty geolocation',
+                $signalement->getUuid(),
+            );
+            $this->logger->info($logMessage);
+            \Sentry\captureMessage($logMessage);
             return;
         }
         $adminEmail = $this->parameterBag->get('user_system_email');

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -59,6 +59,7 @@ class AutoAssigner
             );
             $this->logger->info($logMessage);
             \Sentry\captureMessage($logMessage);
+
             return;
         }
         $adminEmail = $this->parameterBag->get('user_system_email');

--- a/src/Specification/Affectation/CodeInseeSpecification.php
+++ b/src/Specification/Affectation/CodeInseeSpecification.php
@@ -103,6 +103,10 @@ class CodeInseeSpecification implements SpecificationInterface
 
     private function isSignalementInZone(Signalement $signalement, Zone $zone): bool
     {
+        if (empty($signalement->getGeoloc())) {
+            return false;
+        }
+
         $parser = new Parser($zone->getArea());
         $zoneArea = $parser->parse();
         $signalementCoordinate = new Coordinate($signalement->getGeoloc()['lat'], $signalement->getGeoloc()['lng']);

--- a/tests/Unit/Service/AutoAssignerTest.php
+++ b/tests/Unit/Service/AutoAssignerTest.php
@@ -16,6 +16,7 @@ use App\Repository\SignalementRepository;
 use App\Service\Signalement\AutoAssigner;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
@@ -235,6 +236,8 @@ class AutoAssignerTest extends KernelTestCase
         $parameterBag = $this->createMock(ParameterBagInterface::class);
         /** @var InterconnectionBus|MockObject $esaboraBus */
         $esaboraBus = $this->createMock(InterconnectionBus::class);
+        /** @var LoggerInterface $logger */
+        $logger = $this->createMock(LoggerInterface::class);
         $autoAssigner = new AutoAssigner(
             $signalementManager,
             $this->affectationManager,
@@ -243,6 +246,7 @@ class AutoAssignerTest extends KernelTestCase
             $userManager,
             $parameterBag,
             $esaboraBus,
+            $logger,
         );
 
         $autoAssigner->assign($signalement);


### PR DESCRIPTION
## Ticket

#3468   

## Description
En cas de signalement sans géolocalisation, on ne fait pas l'auto-affectation, pour forcer les RT à passer sur ces signalements, et éviter des sauts d'affectation qui seraient utiles.

## Tests
- [ ] Créer ou vérifier une règle d'auto-affectation
- [ ] Créer un signalement en changeant l'adresse à la main pour une adresse fictive qui devrait être concernée par cette auto-affectation
- [ ] L'affectation ne se fait pas
