### PR TITLE
[FO - Sites Faciles] Prévoir iFrame statistiques front

### DIFF
--- a/assets/scripts/vue/components/front-stats/TheHistoAppFrontStats.vue
+++ b/assets/scripts/vue/components/front-stats/TheHistoAppFrontStats.vue
@@ -119,6 +119,9 @@ export default defineComponent({
     text-align: left;
     color: var(--blue-france-sun-113-625);
   }
+  .iframed .histo-app-front-stats h1 {
+    display: none;
+  }
 
   .histo-app-front-stats a {
     color: var(--blue-france-sun-113-625);

--- a/src/Controller/IframeController.php
+++ b/src/Controller/IframeController.php
@@ -25,6 +25,12 @@ class IframeController extends AbstractController
         ]);
     }
 
+    #[Route('/stats', name: 'iframe_stats', methods: ['GET'])]
+    public function stats(): Response
+    {
+        return $this->render('iframe/statistiques.html.twig');
+    }
+
     #[Route('/test', name: 'iframe_test', methods: ['GET'])]
     #[When('dev')]
     #[When('test')]

--- a/templates/iframe/statistiques.html.twig
+++ b/templates/iframe/statistiques.html.twig
@@ -1,0 +1,14 @@
+{% extends 'iframe/base-iframe.html.twig' %}
+
+{% block customscripts %}
+    {{ encore_entry_script_tags('app') }}
+    {{ encore_entry_link_tags('app') }}
+    {{ encore_entry_script_tags('app-front-stats') }}
+    {{ encore_entry_link_tags('app-front-stats') }}
+{% endblock %}
+
+{% block body %}
+    <main id="content">
+        <div id="app-front-stats" data-ajaxurl="{{ path('front_statistiques_filter') }}"></div>
+    </main>
+{% endblock %}


### PR DESCRIPTION
## Ticket

#3667   

## Description
Préparation de l'iframe "Statistiques" pour intégrer via sites-facile

## Pré-requis
`npm run watch`

## Tests
- [ ] Tester http://localhost:8080/iframe/stats
