### PR TITLE
[BO - Auto-Affectation] Filtrage des partenaires par périmètre géographique avant d'étudier les règles d'auto-affectation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
         "knplabs/knp-snappy-bundle": "^1.9",
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-bundle": "^3.0",
-        "longitude-one/wkt-parser": "^3.0",
-        "mjaschen/phpgeo": "^5.0",
         "nelmio/cors-bundle": "^2.2",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpoffice/phpspreadsheet": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "727f9a63054c0e1f2b9ac17c5ca06b06",
+    "content-hash": "5096f2ed35426df739daceb598708c81",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3352,74 +3352,6 @@
             "time": "2024-03-23T07:42:40+00:00"
         },
         {
-            "name": "longitude-one/wkt-parser",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/longitude-one/wkt-parser.git",
-                "reference": "cb9ded868bfd0200e5134bf259b1e001b83ebaa2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/longitude-one/wkt-parser/zipball/cb9ded868bfd0200e5134bf259b1e001b83ebaa2",
-                "reference": "cb9ded868bfd0200e5134bf259b1e001b83ebaa2",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^2.1|^3.0",
-                "php": "^8.1"
-            },
-            "replace": {
-                "creof/wkt-parser": "*"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "LongitudeOne\\Geo\\WKT": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Alexandre Tranchant",
-                    "email": "alexandre.tranchant@gmail.com"
-                },
-                {
-                    "name": "axi"
-                },
-                {
-                    "name": "Derek J. Lambert",
-                    "email": "dlambert@dereklambert.com"
-                },
-                {
-                    "name": "ellisgl"
-                }
-            ],
-            "description": "Parser for well-known text (WKT) object strings",
-            "keywords": [
-                "ewkt",
-                "geography",
-                "geometry",
-                "lexer",
-                "parser",
-                "spatial",
-                "string",
-                "text",
-                "wkt"
-            ],
-            "support": {
-                "issues": "https://github.com/longitude-one/wkt-parser/issues",
-                "source": "https://github.com/longitude-one/wkt-parser/tree/3.0.0"
-            },
-            "time": "2024-04-27T07:44:31+00:00"
-        },
-        {
             "name": "lorenzo/pinky",
             "version": "1.1.0",
             "source": {
@@ -3723,89 +3655,6 @@
                 "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
             },
             "time": "2024-03-31T07:05:07+00:00"
-        },
-        {
-            "name": "mjaschen/phpgeo",
-            "version": "5.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mjaschen/phpgeo.git",
-                "reference": "20524a47c8edc76364c7373911224a710aeb1cae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mjaschen/phpgeo/zipball/20524a47c8edc76364c7373911224a710aeb1cae",
-                "reference": "20524a47c8edc76364c7373911224a710aeb1cae",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "squizlabs/php_codesniffer": "^3.7",
-                "vimeo/psalm": "^5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Location\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marcus Jaschen",
-                    "email": "mjaschen@gmail.com",
-                    "homepage": "https://www.marcusjaschen.de/"
-                }
-            ],
-            "description": "Simple Yet Powerful Geo Library",
-            "homepage": "https://phpgeo.marcusjaschen.de/",
-            "keywords": [
-                "Polygon",
-                "area",
-                "bearing",
-                "bounds",
-                "calculation",
-                "coordinate",
-                "distance",
-                "earth",
-                "ellipsoid",
-                "geo",
-                "geofence",
-                "gis",
-                "gps",
-                "haversine",
-                "length",
-                "perpendicular",
-                "point",
-                "polyline",
-                "projection",
-                "simplify",
-                "track",
-                "vincenty"
-            ],
-            "support": {
-                "docs": "https://phpgeo.marcusjaschen.de/Installation.html",
-                "email": "mjaschen@gmail.com",
-                "issues": "https://github.com/mjaschen/phpgeo/issues",
-                "source": "https://github.com/mjaschen/phpgeo/tree/5.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/mjaschen",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/mjaschen",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-12-07T09:53:11+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/migrations/Version20250122140631.php
+++ b/migrations/Version20250122140631.php
@@ -16,8 +16,8 @@ final class Version20250122140631 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE auto_affectation_rule CHANGE insee_to_include insee_to_include VARCHAR(255) DEFAULT NULL COMMENT \'Value possible null or an array of code insee\'');
-        $this->addSql("UPDATE auto_affectation_rule SET insee_to_include = null WHERE insee_to_include IN ('all','partner_list')");
+        $this->addSql('ALTER TABLE auto_affectation_rule CHANGE insee_to_include insee_to_include VARCHAR(255) NOT NULL COMMENT \'Value possible empty or an array of code insee\'');
+        $this->addSql("UPDATE auto_affectation_rule SET insee_to_include = '' WHERE insee_to_include IN ('all','partner_list')");
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250122140631.php
+++ b/migrations/Version20250122140631.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250122140631 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'AutoAffectationRule change values of insee_to_include ';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auto_affectation_rule CHANGE insee_to_include insee_to_include VARCHAR(255) DEFAULT NULL COMMENT \'Value possible null or an array of code insee\'');
+        $this->addSql("UPDATE auto_affectation_rule SET insee_to_include = null WHERE insee_to_include IN ('all','partner_list')");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auto_affectation_rule CHANGE insee_to_include insee_to_include VARCHAR(255) NOT NULL COMMENT \'Value possible all, partner_list or an array of code insee\'');
+    }
+}

--- a/src/DataFixtures/Files/AutoAffectationRule.yml
+++ b/src/DataFixtures/Files/AutoAffectationRule.yml
@@ -4,7 +4,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "COMMUNE_SCHS"
-    insee_to_include: "partner_list"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -13,7 +13,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "COMMUNE_SCHS"
-    insee_to_include: "partner_list"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "prive"
     allocataire: "all"
@@ -22,7 +22,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "CAF_MSA"
-    insee_to_include: "all"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "prive"
     allocataire: "caf"
