### PR TITLE
[Suivis] Refactorisation de l'envoi de mail pour l'acceptation, le refus et la fermeture des signalements

### DIFF
--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -14,6 +14,7 @@ use App\Manager\SuiviManager;
 use App\Repository\AffectationRepository;
 use App\Repository\SuiviRepository;
 use App\Service\BetaGouv\RnbService;
+use App\Service\Sanitizer;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -14,10 +14,6 @@ use App\Manager\SuiviManager;
 use App\Repository\AffectationRepository;
 use App\Repository\SuiviRepository;
 use App\Service\BetaGouv\RnbService;
-use App\Service\Mailer\NotificationMail;
-use App\Service\Mailer\NotificationMailerRegistry;
-use App\Service\Mailer\NotificationMailerType;
-use App\Service\Sanitizer;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
@@ -36,29 +32,18 @@ class SignalementActionController extends AbstractController
     public function validationResponseSignalement(
         Signalement $signalement,
         Request $request,
-        NotificationMailerRegistry $notificationMailerRegistry,
         SuiviManager $suiviManager,
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_VALIDATE', $signalement);
         if ($this->isCsrfTokenValid('signalement_validation_response_'.$signalement->getId(), $request->get('_token'))
-            && $response = $request->get('signalement-validation-response')) {
+                && $response = $request->get('signalement-validation-response')) {
             if (isset($response['accept'])) {
+                $suiviContext = Suivi::CONTEXT_SIGNALEMENT_ACCEPTED;
                 $statut = SignalementStatus::ACTIVE;
                 $description = 'validé';
                 $signalement->setValidatedAt(new \DateTimeImmutable());
-                $toRecipients = $signalement->getMailUsagers();
-
-                foreach ($toRecipients as $toRecipient) {
-                    $notificationMailerRegistry->send(
-                        new NotificationMail(
-                            type: NotificationMailerType::TYPE_SIGNALEMENT_VALIDATION_TO_USAGER,
-                            to: $toRecipient,
-                            territory: $signalement->getTerritory(),
-                            signalement: $signalement,
-                        )
-                    );
-                }
             } else {
+                $suiviContext = Suivi::CONTEXT_SIGNALEMENT_REFUSED;
                 $statut = SignalementStatus::REFUSED;
                 $motifRefus = MotifRefus::tryFrom($response['motifRefus']);
                 if (!$motifRefus || mb_strlen($response['suivi']) < 10) {
@@ -68,17 +53,6 @@ class SignalementActionController extends AbstractController
                 }
                 $signalement->setMotifRefus($motifRefus);
                 $description = 'fermé car non-valide avec le motif suivant : '.$motifRefus->label().'<br>Plus précisément :<br>'.$response['suivi'];
-
-                $toRecipients = $signalement->getMailUsagers();
-                $notificationMailerRegistry->send(
-                    new NotificationMail(
-                        type: NotificationMailerType::TYPE_SIGNALEMENT_REFUSAL_TO_USAGER,
-                        to: $toRecipients,
-                        territory: $signalement->getTerritory(),
-                        signalement: $signalement,
-                        motif: $response['suivi'],
-                    )
-                );
             }
             /** @var User $user */
             $user = $this->getUser();
@@ -90,7 +64,8 @@ class SignalementActionController extends AbstractController
                 description: 'Signalement '.$description,
                 type : Suivi::TYPE_AUTO,
                 isPublic: true,
-                sendMail: false
+                sendMail: true,
+                context: $suiviContext,
             );
 
             $this->addFlash('success', 'Statut du signalement mis à jour avec succès !');

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -18,9 +18,10 @@ class Suivi implements EntityHistoryInterface
     public const TYPE_PARTNER = 3;
     public const TYPE_TECHNICAL = 4;
     public const TYPE_USAGER_POST_CLOTURE = 5;
-    public const string CONTEXT_NOTIFY_USAGER_ONLY = 'notifyUsagerOnly';
+    public const CONTEXT_NOTIFY_USAGER_ONLY = 'notifyUsagerOnly';
     public const CONTEXT_INTERVENTION = 'intervention';
     public const CONTEXT_SCHS = 'schs';
+    public const CONTEXT_SIGNALEMENT_CLOSED = 'signalementClosed';
 
     public const DEFAULT_PERIOD_INACTIVITY = 30;
     public const DEFAULT_PERIOD_RELANCE = 45;

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -13,28 +13,28 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['signalement_id', 'type', 'created_at'], name: 'idx_suivi_signalement_type_created_at')]
 class Suivi implements EntityHistoryInterface
 {
-    public const TYPE_AUTO = 1;
-    public const TYPE_USAGER = 2;
-    public const TYPE_PARTNER = 3;
-    public const TYPE_TECHNICAL = 4;
-    public const TYPE_USAGER_POST_CLOTURE = 5;
-    public const CONTEXT_NOTIFY_USAGER_ONLY = 'notifyUsagerOnly';
-    public const CONTEXT_INTERVENTION = 'intervention';
-    public const CONTEXT_SCHS = 'schs';
-    public const CONTEXT_SIGNALEMENT_ACCEPTED = 'signalementAccepted';
-    public const CONTEXT_SIGNALEMENT_REFUSED = 'signalementRefused';
-    public const CONTEXT_SIGNALEMENT_CLOSED = 'signalementClosed';
+    public const int TYPE_AUTO = 1;
+    public const int TYPE_USAGER = 2;
+    public const int TYPE_PARTNER = 3;
+    public const int TYPE_TECHNICAL = 4;
+    public const int TYPE_USAGER_POST_CLOTURE = 5;
+    public const string CONTEXT_NOTIFY_USAGER_ONLY = 'notifyUsagerOnly';
+    public const string CONTEXT_INTERVENTION = 'intervention';
+    public const string CONTEXT_SCHS = 'schs';
+    public const string CONTEXT_SIGNALEMENT_ACCEPTED = 'signalementAccepted';
+    public const string CONTEXT_SIGNALEMENT_REFUSED = 'signalementRefused';
+    public const string CONTEXT_SIGNALEMENT_CLOSED = 'signalementClosed';
 
-    public const DEFAULT_PERIOD_INACTIVITY = 30;
-    public const DEFAULT_PERIOD_RELANCE = 45;
+    public const int DEFAULT_PERIOD_INACTIVITY = 30;
+    public const int DEFAULT_PERIOD_RELANCE = 45;
 
-    public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été fermé pour tous';
-    public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été fermé pour';
-    public const DESCRIPTION_SIGNALEMENT_VALIDE = 'Signalement validé';
-    public const DESCRIPTION_DELETED = 'Ce suivi a été supprimé par un administrateur le ';
+    public const string DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été fermé pour tous';
+    public const string DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été fermé pour';
+    public const string DESCRIPTION_SIGNALEMENT_VALIDE = 'Signalement validé';
+    public const string DESCRIPTION_DELETED = 'Ce suivi a été supprimé par un administrateur le ';
 
-    public const ARRET_PROCEDURE = 'arret-procedure';
-    public const POURSUIVRE_PROCEDURE = 'poursuivre-procedure';
+    public const string ARRET_PROCEDURE = 'arret-procedure';
+    public const string POURSUIVRE_PROCEDURE = 'poursuivre-procedure';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -21,6 +21,8 @@ class Suivi implements EntityHistoryInterface
     public const CONTEXT_NOTIFY_USAGER_ONLY = 'notifyUsagerOnly';
     public const CONTEXT_INTERVENTION = 'intervention';
     public const CONTEXT_SCHS = 'schs';
+    public const CONTEXT_SIGNALEMENT_ACCEPTED = 'signalementAccepted';
+    public const CONTEXT_SIGNALEMENT_REFUSED = 'signalementRefused';
     public const CONTEXT_SIGNALEMENT_CLOSED = 'signalementClosed';
 
     public const DEFAULT_PERIOD_INACTIVITY = 30;

--- a/src/EventSubscriber/SignalementClosedSubscriber.php
+++ b/src/EventSubscriber/SignalementClosedSubscriber.php
@@ -2,22 +2,17 @@
 
 namespace App\EventSubscriber;
 
-use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
 use App\Event\SignalementClosedEvent;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
-use App\Service\Mailer\NotificationMail;
-use App\Service\Mailer\NotificationMailerRegistry;
-use App\Service\Mailer\NotificationMailerType;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 readonly class SignalementClosedSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private NotificationMailerRegistry $notificationMailerRegistry,
         private SignalementManager $signalementManager,
         private SuiviManager $suiviManager,
         private Security $security,
@@ -37,55 +32,19 @@ readonly class SignalementClosedSubscriber implements EventSubscriberInterface
         $params = $event->getParams();
         /** @var User $user */
         $user = $this->security->getUser();
+        $signalement->setClosedBy($user);
+
         $suivi = $this->suiviManager->createSuivi(
             signalement: $signalement,
             description: SuiviManager::buildDescriptionClotureSignalement($params),
             type: Suivi::TYPE_PARTNER,
             isPublic: '1' == $params['suivi_public'],
             user: $user,
+            context: Suivi::CONTEXT_SIGNALEMENT_CLOSED,
         );
 
-        $signalement
-            ->setClosedBy($user)
-            ->addSuivi($suivi);
-
-        if ('1' == $params['suivi_public']) {
-            $this->sendMailToUsager($signalement);
-        }
-        $this->sendMailToPartners($signalement);
+        $signalement->addSuivi($suivi);
 
         $this->signalementManager->save($signalement);
-    }
-
-    private function sendMailToUsager(Signalement $signalement): void
-    {
-        $toRecipients = $signalement->getMailUsagers();
-        foreach ($toRecipients as $toRecipient) {
-            $this->notificationMailerRegistry->send(
-                new NotificationMail(
-                    type: NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_USAGER,
-                    to: [$toRecipient],
-                    territory: $signalement->getTerritory(),
-                    signalement: $signalement
-                )
-            );
-        }
-    }
-
-    private function sendMailToPartners(Signalement $signalement): void
-    {
-        $sendTo = $this->signalementManager->findEmailsAffectedToSignalement($signalement);
-        if (empty($sendTo)) {
-            return;
-        }
-
-        $this->notificationMailerRegistry->send(
-            new NotificationMail(
-                type: NotificationMailerType::TYPE_SIGNALEMENT_CLOSED_TO_PARTNERS,
-                to: $sendTo,
-                territory: $signalement->getTerritory(),
-                signalement: $signalement
-            )
-        );
     }
 }

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -37,17 +37,23 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
         }
 
         if (Suivi::CONTEXT_NOTIFY_USAGER_ONLY !== $suivi->getContext()) {
-            $this->notificationAndMailSender->sendNewSuiviToAdminsAndPartners(
-                suivi: $suivi,
-                sendEmail: (SignalementStatus::CLOSED !== $suivi->getSignalement()->getStatut())
-            );
+            if (Suivi::CONTEXT_SIGNALEMENT_CLOSED === $suivi->getContext()) {
+                $this->notificationAndMailSender->sendSignalementIsClosedToPartners($suivi);
+            } else {
+                $this->notificationAndMailSender->sendNewSuiviToAdminsAndPartners(
+                    suivi: $suivi,
+                    sendEmail: (SignalementStatus::CLOSED !== $suivi->getSignalement()->getStatut())
+                );
+            }
         }
 
