### PR TITLE
[Formulaire] Modification de texte suite aux retours du PNLHI

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -70,7 +70,7 @@
   },  
   {
     "type": "SignalementFormScreen",
-    "label": "Le bâtiment",
+    "label": "Le bâtiment (et / ou parties communes)",
     "description": "Sélectionnez les catégories de désordres qui vous concernent puis validez votre sélection pour détailler les problèmes.",
     "icon": {
       "src": "/img/form/BATIMENT/Picto-batiment.svg",

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -83,7 +83,7 @@
   },    
   {
     "type": "SignalementFormScreen",
-    "label": "Le bâtiment",
+    "label": "Le bâtiment (et / ou parties communes)",
     "description": "Sélectionnez les catégories de désordres qui vous concernent puis validez votre sélection pour détailler les problèmes.",
     "icon": {
       "src": "/img/form/BATIMENT/Picto-batiment.svg",

--- a/assets/json/Signalement/dictionary.json
+++ b/assets/json/Signalement/dictionary.json
@@ -1,7 +1,7 @@
 {
-  "batiment": { "default": "le <span class=\"fr-span-highlight-batiment\">bâtiment</span>" },
+  "batiment": { "default": "le <span class=\"fr-span-highlight-batiment\">bâtiment (et / ou parties communes)</span>" },
   "logement": { "default": "le <span class=\"fr-span-highlight-logement\">logement</span>" },
-  "batiment_logement": { "default": "le <span class=\"fr-span-highlight-batiment\">bâtiment</span> et le <span class=\"fr-span-highlight-logement\">logement</span>" },
+  "batiment_logement": { "default": "le <span class=\"fr-span-highlight-batiment\">bâtiment (et / ou parties communes)</span> et le <span class=\"fr-span-highlight-logement\">logement</span>" },
   "electrique": { "default": "électrique" },
   "gaz": { "default": "gaz, bois, éthanol ou fioul" },
   "aucun": { "default": "aucun" },

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1887,7 +1887,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -222,7 +222,7 @@
           "slug": "zone_concernee_zone",
           "values": [
             {
-              "label": "Le batiment",
+              "label": "Le bâtiment (et / ou parties communes)",
               "value": "batiment"
             },
             {
@@ -323,7 +323,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergétique (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1048,7 +1048,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_dpe",
-          "label": "Avez-vous réalisé un DPE pour le logement ? (diagnostic performance énergie)",
+          "label": "Avez-vous réalisé un DPE pour le logement ? (diagnostic performance énergétique)",
           "values": [
             {
               "label": "Oui",
@@ -1064,7 +1064,7 @@
             }
           ],
           "validate": {
-            "message": "Veuillez indiquer si vous avez réalisé le DPE (diagnostic performance énergie) du logement."
+            "message": "Veuillez indiquer si vous avez réalisé le DPE (diagnostic performance énergétique) du logement."
           }
         },
         {
@@ -1306,7 +1306,7 @@
         },
         {
           "type": "SignalementFormCounter",
-          "label": "Quel est le montant de l'allocation ? (facultatif)",
+          "label": "Quel est le montant mensuel de l'allocation ? (facultatif)",
           "description": "Format attendu : Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
@@ -1887,7 +1887,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il sera pris en charge par l'administration sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -1697,7 +1697,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -153,7 +153,7 @@
           "slug": "zone_concernee_zone",
           "values": [
             {
-              "label": "Le batiment",
+              "label": "Le bâtiment (et / ou parties communes)",
               "value": "batiment"
             },
             {
@@ -231,7 +231,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les informations utiles sont :</p><ul><li>La composition des pièces</li><li>Le diagnostic performance énergie (DPE)</li><li>Le nombre de personnes occupant le logement</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les informations utiles sont :</p><ul><li>La composition des pièces</li><li>Le diagnostic performance énergétique (DPE)</li><li>Le nombre de personnes occupant le logement</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -880,7 +880,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_dpe",
-          "label": "Avez-vous réalisé un DPE pour le logement ? (diagnostic performance énergie)",
+          "label": "Avez-vous réalisé un DPE pour le logement ? (diagnostic performance énergétique)",
           "values": [
             {
               "label": "Oui",
@@ -896,7 +896,7 @@
             }
           ],
           "validate": {
-            "message": "Veuillez indiquer si vous avez réalisé un DPE (diagnostic performance énergie) pour le logement."
+            "message": "Veuillez indiquer si vous avez réalisé un DPE (diagnostic performance énergétique) pour le logement."
           }
         },
         {
@@ -1184,7 +1184,7 @@
         },
         {
           "type": "SignalementFormCounter",
-          "label": "Quel est le montant de votre allocation ? (facultatif)",
+          "label": "Quel est le montant mensuel de votre allocation ? (facultatif)",
           "description": "Format attendu : Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
@@ -1697,7 +1697,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il sera pris en charge par l'administration sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -2068,7 +2068,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -265,7 +265,7 @@
           "slug": "zone_concernee_zone",
           "values": [
             {
-              "label": "Le batiment",
+              "label": "Le bâtiment (et / ou parties communes)",
               "value": "batiment"
             },
             {
@@ -343,7 +343,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergétique (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1074,7 +1074,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_dpe",
-          "label": "Avez-vous reçu le DPE du logement ? (diagnostic performance énergie)",
+          "label": "Avez-vous reçu le DPE du logement ? (diagnostic performance énergétique)",
           "values": [
             {
               "label": "Oui",
@@ -1090,7 +1090,7 @@
             }
           ],
           "validate": {
-            "message": "Veuillez indiquer si vous avez reçu le DPE (diagnostic performance énergie) du logement."
+            "message": "Veuillez indiquer si vous avez reçu le DPE (diagnostic performance énergétique) du logement."
           }
         },
         {
@@ -1378,7 +1378,7 @@
         },
         {
           "type": "SignalementFormCounter",
-          "label": "Quel est le montant de votre allocation ? (facultatif)",
+          "label": "Quel est le montant mensuel de votre allocation ? (facultatif)",
           "description": "Format attendu : Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
@@ -2068,7 +2068,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il sera pris en charge par l'administration sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1672,7 +1672,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -343,7 +343,7 @@
           "slug": "zone_concernee_zone",
           "values": [
             {
-              "label": "Le batiment",
+              "label": "Le bâtiment (et / ou parties communes)",
               "value": "batiment"
             },
             {
@@ -1135,7 +1135,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_dpe",
-          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergie)",
+          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergétique)",
           "values": [
             {
               "label": "Oui",
@@ -1151,7 +1151,7 @@
             }
           ],
           "validate": {
-            "message": "Veuillez indiquer si le foyer a reçu le DPE (diagnostic performance énergie) du logement."
+            "message": "Veuillez indiquer si le foyer a reçu le DPE (diagnostic performance énergétique) du logement."
           }
         },
         {
@@ -1672,7 +1672,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il sera pris en charge par l'administration sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -352,7 +352,7 @@
           "slug": "zone_concernee_zone",
           "values": [
             {
-              "label": "Le batiment",
+              "label": "Le bâtiment (et / ou parties communes)",
               "value": "batiment"
             },
             {
@@ -453,7 +453,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergétique (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1169,7 +1169,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_dpe",
-          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergie)",
+          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergétique)",
           "values": [
             {
               "label": "Oui",
@@ -1185,7 +1185,7 @@
             }
           ],
           "validate": {
-            "message": "Veuillez indiquer si le foyer a reçu le DPE (diagnostic performance énergie) du logement."
+            "message": "Veuillez indiquer si le foyer a reçu le DPE (diagnostic performance énergétique) du logement."
           }
         },
         {
@@ -1427,7 +1427,7 @@
         },
         {
           "type": "SignalementFormCounter",
-          "label": "Quel est le montant de l'allocation ? (facultatif)",
+          "label": "Quel est le montant mensuel de l'allocation ? (facultatif)",
           "description": "Format attendu : Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
@@ -2127,7 +2127,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il sera pris en charge par l'administration sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -2127,7 +2127,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -337,7 +337,7 @@
           "slug": "zone_concernee_zone",
           "values": [
             {
-              "label": "Le batiment",
+              "label": "Le bâtiment (et / ou parties communes)",
               "value": "batiment"
             },
             {
@@ -438,7 +438,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Type et composition du logement",
-    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergie (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
+    "description": "<p>Nous allons vous poser des questions sur la composition du logement.</p><p>Les documents utiles sont :</p><ul><li>Le bail</li><li>L'état des lieux d'entrée</li><li>Le diagnostic performance énergétique (DPE)</li></ul><p><b>Toutes les questions sont obligatoires, sauf mention contraire.</b></p>",
     "slug": "ecran_intermediaire_type_composition",
     "screenCategory": "Type et composition",
     "icon": {
@@ -1153,7 +1153,7 @@
         {
           "type": "SignalementFormOnlyChoice",
           "slug": "bail_dpe_dpe",
-          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergie)",
+          "label": "Est-ce que le foyer a reçu DPE du logement ? (diagnostic performance énergétique)",
           "values": [
             {
               "label": "Oui",
@@ -1169,7 +1169,7 @@
             }
           ],
           "validate": {
-            "message": "Veuillez indiquer si le foyer a reçu le DPE (diagnostic performance énergie) du logement."
+            "message": "Veuillez indiquer si le foyer a reçu le DPE (diagnostic performance énergétique) du logement."
           }
         },
         {
@@ -1411,7 +1411,7 @@
         },
         {
           "type": "SignalementFormCounter",
-          "label": "Quel est le montant de l'allocation ? (facultatif)",
+          "label": "Quel est le montant mensuel de l'allocation ? (facultatif)",
           "description": "Format attendu : Saisir un nombre entier",
           "slug": "logement_social_montant_allocation",
           "conditional": {
@@ -2122,7 +2122,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il sera pris en charge par l'administration sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -2122,7 +2122,7 @@
   {
     "type": "SignalementFormScreen",
     "label": "Votre signalement a bien été enregistré !",
-    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
+    "description": "<p>Votre numéro de signalement est le : <b>#{{formStore.data.signalementReference}}</b><br>Il va être étudié par l'administration et vous recevrez un retour sous <u>7 jours ouvrés</u>.</p><p>Vous pouvez suivre l'avancée de votre dossier ou ajouter des informations en cliquant sur le bouton ci-dessous.</p>",
     "slug": "confirmation_signalement",
     "screenCategory": "Récapitulatif",
     "components": {

--- a/assets/json/Signalement/questions_profile_tous.json
+++ b/assets/json/Signalement/questions_profile_tous.json
@@ -3,7 +3,7 @@
     "type": "SignalementFormScreen",
     "label": "Signaler un problème de logement avec Histologe",
     "slug": "introduction",
-    "description": "<h2>Avant de démarrer…</h2><p>Lisez bien les conseils ci-dessous.<br>Après cette page, cela vous prendra <b>environ 25 minutes</b> pour signaler vos problèmes de logement.</p><h2>Comment déposer un signalement ?</h2><p>Pour déposer votre signalement, il faut remplir toutes les étapes du formulaire et répondre à des questions sur :<ul><li>L'état du logement</li><li>L'adresse du logement</li><li>Le logement en général (taille en m², nombre de personnes vivant dans le logement, etc.)</li></ul></p><div class=\"fr-alert fr-alert--info fr-alert--sm fr-mb-8v\"><p>Attention à vos données ! Merci de ne pas transmettre de données personnelles sur votre santé ou celle d'autres personnes !</p></div><p>Si possible, préparez les documents suivants :<ul><li>Des photos des problèmes dans le logement</li><li>Les coordonnées du bailleur (propriétaire)</li><li>Si vous les avez : le bail, l'état des lieux et le DPE du logement</li><li>Si concerné : le numéro d’allocataire</li></ul></p><div class=\"fr-notice fr-notice--info\"><div class=\"fr-container\"><div class=\"fr-notice__body\"><p class=\"fr-notice__title\">Un signalement complet permet une meilleure prise en charge du dossier !</p></div></div></div><br><h2>Qui aura accès à mon signalement ?</h2><p>Les informations demandées sont nécessaires au bon traitement du signalement.<br>Elles seront <b>uniquement partagées avec les administrations compétentes</b> pour traiter votre dossier.</p><h2>Est-ce que je peux déposer un signalement pour quelqu'un d'autre ?</h2><p>Oui. Vous pouvez déposer un signalement pour une autre personne.<br>Assurez-vous d'avoir sa permission et préparez les informations sur son logement.</p>",
+    "description": "<h2>Avant de démarrer…</h2><p>Lisez bien les conseils ci-dessous.<br>Après cette page, cela vous prendra <b>environ 25 minutes</b> pour signaler les problèmes de logement.</p><h2>Comment déposer un signalement ?</h2><p>Pour déposer votre signalement, il faut remplir toutes les étapes du formulaire et répondre à des questions sur :<ul><li>L'état du logement</li><li>L'adresse du logement ou de l'immeuble</li><li>Le logement en général (taille en m², nombre de personnes vivant dans le logement, etc.)</li></ul></p><div class=\"fr-alert fr-alert--info fr-alert--sm fr-mb-8v\"><p>Attention à vos données ! Merci de ne pas transmettre de données personnelles sur votre santé ou celle d'autres personnes !</p></div><p>Si possible, préparez les documents suivants :<ul><li>Des photos des problèmes dans le logement</li><li>Les coordonnées du bailleur (propriétaire)</li><li>Si vous les avez : le bail, l'état des lieux et le DPE du logement</li><li>Si concerné : le numéro d’allocataire</li></ul></p><div class=\"fr-notice fr-notice--info\"><div class=\"fr-container\"><div class=\"fr-notice__body\"><p class=\"fr-notice__title\">Un signalement complet permet une meilleure prise en charge du dossier !</p></div></div></div><br><h2>Qui aura accès à mon signalement ?</h2><p>Les informations demandées sont nécessaires au bon traitement du signalement.<br>Elles seront <b>uniquement partagées avec les administrations compétentes</b> pour traiter votre dossier.</p><h2>Est-ce que je peux déposer un signalement pour quelqu'un d'autre ?</h2><p>Oui. Vous pouvez déposer un signalement pour une autre personne.<br>Assurez-vous d'avoir sa permission et préparez les informations sur son logement.</p>",
     "customCss": "fr-my-md-10w",
     "components": {
       "body": [
@@ -168,7 +168,7 @@
   {
     "type": "SignalementFormScreen",
     "slug": "signalement_concerne",
-    "label": "Vous déposez un signalement…",
+    "label": "Qui est concerné par votre signalement ?",
     "screenCategory": "Adresse et coordonnées",
     "components": {
       "body": [
@@ -190,7 +190,7 @@
         },
         {
           "type": "SignalementFormOnlyChoice",
-          "label": "Qui est concerné par votre signalement ?",
+          "label": "Vous déposez un signalement…",
           "slug": "signalement_concerne_profil",
           "values": [
             {

--- a/src/Form/SignalementDraftSituationType.php
+++ b/src/Form/SignalementDraftSituationType.php
@@ -79,7 +79,7 @@ class SignalementDraftSituationType extends AbstractType
                 'data' => $bail,
             ])
             ->add('dpe', ChoiceType::class, [
-                'label' => 'Diagnostic performance énergie (DPE)',
+                'label' => 'Diagnostic performance énergétique (DPE)',
                 'choices' => [
                     'Oui' => 'oui',
                     'Non' => 'non',


### PR DESCRIPTION
## Ticket

#3598   

## Description
Suite aux retours du PNLHI, nous avons convenu de faire les modifications suivantes : 
- Renommer la zone de désordres `Bâtiment` en `Bâtiment (et / ou parties communes)`
- Sur la page `avant de démarrer` remplacer `Après cette page, cela vous prendra environ 25 minutes pour signaler vos problèmes de logement.` par `Après cette page, cela vous prendra environ 25 minutes pour signaler les problèmes de logement.`
- Sur l'écran `introduction` pour l'adresse : remplacer `L'adresse du logement` par `L'adresse du logement ou de l'immeuble`
- Sur l'écran `signalement_concerne_profil` inverser le titre de la page et le label de la question : 
   - le titre devient `Qui est concerné par votre signalement ?`
   - le label de la question devient `Vous déposez un signalement...` 
- Dans le formulaire, modifier la mention `diagnostic performance énergie` par `diagnostic performance énergétique`
- Sur l'écran `logement_social` 
   - remplacer la question `Quel est le montant de votre allocation ?` par `Quel est le montant mensuel de votre allocation ?`
   - remplacer `Quel est le montant de l'allocation ?` par `Quel est le montant mensuel de l'allocation ?` (tiers)
- Sur l'écran de confirmation, remplacer `Il sera pris en charge par l'administration sous 7 jours.` par `Il va être étudié par l'administration et vous recevrez un retour sous 7 jours.` 

## Changements apportés
* Changements des json

## Pré-requis
`npm run watch`

## Tests
- [ ] Déposer un signalement avec 2/3 profils différents et vérifier les différents changement de texte
