### PR TITLE
[FO - Sites Faciles] Ajouter profils locataire de parc privé et de parc public

### DIFF
--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -135,6 +135,16 @@ export default defineComponent({
           formStore.data.signalement_concerne_profil = 'logement_occupez'
           formStore.data.signalement_concerne_profil_detail_occupant = 'locataire'
           break
+        case 'locataire_parc_prive':
+          formStore.data.signalement_concerne_profil = 'logement_occupez'
+          formStore.data.signalement_concerne_profil_detail_occupant = 'locataire'
+          formStore.data.signalement_concerne_logement_social_autre_tiers = 'non'
+          break
+        case 'locataire_parc_public':
+          formStore.data.signalement_concerne_profil = 'logement_occupez'
+          formStore.data.signalement_concerne_profil_detail_occupant = 'locataire'
+          formStore.data.signalement_concerne_logement_social_autre_tiers = 'oui'
+          break
         case 'bailleur_occupant':
           formStore.data.signalement_concerne_profil = 'logement_occupez'
           formStore.data.signalement_concerne_profil_detail_occupant = 'bailleur_occupant'


### PR DESCRIPTION
## Ticket

#3830   

## Description
Avec Sites Facile, on pourra ouvrir le formulaire depuis différents liens, selon le profil de l'utilisateur.
On a différencié les profils locataire parc public et locataire parc privé
Il faudrait donc ajouter un paramètre pour que la case Logement social ? oui / non soit cochée en fonction du profil

## Pré-requis
`npm run watch`

## Tests des différents cas possibles d'ouverture
- [ ] http://localhost:8080/signalement
- [ ] http://localhost:8080/signalement?profil=locataire
- [ ] http://localhost:8080/signalement?profil=locataire_parc_prive
- [ ] http://localhost:8080/signalement?profil=locataire_parc_public
