### PR TITLE
[API] Création de suivi

### DIFF
--- a/src/Controller/Api/SignalementController.php
+++ b/src/Controller/Api/SignalementController.php
@@ -7,7 +7,7 @@ use App\Dto\Api\Response\SignalementResponse;
 use App\Entity\User;
 use App\Factory\Api\SignalementResponseFactory;
 use App\Repository\SignalementRepository;
-use Nelmio\ApiDocBundle\Annotation\Model;
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\When;

--- a/src/Controller/Api/SignalementFileUploadController.php
+++ b/src/Controller/Api/SignalementFileUploadController.php
@@ -11,7 +11,7 @@ use App\Event\FileUploadedEvent;
 use App\Factory\Api\FileFactory;
 use App\Service\Signalement\SignalementFileProcessor;
 use Doctrine\ORM\EntityManagerInterface;
-use Nelmio\ApiDocBundle\Annotation\Model;
+use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\When;

--- a/src/Controller/Api/SuiviCreateController.php
+++ b/src/Controller/Api/SuiviCreateController.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Dto\Api\Request\SuiviRequest;
+use App\Dto\Api\Response\SuiviResponse;
+use App\Entity\File;
+use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Entity\User;
+use App\EventListener\SecurityApiExceptionListener;
+use App\Manager\SuiviManager;
+use App\Service\Sanitizer;
+use Nelmio\ApiDocBundle\Attribute\Model;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[When('dev')]
+#[When('test')]
+#[Route('/api')]
+class SuiviCreateController extends AbstractController
+{
+    public function __construct(
+        readonly private SuiviManager $suiviManager,
+        readonly private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    #[Route('/signalements/{uuid:signalement}/suivis', name: 'api_signalements_suivis_post', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/signalements/{uuid}/suivis',
+        description: 'Création d\'un suivi',
+        summary: 'Création d\'un suivi',
+        security: [['Bearer' => []]],
+        tags: ['Suivis']
+    )]
+    #[OA\Response(
+        response: Response::HTTP_CREATED,
+        description: 'Suivi crée avec succès',
+        content: new OA\JsonContent(ref: new Model(type: SuiviResponse::class))
+    )]
+    #[OA\Response(
+        response: Response::HTTP_NOT_FOUND,
+        description: 'Signalement introuvable',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'message',
+                    type: 'string',
+                    example: 'Signalement introuvable'
+                ),
+                new OA\Property(
+                    property: 'statut',
+                    type: 'int',
+                    example: Response::HTTP_NOT_FOUND
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: Response::HTTP_BAD_REQUEST,
+        description: 'Mauvaise payload (données invalides).',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'message',
+                    type: 'string',
+                    example: 'Valeurs invalides pour les champs suivants :'
+                ),
+                new OA\Property(
+                    property: 'status',
+                    type: 'integer',
+                    example: 400
+                ),
+                new OA\Property(
+                    property: 'errors',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(
+                                property: 'property',
+                                type: 'string',
+                                example: 'description'
+                            ),
+                            new OA\Property(
+                                property: 'message',
+                                type: 'string',
+                                example: 'Le contenu du suivi doit faire au moins 10 caractères !'
+                            ),
+                        ],
+                        type: 'object'
+                    )
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: Response::HTTP_FORBIDDEN,
+        description: 'Accès à la ressource non autorisé.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'message',
+                    type: 'string',
+                    example: 'Vous n\'avez pas l\'autorisation d\'accéder à cette ressource.'
+                ),
+                new OA\Property(
+                    property: 'statut',
+                    type: 'int',
+                    example: Response::HTTP_FORBIDDEN
+                ),
+            ],
+            type: 'object'
+        )
+    )]
+    public function __invoke(
+        #[MapRequestPayload]
+        SuiviRequest $suiviRequest,
+        ?Signalement $signalement = null,
+    ): JsonResponse {
+        if (null === $signalement) {
+            return $this->json(
+                ['message' => 'Signalement introuvable', 'status' => Response::HTTP_NOT_FOUND],
+                Response::HTTP_NOT_FOUND
+            );
+        }
+        $this->denyAccessUnlessGranted('COMMENT_CREATE',
+            $signalement,
+            SecurityApiExceptionListener::ACCESS_DENIED
+        );
+
+        /** @var User $user */
+        $user = $this->getUser();
+        $suivi = $this->suiviManager->createSuivi(
+            signalement: $signalement,
+            description: $this->buildDescription($signalement, $suiviRequest),
+            type: Suivi::TYPE_PARTNER,
+            isPublic: $suiviRequest->notifyUsager,
+            user: $user,
+        );
+
+        return $this->json(new SuiviResponse($suivi), Response::HTTP_CREATED);
+    }
+
+    private function buildDescription(Signalement $signalement, SuiviRequest $suiviRequest): string
+    {
+        $fileListAsHtml = '';
+        $description = Sanitizer::sanitize($suiviRequest->description);
+        $filesFiltered = $signalement->getFiles()->filter(function (File $file) use ($suiviRequest) {
+            return in_array($file->getUuid(), $suiviRequest->files, true);
+        });
+
+        if ($filesFiltered->count() > 0) {
+            $fileListAsHtml = '<ul>';
+            /** @var File $file */
+            foreach ($filesFiltered as $file) {
+                $fileUrl = $this->urlGenerator->generate(
+                    'show_file',
+                    ['uuid' => $file->getUuid()],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                );
+                $fileListAsHtml .= sprintf("<li><a class='fr-link' target='_blank' rel='noopener' href='%s'>%s</a>",
+                    $fileUrl,
+                    $file->getTitle()
+                );
+            }
+            $fileListAsHtml .= '</ul>';
+        }
+
+        return $description.$fileListAsHtml;
+    }
+}

