### PR TITLE
[BO - Multi-territoire] dashboard/listes/carto/stats

### DIFF
--- a/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoAppDashboard.vue
@@ -32,7 +32,7 @@
                 </div>
             </div>
           </div>
-          <div v-if="sharedState.user.isAdmin" class="fr-col fr-col-md-3">
+          <div v-if="sharedState.user.isAdmin || sharedState.user.isMultiTerritoire" class="fr-col fr-col-md-3">
             <HistoSelect
               id="filter-territoires"
               v-model="sharedState.filters.territory"
@@ -112,6 +112,7 @@ export default defineComponent({
       this.sharedState.user.isAdmin = requestResponse.roleLabel === 'Super Admin'
       this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
       this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin. partenaire'
+      this.sharedState.user.isMultiTerritoire = requestResponse.isMultiTerritoire === true
       this.sharedState.user.canSeeNonDecenceEnergetique = requestResponse.canSeeNDE === '1'
       this.sharedState.user.prenom = requestResponse.firstname
       this.sharedState.user.avatarOrPlaceHolder = requestResponse.avatarOrPlaceHolder
@@ -156,8 +157,8 @@ export default defineComponent({
       this.sharedState.signalements.percent = requestResponse.data.countSignalement.percentage.active
       this.sharedState.closedSignalements.count = requestResponse.data.countSignalement.closed
       this.sharedState.closedSignalements.percent = requestResponse.data.countSignalement.percentage.closed
-      this.sharedState.newSignalements.count = requestResponse.data.countSignalement.new
-      this.sharedState.newSignalements.percent = requestResponse.data.countSignalement.percentage.new
+      this.sharedState.newSignalementsStats.count = requestResponse.data.countSignalement.new
+      this.sharedState.newSignalementsStats.percent = requestResponse.data.countSignalement.percentage.new
       this.sharedState.refusedSignalements.count = requestResponse.data.countSignalement.refused
       this.sharedState.refusedSignalements.percent = requestResponse.data.countSignalement.percentage.refused
       this.sharedState.suivis.countMoyen = requestResponse.data.countSuivi.average

--- a/assets/scripts/vue/components/dashboard/TheHistoDashboardHeader.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoDashboardHeader.vue
@@ -6,8 +6,8 @@
       </div>
       <div class="header-group-item">
         <div class="header-item">
-          <strong>{{ sharedState.newSignalements.count }} nouveaux</strong><br>
-          soit {{ sharedState.newSignalements.percent }} %
+          <strong>{{ sharedState.newSignalementsStats.count }} nouveaux</strong><br>
+          soit {{ sharedState.newSignalementsStats.percent }} %
         </div>
         <div class="header-item">
           <strong>{{ sharedState.signalements.count }} en cours</strong><br>

--- a/assets/scripts/vue/components/dashboard/store.ts
+++ b/assets/scripts/vue/components/dashboard/store.ts
@@ -8,11 +8,16 @@ export const store = {
       isAdmin: false,
       isResponsableTerritoire: false,
       isAdministrateurPartenaire: false,
+      isMultiTerritoire: false,
       canSeeNonDecenceEnergetique: false
     },
     territories: new Array<HistoInterfaceSelectOption>(),
     filters: {
       territory: 'all'
+    },
+    newSignalementsStats: {
+      count: 0,
+      percent: 0
     },
     newSignalements: {
       count: 0,

--- a/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
+++ b/assets/scripts/vue/components/signalement-list/TheSignalementAppList.vue
@@ -149,6 +149,7 @@ export default defineComponent({
       this.sharedState.user.isResponsableTerritoire = requestResponse.roleLabel === 'Resp. Territoire'
       this.sharedState.user.isAdministrateurPartenaire = requestResponse.roleLabel === 'Admin. partenaire'
       this.sharedState.user.isAgent = ['Admin. partenaire', 'Agent'].includes(requestResponse.roleLabel)
+      this.sharedState.user.isMultiTerritoire = requestResponse.isMultiTerritoire === true
       const isAdminOrAdminTerritoire = this.sharedState.user.isAdmin || this.sharedState.user.isResponsableTerritoire
       this.sharedState.user.canSeeStatusAffectation = isAdminOrAdminTerritoire
       this.sharedState.user.canSeeBailleurSocial = isAdminOrAdminTerritoire

--- a/assets/scripts/vue/components/signalement-list/components/SignalementListFilters.vue
+++ b/assets/scripts/vue/components/signalement-list/components/SignalementListFilters.vue
@@ -35,7 +35,7 @@
             </ul>
           </div>
           <div class="fr-grid-row fr-grid-row--gutters">
-            <div v-if="sharedState.user.isAdmin" class="fr-col-12 fr-col-lg-6 fr-col-xl-2 grey-background">
+            <div v-if="sharedState.user.isAdmin || sharedState.user.isMultiTerritoire" class="fr-col-12 fr-col-lg-6 fr-col-xl-2 grey-background">
               <HistoSelect
                 v-if="sharedState.territories.length > 0"
                 id="filter-territoire"
@@ -48,7 +48,7 @@
                 <template #label>Territoire</template>
               </HistoSelect>
             </div>
-            <div class="fr-col-12 fr-col-lg-6" :class="sharedState.user.isAdmin ? 'fr-col-xl-3' : 'fr-col-xl-4'">
+            <div class="fr-col-12 fr-col-lg-6" :class="sharedState.user.isAdmin || sharedState.user.isMultiTerritoire ? 'fr-col-xl-3' : 'fr-col-xl-4'">
               <AppSearch
                 id="filter-search-terms"
                 v-model="sharedState.input.filters.searchTerms"
@@ -60,7 +60,7 @@
                 <template #label>Recherche</template>
               </AppSearch>
             </div>
-            <div class="fr-col-12 fr-col-lg-6" :class="sharedState.user.isAdmin ? 'fr-col-xl-2' : 'fr-col-xl-3'">
+            <div class="fr-col-12 fr-col-lg-6" :class="sharedState.user.isAdmin || sharedState.user.isMultiTerritoire ? 'fr-col-xl-2' : 'fr-col-xl-3'">
               <AppAutoComplete
                 id="filter-communes"
                 v-model="sharedState.input.filters.communes"

--- a/assets/scripts/vue/components/signalement-list/store.ts
+++ b/assets/scripts/vue/components/signalement-list/store.ts
@@ -43,6 +43,7 @@ export const store = {
       isResponsableTerritoire: false,
       isAdministrateurPartenaire: false,
       isAgent: false,
+      isMultiTerritoire: false,
       canSeeStatusAffectation: false,
       canSeeBailleurSocial: false,
       canSeeScore: false,

--- a/src/Controller/Back/BackTerritoryController.php
+++ b/src/Controller/Back/BackTerritoryController.php
@@ -123,8 +123,8 @@ class BackTerritoryController extends AbstractController
         BailleurRepository $bailleurRepository,
     ): JsonResponse {
         $this->denyAccessUnlessGranted(TerritoryVoter::GET_BAILLEURS_LIST, $territory);
-        $zip = $territory->getZip();
-        $bailleurs = $bailleurRepository->findBailleursByTerritory($zip);
+        $user = $this->getUser();
+        $bailleurs = $bailleurRepository->findBailleursByTerritory($user, $territory);
 
         return $this->json($bailleurs);
     }

--- a/src/Controller/Back/CartographieController.php
+++ b/src/Controller/Back/CartographieController.php
@@ -49,15 +49,10 @@ class CartographieController extends AbstractController
             );
         }
 
-        $userToFilterCities = $user;
-        if ($this->isGranted('ROLE_ADMIN')) {
-            $userToFilterCities = null;
-        }
-
         return $this->render('back/cartographie/index.html.twig', [
             'title' => $title,
             'filters' => $filters,
-            'filtersOptionData' => $this->searchFilterOptionDataProvider->getData($userToFilterCities),
+            'filtersOptionData' => $this->searchFilterOptionDataProvider->getData($user),
             'countActiveFilters' => $countActiveFilters,
             'displayRefreshAll' => false,
             'signalements' => [/* $signalements */],

--- a/src/Controller/Back/WidgetSettingsController.php
+++ b/src/Controller/Back/WidgetSettingsController.php
@@ -24,14 +24,11 @@ class WidgetSettingsController extends AbstractController
     ): JsonResponse {
         /** @var User $user */
         $user = $this->getUser();
-        $enabledTerritories = $user->getPartnersTerritories();
+        $authorizedTerritories = $user->getPartnersTerritories();
 
         $territory = null;
-        if ($territoryId && ($security->isGranted('ROLE_ADMIN') || isset($enabledTerritories[$territoryId]))) {
+        if ($territoryId && ($security->isGranted('ROLE_ADMIN') || isset($authorizedTerritories[$territoryId]))) {
             $territory = $territoryRepository->find($territoryId);
-        }
-        if (!$territory && !$security->isGranted('ROLE_ADMIN')) {
-            $territory = $user->getFirstTerritory();
         }
 
         return $this->json(

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -249,3 +249,19 @@ affectations:
     motif_cloture: ""
     territory: "Bouches-du-Rhône"
     is_synchronized: true
+  -
+    signalement: 2024-12
+    partner: "partenaire-30-02@histologe.fr"
+    statut: 0
+    answered_by: ""
+    affected_by: "admin-01@histologe.fr"
+    motif_cloture: ""
+    territory: "Gard"
+  -
+    signalement: 2024-08
+    partner: "partenaire-34-04@histologe.fr"
+    statut: 0
+    answered_by: ""
+    affected_by: "admin-01@histologe.fr"
+    motif_cloture: ""
+    territory: "Hérault"

--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -590,6 +590,12 @@ partners:
     territory: "Gard"
     type: "EPCI"
   -
+    nom: "CAF 30"
+    email: "partenaire-30-02@histologe.fr"
+    is_archive: 0
+    territory: "Gard"
+    type: "CAF_MSA"
+  -
     nom: "Partner Habitat 44"
     email: "partenaire-44-05@histologe.fr"
     insee: "[\"44179\"]"

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -446,6 +446,15 @@ users:
     is_generique: 0
     is_mailing_active: 1
   -
+    email: user-partenaire-multi-ter-34-30@histologe.fr
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partners: 
+      - "CAF 34"
+      - "CAF 30"
+    statut: 1
+    is_generique: 0
+    is_mailing_active: 1
+  -
     email: admin-territoire-44-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT Loire-Atlantique"

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -345,11 +345,14 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         return $this;
     }
 
-    public function getPartnersTerritories(): array
+    public function getPartnersTerritories($forceLoadObject = false): array
     {
         $territories = [];
         foreach ($this->userPartners as $userPartner) {
             $territory = $userPartner->getPartner()->getTerritory();
+            if ($forceLoadObject) {
+                $territory->getZip();
+            }
             if ($territory) {
                 $territories[$territory->getId()] = $territory;
             }

--- a/src/Factory/WidgetSettingsFactory.php
+++ b/src/Factory/WidgetSettingsFactory.php
@@ -19,7 +19,7 @@ class WidgetSettingsFactory
     ) {
     }
 
-    public function createInstanceFrom(?User $user = null, ?Territory $territory = null): WidgetSettings
+    public function createInstanceFrom(User $user, ?Territory $territory = null): WidgetSettings
     {
         $filterOptionData = $this->searchFilterOptionDataProvider->getData($user, $territory);
 

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -143,7 +143,7 @@ class AffectationRepository extends ServiceEntityRepository
             ->setParameter('statut_wait', Affectation::STATUS_WAIT)
             ->setParameter('statut_refused', Affectation::STATUS_REFUSED);
 
-        if (count($territories)) {
+        if (\count($territories)) {
             $qb->andWhere('a.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
@@ -160,7 +160,7 @@ class AffectationRepository extends ServiceEntityRepository
             ->setParameter('partners', $user->getPartners())
             ->andWhere('a.statut = :statut_wait')
             ->setParameter('statut_wait', Affectation::STATUS_WAIT);
-        if (count($territories)) {
+        if (\count($territories)) {
             $qb->andWhere('a.territory IN (:territories)')->setParameter('territories', $territories);
         }
 

--- a/src/Repository/CommuneRepository.php
+++ b/src/Repository/CommuneRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Commune;
 use App\Entity\Territory;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -35,14 +36,17 @@ class CommuneRepository extends ServiceEntityRepository
         }
     }
 
-    public function findEpciByCommuneTerritory(?Territory $territory = null): array
+    public function findEpciByCommuneTerritory(?Territory $territory = null, ?User $user = null): array
     {
         $qb = $this->createQueryBuilder('c')
             ->select('distinct e.code, e.nom')
             ->join('c.epci', 'e');
+        if ($user && !$user->isSuperAdmin()) {
+            $qb->andWhere('c.territory IN (:territories)')->setParameter('territories', $user->getPartnersTerritories());
+        }
         if (null !== $territory) {
             $qb
-                ->where('c.territory = :territory')
+                ->andWhere('c.territory = :territory')
                 ->setParameter('territory', $territory);
         }
 

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -8,7 +8,6 @@ use App\Entity\Enum\PartnerType;
 use App\Entity\JobEvent;
 use App\Entity\Partner;
 use App\Entity\Signalement;
-use App\Entity\Territory;
 use App\Repository\Behaviour\EntityCleanerRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\NonUniqueResultException;
@@ -36,7 +35,7 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
     public function findLastJobEventByInterfacageType(
         string $type,
         int $dayPeriod,
-        ?Territory $territory,
+        array $territories,
     ): array {
         $qb = $this->createQueryBuilder('j')
             ->select('j.createdAt, p.id, p.nom, s.reference, j.status, j.action, j.codeStatus, j.response')
@@ -45,8 +44,8 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
             ->where('j.service = :service')
             ->andWhere('j.createdAt >= :date_limit');
 
-        if (null !== $territory) {
-            $qb->andWhere('p.territory = :territory')->setParameter('territory', $territory);
+        if (count($territories) > 0) {
+            $qb->andWhere('p.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
         $qb->setParameter('service', $type)

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -44,7 +44,7 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
             ->where('j.service = :service')
             ->andWhere('j.createdAt >= :date_limit');
 
-        if (count($territories) > 0) {
+        if (\count($territories)) {
             $qb->andWhere('p.territory IN (:territories)')->setParameter('territories', $territories);
         }
 

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -98,7 +98,7 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    public function countSignalementNewSuivi(User $user, ?Territory $territory): int
+    public function countSignalementNewSuivi(User $user, array $territories): int
     {
         $qb = $this->createQueryBuilder('n')
             ->select('COUNT(DISTINCT n.signalement)')
@@ -113,10 +113,10 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
             ->setParameter('type_suivi_usager', Suivi::TYPE_USAGER)
             ->setParameter('type_suivi_partner', Suivi::TYPE_PARTNER);
 
-        if (null !== $territory) {
+        if (\count($territories)) {
             $qb->innerJoin('n.signalement', 's')
-                ->andWhere('s.territory = :territory')
-                ->setParameter('territory', $territory);
+                ->andWhere('s.territory IN (:territories)')
+                ->setParameter('territories', $territories);
         }
 
         return $qb->getQuery()->getSingleScalarResult();
@@ -154,7 +154,7 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    public function countSignalementClosedNotSeen(?User $user, ?Territory $territory): int
+    public function countSignalementClosedNotSeen(?User $user, array $territories): int
     {
         $qb = $this->createQueryBuilder('n');
         $qb
@@ -172,8 +172,8 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
             ->setParameter('description', Suivi::DESCRIPTION_MOTIF_CLOTURE_ALL.'%')
             ->setParameter('user', $user);
 
-        if (null !== $territory) {
-            $qb->andWhere('si.territory = :territory')->setParameter('territory', $territory);
+        if (\count($territories)) {
+            $qb->andWhere('si.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
         return $qb->getQuery()->getSingleScalarResult();
@@ -183,7 +183,7 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    public function countAffectationClosedNotSeen(?User $user, ?Territory $territory): int
+    public function countAffectationClosedNotSeen(?User $user, array $territories): int
     {
         $qb = $this->createQueryBuilder('n');
         $qb
@@ -202,8 +202,8 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
             ->setParameter('status_closed', SignalementStatus::CLOSED)
             ->setParameter('user', $user);
 
-        if (null !== $territory) {
-            $qb->andWhere('si.territory = :territory')->setParameter('territory', $territory);
+        if (\count($territories)) {
+            $qb->andWhere('si.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
         return $qb->getQuery()->getSingleScalarResult();

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -8,6 +8,7 @@ use App\Entity\Enum\Qualification;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
+use App\Entity\User;
 use App\Service\ListFilters\SearchArchivedPartner;
 use App\Service\ListFilters\SearchPartner;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -91,11 +92,14 @@ class PartnerRepository extends ServiceEntityRepository
     /**
      * @throws QueryException
      */
-    public function findAllList(?Territory $territory = null)
+    public function findAllList(?Territory $territory = null, ?User $user = null)
     {
         $qb = $this->createQueryBuilder('p')
             ->where('p.isArchive != 1')
             ->orderBy('p.nom', 'ASC');
+        if ($user && !$user->isSuperAdmin()) {
+            $qb->andWhere('p.territory IN (:territories)')->setParameter('territories', $user->getPartnersTerritories());
+        }
         if ($territory) {
             $qb->andWhere('p.territory = :territory')->setParameter('territory', $territory);
         }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -128,7 +128,7 @@ class SignalementRepository extends ServiceEntityRepository
             $qb->andWhere('s.territory = :territory')->setParameter('territory', $territory);
         }
 
-        if ($user?->isUserPartner() || $user?->isPartnerAdmin()) {
+        if ($user && !$user->isSuperAdmin()) {
             $qb->innerJoin('s.affectations', 'affectations')
                 ->innerJoin('affectations.partner', 'partner')
                 ->andWhere('partner IN (:partners)')
@@ -138,7 +138,7 @@ class SignalementRepository extends ServiceEntityRepository
         return $qb->getQuery()->getSingleScalarResult();
     }
 
-    public function countByStatus(?Territory $territory, ?ArrayCollection $partners, ?int $year = null, bool $removeImported = false, ?Qualification $qualification = null, ?array $qualificationStatuses = null): array
+    public function countByStatus(array $territories, ?ArrayCollection $partners, ?int $year = null, bool $removeImported = false, ?Qualification $qualification = null, ?array $qualificationStatuses = null): array
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id) as count')
@@ -150,8 +150,8 @@ class SignalementRepository extends ServiceEntityRepository
             $qb->andWhere('s.isImported IS NULL OR s.isImported = 0');
         }
 
-        if ($territory) {
-            $qb->andWhere('s.territory = :territory')->setParameter('territory', $territory);
+        if (\count($territories)) {
+            $qb->andWhere('s.territory IN (:territories)')->setParameter('territories', $territories);
         }
         if ($partners && $partners->count() > 0) {
             $qb->leftJoin('s.affectations', 'affectations')
@@ -632,29 +632,27 @@ class SignalementRepository extends ServiceEntityRepository
         return $qb->getQuery()->toIterable();
     }
 
-    public function findCities(?User $user = null, ?Territory $territory = null): array|int|string
+    public function findCities(User $user, ?Territory $territory = null): array|int|string
     {
         return $this->findCommunes($user, $territory, 's.villeOccupant', 'city');
     }
 
-    public function findZipcodes(?User $user = null, ?Territory $territory = null): array|int|string
+    public function findZipcodes(User $user, ?Territory $territory = null): array|int|string
     {
         return $this->findCommunes($user, $territory, 's.cpOccupant', 'zipcode');
     }
 
     public function findCommunes(
-        ?User $user = null,
+        User $user,
         ?Territory $territory = null,
         ?string $field = null,
         ?string $alias = null,
     ): array|int|string {
-        $user = $user?->isUserPartner() || $user?->isPartnerAdmin() ? $user : null;
-
         $qb = $this->createQueryBuilder('s')
             ->select($field.' '.$alias)
             ->where('s.statut != :status')
             ->setParameter('status', Signalement::STATUS_ARCHIVED);
-        if ($user) {
+        if (!$user->isSuperAdmin()) {
             $qb->leftJoin('s.affectations', 'affectations')
                 ->leftJoin('affectations.partner', 'partner')
                 ->andWhere('partner IN (:partners)')
@@ -1106,18 +1104,18 @@ class SignalementRepository extends ServiceEntityRepository
         ])->fetchAllAssociative();
     }
 
-    public function countSignalementAcceptedNoSuivi(Territory $territory)
+    public function countSignalementAcceptedNoSuivi(array $territories): array
     {
         $subquery = $this->_em->createQueryBuilder()
             ->select('IDENTITY(su.signalement)')
             ->from(Suivi::class, 'su')
             ->innerJoin('su.signalement', 'sig')
-            ->where('sig.territory = :territory_1')
+            ->where('sig.territory IN (:territories_1)')
             ->andWhere('sig.statut = :statut')
             ->andWhere('su.type IN (:suivi_type)')
             ->setParameter('suivi_type', [Suivi::TYPE_USAGER, Suivi::TYPE_PARTNER])
             ->setParameter('statut', Signalement::STATUS_ACTIVE)
-            ->setParameter('territory_1', $territory)
+            ->setParameter('territories_1', $territories)
             ->distinct();
 
         $queryBuilder = $this->createQueryBuilder('s')
@@ -1125,11 +1123,11 @@ class SignalementRepository extends ServiceEntityRepository
             ->innerJoin('s.affectations', 'a')
             ->innerJoin('a.partner', 'p')
             ->where('s.statut = :statut')
-            ->andWhere('p.territory = :territory')
+            ->andWhere('p.territory IN (:territories)')
             ->andWhere('s.id NOT IN (:subquery)')
             ->setParameter('statut', Signalement::STATUS_ACTIVE)
             ->setParameter('subquery', $subquery->getQuery()->getSingleColumnResult())
-            ->setParameter('territory', $territory)
+            ->setParameter('territories', $territories)
             ->groupBy('p.nom');
 
         return $queryBuilder->getQuery()->getResult();
@@ -1140,7 +1138,7 @@ class SignalementRepository extends ServiceEntityRepository
      * @throws NoResultException
      * @throws QueryException
      */
-    public function countSignalementByStatus(?Territory $territory = null): CountSignalement
+    public function countSignalementByStatus(array $territories): CountSignalement
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select(
@@ -1161,8 +1159,8 @@ class SignalementRepository extends ServiceEntityRepository
             ->where('s.statut != :archived')
             ->setParameter('archived', Signalement::STATUS_ARCHIVED);
 
-        if (null !== $territory) {
-            $qb->andWhere('s.territory =:territory')->setParameter('territory', $territory);
+        if (\count($territories)) {
+            $qb->andWhere('s.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
         return $qb->getQuery()->getOneOrNullResult();

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -66,11 +66,10 @@ class SuiviRepository extends ServiceEntityRepository
     public function countSignalementNoSuiviSince(
         array $territories,
         array $partnersIds = [],
-        int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
     ): int {
         $connection = $this->getEntityManager()->getConnection();
         $parameters = [
-            'day_period' => $period,
+            'day_period' => Suivi::DEFAULT_PERIOD_INACTIVITY,
             'type_suivi_usager' => Suivi::TYPE_USAGER,
             'type_suivi_partner' => Suivi::TYPE_PARTNER,
             'type_suivi_auto' => Suivi::TYPE_AUTO,

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -33,14 +33,16 @@ class SuiviRepository extends ServiceEntityRepository
     /**
      * @throws Exception
      */
-    public function getAverageSuivi(?Territory $territory = null): float
+    public function getAverageSuivi(array $territories): float
     {
         $connection = $this->getEntityManager()->getConnection();
-        $whereTerritory = $territory instanceof Territory ? 'AND s.territory_id = :territory_id' : null;
+        $whereTerritory = '';
         $parameters['statut'] = Signalement::STATUS_ARCHIVED;
 
-        if (null !== $whereTerritory) {
-            $parameters['territory_id'] = $territory->getId();
+        if (\count($territories)) {
+            $territoriesIds = implode(',', array_keys($territories));
+            $whereTerritory = 'AND s.territory_id IN (:territories)';
+            $parameters['territories'] = $territoriesIds;
         }
 
         $sql = 'SELECT AVG(nb_suivi) as average_nb_suivi
@@ -62,9 +64,9 @@ class SuiviRepository extends ServiceEntityRepository
      * @throws Exception
      */
     public function countSignalementNoSuiviSince(
+        array $territories,
+        array $partnersIds = [],
         int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
-        ?Territory $territory = null,
-        ?array $partnersIds = null,
     ): int {
         $connection = $this->getEntityManager()->getConnection();
         $parameters = [
@@ -77,8 +79,8 @@ class SuiviRepository extends ServiceEntityRepository
             'status_refused' => Signalement::STATUS_REFUSED,
         ];
 
-        if (null !== $territory) {
-            $parameters['territory_id'] = $territory->getId();
+        if (\count($territories)) {
+            $parameters['territories'] = implode(',', array_keys($territories));
         }
         if (!empty($partnersIds)) {
             $parameters['partners'] = implode(',', $partnersIds);
@@ -88,7 +90,7 @@ class SuiviRepository extends ServiceEntityRepository
 
         $sql = 'SELECT COUNT(*) as count_signalement
                 FROM ('.
-                        $this->getSignalementsQuery($territory, $partnersIds)
+                        $this->getSignalementsQuery($territories, $partnersIds)
                 .') as countSignalementSuivi';
 
         $statement = $connection->prepare($sql);
@@ -115,8 +117,10 @@ class SuiviRepository extends ServiceEntityRepository
             'status_refused' => Signalement::STATUS_REFUSED,
         ];
 
+        $territories = [];
         if (null !== $territory) {
-            $parameters['territory_id'] = $territory->getId();
+            $parameters['territories'] = $territory->getId();
+            $territories[] = $territory;
         }
 
         if (!empty($partnersIds)) {
@@ -124,8 +128,7 @@ class SuiviRepository extends ServiceEntityRepository
             $parameters['status_wait'] = AffectationStatus::STATUS_WAIT->value;
             $parameters['status_accepted'] = AffectationStatus::STATUS_ACCEPTED->value;
         }
-
-        $sql = $this->getSignalementsQuery($territory, $partnersIds);
+        $sql = $this->getSignalementsQuery($territories, $partnersIds);
         $statement = $connection->prepare($sql);
 
         return $statement->executeQuery($parameters)->fetchFirstColumn();
@@ -135,7 +138,7 @@ class SuiviRepository extends ServiceEntityRepository
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    public function countSuiviPartner(?Territory $territory = null): int
+    public function countSuiviPartner(array $territories): int
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s) as nb_suivi')
@@ -145,8 +148,8 @@ class SuiviRepository extends ServiceEntityRepository
             ->setParameter('statut', Signalement::STATUS_ARCHIVED)
             ->setParameter('type_suivi', Suivi::TYPE_PARTNER);
 
-        if ($territory instanceof Territory) {
-            $qb->andWhere('sig.territory = :territory')->setParameter('territory', $territory);
+        if (\count($territories)) {
+            $qb->andWhere('sig.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
         return (int) $qb->getQuery()->getSingleScalarResult();
@@ -156,7 +159,7 @@ class SuiviRepository extends ServiceEntityRepository
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    public function countSuiviUsager(?Territory $territory = null): int
+    public function countSuiviUsager(array $territories): int
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s) as nb_suivi')
@@ -167,21 +170,21 @@ class SuiviRepository extends ServiceEntityRepository
             ->setParameter('type_suivi', Suivi::TYPE_USAGER)
             ->setParameter('statut', Signalement::STATUS_ARCHIVED);
 
-        if ($territory instanceof Territory) {
-            $qb->andWhere('sig.territory = :territory')->setParameter('territory', $territory);
+        if (\count($territories)) {
+            $qb->andWhere('sig.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
         return (int) $qb->getQuery()->getSingleScalarResult();
     }
 
     private function getSignalementsQuery(
-        ?Territory $territory = null,
+        array $territories,
         ?array $partnersIds = null,
     ): string {
         $whereTerritory = $wherePartner = $innerPartnerJoin = '';
 
-        if (null !== $territory) {
-            $whereTerritory = 'AND s.territory_id = :territory_id';
+        if (\count($territories)) {
+            $whereTerritory = 'AND s.territory_id IN (:territories)';
         }
 
         if (!empty($partnersIds)) {
@@ -295,7 +298,7 @@ class SuiviRepository extends ServiceEntityRepository
      * @throws Exception
      */
     public function countSignalementNoSuiviAfter3Relances(
-        ?Territory $territory = null,
+        array $territories,
         ?ArrayCollection $partners = null,
     ): int {
         $connection = $this->getEntityManager()->getConnection();
@@ -308,8 +311,8 @@ class SuiviRepository extends ServiceEntityRepository
             'nb_suivi_technical' => 3,
         ];
 
-        if (null !== $territory) {
-            $parameters['territory_id'] = $territory->getId();
+        if (\count($territories)) {
+            $parameters['territories'] = implode(',', array_keys($territories));
         }
         if (null !== $partners && !$partners->isEmpty()) {
             $parameters['partners'] = $partners;
@@ -322,7 +325,7 @@ class SuiviRepository extends ServiceEntityRepository
                             excludeUsagerAbandonProcedure: false,
                             dayPeriod: 0,
                             partners: $partners,
-                            territory: $territory,
+                            territories: $territories,
                         )
                 .') as countSignalementSuivi';
         $statement = $connection->prepare($sql);
@@ -334,13 +337,13 @@ class SuiviRepository extends ServiceEntityRepository
         bool $excludeUsagerAbandonProcedure = true,
         int $dayPeriod = 0,
         ?ArrayCollection $partners = null,
-        ?Territory $territory = null,
+        array $territories = [],
     ): string {
         $joinMaxDateSuivi = $whereTerritory = $wherePartner = $innerPartnerJoin = $whereExcludeUsagerAbandonProcedure
         = $whereLastSuiviDelay = '';
 
-        if (null !== $territory) {
-            $whereTerritory = 'AND s.territory_id = :territory_id ';
+        if (\count($territories)) {
+            $whereTerritory = 'AND s.territory_id IN (:territories) ';
         }
 
         if (null != $partners && !$partners->isEmpty()) {

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Tag;
 use App\Entity\Territory;
+use App\Entity\User;
 use App\Service\ListFilters\SearchTag;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -36,11 +37,15 @@ class TagRepository extends ServiceEntityRepository
 
     public function findAllActive(
         ?Territory $territory = null,
+        ?User $user = null,
     ): mixed {
         $qb = $this->createQueryBuilder('t');
         $qb->andWhere('t.isArchive != 1')
             ->orderBy('t.label', 'ASC')
             ->indexBy('t', 't.id');
+        if ($user && !$user->isSuperAdmin()) {
+            $qb->andWhere('t.territory IN (:territories)')->setParameter('territories', $user->getPartnersTerritories());
+        }
         if ($territory) {
             $qb->andWhere('t.territory = :territory')
                 ->setParameter('territory', $territory);

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -28,7 +28,7 @@ class TagRepository extends ServiceEntityRepository
     ): mixed {
         $qb = $this->createQueryBuilder('t');
         $qb->andWhere('t.isArchive != 1')->orderBy('t.label', 'ASC');
-        if (count($territories)) {
+        if (\count($territories)) {
             $qb->andWhere('t.territory IN (:territories)')->setParameter('territories', $territories);
         }
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -238,7 +238,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     /**
      * @throws NonUniqueResultException
      */
-    public function countUserByStatus(?Territory $territory = null, ?User $user = null): CountUser
+    public function countUserByStatus(array $territories, ?User $user = null): CountUser
     {
         $qb = $this->createQueryBuilder('u');
         $qb->select(\sprintf(
@@ -256,9 +256,8 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->leftJoin('u.userPartners', 'up')
             ->leftJoin('up.partner', 'p');
 
-        if (null !== $territory) {
-            $qb->andWhere('p.territory = :territory')
-            ->setParameter('territory', $territory);
+        if (\count($territories)) {
+            $qb->andWhere('p.territory IN (:territories)')->setParameter('territories', $territories);
         }
 
         if ($user?->isUserPartner() || $user?->isPartnerAdmin()) {

--- a/src/Service/DashboardWidget/Widget.php
+++ b/src/Service/DashboardWidget/Widget.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\DashboardWidget;
 
-use App\Entity\Territory;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 class Widget
@@ -14,7 +13,7 @@ class Widget
         #[Groups(['widget:read'])]
         private ?string $type = null,
         #[Groups(['widget:read'])]
-        private ?Territory $territory = null,
+        private array $territories = [],
         #[Groups(['widget:read'])]
         private ?array $parameters = null,
     ) {
@@ -32,14 +31,14 @@ class Widget
         return $this;
     }
 
-    public function getTerritory(): ?Territory
+    public function getTerritories(): array
     {
-        return $this->territory;
+        return $this->territories;
     }
 
-    public function setTerritory(?Territory $territory): self
+    public function setTerritories(array $territories): self
     {
-        $this->territory = $territory;
+        $this->territories = $territories;
 
         return $this;
     }

--- a/src/Service/DashboardWidget/WidgetDataManager.php
+++ b/src/Service/DashboardWidget/WidgetDataManager.php
@@ -68,7 +68,7 @@ class WidgetDataManager implements WidgetDataManagerInterface
          */ function ($jobEvent) use ($territories) {
             /** @var \DateTimeImmutable $createdAt */
             $createdAt = $jobEvent['createdAt'];
-            $timezone = count($territories) ? reset($territories)->getTimezone() : TimezoneProvider::TIMEZONE_EUROPE_PARIS;
+            $timezone = \count($territories) ? reset($territories)->getTimezone() : TimezoneProvider::TIMEZONE_EUROPE_PARIS;
             $jobEvent['last_event'] = $createdAt
                 ->setTimezone(new \DateTimeZone($timezone))
                 ->format(self::FORMAT_DATE_TIME);

--- a/src/Service/DashboardWidget/WidgetDataManager.php
+++ b/src/Service/DashboardWidget/WidgetDataManager.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\DashboardWidget;
 
-use App\Entity\Territory;
 use App\Repository\AffectationRepository;
 use App\Repository\JobEventRepository;
 use App\Repository\SignalementRepository;
@@ -24,9 +23,9 @@ class WidgetDataManager implements WidgetDataManagerInterface
     ) {
     }
 
-    public function countSignalementAcceptedNoSuivi(Territory $territory, ?array $params = null): array
+    public function countSignalementAcceptedNoSuivi(array $territories, ?array $params = null): array
     {
-        return $this->signalementRepository->countSignalementAcceptedNoSuivi($territory);
+        return $this->signalementRepository->countSignalementAcceptedNoSuivi($territories);
     }
 
     /**
@@ -44,9 +43,9 @@ class WidgetDataManager implements WidgetDataManagerInterface
         }, $countSignalementTerritoryList);
     }
 
-    public function countAffectationPartner(?Territory $territory = null, ?array $params = null): array
+    public function countAffectationPartner(array $territories, ?array $params = null): array
     {
-        $countAffectationPartnerList = $this->affectationRepository->countAffectationPartner($territory);
+        $countAffectationPartnerList = $this->affectationRepository->countAffectationPartner($territories);
 
         return array_map(function ($countAffectationPartnerItem) {
             $countAffectationPartnerItem['waiting'] = (int) $countAffectationPartnerItem['waiting'];
@@ -60,19 +59,18 @@ class WidgetDataManager implements WidgetDataManagerInterface
      * @throws \DateMalformedStringException
      * @throws \DateInvalidTimeZoneException
      */
-    public function findLastJobEventByInterfacageType(string $type, array $params, ?Territory $territory = null): array
+    public function findLastJobEventByInterfacageType(string $type, array $params, array $territories): array
     {
-        $jobEvents = $this->jobEventRepository->findLastJobEventByInterfacageType($type, $params['period'], $territory);
+        $jobEvents = $this->jobEventRepository->findLastJobEventByInterfacageType($type, $params['period'], $territories);
 
         return array_map(/**
          * @throws \Exception
-         */ function ($jobEvent) use ($territory) {
+         */ function ($jobEvent) use ($territories) {
             /** @var \DateTimeImmutable $createdAt */
             $createdAt = $jobEvent['createdAt'];
+            $timezone = count($territories) ? reset($territories)->getTimezone() : TimezoneProvider::TIMEZONE_EUROPE_PARIS;
             $jobEvent['last_event'] = $createdAt
-                ->setTimezone(
-                    new \DateTimeZone($territory ? $territory->getTimezone() : TimezoneProvider::TIMEZONE_EUROPE_PARIS)
-                )
+                ->setTimezone(new \DateTimeZone($timezone))
                 ->format(self::FORMAT_DATE_TIME);
 
             return $jobEvent;
@@ -85,11 +83,11 @@ class WidgetDataManager implements WidgetDataManagerInterface
      * @throws NoResultException
      * @throws Exception
      */
-    public function countDataKpi(?Territory $territory = null, ?array $params = null): WidgetDataKpi
+    public function countDataKpi(array $territories, ?array $params = null): WidgetDataKpi
     {
         return $this->widgetDataKpiBuilder
             ->createWidgetDataKpiBuilder()
-            ->setTerritory($territory)
+            ->setTerritories($territories)
             ->withCountSignalement()
             ->withCountSuivi()
             ->withCountUser()

--- a/src/Service/DashboardWidget/WidgetDataManagerCache.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerCache.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\DashboardWidget;
 
-use App\Entity\Territory;
 use App\Entity\User;
 use App\Service\CacheCommonKeyGenerator;
 use Psr\Cache\InvalidArgumentException;
@@ -33,14 +32,16 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function countSignalementAcceptedNoSuivi(Territory $territory, ?array $params = null): array
+    public function countSignalementAcceptedNoSuivi(array $territories, ?array $params = null): array
     {
+        $territoriesKey = implode('-', array_keys($territories));
+
         return $this->dashboardCache->get(
-            __FUNCTION__.'-'.$this->commonKey.$territory->getZip(),
-            function (ItemInterface $item) use ($territory, $params) {
+            __FUNCTION__.'-'.$this->commonKey.$territoriesKey,
+            function (ItemInterface $item) use ($territories, $params) {
                 $item->expiresAfter($params['expired_after'] ?? null);
 
-                return $this->widgetDataManager->countSignalementAcceptedNoSuivi($territory);
+                return $this->widgetDataManager->countSignalementAcceptedNoSuivi($territories);
             }
         );
     }
@@ -63,14 +64,16 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function countAffectationPartner(?Territory $territory = null, ?array $params = null): array
+    public function countAffectationPartner(array $territories, ?array $params = null): array
     {
+        $territoriesKey = implode('-', array_keys($territories));
+
         return $this->dashboardCache->get(
-            __FUNCTION__.'-'.$this->commonKey.$territory?->getZip(),
-            function (ItemInterface $item) use ($territory, $params) {
+            __FUNCTION__.'-'.$this->commonKey.$territoriesKey,
+            function (ItemInterface $item) use ($territories, $params) {
                 $item->expiresAfter($params['expired_after'] ?? null);
 
-                return $this->widgetDataManager->countAffectationPartner($territory);
+                return $this->widgetDataManager->countAffectationPartner($territories);
             }
         );
     }
@@ -78,14 +81,16 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function findLastJobEventByInterfacageType(string $type, array $params, ?Territory $territory = null): array
+    public function findLastJobEventByInterfacageType(string $type, array $params, array $territories): array
     {
+        $territoriesKey = implode('-', array_keys($territories));
+
         return $this->dashboardCache->get(
-            __FUNCTION__.'-'.$this->commonKey.$territory?->getZip(),
-            function (ItemInterface $item) use ($type, $params, $territory) {
+            __FUNCTION__.'-'.$this->commonKey.$territoriesKey,
+            function (ItemInterface $item) use ($type, $params, $territories) {
                 $item->expiresAfter($params['expired_after'] ?? null);
 
-                return $this->widgetDataManager->findLastJobEventByInterfacageType($type, $params, $territory);
+                return $this->widgetDataManager->findLastJobEventByInterfacageType($type, $params, $territories);
             }
         );
     }
@@ -93,19 +98,20 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function countDataKpi(?Territory $territory = null, ?array $params = null): WidgetDataKpi
+    public function countDataKpi(array $territories, ?array $params = null): WidgetDataKpi
     {
         /** @var User $user */
         $user = $this->security->getUser();
-        $key = __FUNCTION__.'-'.$this->commonKey.$territory?->getZip().'-id-'.$user->getId();
+        $territoriesKey = implode('-', array_keys($territories));
+        $key = __FUNCTION__.'-'.$this->commonKey.$territoriesKey.'-id-'.$user->getId();
 
         return $this->dashboardCache->get(
             $key,
-            function (ItemInterface $item) use ($params, $territory) {
-                $item->tag('data-kpi-'.$territory?->getZip());
+            function (ItemInterface $item) use ($params, $territories, $territoriesKey) {
+                $item->tag('data-kpi-'.$territoriesKey);
                 $item->expiresAfter($params['expired_after'] ?? null);
 
-                return $this->widgetDataManager->countDataKpi($territory, $params);
+                return $this->widgetDataManager->countDataKpi($territories, $params);
             }
         );
     }

--- a/src/Service/DashboardWidget/WidgetDataManagerInterface.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerInterface.php
@@ -2,17 +2,15 @@
 
 namespace App\Service\DashboardWidget;
 
-use App\Entity\Territory;
-
 interface WidgetDataManagerInterface
 {
-    public function countSignalementAcceptedNoSuivi(Territory $territory, ?array $params = null): array;
+    public function countSignalementAcceptedNoSuivi(array $territories, ?array $params = null): array;
 
     public function countSignalementsByTerritory(?array $params = null): array;
 
-    public function countAffectationPartner(?Territory $territory = null, ?array $params = null): array;
+    public function countAffectationPartner(array $territories, ?array $params = null): array;
 
-    public function findLastJobEventByInterfacageType(string $type, array $params, ?Territory $territory = null): array;
+    public function findLastJobEventByInterfacageType(string $type, array $params, array $territories): array;
 
-    public function countDataKpi(?Territory $territory = null, ?array $params = null): WidgetDataKpi;
+    public function countDataKpi(array $territories, ?array $params = null): WidgetDataKpi;
 }

--- a/src/Service/DashboardWidget/WidgetLoader/AffectationPartnerWidgetLoader.php
+++ b/src/Service/DashboardWidget/WidgetLoader/AffectationPartnerWidgetLoader.php
@@ -23,7 +23,7 @@ class AffectationPartnerWidgetLoader extends AbstractWidgetLoader
         parent::load($widget);
         $widget->setData(
             $this->widgetDataManager->countAffectationPartner(
-                $widget->getTerritory(),
+                $widget->getTerritories(),
                 $this->widgetParameter['data']
             )
         );

--- a/src/Service/DashboardWidget/WidgetLoader/DataKpiWidgetLoader.php
+++ b/src/Service/DashboardWidget/WidgetLoader/DataKpiWidgetLoader.php
@@ -21,6 +21,6 @@ class DataKpiWidgetLoader extends AbstractWidgetLoader
     public function load(Widget $widget): void
     {
         parent::load($widget);
-        $widget->setData($this->widgetDataManager->countDataKpi($widget->getTerritory(), $this->widgetParameter['data']));
+        $widget->setData($this->widgetDataManager->countDataKpi($widget->getTerritories(), $this->widgetParameter['data']));
     }
 }

--- a/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
+++ b/src/Service/DashboardWidget/WidgetLoader/EsaboraEventWidgetLoader.php
@@ -26,7 +26,7 @@ class EsaboraEventWidgetLoader extends AbstractWidgetLoader
         $data = $this->widgetDataManager->findLastJobEventByInterfacageType(
             InterfacageType::ESABORA->value,
             $this->widgetParameter['data'],
-            $widget->getTerritory()
+            $widget->getTerritories()
         );
         foreach ($data as $key => $event) {
             $data[$key]['response'] = null;

--- a/src/Service/DashboardWidget/WidgetLoader/SignalementAcceptedNoSuiviWidgetLoader.php
+++ b/src/Service/DashboardWidget/WidgetLoader/SignalementAcceptedNoSuiviWidgetLoader.php
@@ -23,7 +23,7 @@ class SignalementAcceptedNoSuiviWidgetLoader extends AbstractWidgetLoader
         parent::load($widget);
         $widget->setData(
             $this->widgetDataManager->countSignalementAcceptedNoSuivi(
-                $widget->getTerritory(),
+                $widget->getTerritories(),
                 $this->widgetParameter['data']
             )
         );

--- a/src/Service/DashboardWidget/WidgetSettings.php
+++ b/src/Service/DashboardWidget/WidgetSettings.php
@@ -32,6 +32,8 @@ class WidgetSettings
     #[Groups('widget-settings:read')]
     private ?bool $hasSignalementImported = false;
     #[Groups('widget-settings:read')]
+    private ?bool $isMultiTerritoire = false;
+    #[Groups('widget-settings:read')]
     private array $bailleursSociaux = [];
 
     public function __construct(
@@ -58,6 +60,7 @@ class WidgetSettings
         $this->epcis = $epcis;
         $this->tags = $tags;
         $this->hasSignalementImported = $hasSignalementImported;
+        $this->isMultiTerritoire = count($user->getPartnersTerritories()) > 1 ? true : false;
         $this->bailleursSociaux = $bailleursSociaux;
     }
 
@@ -119,6 +122,11 @@ class WidgetSettings
     public function getHasSignalementImported(): bool
     {
         return $this->hasSignalementImported;
+    }
+
+    public function getIsMultiTerritoire(): ?bool
+    {
+        return $this->isMultiTerritoire;
     }
 
     public function getBailleursSociaux(): array

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -113,7 +113,7 @@ class SearchFilter
 
         if (isset($filters['delays'])) {
             $filters['delays_partners'] = $partners->map(fn ($partner) => $partner->getId())->toArray();
-            $filters['delays_territory'] = $territory?->getId();
+            $filters['delays_territory'] = $territory;
         }
 
         if (isset($filters['nouveau_suivi'])) {
@@ -225,7 +225,7 @@ class SearchFilter
                 $partners = $user->getPartners();
             }
             $this->filters['delays'] = (int) $period;
-            $this->filters['delays_territory'] = $territory?->getId();
+            $this->filters['delays_territory'] = $territory;
             $this->filters['delays_partners'] = $partners->map(fn ($partner) => $partner->getId())->toArray();
         }
 

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -98,10 +98,14 @@ class SearchFilter
         $filters = $signalementSearchQuery->getFilters();
         $partners = new ArrayCollection();
 
-        if (!$user->isSuperAdmin()) {
-            $filters['territories'] = [];
+        if (isset($filters['territories'])) {
+            $authorizedTerritories = $user->getPartnersTerritories();
+            foreach ($filters['territories'] as $key => $requestedTerritoryId) {
+                if (!$user->isSuperAdmin() && !isset($authorizedTerritories[$requestedTerritoryId])) {
+                    unset($filters['territories'][$key]);
+                }
+            }
         }
-
         $territory = isset($filters['territories'][0]) ? $this->territoryRepository->find($filters['territories'][0]) : null;
         if (\in_array(User::ROLE_USER_PARTNER, $user->getRoles())) {
             $partners = $user->getPartners();
@@ -183,7 +187,7 @@ class SearchFilter
                 $this->filters['signalement_ids'] = $signalementIds;
             }
 
-            if ($user->isSuperAdmin() && $request->query->get('territoire_id')) {
+            if ($request->query->get('territoire_id')) {
                 ++$this->countActive;
                 $this->filters['territories'] = [$request->query->get('territoire_id')];
             }
@@ -540,12 +544,10 @@ class SearchFilter
     private function getTerritory(User $user, Request $request): ?Territory
     {
         $territory = null;
-        if ($user->isSuperAdmin()) {
-            if ($request->query->get('territoire_id')) {
-                $territory = $this->territoryRepository->find($request->query->get('territoire_id'));
-            }
-        } elseif (1 === $user->getPartners()->count()) {
-            $territory = $user->getFirstTerritory();
+        $authorizedTerritories = $user->getPartnersTerritories();
+        $territoryId = $request->query->get('territoire_id');
+        if ($territoryId && ($user->isSuperAdmin() || isset($authorizedTerritories[$territoryId]))) {
+            $territory = $this->territoryRepository->find($territoryId);
         }
 
         return $territory;

--- a/src/Service/Statistics/GlobalBackAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalBackAnalyticsProvider.php
@@ -16,6 +16,10 @@ class GlobalBackAnalyticsProvider
 
     public function getData(?Territory $territory, ArrayCollection $partners): array
     {
+        $territories = [];
+        if ($territory) {
+            $territories[$territory->getId()] = $territory;
+        }
         $data = [];
         $data['count_signalement'] = $this->getCountSignalementData($territory, $partners);
         $data['average_criticite'] = $this->getAverageCriticiteData($territory, $partners);
@@ -24,7 +28,7 @@ class GlobalBackAnalyticsProvider
 
         $data['count_signalement_archives'] = 0;
         $data['count_signalement_refuses'] = 0;
-        $countByStatus = $this->signalementRepository->countByStatus($territory, $partners, null, true);
+        $countByStatus = $this->signalementRepository->countByStatus($territories, $partners, null, true);
         foreach ($countByStatus as $countByStatusItem) {
             switch ($countByStatusItem['statut']) {
                 case Signalement::STATUS_ARCHIVED:

--- a/src/Service/Statistics/ListTerritoryStatisticProvider.php
+++ b/src/Service/Statistics/ListTerritoryStatisticProvider.php
@@ -3,6 +3,7 @@
 namespace App\Service\Statistics;
 
 use App\Entity\Territory;
+use App\Entity\User;
 use App\Repository\TerritoryRepository;
 
 class ListTerritoryStatisticProvider
@@ -11,10 +12,14 @@ class ListTerritoryStatisticProvider
     {
     }
 
-    public function getData(): array
+    public function getData(?User $user = null): array
     {
         $data = [];
-        $territories = $this->territoryRepository->findAllList();
+        if ($user && !$user->isSuperAdmin()) {
+            $territories = $user->getPartnersTerritories();
+        } else {
+            $territories = $this->territoryRepository->findAllList();
+        }
         /** @var Territory $territory */
         foreach ($territories as $territory) {
             $data[$territory->getId()] = $territory->getZip().' - '.$territory->getName();

--- a/src/Service/Statistics/StatusStatisticProvider.php
+++ b/src/Service/Statistics/StatusStatisticProvider.php
@@ -22,8 +22,12 @@ class StatusStatisticProvider
 
     public function getData(?Territory $territory, ?int $year): array
     {
+        $territories = [];
+        if ($territory) {
+            $territories[$territory->getId()] = $territory;
+        }
         $countPerStatuses = $this->signalementRepository->countByStatus(
-            territory: $territory,
+            territories: $territories,
             partners: null,
             year: $year,
             removeImported: true

--- a/src/Service/UserAvatar.php
+++ b/src/Service/UserAvatar.php
@@ -15,7 +15,7 @@ class UserAvatar implements RuntimeExtensionInterface
     ) {
     }
 
-    public function userAvatarOrPlaceholder(User $user, $size = 74): string
+    public function userAvatarOrPlaceholder(User $user, int $size = 74): string
     {
         $zipCode = ($user->getFirstTerritory()) ? substr($user->getFirstTerritory()->getZip(), 0, 2) : 'SA';
 

--- a/src/Service/UserAvatar.php
+++ b/src/Service/UserAvatar.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\Entity\User;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Twig\Extension\RuntimeExtensionInterface;
@@ -14,7 +15,7 @@ class UserAvatar implements RuntimeExtensionInterface
     ) {
     }
 
-    public function userAvatarOrPlaceholder($user, $size = 74): string
+    public function userAvatarOrPlaceholder(User $user, $size = 74): string
     {
         $zipCode = ($user->getFirstTerritory()) ? substr($user->getFirstTerritory()->getZip(), 0, 2) : 'SA';
 

--- a/templates/_partials/_search_filter_form.html.twig
+++ b/templates/_partials/_search_filter_form.html.twig
@@ -51,7 +51,7 @@
                                 Filtres
                             </h1>
                             <div class="fr-grid-row fr-grid-row--gutters fr-p-3v">
-                                {% if is_granted('ROLE_ADMIN') %}
+                                {% if is_granted('ROLE_ADMIN') or app.user.partnersTerritories|length > 1 %}
                                     <div class="fr-col-12 fr-col-md-6">
                                         <label class="fr-label" for="bo-filters-territories"><strong>Filtrer par territoire</strong></label>
                                         <select id="bo-filters-territories" class="fr-select select-search-filter-form">

--- a/templates/back/header_main_menu.html.twig
+++ b/templates/back/header_main_menu.html.twig
@@ -25,10 +25,14 @@
                             {% for child in item.getChildren %}
                                 {% if child.featureEnable and child.label is not empty and is_granted(child.roleGranted) and not is_granted(child.roleNotGranted) %}
                                     <li>
+                                        {% set ariaCurrent = (child.route == app.request.get('_route') or child.getBaseRoute() in app.request.get('_route')) ? 'page' : 'false' %}
+                                        {% if ariaCurrent == 'page' and child.route == 'back_partner_view' and app.request.get('_route_params') != child.routeParameters %}
+                                            {% set ariaCurrent = 'false' %}
+                                        {% endif %}
                                         <a class="fr-nav__link"
                                            href="{{ path(child.route, child.routeParameters) }}"
                                            target="_self"
-                                           aria-current="{{ child.route == app.request.get('_route') or child.getBaseRoute() in app.request.get('_route') ? 'page' : 'false' }}"
+                                           aria-current="{{ariaCurrent}}"
                                         >{{ child.label }}</a>
                                     </li>
                                 {% endif %}

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -34,7 +34,7 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserList(): iterable
     {
-        yield 'Search without params' => [[], 57];
+        yield 'Search without params' => [[], 58];
         yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 21];
         yield 'Search with territory 13' => [['territory' => 13], 11];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -202,6 +202,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Situation Prévis de départ' => [['situation' => 'preavis_de_depart', 'isImported' => 'oui'], 1];
         yield 'Search by Situation Attente de relogement' => [['situation' => 'attente_relogement', 'isImported' => 'oui'], 2];
         yield 'Search by Signalement Imported' => [['isImported' => 'oui'], 51];
+        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 7];
     }
 
     public function provideFilterSearchMultiTerritorAdminPartner(): \Generator
@@ -216,6 +217,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Status Fermé' => [['isImported' => 'oui', 'status' => 'ferme'], 2];
         yield 'Search by Status Fermé on Territory 1' => [['territoire' => '1', 'isImported' => 'oui', 'status' => 'ferme'], 1];
         yield 'Search by Status Fermé on Territory 13' => [['territoire' => '13', 'isImported' => 'oui', 'status' => 'ferme'], 1];
+        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 1];
     }
 
     /**

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -204,6 +204,20 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Signalement Imported' => [['isImported' => 'oui'], 51];
     }
 
+    public function provideFilterSearchMultiTerritorAdminPartner(): \Generator
+    {
+        yield 'Search All' => [['isImported' => 'oui'], 6];
+        yield 'Search by Commune' => [['communes' => ['gex', 'marseille'], 'isImported' => 'oui'], 6];
+        yield 'Search by Territory 1' => [['territoire' => '1', 'isImported' => 'oui'], 1];
+        yield 'Search by Territory 13' => [['territoire' => '13', 'isImported' => 'oui'], 5];
+        yield 'Search by Status En cours' => [['isImported' => 'oui', 'status' => 'en_cours'], 3];
+        yield 'Search by Status En cours on Territory 1' => [['territoire' => '1', 'isImported' => 'oui', 'status' => 'en_cours'], 0];
+        yield 'Search by Status En cours on Territory 13' => [['territoire' => '13', 'isImported' => 'oui', 'status' => 'en_cours'], 3];
+        yield 'Search by Status Fermé' => [['isImported' => 'oui', 'status' => 'ferme'], 2];
+        yield 'Search by Status Fermé on Territory 1' => [['territoire' => '1', 'isImported' => 'oui', 'status' => 'ferme'], 1];
+        yield 'Search by Status Fermé on Territory 13' => [['territoire' => '13', 'isImported' => 'oui', 'status' => 'ferme'], 1];
+    }
+
     /**
      * @dataProvider provideNewFilterSearch
      */
@@ -216,6 +230,27 @@ class SignalementListControllerTest extends WebTestCase
         /** @var UserRepository $userRepository */
         $userRepository = static::getContainer()->get(UserRepository::class);
         $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+        $route = $generatorUrl->generate('back_signalement_list_json');
+
+        $client->request('GET', $route, $filter, [], ['HTTP_Accept' => 'application/json']);
+        $result = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertEquals($results, $result['pagination']['total_items'], json_encode($result['list']));
+    }
+
+    /**
+     * @dataProvider provideFilterSearchMultiTerritorAdminPartner
+     */
+    public function testFilterSignalementsMultiTerritorAdminPartner(array $filter, int $results)
+    {
+        $client = static::createClient();
+        /** @var UrlGeneratorInterface $generatorUrl */
+        $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-partenaire-multi-ter-13-01@histologe.fr']);
         $client->loginUser($user);
         $route = $generatorUrl->generate('back_signalement_list_json');
 

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -13,6 +13,8 @@ class BackStatistiquesControllerTest extends WebTestCase
     private const USER_SUPER_ADMIN = 'admin-01@histologe.fr';
     private const USER_ADMIN_TERRITOIRE = 'admin-territoire-13-01@histologe.fr';
     private const USER_PARTNER = 'user-13-01@histologe.fr';
+    private const USER_ADMIN_PARTNER_MULTI_TERRITORIES = 'admin-partenaire-multi-ter-13-01@histologe.fr';
+    private const USER_USER_PARTNER_MULTI_TERRITORIES = 'user-partenaire-multi-ter-34-30@histologe.fr';
 
     public function provideRoutesHomepage(): \Generator
     {
@@ -64,6 +66,26 @@ class BackStatistiquesControllerTest extends WebTestCase
             ['result' => 88.4, 'label' => 'average_criticite'],
             ['result' => 0, 'label' => 'count_signalement_filtered'],
             ['result' => 0, 'label' => 'average_criticite_filtered'],
+        ]];
+        yield 'Admin partenaire multi territories' => ['back_statistiques_filter', [], self::USER_ADMIN_PARTNER_MULTI_TERRITORIES, [
+            ['result' => 5, 'label' => 'count_signalement'],
+            ['result' => 0, 'label' => 'count_signalement_refuses'],
+            ['result' => 0, 'label' => 'count_signalement_archives'],
+        ]];
+        yield 'Admin partenaire multi territories filtered on Ain' => ['back_statistiques_filter', ['territoire' => 1], self::USER_ADMIN_PARTNER_MULTI_TERRITORIES, [
+            ['result' => 1, 'label' => 'count_signalement'],
+            ['result' => 0, 'label' => 'count_signalement_refuses'],
+            ['result' => 0, 'label' => 'count_signalement_archives'],
+        ]];
+        yield 'User partenaire multi territories' => ['back_statistiques_filter', [], self::USER_USER_PARTNER_MULTI_TERRITORIES, [
+            ['result' => 2, 'label' => 'count_signalement'],
+            ['result' => 0, 'label' => 'count_signalement_refuses'],
+            ['result' => 0, 'label' => 'count_signalement_archives'],
+        ]];
+        yield 'User partenaire multi territories filtered on Ain' => ['back_statistiques_filter', ['territoire' => 35], self::USER_USER_PARTNER_MULTI_TERRITORIES, [
+            ['result' => 1, 'label' => 'count_signalement'],
+            ['result' => 0, 'label' => 'count_signalement_refuses'],
+            ['result' => 0, 'label' => 'count_signalement_archives'],
         ]];
     }
 

--- a/tests/Functional/Controller/CartographieControllerTest.php
+++ b/tests/Functional/Controller/CartographieControllerTest.php
@@ -13,6 +13,8 @@ class CartographieControllerTest extends WebTestCase
     private const SUPER_ADMIN = 'admin-01@histologe.fr';
     private const ADMIN_TERRITOIRE = 'admin-territoire-13-01@histologe.fr';
     private const PARTNER = 'user-13-01@histologe.fr';
+    private const ADMIN_PARTNER_MULTI_TERRITORIES = 'admin-partenaire-multi-ter-13-01@histologe.fr';
+    private const USER_PARTNER_MULTI_TERRITORIES = 'user-partenaire-multi-ter-34-30@histologe.fr';
 
     protected function setUp(): void
     {
@@ -134,5 +136,7 @@ class CartographieControllerTest extends WebTestCase
         yield 'Super Admin by visites' => [self::SUPER_ADMIN, 'bo-filters-visites', ['0']];
         yield 'Resp territoire by visites' => [self::ADMIN_TERRITOIRE, 'bo-filters-visites', ['0']];
         yield 'Partenaire by visites' => [self::PARTNER, 'bo-filters-visites', ['0']];
+        yield 'Admin partner multi territory by territory' => [self::ADMIN_PARTNER_MULTI_TERRITORIES, 'bo-filters-territories', ['1']];
+        yield 'User partner multi territory by territory' => [self::USER_PARTNER_MULTI_TERRITORIES, 'bo-filters-territories', ['31']];
     }
 }

--- a/tests/Functional/Controller/WidgetControllerTest.php
+++ b/tests/Functional/Controller/WidgetControllerTest.php
@@ -13,6 +13,7 @@ class WidgetControllerTest extends WebTestCase
     private const USER_SUPER_ADMIN = 'admin-01@histologe.fr';
     private const USER_ADMIN_TERRITOIRE = 'admin-territoire-13-01@histologe.fr';
     private const USER_PARTNER = 'user-13-01@histologe.fr';
+    private const USER_MULTI_TER_ADMIN_PARTNER = 'admin-partenaire-multi-ter-13-01@histologe.fr';
 
     public function testWidgetRouteDataKpi(): void
     {
@@ -39,6 +40,128 @@ class WidgetControllerTest extends WebTestCase
         $this->assertArrayHasKey('countSignalement', $response['data']);
         $this->assertArrayHasKey('countSuivi', $response['data']);
         $this->assertArrayHasKey('countUser', $response['data']);
+    }
+
+    public function testWidgetRouteDataKpiForMultiTerritoryAdminPartner(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_MULTI_TER_ADMIN_PARTNER]);
+        $client->loginUser($user);
+
+        /** @var Router $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $responses = [];
+        foreach ($user->getPartnersTerritories() as $territory) {
+            $client->request('GET', $router->generate(
+                'back_dashboard_widget', [
+                    'widgetType' => WidgetType::WIDGET_TYPE_DATA_KPI,
+                    'territory' => $territory->getId(),
+                ])
+            );
+            $response = json_decode($client->getResponse()->getContent(), true);
+            $this->assertEquals('data-kpi', $response['type']);
+            $this->assertCount(1, $response['territories']);
+
+            $responses[] = $response;
+        }
+        // cards
+        $totalCardTousLesSignalements = 0;
+        $totalCardNouvellesAffectations = 0;
+        $totalCardSignalementsNouveauxNonDecence = 0;
+        $totalCardSignalementsEnCoursNonDecence = 0;
+        $totalCardNouveauxSuivis = 0;
+        $totalCardSansSuivi = 0;
+        $totalCardNoSuiviAfter3Relances = 0;
+        // counts signalement
+        $totalClosedByAtLeastOnePartner = 0;
+        $totalClosedAllPartnersRecently = 0;
+        $totalNewNDE = 0;
+        $totalCurrentNDE = 0;
+        $totalAffected = 0;
+        $totalTotal = 0;
+        $totalNew = 0;
+        $totalActive = 0;
+        $totalClosed = 0;
+        $totalRefused = 0;
+        // counts suivi
+        $totalPartner = 0;
+        $totalUsager = 0;
+        $totalSignalementNewSuivi = 0;
+        $totalSignalementNoSuivi = 0;
+        $totalNoSuiviAfter3Relances = 0;
+        // counts user
+        $totalActiveUser = 0;
+        $totalInactiveUser = 0;
+        foreach ($responses as $territoryResponse) {
+            // cards
+            $totalCardTousLesSignalements += $territoryResponse['data']['widgetCards']['cardTousLesSignalements']['count'];
+            $totalCardNouvellesAffectations += $territoryResponse['data']['widgetCards']['cardNouvellesAffectations']['count'];
+            $totalCardSignalementsNouveauxNonDecence += $territoryResponse['data']['widgetCards']['cardSignalementsNouveauxNonDecence']['count'];
+            $totalCardSignalementsEnCoursNonDecence += $territoryResponse['data']['widgetCards']['cardSignalementsEnCoursNonDecence']['count'];
+            $totalCardNouveauxSuivis += $territoryResponse['data']['widgetCards']['cardNouveauxSuivis']['count'];
+            $totalCardSansSuivi += $territoryResponse['data']['widgetCards']['cardSansSuivi']['count'];
+            $totalCardNoSuiviAfter3Relances += $territoryResponse['data']['widgetCards']['cardNoSuiviAfter3Relances']['count'];
+            // counts signalement
+            $totalClosedByAtLeastOnePartner += $territoryResponse['data']['countSignalement']['closedByAtLeastOnePartner'];
+            $totalClosedAllPartnersRecently += $territoryResponse['data']['countSignalement']['closedAllPartnersRecently'];
+            $totalNewNDE += $territoryResponse['data']['countSignalement']['newNDE'];
+            $totalCurrentNDE += $territoryResponse['data']['countSignalement']['currentNDE'];
+            $totalAffected += $territoryResponse['data']['countSignalement']['affected'];
+            $totalTotal += $territoryResponse['data']['countSignalement']['total'];
+            $totalNew += $territoryResponse['data']['countSignalement']['new'];
+            $totalActive += $territoryResponse['data']['countSignalement']['active'];
+            $totalClosed += $territoryResponse['data']['countSignalement']['closed'];
+            $totalRefused += $territoryResponse['data']['countSignalement']['refused'];
+            // counts suivi
+            $totalPartner += $territoryResponse['data']['countSuivi']['partner'];
+            $totalUsager += $territoryResponse['data']['countSuivi']['usager'];
+            $totalSignalementNewSuivi += $territoryResponse['data']['countSuivi']['signalementNewSuivi'];
+            $totalSignalementNoSuivi += $territoryResponse['data']['countSuivi']['signalementNoSuivi'];
+            $totalNoSuiviAfter3Relances += $territoryResponse['data']['countSuivi']['noSuiviAfter3Relances'];
+            // counts user
+            $totalActiveUser += $territoryResponse['data']['countUser']['active'];
+            $totalInactiveUser += $territoryResponse['data']['countUser']['inactive'];
+        }
+
+        $client->request('GET', $router->generate(
+            'back_dashboard_widget', [
+                'widgetType' => WidgetType::WIDGET_TYPE_DATA_KPI,
+            ])
+        );
+        $responseAll = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals('data-kpi', $responseAll['type']);
+        $this->assertCount(2, $responseAll['territories']);
+
+        // cards
+        $this->assertEquals($totalCardTousLesSignalements, $responseAll['data']['widgetCards']['cardTousLesSignalements']['count']);
+        $this->assertEquals($totalCardNouvellesAffectations, $responseAll['data']['widgetCards']['cardNouvellesAffectations']['count']);
+        $this->assertEquals($totalCardSignalementsNouveauxNonDecence, $responseAll['data']['widgetCards']['cardSignalementsNouveauxNonDecence']['count']);
+        $this->assertEquals($totalCardSignalementsEnCoursNonDecence, $responseAll['data']['widgetCards']['cardSignalementsEnCoursNonDecence']['count']);
+        $this->assertEquals($totalCardNouveauxSuivis, $responseAll['data']['widgetCards']['cardNouveauxSuivis']['count']);
+        $this->assertEquals($totalCardSansSuivi, $responseAll['data']['widgetCards']['cardSansSuivi']['count']);
+        $this->assertEquals($totalCardNoSuiviAfter3Relances, $responseAll['data']['widgetCards']['cardNoSuiviAfter3Relances']['count']);
+        // counts signalement
+        $this->assertEquals($totalClosedByAtLeastOnePartner, $responseAll['data']['countSignalement']['closedByAtLeastOnePartner']);
+        $this->assertEquals($totalClosedAllPartnersRecently, $responseAll['data']['countSignalement']['closedAllPartnersRecently']);
+        $this->assertEquals($totalNewNDE, $responseAll['data']['countSignalement']['newNDE']);
+        $this->assertEquals($totalCurrentNDE, $responseAll['data']['countSignalement']['currentNDE']);
+        $this->assertEquals($totalAffected, $responseAll['data']['countSignalement']['affected']);
+        $this->assertEquals($totalTotal, $responseAll['data']['countSignalement']['total']);
+        $this->assertEquals($totalNew, $responseAll['data']['countSignalement']['new']);
+        $this->assertEquals($totalActive, $responseAll['data']['countSignalement']['active']);
+        $this->assertEquals($totalClosed, $responseAll['data']['countSignalement']['closed']);
+        $this->assertEquals($totalRefused, $responseAll['data']['countSignalement']['refused']);
+        // counts suivi
+        $this->assertEquals($totalPartner, $responseAll['data']['countSuivi']['partner']);
+        $this->assertEquals($totalUsager, $responseAll['data']['countSuivi']['usager']);
+        $this->assertEquals($totalSignalementNewSuivi, $responseAll['data']['countSuivi']['signalementNewSuivi']);
+        $this->assertEquals($totalSignalementNoSuivi, $responseAll['data']['countSuivi']['signalementNoSuivi']);
+        $this->assertEquals($totalNoSuiviAfter3Relances, $responseAll['data']['countSuivi']['noSuiviAfter3Relances']);
+        // counts user
+        $this->assertEquals($totalActiveUser, $responseAll['data']['countUser']['active']);
+        $this->assertEquals($totalInactiveUser, $responseAll['data']['countUser']['inactive']);
     }
 
     public function testWidgetRouteEsaboraEvenements(): void
@@ -76,6 +199,7 @@ class WidgetControllerTest extends WebTestCase
         /** @var UserRepository $userRepository */
         $userRepository = self::getContainer()->get(UserRepository::class);
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITOIRE]);
+        $firstTerritory = $user->getFirstTerritory();
         $client->loginUser($user);
 
         /** @var Router $router */
@@ -90,8 +214,8 @@ class WidgetControllerTest extends WebTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals('affectations-partenaires', $response['type']);
-        $this->assertEquals('13', $response['territory']['zip']);
-        $this->assertEquals('Bouches-du-Rhône', $response['territory']['name']);
+        $this->assertEquals('13', $response['territories'][$firstTerritory->getId()]['zip']);
+        $this->assertEquals('Bouches-du-Rhône', $response['territories'][$firstTerritory->getId()]['name']);
 
         foreach ($response['data'] as $data) {
             $this->assertArrayHasKey('waiting', $data);
@@ -137,6 +261,7 @@ class WidgetControllerTest extends WebTestCase
         /** @var UserRepository $userRepository */
         $userRepository = self::getContainer()->get(UserRepository::class);
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITOIRE]);
+        $firstTerritory = $user->getFirstTerritory();
         $client->loginUser($user);
 
         /** @var Router $router */
@@ -151,8 +276,8 @@ class WidgetControllerTest extends WebTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals('signalements-acceptes-sans-suivi', $response['type']);
-        $this->assertEquals('13', $response['territory']['zip']);
-        $this->assertEquals('Bouches-du-Rhône', $response['territory']['name']);
+        $this->assertEquals('13', $response['territories'][$firstTerritory->getId()]['zip']);
+        $this->assertEquals('Bouches-du-Rhône', $response['territories'][$firstTerritory->getId()]['name']);
 
         foreach ($response['data'] as $data) {
             $this->assertArrayHasKey('count_no_suivi', $data);

--- a/tests/Functional/Repository/JobEventRepositoryTest.php
+++ b/tests/Functional/Repository/JobEventRepositoryTest.php
@@ -39,7 +39,7 @@ class JobEventRepositoryTest extends KernelTestCase
         $jobEvents = $jobEventRepository->findLastJobEventByInterfacageType(
             'esabora',
             7,
-            null
+            []
         );
 
         $this->assertCount(8, $jobEvents);

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -92,7 +92,7 @@ class PartnerRepositoryTest extends KernelTestCase
         $signalement = $signalementRepository->findOneBy(['reference' => '2024-08']);
 
         $partners = $this->partnerRepository->findByLocalization($signalement, false);
-        $this->assertCount(5, $partners);
+        $this->assertCount(4, $partners);
 
         $partnerZone = array_filter($partners, function ($partner) {
             return 'Partenaire Zone Agde' === $partner['name'];

--- a/tests/Functional/Repository/SuiviRepositoryTest.php
+++ b/tests/Functional/Repository/SuiviRepositoryTest.php
@@ -46,7 +46,7 @@ class SuiviRepositoryTest extends KernelTestCase
 
     public function testCountSignalementNoSuiviAfter3Relances(): void
     {
-        $result = $this->suiviRepository->countSignalementNoSuiviAfter3Relances();
+        $result = $this->suiviRepository->countSignalementNoSuiviAfter3Relances([]);
         $this->assertEquals(0, $result);
     }
 }

--- a/tests/Unit/Manager/WidgetDataManagerTest.php
+++ b/tests/Unit/Manager/WidgetDataManagerTest.php
@@ -6,7 +6,6 @@ use App\Dto\CountSignalement;
 use App\Dto\CountSuivi;
 use App\Dto\CountUser;
 use App\Entity\Enum\InterfacageType;
-use App\Entity\Territory;
 use App\Repository\AffectationRepository;
 use App\Repository\JobEventRepository;
 use App\Repository\SignalementRepository;
@@ -39,13 +38,13 @@ class WidgetDataManagerTest extends TestCase
 
     public function testCountSignalementAcceptedNoSuivi()
     {
-        $territory = new Territory();
+        $territories = [];
         $this->signalementRepositoryMock
             ->expects($this->once())
             ->method('countSignalementAcceptedNoSuivi')
-            ->with($territory)
+            ->with($territories)
             ->willReturn([]);
-        $this->assertEquals([], $this->widgetDataManager->countSignalementAcceptedNoSuivi($territory));
+        $this->assertEquals([], $this->widgetDataManager->countSignalementAcceptedNoSuivi($territories));
     }
 
     public function testGetCountSignalementsByTerritory()
@@ -65,11 +64,11 @@ class WidgetDataManagerTest extends TestCase
 
     public function testCountAffectationPartner()
     {
-        $territory = new Territory();
+        $territories = [];
         $this->affectationRepositoryMock
             ->expects($this->once())
             ->method('countAffectationPartner')
-            ->with($territory)
+            ->with($territories)
             ->willReturn([
                 ['waiting' => 1, 'refused' => 2],
                 ['waiting' => 3, 'refused' => 4],
@@ -77,7 +76,7 @@ class WidgetDataManagerTest extends TestCase
         $this->assertEquals([
             ['waiting' => 1, 'refused' => 2],
             ['waiting' => 3, 'refused' => 4],
-        ], $this->widgetDataManager->countAffectationPartner($territory));
+        ], $this->widgetDataManager->countAffectationPartner($territories));
     }
 
     public function testFindLastJobEventByType()
@@ -90,13 +89,14 @@ class WidgetDataManagerTest extends TestCase
 
         $this->assertEquals([], $this->widgetDataManager->findLastJobEventByInterfacageType(
             InterfacageType::ESABORA->value,
-            ['period' => 5])
+            ['period' => 5],
+            [])
         );
     }
 
     public function testCountDataKpi()
     {
-        $countDataKpi = $this->widgetDataManager->countDataKpi();
+        $countDataKpi = $this->widgetDataManager->countDataKpi([]);
         $this->assertInstanceOf(CountSignalement::class, $countDataKpi->getCountSignalement());
         $this->assertInstanceOf(CountSuivi::class, $countDataKpi->getCountSuivi());
         $this->assertInstanceOf(CountUser::class, $countDataKpi->getCountUser());

--- a/tests/Unit/Service/DashboardWidget/WidgetTest.php
+++ b/tests/Unit/Service/DashboardWidget/WidgetTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Tests\Unit\Service\DashboardWidget;
 
-use App\Entity\Territory;
 use App\Service\DashboardWidget\Widget;
 use App\Service\DashboardWidget\WidgetType;
 use Monolog\Test\TestCase;
@@ -13,11 +12,11 @@ class WidgetTest extends TestCase
     {
         $widget = (new Widget())
             ->setData(['content' => 'Hello world'])
-            ->setTerritory((new Territory())->setName('Ain')->setZip('01'))
+            ->setTerritories([])
             ->setParameters(['page' => 10])
             ->setType(WidgetType::WIDGET_TYPE_SIGNALEMENT_ACCEPTED_NO_SUIVI);
 
-        $this->assertEquals('01', $widget->getTerritory()->getZip());
+        $this->assertEquals([], $widget->getTerritories());
         $this->assertEquals('signalements-acceptes-sans-suivi', $widget->getType());
         $this->assertArrayHasKey('page', $widget->getParameters());
         $this->assertArrayHasKey('content', $widget->getData());


### PR DESCRIPTION
## Ticket

#3483

## Description
Finalisation de la mis en place du fonctionnement multi-territoires pour les pages 
- Dasboard avec sélecteur de territoire pour les utilisateurs multi
- Liste de signalements avec sélecteur de territoire pour les utilisateurs multi
- Carto avec sélecteur de territoire pour les utilisateurs multi
- Stats avec sélecteur de territoire pour les utilisateurs multi

Étant donnée qu'aujourd'hui on ne peux pas affecter plusieurs partenaires à un utilisateur les controles
- Pas de multi territoire pour les RT
- Pas de partenaires multiples sur le mêmes territoires
Seront intégrés dans le ticket UI/UX restant (#3308)

## Pré-requis
`make load-fixtures`
`make clear-pool pool=--all`
`make npm-build`

## Tests
Les utilisateur de tests multi-territoirs sont les suivants : 
`admin-partenaire-multi-ter-13-01@histologe.fr`
`user-partenaire-multi-ter-34-30@histologe.fr`

- [ ] Tester le dashboard avec des utilisateurs ayant les différents rôles et les utilisateurs multi-territoires 
- [ ] Tester la liste de signalement avec des utilisateurs ayant les différents rôles et les utilisateurs multi-territoires 
- [ ] Tester la cartographie avec des utilisateurs ayant les différents rôles et les utilisateurs multi-territoires 
- [ ] Tester les stats avec des utilisateurs ayant les différents rôles et les utilisateurs multi-territoires 
