### PR TITLE
[QA] Synchronisation des versions Node.js entre local et production

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "es-js-fix": "node_modules/.bin/eslint --parser espree --fix assets/scripts/vanilla/*"
   },
   "engines": {
-    "node": "18.14.2"
+    "node": "22"
   }
 }


### PR DESCRIPTION
## Ticket

#3663    

## Description

![Image](https://github.com/user-attachments/assets/b9a4167e-c327-4c72-998e-89ebb34f29e9)

![Image](https://github.com/user-attachments/assets/3774dfbe-21bc-497d-b471-76bfd209f9a2)

Nous sommes en LTS en local. 
Et depuis notre premier make build de nov-2024 en node-22 mais la version est figé à une vielle LTS sur scalingo (suite à un ancien ticket)

https://nodejs.org/en/about/previous-releases
https://doc.scalingo.com/languages/nodejs/start#:~:text=when%20making%20commits.-,Specifying%20a%20Node.js%20Version,-In%20your%20engines

## Changements apportés
* Mise à jour avec la dernière LTS qui est la 22 qui correpond à la conf locale.

## Pré-requis
```
make build
````
## Tests
- [ ] Si la version locale n'est pas node-22 dans le container `php-fpm`, faire un make build
- [ ] CI et CD OK (voir déploiement review app)