### PR TITLE
[QA - Sentry] Dépréciations et contrôle du numéro allocataire

### DIFF
--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -25,7 +25,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 #[Route('/bo/signalements')]
 class SignalementEditController extends AbstractController
 {
-    private const ERROR_MSG = 'Une erreur s\'est produite. Veuillez actualiser la page.';
+    private const string ERROR_MSG = 'Une erreur s\'est produite. Veuillez actualiser la page.';
 
     #[Route('/{uuid:signalement}/edit-address', name: 'back_signalement_edit_address', methods: 'POST')]
     public function editAddress(

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -370,7 +370,7 @@ class SignalementDraftRequest
     private ?string $logementSocialDateNaissance = null;
     #[Assert\Length(max: 20, maxMessage: 'Le montant de l\'allocation ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $logementSocialMontantAllocation = null;
-    #[Assert\Length(max: 50, maxMessage: 'Le numéro d\'allocataire ne doit pas dépasser {{ limit }} caractères.')]
+    #[Assert\Length(max: 25, maxMessage: 'Le numéro d\'allocataire ne doit pas dépasser {{ limit }} caractères.')]
     private ?string $logementSocialNumeroAllocataire = null;
     #[Assert\Choice(
         choices: ['oui', 'non', 'nsp'],

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -4,14 +4,14 @@ namespace App\Dto\Request\Signalement;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-class SituationFoyerRequest implements RequestInterface
+readonly class SituationFoyerRequest implements RequestInterface
 {
     public function __construct(
         #[Assert\Choice(
             choices: ['oui', 'non', 'nsp'],
             message: 'Le champ "Logement social" est incorrect.',
         )]
-        private readonly ?string $isLogementSocial = null,
+        private ?string $isLogementSocial = null,
         #[Assert\NotBlank(
             message: 'Veuillez préciser si une demande de relogement a été faite.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT']
@@ -20,7 +20,7 @@ class SituationFoyerRequest implements RequestInterface
             choices: ['oui', 'non'],
             message: 'Le champ "Relogement" est incorrect.',
         )]
-        private readonly ?string $isRelogement = null,
+        private ?string $isRelogement = null,
         #[Assert\NotBlank(
             message: 'Veuillez préciser si l\'occupant est allocataire.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO']
@@ -29,7 +29,7 @@ class SituationFoyerRequest implements RequestInterface
             choices: ['oui', 'non', 'CAF', 'MSA'],
             message: 'Le champ "Allocataire" est incorrect.',
         )]
-        private readonly ?string $isAllocataire = null,
+        private ?string $isAllocataire = null,
         #[Assert\DateTime('Y-m-d')]
         #[Assert\When(
             expression: 'this.getIsAllocataire() == "oui" || this.getIsAllocataire() == "CAF" || this.getIsAllocataire() == "MSA"',
@@ -37,11 +37,11 @@ class SituationFoyerRequest implements RequestInterface
                 new Assert\NotBlank(message: 'Merci de préciser la date de naissance.'),
             ],
         )]
-        private readonly ?string $dateNaissanceOccupant = null,
-        #[Assert\Length(max: 50, maxMessage: 'Le numéro d\'allocataire ne doit pas dépasser {{ limit }} caractères.')]
-        private readonly ?string $numAllocataire = null,
+        private ?string $dateNaissanceOccupant = null,
+        #[Assert\Length(max: 25, maxMessage: 'Le numéro d\'allocataire ne doit pas dépasser {{ limit }} caractères.')]
+        private ?string $numAllocataire = null,
         #[Assert\Length(max: 20, maxMessage: 'Le montant de l\'allocation ne doit pas dépasser {{ limit }} caractères.')]
-        private readonly ?string $logementSocialMontantAllocation = null,
+        private ?string $logementSocialMontantAllocation = null,
         #[Assert\NotBlank(message: 'Veuillez définir le champ souhaite quitter le logement.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
         )]
@@ -49,7 +49,7 @@ class SituationFoyerRequest implements RequestInterface
             choices: ['oui', 'non', 'nsp'],
             message: 'Le champ "Souhaite quitter le logement" est incorrect.',
         )]
-        private readonly ?string $travailleurSocialQuitteLogement = null,
+        private ?string $travailleurSocialQuitteLogement = null,
         #[Assert\When(
             expression: 'this.getTravailleurSocialQuitteLogement() == "oui"',
             constraints: [
@@ -60,7 +60,7 @@ class SituationFoyerRequest implements RequestInterface
             choices: ['oui', 'non', 'nsp'],
             message: 'Le champ "Préavis de départ" est incorrect.',
         )]
