### PR TITLE
[BO - Signalement] Marseille Geoloc plus recuperee aupres de la BAN

### DIFF
--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -1098,7 +1098,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function getAddressCompleteOccupant($withArrondisement = true): ?string
     {
-        $ville = $withArrondisement ? $this->villeOccupant : CommuneHelper::getCommuneFromArrondissements($this->villeOccupant);
+        $ville = $withArrondisement ? $this->villeOccupant : CommuneHelper::getCommuneFromArrondissement($this->villeOccupant);
 
         return \sprintf(
             '%s %s %s',

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -18,6 +18,7 @@ use App\Entity\Model\SituationFoyer;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Repository\SignalementRepository;
 use App\Service\TimezoneProvider;
+use App\Utils\CommuneHelper;
 use App\Utils\Phone;
 use App\Validator as AppAssert;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -1095,13 +1096,15 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         return $this;
     }
 
-    public function getAddressCompleteOccupant(): ?string
+    public function getAddressCompleteOccupant($withArrondisement = true): ?string
     {
+        $ville = $withArrondisement ? $this->villeOccupant : CommuneHelper::getCommuneFromArrondissements($this->villeOccupant);
+
         return \sprintf(
             '%s %s %s',
             $this->adresseOccupant,
             $this->cpOccupant,
-            $this->villeOccupant
+            $ville
         );
     }
 

--- a/src/Service/Signalement/SignalementAddressUpdater.php
+++ b/src/Service/Signalement/SignalementAddressUpdater.php
@@ -18,7 +18,7 @@ class SignalementAddressUpdater
 
     public function updateAddressOccupantFromBanData(Signalement $signalement, bool $updateGeolocAndRnbId = true): void
     {
-        $addressResult = $this->addressService->getAddress($signalement->getAddressCompleteOccupant());
+        $addressResult = $this->addressService->getAddress($signalement->getAddressCompleteOccupant(false));
         if ($addressResult->getScore() > self::SCORE_IF_BAN_ID_ACCEPTED) {
             $signalement->setBanIdOccupant($addressResult->getBanId());
             if ($updateGeolocAndRnbId) {

--- a/src/Utils/CommuneHelper.php
+++ b/src/Utils/CommuneHelper.php
@@ -63,4 +63,17 @@ class CommuneHelper
         'Lyon' => self::LYON_ARRONDISSEMENTS,
         'Paris' => self::PARIS_ARRONDISSEMENTS,
     ];
+
+    public static function getCommuneFromArrondissements(?string $commune): ?string
+    {
+        foreach (self::COMMUNES_ARRONDISSEMENTS as $communeName => $arrondissements) {
+            foreach ($arrondissements as $arrondissement) {
+                if ($commune === $arrondissement) {
+                    return $communeName;
+                }
+            }
+        }
+
+        return $commune;
+    }
 }

--- a/src/Utils/CommuneHelper.php
+++ b/src/Utils/CommuneHelper.php
@@ -64,13 +64,11 @@ class CommuneHelper
         'Paris' => self::PARIS_ARRONDISSEMENTS,
     ];
 
-    public static function getCommuneFromArrondissements(?string $commune): ?string
+    public static function getCommuneFromArrondissement(?string $commune): ?string
     {
-        foreach (self::COMMUNES_ARRONDISSEMENTS as $communeName => $arrondissements) {
-            foreach ($arrondissements as $arrondissement) {
-                if ($commune === $arrondissement) {
-                    return $communeName;
-                }
+        foreach (self::COMMUNES_ARRONDISSEMENTS as $communeName => $communeArrondissements) {
+            if (in_array($commune, $communeArrondissements)) {
+                return $communeName;
             }
         }
 

--- a/tests/Unit/Utils/CommuneHelperTest.php
+++ b/tests/Unit/Utils/CommuneHelperTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Tests\Unit\Utils;
+
+use App\Utils\CommuneHelper;
+use PHPUnit\Framework\TestCase;
+
+class CommuneHelperTest extends TestCase
+{
+    public function testGetCommuneFromArrondissement()
+    {
+        $this->assertEquals('Marseille', CommuneHelper::getCommuneFromArrondissement('Marseille'));
+        $this->assertEquals('Marseille', CommuneHelper::getCommuneFromArrondissement('Marseille 1er Arrondissement'));
+        $this->assertEquals('Marseille', CommuneHelper::getCommuneFromArrondissement('Marseille 16e Arrondissement'));
+        $this->assertEquals('Lyon', CommuneHelper::getCommuneFromArrondissement('Lyon 1er Arrondissement'));
+        $this->assertEquals('Lyon', CommuneHelper::getCommuneFromArrondissement('Lyon 9e Arrondissement'));
+        $this->assertEquals('Montpellier', CommuneHelper::getCommuneFromArrondissement('Montpellier'));
+        $this->assertNull(CommuneHelper::getCommuneFromArrondissement(null));
+    }
+}


### PR DESCRIPTION
## Ticket

#3795

## Description
Dans les ville avec arrondissements, le libellé de l'adresse retourné par la BAN contient le nom de la ville principale, mais la ville contient le nm de la ville avec l’arrondissement de précisé.
Hors quand on compare les deux, le score retourné par la BAN n'est plus fiable et on l'ignore 
![Screenshot 2025-03-07 at 11-44-50 Symfony Profiler](https://github.com/user-attachments/assets/88c5f97e-5142-473c-b15f-696550cd1d29)
Correctif pour ignorer l'arrondissement lors de cette comparaison
