### PR TITLE
[BO - Export] Correction de la valeur de Allocataire quand elle est vide en BDD

### DIFF
--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -18,7 +18,7 @@ class SignalementExportFactory
     public const OUI = 'Oui';
     public const NON = 'Non';
     public const NON_RENSEIGNE = 'Non renseigné';
-    public const ALLOCATAIRE = ['CAF', 'MSA', 'Oui', 1];
+    public const ALLOCATAIRE = ['CAF', 'MSA', 'oui', 1];
     public const DATE_FORMAT = 'd/m/Y';
 
     public function createInstanceFrom(User $user, array $data): SignalementExport

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -126,7 +126,7 @@ class SignalementExportFactory
                     : (1 == $data[$keyColumn] ? self::OUI : self::NON);
                 break;
             case 'isAllocataire':
-                $value = null === $data[$keyColumn]
+                $value = null === $data[$keyColumn] || '' === $data[$keyColumn]
                     ? self::NON_RENSEIGNE
                     : (\in_array($data[$keyColumn], self::ALLOCATAIRE) ? self::OUI : self::NON);
                 break;


### PR DESCRIPTION
## Ticket

#3508   

## Description
Dans les exports, la valeur de Allocataire était à `Non` alors qu'elle s'affichait à `Non renseigné` sur la fiche.
Il s'avère qu'on enregistre une valeur vide quand c'est `Non renseigné` et qu'on ne prenait pas en compte cette valeur lors de l'export.

## Tests
- [ ] Avoir différents signalements avec différentes valeurs pour isAllocataire
- [ ] Vérifier que l'export correspond à ce qui a été renseigné
