### PR TITLE
[FO - Form] Correction d'un bug en cas de chccangement de profil

### DIFF
--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -190,6 +190,7 @@ export default defineComponent({
     },
     saveAndChangeScreenBySlug (slug:string, isSaveAndCheck:boolean, isCheckLocation:boolean = false) {
       this.nextSlug = slug
+      this.removeNextScreensIfProfileUpdated()
       if (isSaveAndCheck) {
         if (formStore.data.uuidSignalementDraft === '') {
           requests.checkIfAlreadyExists(this.showDraftModalOrNot)
@@ -308,7 +309,6 @@ export default defineComponent({
       }
 
       if (formStore.screenData) {
-        this.removeNextScreensIfProfileUpdated()
         // si le signalement n'a pas pu être créé (par exemple pas de désordres) la route ne renvoie pas de référence de signalement
         // du coup on ne va pas sur la page de confirmation, mais sur une page spéciale
         if (this.nextSlug === 'confirmation_signalement' && formStore.data.signalementReference === '') {

--- a/assets/scripts/vue/components/signalement-form/requests.ts
+++ b/assets/scripts/vue/components/signalement-form/requests.ts
@@ -91,7 +91,8 @@ export const requests = {
   },
 
   saveSignalementDraft (functionReturn: Function) {
-    if (formStore.data.uuidSignalementDraft !== '') {
+    // on n'enregistre rien si on est sur la page signalement_concerne car on a peut-être changé de profil et on n'a plus l'email-décclarant   
+    if (formStore.data.uuidSignalementDraft !== '' && formStore.currentScreen != null && formStore.currentScreen.slug !== 'signalement_concerne') {
       // TODO : il y a sûrement plus élégant à faire pour construire l'url (cf controlleur et twig)
       const url = formStore.props.ajaxurlPutSignalementDraft.replace('uuid', formStore.data.uuidSignalementDraft)
       requests.doRequestPut(url, formStore.data, functionReturn)


### PR DESCRIPTION
## Ticket

#3758    

## Description
Quand on change plusieurs fois de profil (en passant d'occupant à tiers) , on est bloqué car les coordonnées ne sont pas remplies. 
https://sentry.incubateur.net/organizations/betagouv/issues/152236/events/3ea7ef598d6e4749a2a5c19d81bf1a1a/?project=61&referrer=next-event

## Changements apportés
* On n'enregistre pas le draft si on est sur l'écran de choix de profil
* On met à jour le profil dans le formData avant d'enregistrer le draft (pour avoir une donnée cohérente entre `profil` et `signalement_concerne_profil_detail_tiers` ou `signalement_concerne_profil_detail_occupant`

## Pré-requis
`npm run watch`

## Tests
- [ ] Faire un signalement en profil occupant sur quelques écrans
- [ ] Revenir en arrière et passer en profil tiers et vérifier qu'ono n'a pas d'erreur sur l'absence de coordonnées (tester 2 fois de suite)
