### PR TITLE
[QA] Commande maj géolocalisation - limiter la plage de date à 1 mois

### DIFF
--- a/src/Command/RetryFailedEmailsCommand.php
+++ b/src/Command/RetryFailedEmailsCommand.php
@@ -22,9 +22,9 @@ use Symfony\Component\Mime\Address;
 class RetryFailedEmailsCommand extends Command
 {
     public function __construct(
-        private EntityManagerInterface $entityManager,
-        private FailedEmailRepository $failedEmailRepository,
-        private MailerInterface $mailer,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly FailedEmailRepository $failedEmailRepository,
+        private readonly MailerInterface $mailer,
     ) {
         parent::__construct();
     }
@@ -51,7 +51,9 @@ class RetryFailedEmailsCommand extends Command
             ;
 
             foreach ($failedEmail->getToEmail() as $toEmail) {
-                $toEmail && $emailMessage->addTo($toEmail);
+                if ('NC' !== $toEmail) {
+                    $toEmail && $emailMessage->addTo($toEmail);
+                }
             }
             if (
                 \array_key_exists('tagHeader', $failedEmail->getContext())

--- a/src/Command/UpdateSignalementGeolocalisationCommand.php
+++ b/src/Command/UpdateSignalementGeolocalisationCommand.php
@@ -95,7 +95,7 @@ class UpdateSignalementGeolocalisationCommand extends Command
         $this->entityManager->flush();
         $progressBar->finish();
         $io->newLine();
-        $io->success(sprintf("%s signalements updated", $i));
+        $io->success(sprintf('%s signalements updated', $i));
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
## Ticket

#3496   
#3495 

## Description
Gérer la contrainte mémoire scalingo, limiter la plage de date à 1 mois 
Ne pas faire d'envoi sur les email "NC"

## Changements apportés
* Ajout d'1 mois à partir de la date de début au lieu de la date du jour 
* Ajout d'une condition pour ne pas envoyer aux mails "NC"

## Pré-requis
make load-data

## Tests
- [ ] Exécuter la commande ` make console app="update-signalement-geolocalisation --from_created_at=2024-02-01"`
- [ ] Exécuter la commande `make console app="retry-failed-emails"` et vérifier qu'il n'y ai pas d'erreur critique. 
