### PR TITLE
[Partout] Remplacer "clôturé" par "fermé" pour les signalements

### DIFF
--- a/assets/scripts/vue/components/dashboard/TheHistoDashboardCards.vue
+++ b/assets/scripts/vue/components/dashboard/TheHistoDashboardCards.vue
@@ -129,7 +129,7 @@
               <a :href=getSanitizedUrl(sharedState.cloturesGlobales.link)>Clôtures globales</a>
             </h3>
             <p class="fr-card__desc">
-              Retrouvez les signalements récemment clôturés par les responsables territoire.
+              Retrouvez les signalements récemment fermés par les responsables territoire.
             </p>
           </div>
         </div>
@@ -149,7 +149,7 @@
               <a :href=getSanitizedUrl(sharedState.cloturesPartenaires.link)>Clôtures partenaires</a>
             </h3>
             <p class="fr-card__desc">
-              Retrouvez les signalements récemment clôturés par les partenaires.
+              Retrouvez les signalements récemment fermés par les partenaires.
             </p>
           </div>
         </div>

--- a/assets/scripts/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
+++ b/assets/scripts/vue/components/front-stats/TheHistoFrontStatsTerritory.vue
@@ -28,7 +28,7 @@
           </TheHistoFrontStatsTerritoryItem>
 
           <TheHistoFrontStatsTerritoryItem sizeClass="12" v-model="sharedState.filters.perMotifClotureYearType" :onChange="handleChangePerMotifCloture">
-            <template #title>Répartition des signalements clôturés par motif de clôture</template>
+            <template #title>Répartition des signalements fermés par motif de clôture</template>
             <template #graph>
               <HistoChartBar v-if="!isLoadingPerMotifCloture" :items=perMotifClotureData indexAxis="x"  />
             </template>

--- a/assets/scripts/vue/components/stats/TheHistoStatsDetails.vue
+++ b/assets/scripts/vue/components/stats/TheHistoStatsDetails.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         'Signalements',
         'En attente',
         'En cours',
-        'Clôturés'
+        'Fermés'
       ]
     }
   },

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -66,7 +66,7 @@ class SignalementActionController extends AbstractController
                     return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
                 }
                 $signalement->setMotifRefus($motifRefus);
-                $description = 'cloturé car non-valide avec le motif suivant : '.$motifRefus->label().'<br>Plus précisément :<br>'.$response['suivi'];
+                $description = 'fermé car non-valide avec le motif suivant : '.$motifRefus->label().'<br>Plus précisément :<br>'.$response['suivi'];
 
                 $toRecipients = $signalement->getMailUsagers();
                 $notificationMailerRegistry->send(
@@ -190,7 +190,7 @@ class SignalementActionController extends AbstractController
                 $affectationRepository->updateStatusBySignalement(Affectation::STATUS_WAIT, $signalement);
                 $reopenFor = 'tous les partenaires';
             } elseif (!$this->isGranted('ROLE_ADMIN_TERRITORY') && SignalementStatus::CLOSED === $signalement->getStatut()) {
-                $this->addFlash('error', 'Seul un responsable de territoire peut réouvrir un signalement clôturé !');
+                $this->addFlash('error', 'Seul un responsable de territoire peut réouvrir un signalement fermé !');
 
                 return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
             } else {

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -151,7 +151,7 @@ class SignalementController extends AbstractController
             }
 
             if (!empty($entity)) {
-                $this->addFlash('success', sprintf('Signalement #%s cloturé avec succès !', $reference));
+                $this->addFlash('success', sprintf('Signalement #%s fermé avec succès !', $reference));
             }
             $signalementSearchQuery = $request->getSession()->get('signalementSearchQuery');
             $url = $signalementSearchQuery ? $this->generateUrl('back_signalements_index').$signalementSearchQuery->getQueryStringForUrl() : $this->generateUrl('back_signalements_index');

--- a/src/Dto/Api/Response/SignalementResponse.php
+++ b/src/Dto/Api/Response/SignalementResponse.php
@@ -67,14 +67,14 @@ class SignalementResponse
     public ?string $dateValidation;
 
     #[OA\Property(
-        description: 'Date à laquelle le signalement a été cloturé par un responsable territoire.<br>
+        description: 'Date à laquelle le signalement a été fermé par un responsable territoire.<br>
         Exemple : `2025-01-05T15:30:15+00:00`',
         format: 'date-time',
         example: '2025-01-05T15:30:15+00:00'
     )]
     public ?string $dateCloture;
     #[OA\Property(
-        description: 'Motif de clôture du signalement, précisant la raison pour laquelle il a été clôturé.',
+        description: 'Motif de clôture du signalement, précisant la raison pour laquelle il a été fermé.',
         example: 'LOGEMENT_DECENT',
         nullable: true
     )]

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -25,8 +25,8 @@ class Suivi implements EntityHistoryInterface
     public const DEFAULT_PERIOD_INACTIVITY = 30;
     public const DEFAULT_PERIOD_RELANCE = 45;
 
-    public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';
-    public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été cloturé pour';
+    public const DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été fermé pour tous';
+    public const DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été fermé pour';
     public const DESCRIPTION_SIGNALEMENT_VALIDE = 'Signalement validé';
     public const DESCRIPTION_DELETED = 'Ce suivi a été supprimé par un administrateur le ';
 

--- a/src/Manager/HistoryEntryManager.php
+++ b/src/Manager/HistoryEntryManager.php
@@ -195,7 +195,7 @@ class HistoryEntryManager extends AbstractManager
                     }
                     break;
                 case SignalementStatus::CLOSED->value:
