### PR TITLE
[BO - Formulaire pro] Parcours et gestion des fichiers en Ajax

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -17,6 +17,7 @@ tabButtons.forEach((tabButton) => {
 function saveCurrentTab(event) {
   const currentTab = document?.querySelector('.fr-tabs__panel.fr-tabs__panel--selected')
   currentTab.classList.add('fr-tabs__panel--saving')
+  const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
 
   let formData = null
   let formAction = null
@@ -25,7 +26,6 @@ function saveCurrentTab(event) {
     formAction = event.target.action
   }
   if (event.type === 'click') {
-    const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
     const currentTabForm = currentTab?.querySelector('form#bo-form-signalement-' + currentTabName)
     formData = new FormData(currentTabForm)
     formAction = currentTabForm.action
@@ -45,7 +45,6 @@ function saveCurrentTab(event) {
 
         currentTab.classList.remove('fr-tabs__panel--saving')
         
-        const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
         document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = response.tabContent
         document.querySelector('#tabpanel-' +currentTabName).scrollIntoView({ behavior: 'smooth' });
 
@@ -67,15 +66,15 @@ function saveCurrentTab(event) {
             modaleDuplicateOpenLink.href = response.linkDuplicates
             dsfr(modaleDuplicate).modal.disclose();
           } else {
-            const errorAlertStr = '<div class="fr-alert fr-alert--error fr-mb-2v" role="alert"><p class="fr-alert__title">Merci de corriger les champs où des erreurs sont signalées.</p></div>'
+            const errorAlertStr = '<div class="fr-alert fr-alert--sm fr-alert--error fr-mb-2v" role="alert"><p class="fr-alert__title">Merci de corriger les champs où des erreurs sont signalées.</p></div>'
             document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = errorAlertStr + document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML
           }
           initBoFormSignalementSubmit(currentTabName)
         }
       });
     } else {
-      const errorHtml = '<div class="fr-alert fr-alert--error" role="alert"><p class="fr-alert__title">Une erreur est survenue lors de la soumission du formulaire, veuillez rafraichir la page.</p></div>';
-      document.querySelector("#tabpanel-adresse-panel").innerHTML = errorHtml; 
+      const errorHtml = '<div class="fr-alert fr-alert--sm fr-alert--error" role="alert"><p class="fr-alert__title">Une erreur est survenue lors de la soumission du formulaire, veuillez rafraichir la page.</p></div>';
+      document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = errorHtml; 
     }
   })
 }
@@ -103,6 +102,12 @@ function initBoFormSignalementSubmit(tabName) {
   const tabSelects = boFormSignalementTab?.querySelectorAll('select')
   tabSelects.forEach((tabSelect) => {
     tabSelect.addEventListener('change', (event) => {
+      boFormSignalementCurrentTabIsDirty = true
+    })
+  })
+  const tabTextAreas = boFormSignalementTab?.querySelectorAll('textarea')
+  tabTextAreas.forEach((tabTextArea) => {
+    tabTextArea.addEventListener('change', (event) => {
       boFormSignalementCurrentTabIsDirty = true
     })
   })

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -3,6 +3,15 @@ import { attacheAutocompleteAddressEvent } from '../../services/component_search
 let boFormSignalementCurrentTabIsDirty = false
 let boFormSignalementTargetTab = ''
 
+const modaleDuplicateIgnoreButton = document.querySelector('#fr-modal-duplicate-ignore-duplicates')
+if(modaleDuplicateIgnoreButton) {
+  modaleDuplicateIgnoreButton?.addEventListener('click', (event) => {
+    const inputForceSave = document?.querySelector('#signalement_draft_address_forceSave')
+    inputForceSave.value = 1
+    saveCurrentTab(event)
+  });
+}
+
 const tabButtons = document?.querySelectorAll('ul.fr-tabs__list.fr-tabs__list--bo-create button')
 tabButtons.forEach((tabButton) => {
   tabButton.addEventListener('click', (event) => {
@@ -184,10 +193,7 @@ if (document?.querySelector('#bo-form-signalement-situation')) {
 
 function initBoFormSignalementAdresse() {
   const inputAdresse = document?.querySelector('#signalement_draft_address_adresseCompleteOccupant')
-  const inputForceSave = document?.querySelector('#signalement_draft_address_forceSave')
   attacheAutocompleteAddressEvent(inputAdresse)
-
-  const modaleDuplicateIgnoreButton = document.querySelector('#fr-modal-duplicate-ignore-duplicates')
 
   const manualAddressSwitcher = document?.querySelector('#bo-signalement-manual-address-switcher')
   const manualAddressContainer = document?.querySelector('#bo-form-signalement-manual-address-container')
@@ -215,11 +221,6 @@ function initBoFormSignalementAdresse() {
   if(inputAdresse.value == '' && hasManualAddressValues) {
     manualAddressSwitcher.click()
   }
-
-  modaleDuplicateIgnoreButton?.addEventListener('click', (event) => {
-    inputForceSave.value = 1
-    document.querySelector('#signalement_draft_address_save').click()
-  });
 }
 
 function initBoFormSignalementLogement() {

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -316,7 +316,7 @@ function initBoFormSignalementSituation() {
   )
   initRefreshFromRadio(
     'situation',
-    'signalement_draft_situation_proprietaireAverti',
+    'signalement_draft_situation_isProprioAverti',
     [
       '#signalement_draft_situation_dateProprietaireAverti',
       '#signalement_draft_situation_moyenInformationProprietaire',
@@ -337,4 +337,62 @@ function initBoFormSignalementSituation() {
       '#signalement_draft_situation_reponseAssurance',
     ]
   )
+  reloadDeleteFileList()
+}
+
+window.addEventListener('refreshUploadedFileList', (e) => {
+  reloadFileList()
+})
+
+function reloadFileList() {
+  const urlListFiles = document?.querySelector('#url-signalement-files').value
+  fetch(urlListFiles, {method: 'GET'}).then(response => {
+    if (response.ok) {
+      response.json().then((response) => {
+        let newList = ''
+        response.forEach((responseItem, index) => {
+          newList += '<div class="fr-grid-row">'
+          newList += '<div class="fr-col-8">'
+          newList += '<i>' + responseItem.filename + '</i> (Type ' + responseItem.type + ')'
+          newList += '</div>'
+          newList += '<div class="fr-col-4">'
+          newList += '<button form="form-delete-file" '
+          newList += 'class="fr-link fr-icon-close-circle-line fr-link--icon-left fr-link--error" '
+          newList += 'aria-label="Supprimer le fichier ' + responseItem.filename + '" '
+          newList += 'title="Supprimer le fichier ' + responseItem.filename + '" '
+          newList += 'data-doc="' + responseItem.id + '" '
+          newList += '>Supprimer</button>'
+          newList += '</div>'
+          newList += '</div>'
+        })
+
+        document.querySelector('#bo-create-file-list').innerHTML = newList
+
+        reloadDeleteFileList()
+      })
+    }
+  })
+}
+
+function reloadDeleteFileList() {
+  const deleteFilesButtons = document?.querySelectorAll('#bo-create-file-list button')
+  if (deleteFilesButtons) {
+    deleteFilesButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault()
+        button.disabled = true
+        button.innerHTML = 'Suppression en cours...'
+        const formDeleteFile = document?.querySelector('#form-delete-file')
+        formDeleteFile.querySelector('input[name="file_id"]').value = button.getAttribute('data-doc')
+        const formData = new FormData(formDeleteFile)
+        const formAction = formDeleteFile.action
+
+        fetch(formAction, {method: 'POST', body: formData}).then(response => {
+          if (response.ok) {
+            reloadFileList()
+          }
+        })
+      })
+    })
+  }
 }

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -35,15 +35,6 @@ function saveCurrentTab(event) {
   fetch(formAction, {method: 'POST', body: formData}).then(response => {
     if (response.ok) {
       response.json().then((response) => {
-        if (response.redirect && response.url !== undefined && response.url !== '') {
-          const currentUrl = window.location.href.split('#')[0];
-          const newUrl = response.url.split('#')[0];
-          window.location.href = response.url;
-          if (currentUrl === newUrl) {
-            window.location.reload(true);
-          }
-        }
-
         currentTab.classList.remove('fr-tabs__panel--saving')
         
         document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = response.tabContent
@@ -396,8 +387,8 @@ function reloadDeleteFileList() {
       })
     })
   }
-
-  window.addEventListener('refreshUploadedFileList', (e) => {
-    reloadFileList()
-  })
 }
+
+window.addEventListener('refreshUploadedFileList', (e) => {
+  reloadFileList()
+})

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -69,8 +69,8 @@ function saveCurrentTab(event) {
             const errorAlertStr = '<div class="fr-alert fr-alert--sm fr-alert--error fr-mb-2v" role="alert"><p class="fr-alert__title">Merci de corriger les champs où des erreurs sont signalées.</p></div>'
             document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = errorAlertStr + document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML
           }
-          initBoFormSignalementSubmit(currentTabName)
         }
+        initBoFormSignalementSubmit(currentTabName)
       });
     } else {
       const errorHtml = '<div class="fr-alert fr-alert--sm fr-alert--error" role="alert"><p class="fr-alert__title">Une erreur est survenue lors de la soumission du formulaire, veuillez rafraichir la page.</p></div>';

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -111,6 +111,18 @@ function initBoFormSignalementSubmit(tabName) {
       boFormSignalementCurrentTabIsDirty = true
     })
   })
