### PR TITLE
[Synchro Metabase] Recevoir mail quand OK

### DIFF
--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -134,29 +133,5 @@ class SecurityController extends AbstractController
     public function logout(): void
     {
         throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
-    }
-
-    #[Route('/send-error-email', methods: ['POST'])]
-    public function handleSendErrorEmail(
-        Request $request,
-        LoggerInterface $logger,
-    ): JsonResponse {
-        $expectedToken = $this->getParameter('send_error_email_token');
-        $providedToken = $request->headers->get('Authorization');
-
-        if ($providedToken !== 'Bearer '.$expectedToken) {
-            return new JsonResponse(['error' => 'Unauthorized'], 403);
-        }
-
-        $data = json_decode($request->getContent(), true);
-
-        if (!$data || !isset($data['title'], $data['timestamp'], $data['host'], $data['database'], $data['error'])) {
-            return new JsonResponse(['error' => 'Invalid request'], 400);
-        }
-
-        // Log de l'erreur
-        $logger->error("send-error-mail: {$data['title']} {$data['error']} (DB: {$data['database']}, Host: {$data['host']}, Time: {$data['timestamp']})");
-
-        throw new HttpException(500, $data['title'], null, ['timestamp' => $data['timestamp'], 'database' => $data['database'], 'host' => $data['host'], 'error' => $data['error']]);
     }
 }

--- a/src/Controller/SendEmailController.php
+++ b/src/Controller/SendEmailController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\Mailer\NotificationMail;
+use App\Service\Mailer\NotificationMailerRegistry;
+use App\Service\Mailer\NotificationMailerType;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+class SendEmailController extends AbstractController
+{
+    #[Route('/send-email', methods: ['POST'])]
+    public function handleSendEmail(
+        Request $request,
+        LoggerInterface $logger,
+        NotificationMailerRegistry $notificationMailerRegistry,
+    ): JsonResponse {
+        $expectedToken = $this->getParameter('send_error_email_token');
+        $providedToken = $request->headers->get('Authorization');
+
+        if ($providedToken !== 'Bearer '.$expectedToken) {
+            return new JsonResponse(['error' => 'Unauthorized'], 403);
+        }
+
+        $data = json_decode($request->getContent(), true);
+
+        if (!$data || !isset($data['title'], $data['timestamp'], $data['host'], $data['database'])) {
+            return new JsonResponse(['error' => 'Invalid request'], 400);
+        }
+
+        if (isset($data['error'])) {
+            // Log de l'erreur
+            $logger->error("send-error-mail: {$data['title']} {$data['error']} (DB: {$data['database']}, Host: {$data['host']}, Time: {$data['timestamp']})");
+
+            $message = " erreur s'est produite.";
+            $errorMessages = [];
+            $errorMessages[] = '📅 Date : '.($data['timestamp'] ?? 'N/A');
+            $errorMessages[] = '💾 Base : '.($data['database'] ?? 'N/A');
+            $errorMessages[] = '🔍 Hôte : '.($data['host'] ?? 'N/A');
+            $errorMessages[] = '❗ Erreur : '.($data['error'] ?? 'N/A');
+
+            $notificationMailerRegistry->send(
+                new NotificationMail(
+                    type: NotificationMailerType::TYPE_CRON,
+                    to: $this->getParameter('admin_email'),
+                    cronLabel: $data['title'],
+                    params: [
+                        'count_failed' => 1,
+                        'message_failed' => $message,
+                        'error_messages' => $errorMessages,
+                    ],
+                )
+            );
+        } else {
+            $notificationMailerRegistry->send(
+                new NotificationMail(
+                    type: NotificationMailerType::TYPE_CRON,
+                    to: $this->getParameter('admin_email'),
+                    cronLabel: $data['title'],
+                    params: [
+                        'count_success' => 1,
+                        'message_success' => $data['message']." (DB: {$data['database']}, Host: {$data['host']}, Time: {$data['timestamp']})",
+                    ],
+                )
+            );
+        }
+
+        return new JsonResponse(['message' => 'Mail sent']);
+    }
+}

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -11,7 +11,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
@@ -47,26 +46,11 @@ readonly class ExceptionListener
         }
 
         if ($this->shouldNotifyForException($exception)) {
-            $extraData = [];
-            if ($exception instanceof HttpException) {
-                $extraData = $exception->getHeaders();
-            }
-
-            $message = "Une erreur s'est produite : {$exception->getMessage()}";
-
-            if (!empty($extraData)) {
-                $message .= "\n\n📅 Date : ".($extraData['timestamp'] ?? 'N/A');
-                $message .= "\n💾 Base : ".($extraData['database'] ?? 'N/A');
-                $message .= "\n🔍 Hôte : ".($extraData['host'] ?? 'N/A');
-                $message .= "\n❗ Erreur : ".($extraData['error'] ?? 'N/A');
-            }
-
             $this->notificationMailerRegistry->send(
                 new NotificationMail(
                     type: NotificationMailerType::TYPE_ERROR_SIGNALEMENT,
                     to: $this->params->get('admin_email'),
-                    event: $event,
-                    message: $message
+                    event: $event
                 )
             );
         }

