### PR TITLE
[API] Mise à jour affectation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -87,6 +87,11 @@ services:
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.exception' }
 
+
+    App\EventListener\SecurityApiExceptionListener:
+        tags:
+            - { name: 'kernel.event_listener', event: 'kernel.exception' }
+
     App\EventListener\SeoPageNotFoundRedirectListener:
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.request' }

--- a/migrations/Version20250130150909.php
+++ b/migrations/Version20250130150909.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250130150909 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add uuid column to affectation table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE affectation ADD uuid VARCHAR(255) NOT NULL AFTER territory_id');
+        $this->addSql('UPDATE affectation SET uuid = UUID()');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE affectation DROP uuid');
+    }
+}

--- a/migrations/Version20250130150909.php
+++ b/migrations/Version20250130150909.php
@@ -18,10 +18,12 @@ final class Version20250130150909 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE affectation ADD uuid VARCHAR(255) NOT NULL AFTER territory_id');
         $this->addSql('UPDATE affectation SET uuid = UUID()');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_F4DD61D3D17F50A6 ON affectation (uuid)');
     }
 
     public function down(Schema $schema): void
     {
+        $this->addSql('DROP INDEX UNIQ_F4DD61D3D17F50A6 ON affectation');
         $this->addSql('ALTER TABLE affectation DROP uuid');
     }
 }

--- a/src/Controller/Api/AffectationUpdateController.php
+++ b/src/Controller/Api/AffectationUpdateController.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Dto\Api\Request\AffectationRequest;
+use App\Dto\Api\Response\AffectationResponse;
+use App\Entity\Affectation;
+use App\Entity\Enum\AffectationNewStatus;
+use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\MotifRefus;
+use App\Entity\User;
+use App\EventListener\SecurityApiExceptionListener;
+use App\Exception\Suivi\UsagerNotificationRequiredException;
+use App\Manager\AffectationManager;
+use App\Security\Voter\AffectationVoter;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[When('dev')]
+#[When('test')]
+#[Route('/api')]
+class AffectationUpdateController extends AbstractController
+{
+    public function __construct(private readonly AffectationManager $affectationManager)
+    {
+    }
+
+    /**
+     * @throws UsagerNotificationRequiredException
+     */
+    #[Route('/affectations/{uuid:affectation}', name: 'api_affectations_update', methods: 'PATCH')]
+    #[OA\Patch(
+        path: '/api/affectations/{uuid}',
+        description: 'Mise à jour d\'une affectation',
+        summary: 'Mise à jour d\'une affectation',
+        security: [['Bearer' => []]],
+        tags: ['Affectations'],
+    )]
+    #[OA\Response(
+        response: Response::HTTP_OK,
+        description: 'Une affectation',
+        content: new OA\JsonContent(ref: '#/components/schemas/Affectation')
+    )]
+    #[OA\Response(
+        response: Response::HTTP_NOT_FOUND,
+        description: 'Affectation introuvable',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'message',
+                    type: 'string',
+                    example: 'Affectation introuvable'
+                ),
+                new OA\Property(
+                    property: 'statut',
+                    type: 'int',
+                    example: Response::HTTP_NOT_FOUND
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: Response::HTTP_BAD_REQUEST,
+        description: 'Mauvaise payload (données invalides).',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'message',
+                    type: 'string',
+                    example: 'Valeurs invalides pour les champs suivants :'
+                ),
+                new OA\Property(
+                    property: 'status',
+                    type: 'integer',
+                    example: 400
+                ),
+                new OA\Property(
+                    property: 'errors',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(
+                                property: 'property',
+                                type: 'string',
+                                example: 'statut'
+                            ),
+                            new OA\Property(
+                                property: 'message',
+                                type: 'string',
+                                example: 'Cette valeur doit être l\'un des choix suivants : \"NOUVEAU\", \"EN_COURS\", \"FERME\", \"REFUSE\"'
+                            ),
+                            new OA\Property(
+                                property: 'invalidValue',
+                                type: 'string',
+                                example: 'NOUVEAddU'
+                            ),
+                        ],
+                        type: 'object'
+                    )
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: Response::HTTP_FORBIDDEN,
+        description: 'Accès à la ressource non autorisée.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'message',
+                    type: 'string',
+                    example: 'Vous n\'avez pas l\'autorisation d\'accéder à cette ressource.'
+                ),
+                new OA\Property(
+                    property: 'statut',
+                    type: 'int',
+                    example: Response::HTTP_FORBIDDEN
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    public function index(
+        #[MapRequestPayload] AffectationRequest $affectationRequest,
+        ?Affectation $affectation = null,
+    ): JsonResponse {
+        if (null === $affectation) {
+            return new JsonResponse(
+                ['message' => 'Affectation introuvable.', 'status' => Response::HTTP_NOT_FOUND],
+                Response::HTTP_NOT_FOUND
+            );
+        }
+        $affectation->setNextStatut(AffectationNewStatus::mapStatus($affectationRequest->statut));
+        $this->denyAccessUnlessGranted(AffectationVoter::ANSWER, $affectation, SecurityApiExceptionListener::ACCESS_DENIED);
+        $this->denyAccessUnlessGranted(AffectationVoter::UPDATE_STATUT, $affectation, SecurityApiExceptionListener::TRANSITION_STATUT_DENIED);
+        $this->applyUsagerNotification($affectationRequest, $affectation);
+
+        $affectation = $this->update($affectationRequest, $affectation);
+
+        return new JsonResponse(new AffectationResponse($affectation), Response::HTTP_OK);
+    }
+
+    private function update(AffectationRequest $affectationRequest, Affectation $affectation): Affectation
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $statut = AffectationNewStatus::mapStatus($affectationRequest->statut);
+        if ($statut !== $affectation->getStatut()) {
+            if (Affectation::STATUS_CLOSED === $statut) {
+                $motifCloture = MotifCloture::tryFrom($affectationRequest->motifCloture);
+
+                return $this->affectationManager->closeAffectation(
+                    $affectation,
+                    $user,
+                    $motifCloture,
+                    $affectationRequest->message,
+                    true
+                );
+            }
+            $motifRefus = $message = null;
+            if (Affectation::STATUS_REFUSED === $statut) {
+                $motifRefus = MotifRefus::tryFrom($affectationRequest->motifRefus)->value;
+                $message = $affectationRequest->message;
+            }
+
+            return $this->affectationManager->updateAffectation($affectation, $user, $statut, $motifRefus, $message);
+        }
+
+        return $affectation;
+    }
+
+    /**
+     * @throws UsagerNotificationRequiredException
+     */
+    private function applyUsagerNotification(AffectationRequest $affectationRequest, Affectation $affectation): void
+    {
+        if (Affectation::STATUS_CLOSED === $affectation->getStatut()
+            && Affectation::STATUS_WAIT === $affectation->getNextStatut()) {
+            if (null === $affectationRequest->notifyUsager) {
+                throw new UsagerNotificationRequiredException($affectationRequest);
+            }
+
+            $affectation->setHasNotificationUsagerToCreate($affectationRequest->notifyUsager);
+        }
+    }
+}

--- a/src/Controller/Api/AffectationUpdateController.php
+++ b/src/Controller/Api/AffectationUpdateController.php
@@ -150,7 +150,7 @@ class AffectationUpdateController extends AbstractController
     )]
     #[OA\Response(
         response: Response::HTTP_FORBIDDEN,
-        description: 'Accès à la ressource non autorisée.',
+        description: 'Accès à la ressource non autorisé.',
         content: new OA\JsonContent(
             properties: [
                 new OA\Property(
@@ -213,17 +213,10 @@ class AffectationUpdateController extends AbstractController
         return $this->affectationManager->updateAffectation($affectation, $user, $statut, $motifRefus, $message);
     }
 
-    /**
-     * @throws UsagerNotificationRequiredException
-     */
     private function applyUsagerNotification(AffectationRequest $affectationRequest, Affectation $affectation): void
     {
         if (Affectation::STATUS_CLOSED === $affectation->getStatut()
             && Affectation::STATUS_WAIT === $affectation->getNextStatut()) {
-            if (null === $affectationRequest->notifyUsager) {
-                throw new UsagerNotificationRequiredException($affectationRequest);
-            }
-
             $affectation->setHasNotificationUsagerToCreate($affectationRequest->notifyUsager);
         }
     }

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -204,11 +204,11 @@ class SignalementActionController extends AbstractController
             }
             $signalement->setStatut(Signalement::STATUS_ACTIVE);
             $suiviManager->createSuivi(
-                user: $user,
                 signalement: $signalement,
                 description: 'Signalement rouvert pour '.$reopenFor,
                 type: Suivi::TYPE_AUTO,
                 isPublic: '1' === $request->get('publicSuivi'),
+                user: $user,
             );
             $this->addFlash('success', 'Signalement rouvert avec succès !');
         } else {

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -131,15 +131,19 @@ class SignalementController extends AbstractController
                     $eventParams['motif_cloture']
                 );
                 $reference = $signalement->getReference();
