### PR TITLE
[BO] Données de type doctrine ne se mettrait pas à jour

### DIFF
--- a/migrations/Version20250127183041.php
+++ b/migrations/Version20250127183041.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250127183041 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update JSON fields with signalement column value.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE `signalement`
+            SET type_composition_logement = JSON_SET(type_composition_logement, '$.type_logement_nature', nature_logement)
+            WHERE JSON_VALID(type_composition_logement) AND nature_logement IS NOT NULL;
+        ");
+
+        $this->addSql("
+            UPDATE `signalement`
+            SET situation_foyer = JSON_SET(situation_foyer, '$.logement_social_date_naissance', DATE(date_naissance_occupant))
+            WHERE JSON_VALID(situation_foyer) AND date_naissance_occupant IS NOT NULL;");
+
+        $this->addSql("
+            UPDATE `signalement`
+            SET situation_foyer = JSON_SET(situation_foyer, '$.logement_social_numero_allocataire', num_allocataire)
+            WHERE JSON_VALID(situation_foyer) AND num_allocataire IS NOT NULL;");
+
+        $this->addSql("
+            UPDATE `signalement`
+            SET information_complementaire = JSON_SET(information_complementaire, '$.informations_complementaires_logement_montant_loyer', loyer)
+            WHERE JSON_VALID(information_complementaire) AND loyer IS NOT NULL;");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -296,6 +296,9 @@ class SignalementEditController extends AbstractController
         return $this->json($response, $response['code']);
     }
 
+    /**
+     * @throws \DateMalformedStringException
+     */
     #[Route('/{uuid:signalement}/edit-situation-foyer', name: 'back_signalement_edit_situation_foyer', methods: 'POST')]
     public function editSituationFoyer(
         Signalement $signalement,

--- a/src/Factory/Signalement/TypeCompositionLogementFactory.php
+++ b/src/Factory/Signalement/TypeCompositionLogementFactory.php
@@ -7,7 +7,7 @@ use App\Entity\Model\TypeCompositionLogement;
 use App\Serializer\SignalementDraftRequestSerializer;
 use App\Utils\DataPropertyArrayFilter;
 
-class TypeCompositionLogementFactory
+readonly class TypeCompositionLogementFactory
 {
     public function __construct(private SignalementDraftRequestSerializer $serializer)
     {
@@ -33,7 +33,6 @@ class TypeCompositionLogementFactory
             typeLogementSousSolSansFenetre: $data['type_logement_sous_sol_sans_fenetre'] ?? null,
             typeLogementSousCombleSansFenetre: $data['type_logement_sous_comble_sans_fenetre'] ?? null,
             typeLogementCommoditesCuisine: $data['type_logement_commodites_cuisine'] ?? null,
-            typeLogementCommoditesPieceAVivre9m: $data['type_logement_commodites_piece_a_vivre_9m'] ?? null,
             typeLogementCommoditesCuisineCollective: $data['type_logement_commodites_cuisine_collective'] ?? null,
             typeLogementCommoditesSalleDeBain: $data['type_logement_commodites_salle_de_bain'] ?? null,
             typeLogementCommoditesSalleDeBainCollective: $data['type_logement_commodites_salle_de_bain_collective'] ?? null,
@@ -47,6 +46,7 @@ class TypeCompositionLogementFactory
             compositionLogementNombrePersonnes: $data['composition_logement_nombre_personnes'] ?? null,
             compositionLogementNombreEnfants: $data['composition_logement_nombre_enfants'] ?? null,
             compositionLogementEnfants: $data['composition_logement_enfants'] ?? null,
+            typeLogementCommoditesPieceAVivre9m: $data['type_logement_commodites_piece_a_vivre_9m'] ?? null,
             bailDpeBail: $data['bail_dpe_bail'] ?? null,
             bailDpeInvariant: $data['bail_dpe_invariant'] ?? null,
             bailDpeDpe: $data['bail_dpe_dpe'] ?? null,


### PR DESCRIPTION
## Ticket

#3426   

## Description
Revue des champs JSON posté depuis un nouveau formulaire. 
Pour rester cohérent, les champs JSON doivent rester synchronisé même si la colonne existe. 

## Changements apportés
* Mises à jour des propriétés manquantes champs de type JSON 
* Ajout de migration

## Pré-requis
Créer un nouveau signalement et travailler sur un signalement fraichement posté.
Executer `make load-data`
## Tests
- [ ] Mettre à jour le type dans la description du logement et vérifier dans l'historique que le JSON se met à jour
- [ ] Mettre à jour la date de naissance et le numéro d'allocataire dans la situation foyer et vérifier dans l'historique que le JSON se met à jour
- [ ] Mettre à jour le montant du loyer dans information sur logement et vérifier dans l'historique que le JSON se met à jour
- [ ] Modifier les valeurs des 4 colonnes en base puis jouer la migration. Vérifier que les JSON sont à jour. 
    - `make execute-migration name="Version20250127183041" direction="up"` 