--- a/src/Controller/Api/SuiviCreateController.php
+++ b/src/Controller/Api/SuiviCreateController.php
@@ -42,7 +42,7 @@ class SuiviCreateController extends AbstractController
     )]
     #[OA\Response(
         response: Response::HTTP_CREATED,
-        description: 'Suivi crée avec succès',
+        description: 'Suivi créé avec succès',
         content: new OA\JsonContent(ref: new Model(type: SuiviResponse::class))
     )]
     #[OA\Response(

--- a/src/Dto/Api/Request/SuiviRequest.php
+++ b/src/Dto/Api/Request/SuiviRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Dto\Api\Request;
+
+use App\Validator\SanitizedLength;
+use App\Validator\ValidFiles;
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    description: 'Payload pour créer un suivi.',
+    required: ['description'],
+)]
+class SuiviRequest implements RequestInterface
+{
+    #[OA\Property(
+        description: 'Un message de 10 caractère minimum est obligatoire.',
+        example: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    )]
+    #[SanitizedLength(min: 10)]
+    public ?string $description = null;
+
+    #[OA\Property(
+        description: 'Permet d\'indiquer si l\'usager doit être notifié.',
+        default: false,
+        example: true,
+    )]
+    public bool $notifyUsager = false;
+
+    #[OA\Property(
+        description: 'Tableau contenant une liste d\'UUID des fichiers associés au signalement.',
+        type: 'array',
+        items: new OA\Items(type: 'string', format: 'uuid'),
+        example: ['f47ac10b-58cc-4372-a567-0e02b2c3d479', '8d3c7db7-fc90-43f4-8066-7522f0e9b163']
+    )]
+    #[ValidFiles]
+    public array $files = [];
+}

--- a/src/Dto/Api/Request/SuiviRequest.php
+++ b/src/Dto/Api/Request/SuiviRequest.php
@@ -13,7 +13,7 @@ use OpenApi\Attributes as OA;
 class SuiviRequest implements RequestInterface
 {
     #[OA\Property(
-        description: 'Un message de 10 caractère minimum est obligatoire.',
+        description: 'Un message de 10 caractères minimum est obligatoire.',
         example: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
     )]
     #[SanitizedLength(min: 10)]

--- a/src/Dto/Api/Response/SignalementResponse.php
+++ b/src/Dto/Api/Response/SignalementResponse.php
@@ -755,14 +755,12 @@ class SignalementResponse
         items: new OA\Items(ref: new Model(type: Suivi::class)),
         example: [
             [
-                'id' => 1,
                 'dateCreation' => '2024-11-01T10:00:00+00:00',
                 'description' => 'Premier suivi associé.',
                 'public' => true,
                 'createdBy' => 'John Doe',
             ],
             [
-                'id' => 2,
                 'dateCreation' => '2024-11-02T12:30:00+00:00',
                 'description' => 'Deuxième suivi, accès limité.',
                 'public' => false,

--- a/src/Dto/Api/Response/SuiviResponse.php
+++ b/src/Dto/Api/Response/SuiviResponse.php
@@ -1,15 +1,11 @@
 <?php
 
-namespace App\Dto\Api\Model;
+namespace App\Dto\Api\Response;
 
-use App\Entity\Suivi as SuiviEntity;
+use App\Entity\Suivi;
 use OpenApi\Attributes as OA;
 
-#[OA\Schema(
-    schema: 'Suivi',
-    description: 'Représentation d\'un suivi.'
-)]
-class Suivi
+class SuiviResponse
 {
     #[OA\Property(
         description: 'Date de création du suivi.<br>Exemple : `2024-11-01T10:00:00+00:00`',
@@ -18,10 +14,11 @@ class Suivi
         example: '2024-11-01T10:00:00+00:00'
     )]
     public string $dateCreation;