-
+                $eventDispatcher->dispatch(new SignalementClosedEvent($entity, $eventParams), SignalementClosedEvent::NAME);
             /* @var Affectation $affectation */
             } elseif ($affectation) {
-                $entity = $affectationManager->closeAffectation($affectation, $user, $eventParams['motif_cloture'], true);
+                $entity = $affectationManager->closeAffectation(
+                    $affectation,
+                    $user,
+                    $eventParams['motif_cloture'],
+                    $eventParams['motif_suivi'],
+                    true);
                 $reference = $entity->getSignalement()->getReference();
             }
 
             if (!empty($entity)) {
-                $eventDispatcher->dispatch(new SignalementClosedEvent($entity, $eventParams), SignalementClosedEvent::NAME);
                 $this->addFlash('success', sprintf('Signalement #%s cloturé avec succès !', $reference));
             }
             $signalementSearchQuery = $request->getSession()->get('signalementSearchQuery');

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -265,3 +265,11 @@ affectations:
     affected_by: "admin-01@histologe.fr"
     motif_cloture: ""
     territory: "Hérault"
+  -
+    signalement: 2023-13
+    partner: "partenaire-13-01@histologe.fr"
+    statut: 3
+    answered_by: "api-01@histologe.fr"
+    affected_by: "admin-03@histologe.fr"
+    motif_cloture: "DEPART_OCCUPANT"
+    territory: "Bouches-du-Rhône"

--- a/src/Dto/Api/Model/Affectation.php
+++ b/src/Dto/Api/Model/Affectation.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Dto\Api\Model;
+
+use App\Entity\Enum\AffectationNewStatus;
+use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\MotifRefus;
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'Affectation',
+    description: 'Représentation d\'une affectation.',
+)]
+class Affectation
+{
+    #[OA\Property(
+        description: 'Identifiant unique de l\'affectation.',
+        type: 'string',
+        example: 'e96325bf-139e-4793-a7b4-a4c713a0fbd9',
+    )]
+    public ?string $uuid = null;
+    #[OA\Property(
+        description: 'Le statut d\'affectation',
+        example: 'FERME'
+    )]
+    public AffectationNewStatus $statut;
+
+    #[OA\Property(
+        description: 'Date d\'affectation du signalement au partenaire.<br>Exemple : `2025-01-05T15:30:15+00:00`',
+        format: 'date-time',
+        example: '2025-01-05T14:30:15+00:00'
+    )]
+    public ?string $dateAffectation = null;
+
+    #[OA\Property(
+        description: 'Date d\'acceptation du signalement par le partenaire.<br>Exemple : `2025-01-05T15:30:15+00:00`',
+        format: 'date-time',
+        example: '2025-01-05T14:30:15+00:00'
+    )]
+    public ?string $dateAcceptation = null;
+
+    #[OA\Property(
+        description: 'Motif de clôture de l\'affectation, précisant la raison pour laquelle il a été clôturé.',
+        example: 'LOGEMENT_DECENT',
+        nullable: true
+    )]
+    public ?MotifCloture $motifCloture = null;
+
+    #[OA\Property(
+        description: 'Motif du refus de l\'affectation, précisant la raison pour laquelle il a été refusé.',
+        example: 'HORS_COMPETENCE',
+        nullable: true
+    )]
+    public ?MotifRefus $motifRefus = null;
+}

--- a/src/Dto/Api/Request/AffectationRequest.php
+++ b/src/Dto/Api/Request/AffectationRequest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Dto\Api\Request;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[OA\Schema(
+    description: 'Payload pour mettre à jour une affectation.',
+)]
+class AffectationRequest implements RequestInterface
+{
+    public function __construct(
+        #[OA\Property(
+            description: 'Statut de l\'affectation. <br>
+            Les transitions possibles entre statuts sont soumises à des contraintes spécifiques :<br>
+            <ul>
+              <li>`NOUVEAU` : peut évoluer vers `EN_COURS` ou `REFUSE`</li>
+              <li>`EN_COURS` : peut évoluer vers `FERME`</li>
+              <li>`REFUSE` : peut évoluer vers `EN_COURS`</li>
+              <li>`FERME` : peut revenir à `NOUVEAU`</li>
+            </ul>',
+            enum: ['NOUVEAU', 'EN_COURS', 'FERME', 'REFUSE'],
+            example: 'EN_COURS',
+        )]
+        #[Assert\Choice(
+            choices: ['NOUVEAU', 'EN_COURS', 'FERME', 'REFUSE'],
+            message: 'Cette valeur doit être l\'un des choix suivants : {{ choices }}')
+        ]
+        public ?string $statut = null,
+        #[OA\Property(
+            description: 'Le motif de cloture de l\'affectation, celui doit être accompagné d\'un message',
+            enum: [
+                'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE',
+                'DEPART_OCCUPANT',
+                'INSALUBRITE',
+                'LOGEMENT_DECENT',
+                'NON_DECENCE',
+                'PERIL',
+                'REFUS_DE_VISITE',
+                'REFUS_DE_TRAVAUX',
+                'RELOGEMENT_OCCUPANT',
+                'RESPONSABILITE_DE_L_OCCUPANT',
+                'RSD',
+                'TRAVAUX_FAITS_OU_EN_COURS',
+                'DOUBLON',
+                'AUTRE',
+            ],
+            example: 'DEPART_OCCUPANT',
+        )]
+        #[Assert\Choice(
+            choices: [
+                'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE',
+                'DEPART_OCCUPANT',
+                'INSALUBRITE',
+                'LOGEMENT_DECENT',
+                'NON_DECENCE',
+                'PERIL',
+                'REFUS_DE_VISITE',
+                'REFUS_DE_TRAVAUX',
+                'RELOGEMENT_OCCUPANT',
+                'RESPONSABILITE_DE_L_OCCUPANT',
+                'RSD',
+                'TRAVAUX_FAITS_OU_EN_COURS',
+                'DOUBLON',
+                'AUTRE',
+            ],
+            message: 'Cette valeur doit être l\'un des choix suivants : {{ choices }}'
+        )]
+        #[Assert\When(
+            expression: 'this.statut === "FERME"',
+            constraints: [
+                new Assert\NotNull(message: 'Le motifCloture est obligatoire lorsque statut est FERME.'),
+            ]
+        )]
+        public ?string $motifCloture = null,
+        #[OA\Property(
+            description: 'Le motif de refus de l\'affectation, celui doit être accompagné d\'un message',
+            enum: [
+                'HORS_PDLHI',
+                'HORS_ZONE_GEOGRAPHIQUE',
+                'HORS_COMPETENCE',
+                'DOUBLON',
+                'AUTRE',
+            ],
+            example: 'EN_COURS',
+        )]
+        #[Assert\Choice(
+            choices: [
+                'HORS_PDLHI',
+                'HORS_ZONE_GEOGRAPHIQUE',
+                'HORS_COMPETENCE',
+                'DOUBLON',
+                'AUTRE',
+            ],
+            message: 'Cette valeur doit être l\'un des choix suivants : {{ choices }}'
+        )]
+        #[Assert\When(
+            expression: 'this.statut === "REFUSE"',
+            constraints: [
+                new Assert\NotNull(message: 'Le motifRefus est obligatoire lorsque statut est REFUSE.'),
+            ]
+        )]
+        public ?string $motifRefus = null,
+
+        #[OA\Property(
+            description: 'Un message est obligatoire lorsque statut est REFUSE ou FERME.',
+            example: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        )]
+        #[Assert\When(
+            expression: 'this.statut === "REFUSE" || this.statut === "FERME"',
+            constraints: [
+                new Assert\NotNull(message: 'Le message est obligatoire lorsque statut est REFUSE ou FERME.'),
+            ]
+        )]
+        #[Assert\Length(min: 10)]
+        public ?string $message = null,
+
+        #[OA\Property(
+            description: 'Il est obligatoire d\'indiquer si l\'usager doit être notifié lors d\'une réouverture (TRANSITION : FERME → NOUVEAU).',
+            example: 'true',
+        )]
+        public ?bool $notifyUsager = null,
+    ) {
+    }
+}

--- a/src/Dto/Api/Request/AffectationRequest.php
+++ b/src/Dto/Api/Request/AffectationRequest.php
@@ -7,6 +7,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 #[OA\Schema(
     description: 'Payload pour mettre à jour une affectation.',
+    required: ['statut'],
 )]
 class AffectationRequest implements RequestInterface
 {
@@ -23,6 +24,7 @@ class AffectationRequest implements RequestInterface
             enum: ['NOUVEAU', 'EN_COURS', 'FERME', 'REFUSE'],
             example: 'EN_COURS',
         )]
+        #[Assert\NotNull(message: 'Le statut est obligatoire.')]
         #[Assert\Choice(
             choices: ['NOUVEAU', 'EN_COURS', 'FERME', 'REFUSE'],
             message: 'Cette valeur doit être l\'un des choix suivants : {{ choices }}')
