### PR TITLE
[BO - Liste signalements] Correction de la liste des communes vide pour les RT

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -654,7 +654,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->select($field.' '.$alias)
             ->where('s.statut != :status')
             ->setParameter('status', Signalement::STATUS_ARCHIVED);
-        if (!$user->isSuperAdmin()) {
+        if (!$user->isSuperAdmin() && !$user->isTerritoryAdmin()) {
             $qb->leftJoin('s.affectations', 'affectations')
                 ->leftJoin('affectations.partner', 'partner')
                 ->andWhere('partner IN (:partners)')
@@ -663,6 +663,9 @@ class SignalementRepository extends ServiceEntityRepository
         if ($territory) {
             $qb->andWhere('s.territory = :territory')
                 ->setParameter('territory', $territory);
+        } elseif (!$user->isSuperAdmin()) {
+            $qb->andWhere('s.territory IN (:territories)')
+                ->setParameter('territories', $user->getPartnersTerritories());
         }
 
         return $qb


### PR DESCRIPTION
## Ticket

#3569   

## Description
La liste des communes en tant que RT est vide. Elle ne devrait pas l'être et devrait contenir l'ensemble des communes des territoires de ses partenaires.

## Tests
Tests sur les département dont on pré-charge les communes (sinon faire un `make console app="update-communes"`)
Idéalement `make clear-pool pool=--all` entre chaque test
- [ ] Se connecter avec différents profils sur le 13 et vérifier la liste des communes
- [ ] Idem dans le 01
