### PR TITLE
[FO - Sites Faciles] Prévoir iFrame récupération lien de suivi

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -773,10 +773,10 @@ ul.fr-autocomplete-list {
         position: absolute;
         width: 100%;
     }
-    .fr-address-group.iframed {
-        max-height: 145px;
-        overflow: auto;
-    }
+}
+.iframed .fr-address-group {
+    max-height: 145px;
+    overflow: auto;
 }
 
 .fr-input:not([type="radio"]):read-only {

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -773,7 +773,12 @@ ul.fr-autocomplete-list {
         position: absolute;
         width: 100%;
     }
+    .fr-address-group.iframed {
+        max-height: 145px;
+        overflow: auto;
+    }
 }
+
 .fr-input:not([type="radio"]):read-only {
     box-shadow: inset 0 -2px 0 0 var(--border-disabled-grey);
     color: var(--text-disabled-grey);

--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -51,7 +51,7 @@ parameters:
       - "'self'"
       - "https://fonts.gstatic.com"
     frame-src:
-      - "'none'"
+      - "'self'"
     object-src:
       - "'none'"
     base-uri:

--- a/src/Controller/IframeController.php
+++ b/src/Controller/IframeController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Controller;
+
+use App\Dto\DemandeLienSignalement;
+use App\Form\DemandeLienSignalementType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/iframe')]
+class IframeController extends AbstractController
+{
+    #[Route('/demande-lien-signalement', name: 'iframe_demande_lien_signalement', methods: ['GET'])]
+    public function demandeLienSignalement(): Response
+    {
+        $demandeLienSignalement = new DemandeLienSignalement();
+        $formDemandeLienSignalement = $this->createForm(DemandeLienSignalementType::class, $demandeLienSignalement, [
+            'action' => $this->generateUrl('front_demande_lien_signalement'),
+        ]);
+
+        return $this->render('iframe/demande_lien_signalement.html.twig', [
+            'formDemandeLienSignalement' => $formDemandeLienSignalement,
+        ]);
+    }
+
+    #[Route('/test', name: 'iframe_test', methods: ['GET'])]
+    #[When('dev')]
+    #[When('test')]
+    public function test(): Response
+    {
+        return $this->render('iframe/test.html.twig');
+    }
+}

--- a/templates/_partials/_demande-lien-signalement.html.twig
+++ b/templates/_partials/_demande-lien-signalement.html.twig
@@ -15,7 +15,6 @@
 	</p>
 {% endif %}
 <div id="container-form-demande-lien-signalement">
-	{% set iframed = iframed is defined ? iframed : false %}
-	{% include 'form/form-demande-lien-signalement.html.twig' with {'form': formDemandeLienSignalement, 'iframed': iframed} only %}
+	{% include 'form/form-demande-lien-signalement.html.twig' with {'form': formDemandeLienSignalement} only %}
 </div>
 

--- a/templates/_partials/_demande-lien-signalement.html.twig
+++ b/templates/_partials/_demande-lien-signalement.html.twig
@@ -15,6 +15,7 @@
 	</p>
 {% endif %}
 <div id="container-form-demande-lien-signalement">
-	{% include 'form/form-demande-lien-signalement.html.twig' with {'form': formDemandeLienSignalement} only %}
+	{% set iframed = iframed is defined ? iframed : false %}
+	{% include 'form/form-demande-lien-signalement.html.twig' with {'form': formDemandeLienSignalement, 'iframed': iframed} only %}
 </div>
 

--- a/templates/form/form-demande-lien-signalement.html.twig
+++ b/templates/form/form-demande-lien-signalement.html.twig
@@ -8,12 +8,12 @@
 	<div class="fr-col-12 fr-col-lg-5">
 		{{ form_row(form.adresseHelper) }}
 		<div class="fr-address-group-container">
-			<div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
+			<div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group {% if iframed is defined and iframed %}iframed{% endif %}">
 			</div>
 		</div>
 	</div>
 	<div class="fr-col-12 fr-col-lg-3">
-		<div class="fr-mt-md-7w">
+		<div class="fr-mt-md-8w">
 			{{ form_row(form.save) }}
 		</div>
 	</div>

--- a/templates/form/form-demande-lien-signalement.html.twig
+++ b/templates/form/form-demande-lien-signalement.html.twig
@@ -8,7 +8,7 @@
 	<div class="fr-col-12 fr-col-lg-5">
 		{{ form_row(form.adresseHelper) }}
 		<div class="fr-address-group-container">
-			<div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group {% if iframed is defined and iframed %}iframed{% endif %}">
+			<div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
 			</div>
 		</div>
 	</div>

--- a/templates/iframe/base-iframe.html.twig
+++ b/templates/iframe/base-iframe.html.twig
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="fr">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="robots" content="noindex, nofollow">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <title>{{ platform.name }}</title>
+        <link rel="icon" href={{ asset('favicon.ico') }}>
+        <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-buildings/icons-buildings.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-business/icons-business.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-communication/icons-communication.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-others/icons-others.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-device/icons-device.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-design/icons-design.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-document/icons-document.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-editor/icons-editor.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-media/icons-media.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-system/icons-system.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}">
+        <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-weather/icons-weather.min.css') }}">
+        <link rel="stylesheet" href={{ asset('build/app.css') }}>
+        {% block customscripts %}
+            {{ encore_entry_script_tags('app') }}
+            {{ encore_entry_link_tags('app') }}
+        {% endblock %}
+    </head>
+
+    <body>
+        {% block body %}{% endblock %}
+    </body>
+</html>