@@ -40,7 +40,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "LOCATAIRE"
     partner_type: "EPCI"
-    insee_to_include: "partner_list"
+    insee_to_include: null
     insee_to_exclude: 
       - "34048"
     parc: "prive"
@@ -50,7 +50,7 @@ auto_affectation_rules:
     status: "ARCHIVED"
     profile_declarant: "all"
     partner_type: "EPCI"
-    insee_to_include: "partner_list"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -59,7 +59,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "POLICE_GENDARMERIE"
-    insee_to_include: "all"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -70,7 +70,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "COMMUNE_SCHS"
-    insee_to_include: "partner_list"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -79,7 +79,7 @@ auto_affectation_rules:
     status: "ARCHIVED"
     profile_declarant: "all"
     partner_type: "EPCI"
-    insee_to_include: "partner_list"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -88,7 +88,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "BAILLEUR_SOCIAL"
-    insee_to_include: "all"
+    insee_to_include: null
     insee_to_exclude: null
     parc: "public"
     allocataire: "all"

--- a/src/DataFixtures/Files/AutoAffectationRule.yml
+++ b/src/DataFixtures/Files/AutoAffectationRule.yml
@@ -4,7 +4,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "COMMUNE_SCHS"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -13,7 +13,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "COMMUNE_SCHS"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "prive"
     allocataire: "all"
@@ -22,7 +22,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "CAF_MSA"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "prive"
     allocataire: "caf"
@@ -40,7 +40,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "LOCATAIRE"
     partner_type: "EPCI"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: 
       - "34048"
     parc: "prive"
@@ -50,7 +50,7 @@ auto_affectation_rules:
     status: "ARCHIVED"
     profile_declarant: "all"
     partner_type: "EPCI"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -59,7 +59,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "POLICE_GENDARMERIE"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -70,7 +70,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "COMMUNE_SCHS"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -79,7 +79,7 @@ auto_affectation_rules:
     status: "ARCHIVED"
     profile_declarant: "all"
     partner_type: "EPCI"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "all"
     allocataire: "all"
@@ -88,7 +88,7 @@ auto_affectation_rules:
     status: "ACTIVE"
     profile_declarant: "all"
     partner_type: "BAILLEUR_SOCIAL"
-    insee_to_include: null
+    insee_to_include: ''
     insee_to_exclude: null
     parc: "public"
     allocataire: "all"

--- a/src/Entity/AutoAffectationRule.php
+++ b/src/Entity/AutoAffectationRule.php
@@ -53,10 +53,10 @@ class AutoAffectationRule implements EntityHistoryInterface
     #[AppAssert\ValidProfileDeclarant()]
     private string $profileDeclarant;
 
-    #[ORM\Column(nullable: true, length: 255, options: ['comment' => 'Value possible null or an array of code insee'])]
+    #[ORM\Column(length: 255, options: ['comment' => 'Value possible empty or an array of code insee'])]
     #[Assert\Length(max: 255)]
     #[AppAssert\InseeToInclude()]
-    private ?string $inseeToInclude;
+    private string $inseeToInclude;
 
     #[ORM\Column(nullable: true, options: ['comment' => 'Value possible null or an array of code insee'])]
     #[AppAssert\InseeToExclude()]
@@ -143,12 +143,12 @@ class AutoAffectationRule implements EntityHistoryInterface
         return $this;
     }
 
-    public function getInseeToInclude(): ?string
+    public function getInseeToInclude(): string
     {
         return $this->inseeToInclude;
     }
 
-    public function setInseeToInclude(?string $inseeToInclude): self
+    public function setInseeToInclude(string $inseeToInclude): self
     {
         $this->inseeToInclude = $inseeToInclude;
 
@@ -292,6 +292,7 @@ class AutoAffectationRule implements EntityHistoryInterface
         $description .= ' Elle s\'applique ';
         switch ($this->getInseeToInclude()) {
             case null:
+            case '':
                 $description .= 'aux logements situés dans le périmètre géographique du partenaire (codes insee et/ou zones)';
                 break;
             default:

--- a/src/Entity/AutoAffectationRule.php
+++ b/src/Entity/AutoAffectationRule.php
@@ -53,11 +53,10 @@ class AutoAffectationRule implements EntityHistoryInterface
     #[AppAssert\ValidProfileDeclarant()]
     private string $profileDeclarant;
 
-    #[ORM\Column(length: 255, options: ['comment' => 'Value possible all, partner_list or an array of code insee'])]
-    #[Assert\NotBlank(message: 'Merci de renseigner les code insee des communes concernées.')]
+    #[ORM\Column(nullable: true, length: 255, options: ['comment' => 'Value possible null or an array of code insee'])]
     #[Assert\Length(max: 255)]
     #[AppAssert\InseeToInclude()]
-    private string $inseeToInclude;
+    private ?string $inseeToInclude;
 
     #[ORM\Column(nullable: true, options: ['comment' => 'Value possible null or an array of code insee'])]
     #[AppAssert\InseeToExclude()]
@@ -144,12 +143,12 @@ class AutoAffectationRule implements EntityHistoryInterface
         return $this;
     }
 
-    public function getInseeToInclude(): string
+    public function getInseeToInclude(): ?string
     {
         return $this->inseeToInclude;
     }
 
-    public function setInseeToInclude(string $inseeToInclude): self
+    public function setInseeToInclude(?string $inseeToInclude): self
     {
         $this->inseeToInclude = $inseeToInclude;
 
@@ -292,14 +291,11 @@ class AutoAffectationRule implements EntityHistoryInterface
 
         $description .= ' Elle s\'applique ';
         switch ($this->getInseeToInclude()) {
-            case 'all':
-                $description .= 'à tous les logements du territoire';
-                break;
-            case 'partner_list':
+            case null:
                 $description .= 'aux logements situés dans le périmètre géographique du partenaire (codes insee et/ou zones)';
                 break;
             default:
-                $description .= 'aux logements situés dans les communes aux codes insee suivants : '.$this->getInseeToInclude();
+                $description .= 'aux logements situés dans le périmètre géographique du partenaire (codes insee et/ou zones), limités aux codes insee suivants : '.$this->getInseeToInclude();
                 break;
         }
         if ($this->getInseeToExclude()) {

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -124,12 +124,12 @@ class AutoAffectationRuleType extends AbstractType
                 ],
             ])
             ->add('inseeToInclude', TextType::class, [
-                'label' => 'Périmètre géographique à inclure',
+                'label' => 'Périmètre géographique à inclure (facultatif)',
                 'attr' => [
                     'class' => 'fr-input',
                 ],
-                'required' => true,
-                'help' => 'Valeurs possibles : "all", "partner_list" (codes insee, et zones) ou une liste de codes insee séparés par des virgules.',
+                'required' => false,
+                'help' => 'Une liste de codes insee séparés par des virgules.',
                 'help_attr' => [
                     'class' => 'fr-hint-text',
                 ],

--- a/src/Form/AutoAffectationRuleType.php
+++ b/src/Form/AutoAffectationRuleType.php
@@ -124,7 +124,7 @@ class AutoAffectationRuleType extends AbstractType
                 ],
             ])
             ->add('inseeToInclude', TextType::class, [
-                'label' => 'Périmètre géographique à inclure (facultatif)',
+                'label' => 'Code insee à inclure (facultatif)',
                 'attr' => [
                     'class' => 'fr-input',
                 ],

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -13,6 +13,7 @@ use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
 use App\Manager\UserManager;
 use App\Messenger\InterconnectionBus;
+use App\Repository\PartnerRepository;
 use App\Specification\Affectation\AllocataireSpecification;
 use App\Specification\Affectation\CodeInseeSpecification;
 use App\Specification\Affectation\ParcSpecification;
@@ -37,6 +38,7 @@ class AutoAssigner
         private UserManager $userManager,
         private ParameterBagInterface $parameterBag,
         private InterconnectionBus $interconnectionBus,
+        private PartnerRepository $partnerRepository,
         private LoggerInterface $logger,
     ) {
     }
@@ -62,7 +64,7 @@ class AutoAssigner
         }
         $adminEmail = $this->parameterBag->get('user_system_email');
         $adminUser = $this->userManager->findOneBy(['email' => $adminEmail]);
