### PR TITLE
[BO - Agent multi territoires] Ajouter des modales à l'ajout / suppression d'un territoire

### DIFF
--- a/assets/scripts/app-back-bo.ts
+++ b/assets/scripts/app-back-bo.ts
@@ -6,7 +6,7 @@ import './vue/signalement-carto.ts';
 import './vue/dashboard.ts';
 
 import './vanilla/services/data_delete.js'
-import './vanilla/services/modale_cgu_bo.js';
+import './vanilla/services/bo_modales.js';
 import './vanilla/services/pagination.js'
 import './vanilla/services/search_filter_form.js'
 import './vanilla/services/table_sortable.js'

--- a/assets/scripts/vanilla/services/bo_modales.js
+++ b/assets/scripts/vanilla/services/bo_modales.js
@@ -45,3 +45,24 @@ function handleAcceptButton () {
 acceptCguBoCheckbox?.addEventListener('click', handleAcceptCheck)
 acceptCguBoButton?.addEventListener('click', handleAcceptButton)
 modalCguBo?.addEventListener('dsfr.disclose', handleModalDisclose)
+
+document.addEventListener('DOMContentLoaded', () => {
+  const modalPopNotification = document.getElementById('fr-modal-pop-notification')
+  if(modalPopNotification){
+    modalPopNotification.addEventListener('dsfr.conceal', (e) => {
+        const deletePopNotificationUrl = modalPopNotification.dataset.deleteUrl;
+        console.log(e)
+        console.log(deletePopNotificationUrl)
+        //fetch(deletePopNotificationUrl, {})
+    });
+  }
+
+  if(modalCguBo && modalPopNotification){
+    modalCguBo.addEventListener('dsfr.conceal', (e) => {
+      dsfr(modalPopNotification).modal.disclose()
+    });
+  }else if(modalPopNotification){
+    dsfr(modalPopNotification).modal.disclose()
+  }
+});
+

--- a/assets/scripts/vanilla/services/bo_modales.js
+++ b/assets/scripts/vanilla/services/bo_modales.js
@@ -58,11 +58,11 @@ if(modalPopNotification){
             fetch(deletePopNotificationUrl, {})
         });
 
-      if (modalCguBo && modalPopNotification) {
+      if (modalCguBo) {
         modalCguBo.addEventListener('dsfr.conceal', (e) => {
           dsfr(modalPopNotification).modal.disclose();
         });
-      } else if (modalPopNotification) {
+      } else {
         dsfr(modalPopNotification).modal.disclose();
       }
     }

--- a/assets/scripts/vanilla/services/bo_modales.js
+++ b/assets/scripts/vanilla/services/bo_modales.js
@@ -46,23 +46,26 @@ acceptCguBoCheckbox?.addEventListener('click', handleAcceptCheck)
 acceptCguBoButton?.addEventListener('click', handleAcceptButton)
 modalCguBo?.addEventListener('dsfr.disclose', handleModalDisclose)
 
-document.addEventListener('DOMContentLoaded', () => {
-  const modalPopNotification = document.getElementById('fr-modal-pop-notification')
-  if(modalPopNotification){
-    modalPopNotification.addEventListener('dsfr.conceal', (e) => {
-        const deletePopNotificationUrl = modalPopNotification.dataset.deleteUrl;
-        console.log(e)
-        console.log(deletePopNotificationUrl)
-        //fetch(deletePopNotificationUrl, {})
-    });
-  }
+const modalPopNotification = document.getElementById('fr-modal-pop-notification')
+if(modalPopNotification){
+  //prevent error dsfr is not defined or null
+  const checkDsfrInterval = setInterval(() => {
+    if (typeof dsfr !== 'undefined' && dsfr !== null) {
+      clearInterval(checkDsfrInterval);
 
-  if(modalCguBo && modalPopNotification){
-    modalCguBo.addEventListener('dsfr.conceal', (e) => {
-      dsfr(modalPopNotification).modal.disclose()
-    });
-  }else if(modalPopNotification){
-    dsfr(modalPopNotification).modal.disclose()
-  }
-});
+        modalPopNotification.addEventListener('dsfr.conceal', (e) => {
+            const deletePopNotificationUrl = modalPopNotification.dataset.deleteUrl;
+            fetch(deletePopNotificationUrl, {})
+        });
+
+      if (modalCguBo && modalPopNotification) {
+        modalCguBo.addEventListener('dsfr.conceal', (e) => {
+          dsfr(modalPopNotification).modal.disclose();
+        });
+      } else if (modalPopNotification) {
+        dsfr(modalPopNotification).modal.disclose();
+      }
+    }
+  }, 100);
+}
 