@@ -83,7 +85,7 @@ class AffectationRequest implements RequestInterface
                 'DOUBLON',
                 'AUTRE',
             ],
-            example: 'EN_COURS',
+            example: 'HORS_COMPETENCE',
         )]
         #[Assert\Choice(
             choices: [

--- a/src/Dto/Api/Request/AffectationRequest.php
+++ b/src/Dto/Api/Request/AffectationRequest.php
@@ -31,7 +31,7 @@ class AffectationRequest implements RequestInterface
         ]
         public ?string $statut = null,
         #[OA\Property(
-            description: 'Le motif de cloture de l\'affectation, celui doit être accompagné d\'un message',
+            description: 'Le motif de cloture de l\'affectation, il doit être accompagné d\'un message.',
             enum: [
                 'ABANDON_DE_PROCEDURE_ABSENCE_DE_REPONSE',
                 'DEPART_OCCUPANT',
@@ -77,7 +77,7 @@ class AffectationRequest implements RequestInterface
         )]
         public ?string $motifCloture = null,
         #[OA\Property(
-            description: 'Le motif de refus de l\'affectation, celui doit être accompagné d\'un message',
+            description: 'Le motif de refus de l\'affectation, il doit être accompagné d\'un message',
             enum: [
                 'HORS_PDLHI',
                 'HORS_ZONE_GEOGRAPHIQUE',
@@ -121,6 +121,12 @@ class AffectationRequest implements RequestInterface
         #[OA\Property(
             description: 'Il est obligatoire d\'indiquer si l\'usager doit être notifié lors d\'une réouverture (TRANSITION : FERME → NOUVEAU).',
             example: 'true',
+        )]
+        #[Assert\When(
+            expression: 'this.statut === "NOUVEAU"',
+            constraints: [
+                new Assert\NotNull(message: 'Il est obligatoire d\'indiquer si l\'usager doit être notifié lors d\'une réouverture.'),
+            ]
         )]
         public ?bool $notifyUsager = null,
     ) {

--- a/src/Dto/Api/Response/AffectationResponse.php
+++ b/src/Dto/Api/Response/AffectationResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Dto\Api\Response;
+
+use App\Dto\Api\Model\Affectation;
+use App\Entity\Enum\AffectationStatus;
+
+class AffectationResponse extends Affectation
+{
+    public function __construct(\App\Entity\Affectation $affectation)
+    {
+        $this->uuid = $affectation->getUuid();
+        $this->statut = AffectationStatus::mapNewStatus($affectation->getStatut());
+        $this->dateAffectation = $affectation->getCreatedAt()->format(\DATE_ATOM);
+        $this->dateAcceptation = $affectation->getAnsweredAt()->format(\DATE_ATOM);
+        $this->motifRefus = $affectation->getMotifRefus();
+        $this->motifCloture = $affectation->getMotifCloture();
+    }
+}

--- a/src/Dto/Api/Response/SignalementResponse.php
+++ b/src/Dto/Api/Response/SignalementResponse.php
@@ -3,12 +3,12 @@
 namespace App\Dto\Api\Response;
 
 use App\Dto\Api\Model\Adresse;
+use App\Dto\Api\Model\Affectation;
 use App\Dto\Api\Model\Desordre;
 use App\Dto\Api\Model\File;
 use App\Dto\Api\Model\Intervention;
 use App\Dto\Api\Model\Personne;
 use App\Dto\Api\Model\Suivi;
-use App\Entity\Enum\AffectationNewStatus;
 use App\Entity\Enum\DebutDesordres;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\MotifRefus;
@@ -38,12 +38,14 @@ class SignalementResponse
         example: '2025-01-05T14:30:15+00:00'
     )]
     public string $dateCreation;
+
     #[OA\Property(
-        description: 'Date d\'affectation du signalement au partenaire.<br>Exemple : `2025-01-05T15:30:15+00:00`',
-        format: 'date-time',
-        example: '2025-01-05T14:30:15+00:00'
+        ref: new Model(type: Affectation::class),
+        description: 'Informations détaillées sur l\'affectation du partenaire',
+        type: 'object',
     )]
-    public string $dateAffectation;
+    public Affectation $affectation;
+
     #[OA\Property(
         ref: new Model(type: Adresse::class),
         description: 'Informations détaillées sur l\'adresse de l\'occupant',
@@ -55,12 +57,6 @@ class SignalementResponse
         example: 'FERME'
     )]
     public SignalementNewStatus $statut;
-
-    #[OA\Property(
-        description: 'Le statut d\'affectation',
-        example: 'FERME'
-    )]
-    public AffectationNewStatus $statutAffectation;
 
     #[OA\Property(
         description: 'Date à laquelle le signalement a été validé par un responsable territoire.<br>

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -24,8 +24,8 @@ class Affectation implements EntityHistoryInterface
     #[ORM\Column(type: 'integer')]
     private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 255)]
-    private ?string $uuid = null;
+    #[ORM\Column(type: 'string', length: 255, unique: true)]
+    private ?string $uuid;
 
     #[ORM\ManyToOne(targetEntity: Signalement::class, inversedBy: 'affectations')]
     #[ORM\JoinColumn(nullable: false)]
@@ -85,13 +85,6 @@ class Affectation implements EntityHistoryInterface
     public function getUuid(): ?string
     {
         return $this->uuid;
-    }
-
-    public function setUuid(?string $uuid): static
-    {
-        $this->uuid = $uuid;
-
-        return $this;
     }
 
     public function getSignalement(): ?Signalement
@@ -287,7 +280,7 @@ class Affectation implements EntityHistoryInterface
         $this->hasNotificationUsagerToCreate = $hasNotificationUsagerToCreate;
     }
 
-    public function clear(): void
+    public function clearMotifs(): void
     {
         $this->motifRefus = null;
         $this->motifCloture = null;

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -10,6 +10,7 @@ use App\Repository\AffectationRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: AffectationRepository::class)]
 class Affectation implements EntityHistoryInterface
@@ -22,6 +23,9 @@ class Affectation implements EntityHistoryInterface
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
     private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private ?string $uuid = null;
 
     #[ORM\ManyToOne(targetEntity: Signalement::class, inversedBy: 'affectations')]
     #[ORM\JoinColumn(nullable: false)]
@@ -62,11 +66,15 @@ class Affectation implements EntityHistoryInterface
     #[ORM\JoinColumn(nullable: true)]
     private ?Territory $territory;
 
+    private ?int $nextStatut = null;
+    private ?bool $hasNotificationUsagerToCreate = null;
+
     public function __construct()
     {
         $this->statut = self::STATUS_WAIT;
         $this->createdAt = new \DateTimeImmutable();
         $this->notifications = new ArrayCollection();
+        $this->uuid = Uuid::v4();
     }
 
     public function getId(): ?int
@@ -74,12 +82,24 @@ class Affectation implements EntityHistoryInterface
         return $this->id;
     }
 
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(?string $uuid): static
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+
     public function getSignalement(): ?Signalement
     {
         return $this->signalement;
     }
 
-    public function setSignalement(?Signalement $signalement): self
+    public function setSignalement(?Signalement $signalement): static
     {
         $this->signalement = $signalement;
 
@@ -91,7 +111,7 @@ class Affectation implements EntityHistoryInterface
         return $this->partner;
     }
 
-    public function setPartner(?Partner $partner): self
+    public function setPartner(?Partner $partner): static
     {
         $this->partner = $partner;
 
@@ -103,7 +123,7 @@ class Affectation implements EntityHistoryInterface
         return $this->answeredAt;
     }
 
