### PR TITLE
[FO - Signalement] Modification du texte concernant les baux manquants

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -978,7 +978,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Etablir un bail écrit et signé avec ses locataires est fortement recommandé. Pour savoir comment rédiger un bail, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Depuis le 9 avril 2024, il est obligatoire d'avoir un bail écrit et signé avec ses locataires. Si le bail a été conclu avant cette date et à l'oral, nous vous recommandons fortement d'en rédiger une version écrite ! Pour savoir comment rédiger un bail, rendez-vous sur <a href='https://www.service-public.fr/particuliers/vosdroits/F920' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -323,7 +323,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.<p><p>Les documents utiles sont:</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -231,7 +231,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.<p><p>Les documents utiles sont:</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les informations utiles sont :</p><ul><li>La composition des pièces</li><li>Le diagnostic performance énergie (DPE)</li><li>Le nombre de personnes occupant le logement</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -343,7 +343,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.<p><p>Les documents utiles sont:</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1004,7 +1004,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si le bail du logement est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit au propriétaire ou bailleur, il ne peut pas refuser de le faire ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1004,7 +1004,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir vos droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1075,7 +1075,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -444,7 +444,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.<p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1075,7 +1075,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si le bail du logement est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit au propriétaire ou bailleur, il ne peut pas refuser de le faire ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1109,7 +1109,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -453,7 +453,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.<p><p>Les documents utiles sont:</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1109,7 +1109,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si le bail du logement est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit au propriétaire ou bailleur, il ne peut pas refuser de le faire ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -438,7 +438,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.<p><p>Les documents utiles sont:</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1093,7 +1093,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si le bail du logement est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit au propriétaire ou bailleur, il ne peut pas refuser de le faire ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1093,7 +1093,7 @@
         {
           "type": "SignalementFormInfo",
           "slug": "bail_dpe_bail_info",
-          "label": "Avoir un bail écrit et signé pour son logement est fortement recommandé pour faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
+          "label": "Avoir un contrat de location (bail) est obligatoire, qu'il soit verbal ou à l'écrit. Depuis le 9 avril 2024, le bail d'un logement doit être rédigé à l'écrit. Si votre bail est verbal (fait à l'oral), nous vous recommandons de demander un bail écrit à votre propriétaire ou bailleur, c'est le meilleur moyen de faire valoir ses droits ! Plus d'info sur <a href='https://www.service-public.fr/particuliers/vosdroits/N349' target='_blank' rel='noopener' title='Le site du Service Public - Ouvre une nouvelle fenêtre'>le site du Service Public</a>.",
           "conditional": {
             "show": "formStore.data.bail_dpe_bail === 'non' || formStore.data.bail_dpe_bail === 'nsp'"
           }


### PR DESCRIPTION
## Ticket

#3661   

## Description
Les baux écrits sont devenus obligatoires depuis avril 2024. On affiche donc un message modifié, et on modifie le lien vers le site du service public.
Profils concernés : locataire, bailleur, tiers particulier, tiers pro, service de secours.

## Tests
- [ ] Tester le formulaire pour un bailleur jusqu'au bail
- [ ] Tester le formulaire pour 2 autres profils jusqu'au bail