+
+  switch (tabName) {
+    case 'adresse':
+      initBoFormSignalementAdresse()
+      break
+    case 'logement':
+      initBoFormSignalementLogement()
+      break
+    case 'situation':
+      initBoFormSignalementSituation()
+      break
+  }
 }
 
 function initRefreshFromRadio(tabName, radioName, listElements) {
@@ -168,15 +180,12 @@ function refreshElementEnable(tabName, elementSelector, isEnabled) {
 
 if (document?.querySelector('#bo-form-signalement-adresse')) {
   initBoFormSignalementSubmit('adresse')
-  initBoFormSignalementAdresse()
 }
 if (document?.querySelector('#bo-form-signalement-logement')) {
   initBoFormSignalementSubmit('logement')
-  initBoFormSignalementLogement()
 }
 if (document?.querySelector('#bo-form-signalement-situation')) {
   initBoFormSignalementSubmit('situation')
-  initBoFormSignalementSituation()
 }
 
 function initBoFormSignalementAdresse() {

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -25,7 +25,8 @@ function saveCurrentTab(event) {
     formAction = event.target.action
   }
   if (event.type === 'click') {
-    const currentTabForm = currentTab?.querySelector('form')
+    const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
+    const currentTabForm = currentTab?.querySelector('form#bo-form-signalement-' + currentTabName)
     formData = new FormData(currentTabForm)
     formAction = currentTabForm.action
   }
@@ -33,6 +34,15 @@ function saveCurrentTab(event) {
   fetch(formAction, {method: 'POST', body: formData}).then(response => {
     if (response.ok) {
       response.json().then((response) => {
+        if (response.redirect && response.url !== undefined && response.url !== '') {
+          const currentUrl = window.location.href.split('#')[0];
+          const newUrl = response.url.split('#')[0];
+          window.location.href = response.url;
+          if (currentUrl === newUrl) {
+            window.location.reload(true);
+          }
+        }
+
         currentTab.classList.remove('fr-tabs__panel--saving')
         
         const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
@@ -41,9 +51,13 @@ function saveCurrentTab(event) {
 
         if (response.redirect) {
           boFormSignalementCurrentTabIsDirty = false
-          const targetTabButton = document?.querySelector('#tabpanel-' + boFormSignalementTargetTab)
-          boFormSignalementTargetTab = ''
-          targetTabButton.click()
+
+          if (response.url === undefined || response.url === '') {
+            const targetTabButton = document?.querySelector('#tabpanel-' + boFormSignalementTargetTab)
+            boFormSignalementTargetTab = ''
+            targetTabButton.click()
+          }
+
         } else {
           if (currentTabName === 'adresse' && response.hasDuplicates) {
             const modaleDuplicate = document.querySelector('#fr-modal-duplicate')

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -34,15 +34,17 @@ function saveCurrentTab(event) {
     if (response.ok) {
       response.json().then((response) => {
         currentTab.classList.remove('fr-tabs__panel--saving')
+        
+        const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
+        document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = response.tabContent
+        document.querySelector('#tabpanel-' +currentTabName).scrollIntoView({ behavior: 'smooth' });
+
         if (response.redirect) {
           boFormSignalementCurrentTabIsDirty = false
           const targetTabButton = document?.querySelector('#tabpanel-' + boFormSignalementTargetTab)
           boFormSignalementTargetTab = ''
           targetTabButton.click()
         } else {
-          const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
-          document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = response.tabContent
-          document.querySelector('#tabpanel-' +currentTabName).scrollIntoView({ behavior: 'smooth' });
           if (currentTabName === 'adresse' && response.hasDuplicates) {
             const modaleDuplicate = document.querySelector('#fr-modal-duplicate')
             const modaleDuplicateContainer = document.querySelector('#fr-modal-duplicate-container')
@@ -54,6 +56,7 @@ function saveCurrentTab(event) {
             const errorAlertStr = '<div class="fr-alert fr-alert--error fr-mb-2v" role="alert"><p class="fr-alert__title">Merci de corriger les champs où des erreurs sont signalées.</p></div>'
             document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML = errorAlertStr + document.querySelector('#tabpanel-' +currentTabName+ '-panel').innerHTML
           }
+          initBoFormSignalementSubmit(currentTabName)
         }
       });
     } else {

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -23,6 +23,7 @@ function saveCurrentTab(event) {
   let formAction = null
   if (event.type === 'submit') {
     formData = new FormData(event.target)
+    formData.append(event.submitter.name, event.submitter.value)
     formAction = event.target.action
   }
   if (event.type === 'click') {
@@ -55,6 +56,8 @@ function saveCurrentTab(event) {
             const targetTabButton = document?.querySelector('#tabpanel-' + boFormSignalementTargetTab)
             boFormSignalementTargetTab = ''
             targetTabButton.click()
+          } else {
+            window.location.href = response.url;
           }
 
         } else {
@@ -337,12 +340,10 @@ function initBoFormSignalementSituation() {
       '#signalement_draft_situation_reponseAssurance',
     ]
   )
+  window.dispatchEvent(new Event('refreshUploadButtonEvent'))
+
   reloadDeleteFileList()
 }
-
-window.addEventListener('refreshUploadedFileList', (e) => {
-  reloadFileList()
-})
 
 function reloadFileList() {
   const urlListFiles = document?.querySelector('#url-signalement-files').value
@@ -389,10 +390,14 @@ function reloadDeleteFileList() {
 
         fetch(formAction, {method: 'POST', body: formData}).then(response => {
           if (response.ok) {
-            reloadFileList()
+            window.dispatchEvent(new Event('refreshUploadedFileList'))
           }
         })
       })
     })
   }
+
+  window.addEventListener('refreshUploadedFileList', (e) => {
+    reloadFileList()
+  })
 }

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -304,10 +304,27 @@ function initializeUploadModal (
     })
   }
 
+  function reloadFileList() {
+    const urlListFiles = document?.querySelector('#url-signalement-files').value
+    console.log('reloadFileList > ' + urlListFiles)
+    fetch(urlListFiles, {method: 'GET'}).then(response => {
+      if (response.ok) {
+        response.json().then((response) => {
+          // #bo-create-file-list
+        })
+      }
+    })
+  }
+
   modal.addEventListener('dsfr.conceal', (e) => {
     if (modal.dataset.validated === 'true' && modal.dataset.hasChanges === 'true') {
       fetch(waitingSuiviRoute).then((response) => {
-        window.location.reload()
+        if (btnValidate.getAttribute('data-context') !== 'form-bo-create') {
+          window.location.reload()
+        } else {
+          console.log('goto reloadFileList')
+          reloadFileList()
+        }
         window.scrollTo(0, 0)
       })
       return true

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -329,8 +329,6 @@ function initializeUploadModal (
 
   let fileType, fileFilter, documentType, interventionId, acceptedTypeMimes, acceptedExtensions
 
-  window.dispatchEvent(new Event('refreshUploadButtonEvent'))
-
   window.addEventListener('refreshUploadButtonEvent', (e) => {
     document.querySelectorAll('.open-modal-upload-files-btn').forEach((button) => {
       button.addEventListener('click', (e) => {
@@ -343,6 +341,8 @@ function initializeUploadModal (
       })
     })
   })
+
+  window.dispatchEvent(new Event('refreshUploadButtonEvent'))
 
   modal.addEventListener('dsfr.disclose', (e) => {
     nbFilesProccessing = 0

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -306,26 +306,71 @@ function initializeUploadModal (
 
   function reloadFileList() {
     const urlListFiles = document?.querySelector('#url-signalement-files').value
-    console.log('reloadFileList > ' + urlListFiles)
     fetch(urlListFiles, {method: 'GET'}).then(response => {
       if (response.ok) {
         response.json().then((response) => {
-          // #bo-create-file-list
+          let newList = ''
+          response.forEach((responseItem, index) => {
+            newList += '<div class="fr-grid-row">'
+            newList += '<div class="fr-col-8">'
+            newList += '<i>' + responseItem.filename + '</i> (Type ' + responseItem.type + ')'
+            newList += '</div>'
+            newList += '<div class="fr-col-4">'
+            newList += '<button form="form-delete-file" '
+            newList += 'class="fr-link fr-icon-close-circle-line fr-link--icon-left fr-link--error" '
+            newList += 'aria-label="Supprimer le fichier ' + responseItem.filename + '" '
+            newList += 'title="Supprimer le fichier ' + responseItem.filename + '" '
+            newList += 'data-doc="' + responseItem.id + '" '
+            newList += '>Supprimer</button>'
+            newList += '</div>'
+            newList += '</div>'
+          })
+
+          document.querySelector('#bo-create-file-list').innerHTML = newList
+
+          reloadDeleteFileList()
         })
       }
     })
   }
 
+  function reloadDeleteFileList() {
+    const deleteFilesButtons = document?.querySelectorAll('#bo-create-file-list button')
+    if (deleteFilesButtons) {
+      deleteFilesButtons.forEach((button) => {
+        button.addEventListener('click', (event) => {
+          event.preventDefault()
+          button.disabled = true
+          button.innerHTML = 'Suppression en cours...'
+          const formDeleteFile = document?.querySelector('#form-delete-file')
+          formDeleteFile.querySelector('input[name="file_id"]').value = button.getAttribute('data-doc')
+          const formData = new FormData(formDeleteFile)
+          const formAction = formDeleteFile.action
+
+          fetch(formAction, {method: 'POST', body: formData}).then(response => {
+            if (response.ok) {
+              reloadFileList()
+            }
+          })
+        })
+      })
+    }
+  }
+  reloadDeleteFileList()
+
   modal.addEventListener('dsfr.conceal', (e) => {
     if (modal.dataset.validated === 'true' && modal.dataset.hasChanges === 'true') {
+      if (btnValidate.getAttribute('data-context') === 'form-bo-create') {
+        document.querySelector('#bo-create-file-list').innerHTML = 'Sauvegarde des fichiers...'
+      }
+
       fetch(waitingSuiviRoute).then((response) => {
-        if (btnValidate.getAttribute('data-context') !== 'form-bo-create') {
-          window.location.reload()
-        } else {
-          console.log('goto reloadFileList')
+        if (btnValidate.getAttribute('data-context') === 'form-bo-create') {
           reloadFileList()
+        } else {
+          window.location.reload()
+          window.scrollTo(0, 0)
         }
-        window.scrollTo(0, 0)
       })
       return true
     }

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -304,60 +304,6 @@ function initializeUploadModal (
     })
   }
 
-  function reloadFileList() {
-    const urlListFiles = document?.querySelector('#url-signalement-files').value
-    fetch(urlListFiles, {method: 'GET'}).then(response => {
-      if (response.ok) {
-        response.json().then((response) => {
-          let newList = ''
-          response.forEach((responseItem, index) => {
-            newList += '<div class="fr-grid-row">'
-            newList += '<div class="fr-col-8">'
-            newList += '<i>' + responseItem.filename + '</i> (Type ' + responseItem.type + ')'
-            newList += '</div>'
-            newList += '<div class="fr-col-4">'
-            newList += '<button form="form-delete-file" '
-            newList += 'class="fr-link fr-icon-close-circle-line fr-link--icon-left fr-link--error" '
-            newList += 'aria-label="Supprimer le fichier ' + responseItem.filename + '" '
-            newList += 'title="Supprimer le fichier ' + responseItem.filename + '" '
-            newList += 'data-doc="' + responseItem.id + '" '
-            newList += '>Supprimer</button>'
-            newList += '</div>'
-            newList += '</div>'
-          })
-
-          document.querySelector('#bo-create-file-list').innerHTML = newList
-
-          reloadDeleteFileList()
-        })
-      }
-    })
-  }
-
-  function reloadDeleteFileList() {
-    const deleteFilesButtons = document?.querySelectorAll('#bo-create-file-list button')
-    if (deleteFilesButtons) {
-      deleteFilesButtons.forEach((button) => {
-        button.addEventListener('click', (event) => {
-          event.preventDefault()
-          button.disabled = true
-          button.innerHTML = 'Suppression en cours...'
-          const formDeleteFile = document?.querySelector('#form-delete-file')
-          formDeleteFile.querySelector('input[name="file_id"]').value = button.getAttribute('data-doc')
-          const formData = new FormData(formDeleteFile)
-          const formAction = formDeleteFile.action
-
-          fetch(formAction, {method: 'POST', body: formData}).then(response => {
-            if (response.ok) {
-              reloadFileList()
-            }
-          })
-        })
-      })
-    }
-  }
-  reloadDeleteFileList()
-
   modal.addEventListener('dsfr.conceal', (e) => {
     if (modal.dataset.validated === 'true' && modal.dataset.hasChanges === 'true') {
       if (btnValidate.getAttribute('data-context') === 'form-bo-create') {
@@ -366,7 +312,8 @@ function initializeUploadModal (
 
       fetch(waitingSuiviRoute).then((response) => {
         if (btnValidate.getAttribute('data-context') === 'form-bo-create') {
-          reloadFileList()
+          window.dispatchEvent(new Event('refreshUploadedFileList'))
+
         } else {
           window.location.reload()
           window.scrollTo(0, 0)
@@ -382,6 +329,7 @@ function initializeUploadModal (
 
   let fileType, fileFilter, documentType, interventionId, acceptedTypeMimes, acceptedExtensions
   document.querySelectorAll('.open-modal-upload-files-btn').forEach((button) => {
+    // TODO => Ici, GIGA PALIER
     button.addEventListener('click', (e) => {
       fileType = e.target.dataset.fileType
       fileFilter = e.target.dataset.fileFilter ?? null

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -328,15 +328,19 @@ function initializeUploadModal (
   })
 
   let fileType, fileFilter, documentType, interventionId, acceptedTypeMimes, acceptedExtensions
-  document.querySelectorAll('.open-modal-upload-files-btn').forEach((button) => {
-    // TODO => Ici, GIGA PALIER
-    button.addEventListener('click', (e) => {
-      fileType = e.target.dataset.fileType
-      fileFilter = e.target.dataset.fileFilter ?? null
-      documentType = e.target.dataset.documentType ?? null
-      interventionId = e.target.dataset.interventionId ?? null
-      acceptedTypeMimes = e.target.dataset.acceptedTypeMimes ?? null
-      acceptedExtensions = e.target.dataset.acceptedExtensions ?? null
+
+  window.dispatchEvent(new Event('refreshUploadButtonEvent'))
+
+  window.addEventListener('refreshUploadButtonEvent', (e) => {
+    document.querySelectorAll('.open-modal-upload-files-btn').forEach((button) => {
+      button.addEventListener('click', (e) => {
+        fileType = e.target.dataset.fileType
+        fileFilter = e.target.dataset.fileFilter ?? null
+        documentType = e.target.dataset.documentType ?? null
+        interventionId = e.target.dataset.interventionId ?? null
+        acceptedTypeMimes = e.target.dataset.acceptedTypeMimes ?? null
+        acceptedExtensions = e.target.dataset.acceptedExtensions ?? null
+      })
     })
   })
 

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -1021,3 +1021,17 @@ ul + p {
         }
     }
 }
+
+.fr-tabs__panel.fr-tabs__panel--saving::after {
+    display: block;
+    position: absolute;
+    content: "Sauvegarde en cours...";
+    width: 99%;
+    height: 100%;
+    top: 0;
+    left: 1px;
+    padding-top: 20px;
+    font-size: 20px;
+    background-color: #FFF;
+    text-align: center;
+}

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -202,9 +202,12 @@ class SignalementCreateController extends AbstractController
                     $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'logement'], UrlGeneratorInterface::ABSOLUTE_URL);
                 }
 
-                return $this->json(['redirect' => true, 'url' => $url]);
+                $tabContent = $this->renderView('back/signalement_create/tabs/tab-adresse.html.twig', ['form' => $form]);
+
+                return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
             }
         }
+
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-adresse.html.twig', ['form' => $form]);
 
         return $this->json(['tabContent' => $tabContent, 'hasDuplicates' => $hasDuplicates, 'duplicateContent' => $duplicateContent, 'linkDuplicates' => $linkDuplicates]);
@@ -232,8 +235,11 @@ class SignalementCreateController extends AbstractController
                 $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'situation'], UrlGeneratorInterface::ABSOLUTE_URL);
             }
 
-            return $this->json(['redirect' => true, 'url' => $url]);
+            $tabContent = $this->renderView('back/signalement_create/tabs/tab-logement.html.twig', ['formLogement' => $form]);
+
+            return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
         }
+
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-logement.html.twig', ['formLogement' => $form]);
 
         return $this->json(['tabContent' => $tabContent]);
@@ -261,9 +267,12 @@ class SignalementCreateController extends AbstractController
                 $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'coordonnees'], UrlGeneratorInterface::ABSOLUTE_URL);
             }
 
-            return $this->json(['redirect' => true, 'url' => $url]);
+            $tabContent = $this->renderView('back/signalement_create/tabs/tab-situation.html.twig', ['formSituation' => $form, 'signalement' => $signalement]);
+
+            return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
         }
-        $tabContent = $this->renderView('back/signalement_create/tabs/tab-situation.html.twig', ['formSituation' => $form]);
+
+        $tabContent = $this->renderView('back/signalement_create/tabs/tab-situation.html.twig', ['formSituation' => $form, 'signalement' => $signalement]);
 
         return $this->json(['tabContent' => $tabContent]);
     }

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -200,12 +200,12 @@ class SignalementCreateController extends AbstractController
                     $this->addFlash('success', 'Le brouillon est bien enregistré, n\'oubliez pas de le terminer !');
                     $url = $this->generateUrl('back_signalement_drafts', [], UrlGeneratorInterface::ABSOLUTE_URL);
                 } else {
-                    $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'logement'], UrlGeneratorInterface::ABSOLUTE_URL);
+                    $url = $isCreation ? $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'logement'], UrlGeneratorInterface::ABSOLUTE_URL) : '';
                 }
 
                 $tabContent = $this->renderView('back/signalement_create/tabs/tab-adresse.html.twig', ['form' => $form]);
 
-                return $this->json(['redirect' => true, 'url' => $isCreation ? $url : '', 'tabContent' => $tabContent]);
+                return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
             }
         }
 
@@ -233,12 +233,12 @@ class SignalementCreateController extends AbstractController
                 $this->addFlash('success', 'Le brouillon est bien enregistré, n\'oubliez pas de le terminer !');
                 $url = $this->generateUrl('back_signalement_drafts', [], UrlGeneratorInterface::ABSOLUTE_URL);
             } else {
-                $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'situation'], UrlGeneratorInterface::ABSOLUTE_URL);
+                $url = '';
             }
 
             $tabContent = $this->renderView('back/signalement_create/tabs/tab-logement.html.twig', ['formLogement' => $form]);
 
-            return $this->json(['redirect' => true, 'tabContent' => $tabContent]);
+            return $this->json(['redirect' => true, 'tabContent' => $tabContent, 'url' => $url]);
         }
 
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-logement.html.twig', ['formLogement' => $form]);
@@ -265,12 +265,12 @@ class SignalementCreateController extends AbstractController
                 $this->addFlash('success', 'Le brouillon est bien enregistré, n\'oubliez pas de le terminer !');
                 $url = $this->generateUrl('back_signalement_drafts', [], UrlGeneratorInterface::ABSOLUTE_URL);
             } else {
-                $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'coordonnees'], UrlGeneratorInterface::ABSOLUTE_URL);
+                $url = '';
             }
 
             $tabContent = $this->renderView('back/signalement_create/tabs/tab-situation.html.twig', ['formSituation' => $form, 'signalement' => $signalement]);
 
-            return $this->json(['redirect' => true, 'tabContent' => $tabContent]);
+            return $this->json(['redirect' => true, 'tabContent' => $tabContent, 'url' => $url]);
         }
 
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-situation.html.twig', ['formSituation' => $form, 'signalement' => $signalement]);

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -178,7 +178,7 @@ class SignalementCreateController extends AbstractController
     ): JsonResponse {
         $entityManager->beginTransaction();
         $isCreation = empty($signalement->getId());
-        $action = $isCreation ? $this->generateUrl('back_signalement_draft_form_address_edit', ['uuid' => $signalement->getUuid()]) : $this->generateUrl('back_signalement_draft_form_address');
+        $action = $isCreation ? $this->generateUrl('back_signalement_draft_form_address') : $this->generateUrl('back_signalement_draft_form_address_edit', ['uuid' => $signalement->getUuid()]);
         $form = $this->createForm(SignalementDraftAddressType::class, $signalement, ['action' => $action]);
         $form->handleRequest($request);
         $hasDuplicates = false;

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -135,7 +135,16 @@ class SignalementCreateController extends AbstractController
 
         $files = $fileRepository->findBy(['signalement' => $signalement]);
 
-        return $this->json($files);
+        $jsonResult = [];
+        foreach ($files as $file) {
+            $jsonResult []= [
+                'id' => $file->getId(),
+                'filename' => $file->getFilename(),
+                'type' => $file->getDocumentType()->label()
+            ];
+        }
+
+        return $this->json($jsonResult);
     }
 
     #[Route('/bo-form-address/{uuid:signalement}', name: 'back_signalement_draft_form_address_edit', methods: ['POST'])]

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -10,6 +10,7 @@ use App\Form\SignalementDraftAddressType;
 use App\Form\SignalementDraftLogementType;
 use App\Form\SignalementDraftSituationType;
 use App\Manager\SignalementManager;
+use App\Repository\FileRepository;
 use App\Repository\SignalementRepository;
 use App\Service\ListFilters\SearchDraft;
 use App\Service\Signalement\SignalementBoManager;
@@ -123,6 +124,18 @@ class SignalementCreateController extends AbstractController
             'formSituation' => $formSituation,
             'signalement' => $signalement,
         ]);