-        if ($suivi->getSendMail()
-                && $suivi->getIsPublic()
-                && SignalementStatus::CLOSED !== $suivi->getSignalement()->getStatut()
-                && SignalementStatus::REFUSED !== $suivi->getSignalement()->getStatut()) {
-            $this->notificationAndMailSender->sendNewSuiviToUsagers($suivi);
+        if ($suivi->getSendMail() && $suivi->getIsPublic()) {
+            if (Suivi::CONTEXT_SIGNALEMENT_CLOSED === $suivi->getContext()) {
+                $this->notificationAndMailSender->sendSignalementIsClosedToUsager($suivi);
+            } elseif (SignalementStatus::CLOSED !== $suivi->getSignalement()->getStatut()
+                        && SignalementStatus::REFUSED !== $suivi->getSignalement()->getStatut()) {
+                $this->notificationAndMailSender->sendNewSuiviToUsagers($suivi);
+            }
         }
     }
 }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -236,24 +236,6 @@ class SignalementManager extends AbstractManager
         return $signalement;
     }
 
-    public function findEmailsAffectedToSignalement(Signalement $signalement): array
-    {
-        $sendTo = [];
-        /** @var SignalementRepository $signalementRepository */
-        $signalementRepository = $this->getRepository();
-
-        $usersPartnerEmail = $signalementRepository->findUsersPartnerEmailAffectedToSignalement(
-            $signalement->getId(),
-        );
-        $sendTo = array_merge($sendTo, $usersPartnerEmail);
-
-        $partnersEmail = $signalementRepository->findPartnersEmailAffectedToSignalement(
-            $signalement->getId()
-        );
-
-        return array_merge($sendTo, $partnersEmail);
-    }
-
     public function findUsersAffectedToSignalement(
         Signalement $signalement,
         AffectationStatus $statusAffectation,

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -752,26 +752,6 @@ class SignalementRepository extends ServiceEntityRepository
         return $usersEmail;
     }
 
