### PR TITLE
[Contact] Changement adresse mail du formulaire de contact

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,7 @@ WKHTMLTOIMAGE_PATH=wkhtmltoimage
 ### histologe ###
 ADMIN_EMAIL=support@histologe.beta.gouv.fr
 NOTIFICATIONS_EMAIL=notifications@histologe.beta.gouv.fr
-CONTACT_EMAIL=contact@histologe.beta.gouv.fr
+CONTACT_EMAIL=formulaire-contact@histologe.beta.gouv.fr
 USER_SYSTEM_EMAIL=admin@histologe.net
 REPLY_TO_EMAIL=ne-pas-repondre@histologe.beta.gouv.fr
 WIDGET_DATA_KPI_CACHE_EXPIRED_AFTER=3600 #second

--- a/.env.sample
+++ b/.env.sample
@@ -67,7 +67,7 @@ WKHTMLTOIMAGE_PATH=wkhtmltoimage
 ### histologe ###
 ADMIN_EMAIL=support@histologe.beta.gouv.fr
 NOTIFICATIONS_EMAIL=notifications@histologe.beta.gouv.fr
-CONTACT_EMAIL=contact@histologe.beta.gouv.fr
+CONTACT_EMAIL=formulaire-contact@histologe.beta.gouv.fr
 USER_SYSTEM_EMAIL=admin@histologe.net
 REPLY_TO_EMAIL=ne-pas-repondre@histologe.beta.gouv.fr
 WIDGET_DATA_KPI_CACHE_EXPIRED_AFTER=3600 #second

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
           APP_SECRET: ${{ secrets.APP_SECRET }}
           DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db
           NOTIFICATIONS_EMAIL: notifications@histologe.beta.gouv.fr
-          CONTACT_EMAIL: contact@histologe.beta.gouv.fr
+          CONTACT_EMAIL: formulaire-contact@histologe.beta.gouv.fr
           HISTOLOGE_URL: http://localhost:8080
           SERVER_NAME: localhost:8080
           MAILER_DSN: ${{ secrets.MAILER_DSN_CI }}
@@ -164,7 +164,7 @@ jobs:
           DATABASE_URL: mysql://root:histologe@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/histologe_db
           ADMIN_EMAIL: support@histologe.beta.gouv.fr
           NOTIFICATIONS_EMAIL: notifications@histologe.beta.gouv.fr
-          CONTACT_EMAIL: contact@histologe.beta.gouv.fr
+          CONTACT_EMAIL: formulaire-contact@histologe.beta.gouv.fr
           HISTOLOGE_URL: http://localhost:8080
           SERVER_NAME: localhost:8080
           MAILER_DSN: ${{ secrets.MAILER_DSN_CI }}

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -166,7 +166,7 @@ class HomepageController extends AbstractController
         '/contact',
         name: 'front_contact',
         methods: ['GET'],
-        defaults: ['show_sitemap' => true]
+        defaults: ['show_sitemap' => false]
     )]
     public function contact(
         ParameterBagInterface $parameterBag,

--- a/tests/Functional/Controller/HomepageControllerTest.php
+++ b/tests/Functional/Controller/HomepageControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Functional\Controller;
 
 use Faker\Factory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class HomepageControllerTest extends WebTestCase
@@ -57,7 +58,7 @@ class HomepageControllerTest extends WebTestCase
         $client = static::createClient();
         /** @var UrlGeneratorInterface $generatorUrl */
         $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
-        $crawler = $client->request('GET', $generatorUrl->generate('front_contact'));
+        $client->request('GET', $generatorUrl->generate('front_contact'));
 
         $client->submitForm('Envoyer le message', [
             'contact[nom]' => 'John Doe',
@@ -71,9 +72,10 @@ class HomepageControllerTest extends WebTestCase
         $client->enableProfiler();
         $this->assertEmailCount(1);
 
+        $parameterBag = self::getContainer()->get(ParameterBagInterface::class);
         $email = $this->getMailerMessage();
-        $this->assertEmailHeaderSame($email, 'From', 'HISTOLOGE - ALERTE <notifications@histologe.beta.gouv.fr>');
-        $this->assertEmailHeaderSame($email, 'To', 'contact@histologe.beta.gouv.fr');
+        $this->assertEmailHeaderSame($email, 'From', 'HISTOLOGE - ALERTE <' .$parameterBag->get('notifications_email'). '>');
+        $this->assertEmailHeaderSame($email, 'To', $parameterBag->get('contact_email'));
     }
 
     public function testSubmitContactWithEmptyMessage(): void

--- a/tests/Functional/Controller/HomepageControllerTest.php
+++ b/tests/Functional/Controller/HomepageControllerTest.php
@@ -74,7 +74,7 @@ class HomepageControllerTest extends WebTestCase
 
         $parameterBag = self::getContainer()->get(ParameterBagInterface::class);
         $email = $this->getMailerMessage();
-        $this->assertEmailHeaderSame($email, 'From', 'HISTOLOGE - ALERTE <' .$parameterBag->get('notifications_email'). '>');
+        $this->assertEmailHeaderSame($email, 'From', 'HISTOLOGE - ALERTE <'.$parameterBag->get('notifications_email').'>');
         $this->assertEmailHeaderSame($email, 'To', $parameterBag->get('contact_email'));
     }
 


### PR DESCRIPTION
## Ticket

#3584   

## Description
Afin de limiter les mails de support :
- on crée une nouvelle adresse `formulaire-contact` vers laquelle sont redirigés les mails qui viennent du formulaire de contact
- on désindexe la page de contact
- fait par ailleurs lors de la MEP : on met en place un répondeur automatique sur l'adresse `contact`

## Tests
- [ ] Utiliser le formulaire de contact et vérifier le destinataire