+    }
+
+    #[Route('/brouillon/{uuid:signalement}/liste-fichiers', name: 'back_signalement_create_file_list', methods: ['GET'])]
+    public function getSignalementFileList(
+        Signalement $signalement,
+        FileRepository $fileRepository,
+    ): JsonResponse {
+        $this->denyAccessUnlessGranted('SIGN_EDIT_DRAFT', $signalement);
+
+        $files = $fileRepository->findBy(['signalement' => $signalement]);
+
+        return $this->json($files);
     }
 
     #[Route('/bo-form-address/{uuid:signalement}', name: 'back_signalement_draft_form_address_edit', methods: ['POST'])]

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -177,7 +177,8 @@ class SignalementCreateController extends AbstractController
         EntityManagerInterface $entityManager,
     ): JsonResponse {
         $entityManager->beginTransaction();
-        $action = $signalement->getId() ? $this->generateUrl('back_signalement_draft_form_address_edit', ['uuid' => $signalement->getUuid()]) : $this->generateUrl('back_signalement_draft_form_address');
+        $isCreation = empty($signalement->getId());
+        $action = $isCreation ? $this->generateUrl('back_signalement_draft_form_address_edit', ['uuid' => $signalement->getUuid()]) : $this->generateUrl('back_signalement_draft_form_address');
         $form = $this->createForm(SignalementDraftAddressType::class, $signalement, ['action' => $action]);
         $form->handleRequest($request);
         $hasDuplicates = false;
@@ -204,7 +205,7 @@ class SignalementCreateController extends AbstractController
 
                 $tabContent = $this->renderView('back/signalement_create/tabs/tab-adresse.html.twig', ['form' => $form]);
 
-                return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
+                return $this->json(['redirect' => true, 'url' => $isCreation ? $url : '', 'tabContent' => $tabContent]);
             }
         }
 