+
     #[OA\Property(
         description: 'Description détaillée du suivi, peut contenir des balises HTML.',
         type: 'string',
-        example: 'Premier <em>suivi associé</em>.'
+        example: '<ul><li>lorem</li><li>ipsum</li></ul>'
     )]
     public string $description;
 
@@ -32,19 +29,10 @@ class Suivi
     )]
     public bool $public;
 
-    #[OA\Property(
-        description: 'Auteur ayant créé le suivi.',
-        type: 'string',
-        example: 'John Doe'
-    )]
-    public string $createdBy;
-
-    public function __construct(
-        SuiviEntity $suivi,
-    ) {
+    public function __construct(Suivi $suivi)
+    {
         $this->dateCreation = $suivi->getCreatedAt()->format(\DATE_ATOM);
         $this->description = $suivi->getDescription();
         $this->public = $suivi->getIsPublic();
-        $this->createdBy = $suivi->getCreatedByLabel();
     }
 }

--- a/src/EventListener/SecurityApiExceptionListener.php
+++ b/src/EventListener/SecurityApiExceptionListener.php
@@ -17,7 +17,6 @@ class SecurityApiExceptionListener
     public function onKernelException(ExceptionEvent $event): void
     {
         $exception = $event->getThrowable();
-
         if ($this->supports($exception)) {
             $previous = $exception->getPrevious();
             $affectation = null;

--- a/src/Validator/SanitizedLength.php
+++ b/src/Validator/SanitizedLength.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class SanitizedLength extends Constraint
+{
+    public string $message = 'Le texte doit contenir au moins {{ limit }} caractères après sanitation.';
+    public int $min;
+
+    public function __construct(int $min, ?string $message = null)
+    {
+        parent::__construct([]);
+        $this->min = $min;
+        if ($message) {
+            $this->message = $message;
+        }
+    }
+}

--- a/src/Validator/SanitizedLengthValidator.php
+++ b/src/Validator/SanitizedLengthValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Validator;
+
+use App\Service\Sanitizer;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class SanitizedLengthValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof SanitizedLength) {
+            throw new UnexpectedTypeException($constraint, SanitizedLength::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        $sanitizedText = Sanitizer::sanitize($value);
+
+        if (mb_strlen(trim(strip_tags($sanitizedText))) < $constraint->min) {
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setParameter('{{ limit }}', (string) $constraint->min)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Validator/ValidFiles.php
+++ b/src/Validator/ValidFiles.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class ValidFiles extends Constraint
+{
+    public string $message = 'Le fichier avec l\'UUID "{{ uuid }}" est invalide ou inexistant.';
+
+    public function __construct(?string $message = null)
+    {
+        parent::__construct([]);
+        if ($message) {
+            $this->message = $message;
+        }
+    }
+}

--- a/src/Validator/ValidFilesValidator.php
+++ b/src/Validator/ValidFilesValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Validator;
+
+use App\Entity\File;
+use App\Repository\SignalementRepository;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class ValidFilesValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly SignalementRepository $signalementRepository,
+    ) {
+    }
+
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidFiles) {
+            throw new UnexpectedTypeException($constraint, ValidFiles::class);
+        }
+
+        if (!is_array($value)) {
+            throw new UnexpectedValueException($value, 'array');
+        }
+
+        $signalement = $this->signalementRepository->findOneBy([
+            'uuid' => $this->requestStack->getCurrentRequest()->get('signalement')]
+        );
+
+        if (null === $signalement) {
+            return;
+        }
+
+        $uuidFiles = array_map(fn (File $file) => $file->getUuid(), $signalement->getFiles()->toArray());
+
+        foreach ($value as $uuid) {
+            if (!is_string($uuid) || !UuidV4::isValid($uuid)) {
+                $this->context->buildViolation('Le fichier avec l\'UUID "{{ uuid }}" n\'est pas un UUID valide.')
+                    ->setParameter('{{ uuid }}', $uuid)
+                    ->addViolation();
+                continue;
+            }
+            if (!in_array($uuid, $uuidFiles)) {
+                $this->context->buildViolation('Le fichier avec l\'UUID "{{ uuid }}" n\'appartient pas au signalement.')
+                    ->setParameter('{{ uuid }}', $uuid)
+                    ->addViolation();
+            }
+        }
+    }
+}

