### PR TITLE
[Partenaires] Ajout d'une commande pour supprimer les espaces en début de nom

### DIFF
--- a/src/Command/TrimPartnerNamesCommand.php
+++ b/src/Command/TrimPartnerNamesCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\PartnerRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:trim-partner-names',
+    description: 'Trim partner names'
+)]
+class TrimPartnerNamesCommand extends Command
+{
+    public function __construct(
+        private readonly PartnerRepository $partnerRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->partnerRepository->trimPartnerNames();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -303,7 +303,8 @@ class PartnerRepository extends ServiceEntityRepository
     public function trimPartnerNames(): void
     {
         $connection = $this->getEntityManager()->getConnection();
-        $sql = 'UPDATE partner SET nom = TRIM(nom)';
-        $connection->prepare($sql)->executeQuery();
+        // Replace unbreakable spaces, and then trim
+        $sql = 'UPDATE partner SET nom = TRIM(REPLACE(nom, UNHEX("C2A0"), " "))';
+        $connection->prepare($sql)->executeStatement();
     }
 }

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -299,4 +299,11 @@ class PartnerRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function trimPartnerNames(): void
+    {
+        $connection = $this->getEntityManager()->getConnection();
+        $sql = 'UPDATE partner SET nom = TRIM(nom)';
+        $connection->prepare($sql)->executeQuery();
+    }
 }

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -209,7 +209,7 @@ class GridAffectationLoader
         }
         foreach ($data as $item) {
             if (\count($item) > 1) {
-                $partnerName = trim($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]);
+                $partnerName = trim($item[GridAffectationHeader::PARTNER_NAME_INSTITUTION]); // Replace with mb_trim($name); when php 8.4
                 $partnerType = PartnerType::tryFromLabel($item[GridAffectationHeader::PARTNER_TYPE]);
 
                 if (!\in_array($partnerName, $newPartnerNames)) {


### PR DESCRIPTION
## Ticket

#3693   

## Description
Certains noms de partenaires (notamment en Gironde) ont un espace en début de nom. En l'occurence, il s'agit d'un espace insécable.

## Changements apportés
* Ajout d'une commande qui permet de nettoyer les noms
* Ajout d'un commentaire pour améliorer le `trim` lorsqu'on passera à php 8.4, lors de l'import de grille d'affectation

## Pré-requis
Utiliser la BDD de prod

## Tests
- [ ] Les partenaires de Gironde comporte à 80% un espace devant leur nom
- [ ] `make console app="trim-partner-names"`
- [ ] Aucun partenaire ne comporte un espace devant son nom
