### PR TITLE
[INFRA] Mise à jour Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - .:/home/wiremock
 
   histologe_redis:
-    image: redis:7.2.5-alpine
+    image: redis:7.2.7-alpine
     container_name: histologe_redis
 
   histologe_clamav:


### PR DESCRIPTION
## Ticket

#3822    

## Description
Avant l'upgrade redis sur scalingo, mise à jour de l'env locale dans un premier temps
![image](https://github.com/user-attachments/assets/2ce12984-3823-43c2-b4f0-c343be7be270)


## Changements apportés
* Upgrade de la version de redis `docker-compose`

## Pré-requis
```
make build
```
## Tests
- [ ] Tester la connexion (TNR sur la navigation sur le BO)
- [ ] Tester le dashboard et vérifier que le système de cache fonctionne
