### PR TITLE
[BO - Signalement] Pouvoir voir et éditer date de naissance bailleur quand tiers déclarant

### DIFF
--- a/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesTiersRequest.php
@@ -3,11 +3,15 @@
 namespace App\Dto\Request\Signalement;
 
 use App\Validator as AppAssert;
+use App\Validator\DateNaissanceValidatorTrait;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class CoordonneesTiersRequest implements RequestInterface
 {
+    use DateNaissanceValidatorTrait;
+
     public function __construct(
         #[Assert\Choice(choices: ['ORGANISME_SOCIETE', 'PARTICULIER'], message: 'Le type de propriétaire est incorrect.')]
         private readonly ?string $typeProprio = null,
@@ -34,7 +38,15 @@ class CoordonneesTiersRequest implements RequestInterface
         )]
         #[Assert\Length(max: 200, maxMessage: 'Le nom de la structure ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $structure = null,
+        #[Assert\DateTime('Y-m-d')]
+        private readonly ?string $dateNaissance = null,
     ) {
+    }
+
+    #[Assert\Callback]
+    public function validate(ExecutionContextInterface $context): void
+    {
+        $this->validateDateNaissance($this->dateNaissance, 'dateNaissance', $context);
     }
 
     public function getTypeProprio(): ?string
@@ -70,5 +82,10 @@ class CoordonneesTiersRequest implements RequestInterface
     public function getStructure(): ?string
     {
         return $this->structure;
+    }
+
+    public function getDateNaissance(): ?string
+    {
+        return $this->dateNaissance;
     }
 }

--- a/src/Entity/Model/InformationComplementaire.php
+++ b/src/Entity/Model/InformationComplementaire.php
@@ -168,6 +168,15 @@ class InformationComplementaire
         return $this;
     }
 
+    public function getInformationsComplementairesSituationBailleurDateNaissanceDate(): ?\DateTime
+    {
+        if ($this->informationsComplementairesSituationBailleurDateNaissance) {
+            return new \DateTime($this->informationsComplementairesSituationBailleurDateNaissance);
+        }
+
+        return null;
+    }
+
     public function getInformationsComplementairesSituationBailleurDateNaissance(): ?string
     {
         return $this->informationsComplementairesSituationBailleurDateNaissance;

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -356,6 +356,17 @@ class SignalementManager extends AbstractManager
             ->setLienDeclarantOccupant($coordonneesTiersRequest->getLien())
             ->setStructureDeclarant($coordonneesTiersRequest->getStructure());
 
+        $informationComplementaire = new InformationComplementaire();
+        if (!empty($signalement->getInformationComplementaire())) {
+            $informationComplementaire = clone $signalement->getInformationComplementaire();
+        }
+        if ($coordonneesTiersRequest->getDateNaissance()) {
+            $informationComplementaire->setInformationsComplementairesSituationBailleurDateNaissance(
+                $coordonneesTiersRequest->getDateNaissance()
+            );
+            $signalement->setInformationComplementaire($informationComplementaire);
+        }
+
         $this->save($signalement);
         $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-tiers.html.twig
@@ -62,6 +62,14 @@
                                 <label class="fr-label" for="coordonneesTiersStructure">Structure (si lien avec l'occupant: professionnel(le) ou service de secours)</label>
                                 <input class="fr-input" type="text" id="coordonneesTiersStructure" name="structure" value="{{ signalement.structureDeclarant }}">
                             </div>
+
+                            {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR %}
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesBailleurDateNaissance">Date de naissance (facultatif)</label>
+                                <input class="fr-input" type="date" id="coordonneesBailleurDateNaissance" name="dateNaissance" value="{{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissance ?? '' }}">
+                            </div>
+                            {% endif %}
+
                             <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_tiers_'~signalement.id) }}">
                         </div>
                         

--- a/templates/back/signalement/view/information/information-tiers.html.twig
+++ b/templates/back/signalement/view/information/information-tiers.html.twig
@@ -53,4 +53,12 @@
     <div class="fr-col-12">
         <strong>Tél. :</strong> {{ signalement.telDeclarantDecoded|phone }}
     </div>
+    {% if signalement.profileDeclarant and signalement.profileDeclarant is same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR  %}
+    <div class="fr-col-12">
+        <strong>Date de naissance :</strong>
+        {% if signalement.informationComplementaire and signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissanceDate %}
+            {{ signalement.informationComplementaire.informationsComplementairesSituationBailleurDateNaissanceDate.format('d/m/Y') }}
+        {% endif %}
+    </div>
+    {% endif %}
 </div>


### PR DESCRIPTION
## Ticket

#3763   

## Description
Quand le tiers-déclarant est un bailleur, il peut saisir sa date de naissance dans le formulaire.
Par contre, jusque-là, on ne l'affichait pas dans la fiche signalement.

## Pré-requis
`npm run watch`

## Tests
- [ ] Faire un signalement en tiers-déclarant bailleur et remplir date de naissance
- [ ] Vérifier qu'elle s'affiche bien dans la fiche signalement, et qu'on peut l'éditer
- [ ] Vérifier affichage et édition sur un signalement autre