-        $partners = $signalement->getTerritory()->getPartners();
+        $partners = $this->partnerRepository->findPartnersByLocalization($signalement);
         $assignablePartners = [];
 
         /** @var AutoAffectationRule $rule */

--- a/src/Specification/Affectation/CodeInseeSpecification.php
+++ b/src/Specification/Affectation/CodeInseeSpecification.php
@@ -2,26 +2,16 @@
 
 namespace App\Specification\Affectation;
 
-use App\Entity\Partner;
 use App\Entity\Signalement;
-use App\Entity\Zone;
 use App\Specification\Context\PartnerSignalementContext;
 use App\Specification\Context\SpecificationContextInterface;
 use App\Specification\SpecificationInterface;
-use Doctrine\Common\Collections\Collection;
-use Location\Coordinate;
-use Location\Polygon;
-use LongitudeOne\Geo\WKT\Parser;
 
 class CodeInseeSpecification implements SpecificationInterface
 {
-    private const TYPE_POLYGON = 'POLYGON';
-    private const TYPE_MULTIPOLYGON = 'MULTIPOLYGON';
-    private const TYPE_GEOMETRYCOLLECTION = 'GEOMETRYCOLLECTION';
-
-    public function __construct(private array|string $inseeToInclude, private ?array $inseeToExclude)
+    public function __construct(private string|array|null $inseeToInclude, private ?array $inseeToExclude)
     {
-        if ('all' !== $inseeToInclude && 'partner_list' !== $inseeToInclude) {
+        if (null !== $inseeToInclude) {
             $this->inseeToInclude = explode(',', $inseeToInclude);
         } else {
             $this->inseeToInclude = $inseeToInclude;
@@ -45,129 +35,18 @@ class CodeInseeSpecification implements SpecificationInterface
         /** @var Signalement $signalement */
         $signalement = $context->getSignalement();
 
-        /** @var Partner $partner */
-        $partner = $context->getPartner();
-
         if ($this->isExcludedSignalement($signalement)) {
             return false;
         }
 
         return match ($this->inseeToInclude) {
-            'all' => true,
-            'partner_list' => $this->isPartnerListSatisfied($signalement, $partner),
+            null => true,
             default => $this->isInseeIncluded($signalement->getInseeOccupant()),
         };
-    }
-
-    private function isPartnerListSatisfied(Signalement $signalement, Partner $partner): bool
-    {
-        $isZoneExcludedOK = true;
-        $isInseeOK = $this->isInseeIncludeInPartnerList($partner, $signalement->getInseeOccupant());
-        $isZoneOK = $this->isInZone($signalement, $partner->getZones());
-        if ($partner->getExcludedZones()->count() > 0) {
-            $isZoneExcludedOK = !$this->isInZone($signalement, $partner->getExcludedZones());
-        }
-
-        return ($isInseeOK || $isZoneOK) && $isZoneExcludedOK;
-    }
-
-    private function isInZone(Signalement $signalement, Collection $zones): bool
-    {
-        if (0 === $zones->count()) {
-            return false;
-        }
-
-        foreach ($zones as $zone) {
-            if ($this->isSignalementInZone($signalement, $zone)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isInseeIncludeInPartnerList(Partner $partner, string $insee)
-    {
-        if (0 === \count($partner->getInsee())) {
-            return false;
-        }
-
-        return \in_array($insee, $partner->getInsee());
     }
 
     private function isInseeIncluded(string $insee): bool
     {
         return !empty($this->inseeToInclude) && \in_array($insee, $this->inseeToInclude);
-    }
-
-    private function isSignalementInZone(Signalement $signalement, Zone $zone): bool
-    {
-        if (empty($signalement->getGeoloc())) {
-            return false;
-        }
-
-        $parser = new Parser($zone->getArea());
-        $zoneArea = $parser->parse();
-        $signalementCoordinate = new Coordinate($signalement->getGeoloc()['lat'], $signalement->getGeoloc()['lng']);
-
-        return match ($zoneArea['type']) {
-            self::TYPE_POLYGON => $this->isPointInPolygon($signalementCoordinate, $zoneArea['value']),
-            self::TYPE_MULTIPOLYGON => $this->isPointInMultiPolygon($signalementCoordinate, $zoneArea['value']),
-            self::TYPE_GEOMETRYCOLLECTION => $this->isPointInGeometryCollection($signalementCoordinate, $zoneArea['value']),
-            default => false,
-        };
-    }
-
-    private function isPointInPolygon(Coordinate $point, array $polygonData): bool
-    {
-        // special case : POLYGON ((X1 Y1, X2 Y2)))
-        if (1 === \count($polygonData)) {
-            $polygonData = $polygonData[0];
-        }
-        $polygon = $this->buildPolygon($polygonData);
-
-        return $polygon->contains($point);
-    }
-
-    private function isPointInMultiPolygon(Coordinate $point, array $multiPolygonData): bool
-    {
-        // special case : MULTIPOLYGON (((X1 Y1, X2 Y2),(X3 Y3, X4 Y4)))
-        if (1 === \count($multiPolygonData)) {
-            $multiPolygonData = $multiPolygonData[0];
-        }
-        foreach ($multiPolygonData as $polygonData) {
-            if ($this->isPointInPolygon($point, $polygonData)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isPointInGeometryCollection(Coordinate $point, array $geometryCollection): bool
-    {
-        foreach ($geometryCollection as $geometry) {
-            if (self::TYPE_POLYGON === $geometry['type'] && $this->isPointInPolygon($point, $geometry['value'])) {
-                return true;
-            }
-            if (self::TYPE_MULTIPOLYGON === $geometry['type'] && $this->isPointInMultiPolygon($point, $geometry['value'])) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function buildPolygon(array $points): Polygon
-    {
-        $geofence = new Polygon();
-        if (1 === \count($points) && \count($points[0]) > 2) {
-            $points = $points[0];
-        }
-        foreach ($points as $point) {
-            $geofence->addPoint(new Coordinate($point[1], $point[0]));
-        }
-
-        return $geofence;
     }
 }

--- a/src/Specification/Affectation/CodeInseeSpecification.php
+++ b/src/Specification/Affectation/CodeInseeSpecification.php
@@ -9,9 +9,9 @@ use App\Specification\SpecificationInterface;
 
 class CodeInseeSpecification implements SpecificationInterface
 {
-    public function __construct(private string|array|null $inseeToInclude, private ?array $inseeToExclude)
+    public function __construct(private string|array $inseeToInclude, private ?array $inseeToExclude)
     {
-        if (null !== $inseeToInclude) {
+        if ('' !== $inseeToInclude) {
             $this->inseeToInclude = explode(',', $inseeToInclude);
         } else {
             $this->inseeToInclude = $inseeToInclude;
@@ -40,7 +40,7 @@ class CodeInseeSpecification implements SpecificationInterface
         }
 
         return match ($this->inseeToInclude) {
-            null => true,
+            '' => true,
             default => $this->isInseeIncluded($signalement->getInseeOccupant()),
         };
     }

--- a/src/Validator/InseeToInclude.php
+++ b/src/Validator/InseeToInclude.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 class InseeToInclude extends Constraint
 {
-    public $message = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.';
+    public $message = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit vide soit une liste de codes INSEE séparés par des virgules.';
 
     public function getTargets(): string
     {

--- a/src/Validator/InseeToIncludeValidator.php
+++ b/src/Validator/InseeToIncludeValidator.php
@@ -14,7 +14,15 @@ class InseeToIncludeValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\InseeToInclude');
         }
         /* @var InseeToInclude $constraint */
-        if (null === $value || '' === $value) {
+        if ('' === $value) {
+            return;
+        }
+
+        if (null === $value) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', 'null')
+                ->addViolation();
+
             return;
         }
 

--- a/src/Validator/InseeToIncludeValidator.php
+++ b/src/Validator/InseeToIncludeValidator.php
@@ -18,10 +18,6 @@ class InseeToIncludeValidator extends ConstraintValidator
             return;
         }
 
-        if (\in_array($value, ['all', 'partner_list'], true)) {
-            return;
-        }
-
         $inseeCodes = explode(',', $value);
         foreach ($inseeCodes as $code) {
             if (!preg_match('/^\d{5}$/', trim($code))) {

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -76,12 +76,12 @@
                     <td>{{ autoaffectationrule.parc }}</td>
                     <td>{{ autoaffectationrule.allocataire }}</td>
                     <td>
-                        {% if autoaffectationrule.inseeToInclude is same as('all') or autoaffectationrule.inseeToInclude is same as('partner_list') %}
-                            {{ autoaffectationrule.inseeToInclude }}
-                        {% else %}
+                        {% if autoaffectationrule.inseeToInclude %}
                             {% for insee in autoaffectationrule.inseeToInclude|split(',') %}
                                 <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ insee }}</div>
                             {% endfor %}
+                        {% else %}
+                            /
                         {% endif %}
                     </td>
                     <td>

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -512,7 +512,7 @@ trait FixturesHelper
             ->setProfileDeclarant('all')
             ->setParc('prive')
             ->setAllocataire('oui')
-            ->setInseeToInclude(null)
+            ->setInseeToInclude('')
             ->setInseeToExclude(null)
             ->setPartnerToExclude([])
             ->setStatus(AutoAffectationRule::STATUS_ACTIVE);

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -512,7 +512,7 @@ trait FixturesHelper
             ->setProfileDeclarant('all')
             ->setParc('prive')
             ->setAllocataire('oui')
-            ->setInseeToInclude('partner_list')
+            ->setInseeToInclude(null)
             ->setInseeToExclude(null)
             ->setPartnerToExclude([])
             ->setStatus(AutoAffectationRule::STATUS_ACTIVE);

--- a/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
@@ -52,7 +52,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
                 'auto_affectation_rule[profileDeclarant]' => 'occupant',
                 'auto_affectation_rule[parc]' => 'all',
                 'auto_affectation_rule[allocataire]' => 'oui',
-                'auto_affectation_rule[inseeToInclude]' => null,
+                'auto_affectation_rule[inseeToInclude]' => '',
                 'auto_affectation_rule[inseeToExclude]' => '',
                 'auto_affectation_rule[partnerToExclude]' => '',
             ]
@@ -77,7 +77,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
                 'auto_affectation_rule[profileDeclarant]' => 'occupant',
                 'auto_affectation_rule[parc]' => 'all',
                 'auto_affectation_rule[allocataire]' => 'oui',
-                'auto_affectation_rule[inseeToInclude]' => null,
+                'auto_affectation_rule[inseeToInclude]' => '',
                 'auto_affectation_rule[inseeToExclude]' => '',
                 'auto_affectation_rule[partnerToExclude]' => '',
             ]

--- a/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
+++ b/tests/Functional/Controller/AutoAffectationRuleControllerTest.php
@@ -52,7 +52,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
                 'auto_affectation_rule[profileDeclarant]' => 'occupant',
                 'auto_affectation_rule[parc]' => 'all',
                 'auto_affectation_rule[allocataire]' => 'oui',
-                'auto_affectation_rule[inseeToInclude]' => 'all',
+                'auto_affectation_rule[inseeToInclude]' => null,
                 'auto_affectation_rule[inseeToExclude]' => '',
                 'auto_affectation_rule[partnerToExclude]' => '',
             ]
@@ -77,7 +77,7 @@ class AutoAffectationRuleControllerTest extends WebTestCase
                 'auto_affectation_rule[profileDeclarant]' => 'occupant',
                 'auto_affectation_rule[parc]' => 'all',
                 'auto_affectation_rule[allocataire]' => 'oui',
-                'auto_affectation_rule[inseeToInclude]' => 'all',
+                'auto_affectation_rule[inseeToInclude]' => null,
                 'auto_affectation_rule[inseeToExclude]' => '',
                 'auto_affectation_rule[partnerToExclude]' => '',
             ]

--- a/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
+++ b/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
@@ -42,15 +42,15 @@ class CodeInseeSpecificationTest extends KernelTestCase
 
     public function provideRulesAndSignalement(): \Generator
     {
-        yield 'null - same insee as partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, null, true];
-        yield 'null - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, [self::INSEE_STMARS], false];
-        yield 'null - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, [self::INSEE_CELLIER], true];
-        yield 'null - different insee than partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, null, true];
-        yield 'null - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, [self::INSEE_STMARS], false];
-        yield 'null - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, [self::INSEE_CELLIER], true];
-        yield 'null - partner without insee - no exclude' => [self::INSEE_STMARS, [], null, null, true];
-        yield 'null - partner without insee - but excluded' => [self::INSEE_STMARS, [], null, [self::INSEE_STMARS], false];
-        yield 'null - partner without insee - another excluded' => [self::INSEE_STMARS, [], null, [self::INSEE_CELLIER], true];
+        yield 'empty - same insee as partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_STMARS], '', null, true];
+        yield 'empty - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], '', [self::INSEE_STMARS], false];
+        yield 'empty - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], '', [self::INSEE_CELLIER], true];
+        yield 'empty - different insee than partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_CELLIER], '', null, true];
+        yield 'empty - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], '', [self::INSEE_STMARS], false];
+        yield 'empty - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], '', [self::INSEE_CELLIER], true];
+        yield 'empty - partner without insee - no exclude' => [self::INSEE_STMARS, [], '', null, true];
+        yield 'empty - partner without insee - but excluded' => [self::INSEE_STMARS, [], '', [self::INSEE_STMARS], false];
+        yield 'empty - partner without insee - another excluded' => [self::INSEE_STMARS, [], '', [self::INSEE_CELLIER], true];
 
         yield 'array of insee with this one - same insee as partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_STMARS, null, true];
         yield 'array of insee with this one - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_STMARS, [self::INSEE_STMARS], false];
@@ -73,7 +73,7 @@ class CodeInseeSpecificationTest extends KernelTestCase
         yield 'array of insee without this one - partner without insee - another excluded' => [self::INSEE_STMARS, [], self::INSEE_CELLIER, [self::INSEE_CELLIER], false];
 
         // tous les cas ne sont pas testés en cas d'absence d'insee sur le signalement, car ça renvoie toujours false
-        yield 'null - no insee signalement' => [null, [self::INSEE_CELLIER], null, [self::INSEE_CELLIER], false];
+        yield 'empty - no insee signalement' => [null, [self::INSEE_CELLIER], '', [self::INSEE_CELLIER], false];
         yield 'array of insee - no insee signalement - another excluded' => [null, [], self::INSEE_STMARS, [self::INSEE_CELLIER], false];
     }
 }

--- a/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
+++ b/tests/Functional/Specification/Affectation/CodeInseeSpecificationTest.php
@@ -4,179 +4,22 @@ namespace App\Tests\Functional\Specification\Affectation;
 
 use App\Entity\Partner;
 use App\Entity\Signalement;
-use App\Entity\Zone;
 use App\Specification\Affectation\CodeInseeSpecification;
 use App\Specification\Context\PartnerSignalementContext;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class CodeInseeSpecificationTest extends KernelTestCase
 {
-    private string $zoneBourgStMars = 'GEOMETRYCOLLECTION(POLYGON ((-1.403246 47.368071, -1.405563 47.369234, -1.409512 47.368652, -1.41346 47.369699, -1.41758 47.368478, -1.417408 47.365571, -1.41758 47.362316, -1.415176 47.359932, -1.410713 47.359583, -1.40625 47.358479, -1.401443 47.358188, -1.400757 47.362374, -1.40316 47.365339, -1.403246 47.368071)), POLYGON ((-1.423073 47.368304, -1.419983 47.369641, -1.420326 47.372024, -1.424017 47.372489, -1.426506 47.371036, -1.42642 47.369583, -1.423073 47.368304)))';
-    private string $zoneLaBodiniere = 'POLYGON ((-1.444273 47.350861, -1.448994 47.352024, -1.450453 47.350745, -1.44865 47.349059, -1.446505 47.348593, -1.444273 47.349, -1.444273 47.350861))';
-
-    private array $geolocLaBodiniere = [
-        'lat' => 47.349698,
-        'lng' => -1.446676,
-    ];
-
-    private array $geolocLaTourmentinerie = [
-        'lat' => 47.363934,
-        'lng' => -1.41422,
-    ];
-
-    private array $geolocLaGree = [
-        'lat' => 47.37025,
-        'lng' => -1.455196,
-    ];
-
     private const string INSEE_STMARS = '44179';
     private const string INSEE_CELLIER = '44028';
 
     /**
-     * @dataProvider provideRulesAndSignalementWithZone
+     * @dataProvider provideRulesAndSignalement
      */
-    public function testIsSatisfiedByWithZone(
+    public function testIsSatisfiedBy(
         ?string $inseeSignalement,
         array $inseePartenaire,
-        ?array $inseeToExcludeRule,
-        array $geolocSignalement,
-        ?string $zoneToInclude,
-        ?string $zoneToExclude,
-        bool $isSatisfied,
-    ): void {
-        $partner = new Partner();
-        $partner->setInsee($inseePartenaire);
-        $this->assertEquals($inseePartenaire, $partner->getInsee());
-        if (null !== $zoneToInclude) {
-            /** @var Zone $zone */
-            $zone = new Zone();
-            $zone->setArea($zoneToInclude);
-            $partner->addZone($zone);
-            $this->assertEquals($zoneToInclude, $partner->getZones()[0]->getArea());
-        }
-        if (null !== $zoneToExclude) {
-            /** @var Zone $zone */
-            $zone = new Zone();
-            $zone->setArea($zoneToExclude);
-            $partner->addExcludedZone($zone);
-            $this->assertEquals($zoneToExclude, $partner->getExcludedZones()[0]->getArea());
-        }
-
-        $signalement = new Signalement();
-        $signalement->setInseeOccupant($inseeSignalement);
-        $signalement->setGeoloc($geolocSignalement);
-        $this->assertEquals($inseeSignalement, $signalement->getInseeOccupant());
-
-        $specification = new CodeInseeSpecification('partner_list', $inseeToExcludeRule);
-        $context = new PartnerSignalementContext($partner, $signalement);
-        if ($isSatisfied) {
-            $this->assertTrue($specification->isSatisfiedBy($context));
-        } else {
-            $this->assertFalse($specification->isSatisfiedBy($context));
-        }
-    }
-
-    public function provideRulesAndSignalementWithZone(): \Generator
-    {
-        yield 'same insee as partner - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'same insee as partner - no excluded insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'same insee as partner - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - no excluded insee - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, null, null, true];
-        yield 'same insee as partner - no excluded insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'same insee as partner - no excluded insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - no excluded insee - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, true];
-        yield 'same insee as partner - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, true];
-
-        // tout cela est illogique, et doit renvoyer false
-        yield 'same insee as partner - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'same insee as partner - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false];
-        yield 'same insee as partner - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - but excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, null, false];
-        yield 'same insee as partner - but excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'same insee as partner - but excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - but excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'same insee as partner - but excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - but excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_STMARS], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'same insee as partner - another insee excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'same insee as partner - another insee excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'same insee as partner - another insee excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - another insee excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, null, true];
-        yield 'same insee as partner - another insee excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'same insee as partner - another insee excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, true];
-        yield 'same insee as partner - another insee excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, true];
-        yield 'same insee as partner - another insee excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'same insee as partner - another insee excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], [self::INSEE_CELLIER], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, true];
-
-        yield 'different insee than partner - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'different insee than partner - no excluded insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'different insee than partner - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'different insee than partner - no excluded insee - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, null, null, false];
-        yield 'different insee than partner - no excluded insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'different insee than partner - no excluded insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - no excluded insee - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'different insee than partner - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'different insee than partner - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'different insee than partner - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'different insee than partner - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - but excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, null, false];
-        yield 'different insee than partner - but excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'different insee than partner - but excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - but excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'different insee than partner - but excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - but excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_STMARS], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'different insee than partner - another insee excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'different insee than partner - another insee excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'different insee than partner - another insee excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'different insee than partner - another insee excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, null, false];
-        yield 'different insee than partner - another insee excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'different insee than partner - another insee excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - another insee excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'different insee than partner - another insee excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'different insee than partner - another insee excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], [self::INSEE_CELLIER], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'partner without insee - no excluded insee - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'partner without insee - no excluded insee - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - no excluded insee - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'partner without insee - no excluded insee - no zone - no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, null, false];
-        yield 'partner without insee - no excluded insee - no zone - same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'partner without insee - no excluded insee - no zone - different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'partner without insee - no excluded insee - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'partner without insee - no excluded insee - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'partner without insee - no excluded insee - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], null, $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'partner without insee - but excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, false];
-        yield 'partner without insee - but excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - but excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, false];
-        yield 'partner without insee - but excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, null, false];
-        yield 'partner without insee - but excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'partner without insee - but excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'partner without insee - but excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'partner without insee - but excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'partner without insee - but excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_STMARS], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-
-        yield 'partner without insee - another insee excluded - same zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, null, true];
-        yield 'partner without insee - another insee excluded - same zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneLaBodiniere, false]; // illogique, mais à tester, doit renvoyer false
-        yield 'partner without insee - another insee excluded - same zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneLaBodiniere, $this->zoneBourgStMars, true];
-        yield 'partner without insee - another insee excluded - no zone - no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, null, false];
-        yield 'partner without insee - another insee excluded - no zone - same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneLaBodiniere, false];
-        yield 'partner without insee - another insee excluded - no zone - different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, null, $this->zoneBourgStMars, false];
-        yield 'partner without insee - another insee excluded - different zone as geoloc, no zone excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaBodiniere, $this->zoneBourgStMars, null, false];
-        yield 'partner without insee - another insee excluded - different zone as geoloc, same zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaTourmentinerie, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-        yield 'partner without insee - another insee excluded - different zone as geoloc, different zone as excluded' => [self::INSEE_STMARS, [], [self::INSEE_CELLIER], $this->geolocLaGree, $this->zoneBourgStMars, $this->zoneBourgStMars, false];
-    }
-
-    /**
-     * @dataProvider provideRulesAndSignalementWithoutZone
-     */
-    public function testIsSatisfiedByWithoutZone(
-        ?string $inseeSignalement,
-        array $inseePartenaire,
-        string $inseeToIncludeRule,
+        ?string $inseeToIncludeRule,
         ?array $inseeToExcludeRule,
         bool $isSatisfied,
     ): void {
@@ -197,27 +40,17 @@ class CodeInseeSpecificationTest extends KernelTestCase
         }
     }
 
