### PR TITLE
[FO - Signalement] Pouvoir initialiser le formulaire avec un profil

### DIFF
--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -104,11 +104,12 @@ export default defineComponent({
       this.sharedProps.ajaxurlSendMailContinueFromDraft = initElements.dataset.ajaxurlSendMailContinueFromDraft
       this.sharedProps.ajaxurlSendMailGetLienSuivi = initElements.dataset.ajaxurlSendMailGetLienSuivi
       this.sharedProps.ajaxurlArchiveDraft = initElements.dataset.ajaxurlArchiveDraft
+      this.sharedProps.initProfile = initElements.dataset.initProfile
       if (initElements.dataset.ajaxurlGetSignalementDraft !== undefined) {
         this.sharedProps.ajaxurlGetSignalementDraft = initElements.dataset.ajaxurlGetSignalementDraft
         requests.initWithExistingData(this.handleInitData)
       } else {
-        requests.initDictionary(this.handleInitDictionary)
+        this.initProfile()
       }
     } else {
       this.isErrorInit = true
@@ -124,6 +125,35 @@ export default defineComponent({
       }
       if (formStore.data.currentStep !== undefined) {
         this.nextSlug = formStore.data.currentStep
+      }
+      requests.initDictionary(this.handleInitDictionary)
+    },
+    initProfile () {
+      switch (this.sharedProps.initProfile) {
+        case 'locataire':
+          formStore.data.signalement_concerne_profil = 'logement_occupez'
+          formStore.data.signalement_concerne_profil_detail_occupant = 'locataire'
+          break
+        case 'bailleur_occupant':
+          formStore.data.signalement_concerne_profil = 'logement_occupez'
+          formStore.data.signalement_concerne_profil_detail_occupant = 'bailleur_occupant'
+          break
+        case 'tiers_particulier':
+          formStore.data.signalement_concerne_profil = 'autre_logement'
+          formStore.data.signalement_concerne_profil_detail_tiers = 'tiers_particulier'
+          break
+        case 'tiers_pro':
+          formStore.data.signalement_concerne_profil = 'autre_logement'
+          formStore.data.signalement_concerne_profil_detail_tiers = 'tiers_pro'
+          break
+        case 'bailleur':
+          formStore.data.signalement_concerne_profil = 'autre_logement'
+          formStore.data.signalement_concerne_profil_detail_tiers = 'bailleur'
+          break
+        case 'service_secours':
+          formStore.data.signalement_concerne_profil = 'autre_logement'
+          formStore.data.signalement_concerne_profil_detail_tiers = 'service_secours'
+          break
       }
       requests.initDictionary(this.handleInitDictionary)
     },

--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -80,6 +80,7 @@ export default defineComponent({
       nextSlug: '',
       isErrorInit: false,
       isLoadingInit: true,
+      isIntroSkipped: false,
       formStore,
       dictionaryStore,
       matomo,
@@ -154,6 +155,15 @@ export default defineComponent({
           formStore.data.signalement_concerne_profil = 'autre_logement'
           formStore.data.signalement_concerne_profil_detail_tiers = 'service_secours'
           break
+        case 'bailleur_social':
+          formStore.data.signalement_concerne_profil = 'autre_logement'
+          formStore.data.signalement_concerne_profil_detail_tiers = 'bailleur'
+          formStore.data.signalement_concerne_profil_detail_bailleur_bailleur = 'organisme_societe'
+          formStore.data.signalement_concerne_logement_social_autre_tiers = 'oui'
+          break
+      }
+      if (this.sharedProps.initProfile !== '' && formStore.data.signalement_concerne_profil != undefined) {
+        this.isIntroSkipped = true
       }
       requests.initDictionary(this.handleInitDictionary)
     },
@@ -172,7 +182,8 @@ export default defineComponent({
         if (this.nextSlug !== '') {
           this.changeScreenBySlug(undefined) // TODO : que mettre ?
         } else {
-          formStore.currentScreen = requestResponse[0]
+          let screenIndex = this.isIntroSkipped ? 1 : 0
+          formStore.currentScreen = requestResponse[screenIndex]
         }
       }
     },

--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -138,6 +138,7 @@ export default defineComponent({
         case 'bailleur_occupant':
           formStore.data.signalement_concerne_profil = 'logement_occupez'
           formStore.data.signalement_concerne_profil_detail_occupant = 'bailleur_occupant'
+          formStore.data.signalement_concerne_profil_detail_bailleur_proprietaire = 'particulier'
           break
         case 'tiers_particulier':
           formStore.data.signalement_concerne_profil = 'autre_logement'

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -88,7 +88,8 @@ const formStore: FormStore = reactive({
     ajaxurlCheckSignalementOrDraftAlreadyExists: '',
     ajaxurlSendMailContinueFromDraft: '',
     ajaxurlSendMailGetLienSuivi: '',
-    ajaxurlArchiveDraft: ''
+    ajaxurlArchiveDraft: '',
+    initProfile: ''
   },
   screenData: [],
   currentScreen: null,

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -49,13 +49,15 @@ class SignalementController extends AbstractController
         defaults: ['show_sitemap' => true]
     )]
     public function index(
+        Request $request,
     ): Response {
-        return $this->render('front/nouveau_formulaire.html.twig', [
+        return $this->render('front/formulaire_signalement.html.twig', [
             'uuid_signalement' => null,
+            'profile' => $request->query->get('profil'),
         ]);
     }
 
-    #[Route('/signalement-draft/{uuid:signalementDraft}', name: 'front_nouveau_formulaire_edit', methods: 'GET')]
+    #[Route('/signalement-draft/{uuid:signalementDraft}', name: 'front_formulaire_signalement_edit', methods: 'GET')]
     public function edit(
         SignalementDraft $signalementDraft,
     ): Response {
@@ -65,12 +67,12 @@ class SignalementController extends AbstractController
             return $this->redirectToRoute('front_signalement');
         }
 
-        return $this->render('front/nouveau_formulaire.html.twig', [
+        return $this->render('front/formulaire_signalement.html.twig', [
             'uuid_signalement' => $signalementDraft->getUuid(),
         ]);
     }
 
-    #[Route('/signalement-draft/envoi', name: 'envoi_nouveau_signalement_draft', methods: 'POST')]
+    #[Route('/signalement-draft/envoi', name: 'envoi_formulaire_signalement_draft', methods: 'POST')]
     public function sendSignalementDraft(
         Request $request,
         SignalementDraftRequestSerializer $serializer,
@@ -180,7 +182,7 @@ class SignalementController extends AbstractController
         return $this->json($errors);
     }
 
-    #[Route('/signalement-draft/{uuid:signalementDraft}/envoi', name: 'mise_a_jour_nouveau_signalement_draft', methods: 'PUT')]
+    #[Route('/signalement-draft/{uuid:signalementDraft}/envoi', name: 'mise_a_jour_formulaire_signalement_draft', methods: 'PUT')]
     public function updateSignalementDraft(
         Request $request,
         SignalementDraftRequestSerializer $serializer,

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -69,6 +69,7 @@ class SignalementController extends AbstractController
 
         return $this->render('front/formulaire_signalement.html.twig', [
             'uuid_signalement' => $signalementDraft->getUuid(),
+            'profile' => '',
         ]);
     }
 

--- a/src/Service/Mailer/Mail/Signalement/ContinueFromDraftMailer.php
+++ b/src/Service/Mailer/Mail/Signalement/ContinueFromDraftMailer.php
@@ -35,7 +35,7 @@ class ContinueFromDraftMailer extends AbstractNotificationMailer
             'signalement_draft_createdAt' => $signalementDraft->getCreatedAt()->format('d/m/Y'),
             'signalement_draft_addressComplete' => $signalementDraft->getAddressComplete(),
             'lien_draft' => $this->urlGenerator->generate(
-                'front_nouveau_formulaire_edit',
+                'front_formulaire_signalement_edit',
                 [
                     'uuid' => $signalementDraft->getUuid(),
                 ],

--- a/templates/front/formulaire_signalement.html.twig
+++ b/templates/front/formulaire_signalement.html.twig
@@ -17,8 +17,8 @@
         data-ajaxurl-dictionary="{{ path('public_api_dictionary') }}"
         data-ajaxurl-questions="{{ path('public_api_question_profile') }}?profil="
         data-ajaxurl-desordres="{{ path('public_api_desordres_profile') }}?profil="
-        data-ajaxurl-post-signalement-draft="{{ path('envoi_nouveau_signalement_draft') }}"
-        data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_nouveau_signalement_draft', {uuid: 'uuid'}) }}"
+        data-ajaxurl-post-signalement-draft="{{ path('envoi_formulaire_signalement_draft') }}"
+        data-ajaxurl-put-signalement-draft="{{ path('mise_a_jour_formulaire_signalement_draft', {uuid: 'uuid'}) }}"
         data-ajaxurl-handle-upload="{{ path('handle_upload') }}"
         {% if uuid_signalement is not null %}
           data-ajaxurl-get-signalement-draft="{{ path('informations_signalement_draft', {uuid: uuid_signalement}) }}"
@@ -29,6 +29,7 @@
         data-ajaxurl-send-mail-continue-from-draft="{{ path('send_mail_continue_from_draft') }}"
         data-ajaxurl-send-mail-get-lien-suivi="{{ path('send_mail_get_lien_suivi', {uuid: 'uuid'}) }}"
         data-ajaxurl-archive-draft="{{ path('archive_draft') }}"
+        data-init-profile="{{ profile }}"
         >
     </div>
   </main>

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -144,7 +144,7 @@ class SignalementControllerTest extends WebTestCase
 
         /** @var RouterInterface $router */
         $router = $client->getContainer()->get(RouterInterface::class);
-        $urlPutSignalement = $router->generate('envoi_nouveau_signalement_draft');
+        $urlPutSignalement = $router->generate('envoi_formulaire_signalement_draft');
 
         $payloadLocataireSignalement = file_get_contents(__DIR__.'../../../files/post_signalement_draft_payload.json');
 
@@ -167,7 +167,7 @@ class SignalementControllerTest extends WebTestCase
 
         /** @var RouterInterface $router */
         $router = $client->getContainer()->get(RouterInterface::class);
-        $urlPutSignalement = $router->generate('mise_a_jour_nouveau_signalement_draft', [
+        $urlPutSignalement = $router->generate('mise_a_jour_formulaire_signalement_draft', [
             'uuid' => $uuidSignalement,
         ]);
 
@@ -201,7 +201,7 @@ class SignalementControllerTest extends WebTestCase
 
         /** @var RouterInterface $router */
         $router = $client->getContainer()->get(RouterInterface::class);
-        $urlPutSignalement = $router->generate('mise_a_jour_nouveau_signalement_draft', [
+        $urlPutSignalement = $router->generate('mise_a_jour_formulaire_signalement_draft', [
             'uuid' => '00000000-0000-0000-2024-locataire003',
         ]);
 
@@ -237,18 +237,18 @@ class SignalementControllerTest extends WebTestCase
 
         /** @var RouterInterface $router */
         $router = static::getContainer()->get(RouterInterface::class);
-        $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => 'test']);
+        $urlSignalementEdit = $router->generate('front_formulaire_signalement_edit', ['uuid' => 'test']);
         $client->request('GET', $urlSignalementEdit);
 
         $this->assertEquals(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
 
-        $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => '00000000-0000-0000-2024-locataire003']);
+        $urlSignalementEdit = $router->generate('front_formulaire_signalement_edit', ['uuid' => '00000000-0000-0000-2024-locataire003']);
         $client->request('GET', $urlSignalementEdit);
 
         $this->assertEquals(Response::HTTP_FOUND, $client->getResponse()->getStatusCode());
         $this->assertResponseRedirects('/signalement');
 
-        $urlSignalementEdit = $router->generate('front_nouveau_formulaire_edit', ['uuid' => '00000000-0000-0000-2023-locataire001']);
+        $urlSignalementEdit = $router->generate('front_formulaire_signalement_edit', ['uuid' => '00000000-0000-0000-2023-locataire001']);
         $client->request('GET', $urlSignalementEdit);
 
         $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());


### PR DESCRIPTION
## Ticket

#3669   

## Description
Avec Sites Facile, on pourra ouvrir le formulaire depuis différents liens, selon le profil de l'utilisateur.
Pour lui éviter de re-saisir des informations qu'il pense avoir déjà choisies, on permet la pré-sélection des options avec un paramètre transmis via URL.

## Pré-requis
`npm run watch`

## Tests des différents cas possibles d'ouverture
- [ ] http://localhost:8080/signalement
- [ ] http://localhost:8080/signalement?profil=locataire
- [ ] http://localhost:8080/signalement?profil=bailleur_occupant
- [ ] http://localhost:8080/signalement?profil=tiers_particulier
- [ ] http://localhost:8080/signalement?profil=tiers_pro
- [ ] http://localhost:8080/signalement?profil=bailleur
- [ ] http://localhost:8080/signalement?profil=service_secours
- [ ] http://localhost:8080/signalement?profil=bailleur_social
