### PR TITLE
[CI] Blacklist les fonctions de debug

### DIFF
--- a/assets/scripts/vanilla/services/form_helper.js
+++ b/assets/scripts/vanilla/services/form_helper.js
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/browser";
+
 Node.prototype.addEventListeners = function (eventNames, eventFunction) {
   for (const eventName of eventNames.split(' ')) { this.addEventListener(eventName, eventFunction) }
 }
@@ -97,8 +99,6 @@ forms.forEach((form) => {
           const finishSubmitBtn = document.querySelector('#form_finish_submit')
           request.open('POST', event.target.getAttribute('data-handle-url'))
           request.upload.addEventListener('progress', function (e) {
-            console.log('progress')
-            console.log(e)
             totalProgress.classList.remove('fr-hidden')
             finishSubmitBtn.disabled = true
             finishSubmitBtn.innerHTML = 'Téléversement en cours, veuillez patienter....'
@@ -112,8 +112,6 @@ forms.forEach((form) => {
             progress.value = percentCompleted
           })
           request.addEventListener('load', function (e) {
-            console.log('load')
-            console.log(e)
             event.target.parentElement.classList.remove('fr-icon-refresh-line');
             [preview, deleter].forEach(el => el?.classList?.remove('fr-hidden'))
             progress.value = 0
@@ -124,6 +122,8 @@ forms.forEach((form) => {
               resTextEl.innerText = jsonRes.error
               resTextEl.classList.remove('fr-hidden')
               resTextEl.classList.add('fr-text-label--red-marianne')
+              console.error(jsonRes.error)
+              Sentry.captureException(new Error(error))
             } else {
               resTextEl.innerText = jsonRes.titre
               resTextEl.classList.remove('fr-hidden')

--- a/assets/scripts/vanilla/services/search_filter_form.js
+++ b/assets/scripts/vanilla/services/search_filter_form.js
@@ -30,7 +30,6 @@ const removeBadge = (badge) => {
   select.querySelector(`option[value="${val}"]`)?.classList?.remove('fr-hidden')
   input?.remove()
   const badges = badge.parentElement.querySelectorAll('.fr-badge[data-value]').length !== 1
-  console.log(badge.parentElement.querySelectorAll('.fr-badge[data-value]').length)
   if (!badges) {
     badge?.parentElement?.querySelector('.fr-badge:not([data-value])')?.classList?.remove('fr-hidden')
     if (select.tagName === 'SELECT') { select.options[0].selected = true }

--- a/composer.json
+++ b/composer.json
@@ -74,9 +74,11 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "8.2.*",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
+        "ekino/phpstan-banned-code": "^2.1",
         "fakerphp/faker": "^1.20",
         "nelmio/api-doc-bundle": "^4.32",
         "phpro/grumphp-shim": "^1.13",
+        "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "1.10.44",
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "7.1.*",
@@ -90,10 +92,11 @@
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "symfony/flex": true,
-            "symfony/runtime": true,
+            "php-http/discovery": true,
             "phpro/grumphp-shim": true,
-            "php-http/discovery": true
+            "phpstan/extension-installer": true,
+            "symfony/flex": true,
+            "symfony/runtime": true
         },
         "optimize-autoloader": true,
         "classmap-authoritative": true,

--- a/composer.lock
+++ b/composer.lock
@@ -12472,6 +12472,72 @@
             "time": "2024-11-13T07:41:29+00:00"
         },
         {
+            "name": "ekino/phpstan-banned-code",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ekino/phpstan-banned-code.git",
+                "reference": "e1c3e4722753404fd633fec81f67c199e99cfe7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ekino/phpstan-banned-code/zipball/e1c3e4722753404fd633fec81f67c199e99cfe7a",
+                "reference": "e1c3e4722753404fd633fec81f67c199e99cfe7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "phpstan/phpstan": "^1.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.6",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "nikic/php-parser": "^4.3",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/var-dumper": "^5.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ekino\\PHPStanBannedCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rémi Marseille",
+                    "email": "remi.marseille@ekino.com",
+                    "homepage": "https://www.ekino.com"
+                }
+            ],
+            "description": "Detected banned code using PHPStan",
+            "homepage": "https://github.com/ekino/phpstan-banned-code",
+            "keywords": [
+                "PHPStan",
+                "code quality",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/ekino/phpstan-banned-code/issues",
+                "source": "https://github.com/ekino/phpstan-banned-code/tree/v2.1.0"
+            },
+            "time": "2024-08-14T07:20:46+00:00"
+        },
+        {
             "name": "fakerphp/faker",
             "version": "v1.24.0",
             "source": {
@@ -12950,6 +13016,54 @@
                 "source": "https://github.com/phpro/grumphp-shim/tree/v1.16.0"
             },
             "time": "2023-04-27T11:06:59+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default [
             "no-unused-expressions": "off",
             "vue/no-mutating-props": "off",
             "vue/no-reserved-component-names": "off",
+            "no-console": ["error", { "allow": ["warn", "error"] }]
         },
     },
 ]

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -4,14 +4,6 @@ grumphp:
         enforce_capitalized_subject: false
         matchers:
            must contain github issue number: '/#(\d+)$/'
-      git_blacklist:
-        keywords:
-          - 'var_dump('
-          - 'dump('
-          - ' dd('
-          - ';dd('
-          - 'die('
-          - 'exit('
       yamllint:
         parse_custom_tags: true
       phpstan: ~

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "histologe",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Ticket

#3641    

## Description
Phpstan est une tache de la CI et il est possible d'étendre les fonctionnalités de phpstan pour utiliser des extensions. 
Il en existe une qui blackliste les fonctions de debug php

## Changements apportés
* Installation de[ phpstan/extension-installer](https://github.com/phpstan/extension-installer) pour activer les extensions 
* Installation de l'extension [ekino/phpstan-banned-code](https://github.com/ekino/phpstan-banned-code) pour blackliste les fonctions de debug
* Mise de la conf eslint pour blacklist console.log
* Suppression des directives grumphp pour les fonction de blacklist

## Pré-requis
**EDIT** : ```make  npm-install```

```make composer```
```make npm-watch```



## Tests
- [ ] Ajouter des fonctions de debug php et executer `make stan` et vérifier qu'ils soient bien détecté
- [ ] Ajouter des console.log et exécuter `make es-vue-fix`  et `make es-js-fix` et vérifier qu'ils soient bien détecté