--- a/migrations/Version20250129155205.php
+++ b/migrations/Version20250129155205.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250129155205 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create pop_notification table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE pop_notification (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', params JSON NOT NULL, INDEX IDX_257F9F96A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE pop_notification ADD CONSTRAINT FK_257F9F96A76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE pop_notification DROP FOREIGN KEY FK_257F9F96A76ED395');
+        $this->addSql('DROP TABLE pop_notification');
+    }
+}

--- a/migrations/Version20250204083053.php
+++ b/migrations/Version20250204083053.php
@@ -7,7 +7,7 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-final class Version20250129155205 extends AbstractMigration
+final class Version20250204083053 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -16,7 +16,7 @@ final class Version20250129155205 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE pop_notification (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', params JSON NOT NULL, INDEX IDX_257F9F96A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE pop_notification (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, params JSON NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_257F9F96A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE pop_notification ADD CONSTRAINT FK_257F9F96A76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
     }
 

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -19,6 +19,7 @@ use App\Form\UserPartnerType;
 use App\Manager\AffectationManager;
 use App\Manager\InterventionManager;
 use App\Manager\PartnerManager;
+use App\Manager\PopNotificationManager;
 use App\Manager\UserManager;
 use App\Repository\AutoAffectationRuleRepository;
 use App\Repository\JobEventRepository;
@@ -360,6 +361,7 @@ class PartnerController extends AbstractController
         UserRepository $userRepository,
         UserManager $userManager,
         NotificationMailerRegistry $notificationMailerRegistry,