-                    $description .= ' a clôturé le signalement ';
+                    $description .= ' a fermé le signalement ';
                     break;
                 case SignalementStatus::ARCHIVED->value:
                     $description .= ' a archivé le signalement ';

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -207,7 +207,7 @@ class SuiviManager extends Manager
         $motifSuivi = Sanitizer::sanitize($params['motif_suivi']);
 
         return \sprintf(
-            'Le signalement a été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
+            'Le signalement a été fermé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
             $params['subject'],
             $params['motif_cloture']->label(),
             $motifSuivi

--- a/src/Service/Signalement/Export/SignalementExportSelectableColumns.php
+++ b/src/Service/Signalement/Export/SignalementExportSelectableColumns.php
@@ -39,7 +39,7 @@ class SignalementExportSelectableColumns
         'CONCLUSION_VISITE' => ['name' => 'Ccl. de la dernière visite', 'description' => 'La conclusion de la dernière visite (procédures constatées)', 'export' => 'interventionConcludeProcedure'],
         'COMMENTAIRE_VISITE' => ['name' => 'Comm. de la dernière visite', 'description' => 'Le commentaire laissé par l\'opérateur suite à la dernière visite', 'export' => 'interventionDetails'],
         'DERNIERE_MAJ' => ['name' => 'Dernière MAJ le', 'description' => 'La date de la dernière mise à jour du signalement', 'export' => 'modifiedAt'],
-        'DATE_CLOTURE' => ['name' => 'Clôturé le', 'description' => 'La date de clôture du signalement', 'export' => 'closedAt'],
+        'DATE_CLOTURE' => ['name' => 'Fermé le', 'description' => 'La date de clôture du signalement', 'export' => 'closedAt'],
         'MOTIF_CLOTURE' => ['name' => 'Motif de clôture', 'description' => 'Le motif de clôture du signalement', 'export' => 'motifCloture'],
         'GEOLOCALISATION' => ['name' => 'Géolocalisation', 'description' => 'Les coordonnées GPS du logement', 'export' => 'geoloc'],
         'DEBUT_DESORDRES' => ['name' => 'Début des désordres', 'description' => 'Début des désordres', 'export' => 'debutDesordres'],

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -59,7 +59,7 @@
                         {% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').REFUSED %}
                             <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
                         {% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}
-                            <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
+                            <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Fermé</span>
                         {% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').ARCHIVED %} <!-- NE DOIT PAS ARRIVER -->
                             <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Archivé</span>
                         {% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').DRAFT %} <!-- NE DOIT PAS ARRIVER -->

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -42,7 +42,7 @@
 	{% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED
 		and date(signalement.closedAt) < date('-30days') %}
 		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
-			<p>Votre dossier a été clôturé il y a plus de 30 jours, vous ne pouvez plus envoyer de messages.</p>
+			<p>Votre dossier a été fermé il y a plus de 30 jours, vous ne pouvez plus envoyer de messages.</p>
 		</div>
 	{% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').ARCHIVED %}
 		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">

--- a/templates/front/index.html.twig
+++ b/templates/front/index.html.twig
@@ -311,7 +311,7 @@
                                     <h3 class="fr-card__title fr-h1 fr-text-title--blue-france">
                                         {{ stats.clotures }} %
                                     </h3>
-                                    <p class="fr-card__desc fr-text--lg">de signalements clôturés</p>
+                                    <p class="fr-card__desc fr-text--lg">de signalements fermés</p>
                                 </div>
                             </div>
                         </div>

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -26,7 +26,7 @@ class SignalementControllerTest extends WebTestCase
     public function provideStatusSignalement(): \Generator
     {
         yield 'Actif' => [SignalementStatus::ACTIVE->value];
-        yield 'Clôturé' => [SignalementStatus::CLOSED->value];
+        yield 'Fermé' => [SignalementStatus::CLOSED->value];
         yield 'Refusé' => [SignalementStatus::REFUSED->value];
         yield 'Archivé' => [SignalementStatus::ARCHIVED->value];
         yield 'Brouillon' => [SignalementStatus::DRAFT->value];

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -82,7 +82,7 @@ class SuiviManagerTest extends KernelTestCase
         $this->assertEquals(Suivi::TYPE_PARTNER, $suivi->getType());
         $this->assertNotEquals($countSuivisBeforeCreate, $countSuivisAfterCreate);
         $this->assertInstanceOf(Suivi::class, $suivi);
-        $desc = 'Le signalement a été cloturé pour test avec le motif suivant <br /><strong>Non décence</strong><br /><strong>Desc. : </strong>Lorem ipsum suivi sit amet, consectetur adipiscing elit.';
+        $desc = 'Le signalement a été fermé pour test avec le motif suivant <br /><strong>Non décence</strong><br /><strong>Desc. : </strong>Lorem ipsum suivi sit amet, consectetur adipiscing elit.';
         $this->assertEquals($desc, $suivi->getDescription());
         $this->assertTrue($suivi->getIsPublic());
         $this->assertTrue($suivi->getIsSanitized());


### PR DESCRIPTION
## Ticket

#3730    

## Description
Remplacer "clôturé" par "fermé" pour les signalements

## Changements apportés
* Remplacer "clôturé" par "fermé" pour les signalements

## Pré-requis

## Tests
- [ ] CI OK
- [ ] Vérifier différents affichages
