### PR TITLE
[BUG] Fix request mdp perdu quand un autre compte "ROLE_USAGER" existe

### DIFF
--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -87,8 +87,8 @@ class UserAccountController extends AbstractController
                 ]);
             }
 
-            $user = $userRepository->findOneBy(['email' => $email]);
-            if ($user && User::STATUS_ACTIVE === $user->getStatut() && !\in_array('ROLE_USAGER', $user->getRoles())) {
+            $user = $userRepository->findAgentByEmail($email);
+            if ($user && User::STATUS_ACTIVE === $user->getStatut()) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_LOST_PASSWORD,

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -42,8 +42,8 @@ class UserAccountController extends AbstractController
                 ]);
             }
 
-            $user = $userRepository->findOneBy(['email' => $email]);
-            if ($user && User::STATUS_INACTIVE === $user->getStatut() && !\in_array('ROLE_USAGER', $user->getRoles())) {
+            $user = $userRepository->findAgentByEmail($email, User::STATUS_INACTIVE);
+            if ($user) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_ACCOUNT_ACTIVATION_FROM_FO,

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -453,16 +453,21 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         return $qb;
     }
 
-    public function findAgentByEmail(string $email): ?User
+    public function findAgentByEmail(string $email, ?int $userStatus = null): ?User
     {
-        $queryBuilder = $this->createQueryBuilder('u');
-
-        return $queryBuilder
+        $queryBuilder = $this->createQueryBuilder('u')
             ->andWhere('u.email = :email')
             ->setParameter('email', $email)
             ->andWhere('JSON_CONTAINS(u.roles, :roles) = 0')
-            ->setParameter('roles', '"ROLE_USAGER"')
-            ->getQuery()
+            ->setParameter('roles', '"ROLE_USAGER"');
+
+        if (null !== $userStatus) {
+            $queryBuilder
+                ->andWhere('u.statut = :userStatus')
+                ->setParameter('userStatus', $userStatus);
+        }
+
+        return $queryBuilder->getQuery()
             ->getOneOrNullResult();
     }
 }

--- a/src/Security/FormLoginAuthenticator.php
+++ b/src/Security/FormLoginAuthenticator.php
@@ -49,7 +49,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
 
         $passport = new Passport(
             new UserBadge($email, function (string $email) {
-                return $this->userRepository->findOneBy(['email' => $email, 'statut' => User::STATUS_ACTIVE]);
+                return $this->userRepository->findAgentByEmail($email, User::STATUS_ACTIVE);
             }),
             new PasswordCredentials($request->request->get('password', '')),
             [


### PR DESCRIPTION
## Ticket

#3786

## Description
Nous avons en stock quelques comptes ayant la même adresse email (un usager et un agent ) cela provoquait des problèmes :
- Si le compte user est antécédent à celui de l'agent : impossible d’utiliser le système de récupération de mot de passe
- Si le compte user est antécédent à celui de l'agent et actif : Impossible de se connecter

## Tests
Sur base de prod tester avec l'emai posant soucis (voir mattermost)
- [ ] Demande mot de passe perdu
- [ ] Connexion suite au changement de mot de passe
