### PR TITLE
[Tech] Simplification des statuts dans le code twig de la fiche signalement

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -15,6 +15,7 @@ use App\Manager\UserManager;
 use App\Messenger\InterconnectionBus;
 use App\Repository\AffectationRepository;
 use App\Repository\PartnerRepository;
+use App\Security\Voter\AffectationVoter;
 use App\Service\Signalement\SearchFilterOptionDataProvider;
 use App\Specification\Signalement\FirstAffectationAcceptedSpecification;
 use Psr\Cache\InvalidArgumentException;
@@ -50,7 +51,7 @@ class AffectationController extends AbstractController
         Signalement $signalement,
         TagAwareCacheInterface $cache,
     ): RedirectResponse|JsonResponse {
-        $this->denyAccessUnlessGranted('ASSIGN_TOGGLE', $signalement);
+        $this->denyAccessUnlessGranted(AffectationVoter::TOGGLE, $signalement);
         if ($this->isCsrfTokenValid('signalement_affectation_'.$signalement->getId(), $request->get('_token'))) {
             $data = $request->get('signalement-affectation');
             if (isset($data['partners'])) {
@@ -96,7 +97,7 @@ class AffectationController extends AbstractController
         Signalement $signalement,
         AffectationRepository $affectationRepository,
     ): RedirectResponse|JsonResponse {
-        $this->denyAccessUnlessGranted('ASSIGN_TOGGLE', $signalement);
+        $this->denyAccessUnlessGranted(AffectationVoter::TOGGLE, $signalement);
         $idAffectation = $request->get('affectation');
         $affectation = $affectationRepository->findOneBy(['id' => $idAffectation]);
         if (!$affectation || $affectation->getSignalement()->getId() !== $signalement->getId()) {
@@ -132,7 +133,7 @@ class AffectationController extends AbstractController
         DossierMessageFactory $dossierMessageFactory,
         MessageBusInterface $bus,
     ): Response {
-        $this->denyAccessUnlessGranted('ASSIGN_ANSWER', $affectation);
+        $this->denyAccessUnlessGranted(AffectationVoter::ANSWER, $affectation);
         if ($this->isCsrfTokenValid('signalement_affectation_response_'.$signalement->getId(), $request->get('_token'))
             && $response = $request->get('signalement-affectation-response')
         ) {

--- a/src/Controller/Back/HistoryEntryController.php
+++ b/src/Controller/Back/HistoryEntryController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Back;
 
 use App\Manager\HistoryEntryManager;
 use App\Repository\SignalementRepository;
+use App\Security\Voter\AffectationVoter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,7 +23,7 @@ class HistoryEntryController extends AbstractController
         if (
             !$signalement
             || !$this->isGranted('SIGN_VIEW', $signalement)
-            || !$this->isGranted('ASSIGN_SEE', $signalement)
+            || !$this->isGranted(AffectationVoter::SEE, $signalement)
         ) {
             return $this->json(['response' => 'error'], Response::HTTP_FORBIDDEN);
         }

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -76,7 +76,8 @@ class SignalementController extends AbstractController
         );
 
         $canAnswerAssignment = $canCancelRefusedAssignment = false;
-        $isAssignmentRefused = $isAssignmentAccepted = $isClosedForMe = false;
+        $isAssignmentRefused = $isAssignmentAccepted = false;
+        $isClosedForMe = null;
         $partner = $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory());
         if ($affectation = $signalement->getAffectations()->filter(function (Affectation $affectation) use ($partner) {
             return $affectation->getPartner() === $partner;

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -76,17 +76,17 @@ class SignalementController extends AbstractController
         );
 
         $canAnswerAssignment = $canCancelRefusedAssignment = false;
-        $isAssignmentRefused = $isAssignmentAccepted = $isClosedForMe = null;
+        $isAssignmentRefused = $isAssignmentAccepted = $isClosedForMe = false;
         $partner = $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory());
         if ($affectation = $signalement->getAffectations()->filter(function (Affectation $affectation) use ($partner) {
             return $affectation->getPartner() === $partner;
         })->first()) {
             switch ($affectation->getStatut()) {
                 case Affectation::STATUS_ACCEPTED:
-                    $isAssignmentAccepted = $affectation;
+                    $isAssignmentAccepted = true;
                     break;
                 case Affectation::STATUS_REFUSED:
-                    $isAssignmentRefused = $affectation;
+                    $isAssignmentRefused = true;
                     $canCancelRefusedAssignment = $this->isGranted(AssignmentVoter::ANSWER, $affectation);
                     break;
                 case Affectation::STATUS_CLOSED:

--- a/src/Security/Voter/AffectationVoter.php
+++ b/src/Security/Voter/AffectationVoter.php
@@ -11,11 +11,11 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class AffectationVoter extends Voter
 {
-    public const SEE = 'ASSIGN_SEE';
-    public const TOGGLE = 'ASSIGN_TOGGLE';
-    public const ANSWER = 'ASSIGN_ANSWER';
-    public const CLOSE = 'ASSIGN_CLOSE';
-    public const REOPEN = 'ASSIGN_REOPEN';
+    public const SEE = 'AFFECTATION_SEE';
+    public const TOGGLE = 'AFFECTATION_TOGGLE';
+    public const ANSWER = 'AFFECTATION_ANSWER';
+    public const CLOSE = 'AFFECTATION_CLOSE';
+    public const REOPEN = 'AFFECTATION_REOPEN';
 
     protected function supports(string $attribute, $subject): bool
     {

--- a/src/Security/Voter/AffectationVoter.php
+++ b/src/Security/Voter/AffectationVoter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class AssignmentVoter extends Voter
+class AffectationVoter extends Voter
 {
     public const SEE = 'ASSIGN_SEE';
     public const TOGGLE = 'ASSIGN_TOGGLE';
@@ -61,18 +61,18 @@ class AssignmentVoter extends Voter
             && Signalement::STATUS_ACTIVE === $signalement->getStatut();
     }
 
-    private function canAnswer(Affectation $assignment, User $user): bool
+    private function canAnswer(Affectation $affectation, User $user): bool
     {
-        return $assignment->getPartner() === $user->getPartnerInTerritory($assignment->getSignalement()->getTerritory()) && Signalement::STATUS_ACTIVE === $assignment->getSignalement()->getStatut();
+        return $affectation->getPartner() === $user->getPartnerInTerritory($affectation->getSignalement()->getTerritory()) && Signalement::STATUS_ACTIVE === $affectation->getSignalement()->getStatut();
     }
 
-    private function canClose(Affectation $assignment, User $user): bool
+    private function canClose(Affectation $affectation, User $user): bool
     {
-        return $this->canAnswer($assignment, $user) && Affectation::STATUS_ACCEPTED === $assignment->getStatut();
+        return $this->canAnswer($affectation, $user) && Affectation::STATUS_ACCEPTED === $affectation->getStatut();
     }
 
-    private function canReopen(Affectation $assignment, User $user): bool
+    private function canReopen(Affectation $affectation, User $user): bool
     {
-        return $this->canAnswer($assignment, $user) && Affectation::STATUS_CLOSED === $assignment->getStatut();
+        return $this->canAnswer($affectation, $user) && Affectation::STATUS_CLOSED === $affectation->getStatut();
     }
 }

--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -74,7 +74,7 @@
                                         Clôturer pour tous les partenaires
                                     </button>
                                 </li>
-                                {% if isAffected and isAccepted %}
+                                {% if affectation and isAssignmentAccepted %}
                                     <li>
                                         <button class="fr-btn fr-icon-check-line"
                                                 form="cloture_form"

--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -74,7 +74,7 @@
                                         Clôturer pour tous les partenaires
                                     </button>
                                 </li>
-                                {% if affectation and isAssignmentAccepted %}
+                                {% if affectation and isAffectationAccepted %}
                                     <li>
                                         <button class="fr-btn fr-icon-check-line"
                                                 form="cloture_form"

--- a/templates/_partials/_modal_refus_affectation.html.twig
+++ b/templates/_partials/_modal_refus_affectation.html.twig
@@ -3,7 +3,7 @@
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
-                    <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isAffected.id}) }}"
+                    <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:affectation.id}) }}"
                             class="tinyCheck fr-mb-3v" id="signalement-affectation-response-deny-form"
                             name="signalement-affectation-response-form" method="POST">
                         <div class="fr-modal__header">

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -26,14 +26,12 @@
     {% include '_partials/_modal_file_delete.html.twig' %}
     {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
 
-    {% if is_granted('SIGN_REOPEN', signalement) or canReopenAssignment %}
-        {% if is_granted('SIGN_REOPEN', signalement) %}
-            {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
-        {% endif %}
-        
-        {% if canReopenAssignment %}
-            {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
-        {% endif %}
+    {% if is_granted('SIGN_REOPEN', signalement) %}
+        {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
+    {% endif %}
+    
+    {% if canReopenAssignment %}
+        {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
     {% endif %}
 
     <div class="fr-background--white

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -11,7 +11,7 @@
         {% include '_partials/_modal_historique_affectation.html.twig' %}
     {% endif %}
     {% include '_partials/_modal_dpe.html.twig' %}
-    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') and not isClosed and not isClosedForMe and ((isAffected and isAccepted)) or is_granted('ROLE_ADMIN_TERRITORY') %}
+    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') and not isSignalementClosed and not isClosedForMe and ((affectation and isAssignmentAccepted)) or is_granted('ROLE_ADMIN_TERRITORY') %}
         {% include '_partials/_modal_cloture.html.twig' %}
     {% endif %}
     {% if canEditNDE %}
@@ -26,12 +26,12 @@
     {% include '_partials/_modal_file_delete.html.twig' %}
     {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
 
-    {% if isClosedForMe or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED')  %}
-        {% if isClosed and is_granted('ROLE_ADMIN_TERRITORY') %}
+    {% if is_granted('SIGN_REOPEN', signalement) or canReopenAssignment %}
+        {% if is_granted('SIGN_REOPEN', signalement) %}
             {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
         {% endif %}
         
-        {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') and isClosedForMe %}
+        {% if canReopenAssignment %}
             {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
         {% endif %}
     {% endif %}

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -11,7 +11,7 @@
         {% include '_partials/_modal_historique_affectation.html.twig' %}
     {% endif %}
     {% include '_partials/_modal_dpe.html.twig' %}
-    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') and not isSignalementClosed and not isClosedForMe and ((affectation and isAssignmentAccepted)) or is_granted('ROLE_ADMIN_TERRITORY') %}
+    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') and not isSignalementClosed and not isClosedForMe and ((affectation and isAffectationAccepted)) or is_granted('ROLE_ADMIN_TERRITORY') %}
         {% include '_partials/_modal_cloture.html.twig' %}
     {% endif %}
     {% if canEditNDE %}
@@ -30,7 +30,7 @@
         {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '1' } %}
     {% endif %}
     
-    {% if canReopenAssignment %}
+    {% if canReopenAffectation %}
         {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
     {% endif %}
 

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -15,7 +15,7 @@
         {% include '_partials/_modal_cloture.html.twig' %}
     {% endif %}
     {% if canEditNDE %}
-        {% include '_partials/_modal_edit_nde.html.twig' %}        
+        {% include '_partials/_modal_edit_nde.html.twig' %}
     {% endif %}
     {% if is_granted('SIGN_EDIT', signalement) %}
         {% include '_partials/_modal_upload_files.html.twig' %}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -63,11 +63,11 @@
                             <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
                         {% endif %}
                     {% else %}
-                        {% if affectation and not isAssignmentAccepted and not isAssignmentRefused and not isSignalementClosed and not isClosedForMe %}
+                        {% if affectation and not isAffectationAccepted and not isAffectationRefused and not isSignalementClosed and not isClosedForMe %}
                             <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
-                        {% elseif isAssignmentAccepted %}
+                        {% elseif isAffectationAccepted %}
                             <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
-                        {% elseif isAssignmentRefused %}
+                        {% elseif isAffectationRefused %}
                             <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
                         {% elseif isClosedForMe %}
                             <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
@@ -147,7 +147,7 @@
             </div>
 
             <div class="fr-mb-4v fr-text--right">
-                {% if canAnswerAssignment %}
+                {% if canAnswerAffectation %}
                     <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:affectation.id}) }}"
                             class="tinyCheck" id="signalement-affectation-response-form"
                             name="signalement-affectation-response-form" method="POST">
@@ -173,7 +173,7 @@
                         </div>
                     </div>
 
-                {% elseif canCancelRefusedAssignment %}
+                {% elseif canCancelRefusedAffectation %}
                     <form method="POST" action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:affectation.id}) }}">
                         <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-checkbox-circle-fill reaffect fr-mb-3v"
                                 name="signalement-affectation-response[accept]" value="1"
@@ -220,7 +220,7 @@
                         Rouvrir pour tous
                     </button>
 
-                {% elseif canReopenAssignment %}
+                {% elseif canReopenAffectation %}
                     <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                             aria-controls="reopen-signalement-modal" data-fr-opened="false">
                         Rouvrir pour {{ app.user.partnerInTerritoryOrFirstOne(signalement.territory) ? app.user.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A' }}

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -147,7 +147,7 @@
             </div>
 
             <div class="fr-mb-4v fr-text--right">                        
-                {% if isAffected and not isAccepted and not isRefused and not needValidation and not isClosed and not isClosedForMe %}
+                {% if canAcceptOrRefuseAffectation %}
                     <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isAffected.id}) }}"
                             class="tinyCheck" id="signalement-affectation-response-form"
                             name="signalement-affectation-response-form" method="POST">