-    public function setAnsweredAt(\DateTimeImmutable $answeredAt): self
+    public function setAnsweredAt(\DateTimeImmutable $answeredAt): static
     {
         $this->answeredAt = $answeredAt;
 
@@ -115,7 +135,7 @@ class Affectation implements EntityHistoryInterface
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
     {
         $this->createdAt = $createdAt;
 
@@ -127,7 +147,7 @@ class Affectation implements EntityHistoryInterface
         return $this->statut;
     }
 
-    public function setStatut(int $statut): self
+    public function setStatut(int $statut): static
     {
         $this->statut = $statut;
 
@@ -139,7 +159,7 @@ class Affectation implements EntityHistoryInterface
         return $this->answeredBy;
     }
 
-    public function setAnsweredBy(?User $answeredBy): self
+    public function setAnsweredBy(?User $answeredBy): static
     {
         $this->answeredBy = $answeredBy;
 
@@ -151,7 +171,7 @@ class Affectation implements EntityHistoryInterface
         return $this->affectedBy;
     }
 
-    public function setAffectedBy(?User $affectedBy): self
+    public function setAffectedBy(?User $affectedBy): static
     {
         $this->affectedBy = $affectedBy;
 
@@ -163,7 +183,7 @@ class Affectation implements EntityHistoryInterface
         return $this->motifRefus;
     }
 
-    public function setMotifRefus(?MotifRefus $motifRefus): self
+    public function setMotifRefus(?MotifRefus $motifRefus): static
     {
         $this->motifRefus = $motifRefus;
 
@@ -175,7 +195,7 @@ class Affectation implements EntityHistoryInterface
         return $this->motifCloture;
     }
 
-    public function setMotifCloture(?MotifCloture $motifCloture): self
+    public function setMotifCloture(?MotifCloture $motifCloture): static
     {
         $this->motifCloture = $motifCloture;
 
@@ -190,7 +210,7 @@ class Affectation implements EntityHistoryInterface
         return $this->notifications;
     }
 
-    public function addNotification(Notification $notification): self
+    public function addNotification(Notification $notification): static
     {
         if (!$this->notifications->contains($notification)) {
             $this->notifications[] = $notification;
@@ -200,7 +220,7 @@ class Affectation implements EntityHistoryInterface
         return $this;
     }
 
-    public function removeNotification(Notification $notification): self
+    public function removeNotification(Notification $notification): static
     {
         if ($this->notifications->removeElement($notification)) {
             // set the owning side to null (unless already changed)
@@ -217,7 +237,7 @@ class Affectation implements EntityHistoryInterface
         return $this->territory;
     }
 
-    public function setTerritory(?Territory $territory): self
+    public function setTerritory(?Territory $territory): static
     {
         $this->territory = $territory;
 
@@ -229,7 +249,7 @@ class Affectation implements EntityHistoryInterface
         return $this->isSynchronized;
     }
 
-    public function setIsSynchronized(bool $isSynchronized): self
+    public function setIsSynchronized(bool $isSynchronized): static
     {
         $this->isSynchronized = $isSynchronized;
 
@@ -245,6 +265,32 @@ class Affectation implements EntityHistoryInterface
             self::STATUS_CLOSED => 'Cloturé',
             default => 'Unexpected affectation status : '.$this->getStatut(),
         };
+    }
+
+    public function getNextStatut(): ?int
+    {
+        return $this->nextStatut;
+    }
+
+    public function setNextStatut(int $nextStatut): void
+    {
+        $this->nextStatut = $nextStatut;
+    }
+
+    public function getHasNotificationUsagerToCreate(): ?bool
+    {
+        return $this->hasNotificationUsagerToCreate;
+    }
+
+    public function setHasNotificationUsagerToCreate(?bool $hasNotificationUsagerToCreate): void
+    {
+        $this->hasNotificationUsagerToCreate = $hasNotificationUsagerToCreate;
+    }
+
+    public function clear(): void
+    {
+        $this->motifRefus = null;
+        $this->motifCloture = null;
     }
 
     public function getHistoryRegisteredEvent(): array

--- a/src/Entity/Enum/AffectationNewStatus.php
+++ b/src/Entity/Enum/AffectationNewStatus.php
@@ -8,4 +8,15 @@ enum AffectationNewStatus: string
     case EN_COURS = 'EN_COURS';
     case FERME = 'FERME';
     case REFUSE = 'REFUSE';
+
+    public static function mapStatus(string $status): ?int
+    {
+        return match ($status) {
+            AffectationNewStatus::NOUVEAU->value => 0,
+            AffectationNewStatus::EN_COURS->value => 1,
+            AffectationNewStatus::REFUSE->value => 2,
+            AffectationNewStatus::FERME->value => 3,
+            default => throw new \UnexpectedValueException('Unexpected affectation status : '.$status),
+        };
+    }
 }

--- a/src/Event/AffectationAnsweredEvent.php
+++ b/src/Event/AffectationAnsweredEvent.php
@@ -3,17 +3,20 @@
 namespace App\Event;
 
 use App\Entity\Affectation;
+use App\Entity\Enum\MotifRefus;
 use App\Entity\User;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class AffectationAnsweredEvent extends Event
 {
-    public const NAME = 'affectation.answered';
+    public const string NAME = 'affectation.answered';
 
     public function __construct(
-        private Affectation $affectation,
-        private User $user,
-        private array $params,
+        private readonly Affectation $affectation,
+        private readonly User $user,
+        private readonly ?int $status,
+        private readonly ?MotifRefus $motifRefus,
+        private readonly ?string $message,
     ) {
     }
 
@@ -27,8 +30,18 @@ class AffectationAnsweredEvent extends Event
         return $this->affectation;
     }
 
-    public function getParams(): array
+    public function getStatus(): ?int
     {
-        return $this->params;
+        return $this->status;
+    }
+
+    public function getMotifRefus(): ?MotifRefus
+    {
+        return $this->motifRefus;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
     }
 }

--- a/src/Event/AffectationClosedEvent.php
+++ b/src/Event/AffectationClosedEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Event;
+
+use App\Entity\Affectation;
+use App\Entity\User;
+
+class AffectationClosedEvent
+{
+    public const string NAME = 'affectation.closed';
+
+    public function __construct(
+        private readonly Affectation $affectation,
+        private readonly User $user,
+        private readonly ?string $message = null,
+    ) {
+    }
+
+    public function getAffectation(): Affectation
+    {
+        return $this->affectation;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+}

--- a/src/Event/SignalementClosedEvent.php
+++ b/src/Event/SignalementClosedEvent.php
@@ -2,26 +2,20 @@
 
 namespace App\Event;
 
-use App\Entity\Affectation;
 use App\Entity\Signalement;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class SignalementClosedEvent extends Event
 {
-    public const NAME = 'signalement.closed';
+    public const string NAME = 'signalement.closed';
 
-    public function __construct(private Signalement|Affectation $entity, private array $params)
+    public function __construct(private readonly Signalement $signalement, private readonly array $params)
     {
     }
 
     public function getSignalement(): ?Signalement
     {
-        return $this->entity instanceof Signalement ? $this->entity : null;
-    }
-
-    public function getAffectation(): ?Affectation
-    {
-        return $this->entity instanceof Affectation ? $this->entity : null;
+        return $this->signalement;
     }
 
     public function getParams(): array

--- a/src/EventListener/RequestApiExceptionListener.php
+++ b/src/EventListener/RequestApiExceptionListener.php
@@ -3,10 +3,12 @@
 namespace App\EventListener;
 
 use App\Dto\Api\Request\RequestInterface;
+use App\Exception\Suivi\UsagerNotificationRequiredException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Exception\ExceptionInterface;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 
 class RequestApiExceptionListener
@@ -14,33 +16,44 @@ class RequestApiExceptionListener
     public function onKernelException(ExceptionEvent $event): void
     {
         $exception = $event->getThrowable();
-        /** @var ValidationFailedException $previous */
-        $previous = $exception->getPrevious();
+        /** @var ValidationFailedException|UsagerNotificationRequiredException $previous */
+        $previous = $exception->getPrevious() ?? $exception;
+
         if (!$this->supports($previous)) {
             return;
         }
 
-        /** @var ConstraintViolationListInterface|null $violations */
-        $violations = $previous->getViolations();
-        $errors = [];
-        foreach ($violations as $violation) {
-            $errors[] = [
-                'property' => $violation->getPropertyPath(),
-                'message' => $violation->getMessage(),
-                'invalidValue' => $violation->getInvalidValue(),
+        if ($previous instanceof ExceptionInterface) {
+            /** @var ConstraintViolationListInterface|null $violations */
+            $violations = $previous->getViolations();
+            $errors = [];
+            foreach ($violations as $violation) {
+                $errors[] = [
+                    'property' => $violation->getPropertyPath(),
+                    'message' => $violation->getMessage(),
+                    'invalidValue' => $violation->getInvalidValue(),
+                ];
+            }
+            $response = [
+                'message' => 'Valeurs invalides pour les champs suivants :',
+                'status' => Response::HTTP_BAD_REQUEST,
+                'errors' => $errors,
+            ];
+        } else {
+            $response = [
+                'message' => $previous->getMessage(),
+                'status' => Response::HTTP_BAD_REQUEST,
+                'errors' => $previous->getErrors(),
             ];
         }
-        $response = [
-            'message' => 'Valeurs invalides pour les champs suivants :',
-            'status' => Response::HTTP_BAD_REQUEST,
-            'errors' => $errors,
-        ];
 
         $event->setResponse(new JsonResponse($response, Response::HTTP_BAD_REQUEST));
     }
 
     private function supports(?\Throwable $exception = null): bool
     {
-        return $exception instanceof ValidationFailedException && $exception->getValue() instanceof RequestInterface;
+        return ($exception instanceof ValidationFailedException
+                || $exception instanceof UsagerNotificationRequiredException
+        ) && $exception->getValue() instanceof RequestInterface;
     }
 }

--- a/src/EventListener/SecurityApiExceptionListener.php
+++ b/src/EventListener/SecurityApiExceptionListener.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Affectation;
+use App\Entity\Enum\AffectationStatus;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class SecurityApiExceptionListener
+{
+    public const string ACCESS_DENIED = 'access_denied';
+    public const string TRANSITION_STATUT_DENIED = 'transition_statut_denied';
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if ($this->supports($exception)) {
+            $previous = $exception->getPrevious();
+            $affectation = null;
+            if (method_exists($previous, 'getSubject')) {
+                /** @var Affectation $affectation */
+                $affectation = $previous->getSubject();
+            }
+
+            $message = self::ACCESS_DENIED === $exception->getMessage()
+                ? 'Vous n\'avez pas l\'autorisation d\'accéder à cette ressource.'
+                : sprintf('Cette transition n\'est pas valide (%s --> %s).',
+                    AffectationStatus::mapNewStatus($affectation?->getStatut())->value,
+                    AffectationStatus::mapNewStatus($affectation?->getNextStatut())->value
+                );
+            $response = [
+                'message' => $message,
+                'status' => Response::HTTP_FORBIDDEN,
+            ];
+            $event->setResponse(new JsonResponse($response, Response::HTTP_FORBIDDEN));
+        }
+    }
+
+    private function supports(?\Throwable $exception = null): bool
+    {
+        return $exception instanceof AccessDeniedHttpException
+            && (
+                self::ACCESS_DENIED === $exception->getMessage()
+                || self::TRANSITION_STATUT_DENIED === $exception->getMessage()
+            );
+    }
+}

--- a/src/EventSubscriber/AffectationAnsweredSubscriber.php
+++ b/src/EventSubscriber/AffectationAnsweredSubscriber.php
@@ -66,14 +66,14 @@ readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
                 user: $user,
             );
         }
