### PR TITLE
[FO - Suivi] Différence entre extension et mimetype du fichier

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -93,7 +93,7 @@ function initializeUploadModal (
     }
     const div = document.createElement('div')
     div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
-    const message = document.createTextNode('Les fichiers de format ' + file.name + ' ne sont pas pris en charge, merci de choisir un fichier au format ' + modal.dataset.acceptedExtensions + '.')
+    const message = document.createTextNode('Impossible d\'ajouter le fichier ' + file.name + ' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' + modal.dataset.acceptedExtensions + '.')
     div.appendChild(message)
     listContainer.prepend(div)
     return false

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -93,7 +93,7 @@ function initializeUploadModal (
     }
     const div = document.createElement('div')
     div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
-    const message = document.createTextNode('Impossible d\'ajouter le fichier ' + file.name + ' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' + modal.dataset.acceptedExtensions + '.')
+    const message = document.createTextNode('Les fichiers de format ' + file.name + ' ne sont pas pris en charge, merci de choisir un fichier au format ' + modal.dataset.acceptedExtensions + '.')
     div.appendChild(message)
     listContainer.prepend(div)
     return false

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -68,7 +68,7 @@ if (modalUploadFiles) {
     }
     const div = document.createElement('div')
     div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
-    const message = document.createTextNode('Les fichiers de format ' + file.name + ' ne sont pas pris en charge, merci de choisir un fichier au format ' + modalUploadFiles.dataset.acceptedExtensions + '.')
+    const message = document.createTextNode('Impossible d\'ajouter le fichier ' + file.name + ' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' + modalUploadFiles.dataset.acceptedExtensions + '.')
     div.appendChild(message)
     listContainer.prepend(div)
     return false

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -68,8 +68,7 @@ if (modalUploadFiles) {
     }
     const div = document.createElement('div')
     div.classList.add('fr-alert', 'fr-alert--error', 'fr-alert--sm')
-
-    const message = document.createTextNode('Impossible d\'ajouter le fichier ' + file.name + ' car le format n\'est pas pris en charge. Veuillez sélectionner un fichier au format ' + modalUploadFiles.dataset.acceptedExtensions + '.')
+    const message = document.createTextNode('Les fichiers de format ' + file.name + ' ne sont pas pris en charge, merci de choisir un fichier au format ' + modalUploadFiles.dataset.acceptedExtensions + '.')
     div.appendChild(message)
     listContainer.prepend(div)
     return false

--- a/src/Exception/File/UnsupportedFileFormatException.php
+++ b/src/Exception/File/UnsupportedFileFormatException.php
@@ -3,17 +3,34 @@
 namespace App\Exception\File;
 
 use App\Service\UploadHandlerService;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UnsupportedFileFormatException extends \Exception
 {
-    public function __construct(?string $mimeType = null, ?string $fileType = 'document')
+    public function __construct(UploadedFile $file, ?string $fileType = 'document')
     {
-        parent::__construct(
-            \sprintf(
-                'Le format %s n\'est pas supporté, merci d\'essayer avec un format %s',
-                $mimeType,
+        parent::__construct(self::getFileFormatErrorMessage($file, $fileType));
+    }
+
+    public static function getFileFormatErrorMessage(UploadedFile $file, string $fileType): string
+    {
+        $ext = $file->getClientOriginalExtension();
+        $mime = $file->getMimeType();
+
+        if (!str_ends_with($mime, '/'.$ext)) {
+            return \sprintf(
+                'Le fichier a une extension %s mais est au format %s. Les fichiers de format %s ne sont pas pris en charge, merci de choisir un fichier au format %s',
+                $ext,
+                $mime,
+                $mime,
                 UploadHandlerService::getAcceptedExtensions($fileType)
-            )
+            );
+        }
+
+        return \sprintf(
+            'Les fichiers de format %s ne sont pas pris en charge, merci de choisir un fichier au format %s',
+            $mime,
+            UploadHandlerService::getAcceptedExtensions($fileType)
         );
     }
 }

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -73,10 +73,7 @@ class SignalementFileProcessor
                     && !UploadHandlerService::isAcceptedDocumentFormat($file, $inputName)
                 ) {
                     $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('document');
-                    $message = <<<ERROR
-                Les fichiers de format {$file->getMimeType()} ne sont pas pris en charge,
-                merci de choisir un fichier au format {$acceptedExtensions}.
-                ERROR;
+                    $message = $this->getFileFormatErrorMessage($file, $acceptedExtensions);
                     $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
                     $this->logger->error($message.$fileInfo);
                     $this->errors[] = $message;
@@ -86,10 +83,7 @@ class SignalementFileProcessor
                     && !ImageManipulationHandler::isAcceptedPhotoFormat($file, $inputName)
                 ) {
                     $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('photo');
-                    $message = <<<ERROR
-                Les fichiers de format {$file->getMimeType()} ne sont pas pris en charge,
-                merci de choisir un fichier au format {$acceptedExtensions}.
-                ERROR;
+                    $message = $this->getFileFormatErrorMessage($file, $acceptedExtensions);
                     $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
                     $this->logger->error($message.$fileInfo);
                     $this->errors[] = $message;
@@ -126,6 +120,25 @@ class SignalementFileProcessor
         }
 
         return $fileList;
