### PR TITLE
[QA] Statut d'affectation vide

### DIFF
--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -29,6 +29,7 @@ class SignalementAffectationHelper
         if (empty($statusAffectation)) {
             return '';
         }
+
         return AffectationStatus::tryFrom($statusAffectation)?->label();
     }
 
@@ -51,6 +52,7 @@ class SignalementAffectationHelper
         if (!empty($statusAffectation)) {
             $signalementStatus = AffectationStatus::tryFrom($statusAffectation)?->mapSignalementStatus();
         }
+
         return [$signalementStatus, $affectations];
     }
 

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -26,6 +26,9 @@ class SignalementAffectationHelper
             }
         }
 
+        if (empty($statusAffectation)) {
+            return '';
+        }
         return AffectationStatus::tryFrom($statusAffectation)?->label();
     }
 
@@ -44,7 +47,11 @@ class SignalementAffectationHelper
             }
         }
 
-        return [AffectationStatus::tryFrom($statusAffectation)?->mapSignalementStatus(), $affectations];
+        $signalementStatus = '';
+        if (!empty($statusAffectation)) {
+            $signalementStatus = AffectationStatus::tryFrom($statusAffectation)?->mapSignalementStatus();
+        }
+        return [$signalementStatus, $affectations];
     }
 
     public static function getQualificationFrom(array $data): ?array

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -48,7 +48,7 @@ class SignalementAffectationHelper
             }
         }
 
-        $signalementStatus = '';
+        $signalementStatus = null;
         if (!empty($statusAffectation)) {
             $signalementStatus = AffectationStatus::tryFrom($statusAffectation)?->mapSignalementStatus();
         }


### PR DESCRIPTION
## Ticket

#3720   

## Description
Certains statuts d'affectation sont vides. Pour éviter une erreur, on retourne une chaine vide.

## Tests
- [ ] Voir si la liste des signalements s'affiche correctement
- [ ] Voir si les exports de liste de signalement se font correctement
