### PR TITLE
[BUG] Controle à la modification d'un agent partenaire si dernier a recevoir les notification

### DIFF
--- a/src/DataFixtures/Files/Partner.yml
+++ b/src/DataFixtures/Files/Partner.yml
@@ -59,6 +59,12 @@ partners:
     territory: "Bouches-du-Rhône"
     type: "AUTRE"
   -
+    nom: "Partenaire 13-08"
+    email: ""
+    is_archive: 0
+    territory: "Bouches-du-Rhône"
+    type: "AUTRE"   
+  -
     nom: "Partenaire 01-01"
     email: "partenaire-01-01@histologe.fr"
     is_archive: 0

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -4,147 +4,126 @@ users:
     roles: "[\"ROLE_API_USER\"]"
     partner: "Partenaire 13-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: api-02@histologe.fr
     roles: "[\"ROLE_API_USER\"]"
     partner: "Alès Agglomération"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: admin-01@histologe.fr
     roles: "[\"ROLE_ADMIN\"]"
     partner: "Administrateurs Histologe ALL"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: admin-02@histologe.fr
     roles: "[\"ROLE_ADMIN\"]"
     partner: "Administrateurs Histologe ALL"
     statut: 2
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-03@histologe.fr
     roles: "[\"ROLE_ADMIN\"]"
     partner: "Administrateurs Histologe ALL"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: admin-territoire-13-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 13-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-13-02@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 13-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: admin-territoire-01-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 01-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: admin-territoire-63-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 63-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-89-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT 89"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-06-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 06-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-59-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 59-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-69-mdl@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "EMHA - Métropole de Lyon"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-69-cor@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "COR"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-69205-mdl@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Commune 69-03 MDL"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-69054-cor@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Commune 69-04 COR"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-69-05@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 69-05"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-69-06@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 69-06"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-partenaire-13-01@histologe.fr
     roles: "[\"ROLE_ADMIN_PARTNER\"]"
     partner: "Partenaire 13-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-partenaire-01-01@histologe.fr
     roles: "[\"ROLE_ADMIN_PARTNER\"]"
     partner: "Partenaire 01-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-13-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-02"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
     last_login_at: '-1 year'
   -
@@ -152,7 +131,6 @@ users:
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-03"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
     last_login_at: '-2 year'
   -
@@ -160,42 +138,36 @@ users:
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-04"
     statut: 0
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-13-04@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-03"
     statut: 0
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-13-05@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-05 ESABORA SCHS"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-13-06@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-06 ESABORA ARS"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-13-07@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-07"
     statut: 2
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-13-08@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-01"
     statut: 2
-    is_generique: 0
     is_mailing_active: 1
     anonymized: true
   -
@@ -203,36 +175,43 @@ users:
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-01"
     statut: 2
-    is_generique: 0
     is_mailing_active: 1
     last_login_at: '-2 year'
+  -
+    email: user-13-10@histologe.fr
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partner: "Partenaire 13-08"
+    statut: 1
+    is_mailing_active: 1
+  -
+    email: user-13-11@histologe.fr
+    roles: "[\"ROLE_USER_PARTNER\"]"
+    partner: "Partenaire 13-08"
+    statut: 0
+    is_mailing_active: 1
   -
     email: user-2A-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 2A-01"
     statut: 0
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-974-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 974-01"
     statut: 2
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-01-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-04"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-01-02@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
     statut: 0
-    is_generique: 0
     is_mailing_active: 1
     token: 00000000-0000-0000-0000-000000000001
   -
@@ -240,165 +219,141 @@ users:
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-01-04@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
     statut: 0
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-01-05@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
     statut: 0
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-01-06@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-02"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-01-06@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     statut: 2
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-01-07@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
     statut: 2
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-01-08@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-02"
     statut: 2
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-01-09@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
     statut: 2
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-01-10@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
     statut: 2
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-63-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ADIL 63"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-63-02@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ALF (OPAH)"
     statut: 0
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-63-03@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "API"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-63-04@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "CAF 63"
     statut: 0
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-89-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ADIL 89"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-89-02@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "CAF 89"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-89-03@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ARS 89"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-89-04@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Mairie de Tonnerre"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-unlinked@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: admin-territoire-38-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT 38"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: user-38-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 38-02"
     statut: 1
