### PR TITLE
[Tech] Optimisations

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@
 APP_ENV=dev
 APP_SECRET=
 MAILER_DSN=smtp://histologe_mailer:1025
-DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=8.0.40&charset=utf8"
+DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_7589?serverVersion=8.0.40&charset=utf8"
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 
 ###> knplabs/knp-snappy-bundle ###

--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@
 APP_ENV=dev
 APP_SECRET=
 MAILER_DSN=smtp://histologe_mailer:1025
-DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_7589?serverVersion=8.0.40&charset=utf8"
+DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=8.0.40&charset=utf8"
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 
 ###> knplabs/knp-snappy-bundle ###

--- a/migrations/Version20250214125623.php
+++ b/migrations/Version20250214125623.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250214125623 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index for cp_occupant column in signalement table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_signalement_cp_occupant ON signalement (cp_occupant)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_signalement_cp_occupant ON signalement');
+    }
+}

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -14,6 +14,7 @@ use App\Form\ClotureType;
 use App\Manager\AffectationManager;
 use App\Manager\SignalementManager;
 use App\Repository\AffectationRepository;
+use App\Repository\CritereRepository;
 use App\Repository\CriticiteRepository;
 use App\Repository\DesordreCategorieRepository;
 use App\Repository\DesordreCritereRepository;
@@ -21,6 +22,7 @@ use App\Repository\DesordrePrecisionRepository;
 use App\Repository\InterventionRepository;
 use App\Repository\NotificationRepository;
 use App\Repository\SignalementQualificationRepository;
+use App\Repository\SituationRepository;
 use App\Repository\TagRepository;
 use App\Repository\ZoneRepository;
 use App\Security\Voter\AffectationVoter;
@@ -58,10 +60,14 @@ class SignalementController extends AbstractController
         DesordreCategorieRepository $desordreCategorieRepository,
         DesordreCritereRepository $desordreCritereRepository,
         ZoneRepository $zoneRepository,
+        SituationRepository $situationRepository,
+        CritereRepository $critereRepository,
     ): Response {
         // load desordres data to prevent n+1 queries
         $desordreCategorieRepository->findAll();
         $desordreCritereRepository->findAll();
+        $situationRepository->findAll();
+        $critereRepository->findAll();
         /** @var User $user */
         $user = $this->getUser();
         if (SignalementStatus::ARCHIVED === $signalement->getStatut()) {

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -60,7 +60,6 @@ class HomepageController extends AbstractController
             return $stats;
         });
 
-
         $displayModal = '';
 
         $form = $this->createForm(PostalCodeSearchType::class, []);

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -34,6 +34,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Index(columns: ['is_imported'], name: 'idx_signalement_is_imported')]
 #[ORM\Index(columns: ['uuid'], name: 'idx_signalement_uuid')]
 #[ORM\Index(columns: ['code_suivi'], name: 'idx_signalement_code_suivi')]
+#[ORM\Index(columns: ['cp_occupant'], name: 'idx_signalement_cp_occupant')]
 class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInterface
 {
     #[ORM\Id]

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -307,4 +307,16 @@ class PartnerRepository extends ServiceEntityRepository
         $sql = 'UPDATE partner SET nom = TRIM(REPLACE(nom, UNHEX("C2A0"), " "))';
         $connection->prepare($sql)->executeStatement();
     }
+
+    public function getWithUserPartners(Partner $partner): Partner
+    {
+        return $this->createQueryBuilder('p')
+        ->select('p', 'up', 'u')
+        ->leftJoin('p.userPartners', 'up')
+        ->leftJoin('up.user', 'u')
+        ->where('p.id = :partner')
+        ->setParameter('partner', $partner)
+        ->getQuery()
+        ->getOneOrNullResult();
+    }
 }

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -64,12 +64,12 @@ class NotificationAndMailSender
         $territory = $this->signalement->getTerritory();
         $recipientsEmail = $this->getRecipientsAdmin($territory);
         $recipientsNotifications = $this->getRecipientsAdmin($territory);
-
         foreach ($this->signalement->getAffectations() as $affectation) {
             if (AffectationStatus::STATUS_WAIT->value === $affectation->getStatut()
                     || AffectationStatus::STATUS_ACCEPTED->value === $affectation->getStatut()) {
-                $partnerRecipientsFiltered = $this->getRecipientsPartner($affectation->getPartner());
-                $partnerRecipients = $this->getRecipientsPartner($affectation->getPartner(), false);
+                $partner = $this->partnerRepository->getWithUserPartners($affectation->getPartner());
+                $partnerRecipientsFiltered = $this->getRecipientsPartner($partner);
+                $partnerRecipients = $this->getRecipientsPartner($partner, false);
                 $recipientsEmail = new ArrayCollection(
                     array_merge($recipientsEmail->toArray(), $partnerRecipientsFiltered->toArray())
                 );
@@ -78,7 +78,6 @@ class NotificationAndMailSender
                 );
             }
         }
-
         $this->sendMail($recipientsEmail, $mailerType);
         $this->createInAppNotifications(
             recipients: $recipientsNotifications,


### PR DESCRIPTION
## Ticket

#3711

## Description
Quelques optimisations mineures pour régler une partie des alertes "bleues" qui remonte le plus souvent sur sentry

## Changements apportés
* Ajout d'un index sur la colonne cp_occupant du signalement. Permet d'accélerer d'un facteur 100 la requête de vérification de l'existence de doublon (draft =>signalement). Voir test sur une boucle lancant 50 de ses requêtes : 
![1_x50_v1](https://github.com/user-attachments/assets/0e43fecb-df65-4407-a40c-74b676b8bce5)
![1_x50_v2](https://github.com/user-attachments/assets/3c457021-d070-4106-a921-7bee66e9e900)

* Préchargement de la liste de situations et critères à la visualisation d'un signalement BO afin d'éviter de les requeter unitairement
![signalement_view_v1](https://github.com/user-attachments/assets/3d726ad6-4a4f-45cd-aa98-c2aae8d08e57)
![signalement_view_v2](https://github.com/user-attachments/assets/68e11941-f3f4-4933-a91f-eacdf8f4e08a)

* Mise en cache (15 minutes) du total de signalement pour les stats sur la homepage (la requête commence a ralentir, et on a pas besoin de temps réel)

* Lors de la création/envoie de notifications suite à l'ajout d'un suivi (depuis BO ou FO) récupération de la liste des UserPartner et Partner d'un partenaire pour éviter de faire des reqûetes unitaire 
![add_suivi_n1_v1 png](https://github.com/user-attachments/assets/95ed9121-9c28-4d54-a5f8-f313dac088c4)
![add_suivi_n1_v2](https://github.com/user-attachments/assets/5c7e4367-215d-4871-9e57-6715924accf7)

## Pré-requis
`execute-migration name=Version20250214125623 direction=up`

## Tests
- [ ] Vérifier que rien est cassé
- [ ] Si vous voulez vérifier certains points, se mettre sur copie de base de prod pour être en conditions réelles


