### PR TITLE
[Tech] Mise à jour de action/cache du workflow GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           update: true
       - name: Cache wkthtmltopdf
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-wkhtmltopdf
         with:
           path: "~/wkhtmltox/"
@@ -111,7 +111,7 @@ jobs:
 
       # https://help.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows
       - name: Cache composer dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
            path: ${{ steps.composer-cache.outputs.dir }}
            key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
## Ticket

#3516   

## Description
On utilisait les versions `actions/cache@v1` et `actions/cache@v2` que GitHub va bientôt déprécier.
Ils encourageaient à passer en v3 ou v4, donc les deux passent en v4.

## Tests
- [ ] La CI passe