-        $this->createFirstAcceptationSpecificationSuivi($event->getAffectation());
+        $this->createSuiviOnFirstAcceptedAffectation($event->getAffectation());
 
         if ($this->dossierMessageFactory->supports($affectation)) {
             $this->bus->dispatch($this->dossierMessageFactory->createInstance($affectation));
         }
     }
 
-    private function createFirstAcceptationSpecificationSuivi(Affectation $affectation): void
+    private function createSuiviOnFirstAcceptedAffectation(Affectation $affectation): void
     {
         if ($this->firstAcceptedAffectationSpecification->isSatisfiedBy($affectation)) {
             $adminEmail = $this->parameterBag->get('user_system_email');

--- a/src/EventSubscriber/AffectationAnsweredSubscriber.php
+++ b/src/EventSubscriber/AffectationAnsweredSubscriber.php
@@ -2,15 +2,28 @@
 
 namespace App\EventSubscriber;
 
+use App\Entity\Affectation;
 use App\Entity\Suivi;
 use App\Event\AffectationAnsweredEvent;
+use App\Factory\Interconnection\Idoss\DossierMessageFactory;
 use App\Manager\SuiviManager;
+use App\Manager\UserManager;
+use App\Specification\Signalement\FirstAffectationAcceptedSpecification;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 
-class AffectationAnsweredSubscriber implements EventSubscriberInterface
+readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly SuiviManager $suiviManager)
-    {
+    public function __construct(
+        private SuiviManager $suiviManager,
+        private FirstAffectationAcceptedSpecification $firstAcceptedAffectationSpecification,
+        private ParameterBagInterface $parameterBag,
+        private UserManager $userManager,
+        private MessageBusInterface $bus,
+        private DossierMessageFactory $dossierMessageFactory,
+    ) {
     }
 
     public static function getSubscribedEvents(): array
@@ -20,17 +33,59 @@ class AffectationAnsweredSubscriber implements EventSubscriberInterface
         ];
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     public function onAffectationAnswered(AffectationAnsweredEvent $event): void
     {
+        $status = $event->getStatus();
         $affectation = $event->getAffectation();
-        $params = $event->getParams();
-        $user = $event->getUser();
         $signalement = $affectation->getSignalement();
-        $this->suiviManager->createSuivi(
-            user: $user,
-            signalement: $signalement,
-            description: SuiviManager::buildDescriptionAnswerAffectation($params),
-            type: Suivi::TYPE_AUTO,
-        );
+        $partner = $affectation->getPartner();
+        $user = $event->getUser();
+        if (Affectation::STATUS_REFUSED == $status) {
+            $signalement = $affectation->getSignalement();
+            $params = [
+                'suivi' => $event->getMessage(),
+                'motifRefus' => $event->getMotifRefus(),
+            ];
+            $this->suiviManager->createSuivi(
+                signalement: $signalement,
+                description: SuiviManager::buildDescriptionAnswerAffectation($params),
+                type: Suivi::TYPE_AUTO,
+                user: $user,
+            );
+        }
+
+        if (Affectation::STATUS_WAIT == $status && !empty($affectation->getHasNotificationUsagerToCreate())) {
+            $this->suiviManager->createSuivi(
+                signalement: $signalement,
+                description: 'Signalement rouvert pour '.mb_strtoupper($partner->getNom()),
+                type: Suivi::TYPE_AUTO,
+                isPublic: $affectation->getHasNotificationUsagerToCreate(),
+                user: $user,
+            );
+        }
+        $this->createFirstAcceptationSpecificationSuivi($event->getAffectation());
+
+        if ($this->dossierMessageFactory->supports($affectation)) {
+            $this->bus->dispatch($this->dossierMessageFactory->createInstance($affectation));
+        }
+    }
+
+    private function createFirstAcceptationSpecificationSuivi(Affectation $affectation): void
+    {
+        if ($this->firstAcceptedAffectationSpecification->isSatisfiedBy($affectation)) {
+            $adminEmail = $this->parameterBag->get('user_system_email');
+            $adminUser = $this->userManager->findOneBy(['email' => $adminEmail]);
+            $this->suiviManager->createSuivi(
+                signalement: $affectation->getSignalement(),
+                description: $this->parameterBag->get('suivi_message')['first_accepted_affectation'],
+                type: Suivi::TYPE_AUTO,
+                isPublic: true,
+                user: $adminUser,
+                context: Suivi::CONTEXT_NOTIFY_USAGER_ONLY,
+            );
+        }
     }
 }

--- a/src/EventSubscriber/AffectationClosedSubscriber.php
+++ b/src/EventSubscriber/AffectationClosedSubscriber.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\Partner;
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Event\AffectationClosedEvent;
+use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
+use App\Repository\SignalementRepository;
+use App\Service\Mailer\NotificationMail;
+use App\Service\Mailer\NotificationMailerRegistry;
+use App\Service\Mailer\NotificationMailerType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+readonly class AffectationClosedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private NotificationMailerRegistry $notificationMailerRegistry,
+        private SignalementManager $signalementManager,
+        private SuiviManager $suiviManager,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            AffectationClosedEvent::NAME => 'onAffectationClosed',
+        ];
+    }
+
+    public function onAffectationClosed(AffectationClosedEvent $event): void
+    {
+        $user = $event->getUser();
+        $affectation = $event->getAffectation();
+        $signalement = $affectation->getSignalement();
+        $params['subject'] = $affectation->getPartner()->getNom();
+        $params['motif_cloture'] = $affectation->getMotifCloture();
+        $params['motif_suivi'] = $event->getMessage();
+        $suivi = $this->suiviManager->createSuivi(
+            signalement: $signalement,
+            description: SuiviManager::buildDescriptionClotureSignalement($params),
+            type: Suivi::TYPE_PARTNER,
+            user: $user,
+        );
+
+        $signalement->addSuivi($suivi);
+        $this->sendMailToPartner(
+            signalement: $signalement,
+            partnerToExclude: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory())
+        );
+
+        $this->signalementManager->save($signalement);
+    }
+
+    private function sendMailToPartner(Signalement $signalement, ?Partner $partnerToExclude = null): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->signalementManager->getRepository();
+        $sendTo = $signalementRepository->findUsersPartnerEmailAffectedToSignalement(
+            $signalement->getId(),
+            $partnerToExclude
+        );
+
+        if (empty($sendTo)) {
+            return;
+        }
+
+        $this->notificationMailerRegistry->send(
+            new NotificationMail(
+                type: NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_PARTNER,
+                to: $sendTo,
+                territory: $signalement->getTerritory(),
+                signalement: $signalement,
+            )
+        );
+    }
+}

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -2,28 +2,25 @@
 
 namespace App\EventSubscriber;
 
-use App\Entity\Affectation;
-use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
 use App\Event\SignalementClosedEvent;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
-use App\Repository\SignalementRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SignalementClosedSubscriber implements EventSubscriberInterface
+readonly class SignalementClosedSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly NotificationMailerRegistry $notificationMailerRegistry,
-        private readonly SignalementManager $signalementManager,
-        private readonly SuiviManager $suiviManager,
-        private readonly Security $security,
+        private NotificationMailerRegistry $notificationMailerRegistry,
+        private SignalementManager $signalementManager,
+        private SuiviManager $suiviManager,
+        private Security $security,
     ) {
     }
 
