### PR TITLE
[BO - Signalement] Quand on upload un document et qu'on ferme la modale trop vite, le document n'est pas enregistré

### DIFF
--- a/assets/scripts/app-back-bo.ts
+++ b/assets/scripts/app-back-bo.ts
@@ -13,6 +13,7 @@ import './vanilla/services/table_sortable.js'
 import './vanilla/services/list_filter_helper.js';
 import './vanilla/services/component_search_checkbox.js';
 import './vanilla/services/tabs_manager.js';
+import './vanilla/services/modales_helper.js';
 
 import './vanilla/controllers/form_account.js';
 import './vanilla/controllers/form_nde.js';

--- a/assets/scripts/app.ts
+++ b/assets/scripts/app.ts
@@ -7,6 +7,7 @@ import './vanilla/services/component_search_address.js';
 import './vanilla/services/form_helper.js';
 import './vanilla/services/cookie_banner.js';
 import './vanilla/services/maintenance_banner.js';
+import './vanilla/services/modales_helper.js';
 
 import './vanilla/controllers/activate_account/activate_account.js';
 import './vanilla/controllers/front_demande_lien_signalement/front_demande_lien_signalement.js';

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -1,3 +1,5 @@
+import { disableHeaderAndFooterButtonOfModal, enableHeaderAndFooterButtonOfModal } from '../../services/modales_helper'
+
 initializeUploadModal(
   '#fr-modal-upload-files',
   '#select-type-situation-to-clone',
@@ -299,28 +301,6 @@ function initializeUploadModal (
       divFileItem.querySelector('#file-description')?.addEventListener('change', (e) => {
         callEditFileRoute(divFileItem)
       })
-    })
-  }
-
-  function disableHeaderAndFooterButtonOfModal(modal){
-    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
-    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
-    headerButtons.forEach(button => {
-      button.setAttribute('disabled', '')
-    })
-    footerButtons.forEach(button => {
-      button.setAttribute('disabled', '')
-    })
-  }
-
-  function enableHeaderAndFooterButtonOfModal(modal){
-    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
-    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
-    headerButtons.forEach(button => {
-      button.removeAttribute('disabled')
-    })
-    footerButtons.forEach(button => {
-      button.removeAttribute('disabled')
     })
   }
 

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -38,6 +38,7 @@ function initializeUploadModal (
   const editFileToken = modal.dataset.editFileToken
   const btnValidate = modal.querySelector('#btn-validate-modal-upload-files')
   const ancre = modal.querySelector('#modal-upload-file-dynamic-content')
+  let nbFilesProccessing = 0;
 
   fileSelector.onclick = () => fileSelectorInput.click()
   fileSelectorInput.onchange = () => {
@@ -100,6 +101,9 @@ function initializeUploadModal (
   }
 
   function uploadFile (file) {
+    nbFilesProccessing++
+    disableHeaderAndFooterButtonOfModal(modal)
+
     const div = document.createElement('div')
     div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w', 'modal-upload-list-item')
     div.innerHTML = initInnerHtml(file)
@@ -124,6 +128,11 @@ function initializeUploadModal (
     }
     http.onreadystatechange = function () {
       if (this.readyState === XMLHttpRequest.DONE) {
+        nbFilesProccessing--
+        if (nbFilesProccessing <= 0) {
+          nbFilesProccessing = 0
+          enableHeaderAndFooterButtonOfModal(modal)
+        }
         const response = JSON.parse(this.response)
         if (this.status === 200) {
           modal.dataset.hasChanges = true
@@ -293,6 +302,28 @@ function initializeUploadModal (
     })
   }
 
+  function disableHeaderAndFooterButtonOfModal(modal){
+    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
+    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
+    headerButtons.forEach(button => {
+      button.setAttribute('disabled', '')
+    })
+    footerButtons.forEach(button => {
+      button.setAttribute('disabled', '')
+    })
+  }
+
+  function enableHeaderAndFooterButtonOfModal(modal){
+    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
+    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
+    headerButtons.forEach(button => {
+      button.removeAttribute('disabled')
+    })
+    footerButtons.forEach(button => {
+      button.removeAttribute('disabled')
+    })
+  }
+
   modal.addEventListener('dsfr.conceal', (e) => {
     if (modal.dataset.validated === 'true' && modal.dataset.hasChanges === 'true') {
       fetch(waitingSuiviRoute).then((response) => {
@@ -320,6 +351,8 @@ function initializeUploadModal (
   })
 
   modal.addEventListener('dsfr.disclose', (e) => {
+    nbFilesProccessing = 0
+    enableHeaderAndFooterButtonOfModal(modal)
     listContainer.innerHTML = ''
     modal.dataset.validated = false
     modal.dataset.hasChanges = false

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -1,3 +1,5 @@
+import { disableHeaderAndFooterButtonOfModal, enableHeaderAndFooterButtonOfModal } from '../../services/modales_helper'
+
 const modalUploadFiles = document?.querySelector('#fr-modal-upload-files-usager')
 if (modalUploadFiles) {
   const dropArea = document.querySelector('.modal-upload-drop-section')
@@ -249,28 +251,6 @@ if (modalUploadFiles) {
             button.removeAttribute('disabled')
           }
         })
-    })
-  }
-
-  function disableHeaderAndFooterButtonOfModal(modal){
-    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
-    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
-    headerButtons.forEach(button => {
-      button.setAttribute('disabled', '')
-    })
-    footerButtons.forEach(button => {
-      button.setAttribute('disabled', '')
-    })
-  }
-
-  function enableHeaderAndFooterButtonOfModal(modal){
-    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
-    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
-    headerButtons.forEach(button => {
-      button.removeAttribute('disabled')
-    })
-    footerButtons.forEach(button => {
-      button.removeAttribute('disabled')
     })
   }
 

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -13,6 +13,7 @@ if (modalUploadFiles) {
   const editFileToken = modalUploadFiles.dataset.editFileToken
   const btnValidate = document.querySelector('#btn-validate-modal-upload-files')
   const ancre = document.querySelector('#modal-upload-file-dynamic-content')
+  let nbFilesProccessing = 0;
 
   fileSelector.onclick = () => fileSelectorInput.click()
   fileSelectorInput.onchange = () => {
@@ -75,6 +76,9 @@ if (modalUploadFiles) {
   }
 
   function uploadFile (file) {
+    nbFilesProccessing++
+    disableHeaderAndFooterButtonOfModal(modalUploadFiles)
+
     const div = document.createElement('div')
     div.classList.add('fr-grid-row', 'fr-grid-row--gutters', 'fr-grid-row--middle', 'fr-mb-2w', 'modal-upload-list-item')
     div.innerHTML = initInnerHtml(file)
@@ -97,6 +101,11 @@ if (modalUploadFiles) {
     }
     http.onreadystatechange = function () {
       if (this.readyState === XMLHttpRequest.DONE) {
+        nbFilesProccessing--
+        if (nbFilesProccessing <= 0) {
+          nbFilesProccessing = 0
+          enableHeaderAndFooterButtonOfModal(modalUploadFiles)
+        }
         const response = JSON.parse(this.response)
         if (this.status === 200) {
           modalUploadFiles.dataset.hasChanges = true
@@ -243,6 +252,28 @@ if (modalUploadFiles) {
     })
   }
 
+  function disableHeaderAndFooterButtonOfModal(modal){
+    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
+    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
+    headerButtons.forEach(button => {
+      button.setAttribute('disabled', '')
+    })
+    footerButtons.forEach(button => {
+      button.setAttribute('disabled', '')
+    })
+  }
+
+  function enableHeaderAndFooterButtonOfModal(modal){
+    const headerButtons = modal.querySelectorAll('.fr-modal__header button')
+    const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
+    headerButtons.forEach(button => {
+      button.removeAttribute('disabled')
+    })
+    footerButtons.forEach(button => {
+      button.removeAttribute('disabled')
+    })
+  }
+
   modalUploadFiles.addEventListener('dsfr.conceal', (e) => {
     if (modalUploadFiles.dataset.validated === 'true' && modalUploadFiles.dataset.hasChanges === 'true') {
       return true
@@ -263,6 +294,7 @@ if (modalUploadFiles) {
   })
 
   modalUploadFiles.addEventListener('dsfr.disclose', (e) => {
+    nbFilesProccessing = 0
     listContainer.innerHTML = ''
     modalUploadFiles.dataset.validated = false
     modalUploadFiles.dataset.hasChanges = false

--- a/assets/scripts/vanilla/services/modales_helper.js
+++ b/assets/scripts/vanilla/services/modales_helper.js
@@ -1,0 +1,21 @@
+export function disableHeaderAndFooterButtonOfModal(modal){
+  const headerButtons = modal.querySelectorAll('.fr-modal__header button')
+  const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
+  headerButtons.forEach(button => {
+    button.setAttribute('disabled', '')
+  })
+  footerButtons.forEach(button => {
+    button.setAttribute('disabled', '')
+  })
+}
+
+export function enableHeaderAndFooterButtonOfModal(modal){
+  const headerButtons = modal.querySelectorAll('.fr-modal__header button')
+  const footerButtons = modal.querySelectorAll('.fr-modal__footer button')
+  headerButtons.forEach(button => {
+    button.removeAttribute('disabled')
+  })
+  footerButtons.forEach(button => {
+    button.removeAttribute('disabled')
+  })
+}


### PR DESCRIPTION
## Ticket

#3764

## Description
Sur les modale d'upload de fichiers, les boutons (de fermeture et d'action) sont à présent bloqué tant que des uploads sont en cours
J'aurais voulu bloquer aussi la fermeture via clic à l'extérieur de la modale (ce qui arrive parfois par erreur) mais je n'ai pas trouvé comment

## Pré-requis
`make npm-build`

## Tests
- [ ] Tester l'upload de document via la fiche du signalement FO et BO
