### PR TITLE
[API] Ajout de documents

### DIFF
--- a/src/Controller/Api/SignalementFileUpdateController.php
+++ b/src/Controller/Api/SignalementFileUpdateController.php
@@ -95,9 +95,14 @@ class SignalementFileUpdateController extends AbstractController
         }
         $this->denyAccessUnlessGranted('FILE_EDIT', $file);
 
-        $file->setDocumentType(DocumentType::tryFrom($fileRequest->documentType));
+        $documentType = DocumentType::tryFrom($fileRequest->documentType);
         if (File::FILE_TYPE_PHOTO === $file->getFileType()) {
+            if (isset(DocumentType::getOrderedPhotosList()[$documentType->name])) {
+                $file->setDocumentType($documentType);
+            }
             $file->setDescription($fileRequest->description);
+        } else {
+            $file->setDocumentType($documentType);
         }
         $this->entityManager->flush();
 

--- a/src/Controller/Api/SignalementFileUpdateController.php
+++ b/src/Controller/Api/SignalementFileUpdateController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Dto\Api\Request\FileRequest;
+use App\Entity\Enum\DocumentType;
+use App\Entity\File;
+use App\Factory\Api\FileFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[When('dev')]
+#[When('test')]
+#[Route('/api')]
+class SignalementFileUpdateController extends AbstractController
+{
+    public function __construct(private readonly EntityManagerInterface $entityManager, private readonly FileFactory $fileFactory)
+    {
+    }
+
+    #[Route('/files/{uuid:file}', name: 'api_signalements_files_patch', methods: ['PATCH'])]
+    #[OA\Patch(
+        path: '/api/files/{uuid}',
+        description: 'Edite le type de document ainsi que la description pour un fichier.',
+        summary: 'Edition d\'un fichier',
+        security: [['Bearer' => []]],
+        requestBody: new OA\RequestBody(
+            description: 'Mettre à jour le type de document et la description.',
+            content: new OA\JsonContent(ref: '#/components/schemas/FileRequest')
+        ),
+        tags: ['Fichiers'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Fichier édité avec succès',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'uuid', type: 'string', example: '123'),
+                        new OA\Property(property: 'documentType', type: 'string', example: 'BAILLEUR_REPONSE_BAILLEUR'),
+                        new OA\Property(property: 'description', type: 'string', example: 'lorem ipsum dolor sit amet'),
+                    ]
+                )
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Erreur de validation ou autres erreurs liées à la requête.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'integer', example: 400),
+                        new OA\Property(property: 'message', type: 'string', example: 'Validation Failed'),
+                        new OA\Property(property: 'errors', type: 'array', items: new OA\Items(
+                            type: 'object'
+                        )),
+                    ]
+                )
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Fichier non trouvé.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'integer', example: 404),
+                        new OA\Property(property: 'message', type: 'string', example: 'Resource Not Found'),
+                    ]
+                )
+            ),
+            new OA\Response(
+                response: 401,
+                description: 'Accès non autorisé.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'status', type: 'integer', example: 401),
+                        new OA\Property(property: 'message', type: 'string', example: 'Unauthorized'),
+                    ]
+                )
+            ),
+        ]
+    )]
+    public function __invoke(
+        #[MapRequestPayload]
+        FileRequest $fileRequest,
+        ?File $file = null,
+    ): JsonResponse {
+        if (null === $file) {
+            return $this->json(
+                ['message' => 'Fichier introuvable', 'status' => Response::HTTP_NOT_FOUND],
+                Response::HTTP_NOT_FOUND
+            );
+        }
+        $this->denyAccessUnlessGranted('FILE_EDIT', $file);
+
+        $file->setDocumentType(DocumentType::tryFrom($fileRequest->documentType));
+        if (File::FILE_TYPE_PHOTO === $file->getFileType()) {
+            $file->setDescription($fileRequest->description);
+        }
+        $this->entityManager->flush();
+
+        return $this->json($this->fileFactory->createFrom($file));
+    }
+}

--- a/src/Controller/Api/SignalementFileUpdateController.php
+++ b/src/Controller/Api/SignalementFileUpdateController.php
@@ -94,16 +94,16 @@ class SignalementFileUpdateController extends AbstractController
             );
         }
         $this->denyAccessUnlessGranted('FILE_EDIT', $file);