@@ -237,7 +238,7 @@ class SignalementCreateController extends AbstractController
 
             $tabContent = $this->renderView('back/signalement_create/tabs/tab-logement.html.twig', ['formLogement' => $form]);
 
-            return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
+            return $this->json(['redirect' => true, 'tabContent' => $tabContent]);
         }
 
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-logement.html.twig', ['formLogement' => $form]);
@@ -269,7 +270,7 @@ class SignalementCreateController extends AbstractController
 
             $tabContent = $this->renderView('back/signalement_create/tabs/tab-situation.html.twig', ['formSituation' => $form, 'signalement' => $signalement]);
 
-            return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
+            return $this->json(['redirect' => true, 'tabContent' => $tabContent]);
         }
 
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-situation.html.twig', ['formSituation' => $form, 'signalement' => $signalement]);

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -137,10 +137,10 @@ class SignalementCreateController extends AbstractController
 
         $jsonResult = [];
         foreach ($files as $file) {
-            $jsonResult []= [
+            $jsonResult[] = [
                 'id' => $file->getId(),
                 'filename' => $file->getFilename(),
-                'type' => $file->getDocumentType()->label()
+                'type' => $file->getDocumentType()->label(),
             ];
         }
 

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -66,7 +66,7 @@ class SignalementFileController extends AbstractController
             if ($request->isXmlHttpRequest()) {
                 return $this->json(['response' => 'Token CSRF invalide ou paramètre manquant, veuillez rechargez la page'], Response::HTTP_BAD_REQUEST);
             }
-            $this->addFlash('error', 'Token CSRF invalide ou paramètre manquant, veuillez rechargez la page');
+            $this->addFlash('error', 'Token CSRF invalide ou paramètre manquant, veuillez recharger la page');
 
             return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));
         }
