### PR TITLE
[Sécurité - Audit] Mots de passe persistant en clair dans la mémoire vive

### DIFF
--- a/src/Controller/Back/ProfilController.php
+++ b/src/Controller/Back/ProfilController.php
@@ -305,6 +305,16 @@ class ProfilController extends AbstractController
                 return $this->redirectToRoute('back_profil', [], Response::HTTP_SEE_OTHER);
             }
             $user = $userManager->resetPassword($user, $password);
+            $payload['password'] = null;
+            $payload['password-repeat'] = null;
+            $password = null;
+            $passwordRepeat = null;
+            $oldPassword = null;
+            unset($payload['password']);
+            unset($payload['password-repeat']);
+            unset($password);
+            unset($passwordRepeat);
+            unset($oldPassword);
 
             $notificationMailerRegistry->send(
                 new NotificationMail(

--- a/src/Controller/Back/ProfilController.php
+++ b/src/Controller/Back/ProfilController.php
@@ -305,16 +305,8 @@ class ProfilController extends AbstractController
                 return $this->redirectToRoute('back_profil', [], Response::HTTP_SEE_OTHER);
             }
             $user = $userManager->resetPassword($user, $password);
-            $payload['password'] = null;
-            $payload['password-repeat'] = null;
-            $password = null;
-            $passwordRepeat = null;
-            $oldPassword = null;
-            unset($payload['password']);
-            unset($payload['password-repeat']);
-            unset($password);
-            unset($passwordRepeat);
-            unset($oldPassword);
+            $payload['password'] = $payload['password-repeat'] = null;
+            $password = $passwordRepeat = $oldPassword = null;
 
             $notificationMailerRegistry->send(
                 new NotificationMail(

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -151,6 +151,7 @@ class UserAccountController extends AbstractController
             }
             $user = $userManager->resetPassword($user, $request->get('password'));
             $this->addFlash('success', 'Votre compte est maintenant activé, vous pouvez vous connecter');
+            $request->request->remove('password');
 
             return $this->redirectToRoute('app_login');
         }

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -111,7 +111,6 @@ class UserManager extends AbstractManager
 
         $this->save($user);
         $password = null;
-        unset($password);
 
         return $user;
     }

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -110,6 +110,8 @@ class UserManager extends AbstractManager
             ->setTokenExpiredAt(null);
 
         $this->save($user);
+        $password = null;
+        unset($password);
 
         return $user;
     }

--- a/src/Security/FormLoginAuthenticator.php
+++ b/src/Security/FormLoginAuthenticator.php
@@ -47,7 +47,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
 
         $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $email);
 
-        return new Passport(
+        $passport = new Passport(
             new UserBadge($email, function (string $email) {
                 return $this->userRepository->findOneBy(['email' => $email, 'statut' => User::STATUS_ACTIVE]);
             }),
@@ -57,6 +57,9 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
                 new RememberMeBadge(),
             ]
         );
+        $request->request->remove('password');
+
+        return $passport;
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response

--- a/src/Security/JsonLoginAuthenticator.php
+++ b/src/Security/JsonLoginAuthenticator.php
@@ -66,10 +66,7 @@ class JsonLoginAuthenticator extends AbstractAuthenticator
             }),
             new PasswordCredentials($password)
         );
-        $password = null;
-        $payload['password'] = null;
-        unset($password);
-        unset($payload['password']);
+        $password = $payload['password'] = null;
 
         return $passport;
     }

--- a/src/Security/JsonLoginAuthenticator.php
+++ b/src/Security/JsonLoginAuthenticator.php
@@ -51,7 +51,7 @@ class JsonLoginAuthenticator extends AbstractAuthenticator
             throw new AuthenticationException('E-mail ou mot de passe manquant.');
         }
 
-        return new Passport(
+        $passport = new Passport(
             new UserBadge($email, function (string $email) {
                 $user = $this->userRepository->findOneBy([
                     'email' => $email,
@@ -66,6 +66,11 @@ class JsonLoginAuthenticator extends AbstractAuthenticator
             }),
             new PasswordCredentials($password)
         );
+        $password = null;
+        $payload['password'] = null;
+        unset($password);
+        unset( $payload['password'] );
+        return $passport;
     }
 
     /**

--- a/src/Security/JsonLoginAuthenticator.php
+++ b/src/Security/JsonLoginAuthenticator.php
@@ -69,7 +69,8 @@ class JsonLoginAuthenticator extends AbstractAuthenticator
         $password = null;
         $payload['password'] = null;
         unset($password);
-        unset( $payload['password'] );
+        unset($payload['password']);
+
         return $passport;
     }
 


### PR DESCRIPTION
## Ticket

#3566   

## Description
On n'a pas besoin d'aller si loin, on peut supprimer les variables de la RAM unset après leur utilisation, ça sera suffisant si je me limite au problème remonté cad stockés durablement

## Changements apportés
* Ecrabouillage et suppression des variables contenant des mots de passe dès que plus besoin

## Pré-requis

## Tests
- [ ] Tester les différentes possibilités d'utilisation du mot de passe et vérifier que tout fonctionne toujours (activation de compte, mot de passe oublié, login, modification de mot de passe sur le profil...) 