-
         $documentType = DocumentType::tryFrom($fileRequest->documentType);
-        if (File::FILE_TYPE_PHOTO === $file->getFileType()) {
-            if (isset(DocumentType::getOrderedPhotosList()[$documentType->name])) {
-                $file->setDocumentType($documentType);
-            }
+        $ext = pathinfo($file->getFilename(), \PATHINFO_EXTENSION);
+        if (in_array($ext, File::IMAGE_EXTENSION) && isset(DocumentType::getOrderedPhotosList()[$documentType->name])) {
+            $file->setFileType(File::FILE_TYPE_PHOTO);
             $file->setDescription($fileRequest->description);
         } else {
-            $file->setDocumentType($documentType);
+            $file->setFileType(File::FILE_TYPE_DOCUMENT);
+            $file->setDescription(null);
         }
+        $file->setDocumentType($documentType);
         $this->entityManager->flush();
 
         return $this->json($this->fileFactory->createFrom($file));

--- a/src/Controller/Api/SignalementFileUploadController.php
+++ b/src/Controller/Api/SignalementFileUploadController.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Dto\Api\Model\File as FileResponse;
+use App\Dto\Api\Request\FilesUploadRequest;
+use App\Entity\File;
+use App\Entity\Signalement;
+use App\Entity\User;
+use App\Event\FileUploadedEvent;
+use App\Factory\Api\FileFactory;
+use App\Service\Signalement\SignalementFileProcessor;
+use Doctrine\ORM\EntityManagerInterface;
+use Nelmio\ApiDocBundle\Annotation\Model;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[When('dev')]
+#[When('test')]
+#[Route('/api')]
+class SignalementFileUploadController extends AbstractController
+{
+    public function __construct(
+        private readonly DenormalizerInterface $normalizer,
+        private readonly ValidatorInterface $validator,
+        private readonly SignalementFileProcessor $signalementFileProcessor,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly FileFactory $fileFactory,
+    ) {
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    #[Route('/signalements/{uuid:signalement}/files', name: 'api_signalements_files_post', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/signalements/{uuid}/files',
+        description: 'Retourne les informations du fichier téléversé pour un signalement.',
+        summary: 'Téléversement d\'un fichier',
+        security: [['Bearer' => []]],
+        requestBody: new OA\RequestBody(
+            description: 'Données de téléversement du fichier',
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(
+                    properties: [
+                        'files' => new OA\Property(
+                            description: 'Liste des fichiers téléversés',
+                            type: 'array',
+                            items: new OA\Items(type: 'string', format: 'binary'),
+                        ),
+                    ],
+                    type: 'object'
+                ),
+                examples: [
+                    new OA\Examples(
+                        example: "Exemple d'envoi d'un fichier",
+                        summary: "Exemple d'envoi d'un fichier",
+                        value: [
+                            'files' => ['file1.jpg', 'file2.pdf'],
+                        ]
+                    ),
+                ]
+            )
+        ),
+        tags: ['Fichiers'],
+    )]
+    #[OA\Response(
+        response: Response::HTTP_OK,
+        description: 'Un document',
+        content: new OA\JsonContent(
+            type: 'array',
+            items: new OA\Items(ref: new Model(type: FileResponse::class))
+        )
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Erreur liée à la validation de la requête.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'message', type: 'string', example: 'Valeurs invalides pour les champs suivants :'),
+                new OA\Property(property: 'status', type: 'integer', example: 400),
+                new OA\Property(
+                    property: 'errors',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'property', type: 'string', example: 'files'),
+                            new OA\Property(property: 'message', type: 'string', example: 'Vous devez téléverser au moins un fichier.'),
+                            new OA\Property(property: 'invalidValue', type: 'array', items: new OA\Items(type: 'string'), example: []),
+                        ]
+                    )
+                ),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Accès non autorisé à la ressource.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'integer', example: 401),
+                new OA\Property(property: 'message', type: 'string', example: 'Unauthorized'),
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Signalement non trouvé.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'status', type: 'integer', example: 404),
+                new OA\Property(property: 'message', type: 'string', example: 'Resource Not Found'),
+            ]
+        )
+    )]
+    public function __invoke(
+        Request $request,
+        ?Signalement $signalement = null,
+    ): JsonResponse {
+        if (null === $signalement) {
+            return $this->json(
+                ['message' => 'Signalement introuvable', 'status' => Response::HTTP_NOT_FOUND],
+                Response::HTTP_NOT_FOUND
+            );
+        }
+        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
+        $data['files'] = $request->files->all();
+        $fileRequest = $this->normalizer->denormalize($data['files'], FilesUploadRequest::class, 'json');
+        $errors = $this->validator->validate($fileRequest);
+        if (count($errors) > 0) {
+            throw new ValidationFailedException($fileRequest, $errors);
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+        $fileList = $this->processFiles($fileRequest);
+        $this->signalementFileProcessor->addFilesToSignalement(
+            fileList: $fileList,
+            signalement: $signalement,
+            user: $user
+        );
+
+        $this->entityManager->persist($signalement);
+        $this->entityManager->flush();
+
+        $fileUploadedEvent = $this->eventDispatcher->dispatch(
+            new FileUploadedEvent($signalement, $user, $fileList),
+            FileUploadedEvent::NAME
+        );
+
+        $response = $this->fileFactory->createFromArray($fileUploadedEvent->getFilesPushed());
+
+        return $this->json($response, Response::HTTP_CREATED);
+    }
+
+    private function processFiles(FilesUploadRequest $fileRequest): array
+    {
+        $files = $fileList = [];
+        foreach ($fileRequest->files as $file) {
+            /** @var UploadedFile $file */
+            if (in_array($file->getMimeType(), File::IMAGE_MIME_TYPES)) {
+                $files['photos'][] = $file;
+            } else {
+                $files['documents'][] = $file;
+            }
+        }
+        if (isset($files['documents'])) {
+            $documentList = $this->signalementFileProcessor->process($files, 'documents');
+            $fileList = [...$fileList, ...$documentList];
+        }
+        if (isset($files['photos'])) {
+            $imageList = $this->signalementFileProcessor->process($files, 'photos');
+            $fileList = [...$fileList, ...$imageList];
+        }
+
+        return $fileList;
+    }
+}

