### PR TITLE
[BUG - Liste des signalement] Signalements importés non affichés par défaut

### DIFF
--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -174,7 +174,7 @@ class WidgetDataKpiBuilder
         return $this;
     }
 
-    private function canAddCard($key): bool
+    private function canAddCard(string $key): bool
     {
         $roles = $this->user->getRoles();
         $role = array_shift($roles);

--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -163,6 +163,7 @@ class WidgetDataKpiBuilder
             $link = $widgetParams['link'] ?? null;
             $label = $widgetParams['label'] ?? null;
             $widgetParams['params']['territoire_id'] = $this->territory?->getId();
+            $widgetParams['params']['isImported'] = 'oui';
             $parameters = array_merge($linkParameters, $widgetParams['params'] ?? []);
             $widgetCard = $this->widgetCardFactory->createInstance($label, $count, $link, $parameters);
             if (!$this->hasWidgetCard($key)) {
@@ -173,7 +174,7 @@ class WidgetDataKpiBuilder
         return $this;
     }
 
-    private function canAddCard($key)
+    private function canAddCard($key): bool
     {
         $roles = $this->user->getRoles();
         $role = array_shift($roles);


### PR DESCRIPTION
## Ticket

#3493    

## Description
Ajouter le paramètre isImported à toutes les cartes du widget par défaut

## Changements apportés
* Mise à jour coté service

## Pré-requis

## Tests
- [ ] Cliquer sur les widget du dashboard et vérifier que `isImported` est présent dans l'url
