### PR TITLE
[BO - Command renvoi FailedEmail] Améliorer

### DIFF
--- a/migrations/Version20250303140936.php
+++ b/migrations/Version20250303140936.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250303140936 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add new columns to failed_email table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DELETE FROM failed_email WHERE retry_count > 900 AND is_resend_successful = 0');
+        $this->addSql('ALTER TABLE failed_email ADD is_recipient_visible TINYINT(1) NOT NULL');
+        $this->addSql('UPDATE failed_email SET is_recipient_visible = 1');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE failed_email DROP is_recipient_visible');
+    }
+}

--- a/src/Command/RetryFailedEmailsCommand.php
+++ b/src/Command/RetryFailedEmailsCommand.php
@@ -56,9 +56,16 @@ class RetryFailedEmailsCommand extends Command
                 )
             ;
 
+            if (!$failedEmail->isRecipientVisible() && isset($failedEmail->getReplyTo()[0])) {
+                $emailMessage->addTo($emailMessage->getReplyTo()[0]);
+            }
             foreach ($failedEmail->getToEmail() as $toEmail) {
                 if ('NC' !== $toEmail) {
-                    $toEmail && $emailMessage->addTo($toEmail);
+                    if ($failedEmail->isRecipientVisible()) {
+                        $toEmail && $emailMessage->addTo($toEmail);
+                    } else {
+                        $toEmail && $emailMessage->addBcc($toEmail);
+                    }
                 }
             }
             if (

--- a/src/Command/RetryFailedEmailsCommand.php
+++ b/src/Command/RetryFailedEmailsCommand.php
@@ -60,11 +60,11 @@ class RetryFailedEmailsCommand extends Command
                 $emailMessage->addTo($emailMessage->getReplyTo()[0]);
             }
             foreach ($failedEmail->getToEmail() as $toEmail) {
-                if ('NC' !== $toEmail) {
+                if ($toEmail && 'NC' !== $toEmail) {
                     if ($failedEmail->isRecipientVisible()) {
-                        $toEmail && $emailMessage->addTo($toEmail);
+                        $emailMessage->addTo($toEmail);
                     } else {
-                        $toEmail && $emailMessage->addBcc($toEmail);
+                        $emailMessage->addBcc($toEmail);
                     }
                 }
             }

--- a/src/Entity/FailedEmail.php
+++ b/src/Entity/FailedEmail.php
@@ -52,6 +52,9 @@ class FailedEmail
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private ?\DateTimeImmutable $lastAttemptAt;
 
+    #[ORM\Column]
+    private ?bool $isRecipientVisible = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -221,6 +224,18 @@ class FailedEmail
     public function setLastAttemptAt(?\DateTimeImmutable $lastAttemptAt): static
     {
         $this->lastAttemptAt = $lastAttemptAt;
+
+        return $this;
+    }
+
+    public function isRecipientVisible(): ?bool
+    {
+        return $this->isRecipientVisible;
+    }
+
+    public function setIsRecipientVisible(bool $isRecipientVisible): static
+    {
+        $this->isRecipientVisible = $isRecipientVisible;
 
         return $this;
     }

--- a/src/Manager/FailedEmailManager.php
+++ b/src/Manager/FailedEmailManager.php
@@ -23,7 +23,6 @@ class FailedEmailManager extends AbstractManager
         string $replyTo,
         bool $notifyUsager,
     ): FailedEmail {
-        $notificationMail->isRecipientVisible();
         $failedEmail = (new FailedEmail())
             ->setType($notificationMail->getTypeName())
             ->setToEmail($notificationMail->getEmails())

--- a/src/Manager/FailedEmailManager.php
+++ b/src/Manager/FailedEmailManager.php
@@ -23,12 +23,14 @@ class FailedEmailManager extends AbstractManager
         string $replyTo,
         bool $notifyUsager,
     ): FailedEmail {
+        $notificationMail->isRecipientVisible();
         $failedEmail = (new FailedEmail())
             ->setType($notificationMail->getTypeName())
             ->setToEmail($notificationMail->getEmails())
             ->setFromEmail($message->getFrom()[0]->getAddress() ?? '')
             ->setFromFullname($message->getFrom()[0]->getName())
             ->setReplyTo($replyTo)
+            ->setIsRecipientVisible($notificationMail->isRecipientVisible())
             ->setSubject($message->getSubject())
             ->setContext($message->getContext())
             ->setNotifyUsager($notifyUsager)


### PR DESCRIPTION
## Ticket

#3771

## Description
- Ajout de la gestion du champ `isRecipientVisible`  dans FailedEmail afin d'être iso avec l'envoie classique 
- Suppression des email en erreur avec +de 900 tentative de renvoie (faisant suite au bug sur l'auto affectation)

## Pré-requis
make execute-migration name=Version20250303140936 direction=up

## Tests
- [ ] Provoquer volontairement une erreur lors de l'envoie d'email
- [ ] Ajouter un suivie (partagé a l'utilisateur) sur un signalement ayant plusieurs affectations
- [ ] Lancer la commande `app:retry-failed-emails` et s'assurer que les destinaire to et bcc sont comme attendus