--- a/src/Dto/Api/Model/File.php
+++ b/src/Dto/Api/Model/File.php
@@ -46,6 +46,11 @@ class File
     )]
     public string $documentType;
     #[OA\Property(
+        description: 'Description du fichier (uniquement pour les documents de type images)',
+        example: 'Dégats dans la cuisine'
+    )]
+    public ?string $description;
+    #[OA\Property(
         description: 'URL du fichier<br>
         Le nom du fichier peut être récupéré avec les informations du header HTTP de la ressource `Content-Disposition` indiquant son nom et son extension.
         <br> Exemple : `Content-Disposition: inline; filename=sample_demo_resize.png`',

--- a/src/Dto/Api/Model/File.php
+++ b/src/Dto/Api/Model/File.php
@@ -11,6 +11,12 @@ use OpenApi\Attributes as OA;
 class File
 {
     #[OA\Property(
+        description: 'Uuid du fichier',
+        example: '123e4567-e89b-12d3-a456-426614174000',
+    )]
+    public string $uuid;
+
+    #[OA\Property(
         description: 'Titre du fichier',
         example: 'sample.png',
     )]

--- a/src/Dto/Api/Request/FileRequest.php
+++ b/src/Dto/Api/Request/FileRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Dto\Api\Request;
+
+use OpenApi\Attributes as OA;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class FileRequest implements RequestInterface
+{
+    #[OA\Property(
+        description: 'Type de document<br>
+        <ul>
+            <li>`AUTRE_PROCEDURE`</li>
+            <li>`AUTRE`</li>
+            <li>`SITUATION_FOYER_DPE`</li>
+            <li>`SITUATION_FOYER_ETAT_DES_LIEUX`</li>
+            <li>`PROCEDURE_RAPPORT_DE_VISITE`</li>
+            <li>`SITUATION_FOYER_BAIL`</li>
+            <li>`PHOTO_SITUATION`</li>
+            <li>`PHOTO_VISITE`</li>
+            <li>`SITUATION_DIAGNOSTIC_PLOMB_AMIANTE`</li>
+            <li>`PROCEDURE_MISE_EN_DEMEURE`</li>
+            <li>`PROCEDURE_ARRETE_PREFECTORAL`</li>
+            <li>`BAILLEUR_REPONSE_BAILLEUR`</li>
+            <li>`PROCEDURE_ARRETE_MUNICIPAL`</li>
+            <li>`PROCEDURE_SAISINE`</li>
+            <li>`BAILLEUR_DEVIS_POUR_TRAVAUX`</li>
+            <li>`EXPORT`</li>
+        </ul>
+        ',
+        example: 'BAILLEUR_REPONSE_BAILLEUR'
+    )]
+    #[Assert\NotBlank()]
+    #[Assert\Choice(
+        choices: [
+            'AUTRE_PROCEDURE',
+            'AUTRE',
+            'SITUATION_FOYER_DPE',
+            'SITUATION_FOYER_ETAT_DES_LIEUX',
+            'PROCEDURE_RAPPORT_DE_VISITE',
+            'SITUATION_FOYER_BAIL',
+            'PHOTO_SITUATION',
+            'PHOTO_VISITE',
+            'SITUATION_DIAGNOSTIC_PLOMB_AMIANTE',
+            'PROCEDURE_MISE_EN_DEMEURE',
+            'PROCEDURE_ARRETE_PREFECTORAL',
+            'BAILLEUR_REPONSE_BAILLEUR',
+            'PROCEDURE_ARRETE_MUNICIPAL',
+            'PROCEDURE_SAISINE',
+            'BAILLEUR_DEVIS_POUR_TRAVAUX',
+            'EXPORT',
+        ],
+        message: 'Veuillez choisir une valeur valide pour le type de document. {{ choices }}'
+    )]
+    public ?string $documentType = null;
+    #[OA\Property(
+        description: 'La description d\'une photo, elle sera ignoré pour un document',
+        example: 'lorem ipsum dolor sit amet'
+    )]
+    #[Assert\Length(max: 255)]
+    public ?string $description = null;
+}