--- a/templates/iframe/base-iframe.html.twig
+++ b/templates/iframe/base-iframe.html.twig
@@ -27,7 +27,7 @@
         {% endblock %}
     </head>
 
-    <body>
+    <body class="iframed">
         {% block body %}{% endblock %}
     </body>
 </html>

--- a/templates/iframe/demande_lien_signalement.html.twig
+++ b/templates/iframe/demande_lien_signalement.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
     <div class="fr-px-2w">
-        {% include '_partials/_demande-lien-signalement.html.twig' with {'iframed': true} %}
+        {% include '_partials/_demande-lien-signalement.html.twig' %}
     </div>
 {% endblock %}
 

--- a/templates/iframe/demande_lien_signalement.html.twig
+++ b/templates/iframe/demande_lien_signalement.html.twig
@@ -1,0 +1,8 @@
+{% extends 'iframe/base-iframe.html.twig' %}
+
+{% block body %}
+    <div class="fr-px-2w">
+        {% include '_partials/_demande-lien-signalement.html.twig' with {'iframed': true} %}
+    </div>
+{% endblock %}
+

--- a/templates/iframe/test.html.twig
+++ b/templates/iframe/test.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Test Iframe{% endblock %}
+
+{% block body %}
+    {% include "breadcrumbs.html.twig" with { 'breadcrumbsLabel': 'Test Iframe' } %}
+	<main id="content">
+		<section class="fr-container">
+			<iframe src="{{ path('iframe_demande_lien_signalement') }}" width="100%" height="500px" frameborder="0"></iframe>
+		</section>
+	</main>
+{% endblock %}


### PR DESCRIPTION
## Ticket

#3666

## Description
Préparation de l'iframe "demand de lien du signalement" pour intégrer via sites-facile

## Changements apportés
* Ajout d'un template `base-iframe` qui importe uniquement les css et script à étendre pour gérer les éléments à intégrer en iframe
* Ajout d'un controller pour gérer les routes des éléments a inclure en iframe
* Ajout d'un style spécifique quand le formulaire de demande de lien est appellé via sa route iframe (vue avec Mathilde)

## Pré-requis
`make npm-build`

## Tests
- [ ] Tester http://localhost:8080/iframe/demande-lien-signalement
- [ ] Tester l'exemplé d'intégration http://localhost:8080/iframe/test
