### PR TITLE
[QA] Mocker BAN API

### DIFF
--- a/src/Service/Signalement/SignalementAddressUpdater.php
+++ b/src/Service/Signalement/SignalementAddressUpdater.php
@@ -19,6 +19,7 @@ class SignalementAddressUpdater
     public function updateAddressOccupantFromBanData(Signalement $signalement, bool $updateGeolocAndRnbId = true): void
     {
         $addressResult = $this->addressService->getAddress($signalement->getAddressCompleteOccupant());
+
         if ($addressResult->getScore() > self::SCORE_IF_BAN_ID_ACCEPTED) {
             $signalement->setBanIdOccupant($addressResult->getBanId());
             if ($updateGeolocAndRnbId) {

--- a/src/Service/Signalement/SignalementAddressUpdater.php
+++ b/src/Service/Signalement/SignalementAddressUpdater.php
@@ -19,7 +19,6 @@ class SignalementAddressUpdater
     public function updateAddressOccupantFromBanData(Signalement $signalement, bool $updateGeolocAndRnbId = true): void
     {
         $addressResult = $this->addressService->getAddress($signalement->getAddressCompleteOccupant());
-
         if ($addressResult->getScore() > self::SCORE_IF_BAN_ID_ACCEPTED) {
             $signalement->setBanIdOccupant($addressResult->getBanId());
             if ($updateGeolocAndRnbId) {

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -5,6 +5,8 @@ namespace App\Tests\Functional\Controller\Back;
 use App\Entity\Signalement;
 use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
+use App\Service\DataGouv\AddressService;
+use App\Service\DataGouv\Response\Address;
 use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -76,6 +78,10 @@ class SignalementEditControllerTest extends WebTestCase
      */
     public function testEditSignalementSuccess(string $routeName, array $payload, string $token): void
     {
+        $addressResult = json_decode(file_get_contents(__DIR__.'/../../../files/datagouv/get_api_ban_item_response_13202.json'), true);
+        $addressMock = $this->createMock(AddressService::class);
+        $addressMock->method('getAddress')->willReturn(new Address($addressResult));
+        $this->client->getContainer()->set(AddressService::class, $addressMock);
         $route = $this->router->generate(
             $routeName,
             ['uuid' => $this->signalement->getUuid()]

--- a/tests/files/datagouv/get_api_ban_item_response_13202.json
+++ b/tests/files/datagouv/get_api_ban_item_response_13202.json
@@ -1,0 +1,36 @@
+{
+  "type": "FeatureCollection",
+  "version": "draft",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.36617,
+          43.30334
+        ]
+      },
+      "properties": {
+        "label": "17 Boulevard Saadé - Quai Joliette 13002 Marseille",
+        "score": 0.9530109090909089,
+        "housenumber": "17",
+        "id": "13202_xarfhv_00017",
+        "name": "17 Boulevard Saadé - Quai Joliette",
+        "postcode": "13002",
+        "citycode": "13202",
+        "x": 900980.45,
+        "y": 6279500.67,
+        "city": "Marseille",
+        "context": "13, Bouches-du-Rhône, Provence-Alpes-Côte d'Azur",
+        "type": "housenumber",
+        "importance": 0.48312,
+        "street": "Boulevard Saadé - Quai Joliette"
+      }
+    }
+  ],
+  "attribution": "BAN",
+  "licence": "ETALAB-2.0",
+  "query": "17 Boulevard Saadé - Quai Joliette 13002 Marseille",
+  "limit": 5
+}

--- a/tests/files/datagouv/get_api_ban_item_response_13203.json
+++ b/tests/files/datagouv/get_api_ban_item_response_13203.json
@@ -1,0 +1,36 @@
+{
+  "type": "FeatureCollection",
+  "version": "draft",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.38107,
+          43.30853
+        ]
+      },
+      "properties": {
+        "label": "15 Boulevard National 13003 Marseille",
+        "score": 0.9530109090909089,
+        "housenumber": "15",
+        "id": "13203_xarfhv_00015",
+        "name": "15 Boulevard National",
+        "postcode": "13003",
+        "citycode": "13203",
+        "x": 901540.75,
+        "y": 6280102.34,
+        "city": "Marseille",
+        "context": "13, Bouches-du-Rhône, Provence-Alpes-Côte d'Azur",
+        "type": "housenumber",
+        "importance": 0.48312,
+        "street": "Boulevard National"
+      }
+    }
+  ],
+  "attribution": "BAN",
+  "licence": "ETALAB-2.0",
+  "query": "15 Boulevard National 13003 Marseille",
+  "limit": 5
+}


### PR DESCRIPTION
## Ticket

#3673    

## Description
* Mocker Appel BAN API dans  SignalementViewedSubscriberTest et SignalementEditControllerTest pour éviter de faire planter les tests si l'API ne répond pas.

## Changements apportés
* Remplacer les appels par des mock
* Ajout json pour réprésenter les réponses à simuler

## Pré-requis

## Tests
- [ ] CI OK
