### PR TITLE
[QA - Sentry] Les fichiers de format ne sont pas pris en charge

### DIFF
--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -65,7 +65,6 @@ class SignalementFileProcessor
                 $fileSizeOk = true;
             }
 
-
             if ($fileSizeOk) {
                 $fileExtension = $file instanceof UploadedFile ? $file->getClientOriginalExtension() : null;
 

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -60,6 +60,7 @@ class SignalementFileProcessor
                     $fileSizeOk = $this->uploadHandlerService->isFileSizeOk($file);
                 } catch (MaxUploadSizeExceededException|EmptyFileException $exception) {
                     $this->errors[] = $exception->getMessage();
+                    $this->logger->error($exception->getMessage());
                 }
             } else {
                 $fileSizeOk = true;

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -7,6 +7,8 @@ use App\Entity\File;
 use App\Entity\Intervention;
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Exception\File\EmptyFileException;
+use App\Exception\File\MaxUploadSizeExceededException;
 use App\Factory\FileFactory;
 use App\Service\Files\FilenameGenerator;
 use App\Service\ImageManipulationHandler;
@@ -40,6 +42,7 @@ class SignalementFileProcessor
     ): array {
         $fileList = [];
         foreach ($files[$inputName] as $key => $file) {
+            $fileSizeOk = false;
             if ($file instanceof UploadedFile) {
                 try {
                     if (!$this->fileScanner->isClean($file->getPathname())) {
@@ -53,61 +56,73 @@ class SignalementFileProcessor
                     $this->logger->error($exception->getMessage());
                     continue;
                 }
-            }
-            $fileExtension = $file instanceof UploadedFile ? $file->getExtension() : null;
-            if (
-                $file instanceof UploadedFile
-                && File::INPUT_NAME_DOCUMENTS === $inputName
-                && !UploadHandlerService::isAcceptedDocumentFormat($file, $inputName)
-            ) {
-                $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('document');
-                $message = <<<ERROR
-                Les fichiers de format {$fileExtension} ne sont pas pris en charge,
-                merci de choisir un fichier au format {$acceptedExtensions}.
-                ERROR;
-                $fileInfo = '( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
-                $this->logger->error($message.$fileInfo);
-                $this->errors[] = $message;
-            } elseif (
-                $file instanceof UploadedFile
-                && File::INPUT_NAME_PHOTOS === $inputName
-                && !ImageManipulationHandler::isAcceptedPhotoFormat($file, $inputName)
-            ) {
-                $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('photo');
-                $message = <<<ERROR
-                Les fichiers de format {$fileExtension} ne sont pas pris en charge,
-                merci de choisir un fichier au format {$acceptedExtensions}.
-                ERROR;
-                $fileInfo = '( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
-                $this->logger->error($message.$fileInfo);
-                $this->errors[] = $message;
-            } else {
-                $inputTypeDetection = $inputName;
                 try {
-                    if ($file instanceof UploadedFile) {
-                        $filename = $this->uploadHandlerService->uploadFromFile(
-                            $file,
-                            $this->filenameGenerator->generate($file),
-                            $inputTypeDetection
-                        );
-                        $title = $this->filenameGenerator->getTitle();
-
-                        if (\in_array($file->getMimeType(), File::IMAGE_MIME_TYPES)) {
-                            $this->imageManipulationHandler->setUseTmpDir(false)->resize($filename)->thumbnail($filename);
-                        } else {
-                            $inputTypeDetection = 'documents';
-                        }
-                    } else {
-                        $filename = $this->uploadHandlerService->moveFromBucketTempFolder($file);
-                        $title = $key;
-                    }
-                } catch (\Exception $exception) {
-                    $this->logger->error($exception->getMessage());
+                    $fileSizeOk = $this->uploadHandlerService->isFileSizeOk($file);
+                } catch (MaxUploadSizeExceededException|EmptyFileException $exception) {
                     $this->errors[] = $exception->getMessage();
-                    continue;
                 }
-                if (!empty($filename)) {
-                    $fileList[] = $this->createFileItem($filename, $title, $inputTypeDetection, $documentType);
+            } else {
+                $fileSizeOk = true;
+            }
+
+
+            if ($fileSizeOk) {
+                $fileExtension = $file instanceof UploadedFile ? $file->getClientOriginalExtension() : null;
+
+                if (
+                    $file instanceof UploadedFile
+                    && File::INPUT_NAME_DOCUMENTS === $inputName
+                    && !UploadHandlerService::isAcceptedDocumentFormat($file, $inputName)
+                ) {
+                    $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('document');
+                    $message = <<<ERROR
+                Les fichiers de format {$fileExtension} ne sont pas pris en charge,
+                merci de choisir un fichier au format {$acceptedExtensions}.
+                ERROR;
+                    $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
+                    $this->logger->error($message.$fileInfo);
+                    $this->errors[] = $message;
+                } elseif (
+                    $file instanceof UploadedFile
+                    && File::INPUT_NAME_PHOTOS === $inputName
+                    && !ImageManipulationHandler::isAcceptedPhotoFormat($file, $inputName)
+                ) {
+                    $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('photo');
+                    $message = <<<ERROR
+                Les fichiers de format {$fileExtension} ne sont pas pris en charge,
+                merci de choisir un fichier au format {$acceptedExtensions}.
+                ERROR;
+                    $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
+                    $this->logger->error($message.$fileInfo);
+                    $this->errors[] = $message;
+                } else {
+                    $inputTypeDetection = $inputName;
+                    try {
+                        if ($file instanceof UploadedFile) {
+                            $filename = $this->uploadHandlerService->uploadFromFile(
+                                $file,
+                                $this->filenameGenerator->generate($file),
+                                $inputTypeDetection
+                            );
+                            $title = $this->filenameGenerator->getTitle();
+
+                            if (\in_array($file->getMimeType(), File::IMAGE_MIME_TYPES)) {
+                                $this->imageManipulationHandler->setUseTmpDir(false)->resize($filename)->thumbnail($filename);
+                            } else {
+                                $inputTypeDetection = 'documents';
+                            }
+                        } else {
+                            $filename = $this->uploadHandlerService->moveFromBucketTempFolder($file);
+                            $title = $key;
+                        }
+                    } catch (\Exception $exception) {
+                        $this->logger->error($exception->getMessage());
+                        $this->errors[] = $exception->getMessage();
+                        continue;
+                    }
+                    if (!empty($filename)) {
+                        $fileList[] = $this->createFileItem($filename, $title, $inputTypeDetection, $documentType);
+                    }
                 }
             }
         }

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -46,7 +46,7 @@ class UploadHandlerService
         }
         $newFilename = $this->filenameGenerator->generate($file);
         $titre = $this->filenameGenerator->getTitle();
-        
+
         if ($this->isFileEmpty($file)) {
             throw new EmptyFileException();
         }

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -46,7 +46,7 @@ class UploadHandlerService
         }
         $newFilename = $this->filenameGenerator->generate($file);
         $titre = $this->filenameGenerator->getTitle();
-
+        
         if ($this->isFileEmpty($file)) {
             throw new EmptyFileException();
         }
@@ -117,6 +117,23 @@ class UploadHandlerService
         $all = implode(', ', $allButLast).' ou '.$last;
 
         return $all;
+    }
+
+    /**
+     * @throws EmptyFileException
+     * @throws MaxUploadSizeExceededException
+     */
+    public function isFileSizeOk(
+        UploadedFile $file,
+    ): bool {
+        if ($this->isFileEmpty($file)) {
+            throw new EmptyFileException();
+        }
+        if ($file->getSize() > self::MAX_FILESIZE) {
+            throw new MaxUploadSizeExceededException(self::MAX_FILESIZE);
+        }
+
+        return true;
     }
 
     public function moveFilePath(string $filePath): ?string


### PR DESCRIPTION
## Ticket

#3336   

## Description
J'ai fait le tour des erreurs sentry de ce type des 30 derniers jours.
Il y avait 2 cas possibles : 
- un type de fichier non supporté, mais le format n'est pas dans l'erreur
- un fichier vide, et la taille n'était pas vérifié avant de vérifier le format

## Changements apportés
* Amélioration du message d'erreur en cas de format non supporté
* Vérificcation de la taille du fichcier avant de vérifier le format

## Pré-requis
Désacctiver la vérification js

## Tests
- [ ] Essayer d'uploader un document avec cun format non supporté, vérifier le message d'erreur
- [ ] Essayer d'uploader un fichier vide, vérifier le message d'erreur