--- a/src/Dto/Api/Request/FileRequest.php
+++ b/src/Dto/Api/Request/FileRequest.php
@@ -17,7 +17,6 @@ class FileRequest implements RequestInterface
             <li>`PROCEDURE_RAPPORT_DE_VISITE`</li>
             <li>`SITUATION_FOYER_BAIL`</li>
             <li>`PHOTO_SITUATION`</li>
-            <li>`PHOTO_VISITE`</li>
             <li>`SITUATION_DIAGNOSTIC_PLOMB_AMIANTE`</li>
             <li>`PROCEDURE_MISE_EN_DEMEURE`</li>
             <li>`PROCEDURE_ARRETE_PREFECTORAL`</li>
@@ -25,7 +24,6 @@ class FileRequest implements RequestInterface
             <li>`PROCEDURE_ARRETE_MUNICIPAL`</li>
             <li>`PROCEDURE_SAISINE`</li>
             <li>`BAILLEUR_DEVIS_POUR_TRAVAUX`</li>
-            <li>`EXPORT`</li>
         </ul>
         ',
         example: 'BAILLEUR_REPONSE_BAILLEUR'
@@ -40,7 +38,6 @@ class FileRequest implements RequestInterface
             'PROCEDURE_RAPPORT_DE_VISITE',
             'SITUATION_FOYER_BAIL',
             'PHOTO_SITUATION',
-            'PHOTO_VISITE',
             'SITUATION_DIAGNOSTIC_PLOMB_AMIANTE',
             'PROCEDURE_MISE_EN_DEMEURE',
             'PROCEDURE_ARRETE_PREFECTORAL',
@@ -48,7 +45,6 @@ class FileRequest implements RequestInterface
             'PROCEDURE_ARRETE_MUNICIPAL',
             'PROCEDURE_SAISINE',
             'BAILLEUR_DEVIS_POUR_TRAVAUX',
-            'EXPORT',
         ],
         message: 'Veuillez choisir une valeur valide pour le type de document. {{ choices }}'
     )]

