### PR TITLE
[FO - Stat Publiques] Modifier calcul resolution (ajout condition Statut Fermé)

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -378,8 +378,8 @@ class SignalementRepository extends ServiceEntityRepository
             ->where('s.motifCloture IS NOT NULL')
             ->andWhere('s.motifCloture != \'0\'')
             ->andWhere('s.closedAt IS NOT NULL')
-            ->andWhere('s.statut NOT IN (:statutList)')
-            ->setParameter('statutList', [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED]);
+            ->andWhere('s.statut = :statut')
+            ->setParameter('statut', SignalementStatus::CLOSED);
 
         if ($removeImported) {
             $qb->andWhere('s.isImported IS NULL OR s.isImported = 0');


### PR DESCRIPTION
## Ticket

#3761   

## Description
Les stats publiques comptent les resolutions sur les motifs de cloture
Mais si un signalement est reouvert, le motif etant toujours présent, le signalement est toujours comptabilisé
Ajouté la condition Statut CLOSED pour le décompte

## Changements apportés
* Modification de la fonction countByMotifCloture dans le SignalemmentRepository pour ne prendre en compte que les signalements au statu CLOSED

## Pré-requis

## Tests
- [ ] Vérifier l'affichage des stats publiques
