### PR TITLE
[BUG] doublonge des création de suivi pour arrétés au 29/01/2025

### DIFF
--- a/migrations/Version20250129102407.php
+++ b/migrations/Version20250129102407.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250129102407 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add on delete cascade on notification suivi_id and delete suivis for arretes and visites created on 2025-01-29';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // add on delete cascade on notification suivi_id
+        $this->addSql('ALTER TABLE notification DROP FOREIGN KEY FK_BF5476CA7FEA59C0');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT FK_BF5476CA7FEA59C0 FOREIGN KEY (suivi_id) REFERENCES suivi (id) ON DELETE CASCADE');
+        // delete suivis for arretes and visites created on 2025-01-29
+        $this->addSql("DELETE FROM suivi WHERE description LIKE '%pris dans le dossier de%' AND context = 'intervention' AND created_at LIKE '2025-01-29%'");
+        $this->addSql("DELETE FROM suivi WHERE description LIKE 'Visite réalisée : une visite du logement situé%' AND context = 'intervention' AND created_at LIKE '2025-01-29%'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE notification DROP FOREIGN KEY FK_BF5476CA7FEA59C0');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT FK_BF5476CA7FEA59C0 FOREIGN KEY (suivi_id) REFERENCES suivi (id)');
+    }
+}

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -29,6 +29,8 @@ use App\Service\UploadHandlerService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -425,6 +427,8 @@ class SignalementController extends AbstractController
         SuiviManager $suiviManager,
         EntityManagerInterface $entityManager,
         SignalementDesordresProcessor $signalementDesordresProcessor,
+        #[Autowire(service: 'html_sanitizer.sanitizer.app.message_sanitizer')]
+        HtmlSanitizerInterface $htmlSanitizer,
     ): RedirectResponse|Response {
         $signalement = $signalementRepository->findOneByCodeForPublic($code);
         if (!$signalement) {
@@ -475,7 +479,7 @@ class SignalementController extends AbstractController
         if (Suivi::POURSUIVRE_PROCEDURE === $suiviAuto) {
             $description = $user->getNomComplet().' ('.$type.') a indiqué vouloir poursuivre la procédure.';
             $suiviPoursuivreProcedure = $suiviManager->findOneBy([
-                'description' => $description,
+                'description' => $htmlSanitizer->sanitize($description),
                 'signalement' => $signalement,
             ]);
             if (null !== $suiviPoursuivreProcedure) {

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -33,6 +33,7 @@ class Notification
     private ?Signalement $signalement;
 
     #[ORM\ManyToOne(targetEntity: Suivi::class)]
+    #[ORM\JoinColumn(onDelete: 'CASCADE')]
     private ?Suivi $suivi;
 
     #[ORM\Column(type: 'datetime_immutable')]

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -28,7 +28,9 @@ use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 class SignalementImportLoader
 {
@@ -66,6 +68,8 @@ class SignalementImportLoader
         private SignalementQualificationUpdater $signalementQualificationUpdater,
         private FileManager $fileManager,
         private FilesystemOperator $fileStorage,
+        #[Autowire(service: 'html_sanitizer.sanitizer.app.message_sanitizer')]
+        private HtmlSanitizerInterface $htmlSanitizer,
     ) {
     }
 
@@ -259,7 +263,7 @@ class SignalementImportLoader
                 $description = trim(preg_replace(self::REGEX_DATE_FORMAT_CSV, '', $suivi));
 
                 $suivi = $this->suiviManager->findOneBy([
-                    'description' => $description,
+                    'description' => $this->htmlSanitizer->sanitize($description),
                     'createdBy' => $this->userSystem,
                     'signalement' => $signalement,
                 ]);

--- a/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
@@ -38,6 +38,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $eventDispatcher = new EventDispatcher();
         $visiteNotifier = static::getContainer()->get(VisiteNotifier::class);
         $suiviManager = static::getContainer()->get(SuiviManager::class);
+        $htmlSanitizer = self::getContainer()->get('html_sanitizer.sanitizer.app.message_sanitizer');
 
         /** @var InterventionRepository $interventionRepository */
         $interventionRepository = $this->entityManager->getRepository(Intervention::class);
@@ -49,7 +50,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
-        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager);
+        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager, $htmlSanitizer);
         $eventDispatcher->addSubscriber($interventionCreatedSubscriber);
 
         $intervention = $interventions[0];
@@ -100,6 +101,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $eventDispatcher = new EventDispatcher();
         $visiteNotifier = static::getContainer()->get(VisiteNotifier::class);
         $suiviManager = static::getContainer()->get(SuiviManager::class);
+        $htmlSanitizer = self::getContainer()->get('html_sanitizer.sanitizer.app.message_sanitizer');
 
         /** @var InterventionRepository $interventionRepository */
         $interventionRepository = $this->entityManager->getRepository(Intervention::class);
@@ -111,7 +113,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@histologe.fr']);
-        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager);
+        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager, $htmlSanitizer);
         $eventDispatcher->addSubscriber($interventionCreatedSubscriber);
 
         $intervention->setScheduledAt($date);

--- a/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
+++ b/tests/Functional/Service/Import/Signalement/SignalementImportLoaderTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 class SignalementImportLoaderTest extends KernelTestCase
 {
@@ -37,6 +38,7 @@ class SignalementImportLoaderTest extends KernelTestCase
     private SignalementQualificationUpdater $signalementQualificationUpdater;
     private FileManager $fileManager;
     private MockObject|FilesystemOperator $filesystemOperator;
+    private HtmlSanitizerInterface $htmlSanitizerInterface;
 
     protected function setUp(): void
     {
@@ -53,6 +55,7 @@ class SignalementImportLoaderTest extends KernelTestCase
         $this->fileManager = self::getContainer()->get(FileManager::class);
         $this->filesystemOperator = $this->createMock(FilesystemOperator::class);
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $this->htmlSanitizerInterface = self::getContainer()->get('html_sanitizer.sanitizer.app.message_sanitizer');
     }
 
     /**
@@ -74,6 +77,7 @@ class SignalementImportLoaderTest extends KernelTestCase
             $this->signalementQualificationUpdater,
             $this->fileManager,
             $this->filesystemOperator,
+            $this->htmlSanitizerInterface
         );
 
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '01']);


### PR DESCRIPTION
## Ticket

#3635

## Description
Suite à la MEP du 28/01 des doublons de suivi (arrêtés et visites) ont été généré dans la nuit du 29/01

## Changements apportés
- Migration pour supprimer les suivis (et leur notifications) générés en doublons
- Correction des appel `suiviManager->findOneBy` afin que la description soit correctement formaté et ne provoque plus la création de doublon
