### PR TITLE
[BO - Zone] Changement de chemins pour les icônes des marqueurs

### DIFF
--- a/public/js/zone_map.js
+++ b/public/js/zone_map.js
@@ -3,6 +3,15 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 }).addTo(map);
+
+// Correction des chemins des icônes
+delete (L.Icon.Default.prototype)._getIconUrl
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: '/build/images/leaflet/marker-icon-2x.png',
+  iconUrl: '/build/images/leaflet/marker-icon.png',
+  shadowUrl: '/build/images/leaflet/marker-shadow.png'
+})
+
 var zoneWkt = document.getElementById('info_zone_map').getAttribute('data-zone');
 const zoneGeoJson = omnivore.wkt.parse(zoneWkt);
 map.fitBounds(zoneGeoJson.getBounds());


### PR DESCRIPTION
## Ticket

#3652   

## Description
Depuis la mise à jour de leaflet les marqueurs n'apparaissaient plus sur la carte des zones

## Changements apportés
* Changement de chemins vers les icones dans zone_map.js (utilisation des mêmes icones que pour la carto)

## Pré-requis

## Tests
- [ ] Vérifier l'apparition des marqueurs
