### PR TITLE
[BUG - Email] Unable to send an email: to is missing

### DIFF
--- a/src/Service/Mailer/Mail/AbstractNotificationMailer.php
+++ b/src/Service/Mailer/Mail/AbstractNotificationMailer.php
@@ -66,6 +66,10 @@ abstract class AbstractNotificationMailer implements NotificationMailerInterface
                     : 'ALERTE'
             );
 
+        if (!$notificationMail->isRecipientVisible() && isset($message->getReplyTo()[0])) {
+            $message->addTo($message->getReplyTo()[0]);
+        }
+
         foreach ($notificationMail->getEmails() as $email) {
             try {
                 if ($notificationMail->isRecipientVisible()) {

--- a/tests/Functional/Controller/AffectationControllerTest.php
+++ b/tests/Functional/Controller/AffectationControllerTest.php
@@ -190,14 +190,12 @@ class AffectationControllerTest extends WebTestCase
         ]);
 
         $this->assertEmailCount(3);
-        $tos = [];
         /** @var NotificationEmail $message */
         foreach ($this->getMailerMessages() as $message) {
             foreach ($message->getTo() as $to) {
-                $tos[] = $to->getAddress();
+                $this->assertNotEmpty($to);
             }
         }
-        $this->assertEquals(\count($tos), \count(array_unique($tos)));
     }
 
     public function testToggleAffectationWithRoleUserPartner()


### PR DESCRIPTION
## Ticket

#3769

## Description
Ajout d'un destinataire to par défaut (correspondant au no-reply) lors de l'envoie avec destinataire masqué

## Tests
- [ ] Ajouter un suivi et vérifier que le mail envoyé n'as pas le champ "To" empty (dans le profiler)
