### PR TITLE
[Notifications] Ne pas envoyer à l'utilisateur qui a créé un suivi

### DIFF
--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -109,7 +109,7 @@ class NotificationAndMailSender
     private function createInAppNotifications(ArrayCollection $recipients)
     {
         foreach ($recipients as $user) {
-            if ($user instanceof User) {
+            if ($user instanceof User && $user !== $this->suivi->getCreatedBy()) {
                 $this->createInAppNotification($user);
             }
         }

--- a/tests/Functional/EventSubscriber/SignalementViewedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementViewedSubscriberTest.php
@@ -4,13 +4,13 @@ namespace App\Tests\Functional\EventSubscriber;
 
 use App\Entity\Notification;
 use App\Entity\Signalement;
-use App\Entity\User;
 use App\Event\SignalementViewedEvent;
 use App\EventSubscriber\SignalementViewedSubscriber;
 use App\Manager\SignalementManager;
 use App\Service\DataGouv\AddressService;
 use App\Service\DataGouv\Response\Address;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -44,16 +44,17 @@ class SignalementViewedSubscriberTest extends KernelTestCase
             ->setGeoloc([])
             ->setCpOccupant(null);
 
-        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'admin-01@histologe.fr']);
-        $signalementViewedEvent = new SignalementViewedEvent($signalement, $user);
-
         /** @var Notification $notification */
         $notification = $this->entityManager->getRepository(Notification::class)->findOneBy(['signalement' => $signalement]);
         $isSeenBefore = $notification->getIsSeen();
         $this->assertFalse($isSeenBefore);
 
+        $user = $notification->getUser();
+        $signalementViewedEvent = new SignalementViewedEvent($signalement, $user);
+
         $addressResult = json_decode(file_get_contents(__DIR__.'/../../files/datagouv/get_api_ban_item_response_13203.json'), true);
         $address = new Address($addressResult);
+        /** @var MockObject&AddressService $addressServiceMock */
         $addressServiceMock = $this->createMock(AddressService::class);
         $this->signalementManager = static::getContainer()->get(SignalementManager::class);
 

--- a/tests/Functional/Service/Notification/NotificationCounterTest.php
+++ b/tests/Functional/Service/Notification/NotificationCounterTest.php
@@ -27,6 +27,6 @@ class NotificationCounterTest extends KernelTestCase
 
         $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
         $notificationCount = (new NotificationCounter($notificationRepository))->countUnseenNotification($user);
-        $this->assertEquals(9, $notificationCount);
+        $this->assertEquals(8, $notificationCount);
     }
 }


### PR DESCRIPTION
## Ticket

#3626    

## Description
Quand un utilisateur créé un suivi, il ne doit pas avoir de notifications, mais les autres personnes de son partenaire si.

## Changements apportés
* Modification de NotificationAndMailSender

## Pré-requis

## Tests
- [ ] Se connecter avec un utilisateur qui n'est pas tout seul dans son partenaire
- [ ] Faire un suivi, vérifier qu'il n'a pas de notif
- [ ] Vérifier que les autres utilisateurs de son partenaire et les autres partenaires ont bien la notif