@@ -173,7 +173,7 @@
                         </div>
                     </div>
 
-                {% elseif isRefused %}
+                {% elseif canCancelRefusedAffectation %}
                     <form method="POST" action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isRefused.id}) }}">
                         <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-checkbox-circle-fill reaffect fr-mb-3v"
                                 name="signalement-affectation-response[accept]" value="1"
@@ -184,7 +184,7 @@
                                 value="{{ csrf_token('signalement_affectation_response_'~signalement.id) }}">
                     </form>
 
-                {% elseif needValidation and not isClosedForMe and is_granted('ROLE_ADMIN_TERRITORY') %}
+                {% elseif canValidateOrRefuseSignalement %}
                     <div class="admin-territory-validation">
                         <form id="signalement-validation-response-form"
                                 action="{{ path('back_signalement_validation_response',{uuid:signalement.uuid}) }}"

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -232,7 +232,7 @@
                         Clôturer
                     </button>
                 
-                {% elseif affectation and is_granted('ASSIGN_CLOSE', affectation) %}
+                {% elseif affectation and is_granted('AFFECTATION_CLOSE', affectation) %}
                     <a id="link-bouton-cloturer" href="#" aria-controls="cloture-modal" data-fr-opened="false"
                         class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left">
                         Clôturer

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -11,7 +11,7 @@
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-7">
             <div class="fr-mb-4v">      
