### PR TITLE
[BUG - BO Zone] retirer le required sur le filtre de recherche "type de zone"

### DIFF
--- a/src/Form/SearchZoneType.php
+++ b/src/Form/SearchZoneType.php
@@ -45,6 +45,7 @@ class SearchZoneType extends AbstractType
             'choice_label' => function ($choice) {
                 return $choice->label();
             },
+            'required' => false,
             'placeholder' => 'Sélectionner le type de zone',
             'label' => false,
         ]);


### PR DESCRIPTION
## Ticket

#3487

## Description
Suppression de l'attribut required du champ "Type de zone" dans les filtre de recherche de la page liste des zones

## Tests
- [ ] Se rendre sur http://localhost:8080/bo/zone/ et lancer une recherche sur le nom d'une zone et s'assurer que la soumission n'est pas blouqé
