### PR TITLE
[FO - Formulaire] Non-enregistrement de la valeur "NON" pour la question is_allocataire

### DIFF
--- a/migrations/Version20250109113158.php
+++ b/migrations/Version20250109113158.php
@@ -21,7 +21,7 @@ final class Version20250109113158 extends AbstractMigration
             if ($payload && isset($payload['logement_social_allocation']) && 'non' === $payload['logement_social_allocation']) {
                 $this->connection->executeStatement(
                     'UPDATE signalement s
-                    SET s.is_allocataire = \'O\'
+                    SET s.is_allocataire = \'0\'
                     WHERE s.id = :signalement_id',
                     [
                         'signalement_id' => $signalement['id'],

--- a/migrations/Version20250109113158.php
+++ b/migrations/Version20250109113158.php
@@ -16,25 +16,18 @@ final class Version20250109113158 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->connection->beginTransaction();
-        try {
-            foreach ($this->getSignalements() as $signalement) {
-                $payload = json_decode($signalement['payload'], true);
-                if ($payload && isset($payload['logement_social_allocation']) && 'non' === $payload['logement_social_allocation']) {
-                    $this->connection->executeStatement(
-                        'UPDATE signalement s
-                        SET s.is_allocataire = \'1\'
-                        WHERE s.id = :signalement_id',
-                        [
-                            'signalement_id' => $signalement['id'],
-                        ]
-                    );
-                }
+        foreach ($this->getSignalements() as $signalement) {
+            $payload = json_decode($signalement['payload'], true);
+            if ($payload && isset($payload['logement_social_allocation']) && 'non' === $payload['logement_social_allocation']) {
+                $this->connection->executeStatement(
+                    'UPDATE signalement s
+                    SET s.is_allocataire = \'1\'
+                    WHERE s.id = :signalement_id',
+                    [
+                        'signalement_id' => $signalement['id'],
+                    ]
+                );
             }
-            $this->connection->commit();
-        } catch (\Throwable $exception) {
-            $this->connection->rollBack();
-            $this->write($exception->getMessage());
         }
     }
 

--- a/migrations/Version20250109113158.php
+++ b/migrations/Version20250109113158.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250109113158 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix value of isAllocataire field for signalements created after 2024-12-20';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->connection->beginTransaction();
+        try {
+            foreach ($this->getSignalements() as $signalement) {
+                $payload = json_decode($signalement['payload'], true);
+                if ($payload && isset($payload['logement_social_allocation']) && 'non' === $payload['logement_social_allocation']) {
+                    $this->connection->executeStatement(
+                        'UPDATE signalement s
+                        SET s.is_allocataire = \'1\'
+                        WHERE s.id = :signalement_id',
+                        [
+                            'signalement_id' => $signalement['id'],
+                        ]
+                    );
+                }
+            }
+            $this->connection->commit();
+        } catch (\Throwable $exception) {
+            $this->connection->rollBack();
+            $this->write($exception->getMessage());
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getSignalements(): array
+    {
+        $query =
+            'SELECT s.id, s.is_allocataire, sd.id as draft_id, sd.payload
+             FROM signalement s
+             LEFT JOIN signalement_draft sd ON s.created_from_id = sd.id
+             WHERE s.created_at >= :createdAt
+             AND (s.is_allocataire IS NULL OR s.is_allocataire = \'\')
+             AND (s.created_from_id IS NOT NULL)'
+        ;
+
+        return $this->connection->fetchAllAssociative(
+            $query,
+            ['createdAt' => '2024-12-20']
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20250109113158.php
+++ b/migrations/Version20250109113158.php
@@ -21,7 +21,7 @@ final class Version20250109113158 extends AbstractMigration
             if ($payload && isset($payload['logement_social_allocation']) && 'non' === $payload['logement_social_allocation']) {
                 $this->connection->executeStatement(
                     'UPDATE signalement s
-                    SET s.is_allocataire = \'1\'
+                    SET s.is_allocataire = \'O\'
                     WHERE s.id = :signalement_id',
                     [
                         'signalement_id' => $signalement['id'],

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -467,6 +467,18 @@ class SignalementBuilder
         return ProfileDeclarant::TIERS_PRO === $this->signalement->getProfileDeclarant();
     }
 
+    private function evalString(?bool $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+        if (!$value) {
+            return '0';
+        }
+
+        return (string) $value;
+    }
+
     private function evalBoolean(?string $value): ?bool
     {
         if (null === $value || 'ne-sais-pas' === $value || 'nsp' === $value) {
@@ -524,7 +536,7 @@ class SignalementBuilder
             return SignalementInputValueMapper::map($this->signalementDraftRequest->getLogementSocialAllocationCaisse());
         }
 
-        return SignalementInputValueMapper::map($this->signalementDraftRequest->getLogementSocialAllocation());
+        return $this->evalString(SignalementInputValueMapper::map($this->signalementDraftRequest->getLogementSocialAllocation()));
     }
 
     private function resolveTiersLien(): ?string


### PR DESCRIPTION
## Ticket

#3533    

## Description
Quand on faisait un signalement en répondant "non" à la question "Recevez-vous une aide ou allocation logement ?", la réponse enregistrée était une chaîne vide, comme si on n'avait pas eu la question où qu'on avait répondu "je ne sais pas"
Cela était du à une modification de la fonction `resolveIsAllocataire` depuis l'ajout de la possibilité de répondre "je ne sais pas" pour quelque profils. https://github.com/MTES-MCT/histologe/issues/3389
Modification (et donc bug) en prod depuis le 20 décembre 2024

## Changements apportés
* Fix sur `resolveIsAllocataire`
* Création d'une migration pour corriger les signalements créés depuis le 20 décembre

## Pré-requis
Avant de descendre la branche, faire un signalement en répondant "NON" à la question

## Tests
- [ ] Executer la migration : `doctrine:migrations:execute --up 'DoctrineMigrations\Version20250109113158'`
- [ ] Vérifier que le signalement créé précédemment a bien été corrigé
- [ ] Redéposer un signalement
- [ ] Vérifier dans le BO, l'édition, la fiche suivi, l'export pdf et la BDD que la valeur est bien '1' (soit NON) et pas une chaine vide