-    public function findPartnersEmailAffectedToSignalement(int $signalementId): array
-    {
-        $queryBuilder = $this->createQueryBuilder('s');
-        $queryBuilder
-            ->select('p.email')
-            ->innerJoin('s.affectations', 'a')
-            ->innerJoin('a.partner', 'p')
-            ->where('s.id = :signalement_id')
-            ->setParameter('signalement_id', $signalementId);
-
-        $partnersEmail = [];
-        foreach ($queryBuilder->getQuery()->getArrayResult() as $value) {
-            if ($value['email'] && !\in_array($value['email'], $partnersEmail)) {
-                $partnersEmail[] = $value['email'];
-            }
-        }
-
-        return $partnersEmail;
-    }
-
     public function getAverageCriticite(
         ?Territory $territory,
         ?ArrayCollection $partners,

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -199,8 +199,9 @@ class NotificationAndMailSender
             if (!$isFilteredAffectationStatus
                     || AffectationStatus::STATUS_WAIT->value === $affectation->getStatut()
                     || AffectationStatus::STATUS_ACCEPTED->value === $affectation->getStatut()) {
-                $partnerRecipientsMailItem = $this->getRecipientsPartner($affectation->getPartner());
-                $partnerRecipientsInAppNotifItem = $this->getRecipientsPartner($affectation->getPartner(), false);
+                $partner = $this->partnerRepository->getWithUserPartners($affectation->getPartner());
+                $partnerRecipientsMailItem = $this->getRecipientsPartner($partner);
+                $partnerRecipientsInAppNotifItem = $this->getRecipientsPartner($partner, false);
                 $partnerRecipientsMail = new ArrayCollection(
                     array_merge($partnerRecipientsMail->toArray(), $partnerRecipientsMailItem->toArray())
                 );

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -86,6 +86,20 @@ class NotificationAndMailSender
         $this->sendMailToUsagers(NotificationMailerType::TYPE_NEW_COMMENT_FRONT_TO_USAGER);
     }
 
+    public function sendSignalementIsAcceptedToUsager(Suivi $suivi): void
+    {
+        $this->suivi = $suivi;
+        $this->signalement = $suivi->getSignalement();
+        $this->sendMailToUsagers(NotificationMailerType::TYPE_SIGNALEMENT_VALIDATION_TO_USAGER);
+    }
+
+    public function sendSignalementIsRefusedToUsager(Suivi $suivi, string $motif): void
+    {
+        $this->suivi = $suivi;
+        $this->signalement = $suivi->getSignalement();
+        $this->sendMailToUsagers(NotificationMailerType::TYPE_SIGNALEMENT_REFUSAL_TO_USAGER, $motif);
+    }
+
     public function sendSignalementIsClosedToUsager(Suivi $suivi): void
     {
         $this->suivi = $suivi;
@@ -123,7 +137,7 @@ class NotificationAndMailSender
         $this->entityManager->persist($notification);
     }
 
-    private function sendMailToUsagers(NotificationMailerType $mailType): void
+    private function sendMailToUsagers(NotificationMailerType $mailType, ?string $motif = null): void
     {
         $recipients = new ArrayCollection($this->signalement->getMailUsagers());
         if (!$recipients->isEmpty()) {
@@ -136,6 +150,7 @@ class NotificationAndMailSender
                         territory: $this->signalement->getTerritory(),
                         signalement: $this->signalement,
                         suivi: $this->suivi,
+                        motif: $motif,
                     )
                 );
             }

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -143,16 +143,6 @@ class SignalementManagerTest extends WebTestCase
         $this->assertTrue($signalementHasAllAffectationsClosed);
     }
 
