### PR TITLE
[BUG - BO] bouton "rouvrir pour xx"

### DIFF
--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -178,6 +178,10 @@ class SignalementActionController extends AbstractController
             if ($this->isGranted('ROLE_ADMIN_TERRITORY') && isset($response['reopenAll'])) {
                 $affectationRepository->updateStatusBySignalement(Affectation::STATUS_WAIT, $signalement);
                 $reopenFor = 'tous les partenaires';
+            } elseif (!$this->isGranted('ROLE_ADMIN_TERRITORY') && Signalement::STATUS_CLOSED === $signalement->getStatut()) {
+                $this->addFlash('error', 'Seul un administrateur peut réouvrir un signalement clôturé !');
+
+                return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
             } else {
                 $partner = $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory());
                 $reopenFor = mb_strtoupper($partner->getNom());

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -179,7 +179,7 @@ class SignalementActionController extends AbstractController
                 $affectationRepository->updateStatusBySignalement(Affectation::STATUS_WAIT, $signalement);
                 $reopenFor = 'tous les partenaires';
             } elseif (!$this->isGranted('ROLE_ADMIN_TERRITORY') && Signalement::STATUS_CLOSED === $signalement->getStatut()) {
-                $this->addFlash('error', 'Seul un administrateur peut réouvrir un signalement clôturé !');
+                $this->addFlash('error', 'Seul un responsable de territoire peut réouvrir un signalement clôturé !');
 
                 return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
             } else {

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -31,7 +31,7 @@
             {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
         {% endif %}
         
-        {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') %}
+        {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') or isClosedForMe %}
             {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
         {% endif %}
     {% endif %}

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -31,7 +31,7 @@
             {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
         {% endif %}
         
-        {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or is_granted('ROLE_ADMIN_TERRITORY') or isClosedForMe %}
+        {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') and isClosedForMe %}
             {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
         {% endif %}
     {% endif %}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -225,7 +225,7 @@
                             </button>
                         {% endif %}
                     {% endif %}
-                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or (is_granted('ROLE_ADMIN_TERRITORY') or isAffected) %}
+                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or (is_granted('ROLE_ADMIN_TERRITORY') or isClosedForMe) %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                                 aria-controls="reopen-signalement-modal" data-fr-opened="false">
                             Rouvrir pour {{ app.user.partnerInTerritoryOrFirstOne(signalement.territory) ? app.user.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A' }}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -225,7 +225,7 @@
                             </button>
                         {% endif %}
                     {% endif %}
-                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or (is_granted('ROLE_ADMIN_TERRITORY') or isClosedForMe) %}
+                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') and isClosedForMe %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                                 aria-controls="reopen-signalement-modal" data-fr-opened="false">
                             Rouvrir pour {{ app.user.partnerInTerritoryOrFirstOne(signalement.territory) ? app.user.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A' }}


### PR DESCRIPTION
## Ticket

#3413

## Description
Mise en cohérence de l'embarquement de la modale de réouverture d'un signalement pour le partenaire avec les régles d'affichage du bouton "Rouvrir pour xx" afin que le bouton ne puisse pas apparaître sans que la modale soit embarquée.  

## Pré-requis
- `make load-fixtures`
- Se connecter en super admin et "clôturer pour tous" le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000015
- Se connecter avec user-13-05@histologe.fr et se rendre sur le même signalement

## Tests
- [ ] Vérifier que l'user n'a pas de bouton "Rouvrir pour Partenaire 13-05 ESABORA SCHS"
- [ ] S'assurer que la correction ne peux pas avoir d'effet de bord
