### PR TITLE
[BO - Filtres signalements] Arrêt de requête en cours lors de mise à jour des filtres

### DIFF
--- a/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
+++ b/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
@@ -173,7 +173,7 @@ export function handleSignalementsShared (context: any, requestResponse: any): a
 export function handleFilters (context: any, ajaxurl: string): any {
   clearScreen(context)
 
-  if (context.abortRequest === true) {
+  if (context.abortRequest !== null) {
     context.abortRequest?.abort()
   }
 


### PR DESCRIPTION
## Ticket

#3657   

## Description
Lorsque plusieurs filtres sont appliqués à la suite des autres, il faut que les requêtes précédentes s'annulent pour laisser la place aux nouvelles.
C'était fonctionnel, mais le test n'était plus valable.

## Tests
- [ ] Jouer avec les filtres sur la liste des signalements
- [ ] Jouer avec les filtres sur la cartographie
