### PR TITLE
[Inter-connexions] Correction de retour null

### DIFF
--- a/src/Service/Interconnection/JobEventHttpClient.php
+++ b/src/Service/Interconnection/JobEventHttpClient.php
@@ -118,11 +118,15 @@ class JobEventHttpClient implements HttpClientInterface
 
     private function filterResponse($response): array
     {
+        if (empty($response)) {
+            return [];
+        }
+
         $responseDecoded = json_decode($response, true);
         if (isset($responseDecoded['rowList'][0]['documentZipContent'])) {
             unset($responseDecoded['rowList'][0]['documentZipContent']);
         }
 
-        return $responseDecoded;
+        return !empty($responseDecoded) ? $responseDecoded : [];
     }
 }


### PR DESCRIPTION
## Ticket

#3478    

## Description
Il y avait un problème d'interprétation si la réponse était `null` lors d'un appel http.
A la place, on retourne un tableau vide.

## Tests
- [ ] Je n'ai pas vraiment réussi à tester. J'ai tenté de modifier le TU sans succès...
