### PR TITLE
[Auto-affectation] Mettre en place un simulateur

### DIFF
--- a/src/Controller/Back/AutoAssignerSimulatorController.php
+++ b/src/Controller/Back/AutoAssignerSimulatorController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\Territory;
+use App\Repository\SignalementRepository;
+use App\Repository\TerritoryRepository;
+use App\Service\Signalement\AutoAssigner;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/bo/auto-assigner-simulator')]
+class AutoAssignerSimulatorController extends AbstractController
+{
+    #[Route('/', name: 'back_auto_assigner_simulator_index')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function index(
+        TerritoryRepository $territoryRepository,
+    ): Response {
+        $territories = $territoryRepository->findAllWithAutoAffectationRules();
+
+        return $this->render('back/auto-assigner-simulator/index.html.twig', ['territories' => $territories]);
+    }
+
+    #[Route('/{territory}', name: 'back_auto_assigner_simulator_territory')]
+    #[IsGranted('ROLE_ADMIN')]
+    public function territory(
+        Request $request,
+        Territory $territory,
+        SignalementRepository $signalementRepository,
+        AutoAssigner $autoAssigner,
+    ): Response {
+        $results = [];
+        $criteria = ['territory' => $territory];
+        $limit = $request->query->getInt('limit', 10);
+        if ($uuid = $request->query->get('uuid')) {
+            $criteria['uuid'] = $uuid;
+        }
+        $signalements = $signalementRepository->findBy($criteria, ['createdAt' => 'DESC'], $limit);
+        foreach ($signalements as $signalement) {
+            $autoAssigner->assign($signalement, true);
+            $assignablePartners = $autoAssigner->getAssignablePartners();
+            $results[] = [
+                'signalement' => $signalement,
+                'assignablePartners' => $assignablePartners,
+            ];
+        }
+
+        return $this->render('back/auto-assigner-simulator/territory.html.twig', ['territory' => $territory, 'results' => $results, 'limit' => $limit, 'uuid' => $uuid]);
+    }
+}

