### PR TITLE
[QA] Integrity constraint violation: 1451 Cannot delete or update a parent row

### DIFF
--- a/migrations/Version20250221154939.php
+++ b/migrations/Version20250221154939.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250221154939 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+                UPDATE signalement_draft d
+                SET status = 'EN_SIGNALEMENT'
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM signalement s
+                    WHERE s.created_from_id = d.id
+                    AND d.status != 'EN_SIGNALEMENT'
+                )
+            ");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace App\EventSubscriber;
 
+use App\Entity\Enum\SignalementDraftStatus;
 use App\Entity\Signalement;
 use App\Entity\SignalementDraft;
 use App\Event\SignalementDraftCompletedEvent;
@@ -69,6 +70,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                 $this->processFiles($signalementDraft, $signalement);
                 $this->dispatchCheckFiles($signalement);
                 $this->dispatchUpdateFromAddress($signalement);
+                $signalementDraft->setStatus(SignalementDraftStatus::EN_SIGNALEMENT);
                 $this->entityManager->commit();
             } else {
                 $this->entityManager->rollback();

--- a/src/Manager/SignalementDraftManager.php
+++ b/src/Manager/SignalementDraftManager.php
@@ -102,7 +102,6 @@ class SignalementDraftManager extends AbstractManager
 
         $signalement = $signalementDraftCompletedEvent->getSignalementDraft()->getSignalements()->first();
         if ($signalement) {
-            $signalementDraft->setStatus(SignalementDraftStatus::EN_SIGNALEMENT);
             $this->eventDispatcher->dispatch(new SignalementCreatedEvent($signalement), SignalementCreatedEvent::NAME);
 
             return $signalement;


### PR DESCRIPTION
## Ticket

#3733

## Description
La commande `app:clear-entities` crashe en prod depuis le 2 Février. La raison tentative de suppression d'un `signalementDraft` référencé dans le champ `createdFrom` d'un `Signalement`.
Cela signifie que lors de la transformation d'un draft en signalement le draft n'a pas pris le statut 3EN_SIGNALEMENT3. Il s'agit d'un cas ultra minoritaire étant données qu'il y'a uniquement deux draft dans ce cas sur la prod.

## Changements apportés
* Ajout d'une migration pour passer les draft référencé comme signalement au bon statut "EN_SIGNALEMENT"
* Déplacement du `$signalementDraft->setStatus(SignalementDraftStatus::EN_SIGNALEMENT);` dans la transcation pour éviter que le cas puise se reproduire

## Pré-requis
Se mettre sur base de prod
`make load-migrations`

## Tests
- [ ] Vérifier que la commande `app:clear-entities` s'exécute sans encombre
