### PR TITLE
[STAGING] Upload fichier impossible

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -12,6 +12,10 @@
     "FRESHCLAM_DISABLE_DAEMON": {
       "description": "When set, this environment variable instructs the image to NOT start the freshclam daemon.",
       "value": "true"
+    },
+    "CLAMAV_SCAN_ENABLE": {
+      "description": "When set to false, this environment variable instructs the application to NOT check virus in files.",
+      "value": "false"
     }
   }
 }

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -2,7 +2,6 @@
 
 namespace App\Controller\Security;
 
-use App\Controller\FileController;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Service\Files\ImageVariantProvider;


### PR DESCRIPTION
## Ticket

#3552   

## Description
Les var d'env sur staging et les reviewApp étaient contradictoires entre `CLAMAV_SCAN_ENABLE` qui était à 1 et `CLAMD_DISABLE_DAEMON/FRESHCLAM_DISABLE_DAEMON` qui étaient configurées à true.

## Changements apportés
* Sur la staging, suppression des vars d'env `CLAMD_DISABLE_DAEMON` et `FRESHCLAM_DISABLE_DAEMON` pour laisser l'antivirus acctivé
* Dans le fichier [scalingo.json](https://github.com/MTES-MCT/histologe/blob/main/scalingo.json)  on passe `CLAMAV_SCAN_ENABLE` à false pour ne pas activer l'antivirus sur les reviewApp

## Pré-requis

## Tests
- [ ] Sur la staging, vérifier qu'on peut uploader un fichier sachant que l'antivirus est activé : https://dashboard.scalingo.com/apps/osc-fr1/histologe-staging/environment
- [ ] Sur la reviewApp aussi, on doit pouvoir uploader un fichcier https://histologe-staging-pr3617.osc-fr1.scalingo.io sachant que l'antivirus est désactivé : https://dashboard.scalingo.com/apps/osc-fr1/histologe-staging-pr3617/environment