--- a/src/Controller/Back/AutoAssignerSimulatorController.php
+++ b/src/Controller/Back/AutoAssignerSimulatorController.php
@@ -41,8 +41,8 @@ class AutoAssignerSimulatorController extends AbstractController
         }
         $signalements = $signalementRepository->findBy($criteria, ['createdAt' => 'DESC'], $limit);
         foreach ($signalements as $signalement) {
-            $autoAssigner->assign($signalement, true);
-            $assignablePartners = $autoAssigner->getAssignablePartners();
+            $assignablePartners = $autoAssigner->assign($signalement, true);
+            dump($assignablePartners);
             $results[] = [
                 'signalement' => $signalement,
                 'assignablePartners' => $assignablePartners,

--- a/src/Controller/Back/AutoAssignerSimulatorController.php
+++ b/src/Controller/Back/AutoAssignerSimulatorController.php
@@ -42,7 +42,6 @@ class AutoAssignerSimulatorController extends AbstractController
         $signalements = $signalementRepository->findBy($criteria, ['createdAt' => 'DESC'], $limit);
         foreach ($signalements as $signalement) {
             $assignablePartners = $autoAssigner->assign($signalement, true);
-            dump($assignablePartners);
             $results[] = [
                 'signalement' => $signalement,
                 'assignablePartners' => $assignablePartners,

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -192,7 +192,7 @@ class PartnerRepository extends ServiceEntityRepository
     /**
      * @throws Exception
      */
-    public function findPartnersByLocalization(Signalement $signalement): array
+    public function findPartnersByLocalization(Signalement $signalement, $addAffectedPartner = false): array
     {
         $queryData = $this->buildLocalizationQuery($signalement, false); // Always use $affected = false
 
@@ -201,6 +201,14 @@ class PartnerRepository extends ServiceEntityRepository
             $queryData['params']
         );
         $partnerIds = array_column($resultSet->fetchAllAssociative(), 'id');
+        if ($addAffectedPartner) {
+            $queryData = $this->buildLocalizationQuery($signalement, true);
+            $resultSet = $this->getEntityManager()->getConnection()->executeQuery(
+                $queryData['sql'],
+                $queryData['params']
+            );
+            $partnerIds = array_merge($partnerIds, array_column($resultSet->fetchAllAssociative(), 'id'));
+        }
 
         return $this->getEntityManager()->getRepository(Partner::class)->findBy(['id' => $partnerIds]);
     }

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -19,8 +19,9 @@
                     <h1 class="fr-h1 fr-mb-0">Règles d'auto-affectation</h1>
                 </div>
                 <div class="fr-col-6 fr-text--right">
-                    <a class="fr-btn fr-btn--success fr-btn--icon-left fr-btn--md fr-fi-add-circle-line" href="{{ path('back_auto_affectation_rule_new') }}"
-                        >Ajouter une règle d'auto-affection</a>
+                    <a class="fr-btn fr-btn--success fr-btn--icon-left fr-btn--md fr-fi-add-circle-line" href="{{ path('back_auto_affectation_rule_new') }}">Ajouter une règle d'auto-affection</a>
+                    <br>
+                    <a class="fr-btn fr-btn--secondary fr-mt-2v" href="{{ path('back_auto_assigner_simulator_index') }}">Simulateur</a>
                 </div>
             </div>
         </header>

--- a/templates/back/auto-assigner-simulator/index.html.twig
+++ b/templates/back/auto-assigner-simulator/index.html.twig
@@ -1,0 +1,42 @@
+{% extends 'back/base_bo.html.twig' %}
+
+{% block title %}Auto Assigner Simulator ⚗️{% endblock %}
+
+{% block content %}
+    <section class="fr-p-5v">
+        {% include 'back/breadcrumb_bo.html.twig' with {
+            'level2Title': 'Outils SA',
+            'level2Link': '',
+            'level2Label': '',
+            'level3Title': 'Auto Assigner Simulator ⚗️',
+            'level3Link': '',
+        } %}
+        <header>
+            <div class="fr-grid-row">
+                <div class="fr-col-12">
+                    <h1 class="fr-h1 fr-mb-0">
+                        Auto Assigner Simulator ⚗️ 
+                        <br>
+                        <small>Liste des territoires ayant des règles d'auto-affectation</small>
+                    </h1>
+                </div>
+            </div>
+        </header>
+    </section>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">Territoire</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for item in territories %}
+                <tr>
+                    <td><a href="{{path('back_auto_assigner_simulator_territory', {territory:item.id})}}">{{ item.zip}} - {{item.name}}</a></td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Auto Assigner Simulator ⚗️', 'tableHead': tableHead, 'tableBody': tableBody } %}
+    </section>
+{% endblock %}

--- a/templates/back/auto-assigner-simulator/territory.html.twig
+++ b/templates/back/auto-assigner-simulator/territory.html.twig
@@ -1,0 +1,62 @@
+{% extends 'back/base_bo.html.twig' %}
+
+{% block title %}Auto Assigner Simulator ⚗️{% endblock %}
+
+{% block content %}
+    <section class="fr-p-5v">
+        {% include 'back/breadcrumb_bo.html.twig' with {
+            'level2Title': 'Outils SA',
+            'level2Link': '',
+            'level2Label': '',
+            'level3Title': 'Auto Assigner Simulator ⚗️',
+            'level3Link': path('back_auto_assigner_simulator_index'),
+            'level3Label': 'Retour à la liste des territoires ayant des règles d\'auto-affectation',
+            'level4Title': 'Simulation',
+            'level4Link': '',
+            'level4Label': '',
+        } %}
+        <header>
+            <div class="fr-grid-row">
+                <div class="fr-col-12">
+                    <h1 class="fr-h1 fr-mb-0">
+                        Auto Assigner Simulator ⚗️ 
+                        <br>
+                        {% if uuid %}
+                            <small>sur le signalement {{uuid}} du territoire {{territory.zip}} - {{territory.name}}</small>
+                        {% else %}
+                            <small>sur les {{limit}} derniers signalements du {{territory.zip}} - {{territory.name}}</small>
+                        {% endif %}
+                    </h1>
+                </div>
+            </div>
+        </header>
+    </section>
+
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">Signalement</th>
+            <th scope="col">Partenaires affectés</th>
+            <th scope="col">Affectations simulées</th>
+        {% endset %}
+
+        {% set tableBody %}
+            {% for item in results %}
+                <tr>
+                    <td><a href="{{path('back_signalement_view', {uuid:item.signalement.uuid})}}">{{ item.signalement.reference}}</a></td>
+                    <td>
+                        {% for affectation in item.signalement.affectations %}
+                            <div class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ affectation.partner.nom }}</div>
+                        {% endfor %}
+                    </td>
+                    <td>
+                        {% for partner in item.assignablePartners %}
+                            <div class="fr-badge fr-mb-1v">{{ partner.nom }}</div>
+                        {% endfor %}
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Auto Assigner Simulator ⚗️', 'tableHead': tableHead, 'tableBody': tableBody } %}
+    </section>
+{% endblock %}


### PR DESCRIPTION
## Ticket

#3590

## Description
Mise en place d'un outil permettant de simuler le traitement d'auto affectation
- Ajout d'un bouton "Simulateur" sur la page "Règles d'affectation"
- Page d'index des territoire ayant des règles d'affectation pour ouvrir le simulateur sur ce territoire
- Page du simulateur pour un territoire. Affiche par défaut les 10 derniers signalement (nombre paramétrable via l'url  ex : `limit=100`, il est aussi possible de recherche un signalement particulier sur le territoire via l'url ex : `uuid=blabla`)

## Tests
- [ ] S'assurer que la version simulée n'enregistre rien en base et n'a pas d'impact sur la version classique
