### PR TITLE
[Tech] Optimisation de la commande npm run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
     "dev-server": "encore dev-server",
     "dev": "encore dev",
     "watch": "encore dev --watch",
+    "watch-base": "encore dev --watch",
+    "watch-front-stats": "encore dev --watch",
+    "watch-form": "encore dev --watch",
+    "watch-bo": "encore dev --watch",
     "build": "encore production --progress",
     "es-vue-fix": "node_modules/.bin/eslint --config=eslint.config.mjs --fix assets/scripts/vue/**/*.{ts,vue}",
     "es-js-fix": "node_modules/.bin/eslint --parser espree --fix assets/scripts/vanilla/*"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,13 +42,21 @@ Encore
      * Each entry will result in one JavaScript file (e.g. app.js)
      * and one CSS file (e.g. app.css) if your JavaScript imports CSS.
      */
-    .addEntry('app', './assets/scripts/app.ts')
-    .addEntry('app-back-bo', './assets/scripts/app-back-bo.ts')
-    .addEntry('app-front-signalement-form', './assets/scripts/app-front-signalement-form.ts')
-    .addEntry('app-front-stats', './assets/scripts/app-front-stats.ts')
+if (process.env.npm_lifecycle_event !== 'watch-front-stats' && process.env.npm_lifecycle_event !== 'watch-bo' && process.env.npm_lifecycle_event !== 'watch-form') {
+    Encore.addEntry('app', './assets/scripts/app.ts')
+}
+if (process.env.npm_lifecycle_event !== 'watch-base' && process.env.npm_lifecycle_event !== 'watch-bo' && process.env.npm_lifecycle_event !== 'watch-form') {
+    Encore.addEntry('app-front-stats', './assets/scripts/app-front-stats.ts')
+}
+if (process.env.npm_lifecycle_event !== 'watch-base' && process.env.npm_lifecycle_event !== 'watch-front-stats' && process.env.npm_lifecycle_event !== 'watch-form') {
+    Encore.addEntry('app-back-bo', './assets/scripts/app-back-bo.ts')
+}
+if (process.env.npm_lifecycle_event !== 'watch-base' && process.env.npm_lifecycle_event !== 'watch-front-stats' && process.env.npm_lifecycle_event !== 'watch-bo') {
+    Encore.addEntry('app-front-signalement-form', './assets/scripts/app-front-signalement-form.ts')
+}
 
     // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
-    .enableStimulusBridge('./assets/controllers.json')
+Encore.enableStimulusBridge('./assets/controllers.json')
 
     // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
     .splitEntryChunks()


### PR DESCRIPTION
## Ticket

#3746   

## Description
Le démarrage de la commande `npm run watch` était de plus en plus lent.
Puisque nous créons 4 exports différents, le même travail est fait plusieurs fois.
Je propose donc 4 nouvelles commandes qui permettent de cibler les exports qui sont en cours de `watch` :
- `npm run watch-form` : formulaire de signalement
- `npm run watch-front-stats` : statistiques front
- `npm run watch-bo` : toutes les pages du bo
- `npm run watch-base` : toutes les autres pages

`npm run watch` continue de fonctionner comme avant si nécessaire.

## Tests
- [ ] Vérifier les différentes commandes et que tout fonctionne
- [ ] Vérifier que `npm run build` fonctionne toujours comme avant
