### PR TITLE
[FO - Stats] La répartition par statut ne s'affiche plus

### DIFF
--- a/src/Service/Statistics/StatusStatisticProvider.php
+++ b/src/Service/Statistics/StatusStatisticProvider.php
@@ -41,8 +41,9 @@ class StatusStatisticProvider
         $data = [];
         foreach ($countPerStatuses as $countPerStatus) {
             $item = self::initStatutByValue($countPerStatus);
+
             if ($item) {
-                $data[$countPerStatus['statut']] = $item;
+                $data[$countPerStatus['statut']->value] = $item;
             }
         }
 
@@ -51,7 +52,7 @@ class StatusStatisticProvider
 
     private static function initStatutByValue($statusResult): bool|array
     {
-        switch ($statusResult['statut']) {
+        switch ($statusResult['statut']->value) {
             case SignalementStatus::REFUSED->value:
                 return [
                     'label' => 'Refusé',


### PR DESCRIPTION
## Ticket

#3772   

## Description
Depuis les changemenst sur les statuts de signalement, la stat de répartition par statut ne fonctionne pas

## Changements apportés
* Correction de StatusStatisticProvider.php

## Pré-requis

## Tests
- [ ] Vérifier l'affichage du camembert de répartition par statut dans les stats front
