### PR TITLE
[Suivis] Remettre "clôturé" plutôt que "fermé" pour les suivis de signalements 

### DIFF
--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -53,7 +53,7 @@ class SignalementActionController extends AbstractController
                     return $this->redirectToRoute('back_signalement_view', ['uuid' => $signalement->getUuid()]);
                 }
                 $signalement->setMotifRefus($motifRefus);
-                $description = 'fermé car non-valide avec le motif suivant : '.$motifRefus->label().'<br>Plus précisément :<br>'.$response['suivi'];
+                $description = 'cloturé car non-valide avec le motif suivant : '.$motifRefus->label().'<br>Plus précisément :<br>'.$response['suivi'];
             }
             /** @var User $user */
             $user = $this->getUser();

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -28,8 +28,8 @@ class Suivi implements EntityHistoryInterface
     public const int DEFAULT_PERIOD_INACTIVITY = 30;
     public const int DEFAULT_PERIOD_RELANCE = 45;
 
-    public const string DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été fermé pour tous';
-    public const string DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été fermé pour';
+    public const string DESCRIPTION_MOTIF_CLOTURE_ALL = 'Le signalement a été cloturé pour tous';
+    public const string DESCRIPTION_MOTIF_CLOTURE_PARTNER = 'Le signalement a été cloturé pour';
     public const string DESCRIPTION_SIGNALEMENT_VALIDE = 'Signalement validé';
     public const string DESCRIPTION_DELETED = 'Ce suivi a été supprimé par un administrateur le ';
 

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -207,7 +207,7 @@ class SuiviManager extends Manager
         $motifSuivi = Sanitizer::sanitize($params['motif_suivi']);
 
         return \sprintf(
-            'Le signalement a été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
+            Suivi::DESCRIPTION_MOTIF_CLOTURE_PARTNER.' %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
             $params['subject'],
             $params['motif_cloture']->label(),
             $motifSuivi

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -207,7 +207,7 @@ class SuiviManager extends Manager
         $motifSuivi = Sanitizer::sanitize($params['motif_suivi']);
 
         return \sprintf(
-            'Le signalement a été fermé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
+            'Le signalement a été cloturé pour %s avec le motif suivant <br><strong>%s</strong><br><strong>Desc. : </strong>%s',
             $params['subject'],
             $params['motif_cloture']->label(),
             $motifSuivi

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -82,7 +82,7 @@ class SuiviManagerTest extends KernelTestCase
         $this->assertEquals(Suivi::TYPE_PARTNER, $suivi->getType());
         $this->assertNotEquals($countSuivisBeforeCreate, $countSuivisAfterCreate);
         $this->assertInstanceOf(Suivi::class, $suivi);
-        $desc = 'Le signalement a été fermé pour test avec le motif suivant <br /><strong>Non décence</strong><br /><strong>Desc. : </strong>Lorem ipsum suivi sit amet, consectetur adipiscing elit.';
+        $desc = 'Le signalement a été cloturé pour test avec le motif suivant <br /><strong>Non décence</strong><br /><strong>Desc. : </strong>Lorem ipsum suivi sit amet, consectetur adipiscing elit.';
         $this->assertEquals($desc, $suivi->getDescription());
         $this->assertTrue($suivi->getIsPublic());
         $this->assertTrue($suivi->getIsSanitized());

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -82,7 +82,7 @@ class SuiviManagerTest extends KernelTestCase
         $this->assertEquals(Suivi::TYPE_PARTNER, $suivi->getType());
         $this->assertNotEquals($countSuivisBeforeCreate, $countSuivisAfterCreate);
         $this->assertInstanceOf(Suivi::class, $suivi);
-        $desc = 'Le signalement a été cloturé pour test avec le motif suivant <br /><strong>Non décence</strong><br /><strong>Desc. : </strong>Lorem ipsum suivi sit amet, consectetur adipiscing elit.';
+        $desc = Suivi::DESCRIPTION_MOTIF_CLOTURE_PARTNER.' test avec le motif suivant <br /><strong>Non décence</strong><br /><strong>Desc. : </strong>Lorem ipsum suivi sit amet, consectetur adipiscing elit.';
         $this->assertEquals($desc, $suivi->getDescription());
         $this->assertTrue($suivi->getIsPublic());
         $this->assertTrue($suivi->getIsSanitized());


### PR DESCRIPTION
## Ticket

#3730   

## Description
Remettre "clôturé" plutôt que "fermé" pour les suivis de signalements 

## Changements apportés
* Remettre "clôturé" plutôt que "fermé" pour les suivis de signalements 

## Pré-requis

## Tests
- [ ] CI OK
- [ ] Vérifier les suivis