### PR TITLE
[QA] Correction de transformation de donnée en majuscule si null

### DIFF
--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -68,7 +68,9 @@ class SignalementExportFactory
         }
 
         $infoProcedureBailMoyen = $infoProcedureBailMoyenLabel = null;
-        if (isset($data['informationProcedure']) && $data['informationProcedure'] instanceof InformationProcedure) {
+        if (isset($data['informationProcedure'])
+                && $data['informationProcedure'] instanceof InformationProcedure
+                && !empty($data['informationProcedure']->getInfoProcedureBailMoyen())) {
             $infoProcedureBailMoyen = strtoupper($data['informationProcedure']->getInfoProcedureBailMoyen());
             $infoProcedureBailMoyenLabel = MoyenContact::tryFrom($infoProcedureBailMoyen)?->label();
         }


### PR DESCRIPTION
## Ticket

#3571   

## Description
Correction de transformation de donnée en majuscule si null de la valeur de `getInfoProcedureBailMoyen`

## Tests
- [ ] Voir la liste des signalements
- [ ] Faire un export de signalements
