### PR TITLE
[Auto-affectation] Prise en compte de format wkt spécifique

### DIFF
--- a/src/Messenger/MessageHandler/SignalementAddressUpdateAndAutoAssignMessageHandler.php
+++ b/src/Messenger/MessageHandler/SignalementAddressUpdateAndAutoAssignMessageHandler.php
@@ -27,8 +27,8 @@ class SignalementAddressUpdateAndAutoAssignMessageHandler
         try {
             $signalement = $this->signalementRepository->find($signalementAddressUpdateAndAutoAssignMessage->getSignalementId());
             $this->signalementAddressUpdater->updateAddressOccupantFromBanData($signalement);
-            $this->autoAssigner->assign($signalement);
             $this->entityManager->flush();
+            $this->autoAssigner->assign($signalement);
         } catch (\Throwable $exception) {
             $this->logger->error(
                 sprintf(

--- a/src/Specification/Affectation/CodeInseeSpecification.php
+++ b/src/Specification/Affectation/CodeInseeSpecification.php
@@ -120,6 +120,10 @@ class CodeInseeSpecification implements SpecificationInterface
 
     private function isPointInPolygon(Coordinate $point, array $polygonData): bool
     {
+        // special case : POLYGON ((X1 Y1, X2 Y2)))
+        if (1 === \count($polygonData)) {
+            $polygonData = $polygonData[0];
+        }
         $polygon = $this->buildPolygon($polygonData);
 
         return $polygon->contains($point);
@@ -127,6 +131,10 @@ class CodeInseeSpecification implements SpecificationInterface
 
     private function isPointInMultiPolygon(Coordinate $point, array $multiPolygonData): bool
     {
+        // special case : MULTIPOLYGON (((X1 Y1, X2 Y2),(X3 Y3, X4 Y4)))
+        if (1 === \count($multiPolygonData)) {
+            $multiPolygonData = $multiPolygonData[0];
+        }
         foreach ($multiPolygonData as $polygonData) {
             if ($this->isPointInPolygon($point, $polygonData)) {
                 return true;


### PR DESCRIPTION
## Ticket

#3588   

## Description
Certaines zones au format WKT ne sont pas prises en compte correctement.
Exemple : `MULTIPOLYGON (((X1 Y1, X2 Y2),(X3 Y3, X4 Y4)))`
Il y a un tableau à un seul élément imbriqué (alors qu'on cherche à récupérer directement cet élément comme une liste.
Cela provoque une erreur d'analyse.

Et comme l'enregistrement en bdd (`flush`) de la géolocalisation est fait après, certaines géolocalisation sont mal initialisées dans ce cas.

## Changements apportés
- Mise en place du `flush` avant de faire l'auto-affectation (pour au moins enregistrer la géolocalisation)
- Prise en compte du format avec tableau avec mono-valeur dans le format wkt

## Tests
- [ ] Utiliser une zone ou plusieurs zones créées sur la prod dans le 34
- [ ] Créer un signalement dont l'auto-affectation fonctionne avec ces zones
