### PR TITLE
[Notifications] Correction des notifications de nouveau signalement et d'accès à la fiche pour le 69

### DIFF
--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -139,10 +139,19 @@ class SignalementVoter extends Voter
         if (Signalement::STATUS_ARCHIVED === $signalement->getStatut()) {
             return false;
         }
-        if ($user->isTerritoryAdmin() && $user->hasPartnerInTerritory($signalement->getTerritory())) {
+
+        if (!$user->hasPartnerInTerritory($signalement->getTerritory())) {
+            return false;
+        }
+
+        $partner = $user->getPartnerInTerritory($signalement->getTerritory());
+        if ($user->isTerritoryAdmin()) {
+            if (!empty($partner->getInsee()) && !empty($signalement->getInseeOccupant()) && !in_array($signalement->getInseeOccupant(), $partner->getInsee())) {
+                return false;
+            }
             return true;
         }
-        $partner = $user->getPartnerInTerritory($signalement->getTerritory());
+
         if (!$partner) {
             return false;
         }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -340,6 +340,7 @@ class SignalementBuilder
             ->setIsLogementSocial($this->isLogementSocial())
             ->setAdresseOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailNumero())
             ->setCpOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal())
+            ->setInseeOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailInsee())
             ->setVilleOccupant($this->signalementDraftRequest->getAdresseLogementAdresseDetailCommune())
             ->setEtageOccupant($this->signalementDraftRequest->getAdresseLogementComplementAdresseEtage())
             ->setEscalierOccupant($this->signalementDraftRequest->getAdresseLogementComplementAdresseEscalier())


### PR DESCRIPTION
## Ticket

#3518   

## Description
Dans le 69, via leur configuration particulière, l'ensemble des RT est notifié pour les nouveaux signalements, alors que le territoire est divisé en deux partenaires.
De plus, en accédant via l'url directe, ils pouvaient voir les signalements, ce qui ne devrait pas être le cas.

## Changements apportés
* Modification du voter pour accéder aux signalements pour prendre en compte la config des codes insee autorisés
* Modification de l'enregistrement des draft pour enregistrer la valeur du code insee depuis le front, et l'avoir à disposition pour filtrer les notifications

## Pré-requis
Utiliser la base de prod pour ne pas avoir à dupliquer les configurations.
En base, modifier le mot de passe d'un utilisateur dans le partenaire COR

## Tests
- [ ] Créer un signalement sur Lyon : seuls les utilisateurs de Lyon Metropole doivent être notifiés
- [ ] Essayer d'accéder au signalement avec l'utilisateur du partenaire COR via l'uuid : on doit être bloqué
- [ ] Créer un signalement dans la COR (Ex : Affoux) : seuls les utilisateurs de la COR doivent être notifiés
