### PR TITLE
[FO - Signalement] Possibilité d'ajouter des documents libres en fin de parcours

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -2818,6 +2818,17 @@
           "validate": {
             "message": "Veuillez détailler votre situation."
           }
+        },
+        {
+          "type": "SignalementFormUploadPhotos",
+          "slug": "message_administration_upload",
+          "label": "Documents et photos complémentaires (facultatif)",
+          "labelInfo": "Merci de ne transmettre aucun document comportant des données de santé. Les photos ne doivent pas contenir de visages de personnes ou d'objets personnels",
+          "description": "Vous pouvez ajouter ici les photos et / ou documents utiles au traitement du dossier.",
+          "labelUpload": "Ajouter des documents",
+          "validate": {
+            "required": false
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -2820,12 +2820,40 @@
           }
         },
         {
-          "type": "SignalementFormUploadPhotos",
-          "slug": "message_administration_upload",
-          "label": "Documents et photos complémentaires (facultatif)",
+          "type": "SignalementFormUploadDocuments",
+          "slug": "message_administration_documents",
+          "label": "Documents complémentaires (facultatif)",
           "labelInfo": "Merci de ne transmettre aucun document comportant des données de santé. Les photos ne doivent pas contenir de visages de personnes ou d'objets personnels",
-          "description": "Vous pouvez ajouter ici les photos et / ou documents utiles au traitement du dossier.",
+          "description": "Vous pouvez ajouter ici les documents utiles au traitement du dossier, par exemple : le bail, les échanges avec le propriétaire ou bailleur, les courriers à votre propriétaire ou assurance, etc.",
           "labelUpload": "Ajouter des documents",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_occupant === 'locataire'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormUploadDocuments",
+          "slug": "message_administration_documents",
+          "label": "Documents complémentaires (facultatif)",
+          "labelInfo": "Merci de ne transmettre aucun document comportant des données de santé. Les photos ne doivent pas contenir de visages de personnes ou d'objets personnels",
+          "description": "Vous pouvez ajouter ici les documents utiles au traitement du dossier, par exemple : les différents diagnostics du logement, les courriers ou échanges avec votre assurance ou avec l'administration, etc.",
+          "labelUpload": "Ajouter des documents",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_occupant === 'bailleur_occupant'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormUploadPhotos",
+          "slug": "message_administration_photos",
+          "label": "Photos complémentaires (facultatif)",
+          "labelInfo": "Les photos ne doivent pas contenir de visages de personnes ou d'objets personnels",
+          "description": "Vous pouvez ajouter ici des photos des désordres rencontrés dans le logement et / ou le bâtiment.",
+          "labelUpload": "Ajouter des photos",
           "validate": {
             "required": false
           }

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -2855,6 +2855,45 @@
           "conditional": {
             "show": "formStore.data.signalement_concerne_profil_detail_tiers !== 'tiers_particulier'"
           }
+        },
+        {
+          "type": "SignalementFormUploadDocuments",
+          "slug": "message_administration_documents",
+          "label": "Documents complémentaires (facultatif)",
+          "labelInfo": "Merci de ne transmettre aucun document comportant des données de santé. Les photos ne doivent pas contenir de visages de personnes ou d'objets personnels",
+          "description": "Vous pouvez ajouter ici les documents utiles au traitement du dossier, par exemple : le bail, les échanges avec le propriétaire ou bailleur, les courriers au propriétaire ou assurance, etc.",
+          "labelUpload": "Ajouter des documents",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers !== 'bailleur'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormUploadDocuments",
+          "slug": "message_administration_documents",
+          "label": "Documents complémentaires (facultatif)",
+          "labelInfo": "Merci de ne transmettre aucun document comportant des données de santé. Les photos ne doivent pas contenir de visages de personnes ou d'objets personnels",
+          "description": "Vous pouvez ajouter ici les documents utiles au traitement du dossier, par exemple : les différents diagnostics du logement, les courriers ou échanges avec votre assurance ou avec l'administration, etc.",
+          "labelUpload": "Ajouter des documents",
+          "conditional": {
+            "show": "formStore.data.signalement_concerne_profil_detail_tiers === 'bailleur'"
+          },
+          "validate": {
+            "required": false
+          }
+        },
+        {
+          "type": "SignalementFormUploadPhotos",
+          "slug": "message_administration_photos",
+          "label": "Photos complémentaires (facultatif)",
+          "labelInfo": "Les photos ne doivent pas contenir de visages de personnes ou d'objets personnels",
+          "description": "Vous pouvez ajouter ici des photos des désordres rencontrés dans le logement et / ou le bâtiment.",
+          "labelUpload": "Ajouter des photos",
+          "validate": {
+            "required": false
+          }
         }
       ],
       "footer": [

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormComponentGenerator.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormComponentGenerator.vue
@@ -56,6 +56,7 @@ import SignalementFormCheckbox from './SignalementFormCheckbox.vue'
 import SignalementFormPhonefield from './SignalementFormPhonefield.vue'
 import SignalementFormUpload from './SignalementFormUpload.vue'
 import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
+import SignalementFormUploadDocuments from './SignalementFormUploadDocuments.vue'
 import SignalementFormOverview from './SignalementFormOverview.vue'
 import SignalementFormConfirmation from './SignalementFormConfirmation.vue'
 import SignalementFormRoomList from './SignalementFormRoomList.vue'
@@ -88,6 +89,7 @@ export default defineComponent({
     SignalementFormPhonefield,
     SignalementFormUpload,
     SignalementFormUploadPhotos,
+    SignalementFormUploadDocuments,
     SignalementFormOverview,
     SignalementFormConfirmation,
     SignalementFormRoomList,

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -104,6 +104,10 @@
       <br>
       <h5 class="fr-h6">Précisions sur la situation</h5>
       <p class="white-space-pre-line">{{ formStore.data[idMessageAdministration] }}</p>
+      <p>
+        <span v-if="formStore.data['message_administration_documents_upload'].length > 0">{{ formStore.data['message_administration_documents_upload'].length }} document(s) complémentaire(s) ajouté(s).<br></span>
+        <span v-if="formStore.data['message_administration_photos_upload'].length > 0">{{ formStore.data['message_administration_photos_upload'].length }} photo(s) complémentaire(s) ajoutée(s).</span>
+      </p>
     </div>
   </div>
 </template>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormDisorderOverview.vue
@@ -105,8 +105,8 @@
       <h5 class="fr-h6">Précisions sur la situation</h5>
       <p class="white-space-pre-line">{{ formStore.data[idMessageAdministration] }}</p>
       <p>
-        <span v-if="formStore.data['message_administration_documents_upload'].length > 0">{{ formStore.data['message_administration_documents_upload'].length }} document(s) complémentaire(s) ajouté(s).<br></span>
-        <span v-if="formStore.data['message_administration_photos_upload'].length > 0">{{ formStore.data['message_administration_photos_upload'].length }} photo(s) complémentaire(s) ajoutée(s).</span>
+        <span v-if="formStore.data['message_administration_documents_upload'] !== undefined && formStore.data['message_administration_documents_upload'].length > 0">{{ formStore.data['message_administration_documents_upload'].length }} document(s) complémentaire(s) ajouté(s).<br></span>
+        <span v-if="formStore.data['message_administration_photos_upload'] !== undefined && formStore.data['message_administration_photos_upload'].length > 0">{{ formStore.data['message_administration_photos_upload'].length }} photo(s) complémentaire(s) ajoutée(s).</span>
       </p>
     </div>
   </div>

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormSubscreen.vue
@@ -99,6 +99,7 @@ import SignalementFormCheckbox from './SignalementFormCheckbox.vue'
 import SignalementFormPhonefield from './SignalementFormPhonefield.vue'
 import SignalementFormUpload from './SignalementFormUpload.vue'
 import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
+import SignalementFormUploadDocuments from './SignalementFormUploadDocuments.vue'
 import SignalementFormOverview from './SignalementFormOverview.vue'
 import SignalementFormConfirmation from './SignalementFormConfirmation.vue'
 import SignalementFormRoomList from './SignalementFormRoomList.vue'
@@ -124,6 +125,7 @@ export default defineComponent({
     SignalementFormPhonefield,
     SignalementFormUpload,
     SignalementFormUploadPhotos,
+    SignalementFormUploadDocuments,
     SignalementFormOverview,
     SignalementFormConfirmation,
     SignalementFormRoomList,

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadDocuments.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadDocuments.vue
@@ -1,7 +1,7 @@
 <template>
   <SignalementFormUploadPhotos
     :id="id"
-    :label="labelUpload"
+    :label="label"
     :description="description"
     v-model="formStore.data[id + '_upload']"
     :labelInfo="labelInfo"

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadDocuments.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUploadDocuments.vue
@@ -1,32 +1,25 @@
 <template>
-  <div class="signalement-form-upload-photos" :id="id">
-    <h3 v-if="label">{{ label }}</h3>
-    <p v-if="description" v-html="description"></p>
-    <SignalementFormInfo
-      :id="id + '_info'"
-      :label="labelInfo"
-      />
-    <SignalementFormUpload
-      :id="id + '_upload'"
-      :label="labelUpload"
-      v-model="formStore.data[id + '_upload']"
-      :multiple="true"
-      :type="fileType"
-      />
-  </div>
+  <SignalementFormUploadPhotos
+    :id="id"
+    :label="labelUpload"
+    :description="description"
+    v-model="formStore.data[id + '_upload']"
+    :labelInfo="labelInfo"
+    :labelUpload="labelUpload"
+    :multiple="true"
+    fileType="documents"
+    />
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import formStore from './../store'
-import SignalementFormInfo from './SignalementFormInfo.vue'
-import SignalementFormUpload from './SignalementFormUpload.vue'
+import formStore from '../store'
+import SignalementFormUploadPhotos from './SignalementFormUploadPhotos.vue'
 
 export default defineComponent({
-  name: 'SignalementFormUploadPhotos',
+  name: 'SignalementFormUploadDocuments',
   components: {
-    SignalementFormInfo,
-    SignalementFormUpload
+    SignalementFormUploadPhotos
   },
   props: {
     id: { type: String, default: null },
@@ -38,7 +31,6 @@ export default defineComponent({
     },
     labelInfo: { type: String, default: null },
     labelUpload: { type: String, default: null },
-    fileType: { type: String, default: 'photos' },
     // les propriétés suivantes ne sont pas utilisées,
     // mais si on ne les met pas, elles apparaissent dans le DOM
     // et ça soulève des erreurs W3C

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -102,7 +102,7 @@ class FileFactory
     private function getFileType(array $file, DocumentType $documentType)
     {
         if ('photos' === $file['key']
-            && File::FILE_TYPE_PHOTO === $documentType->mapFileType()
+            && (File::FILE_TYPE_PHOTO === $documentType->mapFileType() || DocumentType::AUTRE === $documentType)
             && \in_array(
                 strtolower(pathinfo($file['file'], \PATHINFO_EXTENSION)),
                 File::IMAGE_EXTENSION

--- a/src/Service/Signalement/SignalementDocumentTypeMapper.php
+++ b/src/Service/Signalement/SignalementDocumentTypeMapper.php
@@ -12,7 +12,7 @@ class SignalementDocumentTypeMapper
             return DocumentType::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE;
         }
 
-        if (str_starts_with($value, 'desordres_') || str_starts_with($value, 'message_administration_photos')) {
+        if (str_starts_with($value, 'desordres_')) {
             return DocumentType::PHOTO_SITUATION;
         }
 

--- a/src/Service/Signalement/SignalementDocumentTypeMapper.php
+++ b/src/Service/Signalement/SignalementDocumentTypeMapper.php
@@ -12,7 +12,7 @@ class SignalementDocumentTypeMapper
             return DocumentType::SITUATION_DIAGNOSTIC_PLOMB_AMIANTE;
         }
 
-        if (str_starts_with($value, 'desordres_')) {
+        if (str_starts_with($value, 'desordres_') || str_starts_with($value, 'message_administration_photos')) {
             return DocumentType::PHOTO_SITUATION;
         }
 


### PR DESCRIPTION
## Ticket

#3531   

## Description
On donne la possibilité au déclarant de déposer des fichiers plus librement en fin de parcours, sans les lier à des catégories existantes.
On sépare en deux entre photos (qui se rangent dans Photo de la situation) et documents (qui se rangent dans Autre)

## Changements apportés
* Ajout d'un composant `SignalementFormUploadDocuments` qui utilise `SignalementFormUploadPhotos` existant en modifiant son type.
* Ajout d'éléments dans l'écran "Précisions sur votre situation", en modifiant les textes selon les profils.

## Pré-requis
`npm run watch`

## Tests
- [ ] Créer des signalements avec différents profils (au moins 1 occupant et 1 tiers)
  - [ ] Vérifier les textes selon les profils
  - [ ] Uploader des fichiers
  - [ ] Vérifier dans le bo