-                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">          
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">
                     {% if signalement.isLogementSocial is null %}
                         Parc non renseigné
                     {% elseif signalement.isLogementSocial %}
@@ -21,7 +21,7 @@
                     {% endif %}
                 </span>
 
-                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">
                     {% if signalement.isAllocataire in [null, ''] %}
                         Allocataire non renseigné
                     {% elseif signalement.isAllocataire in ['oui', '1'] %}
@@ -33,7 +33,7 @@
                     {% endif %}
                 </span>
 
-                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">   
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">
                     {% if signalement.isProprioAverti is null %}
                         Bailleur averti : NSP
                     {% elseif signalement.isProprioAverti %}
@@ -63,11 +63,11 @@
                             <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
                         {% endif %}
                     {% else %}
-                        {% if isAffected and not isAccepted and not isRefused and not needValidation and not isClosed and not isClosedForMe %}
+                        {% if affectation and not isAssignmentAccepted and not isAssignmentRefused and not isSignalementClosed and not isClosedForMe %}
                             <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
-                        {% elseif isAccepted %}
+                        {% elseif isAssignmentAccepted %}
                             <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
-                        {% elseif isRefused %}
+                        {% elseif isAssignmentRefused %}
                             <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
                         {% elseif isClosedForMe %}
                             <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
