### PR TITLE
[Tech - email] Déclarer le cron pour la commande des mails en échec

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -23,6 +23,9 @@
     },
     {
       "command": "0 20 * * * php bin/console app:retry-failed-push-esabora-sish"
+    },
+    {
+      "command": "30 * * * * php bin/console app:retry-failed-emails"
     }
   ]
 }

--- a/src/Command/RetryFailedEmailsCommand.php
+++ b/src/Command/RetryFailedEmailsCommand.php
@@ -21,6 +21,12 @@ use Symfony\Component\Mime\Address;
 )]
 class RetryFailedEmailsCommand extends Command
 {
+    public const array ERRORS_TO_IGNORE = [
+        'Unable to send an email: email is not valid in to (code 400).',
+        'An email must have a "To", "Cc", or "Bcc" header.',
+    ];
+    public const int START_AT_YEAR = 2025;
+
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly FailedEmailRepository $failedEmailRepository,
@@ -34,7 +40,7 @@ class RetryFailedEmailsCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         /** @var FailedEmail[] $failedEmails */
-        $failedEmails = $this->failedEmailRepository->findBy(['isResendSuccessful' => false]);
+        $failedEmails = $this->failedEmailRepository->findEmailToResend();
 
         foreach ($failedEmails as $failedEmail) {
             $emailMessage = (new TemplatedEmail())


### PR DESCRIPTION
## Ticket

#3355

## Description
Ajout d'un cron une fois par heure pour relancer les erreurs d'envoi d'email
Modification de la commande pour ne pas traiter : 
- Les erreurs enregistrées antérieures à 2025
- Les erreurs enregistrées correspondant à des email malformé

## Tests
- [ ] Tester la commande `app:retry-failed-emails`