@@ -144,7 +144,9 @@ class SignalementFileController extends AbstractController
 
         $entityManager->flush();
 
-        $this->addFlash('success', 'Les documents ont bien été ajoutés.');
+        if (SignalementStatus::DRAFT !== $signalement->getStatut()) {
+            $this->addFlash('success', 'Les documents ont bien été ajoutés.');
+        }
 
         return $this->json(['success' => true]);
     }
@@ -188,10 +190,13 @@ class SignalementFileController extends AbstractController
                         type: Suivi::TYPE_AUTO,
                     );
                 }
-                if (File::FILE_TYPE_DOCUMENT === $type) {
-                    $this->addFlash('success', 'Le document a bien été supprimé.');
-                } else {
-                    $this->addFlash('success', 'La photo a bien été supprimée.');
+
+                if ('1' !== $request->get('is_draft')) {
+                    if (File::FILE_TYPE_DOCUMENT === $type) {
+                        $this->addFlash('success', 'Le document a bien été supprimé.');
+                    } else {
+                        $this->addFlash('success', 'La photo a bien été supprimée.');
+                    }
                 }
             } else {
                 $this->addFlash('error', 'Le fichier n\'a pas été supprimé.');

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -158,7 +158,6 @@ class SignalementFileController extends AbstractController
         Request $request,
         FileRepository $fileRepository,
         UploadHandlerService $uploadHandlerService,
-        EntityManagerInterface $entityManager,
         SuiviManager $suiviManager,
     ): Response {
         $fileId = $request->get('file_id');
@@ -198,11 +197,11 @@ class SignalementFileController extends AbstractController
                 $this->addFlash('error', 'Le fichier n\'a pas été supprimé.');
             }
         } else {
-            $this->addFlash('error', 'Token CSRF invalide, veuillez rechargez la page');
+            $this->addFlash('error', 'Token CSRF invalide, veuillez recharger la page');
         }
 
         if ('1' === $request->get('is_draft')) {
-            return $this->redirect($this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid()]));
+            return $this->json(['success' => true]);
         }
 
         return $this->redirect($this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()]));

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -953,7 +953,7 @@ signalements:
     mail_occupant: "brouillon@yopmail.com"
     adresse_occupant: "2 impasse de la peupleraie"
     cp_occupant: "44850"