@@ -115,7 +115,7 @@
                     </div>
             </div>
             
-            {% if not needValidation %}
+            {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') %}
             <div class="fr-mt-4v fr-p-4v fr-background-alt--grey">
                 <strong>Etiquettes</strong>
                 {% include 'back/signalement/view/tags.html.twig' %}
@@ -146,9 +146,9 @@
                 %}</p>
             </div>
 
-            <div class="fr-mb-4v fr-text--right">                        
-                {% if canAcceptOrRefuseAffectation %}
-                    <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isAffected.id}) }}"
+            <div class="fr-mb-4v fr-text--right">
+                {% if canAnswerAssignment %}
+                    <form action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:affectation.id}) }}"
                             class="tinyCheck" id="signalement-affectation-response-form"
                             name="signalement-affectation-response-form" method="POST">
                         <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-checkbox-circle-fill fr-btn--success"
@@ -173,8 +173,8 @@
                         </div>
                     </div>
 
-                {% elseif canCancelRefusedAffectation %}
-                    <form method="POST" action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isRefused.id}) }}">
+                {% elseif canCancelRefusedAssignment %}
+                    <form method="POST" action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isAssignmentRefused.id}) }}">
                         <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-checkbox-circle-fill reaffect fr-mb-3v"
                                 name="signalement-affectation-response[accept]" value="1"
                                 >