--- a/src/Service/Mailer/Mail/Cron/CronMailer.php
+++ b/src/Service/Mailer/Mail/Cron/CronMailer.php
@@ -14,7 +14,7 @@ class CronMailer extends AbstractNotificationMailer
 {
     protected ?NotificationMailerType $mailerType = NotificationMailerType::TYPE_CRON;
     protected ?string $mailerTemplate = 'cron_email';
-    protected ?string $mailerSubject = 'La tache planifiée s\'est bien éxécutée.';
+    public const MAILER_SUBJECT = 'La tâche planifiée %s.';
 
     public function __construct(
         protected MailerInterface $mailer,
@@ -32,5 +32,15 @@ class CronMailer extends AbstractNotificationMailer
             'message' => $notificationMail->getMessage(),
             'count' => $notificationMail->getCronCount(),
         ];
+    }
+
+    public function updateMailerSubjectFromNotification(NotificationMail $notificationMail): void
+    {
+        $this->mailerSubject = \sprintf(
+            self::MAILER_SUBJECT,
+            isset($notificationMail->getParams()['error_messages']) && $notificationMail->getParams()['error_messages'] > 0 ?
+                's\'est arrêtée en erreur' :
+                's\'est bien exécutée'
+        );
     }
 }

--- a/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
+++ b/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
@@ -34,7 +34,6 @@ class ErrorSignalementMailer extends AbstractNotificationMailer
             'code' => $event->getThrowable()->getCode(),
             'error' => $event->getThrowable()->getMessage(),
             'req' => $event->getRequest()->getContent(),
-            'message' => $notificationMail->getMessage(),
         ];
     }
 }

--- a/templates/emails/cron_email.html.twig
+++ b/templates/emails/cron_email.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
     <p>Plateforme: {{ url }}</p>
-    <p>La tache planifiée <strong>{{ cron_label }}</strong> s'est éxécutée avec succès.</p>
+    <p>La tâche planifiée <strong>{{ cron_label }}</strong> {{ (error_messages is defined and error_messages|length) ? 'a rencontré une erreur' : 's\'est terminée avec succès'}}.</p>
     <p> {{ count is defined ? count : ' '}} {{ message is defined ? message : ' ' }}</p>
     {% if count_success is defined and message_success is defined %}
         <p><span>&#9989;</span> {{ count_success }} {{ message_success }}</p>

--- a/templates/emails/erreur_signalement_email.html.twig
+++ b/templates/emails/erreur_signalement_email.html.twig
@@ -9,10 +9,7 @@
     {% if error is defined %}
         <p>Message erreur: {{ error }}</p>
     {% endif %}
-    {% if message is defined %}
-        <p>{{ message }}</p>
-    {% endif %}
-    {% if req is defined and message is not defined%}
+    {% if req is defined %}
         <p>{{ req|json_encode() }}</p>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Ticket

#3745    

## Description
Envoi d'un mail lors de la synchro de bdd Metabase que ce soit en échec ou que cce soit un succès

## Changements apportés
* Création d'un controlleur spécifique `SendEmailController` qui utilise `CronMailer`
* Modification du `CronMailer` et du template `cron_email.html.twig` pour modifier titre et message pour avoir l'info erreur ou pas directement
* Mise à jour du script de synchro
* Revert des modifications du `SecurityController`, `ExceptionListener`, `ErrorSignalementMailer` et du template `erreur_signalement_email.html.twig` faites dans https://github.com/MTES-MCT/histologe/pull/3702

## Pré-requis

## Tests
- [ ] Tester l'envoi du mail dans les 2 cas avec un curl commme
```
curl -X POST "http://localhost:8080/send-email" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer test" \
     -d '{"title": "[Metabase] Synchronisation de Bdd", "timestamp": "2025-02-27 14:30:00", "host": "myserver", "database": "mydb", "error": "La synchronisation de la bdd a échoué avec le code 999"}'
```
et
	 
```
curl -X POST "http://localhost:8080/send-email" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer test" \
     -d '{"title": "[Metabase] Synchronisation de Bdd", "timestamp": "2025-02-27 14:30:00", "host": "myserver", "database": "mydb", "message": "base de données a été synchronisée avec succès"}'
```
