### PR TITLE
[BO - Signalements] Zones - signalements archivés intégrés

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -8,7 +8,8 @@ twig:
             logosvg: 'logo-histologe.svg'
             url: '%host_url%'
             demo: 'https://app.livestorm.co/mte/demonstration-histologe'
-            cgu_current_version: '%cgu_current_version%'
+            cgu_current_version: '%cgu_current_version%'            
+            feature_bo_signalement_create: '%feature_bo_signalement_create%'
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -9,7 +9,6 @@ twig:
             url: '%host_url%'
             demo: 'https://app.livestorm.co/mte/demonstration-histologe'
             cgu_current_version: '%cgu_current_version%'            
-            feature_bo_signalement_create: '%feature_bo_signalement_create%'
         gitbook:
             documentation: https://documentation.histologe.beta.gouv.fr
             faq: https://faq.histologe.beta.gouv.fr

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -562,6 +562,42 @@ signalements:
     score_logement: 13.990384615385
     score_batiment: 50
   -
+    territory: "Hérault"
+    uuid: "00000000-0000-0000-2025-000000000003"
+    reference: "2024-08"
+    details: "Signalement archivé Agde zone"
+    is_proprio_averti: 1
+    is_allocataire: "CAF"
+    nature_logement: "maison"
+    superficie: 55
+    loyer: null
+    date_entree: "2020-12-01"
+    nom_proprio: "Habitat-PDC"
+    is_logement_social: 0
+    nom_occupant: "Brassens"
+    prenom_occupant: "Georges"
+    tel_occupant: "+330240556677"
+    phone_number: "+330240556677"
+    mail_occupant: "georges.brassens@yopmail.com"
+    adresse_occupant: "240 Avenue Victor Hugo"
+    cp_occupant: "34300"
+    ville_occupant: "AGDE"
+    statut: 7
+    geoloc: "{\"lat\": 43.311679, \"lng\": 3.4677498}"
+    insee_occupant: "34145"
+    nb_pieces_logement: 5
+    nb_occupants_logement: 4
+    score: 35.194711538462
+    created_from_uuid: '00000000-0000-0000-2025-000000000003'
+    profile_declarant: "LOCATAIRE"
+    civilite_occupant: "mme"
+    type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"oui\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"
+    situation_foyer: "{\"logement_social_allocation\": \"non\", \"logement_social_date_naissance\": null, \"logement_social_allocation_caisse\": null, \"travailleur_social_accompagnement\": \"non\", \"logement_social_demande_relogement\": \"non\", \"logement_social_montant_allocation\": null, \"logement_social_numero_allocataire\": null, \"travailleur_social_quitte_logement\": \"non\", \"travailleur_social_accompagnement_declarant\": null}"
+    information_procedure: "{\"utilisation_service_ok_visite\": true, \"utilisation_service_ok_cgu\": true, \"info_procedure_bailleur_prevenu\": \"oui\", \"info_procedure_reponse_assurance\": null, \"info_procedure_assurance_contactee\": \"non\", \"info_procedure_depart_apres_travaux\": \"oui\", \"utilisation_service_ok_demande_logement\": true, \"utilisation_service_ok_prevenir_bailleur\": true}"
+    information_complementaire: "{\"informations_complementaires_logement_montant_loyer\": null, \"informations_complementaires_logement_nombre_etages\": null, \"informations_complementaires_logement_annee_construction\": null, \"informations_complementaires_situation_bailleur_revenu_fiscal\": null, \"informations_complementaires_situation_occupants_loyers_payes\": null, \"informations_complementaires_situation_bailleur_date_naissance\": null, \"informations_complementaires_situation_occupants_date_naissance\": null, \"informations_complementaires_situation_bailleur_beneficiaire_fsl\": null, \"informations_complementaires_situation_bailleur_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_beneficiaire_fsl\": null, \"informations_complementaires_situation_occupants_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_date_emmenagement\": null, \"informations_complementaires_situation_occupants_demande_relogement\": null}"
+    score_logement: 13.990384615385
+    score_batiment: 50
+  -
     territory: "Loire-Atlantique"
     uuid: "00000000-0000-0000-2024-000000000009"
     reference: "2024-09"

