### PR TITLE
[BUG] Historique suppression UserPartner

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -284,7 +284,6 @@ class PartnerController extends AbstractController
                 if ($user->getUserPartners()->count() > 1) {
                     foreach ($user->getUserPartners() as $userPartner) {
                         if ($userPartner->getPartner()->getId() === $partner->getId()) {
-                            $user->removeUserPartner($userPartner);
                             $entityManager->remove($userPartner);
                             break;
                         }
@@ -637,7 +636,6 @@ class PartnerController extends AbstractController
         if ($user->getUserPartners()->count() > 1) {
             foreach ($user->getUserPartners() as $userPartner) {
                 if ($userPartner->getPartner()->getId() === $partner->getId()) {
-                    $user->removeUserPartner($userPartner);
                     $userManager->remove($userPartner);
                     break;
                 }

--- a/src/EventListener/EntityHistoryListener.php
+++ b/src/EventListener/EntityHistoryListener.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 #[AsDoctrineListener(event: Events::postPersist)]
 #[AsDoctrineListener(event: Events::postUpdate)]
 #[AsDoctrineListener(event: Events::preRemove)]
-class EntityHistoryListener
+readonly class EntityHistoryListener
 {
     public const array FIELDS_TO_IGNORE = [
         'lastLoginAt',
@@ -27,15 +27,13 @@ class EntityHistoryListener
         'lastSuiviIsPublic',
     ];
 
-    private array $deletedObjects;
-
     public function __construct(
-        private readonly HistoryEntryManager $historyEntryManager,
-        private readonly EntityManagerInterface $entityManager,
-        private readonly EntityComparator $entityComparator,
-        private readonly LoggerInterface $logger,
+        private HistoryEntryManager $historyEntryManager,
+        private EntityManagerInterface $entityManager,
+        private EntityComparator $entityComparator,
+        private LoggerInterface $logger,
         #[Autowire(env: 'HISTORY_TRACKING_ENABLE')]
-        private readonly string $historyTrackingEnable,
+        private string $historyTrackingEnable,
     ) {
     }
 
@@ -104,11 +102,7 @@ class EntityHistoryListener
             }
         }
         if (HistoryEntryEvent::DELETE === $event) {
-            $className = $this->entityManager->getMetadataFactory()->getMetadataFor($entity::class)->getName();
-            if (!isset($this->deletedObjects[$className][$entity->getId()])) {
-                $this->deletedObjects[$className][$entity->getId()] = $entity;
-                $changes = $this->entityComparator->getEntityPropertiesAndValueNormalized($entity);
-            }
+            $changes = $this->entityComparator->getEntityPropertiesAndValueNormalized($entity);
         }
 
         if (in_array($event, [HistoryEntryEvent::UPDATE, HistoryEntryEvent::DELETE]) && empty($changes)) {


### PR DESCRIPTION
## Ticket

#3576

## Description
Bloque le déclenchement d'une boucle infini lors de l'enregistrement de suppression dans historyEntry (cas se présentant à la suppression d'un utilisateur multi-territoire d'un de ses partenaire)

Il semble que cela soit provoqué par le fait d'avoir des `orphanRemoval: true` sur les relation OneToMany Partner et User mais comme cela peut être utile et que le cas peut se représenter je préfère directement corriger dans le `EntityHistoryListener`

## Tests
- [ ] Supprimer un utilisateur multi-territoire de l'un de ses partenaire et vérifier les requête d'insertion effectué dans history_entry