@@ -44,11 +41,11 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
 
         if ($signalement instanceof Signalement) {
             $suivi = $this->suiviManager->createSuivi(
-                user : $user,
-                signalement : $signalement,
-                description : SuiviManager::buildDescriptionClotureSignalement($params),
-                type : Suivi::TYPE_PARTNER,
+                signalement: $signalement,
+                description: SuiviManager::buildDescriptionClotureSignalement($params),
+                type: Suivi::TYPE_PARTNER,
                 isPublic: '1' == $params['suivi_public'],
+                user: $user,
             );
 
             $signalement
@@ -59,22 +56,6 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
                 $this->sendMailToUsager($signalement);
             }
             $this->sendMailToPartners($signalement);
-        }
-
-        if ($affectation instanceof Affectation) {
-            $signalement = $affectation->getSignalement();
-            $suivi = $this->suiviManager->createSuivi(
-                user : $user,
-                signalement : $signalement,
-                description : SuiviManager::buildDescriptionClotureSignalement($params),
-                type : Suivi::TYPE_PARTNER,
-            );
-
-            $signalement->addSuivi($suivi);
-            $this->sendMailToPartner(
-                signalement: $signalement,
-                partnerToExclude: $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory())
-            );
         }
 
         $this->signalementManager->save($signalement);
@@ -108,29 +89,6 @@ class SignalementClosedSubscriber implements EventSubscriberInterface
                 to: $sendTo,
                 territory: $signalement->getTerritory(),
                 signalement: $signalement
-            )
-        );
-    }
-
-    private function sendMailToPartner(Signalement $signalement, ?Partner $partnerToExclude = null)
-    {
-        /** @var SignalementRepository $signalementRepository */
-        $signalementRepository = $this->signalementManager->getRepository();
-        $sendTo = $signalementRepository->findUsersPartnerEmailAffectedToSignalement(
-            $signalement->getId(),
-            $partnerToExclude
-        );
-
-        if (empty($sendTo)) {
-            return;
-        }
-
-        $this->notificationMailerRegistry->send(
-            new NotificationMail(
-                type: NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_PARTNER,
-                to: $sendTo,
-                territory: $signalement->getTerritory(),
-                signalement: $signalement,
             )
         );
     }

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -34,7 +34,6 @@ readonly class SignalementClosedSubscriber implements EventSubscriberInterface
     public function onSignalementClosed(SignalementClosedEvent $event): void
     {
         $signalement = $event->getSignalement();
-        $affectation = $event->getAffectation();
         $params = $event->getParams();
         /** @var User $user */
         $user = $this->security->getUser();

--- a/src/Exception/Suivi/UsagerNotificationRequiredException.php
+++ b/src/Exception/Suivi/UsagerNotificationRequiredException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Exception\Suivi;
+
+class UsagerNotificationRequiredException extends \Exception
+{
+    private mixed $value;
+
+    private array $errors;
+
+    public function __construct(
+        mixed $value = null,
+        string $message = 'Vous voulez réouvrir pour le partenaire, un suivi de réouverture va être crée. Vous devez indiquer si vous souhaitez notifier l\'usager.',
+        int $code = 0, ?\Throwable $previous = null,
+    ) {
+        $this->value = $value;
+        $this->errors = [
+            [
+                'property' => 'notifyUsager',
+                'message' => 'Veuillez renseigner la valeur true ou false.',
+            ],
+        ];
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -3,6 +3,7 @@
 namespace App\Factory\Api;
 
 use App\Dto\Api\Model\Adresse;
+use App\Dto\Api\Model\Affectation as AffectationModel;
 use App\Dto\Api\Model\Desordre;
 use App\Dto\Api\Model\Intervention;
 use App\Dto\Api\Model\Personne;
@@ -61,8 +62,13 @@ readonly class SignalementResponseFactory
         $signalementResponse->typeDeclarant = $signalement->getProfileDeclarant();
         $signalementResponse->description = $signalement->getDetails();
 
-        $signalementResponse->statutAffectation = AffectationStatus::mapNewStatus($affectation->getStatut());
-        $signalementResponse->dateAffectation = $affectation->getCreatedAt()->format(\DATE_ATOM);
+        $signalementResponse->affectation = new AffectationModel();
+        $signalementResponse->affectation->uuid = $affectation->getUuid();
+        $signalementResponse->affectation->statut = AffectationStatus::mapNewStatus($affectation->getStatut());
+        $signalementResponse->affectation->dateAffectation = $affectation->getCreatedAt()->format(\DATE_ATOM);
+        $signalementResponse->affectation->dateAcceptation = $affectation->getAnsweredAt()?->format(\DATE_ATOM);
+        $signalementResponse->affectation->motifCloture = $affectation->getMotifCloture();
+        $signalementResponse->affectation->motifRefus = $affectation->getMotifRefus();
 
         // infos logement
         $signalementResponse->natureLogement = $signalement->getNatureLogement();

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -8,6 +8,8 @@ use App\Entity\Enum\MotifRefus;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Event\AffectationAnsweredEvent;
+use App\Event\AffectationClosedEvent;
 use App\Event\AffectationCreatedEvent;
 use App\Messenger\Message\DossierMessageInterface;
 use App\Repository\AffectationRepository;
@@ -23,14 +25,19 @@ class AffectationManager extends Manager
         protected SuiviManager $suiviManager,
         protected LoggerInterface $logger,
         protected HistoryEntryManager $historyEntryManager,
-        private EventDispatcherInterface $eventDispatcher,
+        private readonly EventDispatcherInterface $eventDispatcher,
         string $entityName = Affectation::class,
     ) {
         parent::__construct($this->managerRegistry, $entityName);
     }
 
-    public function updateAffectation(Affectation $affectation, User $user, int $status, ?string $motifRefus = null): Affectation
-    {
+    public function updateAffectation(
+        Affectation $affectation,
+        User $user,
+        int $status,
+        ?string $motifRefus = null,
+        ?string $message = null,
+    ): Affectation {
         $affectation
             ->setStatut($status)
             ->setAnsweredBy($user)
@@ -40,7 +47,12 @@ class AffectationManager extends Manager
             $affectation->setMotifRefus(MotifRefus::tryFrom($motifRefus));
         }
 
+        if (Affectation::STATUS_WAIT === $status || Affectation::STATUS_ACCEPTED === $status) {
+            $affectation->clear();
+        }
+
         $this->save($affectation);
+        $this->dispatchAffectationAnsweredEvent($affectation, $user, $status, $affectation->getMotifRefus(), $message);
 
         return $affectation;
     }
@@ -79,7 +91,12 @@ class AffectationManager extends Manager
         return $affectation;
     }
 
-    public function closeAffectation(Affectation $affectation, User $user, MotifCloture $motif, bool $flush = false): Affectation
+    public function closeAffectation(
+        Affectation $affectation,
+        User $user,
+        MotifCloture $motif,
+        ?string $message = null,
+        bool $flush = false): Affectation
     {
         $affectation
             ->setStatut(Affectation::STATUS_CLOSED)
@@ -88,6 +105,14 @@ class AffectationManager extends Manager
             ->setAnsweredBy($user);
         if ($flush) {
             $this->save($affectation);
+            $this->eventDispatcher->dispatch(
+                new AffectationClosedEvent(
+                    affectation: $affectation,
+                    user: $user,
+                    message: $message
+                ),
+                AffectationClosedEvent::NAME
+            );
         }
 
         return $affectation;
@@ -135,5 +160,18 @@ class AffectationManager extends Manager
         /** @var AffectationRepository $affectationRepository */
         $affectationRepository = $this->getRepository();
         $affectationRepository->deleteAffectationsByPartner($partner);
+    }
+
+    private function dispatchAffectationAnsweredEvent(
+        Affectation $affectation,
+        User $user,
+        int $status,
+        ?MotifRefus $motifRefus = null,
+        ?string $message = null,
+    ): void {
+        $this->eventDispatcher->dispatch(
+            new AffectationAnsweredEvent($affectation, $user, $status, $motifRefus, $message),
+            AffectationAnsweredEvent::NAME
+        );
     }
 }

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -48,7 +48,7 @@ class AffectationManager extends Manager
         }
 
         if (Affectation::STATUS_WAIT === $status || Affectation::STATUS_ACCEPTED === $status) {
-            $affectation->clear();
+            $affectation->clearMotifs();
         }
 
         $this->save($affectation);

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -3,7 +3,6 @@
 namespace App\Manager;
 
 use App\Entity\Enum\DocumentType;
-use App\Entity\Enum\MotifRefus;
 use App\Entity\File;
 use App\Entity\Intervention;
 use App\Entity\Signalement;
@@ -76,10 +75,10 @@ class SuiviManager extends Manager
             /** @var User $user */
             $user = $this->security->getUser();
             $this->createSuivi(
-                user: $user,
                 signalement: $signalement,
                 description: $description.$user->getNomComplet(),
                 type: Suivi::TYPE_AUTO,
+                user: $user,
             );
         }
     }
@@ -192,16 +191,15 @@ class SuiviManager extends Manager
             $descriptionList[] = $linkFile;
         }
         $description .= '<ul>'.implode('', $descriptionList).'</ul>';