-    is_generique: 0
     is_mailing_active: 0
   -
     email: admin-territoire-62-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 62-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-62-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 62-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-93-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Mairie de Saint-Denis"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: usager-01@histologe.fr
     roles: "[\"ROLE_USAGER\"]"
     statut: 0
-    is_generique: 0
     is_mailing_active: 0
     last_login_at: '-5 year'
   -
@@ -406,35 +361,30 @@ users:
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT_M 972"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-972-01@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "DDT_M 972"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-972-02@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ARS 972"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-34-01@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire Zone Agde"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-territoire-34-02@histologe.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire Hors Zone Agde"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: admin-partenaire-multi-ter-13-01@histologe.fr
@@ -443,7 +393,6 @@ users:
       - "Partenaire 13-01"
       - "Partenaire 01-01"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-partenaire-multi-ter-34-30@histologe.fr
@@ -452,7 +401,6 @@ users:
       - "CAF 34"
       - "CAF 30"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-partenaire-30@histologe.fr
@@ -460,7 +408,6 @@ users:
     partners: 
       - "CAF 30"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
     has_permission_affectation: 1
   -
@@ -468,26 +415,22 @@ users:
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT Loire-Atlantique"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-44-02@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "SDIS 44"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-44-03@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Mairie de Saint-Mars du Désert"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1
   -
     email: user-44-04@histologe.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Cocoland"
     statut: 1
-    is_generique: 0
     is_mailing_active: 1

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -247,6 +247,23 @@ class Partner implements EntityHistoryInterface
         return $this;
     }
 
+    public function receiveEmailNotifications(?User $excludeUser = null): bool
+    {
+        if ($this->email) {
+            return true;
+        }
+        foreach ($this->getUsers() as $user) {
+            if ($excludeUser && $user->getId() === $excludeUser->getId()) {
+                continue;
+            }
+            if (User::STATUS_ACTIVE === $user->getStatut() && $user->getIsMailingActive()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function getEsaboraUrl(): ?string
     {
         return $this->esaboraUrl;

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -238,22 +238,8 @@ class PartnerType extends AbstractType
     public function validatePartnerCanBeNotified(mixed $value, ExecutionContextInterface $context)
     {
         if ($value instanceof Partner) {
-            $partner = $value;
-            $usersActive = $partner->getUsers()->filter(function (User $user) {
-                return User::STATUS_ACTIVE === $user->getStatut();
-            });
-
-            if (!empty($partner->getEmail()) || $usersActive->isEmpty()) {
-                return;
-            }
-
-            $canBeNotified = $usersActive->exists(function (int $i, User $user) {
-                return $user->getIsMailingActive();
-            });
-
-            if (!$canBeNotified) {
-                $context->addViolation('E-mail générique manquante: Il faut donc obligatoirement qu\'au moins
-                1 compte utilisateur accepte de recevoir les e-mails.');
+            if (!$value->receiveEmailNotifications()) {
+                $context->addViolation('E-mail générique manquant: Il faut obligatoirement qu\'un compte utilisateur accepte de recevoir les e-mails.');
             }
         }
     }

--- a/tests/Functional/Command/Cron/RemindInactiveUserCommandTest.php
+++ b/tests/Functional/Command/Cron/RemindInactiveUserCommandTest.php
@@ -22,7 +22,7 @@ class RemindInactiveUserCommandTest extends KernelTestCase
         $commandTester->assertCommandIsSuccessful();
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('8 users has been notified', $output);
-        $this->assertEmailCount(9);
+        $this->assertStringContainsString('9 users has been notified', $output);
+        $this->assertEmailCount(10);
     }
 }

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -34,14 +34,14 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserList(): iterable
     {
-        yield 'Search without params' => [[], 59];
+        yield 'Search without params' => [[], 61];
         yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 21];
-        yield 'Search with territory 13' => [['territory' => 13], 11];
+        yield 'Search with territory 13' => [['territory' => 13], 13];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];
-        yield 'Search with status 0' => [['statut' => 0], 8];
+        yield 'Search with status 0' => [['statut' => 0], 9];
         yield 'Search with role ROLE_ADMIN' => [['role' => 'ROLE_ADMIN'], 3];
         yield 'Search with role ROLE_ADMIN and territory 13' => [['role' => 'ROLE_ADMIN', 'territory' => 13], 0];
-        yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 9];
+        yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 11];
         yield 'Search with territory 13 and partnerType Ars' => [['territory' => 13, 'partnerType' => 'ARS'], 1];
     }
 