--- a/src/Dto/Api/Request/FilesUploadRequest.php
+++ b/src/Dto/Api/Request/FilesUploadRequest.php
@@ -19,7 +19,7 @@ class FilesUploadRequest implements RequestInterface
             maxSize: '10M',
             mimeTypes: File::DOCUMENT_MIME_TYPES,
             maxSizeMessage: 'Le fichier ne doit pas dépasser 10 Mo.',
-            mimeTypesMessage: 'Seuls les fichiers {{mimeTypes}} sont autorisés.'
+            mimeTypesMessage: 'Seuls les fichiers {{ types }} sont autorisés.'
         ),
     ])]
     #[Assert\Count(

--- a/src/Dto/Api/Request/FilesUploadRequest.php
+++ b/src/Dto/Api/Request/FilesUploadRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Dto\Api\Request;
+
+use App\Entity\File;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[OA\Schema(
+    schema: 'FileRequest',
+    description: 'Payload de téléversement de fichier.',
+)]
+class FilesUploadRequest implements RequestInterface
+{
+    #[Assert\All([
+        new Assert\Type(type: UploadedFile::class, message: 'Chaque élément doit être un fichier valide.'),
+        new Assert\File(
+            maxSize: '10M',
+            mimeTypes: File::DOCUMENT_MIME_TYPES,
+            maxSizeMessage: 'Le fichier ne doit pas dépasser 10 Mo.',
+            mimeTypesMessage: 'Seuls les fichiers {{mimeTypes}} sont autorisés.'
+        ),
+    ])]
+    #[Assert\Count(
+        min: 1,
+        max: 5,
+        minMessage: 'Vous devez téléverser au moins un fichier.',
+        maxMessage: 'Vous ne pouvez pas téléverser plus {{ limit }} fichiers.'
+    )]
+    #[OA\Property(
+        description: 'Liste des fichiers téléversés',
+        type: 'array',
+        items: new OA\Items(type: 'string', format: 'binary')
+    )]
+    public array $files = [];
+}

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -103,7 +103,7 @@ class File implements EntityHistoryInterface
 
     #[ORM\Column(type: 'text', nullable: true, length: 250)]
     #[Assert\Length(max: 250)]
-    private ?string $description;
+    private ?string $description = null;
 
     #[ORM\Column]
     private ?bool $isWaitingSuivi = null;

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -161,7 +161,8 @@ class File implements EntityHistoryInterface
         && ($this->uploadedBy->isSuperAdmin()
         || $this->uploadedBy->isTerritoryAdmin()
         || $this->uploadedBy->isPartnerAdmin()
-        || $this->uploadedBy->isUserPartner());
+        || $this->uploadedBy->isUserPartner()
+        || $this->uploadedBy->isApiUser());
     }
 
     public function getSignalement(): ?Signalement

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -618,6 +618,11 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         return \in_array(self::ROLE_USER_PARTNER, $this->getRoles());
     }
 
+    public function isApiUser(): bool
+    {
+        return \in_array(self::ROLE_API_USER, $this->getRoles());
+    }
+
     public function isUsager(): bool
     {
         return \in_array(self::ROLE_USAGER, $this->getRoles());

--- a/src/Event/FileUploadedEvent.php
+++ b/src/Event/FileUploadedEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Event;
+
+use App\Entity\Signalement;
+use App\Entity\User;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class FileUploadedEvent extends Event
+{
+    public const string NAME = 'file.uploaded';
+
+    public array $filesPushed = [];
+
+    public function __construct(
+        private readonly Signalement $signalement,
+        private readonly User $user,
+        private readonly array $files,
+    ) {
+    }
+
+    public function getSignalement(): Signalement
+    {
+        return $this->signalement;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getFiles(): array
+    {
+        return $this->files;
+    }
+
+    public function getFilesPushed(): array
+    {
+        return $this->filesPushed;
+    }
+
+    public function setFilesPushed(array $filesPushed): self
+    {
+        $this->filesPushed = $filesPushed;
+
+        return $this;
+    }
+}

--- a/src/EventSubscriber/FileUploadedSubscriber.php
+++ b/src/EventSubscriber/FileUploadedSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\File;
+use App\Event\FileUploadedEvent;
+use App\Manager\SuiviManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+readonly class FileUploadedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private SuiviManager $suiviManager)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            FileUploadedEvent::NAME => 'onFileUploaded',
+        ];
+    }
+
+    public function onFileUploaded(FileUploadedEvent $event): void
+    {
+        $files = $event->getFiles();
+        $user = $event->getUser();
+
+        $files = array_map(function ($file) {
+            return $file['file'];
+        }, $files);
+
+        $signalement = $event->getSignalement();
+        $filesFiltered = $signalement->getFiles()->filter(function (File $file) use ($files) {
+            return in_array($file->getFilename(), $files, true);
+        });
+
+        $event->setFilesPushed($filesFilteredArray = $filesFiltered->toArray());
+        $this->suiviManager->createInstanceForFilesSignalement($user, $signalement, $filesFilteredArray);
+    }
+}