-    public function provideRulesAndSignalementWithoutZone(): \Generator
+    public function provideRulesAndSignalement(): \Generator
     {
-        yield 'all - same insee as partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'all', null, true];
-        yield 'all - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'all', [self::INSEE_STMARS], false];
-        yield 'all - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'all', [self::INSEE_CELLIER], true];
-        yield 'all - different insee than partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'all', null, true];
-        yield 'all - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'all', [self::INSEE_STMARS], false];
-        yield 'all - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'all', [self::INSEE_CELLIER], true];
-        yield 'all - partner without insee - no exclude' => [self::INSEE_STMARS, [], 'all', null, true];
-        yield 'all - partner without insee - but excluded' => [self::INSEE_STMARS, [], 'all', [self::INSEE_STMARS], false];
-        yield 'all - partner without insee - another excluded' => [self::INSEE_STMARS, [], 'all', [self::INSEE_CELLIER], true];
-
-        yield 'partner_list - same insee as partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'partner_list', null, true];
-        yield 'partner_list - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'partner_list', [self::INSEE_STMARS], false];
-        yield 'partner_list - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], 'partner_list', [self::INSEE_CELLIER], true];
-        yield 'partner_list - different insee than partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'partner_list', null, false];
-        yield 'partner_list - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'partner_list', [self::INSEE_STMARS], false];
-        yield 'partner_list - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], 'partner_list', [self::INSEE_CELLIER], false];
-        yield 'partner_list - partner without insee - no exclusion' => [self::INSEE_STMARS, [], 'partner_list', null, false];
-        yield 'partner_list - partner without insee - but excluded' => [self::INSEE_STMARS, [], 'partner_list', [self::INSEE_STMARS], false];
-        yield 'partner_list - partner without insee - another excluded' => [self::INSEE_STMARS, [], 'partner_list', [self::INSEE_CELLIER], false];
+        yield 'null - same insee as partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, null, true];
+        yield 'null - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, [self::INSEE_STMARS], false];
+        yield 'null - same insee as partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], null, [self::INSEE_CELLIER], true];
+        yield 'null - different insee than partner - no exclude' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, null, true];
+        yield 'null - different insee than partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, [self::INSEE_STMARS], false];
+        yield 'null - different insee than partner - another excluded' => [self::INSEE_STMARS, [self::INSEE_CELLIER], null, [self::INSEE_CELLIER], true];
+        yield 'null - partner without insee - no exclude' => [self::INSEE_STMARS, [], null, null, true];
+        yield 'null - partner without insee - but excluded' => [self::INSEE_STMARS, [], null, [self::INSEE_STMARS], false];
+        yield 'null - partner without insee - another excluded' => [self::INSEE_STMARS, [], null, [self::INSEE_CELLIER], true];
 
         yield 'array of insee with this one - same insee as partner - no exclusion' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_STMARS, null, true];
         yield 'array of insee with this one - same insee as partner - but excluded' => [self::INSEE_STMARS, [self::INSEE_STMARS], self::INSEE_STMARS, [self::INSEE_STMARS], false];
