### PR TITLE
[BO - Photos] Pouvoir corriger l'orientation des photos

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -24,7 +24,6 @@ document?.querySelector('#btn-display-all-suivis')?.addEventListeners('click tou
 document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
   const swipeId = btn.getAttribute('data-id')
   btn.addEventListeners('click touchdown', (event) => {
-    document?.documentElement.setAttribute('data-fr-scheme', 'dark')
     document?.querySelectorAll('.photos-album')?.forEach(element => {
       element.classList?.remove('fr-hidden')
       displayPhotoAlbum(swipeId)
@@ -33,7 +32,6 @@ document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
 })
 document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
   btn.addEventListeners('click touchdown', (event) => {
-    document?.documentElement.setAttribute('data-fr-scheme', 'light')
     document?.querySelectorAll('.photos-album')?.forEach(element => {
       element.classList?.add('fr-hidden')
     })

--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -24,7 +24,7 @@ document?.querySelector('#btn-display-all-suivis')?.addEventListeners('click tou
 document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
   const swipeId = btn.getAttribute('data-id')
   btn.addEventListeners('click touchdown', (event) => {
-    document?.documentElement.setAttribute('data-fr-theme', 'dark')
+    document?.documentElement.setAttribute('data-fr-scheme', 'dark')
     document?.querySelectorAll('.photos-album')?.forEach(element => {
       element.classList?.remove('fr-hidden')
       displayPhotoAlbum(swipeId)
@@ -33,7 +33,7 @@ document?.querySelectorAll('.open-photo-album')?.forEach(btn => {
 })
 document?.querySelectorAll('.photos-album-btn-close')?.forEach(btn => {
   btn.addEventListeners('click touchdown', (event) => {
-    document?.documentElement.setAttribute('data-fr-theme', 'light')
+    document?.documentElement.setAttribute('data-fr-scheme', 'light')
     document?.querySelectorAll('.photos-album')?.forEach(element => {
       element.classList?.add('fr-hidden')
     })
@@ -93,9 +93,6 @@ const displayPhotoAlbum = (photoId) => {
   document?.querySelector('.photos-album-main-btn-edit[data-id="' + photoId + '"]')?.classList?.remove('fr-hidden')
   document?.querySelector('.photos-album-list-btn-edit[data-id="' + photoId + '"]')?.classList?.add('fr-hidden')
 
-  if (document?.documentElement.getAttribute('data-fr-theme') === 'light') {
-    document?.documentElement.setAttribute('data-fr-theme', 'dark')
-  }
   document?.querySelectorAll('.photos-album-image-item.loop-current')?.forEach(element => {
     element.classList?.remove('loop-current')
     element.classList?.add('fr-hidden')

--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -58,7 +58,41 @@ document?.querySelectorAll('.photos-album-swipe')?.forEach(btn => {
     displayPhotoAlbum(histoPhotoIds[newIndex])
   })
 })
+document?.querySelectorAll('.photos-album-main-btn-edit')?.forEach(btn => {
+  btn.addEventListeners('click touchdown', (event) => {
+    const photoId = btn.dataset.id
+    btn.classList?.add('fr-hidden')
+    document?.querySelector('.photos-album-list-btn-edit[data-id="' + photoId + '"]')?.classList?.remove('fr-hidden')
+  })
+})
+document?.querySelectorAll('.photo-album-rotate-left-btn')?.forEach(btn => {
+  btn.addEventListeners('click touchdown', (event) => {
+    const photoId = btn.dataset.id
+    rotatePhotoAlbumImage(photoId, 'left')
+  })
+})
+document?.querySelectorAll('.photo-album-rotate-right-btn')?.forEach(btn => {
+  btn.addEventListeners('click touchdown', (event) => {
+    const photoId = btn.dataset.id
+    rotatePhotoAlbumImage(photoId, 'right')
+  })
+})
+document?.querySelectorAll('.photo-album-save-rotation')?.forEach(btn => {
+  btn.addEventListeners('click touchdown', (event) => {
+    const photoId = btn.dataset.id
+    const rotate = document.querySelector('.photos-album-image[data-id="' + photoId + '"]').dataset.rotate
+    const action = btn.dataset.action
+    const form = document.querySelector('#form-save-file-rotation')
+    form.querySelector('input[name="rotate"]').value = rotate
+    form.action = action
+    form.submit()
+  })
+})
+
 const displayPhotoAlbum = (photoId) => {
+  document?.querySelector('.photos-album-main-btn-edit[data-id="' + photoId + '"]')?.classList?.remove('fr-hidden')
+  document?.querySelector('.photos-album-list-btn-edit[data-id="' + photoId + '"]')?.classList?.add('fr-hidden')
+
   if (document?.documentElement.getAttribute('data-fr-theme') === 'light') {
     document?.documentElement.setAttribute('data-fr-theme', 'dark')
   }
@@ -69,8 +103,35 @@ const displayPhotoAlbum = (photoId) => {
   document?.querySelectorAll('.photos-album-image-item[data-id="' + photoId + '"]')?.forEach(element => {
     element.classList?.add('loop-current')
     element.classList?.remove('fr-hidden')
+    document.querySelector('.photos-album-image[data-id="' + photoId + '"]').dataset.rotate = 1
+    rotatePhotoAlbumImage(photoId, 'left')
   })
 }
+const rotatePhotoAlbumImage = (photoId, direction) => {
+  const imgElement = document.querySelector('.photos-album-image[data-id="' + photoId + '"]')
+  const parentElement = imgElement.parentElement
+  
+  imgElement.dataset.rotate = parseInt(imgElement.dataset.rotate) + (direction === 'left' ? -1 : 1)
+  if(imgElement.dataset.rotate > 3 || imgElement.dataset.rotate < -3){
+    imgElement.dataset.rotate = 0
+  }
+  let rotation = 0
+  rotation += parseInt(imgElement.dataset.rotate) * 90
+  imgElement.style.transform = `rotate(${rotation}deg)`
+  if (rotation % 180 !== 0) {
+    imgElement.style.width = parentElement.clientHeight + 'px'
+    imgElement.style.height = parentElement.clientWidth + 'px'
+  } else {
+    imgElement.style.width = parentElement.clientWidth + 'px'
+    imgElement.style.height = parentElement.clientHeight + 'px'
+  }
+  if(imgElement.dataset.rotate !== '0') {
+    document.querySelector('.photo-album-save-rotation[data-id="' + photoId + '"]').removeAttribute('disabled')
+  }else{
+    document.querySelector('.photo-album-save-rotation[data-id="' + photoId + '"]').setAttribute('disabled', 'disabled')
+  }
+}
+
 
 loadWindowWithLocalStorage('click', '[data-filter-list-signalement]', 'back_link_signalement_view')
 

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -686,27 +686,28 @@ div.photos-album {
                 display: flex;
                 flex-direction: column;
                 
-                div {
-                    justify-content: center;
+                .photos-album-flex {
                     text-align: center;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    flex: 0 0 4rem;
                 }
     
-                div:nth-child(1) {
-                    height: 4rem;
-                }
-                div:nth-child(2) {
-                    flex: 1;
-                    height: calc(100% - 12rem - 40px);
-
+                .photos-album-flex:nth-child(3) {
+                    flex: 1 1 auto;
+                    height: auto;
+                    min-height: 0;
+                    
                     img {
                         max-width: 100%;
                         max-height: 100%;
+                        object-fit: contain;
+                        width: auto;
+                        height: auto;
+                        margin-left: auto;
+                        margin-right: auto;
                     }
-                }
-                div:nth-child(3) {
-                    height: 4rem;
-                    display: flex;
-                    align-items: center;
                 }
             }
         }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -660,6 +660,21 @@ div.photos-album {
     padding: 2rem;
     color: white;
 
+    .fr-btn{
+        background-color: #8585f6;
+        color: #000091;
+    }
+    .fr-btn:hover {
+        background-color: #b1b1f9;
+    }
+    .fr-btn:active {
+        background-color: #c6c6fb;
+    }
+    .fr-btn:disabled {
+        background-color: #2a2a2a;
+        color: #666;
+    }
+
     .photos-album-close-button-container {
         text-align: right;
     }

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -302,7 +302,7 @@ class SignalementFileController extends AbstractController
         return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
     }
 
-    #[Route('/{uuid:signalement}/file/{id:file}/rotate', name: 'back_signalement_file_rotate', methods: ['POST'])]
+    #[Route('/{uuid:signalement}/file/{id:file}/rotation', name: 'back_signalement_file_rotate', methods: ['POST'])]
     public function rotateFile(
         Signalement $signalement,
         File $file,

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -12,6 +12,8 @@ use App\Manager\SuiviManager;
 use App\Messenger\Message\PdfExportMessage;
 use App\Repository\FileRepository;
 use App\Repository\InterventionRepository;
+use App\Security\Voter\SignalementVoter;
+use App\Service\ImageManipulationHandler;
 use App\Service\Signalement\SignalementFileProcessor;
 use App\Service\UploadHandlerService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -298,5 +300,29 @@ class SignalementFileController extends AbstractController
         }
 
         return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
+    }
+
+    #[Route('/{uuid:signalement}/file/{id:file}/rotate', name: 'back_signalement_file_rotate', methods: ['POST'])]
+    public function rotateFile(
+        Signalement $signalement,
+        File $file,
+        Request $request,
+        ImageManipulationHandler $imageManipulationHandler,
+    ): Response {
+        $this->denyAccessUnlessGranted(SignalementVoter::EDIT, $signalement);
+        $rotate = (int) $request->get('rotate', 0);
+        if (!$rotate) {
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid(), '_fragment' => 'photos']));
+        }
+        if (!$this->isCsrfTokenValid('save_file_rotation', $request->get('_token'))) {
+            $this->addFlash('error', 'Token CSRF invalide, merci de réessayer.');
+
+            return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid(), '_fragment' => 'photos']));
+        }
+        $angle = $rotate * 90;
+        $imageManipulationHandler->rotate($file, $angle);
+        $this->addFlash('success', 'La photo a bien été modifiée.');
+
+        return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid(), '_fragment' => 'photos']));
     }
 }

--- a/src/Service/ImageManipulationHandler.php
+++ b/src/Service/ImageManipulationHandler.php
@@ -109,6 +109,21 @@ class ImageManipulationHandler
         return $this;
     }
 
+    public function rotate(File $file, int $angle): void
+    {
+        $variantNames = self::getVariantNames($file->getFilename());
+
+        foreach ($variantNames as $variant) {
+            if (!$this->fileStorage->fileExists($variant)) {
+                continue;
+            }
+            $image = $this->imageManager->make($this->fileStorage->readStream($variant));
+            $image->rotate($angle);
+            $resource = $image->stream()->detach();
+            $this->fileStorage->writeStream($variant, $resource);
+        }
+    }
+
     /**
      * @throws FilesystemException
      */

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -10,34 +10,59 @@
         <div>
             {% for index, photo in allPhotosOrdered %}
             <div class="photos-album-image-item {{ loop.index > 1 ? 'fr-hidden' : 'loop-current' }}" data-id="{{ photo.id }}">
-                <div>
+                <div class="photos-album-flex">
                     {{ photo.documentType.label}} - {{ loop.index }} / {{ loopLength }}
                 </div>
-                <div>
-                    <img
+                <div class="photos-album-flex">
+                    <div>
+                        <button class="photos-album-main-btn-edit fr-btn fr-btn--icon-left fr-icon-edit-line keep-when-signalement-closed" data-id="{{ photo.id }}">Modifier l'orientation</button>
+                        <ul class="photos-album-list-btn-edit fr-hidden fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left fr-btns-group--center" data-id="{{ photo.id }}">
+                            <li>
+                                <button class="photo-album-rotate-left-btn fr-btn fr-icon-arrow-go-back-line keep-when-signalement-closed" data-id="{{ photo.id }}">Pivoter à gauche</button>
+                            </li>
+                            <li>
+                                <button class="photo-album-rotate-right-btn fr-btn fr-btn--icon-right fr-icon-arrow-go-forward-line keep-when-signalement-closed" data-id="{{ photo.id }}">Pivoter à droite</button>
+                            </li>
+                            <li>
+                                <button 
+                                    class="photo-album-save-rotation fr-btn fr-icon-save-3-line keep-when-signalement-closed" 
+                                    disabled 
+                                    data-action="{{path('back_signalement_file_rotate', {uuid: photo.signalement.uuid, id: photo.id})}}" 
+                                    data-id="{{ photo.id }}">Enregistrer
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="photos-album-flex">
+                    <img class="photos-album-image"
                         src="{{ path('show_file', {uuid: photo.uuid}) }}?variant=resize"
                         alt="Photo ajoutée par : {{ photo.uploadedBy.nomComplet ?? 'N/R' }}"
+                        data-id="{{ photo.id }}"
+                        data-rotate="0"
                         >
                 </div>
-                <div class="fr-mt-1w">
-                    {% if photo.documentType is not same as null
-                        and photo.documentType is not same as enum('App\\Entity\\Enum\\DocumentType').AUTRE %}
-                        {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION
-                                and photo.desordreSlug is not same as null %}
-                            {{ signalement.getDesordreLabel(photo.desordreSlug) }}
-                        {% elseif photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_VISITE %}
-                            {{ photo.documentType.label() }} du {{ photo.intervention.scheduledAt|date('d/m/Y') }} par {{ photo.intervention.partner.nom}}
-                        {% else %}
-                            {{ photo.documentType.label() }}
+                <div class="photos-album-flex">
+                    <div class="fr-mt-1w">
+                        {% if photo.documentType is not same as null
+                            and photo.documentType is not same as enum('App\\Entity\\Enum\\DocumentType').AUTRE %}
+                            {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION
+                                    and photo.desordreSlug is not same as null %}
+                                {{ signalement.getDesordreLabel(photo.desordreSlug) }}
+                            {% elseif photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_VISITE %}
+                                {{ photo.documentType.label() }} du {{ photo.intervention.scheduledAt|date('d/m/Y') }} par {{ photo.intervention.partner.nom}}
+                            {% else %}
+                                {{ photo.documentType.label() }}
+                            {% endif %}
+                            <br>
                         {% endif %}
-                        <br>
-                    {% endif %}
-                    {% if photo.description is not same as null %}
-                        {{ photo.description }}
-                    {% endif %}
-                </div>
-                <div class="fr-mt-1w">
-                    Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
+                        {% if photo.description is not same as null %}
+                            {{ photo.description }}
+                        {% endif %}
+                    </div>
+                    <div class="fr-mt-1w">
+                        Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
+                    </div>
                 </div>
             </div>
             {% endfor %}
@@ -53,3 +78,7 @@
         {% endfor %}
     </script>
 </div>
+<form id="form-save-file-rotation" action="#" method="POST" class="fr-hidden">
+    <input type="hidden" name="rotate" value="0">
+    <input type="hidden" name="_token" value="{{ csrf_token('save_file_rotation') }}">
+</form>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -4,7 +4,7 @@
 {% endif %}
 
 <!DOCTYPE html>
-<html lang="fr"{# data-fr-scheme="light" #} {{ mise_en_berne ? 'data-fr-mourning' : '' }}>
+<html lang="fr" data-fr-scheme="light" {{ mise_en_berne ? 'data-fr-mourning' : '' }}>
 <head>
     <meta charset="UTF-8">
     {% if 'back_' in app.request.get('_route') or 'front_suivi_signalement' in app.request.get('_route') %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -4,7 +4,7 @@
 {% endif %}
 
 <!DOCTYPE html>
-<html lang="fr" data-fr-scheme="light" {{ mise_en_berne ? 'data-fr-mourning' : '' }}>
+<html lang="fr" {{ mise_en_berne ? 'data-fr-mourning' : '' }}>
 <head>
     <meta charset="UTF-8">
     {% if 'back_' in app.request.get('_route') or 'front_suivi_signalement' in app.request.get('_route') %}


### PR DESCRIPTION
## Ticket

#3684

## Description
- Ajout de la possibilité de faire pivoter une image et d'enregistrer la rotation
- Correction du thème utilisé quand la gallerie photo est ouverte (thème sombre)

Pour la question de l'orientation par défaut en fonction des donnée exif, nous n'avons pas l'extension PHP activé nécessaire, je partage la doc consulté ici en cas de besoin : 
- https://image.intervention.io/v2/api/exif 
- https://image.intervention.io/v3/modifying/effects#image-orientation-according-to-exif-data

## Pré-requis
`make npm-build`

## Tests
- [ ] Se rendre un un signalement uploader des images, et tester la feature de rotation et sa sauvegarde