-        $suivi = $this->createSuivi(
-            user: $user,
+
+        return $this->createSuivi(
             signalement: $signalement,
             description: $description,
             type: Suivi::TYPE_AUTO,
             isPublic: $isVisibleUsager,
+            user: $user,
             flush: false
         );
-
-        return $suivi;
     }
 
     public static function buildDescriptionClotureSignalement($params): string
@@ -216,13 +214,13 @@ class SuiviManager extends Manager
         );
     }
 
-    public static function buildDescriptionAnswerAffectation($params): string
+    public static function buildDescriptionAnswerAffectation(array $params): string
     {
         $description = '';
         if (isset($params['accept'])) {
             $description = 'Le signalement a été accepté';
         } elseif (isset($params['suivi'])) {
-            $motifRejected = !empty($params['motifRefus']) ? MotifRefus::tryFrom($params['motifRefus'])->label() : 'Non précisé';
+            $motifRejected = !empty($params['motifRefus']) ? $params['motifRefus']->label() : 'Non précisé';
             $commentaire = Sanitizer::sanitize($params['suivi']);
             $description = 'Le signalement a été refusé avec le motif suivant : '.$motifRejected.'.<br>Plus précisément :<br>'.$commentaire;
         }

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -68,10 +68,10 @@ class EsaboraManager
         $description = $this->updateStatusFor($affectation, $adminUser, $dossierResponse);
         if (!empty($description)) {
             $this->suiviManager->createSuivi(
-                user : $adminUser,
                 signalement: $signalement,
                 description: 'Signalement <b>'.$description.'</b> par '.$affectation->getPartner()->getNom(),
                 type: EsaboraStatus::ESABORA_WAIT->value === $dossierResponse->getSasEtat() ? Suivi::TYPE_TECHNICAL : Suivi::TYPE_AUTO,
+                user: $adminUser,
             );
         }
     }

--- a/src/Specification/Signalement/FirstAffectationAcceptedSpecification.php
+++ b/src/Specification/Signalement/FirstAffectationAcceptedSpecification.php
@@ -8,14 +8,15 @@ use App\Entity\Signalement;
 use App\Repository\SuiviRepository;
 use Doctrine\Common\Collections\Collection;
 
-class FirstAffectationAcceptedSpecification
+readonly class FirstAffectationAcceptedSpecification
 {
     public function __construct(private SuiviRepository $suiviRepository)
     {
     }
 
-    public function isSatisfiedBy(Signalement $signalement, Affectation $affectation): bool
+    public function isSatisfiedBy(Affectation $affectation): bool
     {
+        $signalement = $affectation->getSignalement();
         $suiviAffectationAccepted = $this->suiviRepository->findSuiviByDescription(
             $signalement,
             '<p>Suite à votre signalement, le ou les partenaires compétents'
@@ -50,6 +51,7 @@ class FirstAffectationAcceptedSpecification
         return !$signalement->getIsImported()
         && 1 === $affectationAccepted->count()
         && Affectation::STATUS_ACCEPTED === $affectation->getStatut()
+        && Signalement::STATUS_ACTIVE === $signalement->getStatut()
         && empty($suiviAffectationAccepted)
         && $interventions->isEmpty();
     }

--- a/tests/Functional/Controller/Api/AffectationUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/AffectationUpdateControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Api;
+
+use App\Entity\Affectation;
+use App\Entity\Enum\AffectationStatus;
+use App\Repository\SignalementRepository;
+use App\Repository\UserRepository;
+use Doctrine\Common\Collections\Collection;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class AffectationUpdateControllerTest extends WebTestCase
+{
+    /**
+     * @dataProvider provideValidTransitionData
+     */
+    public function testValidWorkflow(string $signalementUuid, array $payload, string $statut, int $mailSent): void
+    {
+        $client = static::createClient();
+        $user = self::getContainer()->get(UserRepository::class)->findOneBy([
+            'email' => 'api-01@histologe.fr',
+        ]);
+
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $signalement = $signalementRepository->findOneBy(['uuid' => $signalementUuid]);
+        /** @var Collection $affectations */
+        $affectations = $signalement->getAffectations();
+
+        /** @var Affectation $affectation */
+        $affectation = $affectations->filter(function (Affectation $affectation) {
+            return 'Partenaire 13-01' === $affectation->getPartner()->getNom();
+        })->current();
+
+        $client->loginUser($user, 'api');
+        $client->request(
+            method: 'PATCH',
+            uri: '/api/affectations/'.$affectation->getUuid(),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+
+        $this->assertResponseIsSuccessful();
+        $this->assertEquals($statut, AffectationStatus::mapNewStatus($affectation->getStatut())->value);
+        $this->assertEmailCount($mailSent);
+    }
+
+    /** @dataProvider provideUnvalidTransitionData */
+    public function testInvalidWorkflow(string $signalementUuid, array $payload): void
+    {
+        $client = static::createClient();
+        $user = self::getContainer()->get(UserRepository::class)->findOneBy([
+            'email' => 'api-01@histologe.fr',
+        ]);
+
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $signalement = $signalementRepository->findOneBy(['uuid' => $signalementUuid]);
+        /** @var Collection $affectations */
+        $affectations = $signalement->getAffectations();
+
+        /** @var Affectation $affectation */
+        $affectation = $affectations->filter(function (Affectation $affectation) {
+            return 'Partenaire 13-01' === $affectation->getPartner()->getNom();
+        })->current();
+
+        $client->loginUser($user, 'api');
+        $client->request(
+            method: 'PATCH',
+            uri: '/api/affectations/'.$affectation->getUuid(),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Cette transition n\'est pas valide', $response['message']);
+    }
+
+    public function provideValidTransitionData(): \Generator
+    {
+        yield 'NOUVEAU ==> EN_COURS' => [
+            '00000000-0000-0000-2022-000000000001',
+            [
+                'statut' => 'EN_COURS',
+            ],
+            'EN_COURS',
+            0,
+        ];
+        yield 'EN_COURS ==> FERME' => [
+            '00000000-0000-0000-2022-000000000006',
+            [
+                'statut' => 'FERME',
+                'motifCloture' => 'REFUS_DE_VISITE',
+                'message' => 'lorem ipsum dolor sit amet',
+            ],
+            'FERME',
+            1,
+        ];
+
+        yield 'FERME ==> NOUVEAU' => [
+            '00000000-0000-0000-2023-000000000013',
+            [
+                'statut' => 'NOUVEAU',
+                'notifyUsager' => true,
+            ],
+            'NOUVEAU',
+            2,
+        ];
+    }
+
+    public function provideUnvalidTransitionData(): \Generator
+    {
+        yield 'NOUVEAU ==> FERME' => [
+            '00000000-0000-0000-2022-000000000001',
+            [
+                'statut' => 'FERME',
+                'motifCloture' => 'RELOGEMENT_OCCUPANT',
+                'message' => 'Hello world buddy!!!!',
+            ],
+        ];
+        yield 'EN_COURS ==> NOUVEAU' => [
+            '00000000-0000-0000-2022-000000000006',
+            [
+                'statut' => 'NOUVEAU',
+                'notifyUsager' => true,
+            ],
+        ];
+
+        yield 'FERME ==> EN_COURS' => [
+            '00000000-0000-0000-2023-000000000013',
+            [
+                'statut' => 'EN_COURS',
+            ],
+        ];
+    }
+}

--- a/tests/Functional/Controller/Api/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementControllerTest.php
@@ -18,7 +18,7 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertCount(5, $response);
+        $this->assertCount(6, $response);
     }
 
     public function testGetSignalementListWithLimit(): void
@@ -57,7 +57,7 @@ class SignalementControllerTest extends WebTestCase
             'email' => 'api-01@histologe.fr',
         ]);
         $client->loginUser($user, 'api');