--- a/src/Repository/ZoneRepository.php
+++ b/src/Repository/ZoneRepository.php
@@ -62,10 +62,11 @@ class ZoneRepository extends ServiceEntityRepository
             JOIN zone z ON ST_Contains(ST_GeomFromText(z.area),
             Point(JSON_EXTRACT(s.geoloc, "$.lng"), JSON_EXTRACT(s.geoloc, "$.lat")))
             WHERE z.id = :zone AND s.territory_id = z.territory_id
+            AND s.statut NOT IN (:status_draft, :status_archived)
             ORDER BY s.created_at DESC
             ';
 
-        $resultSet = $conn->executeQuery($sql, ['zone' => $zone->getId()]);
+        $resultSet = $conn->executeQuery($sql, ['zone' => $zone->getId(), 'status_draft' => Signalement::STATUS_DRAFT, 'status_archived' => Signalement::STATUS_ARCHIVED]);
         $list = $resultSet->fetchAllAssociative();
         foreach ($list as $key => $value) {
             $list[$key]['geoloc'] = json_decode($value['geoloc'], true);

--- a/tests/Functional/Controller/ArchivedSignalementControllerTest.php
+++ b/tests/Functional/Controller/ArchivedSignalementControllerTest.php
@@ -36,7 +36,7 @@ class ArchivedSignalementControllerTest extends WebTestCase
         $this->client->request('GET', $route);
         $this->assertResponseIsSuccessful();
 
-        $this->assertSelectorTextContains('h2', '2 signalements archivés');
+        $this->assertSelectorTextContains('h2', '3 signalements archivés');
     }
 
     public function testReactiveSignalement()

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -50,8 +50,8 @@ class BackStatistiquesControllerTest extends WebTestCase
     public function provideRoutesStatistiquesDatas(): \Generator
     {
         yield 'Super Admin' => ['back_statistiques_filter', [], self::USER_SUPER_ADMIN, [
-            ['result' => 48, 'label' => 'count_signalement'],
-            ['result' => 57.9, 'label' => 'average_criticite'],
+            ['result' => 49, 'label' => 'count_signalement'],
+            ['result' => 57.5, 'label' => 'average_criticite'],
         ]];
         yield 'Responsable Territoire' => ['back_statistiques_filter', [], self::USER_ADMIN_TERRITOIRE, [
             ['result' => 26, 'label' => 'count_signalement'],

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -138,7 +138,7 @@ class SignalementRepositoryTest extends KernelTestCase
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
         $signalementsArchived = $signalementRepository->findAllArchived(1, 50, null, null);
-        $this->assertEquals(2, \count($signalementsArchived));
+        $this->assertEquals(3, \count($signalementsArchived));
     }
 
     public function testFindAllArchivedTerritory(): void

--- a/tests/Functional/Repository/ZoneRepositoryTest.php
+++ b/tests/Functional/Repository/ZoneRepositoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Tests\Functional\Repository;
+
+use App\Repository\ZoneRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ZoneRepositoryTest extends KernelTestCase
+{
+    private ZoneRepository $zoneRepository;
+
+    protected function setUp(): void
+    {
+        $this->zoneRepository = static::getContainer()->get(ZoneRepository::class);
+    }
+
+    public function testCountSignalementNoSuiviAfter3Relances(): void
+    {
+        $zone = $this->zoneRepository->findOneBy(['name' => 'Permis louer Agde']);
+
+        $result = $this->zoneRepository->findSignalementsByZone($zone);
+        $this->assertCount(1, $result);
+    }
+}


### PR DESCRIPTION
## Ticket

#3592

## Description
Modification de la requête récupérant les signalements dans une zone afin de ne pas afficher dans la liste ceux en statut DRAF ni ARCHIVED 

## Pré-requis
`make load-fixtures`

## Tests
- [ ] S'assurer qu'un seul signalement apparaît sur la carte de la zone "Permis louer Agde"
