### PR TITLE
[BO - Résumés de suivis] Ajout du modèle Google Gemma

### DIFF
--- a/src/Form/SuiviSummariesType.php
+++ b/src/Form/SuiviSummariesType.php
@@ -38,7 +38,7 @@ class SuiviSummariesType extends AbstractType
             ])
 
             ->add('prompt', TextareaType::class, [
-                'data' => 'Tu es un analyste de haute qualité. Ton travail est de résumer en français en quelques mots uniquement, le contenu d\'un email pour que n\'importe qui puisse savoir l\'essence de son propos.',
+                'data' => 'Tu es un analyste de haute qualité. Ton travail est de résumer en français en quelques mots uniquement, le contenu du texte suivant pour que n\'importe qui puisse savoir l\'essence de son propos.',
                 'attr' => [
                     'rows' => 5,
                 ],
@@ -73,7 +73,7 @@ class SuiviSummariesType extends AbstractType
                     // 'BAAI/bge-m3' => 'BAAI/bge-m3',
                     'AgentPublic/llama3-instruct-guillaumetell' => 'AgentPublic/llama3-instruct-guillaumetell',
                     // 'intfloat/multilingual-e5-large' => 'intfloat/multilingual-e5-large',
-                    // 'google/gemma-2-9b-it' => 'google/gemma-2-9b-it',
+                    'google/gemma-2-9b-it' => 'google/gemma-2-9b-it',
                 ],
                 'placeholder' => 'Choisissez un modèle de langage',
                 'multiple' => false,

--- a/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
+++ b/src/Messenger/MessageHandler/SuiviSummariesMessageHandler.php
@@ -130,9 +130,14 @@ class SuiviSummariesMessageHandler
     {
         $messages = [];
 
-        if (!empty($cleanLastSuiviDescription)) {
+        // User system doesn't exist in Google, and needs alternate between user and assistant
+        if ('google/gemma-2-9b-it' === $suiviSummariesMessage->getModel()) {
+            $messages[] = $this->getAlbertMessage(
+                message: $suiviSummariesMessage->getPrompt().' --- '.$cleanLastSuiviDescription,
+            );
+        } elseif (!empty($cleanLastSuiviDescription)) {
             $messages[] = $this->getAlbertMessage($suiviSummariesMessage->getPrompt(), $suiviSummariesMessage->getPromptRole());
-            $messages[] = $this->getAlbertMessage($cleanLastSuiviDescription);
+            $messages[] = $this->getAlbertMessage($cleanLastSuiviDescription, $suiviSummariesMessage->getPromptRole());
         } else {
             return null;
         }


### PR DESCRIPTION
## Ticket

#3512    

## Description
Ajout du modèle Google Gemma qui n'était pas pris en compte précédemment.

## Changements apportés
* Pour le faire fonctionner, on utilise uniquement le rôle user, et on rassemble le prompt et le suivi dans le même message.

## Tests
- [ ] Tester le nouveau modèle `google/gemma-2-9b-it` sur quelques signalements de prod
- [ ] TNR sur un ancien modèle
