### PR TITLE
[QA] Suppression des exports de listes de signalements plus vieux qu'un mois

### DIFF
--- a/src/Command/Cron/ClearStorageTmpFolderCommand.php
+++ b/src/Command/Cron/ClearStorageTmpFolderCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command\Cron;
 
+use App\Repository\FileRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
@@ -28,6 +29,7 @@ class ClearStorageTmpFolderCommand extends AbstractCronCommand
         private readonly ParameterBagInterface $parameterBag,
         private readonly NotificationMailerRegistry $notificationMailerRegistry,
         private readonly LoggerInterface $logger,
+        private readonly FileRepository $fileRepository,
     ) {
         parent::__construct($this->parameterBag);
     }
@@ -38,6 +40,26 @@ class ClearStorageTmpFolderCommand extends AbstractCronCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $nbFiles = $this->cleanFilesOlderThan6Months($io, $output);
+        $nbFiles = $this->cleanExportsOlderThan1Month($io, $output);
+
+        $this->notificationMailerRegistry->send(
+            new NotificationMail(
+                type: NotificationMailerType::TYPE_CRON,
+                to: $this->parameterBag->get('admin_email'),
+                message: $nbFiles > 1
+                    ? sprintf('%s fichiers ont été supprimés', $nbFiles)
+                    : sprintf('%s a été supprimé', $nbFiles),
+                cronLabel: 'Suppression de fichier(s) temporaires s3://tmp',
+                cronCount: $nbFiles,
+            )
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function cleanFilesOlderThan6Months(SymfonyStyle $io, OutputInterface $output): int
+    {
         $datetime = (new \DateTimeImmutable('- 6 months'));
         $timestamp = $datetime->getTimestamp();
 
@@ -46,13 +68,13 @@ class ClearStorageTmpFolderCommand extends AbstractCronCommand
             ->filter(fn (StorageAttributes $attributes) => $attributes->lastModified() < $timestamp)
             ->toArray();
 
-        $nbFiles = count($files);
+        $nbFiles = \count($files);
 
         $io->warning(sprintf(
             '%d fichier(s) déposé(s) avant le %s seront supprimés du repertoire tmp',
             $nbFiles,
-            $datetime->format('Y-m-d H:i:s'))
-        );
+            $datetime->format('Y-m-d H:i:s')
+        ));
 
         $progressBar = new ProgressBar($output, $nbFiles);
         $progressBar->start();
@@ -72,18 +94,36 @@ class ClearStorageTmpFolderCommand extends AbstractCronCommand
         $progressBar->clear();
         $io->success(sprintf('%d document(s) ont été supprimé(s) du repertoire /tmp', $nbFiles));
 
-        $this->notificationMailerRegistry->send(
-            new NotificationMail(
-                type: NotificationMailerType::TYPE_CRON,
-                to: $this->parameterBag->get('admin_email'),
-                message: $nbFiles > 1
-                    ? sprintf('%s fichiers ont été supprimés', $nbFiles)
-                    : sprintf('%s a été supprimé', $nbFiles),
-                cronLabel: 'Suppression de fichier(s) temporaires s3://tmp',
-                cronCount: $nbFiles,
-            )
-        );
+        return $nbFiles;
+    }
 
-        return Command::SUCCESS;
+    private function cleanExportsOlderThan1Month(SymfonyStyle $io, OutputInterface $output): int
+    {
+        $limit = new \DateTimeImmutable('- 1 month');
+        $files = $this->fileRepository->findExportsOlderThan($limit);
+        $nbFiles = \count($files);
+
+        $io->warning(sprintf(
+            '%d exports seront supprimés',
+            $nbFiles,
+        ));
+
+        $progressBar = new ProgressBar($output, $nbFiles);
+        $progressBar->start();
+        foreach ($files as $file) {
+            $filename = $file->getFilename();
+            if ($this->fileStorage->fileExists($filename)) {
+                $this->fileStorage->delete($filename);
+                $this->logger->info(
+                    sprintf('Fichier supprimé : %s', $filename)
+                );
+            }
+            $progressBar->advance();
+        }
+        $progressBar->finish();
+        $progressBar->clear();
+        $io->success(sprintf('%d exports ont été supprimés du repertoire /tmp', $nbFiles));
+
+        return $nbFiles;
     }
 }