-    ville_occupant: "Saint-Mars du Désert"
+    ville_occupant: "Saint-Mars-du-Désert"
     statut: "DRAFT_ARCHIVED"
     created_by: "admin-territoire-44-01@histologe.fr"
     geoloc: "{\"lat\": 47.3688054, \"lng\": -1.4203543}"

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -920,7 +920,7 @@ signalements:
     mail_occupant: "baptiste@yopmail.com"
     adresse_occupant: "2 impasse de la peupleraie"
     cp_occupant: "44850"
-    ville_occupant: "Saint-Mars du Désert"
+    ville_occupant: "Saint-Mars-du-Désert"
     statut: "NEED_VALIDATION"
     created_by: "admin-territoire-44-01@histologe.fr"
     geoloc: "{\"lat\": 47.3688054, \"lng\": -1.4203543}"

--- a/src/Form/SignalementDraftAddressType.php
+++ b/src/Form/SignalementDraftAddressType.php
@@ -176,7 +176,7 @@ class SignalementDraftAddressType extends AbstractType
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Suivant',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right', 'data-target' => 'logement'],
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
         ;

--- a/src/Form/SignalementDraftLogementType.php
+++ b/src/Form/SignalementDraftLogementType.php
@@ -263,13 +263,18 @@ class SignalementDraftLogementType extends AbstractType
             ->add('forceSave', HiddenType::class, [
                 'mapped' => false,
             ])
