### PR TITLE
[CI] Etape wkthtmltopdf KO

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
   code-quality:
     name: Histologe (PHP ${{ matrix.php-versions }})
     # https://hub.docker.com/_/ubuntu/
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       # https://docs.docker.com/samples/library/mysql/
       mysql:


### PR DESCRIPTION
## Ticket

#3527    

## Description
> dpkg: dependency problems prevent configuration of wkhtmltox:
 wkhtmltox depends on libssl1.1; however:
  Package libssl1.1 is not installed.

Une dépendance nécessaire à wkhtmltopdf (libssl1.1) n'est plus disponible dans la version d'Ubuntu utilisée actuellement dans la CI (ubuntu-latest, qui pointe aujourd'hui vers Ubuntu 24.04).

![image](https://github.com/user-attachments/assets/b9cea6da-a164-43e1-9482-dedfe9f5eb98)

Après investigation,  libssl1.1 est disponible que sur Ubuntu 20.04.

https://packages.ubuntu.com/search?keywords=libssl1.1&searchon=names&suite=focal&section=all

La solution la plus safe est de fixer la version d'Ubuntu utilisée dans la CI à 20.04, où cette dépendance est encore disponible.

> [!IMPORTANT]  
> ## Le projet [wkhtmltopdf](https://github.com/wkhtmltopdf/wkhtmltopdf) n'est plus maintenu

## Changements apportés
* Mise à jour yaml

## Pré-requis

## Tests
- [ ] CI OK