--- a/src/DataFixtures/Loader/LoadFileData.php
+++ b/src/DataFixtures/Loader/LoadFileData.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\DataFixtures\Loader;
+
+use App\Entity\Enum\DocumentType;
+use App\Entity\File;
+use App\Factory\FileFactory;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+
+class LoadFileData extends Fixture implements OrderedFixtureInterface
+{
+    public function __construct(
+        private readonly FileFactory $fileFactory,
+    ) {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $file = $this->fileFactory->createInstanceFrom(
+            filename: 'export-histologe-xxxx.xslx',
+            title: 'export-histologe-xxxx.xslx',
+            type: File::FILE_TYPE_DOCUMENT,
+            documentType: DocumentType::EXPORT,
+        );
+        $file->setCreatedAt(new \DateTimeImmutable('- 2 months'));
+        $manager->persist($file);
+        $manager->flush();
+    }
+
+    public function getOrder(): int
+    {
+        return 22;
+    }
+}

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Enum\DocumentType;
 use App\Entity\File;
 use App\Entity\Territory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -87,5 +88,15 @@ class FileRepository extends ServiceEntityRepository
             ->andWhere('f.isOriginalDeleted = false')
             ->andWhere('f.createdAt < :limit')
             ->setParameter('limit', $limit);
+    }
+
+    public function findExportsOlderThan(\DateTimeInterface $limit): array
+    {
+        return $this->createQueryBuilder('f')
+            ->andWhere('f.documentType = :documentType')
+            ->andWhere('f.createdAt < :limit')
+            ->setParameter('documentType', DocumentType::EXPORT)
+            ->setParameter('limit', $limit)
+            ->getQuery()->getResult();
     }
 }

--- a/tests/Functional/Command/Cron/ClearStorageTmpFolderCommandTest.php
+++ b/tests/Functional/Command/Cron/ClearStorageTmpFolderCommandTest.php
@@ -3,7 +3,9 @@
 namespace App\Tests\Functional\Command\Cron;
 
 use App\Command\Cron\ClearStorageTmpFolderCommand;
+use App\Repository\FileRepository;
 use App\Service\Mailer\NotificationMailerRegistry;
+use App\Service\UploadHandlerService;
 use League\Flysystem\DirectoryListing;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -21,6 +23,8 @@ class ClearStorageTmpFolderCommandTest extends KernelTestCase
     private MockObject|ParameterBagInterface $parameterBag;
     private MockObject|NotificationMailerRegistry $mailerRegistry;
     private MockObject|LoggerInterface $logger;
+    private MockObject|FileRepository $fileRepository;
+    private MockObject|UploadHandlerService $uploadHandlerService;
 
     protected function setUp(): void
     {
@@ -28,6 +32,8 @@ class ClearStorageTmpFolderCommandTest extends KernelTestCase
         $this->parameterBag = self::getContainer()->getParameterBag();
         $this->mailerRegistry = self::getContainer()->get(NotificationMailerRegistry::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->fileRepository = self::getContainer()->get(FileRepository::class);
+        $this->uploadHandlerService = self::getContainer()->get(UploadHandlerService::class);
     }
 
     /**
@@ -54,11 +60,14 @@ class ClearStorageTmpFolderCommandTest extends KernelTestCase
             $this->parameterBag,
             $this->mailerRegistry,
             $this->logger,
+            $this->fileRepository,
+            $this->uploadHandlerService,
         );
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
 
         $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('1 exports ont été supprimés', $output);
         $this->assertStringContainsString('1 document(s) ont été supprimé(s) du repertoire /tmp', $output);
         $this->assertEquals(Command::SUCCESS, $commandTester->getStatusCode());
     }


### PR DESCRIPTION
## Ticket

#3127   

## Description
Suppression des exports de listes de signalements plus vieux qu'un mois en utilisant la commande qui purge déjà le fichier /tmp

## Tests
- [ ] Faire un ou plusieurs exports csv
- [ ] Modifier leur date de création dans la bdd
- [ ] `make console app="clear-storage-tmp-folder"`
- [ ] Les fichiers n'existent plus