+            ->add('previous', SubmitType::class, [
+                'label' => 'Précédent',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary', 'data-target' => 'adresse'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ])
             ->add('draft', SubmitType::class, [
                 'label' => 'Finir plus tard',
                 'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline'],
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Suivant',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right', 'data-target' => 'situation'],
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
         ;

--- a/src/Form/SignalementDraftSituationType.php
+++ b/src/Form/SignalementDraftSituationType.php
@@ -373,16 +373,16 @@ class SignalementDraftSituationType extends AbstractType
             ])
             ->add('previous', SubmitType::class, [
                 'label' => 'Précédent',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary', 'data-target' => 'logement'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary', 'data-target' => 'logement', 'value' => 'previous'],
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
             ->add('draft', SubmitType::class, [
                 'label' => 'Finir plus tard',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline', 'value' => 'later'],
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Suivant',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right', 'data-target' => 'coordonnees'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right', 'data-target' => 'coordonnees', 'value' => 'next'],
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
         ;

--- a/src/Form/SignalementDraftSituationType.php
+++ b/src/Form/SignalementDraftSituationType.php
@@ -371,13 +371,18 @@ class SignalementDraftSituationType extends AbstractType
             ->add('forceSave', HiddenType::class, [
                 'mapped' => false,
             ])
+            ->add('previous', SubmitType::class, [
+                'label' => 'Précédent',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary', 'data-target' => 'logement'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ])
             ->add('draft', SubmitType::class, [
                 'label' => 'Finir plus tard',
                 'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline'],
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Suivant',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right', 'data-target' => 'coordonnees'],
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
         ;

--- a/templates/_partials/_modal_duplicate.html.twig
+++ b/templates/_partials/_modal_duplicate.html.twig
@@ -14,7 +14,7 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-fi-edit-line fr-btn--secondary" id="fr-modal-duplicate-ignore-duplicates" type="button">
+                                <button class="fr-btn fr-fi-edit-line fr-btn--secondary" id="fr-modal-duplicate-ignore-duplicates" aria-controls="fr-modal-duplicate" type="button">
                                     Continuer ma saisie
                                 </button>
                             </li>

--- a/templates/_partials/_modal_upload_files.html.twig
+++ b/templates/_partials/_modal_upload_files.html.twig
@@ -111,7 +111,7 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files" id="btn-validate-modal-upload-files">
+                                <button class="fr-btn fr-icon-check-line" aria-controls="fr-modal-upload-files" id="btn-validate-modal-upload-files" data-context="{{ context }}">
                                     Valider
                                 </button>
                             </li>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -18,7 +18,9 @@
         {% include '_partials/_modal_edit_nde.html.twig' %}
     {% endif %}
     {% if is_granted('SIGN_EDIT', signalement) %}
-        {% include '_partials/_modal_upload_files.html.twig' %}
+        {% include '_partials/_modal_upload_files.html.twig' with {
+            'context': 'form-bo-edit'
+        } %}
     {% endif %}
     {% if signalement.geoloc.lat is defined and signalement.geoloc.lng is defined %}
         {% include '_partials/_modal_localisation.html.twig' %}

--- a/templates/back/signalement_create/index.html.twig
+++ b/templates/back/signalement_create/index.html.twig
@@ -3,7 +3,9 @@
 {% block title %}Créer un signalement{% endblock %}
 
 {% block content %}
-    {% include '_partials/_modal_upload_files.html.twig' %}
+    {% include '_partials/_modal_upload_files.html.twig' with {
+        'context': 'form-bo-create'
+    } %}
     {% include '_partials/_modal_file_delete.html.twig' %}
 
     {% include '_partials/_modal_duplicate.html.twig' %}

--- a/templates/back/signalement_create/index.html.twig
+++ b/templates/back/signalement_create/index.html.twig
@@ -34,7 +34,7 @@
     </section>
     <section class="fr-container--fluid">
         <div class="fr-tabs">
-            <ul class="fr-tabs__list" role="tablist" aria-label="Informations du signalement">
+            <ul class="fr-tabs__list fr-tabs__list--bo-create" role="tablist" aria-label="Informations du signalement">
                 <li role="presentation">
                     <button id="tabpanel-adresse" class="fr-tabs__tab"
                         tabindex="0" role="tab" aria-selected="false" aria-controls="tabpanel-adresse-panel">Adresse</button>

--- a/templates/back/signalement_create/index.html.twig
+++ b/templates/back/signalement_create/index.html.twig
@@ -34,6 +34,17 @@
         </header>
     </section>
     <section class="fr-container--fluid">
+
+        {% if signalement.id is not null %}
+        <form method="POST" id="form-delete-file" enctype="application/json" action="{{ path('back_signalement_delete_file',{uuid:signalement.uuid}) }}">
+            <input type="hidden" name="_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
+            <input type="hidden" name="file_id" value="">
+            <input type="hidden" name="is_draft" value="1">
+        </form>
+
+        <input type="hidden" id="url-signalement-files" value="{{ path('back_signalement_create_file_list',{uuid:signalement.uuid}) }}">
+        {% endif %}
+
         <div class="fr-tabs">
             <ul class="fr-tabs__list fr-tabs__list--bo-create" role="tablist" aria-label="Informations du signalement">
                 <li role="presentation">

--- a/templates/back/signalement_create/index.html.twig
+++ b/templates/back/signalement_create/index.html.twig
@@ -6,7 +6,6 @@
     {% include '_partials/_modal_upload_files.html.twig' with {
         'context': 'form-bo-create'
     } %}
-    {% include '_partials/_modal_file_delete.html.twig' %}
 
     {% include '_partials/_modal_duplicate.html.twig' %}
     <section class="fr-p-5v">

--- a/templates/back/signalement_create/tabs/tab-logement.html.twig
+++ b/templates/back/signalement_create/tabs/tab-logement.html.twig
@@ -76,7 +76,12 @@
         </fieldset>
     </div>
 
-    <div class="fr-col-12">
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--left">
+            {{ form_row(formLogement.previous) }}
+        </div>
+    </div>
+    <div class="fr-col-6">
         <div class="fr-grid-row fr-grid-row--right">
             {{ form_row(formLogement.forceSave) }}
             {{ form_row(formLogement.draft) }}

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -135,9 +135,7 @@
                 </button>
             </p>
             <div id="bo-create-file-list" class="fr-mt-1v">
-            {% for index, document in signalement.files|filter(
-                document => document.fileType == 'document'
-            ) %}
+            {% for index, document in signalement.files %}
                 <div class="fr-grid-row">
                     <div class="fr-col-8">
                         <i>{{ document.filename }}</i> (Type {{ document.documentType.label() }})

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -3,7 +3,7 @@
 
 <form method="POST" id="form-delete-file" enctype="application/json" action="{{ path('back_signalement_delete_file',{uuid:signalement.uuid}) }}">
     <input type="hidden" name="_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
-    <input type="hidden" name="file_id" value=""
+    <input type="hidden" name="file_id" value="">
     <input type="hidden" name="is_draft" value="1">
 </form>
 

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -1,14 +1,6 @@
 <h2 class="fr-h4">Situation du foyer et du bail</h2>
 <p>Sauf mention contraire, toutes les réponses sont <strong>facultatives</strong>. Essayez de compléter le dossier au mieux !</p>
 
-<form method="POST" id="form-delete-file" enctype="application/json" action="{{ path('back_signalement_delete_file',{uuid:signalement.uuid}) }}">
-    <input type="hidden" name="_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
-    <input type="hidden" name="file_id" value="">
-    <input type="hidden" name="is_draft" value="1">
-</form>
-
-<input type="hidden" id="url-signalement-files" value="{{ path('back_signalement_create_file_list',{uuid:signalement.uuid}) }}">
-
 {% form_theme formSituation 'form/dsfr_theme.html.twig' %}
 {{ form_start(formSituation, {'attr': {'id': 'bo-form-signalement-situation'}}) }}
 {{ form_errors(formSituation) }}

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -170,7 +170,12 @@
         </div>
     </div>
 
-    <div class="fr-col-12">
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--left">
+            {{ form_row(formSituation.previous) }}
+        </div>
+    </div>
+    <div class="fr-col-6">
         <div class="fr-grid-row fr-grid-row--right">
             {{ form_row(formSituation.forceSave) }}
             {{ form_row(formSituation.draft) }}

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -1,15 +1,11 @@
 <h2 class="fr-h4">Situation du foyer et du bail</h2>
 <p>Sauf mention contraire, toutes les réponses sont <strong>facultatives</strong>. Essayez de compléter le dossier au mieux !</p>
 
-{% for index, document in signalement.files|filter(
-    document => document.fileType == 'document'
-) %}
-<form method="POST" id="form-delete-file-{{ document.id }}" enctype="application/json" action="{{ path('back_signalement_delete_file',{uuid:signalement.uuid}) }}">
+<form method="POST" id="form-delete-file" enctype="application/json" action="{{ path('back_signalement_delete_file',{uuid:signalement.uuid}) }}">
     <input type="hidden" name="_token" value="{{ csrf_token('signalement_delete_file_'~signalement.id) }}">
-    <input type="hidden" name="file_id" value="{{ document.id }}">
+    <input type="hidden" name="file_id" value=""
     <input type="hidden" name="is_draft" value="1">
 </form>
-{% endfor %}
 
 <input type="hidden" id="url-signalement-files" value="{{ path('back_signalement_create_file_list',{uuid:signalement.uuid}) }}">
 
@@ -156,10 +152,11 @@
                     </div>
                     <div class="fr-col-4">
                         <button
-                            form="form-delete-file-{{ document.id }}"
+                            form="form-delete-file"
                             class="fr-link fr-icon-close-circle-line fr-link--icon-left fr-link--error"
                             aria-label="Supprimer le fichier {{ document.filename }}"
                             title="Supprimer le fichier {{ document.filename }}"
+                            data-doc="{{ document.id }}"
                             >
                         Supprimer
                         </button>

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -11,6 +11,8 @@
 </form>
 {% endfor %}
 
+<input type="hidden" id="url-signalement-files" value="{{ path('back_signalement_create_file_list',{uuid:signalement.uuid}) }}">
+
 {% form_theme formSituation 'form/dsfr_theme.html.twig' %}
 {{ form_start(formSituation, {'attr': {'id': 'bo-form-signalement-situation'}}) }}
 {{ form_errors(formSituation) }}
@@ -144,7 +146,7 @@
                     Ajouter des documents
                 </button>
             </p>
-            <div class="fr-mt-1v">
+            <div id="bo-create-file-list" class="fr-mt-1v">
             {% for index, document in signalement.files|filter(
                 document => document.fileType == 'document'
             ) %}

--- a/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
@@ -183,7 +183,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('redirect', $response);
         $this->assertTrue($response['redirect']);
-        $this->assertStringContainsString('/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002#situation', $response['url']);
 
         $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2025-000000000002']);
         $this->assertEquals(SignalementStatus::DRAFT, $signalement->getStatut());
@@ -215,7 +214,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('redirect', $response);
         $this->assertTrue($response['redirect']);
-        $this->assertStringContainsString('/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002#coordonnees', $response['url']);
 
         $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2025-000000000002']);
         $this->assertEquals(SignalementStatus::DRAFT, $signalement->getStatut());

--- a/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
@@ -182,7 +182,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('redirect', $response);
-        $this->assertArrayHasKey('url', $response);
         $this->assertTrue($response['redirect']);
         $this->assertStringContainsString('/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002#situation', $response['url']);
 
@@ -215,7 +214,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('redirect', $response);
-        $this->assertArrayHasKey('url', $response);
         $this->assertTrue($response['redirect']);
         $this->assertStringContainsString('/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002#coordonnees', $response['url']);
 

--- a/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
@@ -202,11 +202,11 @@ class SignalementCreateControllerTest extends WebTestCase
 
         $form = $crawler->filter('#bo-form-signalement-situation')->form();
         $form->setValues([
-            'signalement_draft_logement[bail]' => 'oui',
-            'signalement_draft_logement[dpe]' => 'non',
-            'signalement_draft_logement[classeEnergetique]' => 'A',
-            'signalement_draft_logement[etatDesLieux]' => 'oui',
-            'signalement_draft_logement[allocataire]' => 'oui',
+            'signalement_draft_situation[bail]' => 'oui',
+            'signalement_draft_situation[dpe]' => 'non',
+            'signalement_draft_situation[classeEnergetique]' => 'A',
+            'signalement_draft_situation[etatDesLieux]' => 'oui',
+            'signalement_draft_situation[allocataire]' => 'oui',
         ]);
         $this->client->submit($form);
 

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -50,7 +50,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Territory 13' => [['territoire' => '13', 'isImported' => 'oui'], 26];
         yield 'Search by Commune' => [['communes' => ['gex', 'marseille'], 'isImported' => 'oui'], 31];
         yield 'Search by Commune code postal' => [['communes' => ['13002'], 'isImported' => 'oui'], 2];
-        yield 'Search by EPCIS' => [['epcis' => ['244400503'], 'isImported' => 'oui'], 3];
+        yield 'Search by EPCIS' => [['epcis' => ['244400503'], 'isImported' => 'oui'], 4];
         yield 'Search by Partner' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
         yield 'Search by Etiquettes' => [['etiquettes' => ['5'], 'isImported' => 'oui'], 4];
         yield 'Search by Parc public' => [['natureParc' => 'public', 'isImported' => 'oui'], 7];


### PR DESCRIPTION
## Ticket

#3787   

## Description
Pour éviter les rechargements de pages intempestifs, on valide le parcours et les fichiers en Ajax

## Changements apportés
* Quand on change d'onglet, on vérifie si il y a eu des modifications. Si oui, on sauvegarde avant de valider le changement d'onglet. Si il y a erreur pendant l'enregistrement, on reste sur l'onglet.
* Idem pour les bouton Précédent / Suivant
* Idem pour quand on ajoute un fichier
* Idem pour quand on supprime un fichier
* Le bouton finir plus tard redirige vers la liste des brouillons

Pour cela :
- utilisation d'événements attachés à window pour recharger les différents éléments

## Pré-requis
`npm run watch-bo`

## Tests
- [ ] Créer un brouillon : le premier onglet continue de recharger la page dans l'immédiat (pour créer l'objet Signalement)
- [ ] Parcourir le formulaire et vérifier les rechargements et la gestion des erreurs
- [ ] Ajouter et supprimer des fichiers pour vérifier l'affichage
- [ ] TNR : fiche signalement : ajouter / supprimer des fichiers
