### PR TITLE
[Esabora - SCHS] Ne pas récupérer les événements sans dates

### DIFF
--- a/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
+++ b/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
@@ -107,7 +107,7 @@ class SynchronizeEsaboraSCHSCommand extends AbstractSynchronizeEsaboraCommand
 
     protected function synchronizeEvent(DossierEventSCHS $event, Affectation $affectation): bool
     {
-        if (isset($this->existingEvents[$event->getEventId()])) {
+        if (empty($event->getDate()) || isset($this->existingEvents[$event->getEventId()])) {
             return false;
         }
         $suivi = $this->esaboraManager->createSuiviFromDossierEvent($event, $affectation);

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -244,9 +244,7 @@ class EsaboraManager
             context: Suivi::CONTEXT_SCHS,
             flush: false,
         );
-        if (!empty($event->getDate())) {
-            $suivi->setCreatedAt(\DateTimeImmutable::createFromFormat('d/m/Y', $event->getDate()));
-        }
+        $suivi->setCreatedAt(\DateTimeImmutable::createFromFormat('d/m/Y', $event->getDate()));
         $suivi->setOriginalData($event->getOriginalData());
         $this->entityManager->persist($suivi);
 


### PR DESCRIPTION
## Ticket

#3597

## Description
Ignorer les événements sans date dans la liste de ceux retourner par ESABORA

## Pré-requis
`make load-fixtures`

## Tests
- [ ] Lancer la commande `app:sync-esabora-schs` et s'assurer que 4 (et non 5) evenements sont synchronisé
