### PR TITLE
[QA] RetryFailedEmailsCommand Email::attachFromPath(): Argument #1 ($path) must be of type string

### DIFF
--- a/src/Command/RetryFailedEmailsCommand.php
+++ b/src/Command/RetryFailedEmailsCommand.php
@@ -70,10 +70,11 @@ class RetryFailedEmailsCommand extends Command
             if (\array_key_exists('attach', $failedEmail->getContext())) {
                 if (\is_array($failedEmail->getContext()['attach'])) {
                     foreach ($failedEmail->getContext()['attach'] as $attachPath) {
-                        $emailMessage->attachFromPath($attachPath);
+                        $attachPath && $emailMessage->attachFromPath($attachPath);
                     }
                 } else {
-                    $emailMessage->attachFromPath($failedEmail->getContext()['attach']);
+                    $attachPath = $failedEmail->getContext()['attach'];
+                    $attachPath && $emailMessage->attachFromPath($attachPath);
                 }
             }
             if (\array_key_exists('attachContent', $failedEmail->getContext())) {


### PR DESCRIPTION
## Ticket

#3801

## Description
Ce matin (7 mars) un mail à échoué, le retry provoque un crash TypeError https://sentry.incubateur.net/organizations/betagouv/issues/155042/?environment=prod&project=61&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=5
Ajour d'un contrôle pour éviter l'erreur