-        private readonly ?string $travailleurSocialPreavisDepart = null,
+        private ?string $travailleurSocialPreavisDepart = null,
         #[Assert\NotBlank(
             message: 'Veuillez préciser si l\'occupant est accompagné par un travailleur social.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'TIERS_PARTICULIER', 'TIERS_PRO']
@@ -69,21 +69,21 @@ class SituationFoyerRequest implements RequestInterface
             choices: ['oui', 'non', 'nsp'],
             message: 'Le champ "Accompagnement par un travailleur social" est incorrect.',
         )]
-        private readonly ?string $travailleurSocialAccompagnement = null,
+        private ?string $travailleurSocialAccompagnement = null,
         #[Assert\Length(max: 50)]
-        private readonly ?string $travailleurSocialAccompagnementDeclarant = null,
+        private ?string $travailleurSocialAccompagnementDeclarant = null,
         #[Assert\Choice(
             choices: ['oui', 'non'],
             message: 'Le champ "Bénéficiaire du RSA" est incorrect.',
         )]
-        private readonly ?string $beneficiaireRsa = null,
+        private ?string $beneficiaireRsa = null,
         #[Assert\Choice(
             choices: ['oui', 'non'],
             message: 'Le champ "Bénéficiaire du FSL" est incorrect.',
         )]
-        private readonly ?string $beneficiaireFsl = null,
+        private ?string $beneficiaireFsl = null,
         #[Assert\Length(max: 50)]
-        private readonly ?string $revenuFiscal = null,
+        private ?string $revenuFiscal = null,
     ) {
     }
 

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -166,7 +166,7 @@ class SignalementBuilder
             $this->signalement->setJsonContent($jsonContent);
         }
 
-        if (!empty($this->signalementDraftRequest->getZoneConcerneeConstatationDesordres())) {
+        if (!empty($this->signalementDraftRequest->getZoneConcerneeDebutDesordres())) {
             $this->signalement->setDebutDesordres(
                 DebutDesordres::tryFrom(strtoupper($this->signalementDraftRequest->getZoneConcerneeDebutDesordres()))
             );

--- a/src/Specification/Affectation/AllocataireSpecification.php
+++ b/src/Specification/Affectation/AllocataireSpecification.php
@@ -7,7 +7,7 @@ use App\Specification\Context\PartnerSignalementContext;
 use App\Specification\Context\SpecificationContextInterface;
 use App\Specification\SpecificationInterface;
 
-class AllocataireSpecification implements SpecificationInterface
+readonly class AllocataireSpecification implements SpecificationInterface
 {
     public function __construct(
         private string $ruleAllocataire,
@@ -23,7 +23,7 @@ class AllocataireSpecification implements SpecificationInterface
         /** @var Signalement $signalement */
         $signalement = $context->getSignalement();
 
-        $isAllocataire = strtolower($signalement->getIsAllocataire());
+        $isAllocataire = null === $signalement->getIsAllocataire() ? null : strtolower($signalement->getIsAllocataire());
         switch ($this->ruleAllocataire) {
             case 'all':
                 return true;

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -65,7 +65,7 @@
 
                             <div class="fr-input-group">
                                 <label class="fr-label" for="situationFoyerNumAllocataire">N° allocataire (facultatif)</label>
-                                <input class="fr-input" type="text" id="situationFoyerNumAllocataire" name="numAllocataire" value="{{ signalement.numAllocataire }}">
+                                <input class="fr-input" type="text" id="situationFoyerNumAllocataire" name="numAllocataire" value="{{ signalement.numAllocataire }}" maxlength="25">
                             </div>
 
                             <div class="fr-input-group">


### PR DESCRIPTION
## Ticket

#3486    

## Description
Description de la modification apportée

## Changements apportés
* Ajout de contrôle avant l'usage de `strtoupper` et `strtolower`
* Mise à jour de la contrainte de validation pour le numéro d'allocataire (longueur = 25 comme sur la table Signalement)

## Pré-requis

## Tests
- [ ] Dans la modale d'édition Foyer > Situation du foyer et vérifier qu'il n'est pas possible de saisir un numéro d'allocataire supérieur à 25 caractère