@@ -240,8 +73,7 @@ class CodeInseeSpecificationTest extends KernelTestCase
         yield 'array of insee without this one - partner without insee - another excluded' => [self::INSEE_STMARS, [], self::INSEE_CELLIER, [self::INSEE_CELLIER], false];
 
         // tous les cas ne sont pas testés en cas d'absence d'insee sur le signalement, car ça renvoie toujours false
-        yield 'all - no insee signalement' => [null, [self::INSEE_CELLIER], 'all', [self::INSEE_CELLIER], false];
-        yield 'partner_list - no insee signalement - another excluded' => [null, [], 'partner_list', [self::INSEE_CELLIER], false];
+        yield 'null - no insee signalement' => [null, [self::INSEE_CELLIER], null, [self::INSEE_CELLIER], false];
         yield 'array of insee - no insee signalement - another excluded' => [null, [], self::INSEE_STMARS, [self::INSEE_CELLIER], false];
     }
 }

--- a/tests/Unit/Entity/AutoAffectationRuleTest.php
+++ b/tests/Unit/Entity/AutoAffectationRuleTest.php
@@ -27,7 +27,7 @@ class AutoAffectationRuleTest extends KernelTestCase
         $this->assertEquals('prive', $autoAffectationRule->getParc());
         $this->assertEquals('all', $autoAffectationRule->getProfileDeclarant());
         $this->assertEquals('oui', $autoAffectationRule->getAllocataire());
