### PR TITLE
[Sécurité - Audit] Demander ancien mot de passe lors d'un changement de mot de passe

### DIFF
--- a/assets/scripts/vanilla/controllers/activate_account/activate_account.js
+++ b/assets/scripts/vanilla/controllers/activate_account/activate_account.js
@@ -10,6 +10,9 @@ document?.querySelectorAll('.fr-password-toggle')?.forEach(pwdToggle => {
   })
 })
 document?.querySelector('form[name="login-creation-mdp-form"]')?.querySelectorAll('[name^="password"]').forEach(pwd => {
+  if (pwd.name === 'password-current') {
+    return
+  }
   pwd.addEventListener('input', canSubmitFormReinitPassword)
 })
 document?.querySelector('form[name="login-creation-mdp-form"]')?.addEventListener('submit', (event) => {
@@ -18,7 +21,7 @@ document?.querySelector('form[name="login-creation-mdp-form"]')?.addEventListene
   if (modalCgu) {
     dsfr(modalCgu).modal.conceal()
   }
-  if (canSubmitFormReinitPassword()) {
+  if (canSubmitFormReinitPassword() && document?.querySelector('form[name="login-creation-mdp-form"] #submitter')) {
     event.target.submit()
   }
 })
@@ -27,7 +30,7 @@ function canSubmitFormReinitPassword () {
   const pass = document?.querySelector('form[name="login-creation-mdp-form"] #login-password').value
   const repeat = document?.querySelector('form[name="login-creation-mdp-form"] #login-password-repeat').value
   const pwdMatchError = document?.querySelector('form[name="login-creation-mdp-form"] #password-match-error')
-  const submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter')
+  const submitBtn = document?.querySelector('form[name="login-creation-mdp-form"] #submitter') ?? document?.querySelector('#fr-modal-profil-edit-password #submitter')
   const messageLength = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-length')
   const messageMaj = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-maj')
   const messageMin = document?.querySelector('form[name="login-creation-mdp-form"] #password-input-message-info-min')

--- a/assets/scripts/vanilla/controllers/form_modal_handler.js
+++ b/assets/scripts/vanilla/controllers/form_modal_handler.js
@@ -82,7 +82,8 @@ async function submitPayload (formElement) {
             messageError = messageError + error
           })
           pElement.innerHTML = messageError
-          inputElement.insertAdjacentElement('afterend', pElement)
+
+          inputElement.parentElement.appendChild(pElement)
         }
         if (firstErrorElement) {
           inputElement.focus()

--- a/templates/back/profil/_modal_profil_password.html.twig
+++ b/templates/back/profil/_modal_profil_password.html.twig
@@ -3,16 +3,22 @@
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
-                    <form action="{{ path('back_profil_edit_password') }}" name="login-creation-mdp-form"
-                        id="profil_edit_password_form" method="POST">
-                        <div class="fr-modal__header">
-                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-profil-edit-password">Fermer</button>
-                        </div>
-                        <div class="fr-modal__content">
-                            <h1 id="fr-modal-profil-edit-password-title" class="fr-modal__title">
-                                Modifier mon mot de passe
-                            </h1>    
-                            Pour votre sécurité, choisissez un mot de passe unique pour votre compte {{ platform.name }}.
+                    <div class="fr-modal__header">
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-profil-edit-password">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-profil-edit-password-title" class="fr-modal__title">
+                            Modifier mon mot de passe
+                        </h1>    
+                        Pour votre sécurité, choisissez un mot de passe unique pour votre compte {{ platform.name }}.
+                        <form action="{{ path('back_profil_edit_password') }}" name="login-creation-mdp-form" id="profil_edit_password_form" method="POST">
+                            <div class="fr-input-group fr-grid-row fr-grid-row--middle fr-mt-5v">
+                                <label class="fr-label fr-col-12" for="login-password-current">
+                                    Mot de passe actuel
+                                </label>
+                                <input class="fr-input fr-col-11" type="password" id="login-password-current" name="password-current" required autocomplete="password">
+                                <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                            </div>
                             <div class="fr-input-group fr-input-group-password fr-grid-row fr-grid-row--middle fr-mt-5v">
                                 <label class="fr-label fr-col-12" for="login-password">
                                     Nouveau mot de passe
@@ -39,24 +45,24 @@
                                 </p>
                             </div>
                             <input type="hidden" name="_token" value="{{ csrf_token('profil_edit_password') }}">
-                        </div>
-                        <div class="fr-modal__footer">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                <li>
-                                    <button class="fr-btn fr-icon-check-line" form="profil_edit_password_form"
-                                            id="submitter" type="submit">
-                                        Valider
-                                    </button>
-                                </li>
-                                <li>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
-                                            aria-controls="fr-modal-profil-edit-password" type="button">
-                                        Annuler
-                                    </button>
-                                </li>
-                            </ul>
-                        </div>
-                    </form>
+                        </form>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button class="fr-btn fr-icon-check-line" form="profil_edit_password_form"
+                                        id="submitter" type="submit">
+                                    Valider
+                                </button>
+                            </li>
+                            <li>
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                        aria-controls="fr-modal-profil-edit-password" type="button">
+                                    Annuler
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/back/profil/index.html.twig
+++ b/templates/back/profil/index.html.twig
@@ -93,7 +93,7 @@
     </section>
     <hr>
     <section class="fr-px-5v fr-my-5v">
-        <div class="fr-grid-row fr-grid-row--middle">  
+        <div class="fr-grid-row fr-grid-row--middle" data-ajax-form>  
             {% include 'back/profil/_modal_profil_password.html.twig' %}
             <div class="fr-col-8 fr-text--left">
                 <h2>


### PR DESCRIPTION
## Ticket

#3560

## Description
Demande et vérification du mot de passe actuel lors du changement de mot de passe via la page profil du BO

## Changements apportés
* Ajout du champ mot de passe courant et vérification à la soumission
* Soumission ajax pour avoir un retour d'erreur directement dans la modale sans recharger la page
* Mise à jour des tests

## Pré-requis
`make npm-build`

## Tests
- [ ] Modifier son mot de passe via la page profil en essayant de rentrer un mot de passe courant erroné puis correct
- [ ] Vérifier que les autre modale de soumission ajax affiche correctement les erreurs (ex modale d'édition signalement BO)
- [ ] Vérifier que la modification de mot de passe en mode déconnecté fonctionne toujours (récupérer votre mot de passe)