--- a/src/Factory/Api/FileFactory.php
+++ b/src/Factory/Api/FileFactory.php
@@ -13,9 +13,10 @@ readonly class FileFactory
     ) {
     }
 
-    public function createFromSignalement(FileEntity $fileEntity): File
+    public function createFrom(FileEntity $fileEntity): File
     {
         $file = new File();
+        $file->uuid = $fileEntity->getUuid();
         $file->titre = $fileEntity->getTitle();
         $file->documentType = $fileEntity->getDocumentType()->value;
         $file->url = $this->urlGenerator->generate(
@@ -25,5 +26,15 @@ readonly class FileFactory
         );
 
         return $file;
+    }
+
+    public function createFromArray(array $files): array
+    {
+        $fileList = [];
+        foreach ($files as $file) {
+            $fileList[] = $this->createFrom($file);
+        }
+
+        return $fileList;
     }
 }

--- a/src/Factory/Api/FileFactory.php
+++ b/src/Factory/Api/FileFactory.php
@@ -19,6 +19,7 @@ readonly class FileFactory
         $file->uuid = $fileEntity->getUuid();
         $file->titre = $fileEntity->getTitle();
         $file->documentType = $fileEntity->getDocumentType()->value;
+        $file->description = $fileEntity->getDescription();
         $file->url = $this->urlGenerator->generate(
             'show_file',
             ['uuid' => $fileEntity->getUuid()],

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -142,7 +142,7 @@ readonly class SignalementResponseFactory
             $signalementResponse->interventions[] = new Intervention($intervention);
         }
         foreach ($signalement->getFiles() as $file) {
-            $signalementResponse->files[] = $this->fileFactory->createFromSignalement($file);
+            $signalementResponse->files[] = $this->fileFactory->createFrom($file);
         }
         // divers
         $signalementResponse->territoireNom = $signalement->getTerritory()?->getName();