-        $this->assertEquals('partner_list', $autoAffectationRule->getInseeToInclude());
+        $this->assertNull($autoAffectationRule->getInseeToInclude());
         $this->assertNull($autoAffectationRule->getInseeToExclude());
         $this->assertEmpty($autoAffectationRule->getPartnerToExclude());
         $this->assertEquals(AutoAffectationRule::STATUS_ACTIVE, $autoAffectationRule->getStatus());

--- a/tests/Unit/Entity/AutoAffectationRuleTest.php
+++ b/tests/Unit/Entity/AutoAffectationRuleTest.php
@@ -27,7 +27,7 @@ class AutoAffectationRuleTest extends KernelTestCase
         $this->assertEquals('prive', $autoAffectationRule->getParc());
         $this->assertEquals('all', $autoAffectationRule->getProfileDeclarant());
         $this->assertEquals('oui', $autoAffectationRule->getAllocataire());
-        $this->assertNull($autoAffectationRule->getInseeToInclude());
+        $this->assertEmpty($autoAffectationRule->getInseeToInclude());
         $this->assertNull($autoAffectationRule->getInseeToExclude());
         $this->assertEmpty($autoAffectationRule->getPartnerToExclude());
         $this->assertEquals(AutoAffectationRule::STATUS_ACTIVE, $autoAffectationRule->getStatus());

