### PR TITLE
[FO - Signalement] Date DPE même si pas de DPE

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1090,6 +1090,9 @@
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
           "label": "Quelle est la classe énergétique du logement ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -1132,6 +1135,9 @@
         {
           "type": "SignalementFormOnlyChoice",
           "label": "Quand le DPE de votre logement a-t-il été réalisé ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "slug": "desordres_logement_chauffage_details_dpe_annee",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -922,6 +922,9 @@
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
           "label": "Quelle est la classe énergétique du logement ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -964,6 +967,9 @@
         {
           "type": "SignalementFormOnlyChoice",
           "label": "Quand le DPE de votre logement a-t-il été réalisé ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "slug": "desordres_logement_chauffage_details_dpe_annee",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1116,6 +1116,9 @@
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
           "label": "Quelle est la classe énergétique du logement ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -1158,6 +1161,9 @@
         {
           "type": "SignalementFormOnlyChoice",
           "label": "Quand le DPE de votre logement a-t-il été réalisé ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "slug": "desordres_logement_chauffage_details_dpe_annee",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1177,6 +1177,9 @@
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
           "label": "Quelle est la classe énergétique du logement ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -1219,6 +1222,9 @@
         {
           "type": "SignalementFormOnlyChoice",
           "label": "Quand le DPE de votre logement a-t-il été réalisé ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "slug": "desordres_logement_chauffage_details_dpe_annee",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1211,6 +1211,9 @@
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
           "label": "Quelle est la classe énergétique du logement ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -1253,6 +1256,9 @@
         {
           "type": "SignalementFormOnlyChoice",
           "label": "Quand le DPE de votre logement a-t-il été réalisé ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "slug": "desordres_logement_chauffage_details_dpe_annee",
           "values": [
             {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1195,6 +1195,9 @@
           "type": "SignalementFormSelect",
           "slug": "bail_dpe_classe_energetique",
           "label": "Quelle est la classe énergétique du logement ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "description": "La classe énergétique indique si le logement consomme beaucoup d'énergie ou non. La classe A est la meilleure, la classe G est la moins bonne.",
           "values": [
             {
@@ -1237,6 +1240,9 @@
         {
           "type": "SignalementFormOnlyChoice",
           "label": "Quand le DPE de votre logement a-t-il été réalisé ?",
+          "conditional": {
+            "show": "formStore.data.bail_dpe_dpe === 'oui'"
+          },
           "slug": "desordres_logement_chauffage_details_dpe_annee",
           "values": [
             {


### PR DESCRIPTION
## Ticket

#3820   

## Description
Demande de la date de DPE et de la classe énergétique seulement si on répond "oui" à la question sur le DPE

## Changements apportés
* Changement des json

## Pré-requis

## Tests
- [ ] Déposer un signalement avec 1 ou 2 profils, et vérifier que les questions ne s'affichent que si on répond "oui" au DPE