--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -53,7 +53,6 @@ class FileVoter extends Voter
 
     private function canEdit(File $file, User $user): bool
     {
-        return true;
         return $this->canCreate($file, $user)
             && (
                 $this->isFileUploadedByUser($file, $user)

--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -53,6 +53,7 @@ class FileVoter extends Voter
 
     private function canEdit(File $file, User $user): bool
     {
+        return true;
         return $this->canCreate($file, $user)
             && (
                 $this->isFileUploadedByUser($file, $user)

--- a/src/Service/ImageManipulationHandler.php
+++ b/src/Service/ImageManipulationHandler.php
@@ -12,14 +12,14 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ImageManipulationHandler
 {
-    public const SUFFIX_RESIZE = '_resize';
-    public const SUFFIX_THUMB = '_thumb';
+    public const string SUFFIX_RESIZE = '_resize';
+    public const string SUFFIX_THUMB = '_thumb';
 
-    private const DEFAULT_SIZE_RESIZE = 1000;
-    private const DEFAULT_SIZE_THUMB = 400;
-    private const DEFAULT_SIZE_AVATAR = 150;
+    private const int DEFAULT_SIZE_RESIZE = 1000;
+    private const int DEFAULT_SIZE_THUMB = 400;
+    private const int DEFAULT_SIZE_AVATAR = 150;
     private bool $useTmpDir = true;
-    private string $imagePath;
+    private ?string $imagePath = null;
 
     public function __construct(
         private readonly ParameterBagInterface $parameterBag,

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -31,7 +31,7 @@ class SignalementFileProcessor
         private readonly ImageManipulationHandler $imageManipulationHandler,
         private readonly FileScanner $fileScanner,
         #[Autowire(env: 'CLAMAV_SCAN_ENABLE')]
-        private bool $clamavScanEnable,
+        private readonly bool $clamavScanEnable,
     ) {
     }
 

--- a/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
@@ -33,7 +33,7 @@ class SignalementFileUpdateControllerTest extends WebTestCase
         })->current();
 
         $payload = [
-            'documentType' => 'PROCEDURE_ARRETE_PREFECTORAL',
+            'documentType' => 'PHOTO_SITUATION',
             'description' => 'lorem ipsum dolor sit amet',
         ];
         $this->client->request(
@@ -46,6 +46,29 @@ class SignalementFileUpdateControllerTest extends WebTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertResponseIsSuccessful();
         $this->assertEquals($payload['documentType'], $response['documentType']);
+    }
+
+    public function testUpdateSignalementFileWithIncorrectType(): void
+    {
+        $signalement = self::getContainer()->get(SignalementRepository::class)->find(1);
+        $file = $signalement->getFiles()->filter(function (File $file) {
+            return 'photo' === $file->getFileType();
+        })->current();
+
+        $payload = [
+            'documentType' => 'PROCEDURE_ARRETE_PREFECTORAL',
+            'description' => 'lorem ipsum dolor sit amet',
+        ];
+        $this->client->request(
+            method: 'PATCH',
+            uri: $this->router->generate('api_signalements_files_patch', ['uuid' => $file->getUuid()]),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+        $this->assertEquals('AUTRE', $response['documentType']);
     }
 
     public function testUpdateSignalementFileWithFileNotFound(): void

--- a/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Api;
+
+use App\Entity\File;
+use App\Entity\User;
+use App\Repository\SignalementRepository;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class SignalementFileUpdateControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private RouterInterface $router;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $user = self::getContainer()->get('doctrine')->getRepository(User::class)->findOneBy([
+            'email' => 'api-01@histologe.fr',
+        ]);
+
+        $this->client->loginUser($user, 'api');
+        $this->router = self::getContainer()->get('router');
+    }
+
+    public function testUpdateSignalementFile(): void
+    {
+        $signalement = self::getContainer()->get(SignalementRepository::class)->find(1);
+        $file = $signalement->getFiles()->filter(function (File $file) {
+            return 'photo' === $file->getFileType();
+        })->current();
+
+        $payload = [
+            'documentType' => 'PROCEDURE_ARRETE_PREFECTORAL',
+            'description' => 'lorem ipsum dolor sit amet',
+        ];
+        $this->client->request(
+            method: 'PATCH',
+            uri: $this->router->generate('api_signalements_files_patch', ['uuid' => $file->getUuid()]),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertResponseIsSuccessful();
+        $this->assertEquals($payload['documentType'], $response['documentType']);
+    }
+
+    public function testUpdateSignalementFileWithFileNotFound(): void
+    {
+        $payload = [
+            'documentType' => 'PROCEDURE_ARRETE_PREFECTORAL',
+        ];
+        $this->client->request(
+            method: 'PATCH',
+            uri: $this->router->generate('api_signalements_files_patch', ['uuid' => '1234']),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
@@ -48,7 +48,7 @@ class SignalementFileUpdateControllerTest extends WebTestCase
         $this->assertEquals($payload['documentType'], $response['documentType']);
     }
 
-    public function testUpdateSignalementFileWithIncorrectType(): void
+    public function testUpdateSignalementFileWithFileTypeUpdated(): void
     {
         $signalement = self::getContainer()->get(SignalementRepository::class)->find(1);
         $file = $signalement->getFiles()->filter(function (File $file) {
@@ -68,7 +68,8 @@ class SignalementFileUpdateControllerTest extends WebTestCase
 
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertResponseIsSuccessful();
-        $this->assertEquals('AUTRE', $response['documentType']);
+        $this->assertNull($response['description']);
+        $this->assertEquals('PROCEDURE_ARRETE_PREFECTORAL', $response['documentType']);
     }
 
     public function testUpdateSignalementFileWithFileNotFound(): void

--- a/tests/Functional/Controller/Api/SignalementFileUploadControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementFileUploadControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Api;
+
+use App\Entity\User;
+use App\Service\ImageManipulationHandler;
+use App\Service\UploadHandlerService;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+class SignalementFileUploadControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private RouterInterface $router;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $user = self::getContainer()->get('doctrine')->getRepository(User::class)->findOneBy([
+            'email' => 'api-01@histologe.fr',
+        ]);
+
+        $this->router = self::getContainer()->get('router');
+
+        $this->client->loginUser($user, 'api');
+    }
+
+    public function testFileUploadSuccess(): void
+    {
+        $imageFile = new UploadedFile(
+            __DIR__.'/../../../files/sample.jpg',
+            'sample.jpg',
+            'image/jpeg',
+            null,
+            true
+        );
+
+        $documentFile = new UploadedFile(
+            __DIR__.'/../../../files/sample.pdf',
+            'sample.pdf',
+            'application/pdf',
+            null,
+            true
+        );
+
+        $imageManipulationHandler = $this->createMock(ImageManipulationHandler::class);
+        self::getContainer()->set(ImageManipulationHandler::class, $imageManipulationHandler);
+
+        $uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
+        $uploadHandlerServiceMock
+            ->method('uploadFromFile')
+            ->willReturnOnConsecutiveCalls('sample.jpg', '');
+
+        self::getContainer()->set(UploadHandlerService::class, $uploadHandlerServiceMock);
+        $uuid = '00000000-0000-0000-2022-000000000006';
+        $this->postRequest($uuid, [$imageFile, $documentFile]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+    }
+
+    /**
+     * @dataProvider provideErrorInput
+     */
+    public function testFileUploadWithBadRequest(string $uuid, int $codeHttpStatus): void
+    {
+        $this->postRequest($uuid, []);
+        $this->assertEquals($codeHttpStatus, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function provideErrorInput(): \Generator
+    {
+        yield 'test upload with bad request' => ['00000000-0000-0000-2022-000000000006', Response::HTTP_BAD_REQUEST];
+        yield 'test upload with not found' => ['00000000-0000-0000-2022-000000000000', Response::HTTP_NOT_FOUND];
+        yield 'test upload with forbidden' => ['00000000-0000-0000-2022-000000000004', Response::HTTP_FORBIDDEN];
+    }
+
+    private function postRequest(string $uuid, array $files = []): void
+    {
+        $this->client->request(
+            'POST',
+            $this->router->generate('api_signalements_files_post', ['uuid' => $uuid]),
+            [],
+            ['files' => $files],
+            ['CONTENT_TYPE' => 'multipart/form-data']
+        );
+    }
+}


### PR DESCRIPTION
## Ticket

#3622    
## Remarque 
- Envisager un passage en asynchrone avant d'augmenter la  limitation afin d'éviter de long temps de réponse.
- Envisager une migration de doctrine à une autre solution de queuing (indépendant de la DB, plus performante) pour le transport des messages car la typologie de messages gérés en asynchrones  augmente (~ une dizaine). 

Le choix pourra se porter sur Redis car le service est dispo sur scalingo.
Autre avantage, ça permettra de réduire la charge en écriture sur la base de donnée.
## Description
Mise à disposition deux routes pour la gestion des documents (Limitation à 5 pour commencer et observer l'usage)

 
_1. Requête (Dépôt des fichiers)_
```
POST {{baseUrl}}/api/signalements/00000000-0000-0000-2022-000000000001/files
```
![image](https://github.com/user-attachments/assets/ffff5c0e-37dc-4836-9e09-b524fb83d4fb)

_2. Requête (Edition des fichiers déposés via uuid)_
```
PATCH {{baseUrl}}/api/files/94da1620-ce9b-43eb-a75c-abe0f8f6fac0kk
```
_Payload_
```
{
    "documentType": "PROCEDURE_ARRETE_PREFECTORAL"
}
``` 

## Changements apportés
* Ajout d'un événement file.uploaded 
* Ajout de la propriété uuid dans la classe modèle file 
* Usage de l'uuid pour permettre l'édition du fichier

## Pré-requis

## Tests
- [ ] Tester la route d'upload et vérifier la fiche signalement ainsi que la création de suivi
- [ ] Tester la route d'édition et vérifier les types de documents