--- a/tests/Unit/Validator/InseeToIncludeValidatorTest.php
+++ b/tests/Unit/Validator/InseeToIncludeValidatorTest.php
@@ -26,6 +26,9 @@ class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
         if ($isValid) {
             $this->assertNoViolation();
         } else {
+            if (null === $insee) {
+                $insee = 'null';
+            }
             $this->buildViolation($message)
                 ->setParameter('{{ value }}', $insee)
                 ->assertRaised();
@@ -34,7 +37,8 @@ class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
 
     public function provideValues(): \Generator
     {
-        yield 'null' => [null, true];
+        yield 'null' => [null, false, self::ERROR];
+        yield 'empty' => ['', true];
         yield 'all' => ['all', false, self::ERROR];
         yield 'partner_list' => ['partner_list', false, self::ERROR];
         yield '44058' => ['44058', true];

--- a/tests/Unit/Validator/InseeToIncludeValidatorTest.php
+++ b/tests/Unit/Validator/InseeToIncludeValidatorTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
 {
-    private const ERROR = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit "all", "partner_list", soit une liste de codes INSEE séparés par des virgules.';
+    private const ERROR = 'La valeur "{{ value }}" n\'est pas valide. Elle doit être soit vide soit une liste de codes INSEE séparés par des virgules.';
 
     protected function createValidator(): ConstraintValidatorInterface
     {
@@ -19,7 +19,7 @@ class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider provideValues
      */
-    public function testValues(string $insee, bool $isValid, ?string $message = null): void
+    public function testValues(?string $insee, bool $isValid, ?string $message = null): void
     {
         $constraint = new InseeToInclude();
         $this->validator->validate($insee, $constraint);
@@ -34,8 +34,9 @@ class InseeToIncludeValidatorTest extends ConstraintValidatorTestCase
 
     public function provideValues(): \Generator
     {
-        yield 'all' => ['all', true];
-        yield 'partner_list' => ['partner_list', true];
+        yield 'null' => [null, true];
+        yield 'all' => ['all', false, self::ERROR];
+        yield 'partner_list' => ['partner_list', false, self::ERROR];
         yield '44058' => ['44058', true];
         yield '44058,44890' => ['44058,44890', true];
         yield 'error' => ['error', false, self::ERROR];


### PR DESCRIPTION
## Ticket

#3582    

## Description
Filtrer la liste des partenaires en amont des spécifications dans AutoAssigner en utilisant `partnerRepository->findByLocalization()` (la requête utilisée pour filtrer les partenaires en fonction de leur périmètre géographique pour l'affectation manuelle)
Pour la spécification `CodeInseeSpecification` on retire les options `all` et `partner_list`, on peut soit ne rien mettre, soit restreindre à une liste de code insee

## Changements apportés
* Suppression des librairies mjaschen/phpgeo et longitude-one/wkt-parser (plus nécessaires car le travail est fait en sql comme pour l'affectation manuelle)
* Changement des fixtures
* Changement de l'entité AutoAffectationRule, et migration associée
* Dans la migration, on modifie aussi les règles existantes pour transformer  `all` et `partner_list` en `null`
* Changement du `PartnerRepository` pour créer une fonction `findPartnersByLocalization` et factorisation de la query utilisée à l'origine par `findByLocalization`
* Mise à jour du service AutoAssigner pour utiliser `findPartnersByLocalization`
* Mise à jour de CodeInseeSpecification pour supprimer tout le code qui permettait de vérifier le périmètre géographique des partenaires (code insee et zone)
* Mise à jour des validator associés
* Mise à jour des tests associés

## Tests
Avant de faire le make build, lancer la migration et vérifier que les règles d'auto-affectations sont bien modifiées (plus de `all` ou de `partner_list` dans `insee_to_include`

## Pré-requis
`make build`

## Tests
- [ ] CI ok
- [ ] Editer des règles existantes pour vérifier la valeur de `Code insee à unclure`
- [ ] Créer des règles d'affectation dans un territoire avec des zones et des partners ayant des zones et des zones d'exclusion
- [ ] Créer une règle en laissant vide le champ `Code insee à inclure`
- [ ] Créer un signalement, et en fonction de sa géolocalisation, vérifier qu'il est affecté aux bons partenaires
