### PR TITLE
[BO - Partenaire] Correction liste des bailleurs sociaux quand territoire null 

### DIFF
--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -189,14 +189,12 @@ class PartnerType extends AbstractType
         if (null === $territoryZip) {
             if ($data instanceof Partner && null !== $data->getTerritory()) {
                 $territoryZip = $data->getTerritory()->getZip();
+            } elseif ($this->isAdmin) {
+                $territoryZip = '01';
             } else {
-                if ($this->isAdmin) {
-                    $territoryZip = '01';
-                } elseif ($this->isAdminTerritory) {
-                    /** @var User $user */
-                    $user = $this->security->getUser();
-                    $territoryZip = $user->getFirstTerritory()->getZip();
-                }
+                /** @var User $user */
+                $user = $this->security->getUser();
+                $territoryZip = $user->getFirstTerritory()->getZip();
             }
         }
         $builder->add('bailleur', EntityType::class, [

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -37,14 +37,16 @@ class BailleurRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery()->getResult();
     }
 
-    public function getBailleursByTerritoryQueryBuilder(string $zip): QueryBuilder
+    public function getBailleursByTerritoryQueryBuilder(?string $zip): QueryBuilder
     {
         $queryBuilder = $this
             ->createQueryBuilder('b');
-        $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
-        ->innerJoin('bt.territory', 't')
-        ->where('t.zip = :zip')
-        ->setParameter('zip', $zip);
+        if (null !== $zip) {
+            $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
+                ->innerJoin('bt.territory', 't')
+                ->where('t.zip = :zip')
+                ->setParameter('zip', $zip);
+        }
         $queryBuilder->orderBy('b.name', 'ASC');
 
         return $queryBuilder;

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -24,20 +24,27 @@ class BailleurRepository extends ServiceEntityRepository
 
     public function findBailleursByTerritory(?string $zip = null): array
     {
-        $queryBuilder = $this->getBailleursByTerritoryQueryBuilder($zip);
+        $queryBuilder = $this
+            ->createQueryBuilder('b');
+        if (null !== $zip) {
+            $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
+            ->innerJoin('bt.territory', 't')
+            ->where('t.zip = :zip')
+            ->setParameter('zip', $zip);
+        }
+        $queryBuilder->orderBy('b.name', 'ASC');
 
         return $queryBuilder->getQuery()->getResult();
     }
 
-    public function getBailleursByTerritoryQueryBuilder(?string $zip): QueryBuilder
+    public function getBailleursByTerritoryQueryBuilder(string $zip): QueryBuilder
     {
-        $queryBuilder = $this->createQueryBuilder('b');
-        if (null !== $zip) {
-            $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
-                ->innerJoin('bt.territory', 't')
-                ->where('t.zip = :zip')
-                ->setParameter('zip', $zip);
-        }
+        $queryBuilder = $this
+            ->createQueryBuilder('b');
+        $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
+        ->innerJoin('bt.territory', 't')
+        ->where('t.zip = :zip')
+        ->setParameter('zip', $zip);
         $queryBuilder->orderBy('b.name', 'ASC');
 
         return $queryBuilder;

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -24,27 +24,20 @@ class BailleurRepository extends ServiceEntityRepository
 
     public function findBailleursByTerritory(?string $zip = null): array
     {
-        $queryBuilder = $this
-            ->createQueryBuilder('b');
-        if (null !== $zip) {
-            $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
-            ->innerJoin('bt.territory', 't')
-            ->where('t.zip = :zip')
-            ->setParameter('zip', $zip);
-        }
-        $queryBuilder->orderBy('b.name', 'ASC');
+        $queryBuilder = $this->getBailleursByTerritoryQueryBuilder($zip);
 
         return $queryBuilder->getQuery()->getResult();
     }
 
-    public function getBailleursByTerritoryQueryBuilder(string $zip): QueryBuilder
+    public function getBailleursByTerritoryQueryBuilder(?string $zip): QueryBuilder
     {
-        $queryBuilder = $this
-            ->createQueryBuilder('b');
-        $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
-        ->innerJoin('bt.territory', 't')
-        ->where('t.zip = :zip')
-        ->setParameter('zip', $zip);
+        $queryBuilder = $this->createQueryBuilder('b');
+        if (null !== $zip) {
+            $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
+                ->innerJoin('bt.territory', 't')
+                ->where('t.zip = :zip')
+                ->setParameter('zip', $zip);
+        }
         $queryBuilder->orderBy('b.name', 'ASC');
 
         return $queryBuilder;

--- a/src/Repository/BailleurRepository.php
+++ b/src/Repository/BailleurRepository.php
@@ -37,16 +37,14 @@ class BailleurRepository extends ServiceEntityRepository
         return $queryBuilder->getQuery()->getResult();
     }
 
-    public function getBailleursByTerritoryQueryBuilder(?string $zip): QueryBuilder
+    public function getBailleursByTerritoryQueryBuilder(string $zip): QueryBuilder
     {
         $queryBuilder = $this
             ->createQueryBuilder('b');
-        if (null !== $zip) {
-            $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
-                ->innerJoin('bt.territory', 't')
-                ->where('t.zip = :zip')
-                ->setParameter('zip', $zip);
-        }
+        $queryBuilder->innerJoin('b.bailleurTerritories', 'bt')
+        ->innerJoin('bt.territory', 't')
+        ->where('t.zip = :zip')
+        ->setParameter('zip', $zip);
         $queryBuilder->orderBy('b.name', 'ASC');
 
         return $queryBuilder;


### PR DESCRIPTION
## Ticket

#3504    

## Description
Dans le formulaire d'édition de partenaire, si le territoire est null, on a une erreur sur la recherche des bailleurs sociaux.

## Tests
- [ ] Vérifier que l'édition se fait correctement sur un partenaire bailleur social dont le territoire est null