+        PopNotificationManager $popNotificationManager,
     ): JsonResponse|RedirectResponse {
         if (!$this->featureMultiTerritories) {
             throw $this->createNotFoundException();
@@ -375,6 +377,7 @@ class PartnerController extends AbstractController
             $user = $userRepository->findAgentByEmail($userTmp->getEmail());
             if ($user) {
                 $userPartner->setUser($user);
+                $popNotificationManager->createOrUpdatePopNotification($user, 'addPartner', $partner);
                 $userManager->save($userPartner);
                 $notificationMailerRegistry->send(
                     new NotificationMail(
@@ -612,6 +615,7 @@ class PartnerController extends AbstractController
         Partner $partner,
         UserManager $userManager,
         NotificationMailerRegistry $notificationMailerRegistry,
+        PopNotificationManager $popNotificationManager,
     ): Response {
         $userId = $request->request->get('user_id');
         if (!$this->isCsrfTokenValid('partner_user_delete', $request->request->get('_token'))) {
@@ -636,6 +640,7 @@ class PartnerController extends AbstractController
         if ($user->getUserPartners()->count() > 1) {
             foreach ($user->getUserPartners() as $userPartner) {
                 if ($userPartner->getPartner()->getId() === $partner->getId()) {
+                    $popNotificationManager->createOrUpdatePopNotification($user, 'removePartner', $partner);
                     $userManager->remove($userPartner);
                     break;
                 }

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -268,6 +268,7 @@ class PartnerController extends AbstractController
         WorkflowInterface $interventionPlanningStateMachine,
         InterventionManager $interventionManager,
         AffectationManager $affectationManager,
+        PopNotificationManager $popNotificationManager,
     ): Response {
         $partnerId = $request->request->get('partner_id');
         /** @var ?Partner $partner */
@@ -285,6 +286,7 @@ class PartnerController extends AbstractController
                 if ($user->getUserPartners()->count() > 1) {
                     foreach ($user->getUserPartners() as $userPartner) {
                         if ($userPartner->getPartner()->getId() === $partner->getId()) {
+                            $popNotificationManager->createOrUpdatePopNotification($user, 'removePartner', $partner);
                             $entityManager->remove($userPartner);
                             break;
                         }

--- a/src/Controller/Back/PopNotificationController.php
+++ b/src/Controller/Back/PopNotificationController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\User;
+use App\Manager\PopNotificationManager;
+use App\Repository\PartnerRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/bo/pop-notification')]
+class PopNotificationController extends AbstractController
+{
+    public function show(
+        PartnerRepository $partnerRepository,
+    ): Response {
+        /** @var ?User $user */
+        $user = $this->getUser();
+        $popNotification = $user->getPopNotifications()->first();
+        $addedPartnersIds = isset($popNotification->getParams()['addedPartners']) ? $popNotification->getParams()['addedPartners'] : [];
+        $removedPartnersIds = isset($popNotification->getParams()['removedPartners']) ? $popNotification->getParams()['removedPartners'] : [];
+        $addedPartners = $partnerRepository->findBy(['id' => $addedPartnersIds]);
+        $removedPartners = $partnerRepository->findBy(['id' => $removedPartnersIds]);
+
+        return $this->render('back/pop-notification/index.html.twig', [
+            'user' => $user,
+            'addedPartners' => $addedPartners,
+            'removedPartners' => $removedPartners,
+        ]);
+    }
+
+    #[Route('/delete', name: 'pop_notification_delete')]
+    public function delete(
+        PopNotificationManager $popNotificationManager,
+    ): JsonResponse {
+        /** @var ?User $user */
+        $user = $this->getUser();
+        $popNotification = $user->getPopNotifications()->count() ? $user->getPopNotifications()->first() : null;
+        if ($popNotification) {
+            $popNotificationManager->remove($popNotification);
+        }
+
+        return new JsonResponse(['success' => true]);
+    }
+}

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: PartnerRepository::class)]
+#[ORM\HasLifecycleCallbacks()]
 #[UniqueEntity(
     fields: ['email', 'territory', 'isArchive'],
     message: 'L\'e-mail générique existe déjà pour ce territoire. Veuillez saisir un autre e-mail partenaire.',

--- a/src/Entity/PopNotification.php
+++ b/src/Entity/PopNotification.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PopNotificationRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PopNotificationRepository::class)]
+class PopNotification
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'popNotifications')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column]
+    private array $params = [];
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    public function setParams(array $params): static
+    {
+        $this->params = $params;
+
+        return $this;
+    }
+}

--- a/src/Entity/PopNotification.php
+++ b/src/Entity/PopNotification.php
@@ -2,12 +2,18 @@
 
 namespace App\Entity;
 
+use App\Entity\Behaviour\EntityHistoryInterface;
+use App\Entity\Behaviour\TimestampableTrait;
+use App\Entity\Enum\HistoryEntryEvent;
 use App\Repository\PopNotificationRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: PopNotificationRepository::class)]
-class PopNotification
+#[ORM\HasLifecycleCallbacks()]
+class PopNotification implements EntityHistoryInterface
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -18,15 +24,7 @@ class PopNotification
     private ?User $user = null;
 
     #[ORM\Column]
-    private ?\DateTimeImmutable $createdAt = null;
-
-    #[ORM\Column]
     private array $params = [];
-
-    public function __construct()
-    {
-        $this->createdAt = new \DateTimeImmutable();
-    }
 
     public function getId(): ?int
     {
@@ -45,18 +43,6 @@ class PopNotification
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->createdAt;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $createdAt): static
-    {
-        $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
     public function getParams(): array
     {
         return $this->params;
@@ -67,5 +53,10 @@ class PopNotification
         $this->params = $params;
 
         return $this;
+    }
+
+    public function getHistoryRegisteredEvent(): array
+    {
+        return [HistoryEntryEvent::CREATE, HistoryEntryEvent::UPDATE, HistoryEntryEvent::DELETE];
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -178,6 +178,12 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserPartner::class, orphanRemoval: true)]
     private Collection $userPartners;
 
+    /**
+     * @var Collection<int, PopNotification>
+     */
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: PopNotification::class, orphanRemoval: true)]
+    private Collection $popNotifications;
+
     public function __construct()
     {
         $this->suivis = new ArrayCollection();
@@ -189,6 +195,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         $this->signalementUsagerOccupants = new ArrayCollection();
         $this->apiUserTokens = new ArrayCollection();
         $this->userPartners = new ArrayCollection();
+        $this->popNotifications = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -835,6 +842,36 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
             // set the owning side to null (unless already changed)
             if ($apiUserToken->getOwnedBy() === $this) {
                 $apiUserToken->setOwnedBy(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, PopNotification>
+     */
+    public function getPopNotifications(): Collection
+    {
+        return $this->popNotifications;
+    }
+
+    public function addPopNotification(PopNotification $popNotification): static
+    {
+        if (!$this->popNotifications->contains($popNotification)) {
+            $this->popNotifications->add($popNotification);
+            $popNotification->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removePopNotification(PopNotification $popNotification): static
+    {
+        if ($this->popNotifications->removeElement($popNotification)) {
+            // set the owning side to null (unless already changed)
+            if ($popNotification->getUser() === $this) {
+                $popNotification->setUser(null);
             }
         }
 

--- a/src/Manager/PopNotificationManager.php
+++ b/src/Manager/PopNotificationManager.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Manager;
+
+use App\Entity\Partner;
+use App\Entity\PopNotification;
+use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+
+class PopNotificationManager extends Manager
+{
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+        string $entityName = PopNotification::class,
+    ) {
+        parent::__construct($managerRegistry, $entityName);
+    }
+
+    public function createOrUpdatePopNotification(
+        User $user,
+        string $type,
+        Partner $partner,
+    ): ?PopNotification {
+        if (User::STATUS_ACTIVE !== $user->getStatut()) {
+            return null;
+        }
+        if ($user->getPopNotifications()->count()) {
+            $popNotification = $user->getPopNotifications()->first();
+        } else {
+            $popNotification = new PopNotification();
+            $user->addPopNotification($popNotification);
+            $this->persist($popNotification);
+            $popNotification->setUser($user);
+        }
+        switch ($type) {
+            case 'addPartner':
+                $this->managePartners($popNotification, $partner, 'add');
+                break;
+            case 'removePartner':
+                $this->managePartners($popNotification, $partner, 'remove');
+                break;
+        }
+        if (empty($popNotification->getParams()['addedPartners']) && empty($popNotification->getParams()['removedPartners'])) {
+            $this->remove($popNotification, false);
+
+            return null;
+        }
+
+        return $popNotification;
+    }
+
+    private function managePartners(PopNotification $popNotification, Partner $partner, string $type): void
+    {
+        $keyToAdd = 'addedPartners';
+        $keyToRemove = 'removedPartners';
+        if ('remove' === $type) {
+            $keyToAdd = 'removedPartners';
+            $keyToRemove = 'addedPartners';
+        }
+        $list = isset($popNotification->getParams()[$keyToRemove]) ? $popNotification->getParams()[$keyToRemove] : [];
+        if (!empty($list) && in_array($partner->getId(), $list)) {
+            unset($list[array_search($partner->getId(), $list)]);
+            $params = array_merge($popNotification->getParams(), [$keyToRemove => $list]);
+            $popNotification->setParams($params);
+
+            return;
+        }
+        $list = isset($popNotification->getParams()[$keyToAdd]) ? $popNotification->getParams()[$keyToAdd] : [];
+        $list[] = $partner->getId();
+        $params = array_merge($popNotification->getParams(), [$keyToAdd => $list]);
+        $popNotification->setParams($params);
+    }
+}

--- a/src/Repository/PopNotificationRepository.php
+++ b/src/Repository/PopNotificationRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PopNotification;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PopNotification>
+ */
+class PopNotificationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PopNotification::class);
+    }
+}

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -97,7 +97,7 @@
     {% endif %}
 
     {% if app.user.popNotifications|length %}
-            {{ render(controller('App\\Controller\\Back\\PopNotificationController::show')) }}
+        {{ render(controller('App\\Controller\\Back\\PopNotificationController::show')) }}
     {% endif %}
 
 {% endblock %}

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -43,7 +43,7 @@
     </div>
 {% endblock %}
 
-{% block cgumodale %}
+{% block bo_modales %}
     {% if platform.cgu_current_version is not same as app.user.cguVersionChecked %}
         <button class="fr-hidden" data-fr-opened="true" aria-controls="fr-modal-cgu-bo"></button>
         <dialog aria-labelledby="fr-modal-cgu-bo-title" id="fr-modal-cgu-bo" class="fr-modal" open="true">
@@ -95,4 +95,9 @@
             </div>
         </dialog>
     {% endif %}
+
+    {% if app.user.popNotifications|length %}
+            {{ render(controller('App\\Controller\\Back\\PopNotificationController::show')) }}
+    {% endif %}
+
 {% endblock %}

--- a/templates/back/pop-notification/index.html.twig
+++ b/templates/back/pop-notification/index.html.twig
@@ -17,7 +17,7 @@
                             Votre compte a été ajouté :
                             <ul class="fr-mb-2v fr-mt-0">
                                 {% for partner in addedPartners %}
-                                <li>au partenaire {{partner.nom}} du territoire {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                                <li>au partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
                                 {% endfor %}
                             </ul>
                         {% endif %}
@@ -25,24 +25,24 @@
                             Votre compte a été retiré :
                             <ul class="fr-mb-2v fr-mt-0">
                                 {% for partner in removedPartners %}
-                                <li>du partenaire {{partner.nom}} du territoire {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                                <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
                                 {% endfor %}
                             </ul>
                         {% endif %}
                         Désormais,
                         <br>
-                        1. Vous avez accès aux signalements de :
+                        1. Vous avez accès aux signalements :
                         <ul class="fr-mb-2v fr-mt-0 fr-ml-2v">
                             {% for partner in user.partners %}
-                            <li>{{partner.nom}} - {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                            <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
                             {% endfor %}
                         </ul>
                         {% set nb = 2 %}
                         {% if removedPartners|length %}
-                            {{nb}}. Vous n'avez plus accès aux signalements de :
+                            {{nb}}. Vous n'avez plus accès aux signalements :
                             <ul class="fr-mb-2v fr-mt-0 fr-ml-2v">
                                 {% for partner in removedPartners %}
-                                <li>{{partner.nom}} - {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                                <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
                                 {% endfor %}
                             </ul>
                             {% set nb = nb + 1 %}

--- a/templates/back/pop-notification/index.html.twig
+++ b/templates/back/pop-notification/index.html.twig
@@ -1,0 +1,64 @@
+<button class="fr-hidden" data-fr-opened="false" aria-controls="fr-modal-pop-notification" ></button>
+<dialog aria-labelledby="fr-modal-pop-notification-title" id="fr-modal-pop-notification" class="fr-modal" open="false" data-delete-url="{{path('pop_notification_delete')}}">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-pop-notification-title" class="fr-modal__title">
+                            Modifications sur votre compte
+                        </h1>
+                        <div class="fr-alert fr-alert--info fr-mb-2v">
+                            <p>Des modifications ont été faites sur votre compte, veuillez en prendre connaissance avant de continuer !</p>
+                        </div>
+                        {% if addedPartners|length %}
+                            Votre compte a été ajouté :
+                            <ul class="fr-mb-2v fr-mt-0">
+                                {% for partner in addedPartners %}
+                                <li>au partenaire {{partner.nom}} du territoire {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        {% if removedPartners|length %}
+                            Votre compte a été retiré :
+                            <ul class="fr-mb-2v fr-mt-0">
+                                {% for partner in removedPartners %}
+                                <li>du partenaire {{partner.nom}} du territoire {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        Désormais,
+                        <br>
+                        1. Vous avez accès aux signalements de :
+                        <ul class="fr-mb-2v fr-mt-0 fr-ml-2v">
+                            {% for partner in user.partners %}
+                            <li>{{partner.nom}} - {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                            {% endfor %}
+                        </ul>
+                        {% set nb = 2 %}
+                        {% if removedPartners|length %}
+                            {{nb}}. Vous n'avez plus accès aux signalements de :
+                            <ul class="fr-mb-2v fr-mt-0 fr-ml-2v">
+                                {% for partner in removedPartners %}
+                                <li>{{partner.nom}} - {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                                {% endfor %}
+                            </ul>
+                            {% set nb = nb + 1 %}
+                        {% endif %}
+                        {% if user.partners|length > 1 %}
+                            <p>{{nb}}. Pour vous aider à naviguer, un filtre <strong>Territoire</strong> est disponible sur votre tableau de bord ainsi que sur la liste des signalements.</p>
+                        {% endif %}
+                        <p>Pour plus d'informations, n'hésitez pas à contacter vos responsables de territoire !</p>   
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <button class="fr-btn fr-icon-close-line" aria-controls="fr-modal-pop-notification">Fermer</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/back/profil/index.html.twig
+++ b/templates/back/profil/index.html.twig
@@ -46,9 +46,16 @@
                 {{ user_avatar_or_placeholder(app.user, 74) }}
                 <div class="fr-ml-3v">
                     <span class="fr-display-block"><strong>{{ app.user.prenom ~' '~app.user.nom }}</strong></span>
-                    {% for partner in app.user.partners %}
-                        <span class="fr-display-block">{{ partner.nom}}</span>
-                    {% endfor %}
+                    {% if app.user.partners|length > 1 %}
+                        <p class="fr-mt-2v"><strong>Mes partenaires</strong></p>
+                        <ul>
+                        {% for partner in app.user.partners %}
+                            <li>{{partner.nom}} du territoire {{partner.territory.zip}} - {{partner.territory.name}}</li>
+                        {% endfor %}
+                        <ul>
+                    {% elseif app.user.partners|length == 1 %}
+                        <span class="fr-display-block">{{ app.user.partners.first.nom }}</span>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/templates/back/profil/index.html.twig
+++ b/templates/back/profil/index.html.twig
@@ -52,7 +52,14 @@
                         {% for partner in app.user.partners %}
                             <li>{{partner.nom}} du territoire {{partner.territory.zip}} - {{partner.territory.name}}</li>
                         {% endfor %}
-                        <ul>
+                        </ul>
+                        <div class="fr-alert fr-alert--info">
+                            <p>
+                                Vous ne pouvez pas modifier vos partenaires vous-même. 
+                                <br>
+                                Si vous souhaitez modifier vos partenaires, contactez vos responsables de territoire !
+                            </p>
+                        </div>
                     {% elseif app.user.partners|length == 1 %}
                         <span class="fr-display-block">{{ app.user.partners.first.nom }}</span>
                     {% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -234,6 +234,6 @@
 
 {% block javascripts %}{% endblock %}
 {% block documentation %}{% endblock %}
-{% block cgumodale %}{% endblock %}
+{% block bo_modales %}{% endblock %}
 </body>
 </html>

--- a/tests/Functional/Manager/PopNotificationManagerTest.php
+++ b/tests/Functional/Manager/PopNotificationManagerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests\Functional\Manager;
+
+use App\Entity\Partner;
+use App\Entity\PopNotification;
+use App\Entity\User;
+use App\Manager\PopNotificationManager;
+use App\Repository\PartnerRepository;
+use App\Repository\UserRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class PopNotificationManagerTest extends KernelTestCase
+{
+    private ManagerRegistry $managerRegistry;
+    private PopNotificationManager $popNotificationManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->managerRegistry = self::getContainer()->get(ManagerRegistry::class);
+        $this->popNotificationManager = new PopNotificationManager(
+            $this->managerRegistry,
+            PopNotification::class,
+        );
+    }
+
+    public function testCreateOrUpdatePopNotification(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->managerRegistry->getRepository(User::class);
+        /** @var PartnerRepository $partnerRepository */
+        $partnerRepository = $this->managerRegistry->getRepository(Partner::class);
+
+        $user = $userRepository->findOneBy(['email' => 'user-13-01@histologe.fr']);
+        $addPartners = [];
+        // ajout d'un partenaire
+        $partner63 = $partnerRepository->findOneBy(['nom' => 'ADIL 63']);
+        $popNotification = $this->popNotificationManager->createOrUpdatePopNotification($user, 'addPartner', $partner63);
+        $addPartners[] = $partner63->getId();
+        $this->assertEquals($addPartners, $popNotification->getParams()['addedPartners']);
+        // ajout d'un autre partenaire
+        $partner89 = $partnerRepository->findOneBy(['nom' => 'ADIL 89']);
+        $addPartners[] = $partner89->getId();
+        $popNotification = $this->popNotificationManager->createOrUpdatePopNotification($user, 'addPartner', $partner89);
+        $this->assertEquals($addPartners, $popNotification->getParams()['addedPartners']);
+        // suppression du premier partenaire
+        $popNotification = $this->popNotificationManager->createOrUpdatePopNotification($user, 'removePartner', $partner63);
+        unset($addPartners[array_search($partner63->getId(), $addPartners)]);
+        $this->assertEquals($addPartners, $popNotification->getParams()['addedPartners']);
+        // suppression du second partenaire
+        $popNotification = $this->popNotificationManager->createOrUpdatePopNotification($user, 'removePartner', $partner89);
+        $this->assertNull($popNotification);
+    }
+}


### PR DESCRIPTION
## Ticket

#3623

## Description
Ajout d'un système de notification par modale, pour indiquer à l'agent les modification effectués sur son comptes (ajout/retrait de partenaire)

## Pré-requis
make execute-migration name=Version20250204083053 direction=up

## Tests
- [ ] Ajouter un utilisateur actif sur un nouveau partenaire / ou retirer un utilisateur multi-territoires de l'un de ses partenaires. Se connecter à son compte et vérifier que la popup de notification des modification du compte s'affiche bien.