-    public function testFindEmailsAffectedToSignalement()
-    {
-        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-
-        $signalement = $signalementRepository->findOneBy(['statut' => SignalementStatus::ACTIVE->value]);
-        $emails = $this->signalementManager->findEmailsAffectedToSignalement($signalement);
-
-        $this->assertGreaterThan(1, \count($emails));
-    }
-
     public function testCreateSignalement(): void
     {
         $territoryRepository = $this->entityManager->getRepository(Territory::class);


### PR DESCRIPTION
## Ticket

#3681   

## Description
Suite à la suppression de l'ActivityListener, refactorisation de l'envoi de mail lors de l'acceptation, le refus ou la fermeture de signalements.
Les mails étaient envoyés jusqu'à présent dans des événements.
On les envoie dans l'événement de création de suivi, comme pour les autres mails.

## TNR
- [ ] Mail admin/partenaire lorsqu'un **signalement est déposé**
- [ ] Mail admin/partenaire lorsqu'un **signalement est affecté**
- [ ] Mails et notifications admin/partenaires et usagers lors d'un **suivi sur un signalement**
- [ ] Mails et notifications admin/partenaires lors d'un **suivi sans notifier l'usager sur un signalement**
- [ ] Mail usagers lorsqu'un **signalement est accepté**
- [ ] Mail usagers lorsqu'un **signalement est refusé**
- [ ] Mails et notifications partenaires et usagers lorsqu'un **signalement est fermé** 
