### PR TITLE
[BUG] Filtre zone propose toutes les zones

### DIFF
--- a/src/Repository/ZoneRepository.php
+++ b/src/Repository/ZoneRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Signalement;
 use App\Entity\Territory;
+use App\Entity\User;
 use App\Entity\Zone;
 use App\Service\ListFilters\SearchZone;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -89,9 +90,12 @@ class ZoneRepository extends ServiceEntityRepository
         return $resultSet->fetchAllAssociative();
     }
 
-    public function findAllByTerritory(?Territory $territory): array
+    public function findForUserAndTerritory(User $user, ?Territory $territory): array
     {
         $qb = $this->createQueryBuilder('z');
+        if (!$user->isSuperAdmin()) {
+            $qb->andWhere('z.territory IN (:territories)')->setParameter('territories', $user->getPartnersTerritories());
+        }
         if ($territory) {
             $qb->andWhere('z.territory = :territory')->setParameter('territory', $territory);
         }

--- a/src/Service/Signalement/SearchFilterOptionDataProvider.php
+++ b/src/Service/Signalement/SearchFilterOptionDataProvider.php
@@ -58,7 +58,7 @@ class SearchFilterOptionDataProvider
                     'partners' => $this->partnerRepository->findAllList($territory, $user),
                     'epcis' => $this->communeRepository->findEpciByCommuneTerritory($territory, $user),
                     'tags' => $this->tagsRepository->findAllActive($territory, $user),
-                    'zones' => $this->zoneRepository->findAllByTerritory($territory),
+                    'zones' => $this->zoneRepository->findForUserAndTerritory($user, $territory),
                     'cities' => $this->signalementRepository->findCities($user, $territory),
                     'zipcodes' => $this->signalementRepository->findZipcodes($user, $territory),
                     'listQualificationStatus' => $this->qualificationStatusService->getList(),


### PR DESCRIPTION
## Ticket

#3548

## Description
Correction e la requête récupérant la liste des zones à afficher dans le filtre zone afin qu'elle ne propose que les zones des territoires de l’utilisateur (hors SA qui voit tout)

## Tests
- [ ] Se connecter en SA et vérifier que la liste des zones dans les filtres est complète
- [ ] Se connecter sur un user non SA (ex admin-territoire-34-01@histologe.fr) sur un territoire contenant des zone et vérifier que la liste de filtre contient la liste limité
