### PR TITLE
[FO - Suivi] Un utilisateur connecté au BO ne pouvait plus ajouter de docs/photos sur la page de suivi

### DIFF
--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -74,7 +74,7 @@ class SignalementVoter extends Voter
             self::DELETE => $this->canDelete($subject, $user),
             self::EDIT => $this->canEdit($subject, $user),
             self::VIEW => $this->canView($subject, $user),
-            self::USAGER_EDIT => $this->canUsagerEdit($subject, $user),
+            self::USAGER_EDIT => $this->canUsagerEdit($subject),
             default => false,
         };
     }

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -74,6 +74,7 @@ class SignalementVoter extends Voter
             self::DELETE => $this->canDelete($subject, $user),
             self::EDIT => $this->canEdit($subject, $user),
             self::VIEW => $this->canView($subject, $user),
+            self::USAGER_EDIT => $this->canUsagerEdit($subject, $user),
             default => false,
         };
     }


### PR DESCRIPTION
## Ticket

#3678    

## Description
Suite à ce commit https://github.com/MTES-MCT/histologe/commit/edd1fc61cace63eb79da2796f4528062707c307b, nous avons perdu la possibilité d'ajouter des documents sur la fiche usager si nous sommes connectés au BO

## Changements apportés
* Correction du voter (si un utilisateur est connecté, on regarde le statut du signalement pour dire true ou false)

## Pré-requis

## Tests
- [ ] Tester l'ajoute de photos/documents sur la page de suivi de signalements à différents statuts, avec utilisateur connecté ou pas