+    }
+
+    private function getFileFormatErrorMessage(UploadedFile $file, string $acceptedExtensions): string
+    {
+        $ext = $file->getClientOriginalExtension();
+        $mime = $file->getMimeType();
+
+        if (!str_ends_with($mime, '/'.$ext)) {
+            return <<<ERROR
+            Le fichier a une extension {$ext} mais est au format {$mime}.
+            Les fichiers de format {$mime} ne sont pas pris en charge,
+            merci de choisir un fichier au format {$acceptedExtensions}.
+            ERROR;
+        }
+
+        return <<<ERROR
+            Les fichiers de format {$mime} ne sont pas pris en charge,
+            merci de choisir un fichier au format {$acceptedExtensions}.
+            ERROR;
     }
 
     public function addFilesToSignalement(

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -67,8 +67,6 @@ class SignalementFileProcessor
             }
 
             if ($fileSizeOk) {
-                $fileExtension = $file instanceof UploadedFile ? $file->getClientOriginalExtension() : null;
-
                 if (
                     $file instanceof UploadedFile
                     && File::INPUT_NAME_DOCUMENTS === $inputName
@@ -76,7 +74,7 @@ class SignalementFileProcessor
                 ) {
                     $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('document');
                     $message = <<<ERROR
-                Les fichiers de format {$fileExtension} ne sont pas pris en charge,
+                Les fichiers de format {$file->getMimeType()} ne sont pas pris en charge,
                 merci de choisir un fichier au format {$acceptedExtensions}.
                 ERROR;
                     $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
@@ -89,7 +87,7 @@ class SignalementFileProcessor
                 ) {
                     $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('photo');
                     $message = <<<ERROR
-                Les fichiers de format {$fileExtension} ne sont pas pris en charge,
+                Les fichiers de format {$file->getMimeType()} ne sont pas pris en charge,
                 merci de choisir un fichier au format {$acceptedExtensions}.
                 ERROR;
                     $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -9,6 +9,7 @@ use App\Entity\Signalement;
 use App\Entity\User;
 use App\Exception\File\EmptyFileException;
 use App\Exception\File\MaxUploadSizeExceededException;
+use App\Exception\File\UnsupportedFileFormatException;
 use App\Factory\FileFactory;
 use App\Service\Files\FilenameGenerator;
 use App\Service\ImageManipulationHandler;
@@ -72,8 +73,7 @@ class SignalementFileProcessor
                     && File::INPUT_NAME_DOCUMENTS === $inputName
                     && !UploadHandlerService::isAcceptedDocumentFormat($file, $inputName)
                 ) {
-                    $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('document');
-                    $message = $this->getFileFormatErrorMessage($file, $acceptedExtensions);
+                    $message = UnsupportedFileFormatException::getFileFormatErrorMessage($file, 'document');
                     $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
                     $this->logger->error($message.$fileInfo);
                     $this->errors[] = $message;
@@ -82,8 +82,7 @@ class SignalementFileProcessor
                     && File::INPUT_NAME_PHOTOS === $inputName
                     && !ImageManipulationHandler::isAcceptedPhotoFormat($file, $inputName)
                 ) {
-                    $acceptedExtensions = UploadHandlerService::getAcceptedExtensions('photo');
-                    $message = $this->getFileFormatErrorMessage($file, $acceptedExtensions);
+                    $message = UnsupportedFileFormatException::getFileFormatErrorMessage($file, 'photo');
                     $fileInfo = ' ( Fichier : '.$file->__toString().' MimeType : '.$file->getMimeType().' )';
                     $this->logger->error($message.$fileInfo);
                     $this->errors[] = $message;
@@ -120,25 +119,6 @@ class SignalementFileProcessor
         }
 
         return $fileList;
-    }
-
-    private function getFileFormatErrorMessage(UploadedFile $file, string $acceptedExtensions): string
-    {
-        $ext = $file->getClientOriginalExtension();
-        $mime = $file->getMimeType();
-
-        if (!str_ends_with($mime, '/'.$ext)) {
-            return <<<ERROR
-            Le fichier a une extension {$ext} mais est au format {$mime}.
-            Les fichiers de format {$mime} ne sont pas pris en charge,
-            merci de choisir un fichier au format {$acceptedExtensions}.
-            ERROR;
-        }
-
-        return <<<ERROR
-            Les fichiers de format {$mime} ne sont pas pris en charge,
-            merci de choisir un fichier au format {$acceptedExtensions}.
-            ERROR;
     }
 
     public function addFilesToSignalement(

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -57,12 +57,12 @@ class UploadHandlerService
             File::INPUT_NAME_DOCUMENTS === $fileType
             && !self::isAcceptedDocumentFormat($file, $fileType)
         ) {
-            throw new UnsupportedFileFormatException($file->getMimeType(), $fileType);
+            throw new UnsupportedFileFormatException($file, $fileType);
         } elseif (
             File::INPUT_NAME_PHOTOS === $fileType
             && !ImageManipulationHandler::isAcceptedPhotoFormat($file, $fileType)
         ) {
-            throw new UnsupportedFileFormatException($file->getMimeType(), $fileType);
+            throw new UnsupportedFileFormatException($file, $fileType);
         }
 
         try {
@@ -259,12 +259,12 @@ class UploadHandlerService
             File::INPUT_NAME_DOCUMENTS === $fileType
             && !self::isAcceptedDocumentFormat($file, $fileType)
         ) {
-            throw new UnsupportedFileFormatException($file->getMimeType(), $fileType);
+            throw new UnsupportedFileFormatException($file, $fileType);
         } elseif (
             File::INPUT_NAME_PHOTOS === $fileType
             && !ImageManipulationHandler::isAcceptedPhotoFormat($file, $fileType)
         ) {
-            throw new UnsupportedFileFormatException($file->getMimeType(), $fileType);
+            throw new UnsupportedFileFormatException($file, $fileType);
         }
         try {
             $tmpFilepath = $file->getPathname();

--- a/tests/Functional/Service/UploadHandlerServiceTest.php
+++ b/tests/Functional/Service/UploadHandlerServiceTest.php
@@ -127,9 +127,13 @@ class UploadHandlerServiceTest extends KernelTestCase
             ->expects($this->atLeast(1))
             ->method('getMimeType')
             ->willReturn('video/webm');
+        $uploadedFileMock
+            ->expects($this->atLeast(1))
+            ->method('getClientOriginalExtension')
+            ->willReturn('webm');
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Le format video/webm n\'est pas supporté, merci d\'essayer avec un format '.UploadHandlerService::getAcceptedExtensions('document'));
+        $this->expectExceptionMessage('Les fichiers de format video/webm ne sont pas pris en charge, merci de choisir un fichier au format '.UploadHandlerService::getAcceptedExtensions('document'));
         $uploadHandlerService->uploadFromFile($uploadedFileMock, 'test.webm');
     }
 


### PR DESCRIPTION
## Ticket

#3719

## Description
Utilisation du mimeType dans le message d'erreur de format des fichier plutôt que leur extension

## Tests
- [ ] Renommer un fichier heic en png et l'uploader, s'assurer que le message d'erreur indique le bon format
