### PR TITLE
[bug] pagination page partenaires

### DIFF
--- a/assets/scripts/vanilla/services/form_helper.js
+++ b/assets/scripts/vanilla/services/form_helper.js
@@ -20,6 +20,7 @@ document.querySelectorAll('.fr-disable-button-when-submit')?.forEach(element => 
 const autoSubmitElements = document.querySelectorAll('.fr-auto-submit')
 autoSubmitElements.forEach(autoSubmitElements => {
   autoSubmitElements.addEventListener('change', function () {
+    document.getElementById('page').value = 1
     this.form.submit()
   })
 })

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -70,13 +70,10 @@ class PartnerRepository extends ServiceEntityRepository
         ?SearchPartner $searchPartner = null,
     ): Paginator {
         $queryBuilder = $this->getPartnersQueryBuilder($territory);
-        $queryBuilder->addSelect('z')
+        $queryBuilder->select('p', 'z', 'ez')
             ->leftJoin('p.zones', 'z')
-            ->leftJoin('p.excludedZones', 'ez')
-            ->leftJoin('p.userPartners', 'up')
-            ->leftJoin('up.user', 'u');
+            ->leftJoin('p.excludedZones', 'ez');
 
-        $queryBuilder->select('p');
         $queryBuilder->addSelect(
             '(CASE
                 WHEN p.email IS NOT NULL THEN 1
@@ -126,7 +123,7 @@ class PartnerRepository extends ServiceEntityRepository
         $firstResult = ($page - 1) * $maxResult;
         $queryBuilder->setFirstResult($firstResult)->setMaxResults($maxResult);
 
-        $paginator = new Paginator($queryBuilder->getQuery(), false);
+        $paginator = new Paginator($queryBuilder->getQuery());
 
         return $paginator;
     }


### PR DESCRIPTION
## Ticket

#3792

## Description
Bug remonté par Arnaud lors de sont test sur le Rhône : 
La liste des partenaires n'est pas complète. Le bug fait suite à la PR #3776 (et existait probablement déjà avant mais uniquement ppour les partenaires avec des zones, donc moins visibles)

## Changements apportés
* Correction du paramètre paginator pour corriger le problème
* Correction de la requête pour éviter les query N+1 lors de l'affichage de la liste

## Tests
- [ ] S'assurer que la pagination de la page partenaire fonctionne correctement (les derniers partenaires de la liste doivent être affichés quand on se rend sur la dernière page. ajouter +1 au paramètre page dans l'URL doit retourne une page vide)