@@ -67,13 +67,13 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserExport(): iterable
     {
-        yield 'Search without params' => [[], 11];
-        yield 'Search with queryUser user' => [['queryUser' => 'user'], 6];
+        yield 'Search without params' => [[], 13];
+        yield 'Search with queryUser user' => [['queryUser' => 'user'], 8];
         yield 'Search with partner 6 and 7' => [['partners' => [2]], 5];
-        yield 'Search with status 1' => [['statut' => 1], 9];
-        yield 'Search with role ROLE_USER_PARTNER' => [['role' => 'ROLE_USER_PARTNER'], 6];
-        yield 'Search with role ROLE_USER_PARTNER and status 1' => [['role' => 'ROLE_USER_PARTNER', 'statut' => 1], 4];
-        yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 11];
+        yield 'Search with status 1' => [['statut' => 1], 10];
+        yield 'Search with role ROLE_USER_PARTNER' => [['role' => 'ROLE_USER_PARTNER'], 8];
+        yield 'Search with role ROLE_USER_PARTNER and status 1' => [['role' => 'ROLE_USER_PARTNER', 'statut' => 1], 5];
+        yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 13];
         yield 'Search with partnerType Ars' => [['partnerType' => 'ARS'], 1];
     }
 }

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -115,7 +115,7 @@ class SignalementManagerTest extends WebTestCase
         $this->assertArrayHasKey('not_affected', $partners);
 
         $this->assertCount(1, $partners['affected'], 'One partner should be affected');
-        $this->assertCount(5, $partners['not_affected'], 'Five partners should not be affected');
+        $this->assertCount(6, $partners['not_affected'], 'Five partners should not be affected');
     }
 
     public function testCloseSignalementForAllPartners()

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -46,7 +46,7 @@ class PartnerRepositoryTest extends KernelTestCase
         $signalement = $signalementRepository->findOneBy(['reference' => '2022-1']);
 
         $partners = $this->partnerRepository->findByLocalization($signalement, false);
-        $this->assertCount(5, $partners);
+        $this->assertCount(6, $partners);
     }
 
     public function testFindPossiblePartnersForCOR69(): void

--- a/tests/Functional/Repository/UserRepositoryTest.php
+++ b/tests/Functional/Repository/UserRepositoryTest.php
@@ -29,7 +29,7 @@ class UserRepositoryTest extends KernelTestCase
         $users = $userRepository->findInactiveWithNbAffectationPending();
 
         $this->assertIsArray($users);
-        $this->assertCount(8, $users);
+        $this->assertCount(9, $users);
         foreach ($users as $user) {
             $this->assertArrayHasKey('email', $user);
             if (!empty($user['signalements'])) {


### PR DESCRIPTION
## Ticket

#3688

## Description
A la modification de l'agent d'un partenaire, il n'y avais pas/plus de controle bloquant l'action si il s'agit du dernier agent ayant les notification email activé sur un partenaire sans adresse email générique. Je n'ai pas réussi à retrouver si le contrôle était effectué auparavant.

## Changements apportés
- Ajout du contrôle à la modification d'un utilisateur
- Ajout du contrôle au transfert d'un utilisateur
- Ajout du contrôle à la suppression d'un utilisateur
- Ajout de tests sur chacun des cas

## Tests
- [ ] Vérifier que l'on ne peux pas se retrouver avec un partenaire sans email et sans agent actifs notifiés