-        $client->request('GET', '/api/signalements/00000000-0000-0000-2022-000000000001');
+        $client->request('GET', '/api/signalements/00000000-0000-0000-2022-000000000003');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
         $response = json_decode($client->getResponse()->getContent(), true);

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -209,17 +209,17 @@ class SignalementListControllerTest extends WebTestCase
 
     public function provideFilterSearchMultiTerritorAdminPartner(): \Generator
     {
-        yield 'Search All' => [['isImported' => 'oui'], 6];
-        yield 'Search by Commune' => [['communes' => ['gex', 'marseille'], 'isImported' => 'oui'], 6];
+        yield 'Search All' => [['isImported' => 'oui'], 7];
+        yield 'Search by Commune' => [['communes' => ['gex', 'marseille'], 'isImported' => 'oui'], 7];
         yield 'Search by Territory 1' => [['territoire' => '1', 'isImported' => 'oui'], 1];
-        yield 'Search by Territory 13' => [['territoire' => '13', 'isImported' => 'oui'], 5];
+        yield 'Search by Territory 13' => [['territoire' => '13', 'isImported' => 'oui'], 6];
         yield 'Search by Status En cours' => [['isImported' => 'oui', 'status' => 'en_cours'], 3];
         yield 'Search by Status En cours on Territory 1' => [['territoire' => '1', 'isImported' => 'oui', 'status' => 'en_cours'], 0];
         yield 'Search by Status En cours on Territory 13' => [['territoire' => '13', 'isImported' => 'oui', 'status' => 'en_cours'], 3];
-        yield 'Search by Status Fermé' => [['isImported' => 'oui', 'status' => 'ferme'], 2];
+        yield 'Search by Status Fermé' => [['isImported' => 'oui', 'status' => 'ferme'], 3];
         yield 'Search by Status Fermé on Territory 1' => [['territoire' => '1', 'isImported' => 'oui', 'status' => 'ferme'], 1];
-        yield 'Search by Status Fermé on Territory 13' => [['territoire' => '13', 'isImported' => 'oui', 'status' => 'ferme'], 1];
-        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 1];
+        yield 'Search by Status Fermé on Territory 13' => [['territoire' => '13', 'isImported' => 'oui', 'status' => 'ferme'], 2];
+        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 2];
     }
 
     /**

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -68,7 +68,7 @@ class BackStatistiquesControllerTest extends WebTestCase
             ['result' => 0, 'label' => 'average_criticite_filtered'],
         ]];
         yield 'Admin partenaire multi territories' => ['back_statistiques_filter', [], self::USER_ADMIN_PARTNER_MULTI_TERRITORIES, [
-            ['result' => 5, 'label' => 'count_signalement'],
+            ['result' => 6, 'label' => 'count_signalement'],
             ['result' => 0, 'label' => 'count_signalement_refuses'],
             ['result' => 0, 'label' => 'count_signalement_archives'],
         ]];

--- a/tests/Functional/Controller/WidgetControllerTest.php
+++ b/tests/Functional/Controller/WidgetControllerTest.php
@@ -10,10 +10,10 @@ use Symfony\Component\Routing\RouterInterface;
 
 class WidgetControllerTest extends WebTestCase
 {
-    private const USER_SUPER_ADMIN = 'admin-01@histologe.fr';
-    private const USER_ADMIN_TERRITOIRE = 'admin-territoire-13-01@histologe.fr';
-    private const USER_PARTNER = 'user-13-01@histologe.fr';
-    private const USER_MULTI_TER_ADMIN_PARTNER = 'admin-partenaire-multi-ter-13-01@histologe.fr';
+    private const string USER_SUPER_ADMIN = 'admin-01@histologe.fr';
+    private const string USER_ADMIN_TERRITOIRE = 'admin-territoire-13-01@histologe.fr';
+    private const string USER_PARTNER = 'user-13-01@histologe.fr';
+    private const string USER_MULTI_TER_ADMIN_PARTNER = 'admin-partenaire-multi-ter-13-01@histologe.fr';
 
     public function testWidgetRouteDataKpi(): void
     {

--- a/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
@@ -14,7 +14,6 @@ use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
-use App\Service\Token\TokenGeneratorInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -75,7 +74,6 @@ class SignalementClosedSubscriberTest extends KernelTestCase
                     ),
                 ]
             )->willReturn(true);
-        $tokenGeneratorMock = $this->createMock(TokenGeneratorInterface::class);
         $securityMock = $this->createMock(Security::class);
         $securityMock->expects($this->once())->method('getUser')->willReturn($user);
 
@@ -105,7 +103,6 @@ class SignalementClosedSubscriberTest extends KernelTestCase
         $event = $dispatcher->dispatch($signalementClosedEvent, SignalementClosedEvent::NAME);
 
         $this->assertInstanceOf(Signalement::class, $event->getSignalement());
-        $this->assertNull($event->getAffectation());
         $this->assertIsArray($event->getParams());
     }
 }

--- a/tests/Functional/Manager/AffectationManagerTest.php
+++ b/tests/Functional/Manager/AffectationManagerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class AffectationManagerTest extends KernelTestCase
 {
-    private const REF_SIGNALEMENT = '2022-8';
+    private const string REF_SIGNALEMENT = '2022-8';
     private ManagerRegistry $managerRegistry;
     private SuiviManager $suiviManager;
     private LoggerInterface $logger;
@@ -90,6 +90,7 @@ class AffectationManagerTest extends KernelTestCase
             $affectationAccepted,
             $user,
             MotifCloture::tryFrom('NON_DECENCE'),
+            null,
             true
         );
 

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -140,7 +140,7 @@ class EsaboraManagerTest extends KernelTestCase
             'remis en attente',
             Affectation::STATUS_WAIT,
             Suivi::TYPE_TECHNICAL,
-            false, // suivi mail not sent cause suivi techical
+            false, // suivi mail not sent cause suivi technical
         ];
 
         yield EsaboraStatus::ESABORA_ACCEPTED->value => [

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -200,7 +200,7 @@ class SignalementRepositoryTest extends KernelTestCase
     {
         yield 'Search all for super admin' => ['admin-01@histologe.fr', [], 46];
         yield 'Search in Marseille for super admin' => ['admin-01@histologe.fr', ['cities' => ['Marseille']], 25];
-        yield 'Search all for admin partner multi territories' => ['admin-partenaire-multi-ter-13-01@histologe.fr', [], 5];
+        yield 'Search all for admin partner multi territories' => ['admin-partenaire-multi-ter-13-01@histologe.fr', [], 6];
         yield 'Search in Ain for admin partner multi territories' => ['admin-partenaire-multi-ter-13-01@histologe.fr', ['territories' => 1], 1];
         yield 'Search all for user partner multi territories' => ['user-partenaire-multi-ter-34-30@histologe.fr', [], 2];
         yield 'Search in Hérault for user partner multi territories' => ['user-partenaire-multi-ter-34-30@histologe.fr', ['territories' => 35], 1];

--- a/tests/Functional/Specification/Signalement/FirstAffectationAcceptedSpecificationTest.php
+++ b/tests/Functional/Specification/Signalement/FirstAffectationAcceptedSpecificationTest.php
@@ -41,7 +41,6 @@ class FirstAffectationAcceptedSpecificationTest extends KernelTestCase
 
         $firstAffectationAcceptedSpecification = new FirstAffectationAcceptedSpecification($this->suiviRepository);
         $canAddSuiviFirstAffectation = $firstAffectationAcceptedSpecification->isSatisfiedBy(
-            $signalement,
             $affectation
         );
 
@@ -72,7 +71,6 @@ class FirstAffectationAcceptedSpecificationTest extends KernelTestCase
 
         $firstAffectationAcceptedSpecification = new FirstAffectationAcceptedSpecification($this->suiviRepository);
         $canAddSuiviFirstAffectation = $firstAffectationAcceptedSpecification->isSatisfiedBy(
-            $signalement,
             $affectation
         );
 


### PR DESCRIPTION
## Ticket

#3619    

## Description
Mise à jour des affectations selon le workflow de l'application

```mermaid
flowchart TD
    NOUVEAU[NOUVEAU] -->|Accepter| EN_COURS[EN COURS]
    NOUVEAU -->|Refuser| REFUSE[REFUSÉ]
    EN_COURS -->|Fermer| FERME[FERMÉ]
    REFUSE -->|Annuler le refus| EN_COURS
    FERME -->|Ré-ouvrir| NOUVEAU
```

## Changements apportés
* Mise à jour documentation
* Définition d'un nouveau modèle `Affectation` pour `signalementResponse`
* Ajout d'une nouvelle colonne `uuid` sur la table `affectation`
* Ajout d'une nouvelle route pour la mise à jour d'affectation
* Définition d'un workflow `AffectationVoter::VALID_WORKFLOW_STATUT` dans le voter afin de restreindre les mises à jour aux seules transitions valides.
* Gestion des erreurs d'autorisation API `SecurityApiExceptionListener`
* Refactorisation et centralisation des actions dans les subscribers 
* Ajout d'un nouvel événement `affectation.closed` 
* Ajout d'une affectation dans les fixtures (implique de mettre à jour quelques tests hors scopes)

## Pré-requis
```
make create-db
```
### Configuration
- Importer le fichier openapi.json dans POSTMAN

## Tests
- [ ] Revue de la documentation `http://localhost:8080/api/doc#tag/Affectations/operation/patch_api_affectations_update`
- [ ] Tester les mises à jour du statut `/api/affectations/{{affectation_uuid}}` avec un workflow valide (Même comportement que sur l'app)
    - [ ] Vérifier le statut de l'affectation sur la fiche
    - [ ] Vérifier que les suivi sont bien crée selon le statut
    - [ ] Vérifier que les mails sont bien envoyés
- [ ] Vérifier que les erreurs sont gérés 
    - [ ] Affectation inexistante
    - [ ] Non autorisé à modifier l'affectation
    - [ ] Workflow invalide
    - [ ] Mauvais statut
    - [ ] Champs manquant

## Tests TNR
- Vérifier qu'il n’ya pas de régression sur le workflow de mise à jour de statut signalement/affectation