### PR TITLE
[TECH] Ajout du trait TimestampableTrait sur la table zone

### DIFF
--- a/migrations/Version20250204095010.php
+++ b/migrations/Version20250204095010.php
@@ -17,6 +17,13 @@ final class Version20250204095010 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE zone ADD created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE type type VARCHAR(255) NOT NULL COMMENT \'Value possible enum ZoneType\'');
+        $this->addSql("
+            UPDATE zone z
+            INNER JOIN history_entry h ON z.id = h.entity_id
+            SET z.created_at = h.created_at
+            WHERE h.entity_name LIKE '%Zone'
+              AND h.event LIKE 'CREATE'
+        ");
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version20250204095010.php
+++ b/migrations/Version20250204095010.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250204095010 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add created_at and updated_at fields on Zone';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE zone ADD created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', ADD updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', CHANGE type type VARCHAR(255) NOT NULL COMMENT \'Value possible enum ZoneType\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE zone DROP created_at, DROP updated_at, CHANGE type type VARCHAR(255) DEFAULT \'AUTRE\' NOT NULL COMMENT \'Value possible enum ZoneType\'');
+    }
+}

--- a/src/Entity/Zone.php
+++ b/src/Entity/Zone.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Behaviour\EntityHistoryInterface;
+use App\Entity\Behaviour\TimestampableTrait;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\Enum\ZoneType;
 use App\Repository\ZoneRepository;
@@ -15,6 +16,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ZoneRepository::class)]
+#[ORM\HasLifecycleCallbacks()]
 #[ORM\UniqueConstraint(columns: ['name', 'territory_id'])]
 #[UniqueEntity(
     fields: ['name', 'territory'],
@@ -23,6 +25,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 class Zone implements EntityHistoryInterface
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]


### PR DESCRIPTION
## Ticket

#3650

## Description
Ajout du trait TimestampableTrait sur la table zone

## Pré-requis
`make execute-migration name=Version20250204095010 direction=up`

## Tests
- [ ] Ajouter/Modifier une zone et vérifier les champs created_at et updated_at en base 