@@ -214,28 +214,27 @@
                         </div>
                     </div>
 
-                {% elseif isClosedForMe or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_CLOSED') or signalement.statut is same as constant('App\\Entity\\Signalement::STATUS_REFUSED') %}
-                    {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                        {% if isClosed %}
-                            <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
-                                    aria-controls="reopen-all-signalement-modal" data-fr-opened="false">
-                                Rouvrir pour tous
-                            </button>
-                        {% else %}
-                            <button aria-controls="cloture-modal" data-fr-opened="false"
-                                class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left keep-when-signalement-closed" id="test-bouton-cloturer">
-                                Clôturer
-                            </button>
-                        {% endif %}
+                {% elseif is_granted('SIGN_REOPEN', signalement) or canReopenAssignment %}
+                    {% if is_granted('SIGN_REOPEN', signalement) %}
+                    <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
+                            aria-controls="reopen-all-signalement-modal" data-fr-opened="false">
+                        Rouvrir pour tous
+                    </button>
                     {% endif %}
-                    {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') and isClosedForMe %}
+                    {% if canReopenAssignment %}
                         <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                                 aria-controls="reopen-signalement-modal" data-fr-opened="false">
                             Rouvrir pour {{ app.user.partnerInTerritoryOrFirstOne(signalement.territory) ? app.user.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A' }}
                         </button>
                     {% endif %}
+
+                {% elseif is_granted('SIGN_CLOSE', signalement) %}
+                    <button aria-controls="cloture-modal" data-fr-opened="false"
+                        class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left keep-when-signalement-closed" id="test-bouton-cloturer">
+                        Clôturer
+                    </button>
                 
-                {% elseif (signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_NEED_VALIDATION') and not isClosed and not isClosedForMe and isAffected and isAccepted) or is_granted('ROLE_ADMIN_TERRITORY') %}
+                {% elseif is_granted('ASSIGN_CLOSE', signalement) %}
                     <a href="#" aria-controls="cloture-modal" data-fr-opened="false"
                         class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left">
                         Clôturer

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -214,28 +214,26 @@
                         </div>
                     </div>
 
-                {% elseif is_granted('SIGN_REOPEN', signalement) or canReopenAssignment %}
-                    {% if is_granted('SIGN_REOPEN', signalement) %}
+                {% elseif is_granted('SIGN_REOPEN', signalement) %}
                     <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
                             aria-controls="reopen-all-signalement-modal" data-fr-opened="false">
                         Rouvrir pour tous
                     </button>
-                    {% endif %}
-                    {% if canReopenAssignment %}
-                        <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
-                                aria-controls="reopen-signalement-modal" data-fr-opened="false">
-                            Rouvrir pour {{ app.user.partnerInTerritoryOrFirstOne(signalement.territory) ? app.user.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A' }}
-                        </button>
-                    {% endif %}
+
+                {% elseif canReopenAssignment %}
+                    <button class="fr-btn fr-btn--sm fr-btn--success fr-fi-lock-fill fr-btn--icon-left fr-mt-1v reopen"
+                            aria-controls="reopen-signalement-modal" data-fr-opened="false">
+                        Rouvrir pour {{ app.user.partnerInTerritoryOrFirstOne(signalement.territory) ? app.user.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A' }}
+                    </button>
 
                 {% elseif is_granted('SIGN_CLOSE', signalement) %}
-                    <button aria-controls="cloture-modal" data-fr-opened="false"
-                        class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left keep-when-signalement-closed" id="test-bouton-cloturer">
+                    <button id="test-bouton-cloturer" aria-controls="cloture-modal" data-fr-opened="false"
+                        class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left keep-when-signalement-closed">
                         Clôturer
                     </button>
                 
-                {% elseif is_granted('ASSIGN_CLOSE', signalement) %}
-                    <a href="#" aria-controls="cloture-modal" data-fr-opened="false"
+                {% elseif affectation and is_granted('ASSIGN_CLOSE', affectation) %}
+                    <a id="link-bouton-cloturer" href="#" aria-controls="cloture-modal" data-fr-opened="false"
                         class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-close-line fr-btn--icon-left">
                         Clôturer
                     </a>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -174,7 +174,7 @@
                     </div>
 
                 {% elseif canCancelRefusedAssignment %}
-                    <form method="POST" action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:isAssignmentRefused.id}) }}">
+                    <form method="POST" action="{{ path('back_signalement_affectation_response',{signalement:signalement.id,user:app.user.id,affectation:affectation.id}) }}">
                         <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-checkbox-circle-fill reaffect fr-mb-3v"
                                 name="signalement-affectation-response[accept]" value="1"
                                 >

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -23,54 +23,54 @@
 
     <div class="fr-container--fluid">
         <div class="fr-grid-row fr-grid-row--gutters">
-            {% for affectation in signalement.affectations %}
+            {% for partnerAffectation in signalement.affectations %}
                 <div class="fr-col-12 fr-col-md-6 partner-row">
                     <div class="fr-mb-3v fr-p-3v fr-background-alt--grey">
                         <div class="fr-grid-row fr-grid-row--middle">
                             <div class="fr-col-12 fr-col-lg-7">
-                                {{ affectation.partner ? affectation.partner.nom : 'AUCUN' }}
+                                {{ partnerAffectation.partner ? partnerAffectation.partner.nom : 'AUCUN' }}
                                 <br>
-                                {% if affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_CLOSED') %}
+                                {% if partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_CLOSED') %}
                                     <span class="fr-hint-text">
-                                        Cloturé le {{ affectation.answeredAt|date('d/m/Y') }}
+                                        Cloturé le {{ partnerAffectation.answeredAt|date('d/m/Y') }}
                                         <br>
-                                        {{ affectation.answeredBy ? 'par ' ~ affectation.answeredBy.nomComplet }}
+                                        {{ partnerAffectation.answeredBy ? 'par ' ~ partnerAffectation.answeredBy.nomComplet }}
                                     </span>
-                                {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_ACCEPTED') %}
+                                {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_ACCEPTED') %}
                                     <span class="fr-hint-text">
-                                        Accepté le {{ affectation.answeredAt|date('d/m/Y') }}
+                                        Accepté le {{ partnerAffectation.answeredAt|date('d/m/Y') }}
                                         <br>
-                                        {{ affectation.answeredBy ? 'par ' ~ affectation.answeredBy.nomComplet }}
+                                        {{ partnerAffectation.answeredBy ? 'par ' ~ partnerAffectation.answeredBy.nomComplet }}
                                     </span>
-                                {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_REFUSED') %}
+                                {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_REFUSED') %}
                                     <span class="fr-hint-text">
-                                        Refusé le {{ affectation.answeredAt|date('d/m/Y') }}
+                                        Refusé le {{ partnerAffectation.answeredAt|date('d/m/Y') }}
                                         <br>
-                                        {{ affectation.answeredBy ? 'par ' ~ affectation.answeredBy.nomComplet }}
+                                        {{ partnerAffectation.answeredBy ? 'par ' ~ partnerAffectation.answeredBy.nomComplet }}
                                     </span>
                                 {% else %}
                                     <span class="fr-hint-text">
-                                        Affecté le {{ affectation.createdAt|date('d/m/Y') }}
+                                        Affecté le {{ partnerAffectation.createdAt|date('d/m/Y') }}
                                         <br>
-                                        {{ affectation.affectedBy ? 'par ' ~ affectation.affectedBy.nomComplet }}
+                                        {{ partnerAffectation.affectedBy ? 'par ' ~ partnerAffectation.affectedBy.nomComplet }}
                                     </span>
                                 {% endif %}
                             </div>
                             <div class="fr-col-10 fr-col-lg-3">
-                                {% if affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_WAIT') %}
+                                {% if partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_WAIT') %}
                                     <span class="fr-badge fr-badge--info fr-badge--sm">En attente</span>
-                                {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_ACCEPTED') %}
+                                {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_ACCEPTED') %}
                                     <span class="fr-badge fr-badge--success fr-badge--sm">Acceptée</span>
-                                {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_REFUSED') %}
+                                {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_REFUSED') %}
                                     <span class="fr-badge fr-badge--sm fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line">Refusée</span>
-                                {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_CLOSED') %}
+                                {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_CLOSED') %}
                                     <span class="fr-badge fr-badge--sm fr-fi-close-circle-fill">Clôturée</span>
                                 {% endif %}
                             </div>
                             {% if signalement.statut is not same as constant('App\\Entity\\Signalement::STATUS_CLOSED') %}
                                 <div class="fr-col-2 fr-text--right">
                                     <button title="Désaffecter le partenaire"
-                                            data-delete="{{ path('back_signalement_remove_partner',{uuid:signalement.uuid,affectation:affectation.id}) }}"
+                                            data-delete="{{ path('back_signalement_remove_partner',{uuid:signalement.uuid,affectation:partnerAffectation.id}) }}"
                                             data-token="{{ csrf_token('signalement_remove_partner_'~signalement.id) }}"
                                             class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line partner-row-delete"></button>
                                 </div>
@@ -84,18 +84,18 @@
 
 {% elseif
         not isClosedForMe
-        and isAccepted %}
+        and isAssignmentAccepted %}
     <div class="fr-my-3w">
         <h3 class="fr-h5">Partenaires impliqués</h3>
-        {% for affectation in signalement.affectations %}
-            {% if affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_WAIT') %}
-                <span class="fr-badge fr-badge--info fr-badge--sm">{{ affectation.partner ? affectation.partner.nom : 'AUCUN' }}</span>
-            {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_ACCEPTED') %}
-                <span class="fr-badge fr-badge--success fr-badge--sm">{{ affectation.partner ? affectation.partner.nom : 'AUCUN' }}</span>
-            {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_REFUSED') %}
-                <span class="fr-badge fr-badge--sm fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line">{{ affectation.partner ? affectation.partner.nom : 'AUCUN' }}</span>
-            {% elseif affectation.statut is same as constant('App\\Entity\\Affectation::STATUS_CLOSED') %}
-                <span class="fr-badge fr-badge--sm fr-fi-close-circle-fill">{{ affectation.partner ? affectation.partner.nom : 'AUCUN' }}</span>
+        {% for partnerAffectation in signalement.affectations %}
+            {% if partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_WAIT') %}
+                <span class="fr-badge fr-badge--info fr-badge--sm">{{ partnerAffectation.partner ? partnerAffectation.partner.nom : 'AUCUN' }}</span>
+            {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_ACCEPTED') %}
+                <span class="fr-badge fr-badge--success fr-badge--sm">{{ partnerAffectation.partner ? partnerAffectation.partner.nom : 'AUCUN' }}</span>
+            {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_REFUSED') %}
+                <span class="fr-badge fr-badge--sm fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line">{{ partnerAffectation.partner ? partnerAffectation.partner.nom : 'AUCUN' }}</span>
+            {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_CLOSED') %}
+                <span class="fr-badge fr-badge--sm fr-fi-close-circle-fill">{{ partnerAffectation.partner ? partnerAffectation.partner.nom : 'AUCUN' }}</span>
             {% endif %}
         {% endfor %}
     </div>

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -84,7 +84,7 @@
 
 {% elseif
         not isClosedForMe
-        and isAssignmentAccepted %}
+        and isAffectationAccepted %}
     <div class="fr-my-3w">
         <h3 class="fr-h5">Partenaires impliqués</h3>
         {% for partnerAffectation in signalement.affectations %}

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -61,12 +61,6 @@
         {% else %}
             <div class="fr-col-7 bloc-suivi-content-row fr-pl-3v">
         {% endif %}
-            {#{{ dump(suivi.description
-                |replace({'&t=___TOKEN___':'/'~signalement.uuid})
-                |replace({'?t=___TOKEN___':'/'~signalement.uuid})
-                |replace({'?folder=_up':'/'~signalement.uuid~'?variant=resize'})
-                |sanitize_html('app.message_sanitizer'))
-            }}#}
             {{ suivi.description
                 |replace({'&t=___TOKEN___':'/'~signalement.uuid})
                 |replace({'?t=___TOKEN___':'/'~signalement.uuid})

--- a/tests/Functional/Controller/Back/SignalementActionControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementActionControllerTest.php
@@ -35,7 +35,7 @@ class SignalementActionControllerTest extends WebTestCase
 
     public function testValidationResponseSignalementSuccess(): void
     {
-        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000006']);
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000016']);
         $route = $this->router->generate('back_signalement_validation_response', ['uuid' => $signalement->getUuid()]);
         $this->client->request(
             'GET',
@@ -56,7 +56,7 @@ class SignalementActionControllerTest extends WebTestCase
 
     public function testValidationResponseSignalementError(): void
     {
-        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000006']);
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2023-000000000016']);
         $route = $this->router->generate('back_signalement_validation_response', ['uuid' => $signalement->getUuid()]);
         $this->client->request(
             'GET',

--- a/tests/Functional/Controller/Back/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementControllerTest.php
@@ -63,6 +63,96 @@ class SignalementControllerTest extends WebTestCase
         }
     }
 
+    /**
+     * @dataProvider provideRoleSignalementRoutes
+     */
+    public function testButtonsDisplayedByRole(string $email, string $uuid, string $elementSelector = '', string $elementText = ''): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        /** @var UrlGeneratorInterface $generatorUrl */
+        $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        $user = $userRepository->findOneBy(['email' => $email]);
+        $route = $generatorUrl->generate('back_signalement_view', ['uuid' => $uuid]);
+
+        $client->loginUser($user);
+        $client->request('GET', $route);
+        $this->assertSelectorTextContains(
+            $elementSelector,
+            $elementText
+        );
+    }
+
+    public function provideRoleSignalementRoutes(): \Generator
+    {
+        yield 'SA - Nouveau' => [
+            'admin-01@histologe.fr',
+            '00000000-0000-0000-2025-000000000001',
+            '#signalement-validation-response-form .fr-icon-checkbox-circle-fill',
+            'Valider le signalement',
+        ];
+        yield 'SA - En cours' => [
+            'admin-01@histologe.fr',
+            '00000000-0000-0000-2022-000000000001',
+            '#test-bouton-cloturer',
+            'Clôturer',
+        ];
+        yield 'SA - Fermé' => [
+            'admin-01@histologe.fr',
+            '00000000-0000-0000-2023-000000000001',
+            'button.fr-fi-lock-fill.reopen',
+            'Rouvrir pour tous',
+        ];
+
+        yield '13 - RT - Nouveau' => [
+            'admin-territoire-13-01@histologe.fr',
+            '00000000-0000-0000-2023-000000000017',
+            '#signalement-validation-response-form .fr-icon-checkbox-circle-fill',
+            'Valider le signalement',
+        ];
+        yield '13 - RT - En cours' => [
+            'admin-territoire-13-01@histologe.fr',
+            '00000000-0000-0000-2022-000000000001',
+            '#signalement-affectation-response-form .fr-icon-checkbox-circle-fill',
+            'Accepter',
+        ];
+
+        yield '01 - RT - Fermé' => [
+            'admin-territoire-01-01@histologe.fr',
+            '00000000-0000-0000-2022-000000000002',
+            'button.fr-fi-lock-fill.reopen',
+            'Rouvrir pour tous',
+        ];
+
+        yield '38 - RT - Affectation refusée' => [
+            'admin-territoire-38-01@histologe.fr',
+            '00000000-0000-0000-2023-000000000022',
+            'button.fr-icon-checkbox-circle-fill.reaffect',
+            'Annuler le refus',
+        ];
+        yield '38 - RT - Affectation clôturée' => [
+            'admin-territoire-38-01@histologe.fr',
+            '00000000-0000-0000-2023-000000000023',
+            'button.fr-fi-lock-fill.reopen',
+            'Rouvrir pour DDT 38',
+        ];
+
+        yield '13 - Agent - Nouveau' => [
+            'user-13-06@histologe.fr',
+            '00000000-0000-0000-2023-000000000010',
+            '.fr-icon-checkbox-circle-fill.fr-btn--success',
+            'Accepter',
+        ];
+        yield '13 - Agent - En cours' => [
+            'user-13-01@histologe.fr',
+            '00000000-0000-0000-2023-000000000006',
+            '#link-bouton-cloturer',
+            'Clôturer',
+        ];
+    }
+
     public function testSignalementNDESuccessfullyDisplay(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Ticket

#2367    

## Description
Modification des noms de variables utilisées dans les twig de la fiche signalement, pour les rendre plus explicites, ou utiliser des Voter quand nécessaire.

## Tests
- [ ] Vérifier les boutons affichés dans différents signalements, dans différents statuts, avec le Super Admin
- [ ] Idem avec un RT
- [ ] Idem avec un agent
