### PR TITLE
[BO - Signalement] Edition doc et etiquette pour les RT même si statut fermé

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -155,13 +155,11 @@ class SignalementController extends AbstractController
         $infoDesordres = $signalementDesordresProcessor->process($signalement);
 
         $canEditSignalement = false;
-        $canEditClosedSignalement = false;
         if (SignalementStatus::ACTIVE === $signalement->getStatut()) {
             $canEditSignalement = $this->isGranted('ROLE_ADMIN_TERRITORY') || $isAffectationAccepted;
         }
-        if (SignalementStatus::CLOSED === $signalement->getStatut() && $this->isGranted('ROLE_ADMIN_TERRITORY')) {
-            $canEditClosedSignalement = true;
-        }
+        $canEditClosedSignalement = SignalementStatus::CLOSED === $signalement->getStatut()
+            && $this->isGranted('ROLE_ADMIN_TERRITORY');
 
         $signalementQualificationNDE = $signalementQualificationRepository->findOneBy([
             'signalement' => $signalement,

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -155,10 +155,15 @@ class SignalementController extends AbstractController
         $infoDesordres = $signalementDesordresProcessor->process($signalement);
 
         $canEditSignalement = false;
+        $canEditClosedSignalement = false;
         if (SignalementStatus::ACTIVE === $signalement->getStatut()) {
             $canEditSignalement = $this->isGranted('ROLE_ADMIN')
                 || $this->isGranted('ROLE_ADMIN_TERRITORY')
                 || $isAffectationAccepted;
+        }
+        if (SignalementStatus::CLOSED === $signalement->getStatut()) {
+            $canEditClosedSignalement = $this->isGranted('ROLE_ADMIN')
+                || $this->isGranted('ROLE_ADMIN_TERRITORY');
         }
 
         $signalementQualificationNDE = $signalementQualificationRepository->findOneBy([
@@ -216,6 +221,7 @@ class SignalementController extends AbstractController
             'photos' => $infoDesordres['photos'],
             'criteres' => $infoDesordres['criteres'],
             'canEditSignalement' => $canEditSignalement,
+            'canEditClosedSignalement' => $canEditClosedSignalement,
             'canAnswerAffectation' => $canAnswerAffectation,
             'canCancelRefusedAffectation' => $canCancelRefusedAffectation,
             'canValidateOrRefuseSignalement' => $canValidateOrRefuseSignalement,

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -157,13 +157,10 @@ class SignalementController extends AbstractController
         $canEditSignalement = false;
         $canEditClosedSignalement = false;
         if (SignalementStatus::ACTIVE === $signalement->getStatut()) {
-            $canEditSignalement = $this->isGranted('ROLE_ADMIN')
-                || $this->isGranted('ROLE_ADMIN_TERRITORY')
-                || $isAffectationAccepted;
+            $canEditSignalement = $this->isGranted('ROLE_ADMIN_TERRITORY') || $isAffectationAccepted;
         }
-        if (SignalementStatus::CLOSED === $signalement->getStatut()) {
-            $canEditClosedSignalement = $this->isGranted('ROLE_ADMIN')
-                || $this->isGranted('ROLE_ADMIN_TERRITORY');
+        if (SignalementStatus::CLOSED === $signalement->getStatut() && $this->isGranted('ROLE_ADMIN_TERRITORY')) {
+            $canEditClosedSignalement = true;
         }
 
         $signalementQualificationNDE = $signalementQualificationRepository->findOneBy([

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Back;
 
 use App\Entity\Enum\DocumentType;
+use App\Entity\Enum\SignalementStatus;
 use App\Entity\File;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
@@ -123,7 +124,7 @@ class SignalementFileController extends AbstractController
         if (!\count($files)) {
             return $this->json(['success' => true]);
         }
-        if (Signalement::STATUS_CLOSED !== $signalement->getStatut()) {
+        if (SignalementStatus::CLOSED !== $signalement->getStatut()) {
             $suivi = $suiviManager->createInstanceForFilesSignalement($user, $signalement, $files);
             $entityManager->persist($suivi);
         }

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -123,9 +123,10 @@ class SignalementFileController extends AbstractController
         if (!\count($files)) {
             return $this->json(['success' => true]);
         }
-
-        $suivi = $suiviManager->createInstanceForFilesSignalement($user, $signalement, $files);
-        $entityManager->persist($suivi);
+        if (Signalement::STATUS_CLOSED !== $signalement->getStatut()) {
+            $suivi = $suiviManager->createInstanceForFilesSignalement($user, $signalement, $files);
+            $entityManager->persist($suivi);
+        }
 
         $update = $entityManager->createQueryBuilder()
             ->update(File::class, 'f')
@@ -139,6 +140,7 @@ class SignalementFileController extends AbstractController
         $update->execute();
 
         $entityManager->flush();
+
         $this->addFlash('success', 'Les documents ont bien été ajoutés.');
 
         return $this->json(['success' => true]);

--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -36,6 +36,9 @@ class FileVoter extends Voter
 
     private function canCreate(File $file, User $user): bool
     {
+        if (SignalementStatus::CLOSED === $file->getSignalement()->getStatut() && $this->isAdminOrRTonHisTerritory($file, $user)) {
+            return true;
+        }
         if (SignalementStatus::ACTIVE !== $file->getSignalement()->getStatut()) {
             return false;
         }

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -143,6 +143,9 @@ class SignalementVoter extends Voter
         if ($this->security->isGranted('ROLE_ADMIN')) {
             return true;
         }
+        if (SignalementStatus::CLOSED === $signalement->getStatut() && $user->isTerritoryAdmin() && $user->hasPartnerInTerritory($signalement->getTerritory())) {
+            return true;
+        }
         if (SignalementStatus::ACTIVE !== $signalement->getStatut()) {
             return false;
         }

--- a/templates/back/signalement/view/tags.html.twig
+++ b/templates/back/signalement/view/tags.html.twig
@@ -1,5 +1,5 @@
-{% if canEditSignalement %}
-    <button>
+{% if canEditSignalement or canEditClosedSignalement %}
+    <button class="keep-when-signalement-closed">
         <a class="fr-btn--icon-left fr-a-edit fr-icon-bookmark-line fr-ml-2v" id="tags_select_tooltip_btn" href="#"
         data-fr-opened="false" aria-controls="fr-modal-etiquettes">Gérer les étiquettes</a>
     </button>
@@ -91,12 +91,12 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-icon-check-line" form="form-signalement-save-tags" type="submit">
+                                <button class="fr-btn fr-icon-check-line keep-when-signalement-closed" form="form-signalement-save-tags" type="submit">
                                     Valider
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-etiquettes">
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line keep-when-signalement-closed" type="button" aria-controls="fr-modal-etiquettes">
                                     Annuler
                                 </button>
                             </li>


### PR DESCRIPTION
## Ticket

#3687    

## Description
Rendre possible pour les RT :
-     L'ajout / retrait d'étiquettes d'un signalement en statut fermé
-     L'ajout de documents d'un signalement fermé, sans création de notifications ni de notifications email


## Changements apportés
- Modification des voter SIGN_EDIT, FILE_CREATE et FILE_EDIT pour renvoyer true si le signalement est fermé mais que l'utilisateur est RT ou SA
- Modification du signalementFileController pour s'assurer qu'on ne crée pas de suivi (et donc pas de notification ou e-mail) si le signalement est fermé
- Modification du signalementController pour envoyer au twig un canEditClosedSignalement
- Modification du twig pour faire apparaitre le bouton de gestion des étiquettes (les boutons d'ajout de photos et documents apparaissaient déjà et fonctionnaient mais cela créait un signalement, parfois même visible à l'usager)


## Pré-requis

## Tests
- [ ] Tester en SA et en RT l'ajout d'étiquettes OK sur les signalements fermés et ouvert, et toujours KO sur signalements en attente et refusés
- [ ] Tester en utilisateur ajout d'étiquette OK que pour signalement ouvert
- [ ] Tester en SA et en RT l'ajout de photos et documents dans les différents statuts. Si signalement fermé, cela ne doit pas créer de suivi, ni d'e-mail, ni de notification
- [ ] Tester en utilisateur l'ajout de photos et documents ne doit être possible que pour les signalements ouverts
