### PR TITLE
[Sécurité - Audit] Modifier la protection anti-brute force

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -30,6 +30,9 @@ security:
             custom_authenticators:
                 - App\Security\JsonLoginAuthenticator
                 - App\Security\TokenAuthenticator
+            login_throttling:
+                max_attempts: 5 # '%env(int:FORMS_SUBMIT_LIMITER_LIMIT)%' doesnt work here: fails to cast str to int
+                interval: '%env(FORMS_SUBMIT_LIMITER_INTERVAL)%'
         main:
             lazy: true
             stateless: false
@@ -39,7 +42,7 @@ security:
                 auth_form_path: 2fa_login
                 check_path: 2fa_login_check
             login_throttling:
-                max_attempts: 10 # '%env(int:FORMS_SUBMIT_LIMITER_LIMIT)%' doesnt work here: fails to cast str to int
+                max_attempts: 5 # '%env(int:FORMS_SUBMIT_LIMITER_LIMIT)%' doesnt work here: fails to cast str to int
                 interval: '%env(FORMS_SUBMIT_LIMITER_INTERVAL)%'
             logout:
                 path: app_logout

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -32,7 +32,7 @@ class UserAccountController extends AbstractController
         RateLimiterFactory $loginActivationFormLimiter,
     ): Response {
         if ($request->isMethod('POST') && $email = $request->request->get('email')) {
-            $limiter = $loginActivationFormLimiter->create($request->getClientIp());
+            $limiter = $loginActivationFormLimiter->create($email);
             if (false === $limiter->consume(1)->isAccepted()) {
                 return $this->render('security/login_link_sent.html.twig', [
                     'title' => 'Lien d\'activation',
@@ -77,7 +77,7 @@ class UserAccountController extends AbstractController
     ): Response {
         $title = 'Récupération de votre mot de passe';
         if ($request->isMethod('POST') && $email = $request->request->get('email')) {
-            $limiter = $loginPasswordFormLimiter->create($request->getClientIp());
+            $limiter = $loginPasswordFormLimiter->create($email);
             if (false === $limiter->consume(1)->isAccepted()) {
                 return $this->render('security/login_link_sent.html.twig', [
                     'title' => 'Lien de récupération',

--- a/src/Security/JsonLoginAuthenticator.php
+++ b/src/Security/JsonLoginAuthenticator.php
@@ -92,8 +92,8 @@ class JsonLoginAuthenticator extends AbstractAuthenticator
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
         return new JsonResponse([
-            'error' => $this->translator->trans($exception->getMessageKey(), [], 'security'),
-            'message' => $this->translator->trans($exception->getMessage(), [], 'security'),
+            'error' => $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security'),
+            'message' => $this->translator->trans($exception->getMessage(), $exception->getMessageData(), 'security'),
         ], Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/src/Security/TokenAuthenticator.php
+++ b/src/Security/TokenAuthenticator.php
@@ -58,8 +58,8 @@ class TokenAuthenticator extends AbstractAuthenticator
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
         return new JsonResponse([
-            'error' => $this->translator->trans($exception->getMessageKey(), [], 'security'),
-            'message' => $this->translator->trans($exception->getMessage(), [], 'security'),
+            'error' => $this->translator->trans($exception->getMessageKey(), $exception->getMessageData(), 'security'),
+            'message' => $this->translator->trans($exception->getMessage(), $exception->getMessageData(), 'security'),
         ], Response::HTTP_UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
## Ticket

#3559

## Description
Le système de login est protégé correctement (pas uniquement sur l'IP) d’après ce que je comprends (système par défaut de loggin_throttling de Symfony
![Capture d’écran 2025-02-05 082447](https://github.com/user-attachments/assets/1ba953e0-af75-42ef-9431-61b0668b29fc)

## Changements apportés
* Ajout du système de limitation sur les authentifications API
* Utilisation de l'email au lieu de l'IP pour la limitation sur le système d'activation du compte / changement mot de passe

## Tests
- [ ] Tester les différent système d’authentification
