### PR TITLE
[BO - Date d'entrée] Correction du type de champ pour la date d'entrée du logement dans le formulaire NDE

### DIFF
--- a/assets/scripts/vanilla/controllers/form_nde.js
+++ b/assets/scripts/vanilla/controllers/form_nde.js
@@ -3,9 +3,7 @@ const formBtn = document.querySelector('#signalement-edit-nde-form-submit')
 formBtn?.addEventListener('click', evt => {
   // Check fields
   let postForm = true
-  if (!document.querySelector('#signalement-edit-nde-date-entree-before').checked &&
-        !document.querySelector('#signalement-edit-nde-date-entree-after').checked
-  ) {
+  if (!document.querySelector('#signalement-edit-nde-date-entree')) {
     document.querySelector('#signalement-edit-nde-date-entree-error').classList.remove('fr-hidden')
     postForm = false
   } else {
@@ -57,7 +55,7 @@ formBtn?.addEventListener('click', evt => {
 
     const data = {
       _token: document.getElementById('signalement-edit-nde-token').value,
-      dateEntree: document.querySelector('input[name=dateEntree]:checked')?.value,
+      dateEntree: document.querySelector('input[name=dateEntree]')?.value,
       dpe: stringToBoolean(document.querySelector('input[name=dpe]:checked')?.value),
       dateDernierBail: document.querySelector('input[name=dateDernierBail]:checked')?.value,
       dateDernierDPE: document.querySelector('input[name=dateDernierDPE]:checked')?.value,

--- a/migrations/Version20250102154204.php
+++ b/migrations/Version20250102154204.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Dto\Request\Signalement\QualificationNDERequest;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250102154204 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'rollback fake signalement date_entree if another real date has been entered';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE `signalement`
+                        SET `date_entree` = JSON_EXTRACT(type_composition_logement, \'$.bail_dpe_date_emmenagement\')
+                        WHERE
+                            (`date_entree` = :dateEntreeBefore2023 OR `date_entree` = :dateEntreeAfter2023)
+                            AND JSON_EXTRACT(type_composition_logement, \'$.bail_dpe_date_emmenagement\') IS NOT NULL', [
+            'dateEntreeBefore2023' => QualificationNDERequest::RADIO_VALUE_BEFORE_2023,
+            'dateEntreeAfter2023' => QualificationNDERequest::RADIO_VALUE_AFTER_2023,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20250102154204.php
+++ b/migrations/Version20250102154204.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use App\Dto\Request\Signalement\QualificationNDERequest;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -17,14 +16,8 @@ final class Version20250102154204 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('UPDATE `signalement`
-                        SET `date_entree` = JSON_EXTRACT(type_composition_logement, \'$.bail_dpe_date_emmenagement\')
-                        WHERE
-                            (`date_entree` = :dateEntreeBefore2023 OR `date_entree` = :dateEntreeAfter2023)
-                            AND JSON_EXTRACT(type_composition_logement, \'$.bail_dpe_date_emmenagement\') IS NOT NULL', [
-            'dateEntreeBefore2023' => QualificationNDERequest::RADIO_VALUE_BEFORE_2023,
-            'dateEntreeAfter2023' => QualificationNDERequest::RADIO_VALUE_AFTER_2023,
-        ]);
+        $this->addSql('UPDATE `signalement` SET `date_entree` = \'2012-03-06\' WHERE id = 49266');
+        $this->addSql('UPDATE `signalement` SET `date_entree` = \'2024-08-12\' WHERE id = 68601');
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250102154204.php
+++ b/migrations/Version20250102154204.php
@@ -16,6 +16,10 @@ final class Version20250102154204 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->skipIf(
+            'prod' !== getenv('APP_ENV'),
+            'Cette migration ne s’exécute qu’en environnement de production.'
+        );
         $this->addSql('UPDATE `signalement` SET `date_entree` = \'2012-03-06\' WHERE id = 49266');
         $this->addSql('UPDATE `signalement` SET `date_entree` = \'2024-08-12\' WHERE id = 68601');
     }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -319,6 +319,25 @@ class SignalementManager extends AbstractManager
 
         $signalementQualification->setDetails($qualificationNDERequest->getDetails());
 
+        $typeCompositionLogement = new TypeCompositionLogement();
+        if (!empty($signalement->getTypeCompositionLogement())) {
+            $typeCompositionLogement = clone $signalement->getTypeCompositionLogement();
+        }
+        if (!empty($qualificationNDERequest->getDetails()['DPE'])) {
+            switch ($qualificationNDERequest->getDetails()['DPE']) {
+                case true:
+                    $typeCompositionLogement->setBailDpeDpe('oui');
+                    break;
+                case false:
+                    $typeCompositionLogement->setBailDpeDpe('non');
+                    break;
+                default:
+                    $typeCompositionLogement->setBailDpeDpe('nsp');
+                    break;
+            }
+        }
+        $signalement->setTypeCompositionLogement($typeCompositionLogement);
+
         $this->save($signalementQualification);
 
         $signalementQualification->setStatus(

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -330,18 +330,16 @@ class SignalementManager extends AbstractManager
         if (!empty($signalement->getTypeCompositionLogement())) {
             $typeCompositionLogement = clone $signalement->getTypeCompositionLogement();
         }
-        if (!empty($qualificationNDERequest->getDetails()['DPE'])) {
-            switch ($qualificationNDERequest->getDetails()['DPE']) {
-                case true:
-                    $typeCompositionLogement->setBailDpeDpe('oui');
-                    break;
-                case false:
-                    $typeCompositionLogement->setBailDpeDpe('non');
-                    break;
-                default:
-                    $typeCompositionLogement->setBailDpeDpe('nsp');
-                    break;
-            }
+        switch ($qualificationNDERequest->getDetails()['DPE']) {
+            case true:
+                $typeCompositionLogement->setBailDpeDpe('oui');
+                break;
+            case false:
+                $typeCompositionLogement->setBailDpeDpe('non');
+                break;
+            default:
+                $typeCompositionLogement->setBailDpeDpe('nsp');
+                break;
         }
         $signalement->setTypeCompositionLogement($typeCompositionLogement);
         $this->save($signalement);

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -526,6 +526,11 @@ class SignalementManager extends AbstractManager
         $signalementQualificationNDE->setDetails($qualificationDetails);
         $this->save($signalementQualificationNDE);
 
+        $signalementQualificationNDE->setStatus(
+            $this->qualificationStatusService->getNDEStatus($signalementQualificationNDE)
+        );
+        $this->save($signalementQualificationNDE);
+
         $informationComplementaire = new InformationComplementaire();
         if (!empty($signalement->getInformationComplementaire())) {
             $informationComplementaire = clone $signalement->getInformationComplementaire();

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -520,7 +520,7 @@ class SignalementManager extends AbstractManager
                 $qualificationDetails['DPE'] = false;
                 break;
             default:
-            $qualificationDetails['DPE'] = null;
+                $qualificationDetails['DPE'] = null;
                 break;
         }
         $signalementQualificationNDE->setDetails($qualificationDetails);

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -526,7 +526,7 @@ class SignalementManager extends AbstractManager
             }
             $signalementQualificationNDE->setDetails($qualificationDetails);
             $this->save($signalementQualificationNDE);
-    
+
             $signalementQualificationNDE->setStatus(
                 $this->qualificationStatusService->getNDEStatus($signalementQualificationNDE)
             );

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -511,25 +511,27 @@ class SignalementManager extends AbstractManager
         $signalementQualificationNDE = $signalement->getSignalementQualifications()->filter(function ($qualification) {
             return Qualification::NON_DECENCE_ENERGETIQUE === $qualification->getQualification();
         })->first();
-        $qualificationDetails = $signalementQualificationNDE->getDetails();
-        switch ($informationsLogementRequest->getBailDpeDpe()) {
-            case 'oui':
-                $qualificationDetails['DPE'] = true;
-                break;
-            case 'non':
-                $qualificationDetails['DPE'] = false;
-                break;
-            default:
-                $qualificationDetails['DPE'] = null;
-                break;
+        if ($signalementQualificationNDE) {
+            $qualificationDetails = $signalementQualificationNDE->getDetails();
+            switch ($informationsLogementRequest->getBailDpeDpe()) {
+                case 'oui':
+                    $qualificationDetails['DPE'] = true;
+                    break;
+                case 'non':
+                    $qualificationDetails['DPE'] = false;
+                    break;
+                default:
+                    $qualificationDetails['DPE'] = null;
+                    break;
+            }
+            $signalementQualificationNDE->setDetails($qualificationDetails);
+            $this->save($signalementQualificationNDE);
+    
+            $signalementQualificationNDE->setStatus(
+                $this->qualificationStatusService->getNDEStatus($signalementQualificationNDE)
+            );
+            $this->save($signalementQualificationNDE);
         }
-        $signalementQualificationNDE->setDetails($qualificationDetails);
-        $this->save($signalementQualificationNDE);
-
-        $signalementQualificationNDE->setStatus(
-            $this->qualificationStatusService->getNDEStatus($signalementQualificationNDE)
-        );
-        $this->save($signalementQualificationNDE);
 
         $informationComplementaire = new InformationComplementaire();
         if (!empty($signalement->getInformationComplementaire())) {

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -277,6 +277,13 @@ class SignalementManager extends AbstractManager
         // mise à jour du signalement
         if ($qualificationNDERequest->getDateEntree()) {
             $signalement->setDateEntree(new \DateTimeImmutable($qualificationNDERequest->getDateEntree()));
+            $typeCompositionLogement = new TypeCompositionLogement();
+            if (!empty($signalement->getTypeCompositionLogement())) {
+                $typeCompositionLogement = clone $signalement->getTypeCompositionLogement();
+            }
+            $typeCompositionLogement
+                ->setBailDpeDateEmmenagement($qualificationNDERequest->getDateEntree());
+            $signalement->setTypeCompositionLogement($typeCompositionLogement);
         }
 
         if (null !== $qualificationNDERequest->getSuperficie()
@@ -478,7 +485,8 @@ class SignalementManager extends AbstractManager
             ->setBailDpeInvariant($informationsLogementRequest->getBailDpeInvariant())
             ->setBailDpeEtatDesLieux($informationsLogementRequest->getBailDpeEtatDesLieux())
             ->setBailDpeDpe($informationsLogementRequest->getBailDpeDpe())
-            ->setBailDpeClasseEnergetique($informationsLogementRequest->getBailDpeClasseEnergetique());
+            ->setBailDpeClasseEnergetique($informationsLogementRequest->getBailDpeClasseEnergetique())
+            ->setBailDpeDateEmmenagement($signalement->getDateEntree()?->format('Y-m-d'));
         $signalement->setTypeCompositionLogement($typeCompositionLogement);
 
         $informationComplementaire = new InformationComplementaire();

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -276,17 +276,7 @@ class SignalementManager extends AbstractManager
         $signalement = $signalementQualification->getSignalement();
         // mise à jour du signalement
         if ($qualificationNDERequest->getDateEntree()) {
-            if (QualificationNDERequest::RADIO_VALUE_AFTER_2023 === $qualificationNDERequest->getDateEntree()
-                && (null === $signalement->getDateEntree() || $signalement->getDateEntree()->format('Y') < '2023')
-            ) {
-                $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_AFTER_2023));
-            }
-
-            if (QualificationNDERequest::RADIO_VALUE_BEFORE_2023 === $qualificationNDERequest->getDateEntree()
-                && (null === $signalement->getDateEntree() || $signalement->getDateEntree()->format('Y') >= '2023')
-            ) {
-                $signalement->setDateEntree(new \DateTimeImmutable(QualificationNDERequest::RADIO_VALUE_BEFORE_2023));
-            }
+            $signalement->setDateEntree(new \DateTimeImmutable($qualificationNDERequest->getDateEntree()));
         }
 
         if (null !== $qualificationNDERequest->getSuperficie()

--- a/templates/_partials/_modal_edit_nde.html.twig
+++ b/templates/_partials/_modal_edit_nde.html.twig
@@ -32,7 +32,7 @@
                         </div>
                         <form method="POST" name="signalement-edit-nde" id="signalement-edit-nde-form" enctype="application/json"
                         action="{{ path('back_signalement_qualification_editer',{uuid:signalement.uuid, signalementQualification:signalementQualificationNDE.id}) }}">
-                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-my-3w"
+                            <div class="fr-grid-row fr-grid-row--gutters fr-my-3w"
                                 id="signalement-edit-nde-form-row">
                                 <div class="fr-col-6">
                                     <fieldset class="fr-fieldset fr-fieldset--inline">
@@ -42,17 +42,12 @@
                                         <p id="signalement-edit-nde-date-entree-error" class="fr-error-text fr-hidden fr-my-3v">
                                             Veuillez préciser la date d'entrée dans le logement.
                                         </p>
-                                        <div class="fr-fieldset__content">
-                                            <div class="fr-radio-group">
-                                                <input type="radio" id="signalement-edit-nde-date-entree-before" name="dateEntree" value="1970-01-01" {% if signalement.dateEntree and signalement.dateEntree|date('Y')<2023 %}checked{% endif %}>
-                                                <label class="fr-label" for="signalement-edit-nde-date-entree-before">Avant 2023
-                                                </label>
-                                            </div>
-                                            <div class="fr-radio-group">
-                                                <input type="radio" id="signalement-edit-nde-date-entree-after" name="dateEntree" value="2023-01-02" {% if signalement.dateEntree and signalement.dateEntree|date('Y')>=2023 %}checked{% endif %}>
-                                                <label class="fr-label" for="signalement-edit-nde-date-entree-after">A partir de 2023
-                                                </label>
-                                            </div>
+                                        <div class="fr-input-group">
+                                            {% set dateEntree = '' %}
+                                            {% if signalement.dateEntree %}
+                                                {% set dateEntree = signalement.dateEntree.format('Y-m-d') %}
+                                            {% endif %}
+                                            <input class="fr-input" type="date" id="signalement-edit-nde-date-entree" name="dateEntree" value="{{ dateEntree }}">
                                         </div>
                                     </fieldset>
                                 </div>


### PR DESCRIPTION
## Ticket

#3435    

## Description
Depuis le nouveau formulaire, on enregistre la vraie date d'entrée dans le logement.
Malheureusement, la modale pour éditer la NDE écrase cette donnée avec des dates arbitraires (01/01/1970 et 02/01/2023) qui servaient à savoir si on était avant ou après 2023.
Heureusement, on a conservé la donnée enregistrée à la base dans le formulaire.

## Changements apportés
- migration pour remplacer la colonne date_entree si elle est égale aux dates arbitraires, et qu'on a une date réelle d'enregistrée
- remplacement des boutons radio par un champ de saisie (identifique à celui de la modale d'édition annexe
- enregistrement dans le json de type_composition_logement pour la sauvegarder aux deux endroits 

## Tests
- [ ] Vérifier que l'édition d'un signalement fonctionne dans la modale NDE, et que l'affichage est toujours conforme
- [ ] Vérifier que l'édition d'un signalement fonctionne dans la modale Informations logement, et que l'affichage est toujours conforme
- [ ] Modifier la date d'entrée à la main en BDD pour avoir une des deux dates arbitraires de NDE
- [ ] `make execute-migration name=Version20250102154204 direction=up`
- [ ] Vérifier que la date du json est bien reprise

