### PR TITLE
[BO - List signalements] Si trop d'affectations sur un signalement, la liste ne s'affiche pas

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -468,7 +468,6 @@ class SignalementRepository extends ServiceEntityRepository
             GROUP_CONCAT(DISTINCT CONCAT(p.nom, :concat_separator, a.statut) SEPARATOR :group_concat_separator) as rawAffectations,
             GROUP_CONCAT(DISTINCT p.nom SEPARATOR :group_concat_separator) as affectationPartnerName,
             GROUP_CONCAT(DISTINCT a.statut SEPARATOR :group_concat_separator) as affectationStatus,
-            GROUP_CONCAT(DISTINCT p.id SEPARATOR :group_concat_separator) as affectationPartnerId,
             GROUP_CONCAT(DISTINCT sq.qualification SEPARATOR :group_concat_separator) as qualifications,
             GROUP_CONCAT(DISTINCT sq.status SEPARATOR :group_concat_separator) as qualificationsStatuses,
             GROUP_CONCAT(DISTINCT i.concludeProcedure ORDER BY i.scheduledAt DESC SEPARATOR :group_concat_separator) as conclusionsProcedure')

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -66,7 +66,7 @@ class SignalementAffectationHelper
         return null;
     }
 
-    public static function parseAffectations(?string $rawAffectations): ?array
+    private static function parseAffectations(?string $rawAffectations): array
     {
         if (empty($rawAffectations)) {
             return [];
@@ -74,6 +74,10 @@ class SignalementAffectationHelper
         $affectations = [];
         $affectationsList = explode(SignalementAffectationListView::SEPARATOR_GROUP_CONCAT, $rawAffectations);
         foreach ($affectationsList as $affectationItem) {
+            // if the separator is not found, it means that the query is truncated (by the limit length of group_concat)
+            if (!str_contains($affectationItem, SignalementAffectationListView::SEPARATOR_CONCAT)) {
+                break;
+            }
             list($partner, $status) = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $affectationItem);
             $statusAffectation = AffectationStatus::from($status)->value;
             $affectations[$partner] = [

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -79,7 +79,7 @@ class SignalementAffectationHelper
                 break;
             }
             list($partner, $status) = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $affectationItem);
-            $statusAffectation = AffectationStatus::from($status)->value;
+            $statusAffectation = AffectationStatus::tryFrom($status)->value;
             $affectations[$partner] = [
                 'partner' => $partner,
                 'statut' => $statusAffectation,

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -79,10 +79,12 @@ class SignalementAffectationHelper
                 break;
             }
             list($partner, $status) = explode(SignalementAffectationListView::SEPARATOR_CONCAT, $affectationItem);
-            $statusAffectation = AffectationStatus::tryFrom($status)->value;
+            if ('' === $status || !$statusAffectation = AffectationStatus::tryFrom($status)) {
+                break;
+            }
             $affectations[$partner] = [
                 'partner' => $partner,
-                'statut' => $statusAffectation,
+                'statut' => $statusAffectation->value,
             ];
         }
 

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -37,7 +37,6 @@ class SignalementExportFactoryTest extends TestCase
             'rawAffectations' => 'DDETS-PS-DL PE - Mission Logement indigne||0;M.A.M.P. - CT1 / EAH Marseille||0;MARSEILLE||1',
             'affectationPartnerName' => 'DDETS-PS-DL PE - Mission Logement indigne;M.A.M.P. - CT1 / EAH Marseille;MARSEILLE',
             'affectationStatus' => '0;1',
-            'affectationPartnerId' => '636;645;708',
             'details' => $faker->text(),
             'telOccupant' => $faker->phoneNumber(),
             'telOccupantBis' => null,


### PR DESCRIPTION
## Ticket

#3586

## Description
Un signalement contenant un (très) grand nombre d'affectations peux résulter à une requête limité (par l'utilisation de `GROUP_CONCAT `pour `rawAffectations`). Dans ce cas la fonction `parseAffectations` provoque un crash car les données sont incomplètes et donc le statut renvoyé est invalide.
- Correction de la fonction `parseAffectations` pour qu'elle ignore le statut si il n'est pas disponible ou inconnu
- Ce la signifie que sur la liste des signaleement seul les xx affectations seront affichés (70 environs) mêm si il y'en à plus

## Tests
- [ ] S'assurer que la liste de signalement fonctionne toujours même avec un signalement contenant plus de 100 affectations.