--- a/tests/Functional/Controller/Api/SuiviCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/SuiviCreateControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Api;
+
+use App\Entity\Suivi;
+use App\Entity\User;
+use App\Repository\SignalementRepository;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Routing\RouterInterface;
+
+class SuiviCreateControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private RouterInterface $router;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $user = self::getContainer()->get('doctrine')->getRepository(User::class)->findOneBy([
+            'email' => 'api-01@histologe.fr',
+        ]);
+
+        $this->router = self::getContainer()->get('router');
+
+        $this->client->loginUser($user, 'api');
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testCreateSuivi(string $signalementUuid, bool $notifyUsager, int $nbMailSent): void
+    {
+        $signalement = self::getContainer()->get(SignalementRepository::class)->findOneBy(['uuid' => $signalementUuid]);
+        $firstFile = $signalement?->getFiles()?->first() ?? null;
+        $lastFile = $signalement?->getFiles()?->last() ?? null;
+        $payload = [
+            'description' => 'lorem ipsum dolor sit <em>amet</em>',
+            'notifyUsager' => $notifyUsager,
+        ];
+
+        if (null !== $firstFile && null !== $lastFile) {
+            $payload['files'] = [$firstFile->getUuid(), $lastFile->getUuid()];
+        }
+        $this->client->request(
+            method: 'POST',
+            uri: $this->router->generate('api_signalements_suivis_post', ['uuid' => $signalementUuid]),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+        if ('0000' !== $signalementUuid) {
+            /** @var Suivi $suiviCreated */
+            $suiviCreated = $signalement->getSuivis()->last();
+
+            $this->assertEquals(201, $this->client->getResponse()->getStatusCode());
+            $this->assertEmailCount($nbMailSent);
+
+            $crawler = new Crawler($suiviCreated->getDescription());
+            $links = $crawler->filter('a.fr-link');
+            $this->assertCount(2, $links, 'Il doit y avoir exactement 2 liens dans le contenu HTML.');
+        } else {
+            $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        }
+    }
+
+    public function provideData(): \Generator
+    {
+        yield 'test create suivi with usager notification' => ['00000000-0000-0000-2022-000000000006', true, 2];
+        yield 'test create suivi with no usager notification' => ['00000000-0000-0000-2022-000000000006', false, 1, '00000000-0000-0000-2022-000000000006'];
+        yield 'test create suivi with unknown signalement' => ['0000', false, 1];
+    }
+}

--- a/tests/Unit/Validator/SanitizedLengthValidatorTest.php
+++ b/tests/Unit/Validator/SanitizedLengthValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Tests\Unit\Validator;
+
+use App\Validator\SanitizedLength;
+use App\Validator\SanitizedLengthValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class SanitizedLengthValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): SanitizedLengthValidator
+    {
+        return new SanitizedLengthValidator();
+    }
+
+    /**
+     * @dataProvider provideValidValues
+     */
+    public function testValueIsValid(mixed $value): void
+    {
+        $constraint = new SanitizedLength(10, 'Text too short.');
+        $this->validator->validate($value, $constraint);
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider provideInvalidValues
+     */
+    public function testSanitizedTextTooShort(string $value): void
+    {
+        $constraint = new SanitizedLength(10, 'Text too short.');
+        $this->validator->validate($value, $constraint);
+        $this->buildViolation('Text too short.')
+            ->setParameter('{{ limit }}', '10')
+            ->assertRaised();
+    }
+
+    public function provideValidValues(): \Generator
+    {
+        yield 'null value' => [null];
+        yield 'empty value' => [''];
+        yield 'valid value' => ['<p>Lorem ipsum dolor sit amet</p>'];
+    }
+
+    public function provideInvalidValues(): \Generator
+    {
+        yield 'too short value with no html' => ['Hi buddy!'];
+        yield 'too short value with html' => ['<b>Hi buddy!</b>'];
+    }
+
+    public function testNonStringThrowsException(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $constraint = new SanitizedLength(10, 'Text too short.');
+        $this->validator->validate(12345, $constraint);
+    }
+}


### PR DESCRIPTION
## Ticket

#3621   

## Description
![image](https://github.com/user-attachments/assets/7b630d33-a629-46fb-a5be-08654d00b514)
![image](https://github.com/user-attachments/assets/886fe09d-635e-4b8c-a799-6db45fb183a7)

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis
* Le signalement doit être affecté au partenaire
* Les fichiers doivent être rattaché au signalement

## Tests
- [ ] Créer un suivi sans fichier et vérifier que le suivi s'affiche dans la fiche signalement
- [ ] Créer un suivi avec fichiers (avec et sans balises html) et vérifier que le suivi s'affiche dans la fiche signalement avec les liens de fichiers
- [ ] Vérifier que les erreurs soient gérés (Signalement inexistant, fichiers inexistant, fichier n'appartenant pas au signalement, description trop courte)
- [ ] Vérifier que les envois de mail, notamment lorsque l'usager doit être notifié
