### PR TITLE
[BO - utilisateurs - partenaires] Les utilisateurs API ne doivent pas être visibles (hors SA)

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,6 @@ APP_ENV=dev
 APP_SECRET=
 MAILER_DSN=smtp://histologe_mailer:1025
 DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=8.0.40&charset=utf8"
-# DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_7589?serverVersion=8.0.40&charset=utf8"
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 
 ###> knplabs/knp-snappy-bundle ###

--- a/.env
+++ b/.env
@@ -17,6 +17,7 @@ APP_ENV=dev
 APP_SECRET=
 MAILER_DSN=smtp://histologe_mailer:1025
 DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_db?serverVersion=8.0.40&charset=utf8"
+# DATABASE_URL="mysql://histologe:histologe@histologe_mysql:3307/histologe_7589?serverVersion=8.0.40&charset=utf8"
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 
 ###> knplabs/knp-snappy-bundle ###

--- a/src/Form/SearchUserType.php
+++ b/src/Form/SearchUserType.php
@@ -41,6 +41,7 @@ class SearchUserType extends AbstractType
             $this->isAdmin = true;
         } else {
             unset($this->roleChoices['Super Admin']);
+            unset($this->roleChoices['API']);
         }
     }
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -408,6 +408,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $qb->andWhere('JSON_CONTAINS(u.roles, :roleUsager) = 0')->setParameter('roleUsager', '"ROLE_USAGER"');
         if (!$searchUser->getUser()->isSuperAdmin()) {
             $qb->andWhere('JSON_CONTAINS(u.roles, :roleAdmin) = 0')->setParameter('roleAdmin', '"ROLE_ADMIN"');
+            $qb->andWhere('JSON_CONTAINS(u.roles, :roleAdmin) = 0')->setParameter('roleAdmin', '"ROLE_API_USER"');
         }
         if ($searchUser->getQueryUser()) {
             $qb->andWhere('LOWER(u.nom) LIKE :queryUser

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -234,50 +234,52 @@
 
 			{% set tableBody %}
                 {% for user in partner.users|filter(user => user.id is not null) %}
-                    <tr class="user-row">
-                        <td>{{ user.getLastLoginAtStr('d/m/Y') }}</td>
-                        <td>{{ user.nom }}</td>
-                        <td>{{ user.prenom }}</td>
-                        <td>{{ user.email }}</td>
-                        <td><span class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ user.isMailingActive ? 'OUI' : 'NON' }}</span></td>
-                        <td>{% if user.statut == 0 %}
-                                {% set classe = 'fr-badge--orange-terre-battue' %}
-                                {% set label = 'INACTIF' %}
-                            {% elseif user.statut == 1 %}
-                                {% set classe = 'fr-badge--green-emeraude' %}
-                                {% set label = 'ACTIF' %}
-                            {% elseif user.statut == 2 %}
-                                {% set classe = 'fr-badge--blue-ecume' %}
-                                {% set label = 'ARCHIVE' %}
+                    {% if is_granted('ROLE_ADMIN') or 'ROLE_API_USER' not in user.roles %}
+                        <tr class="user-row">
+                            <td>{{ user.getLastLoginAtStr('d/m/Y') }}</td>
+                            <td>{{ user.nom }}</td>
+                            <td>{{ user.prenom }}</td>
+                            <td>{{ user.email }}</td>
+                            <td><span class="fr-badge fr-badge--blue-ecume fr-mb-1v">{{ user.isMailingActive ? 'OUI' : 'NON' }}</span></td>
+                            <td>{% if user.statut == 0 %}
+                                    {% set classe = 'fr-badge--orange-terre-battue' %}
+                                    {% set label = 'INACTIF' %}
+                                {% elseif user.statut == 1 %}
+                                    {% set classe = 'fr-badge--green-emeraude' %}
+                                    {% set label = 'ACTIF' %}
+                                {% elseif user.statut == 2 %}
+                                    {% set classe = 'fr-badge--blue-ecume' %}
+                                    {% set label = 'ARCHIVE' %}
+                                {% endif %}
+                                <span class="fr-badge {{ classe }} fr-mb-1v">{{ label }}</span></td>
+                            <td>
+                                {{ user.roleLabel() }}
+                            </td>
+                            {% if is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
+                            <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
                             {% endif %}
-                            <span class="fr-badge {{ classe }} fr-mb-1v">{{ label }}</span></td>
-                        <td>
-                            {{ user.roleLabel() }}
-                        </td>
-                        {% if is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
-                        <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
-                        {% endif %}
-                        <td class="fr-text--right">
-                            {% if is_granted('USER_EDIT', user) %}
-                                <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"
-                                    aria-controls="fr-modal-user-edit"
-                                    data-fr-opened="false"
-                                    data-refresh-url="{{ path('back_partner_user_edit',{partner:partner.id, user:user.id}) }}?from=partner"
-                                    >
-                                </a>
-                            {% endif %}
-                            {% if is_granted('USER_TRANSFER', user) and app.request.get('_route') is not same as('back_partner_new') %}
-                                <a href="#" class="fr-btn fr-btn--orange fr-fi-upload-2-fill fr-mt-3v btn-transfer-partner-user"
-                                id="partner_users_transfer_{{ user.id }}" aria-controls="fr-modal-user-transfer"
-                                data-fr-opened="false" data-username="{{ user.nomComplet(true) }}" data-userid="{{ user.id }}"></a>
-                            {% endif %}
-                            {% if is_granted('USER_DELETE', user) and app.request.get('_route') is not same as('back_partner_new') %}
-                                <a href="#" class="fr-btn fr-btn--danger fr-fi-delete-line fr-mt-3v btn-delete-partner-user"
-                                id="partner_users_delete_{{ user.id }}" aria-controls="fr-modal-user-delete"
-                                data-fr-opened="false" data-username="{{ user.nomComplet(true) }}" data-userid="{{ user.id }}" data-useremail="{{ user.email }}"></a>
-                            {% endif %}
-                        </td>
-                    </tr>
+                            <td class="fr-text--right">
+                                {% if is_granted('USER_EDIT', user) %}
+                                    <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"
+                                        aria-controls="fr-modal-user-edit"
+                                        data-fr-opened="false"
+                                        data-refresh-url="{{ path('back_partner_user_edit',{partner:partner.id, user:user.id}) }}?from=partner"
+                                        >
+                                    </a>
+                                {% endif %}
+                                {% if is_granted('USER_TRANSFER', user) and app.request.get('_route') is not same as('back_partner_new') %}
+                                    <a href="#" class="fr-btn fr-btn--orange fr-fi-upload-2-fill fr-mt-3v btn-transfer-partner-user"
+                                    id="partner_users_transfer_{{ user.id }}" aria-controls="fr-modal-user-transfer"
+                                    data-fr-opened="false" data-username="{{ user.nomComplet(true) }}" data-userid="{{ user.id }}"></a>
+                                {% endif %}
+                                {% if is_granted('USER_DELETE', user) and app.request.get('_route') is not same as('back_partner_new') %}
+                                    <a href="#" class="fr-btn fr-btn--danger fr-fi-delete-line fr-mt-3v btn-delete-partner-user"
+                                    id="partner_users_delete_{{ user.id }}" aria-controls="fr-modal-user-delete"
+                                    data-fr-opened="false" data-username="{{ user.nomComplet(true) }}" data-userid="{{ user.id }}" data-useremail="{{ user.email }}"></a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
                 {% else %}
                     <tr>
                         <td colspan="3">Aucun agent trouvé</td>

--- a/templates/back/zone/index.html.twig
+++ b/templates/back/zone/index.html.twig
@@ -115,7 +115,7 @@
             {% endfor %}
         {% endset %}
 
-        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des utilisateurs', 'tableHead': tableHead, 'tableBody': tableBody, 'cancelSortable': true } %}
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des zones', 'tableHead': tableHead, 'tableBody': tableBody, 'cancelSortable': true } %}
 
         <div class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -93,7 +93,6 @@ class BackUserControllerTest extends WebTestCase
 
         $this->assertSelectorTextContains('h1', 'Exporter la liste des 15 utilisateurs');
 
-
         $client->request('GET', $route, ['role' => 'ROLE_API_USER']);
 
         $this->assertSelectorTextContains('h1', 'Exporter la liste des 2 utilisateurs');

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -67,13 +67,35 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserExport(): iterable
     {
-        yield 'Search without params' => [[], 15];
+        yield 'Search without params' => [[], 14];
         yield 'Search with queryUser user' => [['queryUser' => 'user'], 10];
-        yield 'Search with partner 6 and 7' => [['partners' => [2]], 5];
-        yield 'Search with status 1' => [['statut' => 1], 11];
+        yield 'Search with partner 6 and 7' => [['partners' => [2]], 4];
+        yield 'Search with status 1' => [['statut' => 1], 10];
         yield 'Search with role ROLE_USER_PARTNER' => [['role' => 'ROLE_USER_PARTNER'], 10];
         yield 'Search with role ROLE_USER_PARTNER and status 1' => [['role' => 'ROLE_USER_PARTNER', 'statut' => 1], 6];
-        yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 15];
+        yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 14];
         yield 'Search with partnerType Ars' => [['partnerType' => 'ARS'], 1];
+    }
+
+    public function testUserExportSA(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-01@histologe.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('back_user_export');
+        $client->request('GET', $route, ['territory' => 13]);
+
+        $this->assertSelectorTextContains('h1', 'Exporter la liste des 15 utilisateurs');
+
+
+        $client->request('GET', $route, ['role' => 'ROLE_API_USER']);
+
+        $this->assertSelectorTextContains('h1', 'Exporter la liste des 2 utilisateurs');
     }
 }


### PR DESCRIPTION
## Ticket

#3796   

## Description
Retirer de la liste des user (et du choix dans la liste des roles) pour les RT sur la page liste des utilisateurs
Retirer de l'onglet agent d'un partenaire

## Changements apportés
* Modification du SearchUserType
* Modification de findFiltered dans UserRepository
* Modification du template twig de la liste des agents d'un partenaire
* Ajustement des tests

## Pré-requis

## Tests
- [ ] Se connecter en SA, vérifier qu'on voit toujours les utilisateurs API dans la liste des agents d'un partenaire, dans la liste des utilisateurs, qu'on peut filtrer cette liste selon le rôle API, et que l'export de cette liste est conforme
- [ ] Se connecter en RT et refaire les mêmes tests, mais on ne doit plus voir le rôle API, ni les utilisateurs API
