### PR TITLE
[BO - Signalement] Suppression de document sur signalement fermé pour RT

### DIFF
--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -174,7 +174,7 @@ class SignalementFileController extends AbstractController
             $filename = $file->getFilename();
             $type = $file->getFileType();
             if ($uploadHandlerService->deleteFile($file)) {
-                if (!$this->isGranted('ROLE_ADMIN')) {
+                if (!$this->isGranted('ROLE_ADMIN') && SignalementStatus::CLOSED !== $signalement->getStatut()) {
                     /** @var User $user */
                     $user = $this->getUser();
                     $description = $user->getNomComplet().' a supprimé ';

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -42,9 +42,15 @@
                                 <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-1w ">
                                     <p>Pour ajouter des documents concernant la procédure ou le bailleur, rendez-vous dans l'onglet "Documents".</p>
                                 </div>
-                                <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
-                                    <p>Ces documents seront partagés à l'usager.</p>
-                                </div>
+                                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}   
+                                    <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
+                                        <p>Ces documents seront visibles sur la fiche de suivi usager.</p>
+                                    </div>
+                                {% else %}
+                                    <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
+                                        <p>Ces documents seront partagés à l'usager.</p>
+                                    </div>
+                                {% endif %}
                             </div>
                         </div>
                         <div class="type-conditional type-photo">
@@ -54,9 +60,15 @@
                             <div>
                                 Ajouter une ou plusieurs photos au signalement. Pour chaque photo, veuillez sélectionner le désordre auquel elle est rattachée. 
                             </div>
-                            <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
-                                <p>Ces photos seront partagées à l'usager.</p>
-                            </div>
+                            {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}                                
+                                <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
+                                    <p>Ces photos seront visibles sur la fiche de suivi usager.</p>
+                                </div>
+                            {% else %}                            
+                                <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-1w ">
+                                    <p>Ces photos seront partagées à l'usager.</p>
+                                </div>
+                            {% endif %}
                         </div>
                         <div class="modal-upload-upload-container fr-mb-4w">
                             <div class="modal-upload-drop-section">


### PR DESCRIPTION
## Ticket

#3712    

## Description
Suite de https://github.com/MTES-MCT/histologe/pull/3705
Il ne faut pas créer non plus de suivi quand on supprime un fichier sur un signalement fermé.
Et on change le message d'alerte sur les modales d'uploads

## Changements apportés
* Changement de SignalementFileController
* Changement de _modal_upload_files.html.twig

## Pré-requis

## Tests
- [ ] En tant que RT, supprimer un fichier sur un signalement fermé et vérifier qu'il n'y a pas de suivi
- [ ] Vérifier les messages sur les modales d'upload
