### PR TITLE
[FO - Formulaire] Accepter zero comme valeur pour le nombre d'enfants

### DIFF
--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -302,7 +302,7 @@ class SignalementDraftRequest
     )]
     private ?string $compositionLogementNombrePersonnes = null;
 
-    #[Assert\Positive(message: 'Le nombre d\'enfants doit être un nombre positif.')]
+    #[Assert\PositiveOrZero(message: 'Le nombre d\'enfants doit être un nombre positif ou zero.')]
     #[Assert\Type(type: 'numeric', message: 'Le nombre d\'enfants doit être un nombre.')]
     #[Assert\Length(
         max: 10,


### PR DESCRIPTION
## Ticket

#3567   

## Description
Accepter zero comme valeur pour le nombre d'enfants

## Tests
- [ ] Créer un signalement et vérifier les différentes valeurs de nombre d'enfants, vérifier qu'on peut passer à la suite
