### PR TITLE
[Notifications E-mails] Partenaires en copie cachée quand destinataires du même mail

### DIFF
--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -68,7 +68,11 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
 
         foreach ($notificationMail->getEmails() as $email) {
             try {
-                $email && $message->addTo($email);
+                if ($notificationMail->isRecipientVisible()) {
+                    $email && $message->addTo($email);
+                } else {
+                    $email && $message->addBcc($email);
+                }
             } catch (\Exception $e) {
                 $this->logger->error(\sprintf('[%s] %s', $notificationMail->getType()->name, $e->getMessage()));
             }

--- a/src/Service/Mailer/NotificationMail.php
+++ b/src/Service/Mailer/NotificationMail.php
@@ -29,6 +29,7 @@ class NotificationMail
         private readonly ?string $motif = null,
         private readonly ?string $cronLabel = null,
         private readonly ?int $cronCount = null,
+        private readonly bool $isRecipientVisible = true,
         private readonly array $params = [],
     ) {
     }
@@ -131,5 +132,10 @@ class NotificationMail
     public function getCronCount(): ?int
     {
         return $this->cronCount;
+    }
+
+    public function isRecipientVisible(): bool
+    {
+        return $this->isRecipientVisible;
     }
 }

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -139,6 +139,7 @@ class NotificationAndMailSender
                         territory: $this->signalement->getTerritory(),
                         signalement: $this->signalement,
                         suivi: $this->suivi,
+                        isRecipientVisible: false,
                     )
                 );
             }


### PR DESCRIPTION
## Ticket

#3716   

## Description
Lorsqu'on crée un suivi, on envoie un mail unique à tous les partenaires pour les notifier.
Plutôt que de les mettre dans `To`, on les met en `Bcc` pour ne pas qu'ils se voient

## Tests
- [ ] Créer un suivi sur un signalement du 13 avec l'usager en copie
- [ ] Dans MailCatcher, on croit qu'on les voit toujours. Il faut donc vérifier la source : pour l'usager, on voit bien le paramètre `To`, pour les autres, il n'y a rien.
