### PR TITLE
[BO - Signalement] Export CSV xls - non application des filtres

### DIFF
--- a/src/Controller/Back/ExportSignalementController.php
+++ b/src/Controller/Back/ExportSignalementController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller\Back;
 
-use App\Dto\Request\Signalement\SignalementSearchQuery;
 use App\Entity\User;
 use App\Manager\SignalementManager;
 use App\Messenger\Message\ListExportMessage;
@@ -25,12 +24,13 @@ class ExportSignalementController extends AbstractController
         SignalementExportFiltersDisplay $signalementExportFiltersDisplay,
         SignalementManager $signalementManager,
         SearchFilter $searchFilter,
-        SignalementSearchQuery $signalementSearchQuery,
     ): Response {
         /** @var User $user */
         $user = $this->getUser();
-        $signalementSearchQuery = $request->getSession()->get('signalementSearchQuery', $signalementSearchQuery);
-        $filters = $searchFilter->setRequest($signalementSearchQuery)->buildFilters($user);
+        $filters = ['isImported' => '1'];
+        if ($signalementSearchQuery = $request->getSession()->get('signalementSearchQuery')) {
+            $filters = $searchFilter->setRequest($signalementSearchQuery)->buildFilters($user);
+        }
         $count_signalements = $signalementManager->findSignalementAffectationList($user, $filters, true);
         $textFilters = $signalementExportFiltersDisplay->filtersToText($filters);
 
@@ -47,7 +47,6 @@ class ExportSignalementController extends AbstractController
         Request $request,
         MessageBusInterface $messageBus,
         SearchFilter $searchFilter,
-        SignalementSearchQuery $signalementSearchQuery,
     ): RedirectResponse {
         $selectedColumns = $request->get('cols') ?? [];
         $format = $request->get('file-format');
@@ -61,8 +60,10 @@ class ExportSignalementController extends AbstractController
 
         /** @var User $user */
         $user = $this->getUser();
-        $signalementSearchQuery = $request->getSession()->get('signalementSearchQuery', $signalementSearchQuery);
-        $filters = $searchFilter->setRequest($signalementSearchQuery)->buildFilters($user);
+        $filters = ['isImported' => '1'];
+        if ($signalementSearchQuery = $request->getSession()->get('signalementSearchQuery')) {
+            $filters = $searchFilter->setRequest($signalementSearchQuery)->buildFilters($user);
+        }
 
         $message = (new ListExportMessage())
             ->setUserId($user->getId())

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -27,21 +27,20 @@ class SignalementListController extends AbstractController
         SessionInterface $session,
         SignalementManager $signalementManager,
         SearchFilter $searchFilter,
-        #[MapQueryString] ?SignalementSearchQuery $signalementQuery = null,
+        #[MapQueryString] ?SignalementSearchQuery $signalementSearchQuery = null,
     ): JsonResponse {
+        $session->set('signalementSearchQuery', $signalementSearchQuery);
+        $session->save();
         /** @var User $user */
         $user = $this->getUser();
-        $filters = null !== $signalementQuery
-            ? $searchFilter->setRequest($signalementQuery)->buildFilters($user)
+        $filters = null !== $signalementSearchQuery
+            ? $searchFilter->setRequest($signalementSearchQuery)->buildFilters($user)
             : [
                 'maxItemsPerPage' => SignalementSearchQuery::MAX_LIST_PAGINATION,
                 'orderBy' => 'DESC',
                 'sortBy' => 'reference',
                 'isImported' => 'oui',
             ];
-
-        $session->set('filters', $filters);
-        $session->set('signalementSearchQuery', $signalementQuery);
         $signalements = $signalementManager->findSignalementAffectationList($user, $filters);
 
         return $this->json(


### PR DESCRIPTION
## Ticket

#3515

## Description
Chaque modifications de filtre sur la page liste des signalement lance une requête de mise à jour, si une requête est en cours elle est annulée coté javascript mais rien n'arrête le traitement PHP. Certaines requêtes étant beaucoup plus lente que d'autre (en fonction des filtres) et la session étant enregistré en fin de script, dans certains cas c'est une session de requête annulé qui est enregistré postérieurement à la dernière requête effectué.

## Changements apportés
* Sauvegarde des filtres de recherche en session dés le début du traitement pour éviter l’écrasement par une requête plus lente antérieure
* Sauvegarde des filtres tel que dans `SignalementSearchQuery` afin d'alléger la session

## Tests
- [ ] S'assurer que l'export fonctionne correctement
