### PR TITLE
[Sécurité] Autoriser un parent à charger l'url de la plateforme via un iframe

### DIFF
--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -58,7 +58,8 @@ parameters:
     form-action:
       - "'self'"
     frame-ancestors:
-      - "'none'"
+      - "'self'"
+      - "https://histologe-sites-faciles.osc-fr1.scalingo.io/"
     media-src:
       - "'self'"
     worker-src:


### PR DESCRIPTION
## Ticket

#3513    

## Description
Afin de pouvoir charger la page stat dans sites-facile, il faudrait autoriser l'url site-facile à pouvoir charger la page stat conformément aux règles de sécurité CSP.

## Changements apportés
* Changement de la directive `frame-ancestors` dans csp.yaml

## Pré-requis

## Tests
- [ ] Vérifier sur Sites-Faciles qu'on peut intégrer une page de la ReviewApp https://histologe-staging-pr3545.osc-fr1.scalingo.io/ comme par exemple https://histologe-sites-faciles.osc-fr1.scalingo.io/cms-admin/pages/27/edit/preview/
- [ ] vérifier la CPS obtenue sur https://csp-evaluator.withgoogle.com/
