### PR TITLE
[FO - Upload photos] Accepter le format PDF

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_edit_file/back_signalement_edit_file.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_edit_file/back_signalement_edit_file.js
@@ -59,7 +59,7 @@ document.querySelectorAll('.btn-signalement-file-edit').forEach(swbtn => {
     document.querySelector('#file-edit-fileid').value = target.getAttribute('data-file-id')
 
     const selectedDocumentType = target.getAttribute('data-documentType')
-    if (target.getAttribute('data-type') === 'photo') {
+    if (target.getAttribute('data-type') === 'photo' || target.getAttribute('data-documentType') == 'PHOTO_VISITE') {
       document.querySelector('#fileDescription').value = target.getAttribute('data-description')
       document.querySelector('#fr-modal-edit-file-description').classList.remove('fr-hidden')
     } else {

--- a/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/form_upload_documents.js
@@ -181,7 +181,7 @@ function initializeUploadModal (
 
   function initInnerHtml (file) {
     let innerHTML = '<div class="fr-col-12 file-error"></div>'
-    if (modal.dataset.fileType === 'photo') {
+    if (modal.dataset.fileType === 'photo' && file.type !== 'application/pdf') {
       innerHTML += `
             <div class="fr-col-2">
                 <img class="fr-content-media__img" src="${URL.createObjectURL(file)}">

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -171,7 +171,7 @@ if (modalUploadFiles) {
 
   function initInnerHtml (file) {
     let innerHTML = '<div class="fr-col-12 file-error"></div>'
-    if (modal.dataset.fileType === 'photo' && file.type !== 'application/pdf') {
+    if (modalUploadFiles.dataset.fileType === 'photo' && file.type !== 'application/pdf') {
       innerHTML += `
             <div class="fr-col-2">
                 <img class="fr-content-media__img" src="${URL.createObjectURL(file)}">

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -171,7 +171,7 @@ if (modalUploadFiles) {
 
   function initInnerHtml (file) {
     let innerHTML = '<div class="fr-col-12 file-error"></div>'
-    if (modalUploadFiles.dataset.fileType === 'photo') {
+    if (modal.dataset.fileType === 'photo' && file.type !== 'application/pdf') {
       innerHTML += `
             <div class="fr-col-2">
                 <img class="fr-content-media__img" src="${URL.createObjectURL(file)}">

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormUpload.vue
@@ -98,13 +98,15 @@ export default defineComponent({
       photosMimeTypes: [
         'image/jpeg',
         'image/png',
-        'image/gif'
+        'image/gif',
+        'application/pdf',
       ],
       photosExtensions: [
         'jpeg',
         'jpg',
         'png',
-        'gif'
+        'gif',
+        'pdf'
       ],
       documentsMimeTypes: [
         'image/jpeg',

--- a/src/Command/UpdateSignalementDocumentFieldsCommand.php
+++ b/src/Command/UpdateSignalementDocumentFieldsCommand.php
@@ -2,7 +2,6 @@
 
 namespace App\Command;
 
-use App\Entity\File;
 use App\Entity\Territory;
 use App\Manager\FileManager;
 use App\Manager\SignalementManager;
@@ -30,9 +29,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class UpdateSignalementDocumentFieldsCommand extends Command
 {
     private const BATCH_SIZE = 200;
-    private const TYPE_IMAGE = 'image';
-    private const TYPE_DOCUMENT = 'document';
-    private const REGEX_IMAGE = '/(jpe?g|png)/mi';
 
     public function __construct(
         private readonly TerritoryManager $territoryManager,
@@ -92,16 +88,12 @@ class UpdateSignalementDocumentFieldsCommand extends Command
                 }
                 if (null !== $filename) {
                     $currentReference = $row[SignalementImportImageHeader::COLUMN_ID_ENREGISTREMENT];
-                    $fileType = self::TYPE_IMAGE === $this->checkFileType($filename)
-                        ? File::FILE_TYPE_PHOTO
-                        : File::FILE_TYPE_DOCUMENT;
 
                     $signalement = $signalementRepository->findByReferenceChunk($territory, $currentReference);
                     if (null !== $signalement) {
                         $file = $this->fileManager->createOrUpdate(
                             filename: $filename,
                             title: $filename,
-                            type: $fileType,
                             signalement: $signalement,
                         );
                         unset($file);
@@ -127,15 +119,5 @@ class UpdateSignalementDocumentFieldsCommand extends Command
         $io->success(\sprintf('%s files signalement(s) updated', $countFile));
 
         return Command::SUCCESS;
-    }
-
-    private function checkFileType(string $filePath): string
-    {
-        $fileInfo = pathinfo($filePath);
-        if (preg_match(self::REGEX_IMAGE, $fileInfo['extension'])) {
-            return self::TYPE_IMAGE;
-        }
-
-        return self::TYPE_DOCUMENT;
     }
 }

--- a/src/Controller/Api/SignalementFileUpdateController.php
+++ b/src/Controller/Api/SignalementFileUpdateController.php
@@ -96,7 +96,7 @@ class SignalementFileUpdateController extends AbstractController
         $this->denyAccessUnlessGranted('FILE_EDIT', $file);
         $documentType = DocumentType::tryFrom($fileRequest->documentType);
         $ext = pathinfo($file->getFilename(), \PATHINFO_EXTENSION);
-        if (in_array($ext, File::IMAGE_EXTENSION) && isset(DocumentType::getOrderedPhotosList()[$documentType->name])) {
+        if ((in_array($ext, File::IMAGE_EXTENSION) && 'pdf' !== $ext) && isset(DocumentType::getOrderedPhotosList()[$documentType->name])) {
             $file->setFileType(File::FILE_TYPE_PHOTO);
             $file->setDescription($fileRequest->description);
         } else {

--- a/src/Controller/Back/ProfilController.php
+++ b/src/Controller/Back/ProfilController.php
@@ -98,7 +98,7 @@ class ProfilController extends AbstractController
                         }
                         $res = $uploadHandlerService->setKey('avatar');
 
-                        if (\in_array($avatarFile->getMimeType(), File::IMAGE_MIME_TYPES)) {
+                        if (\in_array($avatarFile->getMimeType(), File::RESIZABLE_MIME_TYPES)) {
                             $imageManipulationHandler->avatar($res['filePath']);
                             $uploadHandlerService->moveFilePath($res['filePath']);
                         }

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -409,7 +409,7 @@ class SignalementController extends AbstractController
                         throw new \Exception($res['error']);
                     }
                     $res = $uploadHandlerService->setKey($key);
-                    if (\in_array($file->getMimeType(), File::IMAGE_MIME_TYPES)) {
+                    if (\in_array($file->getMimeType(), File::RESIZABLE_MIME_TYPES)) {
                         $imageManipulationHandler->resize($res['filePath'])->thumbnail();
                     }
 

--- a/src/DataFixtures/Loader/LoadFileData.php
+++ b/src/DataFixtures/Loader/LoadFileData.php
@@ -3,7 +3,6 @@
 namespace App\DataFixtures\Loader;
 
 use App\Entity\Enum\DocumentType;
-use App\Entity\File;
 use App\Factory\FileFactory;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -21,7 +20,6 @@ class LoadFileData extends Fixture implements OrderedFixtureInterface
         $file = $this->fileFactory->createInstanceFrom(
             filename: 'export-histologe-xxxx.xslx',
             title: 'export-histologe-xxxx.xslx',
-            type: File::FILE_TYPE_DOCUMENT,
             documentType: DocumentType::EXPORT,
         );
         $file->setCreatedAt(new \DateTimeImmutable('- 2 months'));

--- a/src/DataFixtures/Loader/LoadInterventionData.php
+++ b/src/DataFixtures/Loader/LoadInterventionData.php
@@ -5,7 +5,6 @@ namespace App\DataFixtures\Loader;
 use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\ProcedureType;
-use App\Entity\File;
 use App\Entity\Intervention;
 use App\Factory\FileFactory;
 use App\Repository\PartnerRepository;
@@ -67,9 +66,6 @@ class LoadInterventionData extends Fixture implements OrderedFixtureInterface
                 $file = $this->fileFactory->createInstanceFrom(
                     filename: $document,
                     title: $document,
-                    type: \in_array(pathinfo($document, \PATHINFO_EXTENSION), File::IMAGE_EXTENSION)
-                        ? File::FILE_TYPE_DOCUMENT
-                        : File::FILE_TYPE_PHOTO,
                     signalement: $intervention->getSignalement(),
                     user: $user,
                     intervention: $intervention,

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -278,7 +278,6 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 user: $user,
                 documentType: DocumentType::AUTRE
             );
-            // if (in_array(pathinfo($document['file'], \PATHINFO_EXTENSION), File::IMAGE_EXTENSION)) {
             if (\in_array($document['mimeType'], File::RESIZABLE_MIME_TYPES)) {
                 $file->setIsVariantsGenerated(true);
                 $file->setCreatedAt($dateMinusTwoMonth);

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -234,31 +234,37 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 'file' => 'test1.23.pdf',
                 'titre' => 'Fiche reperage.pdf',
                 'user' => 1,
+                'mimeType' => 'application/pdf',
             ],
             [
                 'file' => 'test1.pdf',
                 'titre' => 'Compte rendu de visite.pdf',
                 'user' => 22,
+                'mimeType' => 'application/pdf',
             ],
             [
                 'file' => 'blank-'.$row['reference'].'.pdf',
                 'titre' => 'Blank.pdf',
                 'user' => 1,
+                'mimeType' => 'application/pdf',
             ],
             [
                 'file' => 'Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png',
-                'titre' => '20220520_112424.jpg',
+                'titre' => '20220520_112424.png',
                 'user' => 1,
+                'mimeType' => 'image/png',
             ],
             [
                 'file' => 'Capture-d-ecran-du-2023-04-07-15-27-36-64302a1b57a20.png',
-                'titre' => 'IMG_20230220_141432735_HDR.jpg',
+                'titre' => 'IMG_20230220_141432735_HDR.png',
                 'user' => 23,
+                'mimeType' => 'image/png',
             ],
             [
                 'file' => 'blank-'.$row['reference'].'.jpg',
-                'titre' => 'Blank.pdf',
+                'titre' => 'Blank.jpg',
                 'user' => 1,
+                'mimeType' => 'image/jpeg',
             ],
         ];
 
@@ -268,14 +274,12 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             $file = $this->fileFactory->createInstanceFrom(
                 filename: $document['file'],
                 title: $document['titre'],
-                type: \in_array(pathinfo($document['file'], \PATHINFO_EXTENSION), File::IMAGE_EXTENSION)
-                    ? File::FILE_TYPE_PHOTO
-                    : File::FILE_TYPE_DOCUMENT,
                 signalement: $signalement,
                 user: $user,
                 documentType: DocumentType::AUTRE
             );
-            if (in_array(pathinfo($document['file'], \PATHINFO_EXTENSION), File::IMAGE_EXTENSION)) {
+            // if (in_array(pathinfo($document['file'], \PATHINFO_EXTENSION), File::IMAGE_EXTENSION)) {
+            if (\in_array($document['mimeType'], File::RESIZABLE_MIME_TYPES)) {
                 $file->setIsVariantsGenerated(true);
                 $file->setCreatedAt($dateMinusTwoMonth);
             }
@@ -289,7 +293,6 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 $file = $this->fileFactory->createInstanceFrom(
                     filename: 'blank-'.$row['reference'].'-'.$countMorePhoto.'.jpg',
                     title: 'Blank.pdf',
-                    type: File::FILE_TYPE_PHOTO,
                     signalement: $signalement,
                     user: $user,
                     documentType: DocumentType::AUTRE
@@ -469,7 +472,6 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
                 $file = $this->fileFactory->createInstanceFrom(
                     filename: $document['file'],
                     title: $document['titre'],
-                    type: $document['file_type'] ?? File::FILE_TYPE_PHOTO,
                     signalement: $signalement,
                     // user: $user,
                     documentType: DocumentType::tryFrom($document['document_type']) ?? DocumentType::PHOTO_SITUATION,

--- a/src/Entity/Enum/DocumentType.php
+++ b/src/Entity/Enum/DocumentType.php
@@ -77,6 +77,7 @@ enum DocumentType: String
             self::PROCEDURE_SAISINE->name => self::PROCEDURE_SAISINE->label(),
             self::BAILLEUR_DEVIS_POUR_TRAVAUX->name => self::BAILLEUR_DEVIS_POUR_TRAVAUX->label(),
             self::BAILLEUR_REPONSE_BAILLEUR->name => self::BAILLEUR_REPONSE_BAILLEUR->label(),
+            self::PHOTO_VISITE->name => self::PHOTO_VISITE->label(),
             self::AUTRE_PROCEDURE->name => self::AUTRE_PROCEDURE->label(),
         ];
     }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -49,16 +49,23 @@ class File implements EntityHistoryInterface
         'eml',
         'msg',
     ];
+    public const array RESIZABLE_MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+    ];
     public const array IMAGE_MIME_TYPES = [
         'image/jpeg',
         'image/png',
         'image/gif',
+        'application/pdf',
     ];
     public const array IMAGE_EXTENSION = [
         'jpeg',
         'jpg',
         'png',
         'gif',
+        'pdf',
     ];
 
     #[ORM\Id]

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -14,7 +14,6 @@ class FileFactory
     public function createInstanceFrom(
         ?string $filename = null,
         ?string $title = null,
-        ?string $type = null,
         ?Signalement $signalement = null,
         ?User $user = null,
         ?Intervention $intervention = null,
@@ -29,7 +28,7 @@ class FileFactory
         $file = (new File())
             ->setFilename($filename)
             ->setTitle($title)
-            ->setFileType($type)
+            ->setFileType($this->getFileType($filename, $documentType ?? DocumentType::AUTRE))
             ->setIsWaitingSuivi($isWaitingSuivi)
             ->setIsTemp($isTemp);
         if (null !== $signalement) {
@@ -89,7 +88,6 @@ class FileFactory
         return $this->createInstanceFrom(
             filename: $file['file'],
             title: $file['titre'],
-            type: $this->getFileType($file, $documentType),
             signalement: $signalement,
             user: $user,
             intervention: $intervention,
@@ -99,14 +97,12 @@ class FileFactory
         );
     }
 
-    private function getFileType(array $file, DocumentType $documentType)
+    private function getFileType(string $filename, DocumentType $documentType)
     {
-        if ('photos' === $file['key']
-            && (File::FILE_TYPE_PHOTO === $documentType->mapFileType() || DocumentType::AUTRE === $documentType)
-            && \in_array(
-                strtolower(pathinfo($file['file'], \PATHINFO_EXTENSION)),
-                File::IMAGE_EXTENSION
-            )
+        $ext = strtolower(pathinfo($filename, \PATHINFO_EXTENSION));
+        if ((File::FILE_TYPE_PHOTO === $documentType->mapFileType() || DocumentType::AUTRE === $documentType)
+            && \in_array($ext, File::IMAGE_EXTENSION)
+            && 'pdf' !== $ext
         ) {
             return File::FILE_TYPE_PHOTO;
         }

--- a/src/Manager/FileManager.php
+++ b/src/Manager/FileManager.php
@@ -37,7 +37,6 @@ class FileManager extends AbstractManager
             $file = $this->fileFactory->createInstanceFrom(
                 filename: $filename,
                 title: $title,
-                type: $type,
                 signalement: $signalement,
                 user: $user,
                 documentType: $documentType,

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -207,7 +207,6 @@ class InterventionManager extends AbstractManager
     private function createFile(
         Intervention $intervention,
         string $document,
-        string $fileType = File::FILE_TYPE_DOCUMENT,
         DocumentType $documentType = DocumentType::PROCEDURE_RAPPORT_DE_VISITE,
     ): File {
         /** @var User $user */
@@ -216,7 +215,6 @@ class InterventionManager extends AbstractManager
         return $this->fileFactory->createInstanceFrom(
             filename: $document,
             title: $document,
-            type: $fileType,
             signalement: $intervention->getSignalement(),
             user: $user,
             documentType: $documentType

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -306,15 +306,10 @@ class SignalementImportLoader
                 $this->metadata['files_not_found'][$filename] = $filename;
                 continue;
             }
-            $fileType = File::FILE_TYPE_DOCUMENT;
-            if (\in_array($this->fileStorage->mimeType($filename), File::IMAGE_MIME_TYPES)) {
-                $fileType = File::FILE_TYPE_PHOTO;
-            }
 
             $file = $this->fileManager->createOrUpdate(
                 filename: $filename,
                 title: $filename,
-                type: $fileType,
                 signalement: $signalement,
             );
             $signalement->addFile($file);

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -283,14 +283,13 @@ class EsaboraManager
         $fileName = pathinfo($filePath, \PATHINFO_BASENAME);
         $this->uploadHandlerService->uploadFromFilename($fileName);
         $file = new SymfonyFile($filePath);
-        if (\in_array($file->getMimeType(), File::IMAGE_MIME_TYPES)) {
+        if (\in_array($file->getMimeType(), File::RESIZABLE_MIME_TYPES)) {
             $this->imageManipulationHandler->resize($file->getPath())->thumbnail();
             $variantsGenerated = true;
         }
         $file = $this->fileFactory->createInstanceFrom(
             filename: $fileName,
             title: $originalName,
-            type: File::FILE_TYPE_DOCUMENT,
             signalement: $suivi->getSignalement(),
             scannedAt: new \DateTimeImmutable(),
             isVariantsGenerated: $variantsGenerated,

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -97,7 +97,7 @@ class SignalementFileProcessor
                             );
                             $title = $this->filenameGenerator->getTitle();
 
-                            if (\in_array($file->getMimeType(), File::IMAGE_MIME_TYPES)) {
+                            if (\in_array($file->getMimeType(), File::RESIZABLE_MIME_TYPES)) {
                                 $this->imageManipulationHandler->setUseTmpDir(false)->resize($filename)->thumbnail($filename);
                             } else {
                                 $inputTypeDetection = 'documents';
@@ -134,7 +134,6 @@ class SignalementFileProcessor
             $file = $this->fileFactory->createInstanceFrom(
                 filename: $fileItem['file'],
                 title: $fileItem['title'],
-                type: $fileItem['type'],
                 user: $user,
                 intervention: $intervention,
                 documentType: $fileItem['documentType'],

--- a/src/Service/UploadHandlerService.php
+++ b/src/Service/UploadHandlerService.php
@@ -108,6 +108,8 @@ class UploadHandlerService
     {
         if ('document' === $type || 'documents' === $type) {
             $extensions = array_map('strtoupper', File::DOCUMENT_EXTENSION);
+        } elseif ('resizable' === $type) {
+            $extensions = array_map('strtoupper', array_diff(File::IMAGE_EXTENSION, ['pdf']));
         } else {
             $extensions = array_map('strtoupper', File::IMAGE_EXTENSION);
         }

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -164,6 +164,9 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
         if ('document' === $type) {
             return implode(',', File::DOCUMENT_MIME_TYPES);
         }
+        if ('resizable' === $type) {
+            return implode(',', File::RESIZABLE_MIME_TYPES);
+        }
 
         return implode(',', File::IMAGE_MIME_TYPES);
     }

--- a/templates/back/profil/_modal_profil_infos.html.twig
+++ b/templates/back/profil/_modal_profil_infos.html.twig
@@ -23,9 +23,9 @@
                                 <div class="fr-ml-3v">
                                     <div class="fr-upload-group fr-mb-5v">
                                         <label class="fr-label" for="profil_edit_infos[avatar]">Choisir un nouvel avatar (facultatif)
-                                            <span class="fr-hint-text">Taille Maximale : 5 Mo, Formats supportés : {{ get_accepted_extensions('photo')}}</span>
+                                            <span class="fr-hint-text">Taille Maximale : 5 Mo, Formats supportés : {{ get_accepted_extensions('resizable')}}</span>
                                         </label>
-                                        <input class="fr-upload" type="file" accept={{ get_accepted_mime_type('photo')}} name="profil_edit_infos[avatar]" id="profil_edit_infos_avatar">
+                                        <input class="fr-upload" type="file" accept={{ get_accepted_mime_type('resizable')}} name="profil_edit_infos[avatar]" id="profil_edit_infos_avatar">
                                     </div>
                                 </div>
                             </div>

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -107,6 +107,7 @@
                         data-type="photo" 
                         data-file-id="{{ photo.id}}" 
                         data-signalement-uuid="{{ signalement.uuid}}" 
+                        data-file-path="{{ path('show_file', {uuid: photo.uuid}) }}?variant=thumb"
                         data-description="{{ photo.description }}" 
                         data-documentType="{{ photo.documentType.name }}" 
                         data-createdAt="{{ photo.createdAt is defined ? photo.createdAt|date('d.m.Y') : 'N/R' }}"
@@ -131,4 +132,70 @@
             </div>
         </div>
     {% endfor %}
+</div>
+<div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
+    <div class="fr-col-12">
+        {% for index, doc in signalement.files|filter(
+            doc => doc.fileType == 'document'
+                    and doc.documentType.name == 'PHOTO_VISITE'
+                    and doc.intervention is not null
+                    and doc.intervention.id is same as intervention.id
+            ) %}
+            <div class="fr-grid-row fr-grid-row--middle fr-background-alt--grey fr-p-3v signalement-file-item">
+                <div class="fr-col-9">
+                    <div class="fr-grid-row">
+                        <div class="fr-col-12 fr-col-lg-2">
+                            {{ doc.createdAt is defined ? doc.createdAt|date('d.m.Y') : 'N/R' }}
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <i>{{ doc.title|truncate_filename(45) }}</i>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-6 fr-pl-3v">
+                            <b>{{ doc.description }}</b>
+                        </div>
+                    </div>
+                </div>
+                <div class="fr-col-3 fr-text--right">
+                    <a href="{{ path('show_file', {uuid: doc.uuid}) }}"
+                        class="fr-btn fr-btn--sm fr-icon-eye-fill img-box" title="Afficher le document {{ doc.filename }} - ouvre une nouvelle fenêtre"
+                        target="_blank" rel="noopener"></a>    
+                        
+                    {% if is_granted('FILE_EDIT', doc) %}
+                        {% set DocumentType = enum('\\App\\Entity\\Enum\\DocumentType') %}
+                        {% include 'back/signalement/view/edit-modals/edit-file.html.twig' %}
+                        {% set partner = doc.uploadedBy ? doc.uploadedBy.partnerInTerritoryOrFirstOne(signalement.territory) %}       
+                        <button 
+                            class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-edit-line btn-signalement-file-edit"
+                            id="file_edit_{{ doc.id }}" 
+                            title="Editer la photo {{ doc.filename }}"
+                            aria-controls="fr-modal-edit-file"
+                            data-fr-opened="false" 
+                            data-filename="{{ doc.filename }}" 
+                            data-type="document" 
+                            data-file-id="{{ doc.id}}" 
+                            data-signalement-uuid="{{ signalement.uuid}}" 
+                            data-description="{{ doc.description }}" 
+                            data-documentType="{{ doc.documentType.name }}" 
+                            data-createdAt="{{ doc.createdAt is defined ? doc.createdAt|date('d.m.Y') : 'N/R' }}"
+                            data-partner-name="{{ partner ? partner.nom ~ ' - ' : '' }}"
+                            data-user-name="{{ doc.uploadedBy.nomComplet ?? 'N/R' }}"
+                            data-desordreSlug="{{ doc.desordreSlug }}"
+                            data-signalement-desordres="{{ criteres | json_encode }}"
+                        ></button>
+                    {% endif %}        
+                    {% if is_granted('FILE_DELETE', doc) %}
+                        <button class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line btn-signalement-file-delete"
+                            id="file_delete_{{ doc.id }}" 
+                            title="Supprimer le document {{ doc.filename }}"
+                            aria-controls="fr-modal-delete-file"
+                            data-fr-opened="false" 
+                            data-filename="{{ doc.filename }}" 
+                            data-type="document" 
+                            data-file-id="{{ doc.id}}"                     
+                        ></button>
+                    {% endif %}
+                </div>
+            </div>
+        {% endfor %}
+    </div>
 </div>

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -19,13 +19,13 @@ class FileFactoryTest extends TestCase
         $file = (new FileFactory())->createInstanceFrom(
             'sample-123.jpg',
             'sample.jpg',
-            File::FILE_TYPE_PHOTO,
             $this->getSignalement(),
             $this->getUser([User::ROLE_USER_PARTNER])
         );
         $this->assertEquals('sample-123.jpg', $file->getFilename());
         $this->assertEquals('sample.jpg', $file->getTitle());
         $this->assertEquals('photo', $file->getFileType());
+        $this->assertEquals(File::FILE_TYPE_PHOTO, $file->getFileType());
         $this->assertInstanceOf(Signalement::class, $file->getSignalement());
         $this->assertInstanceOf(User::class, $file->getUploadedBy());
         $this->assertInstanceOf(\DateTimeImmutable::class, $file->getCreatedAt());


### PR DESCRIPTION
## Ticket

#3736   

## Description
Il faudrait accepter les PDF dans les photos car certaines personnes (les tiers surtout) ont les photos du logement dans des PDF et ne peuvent pas les uploader.

## Changements apportés
* Dans l'entité File, ajout de pdf dans IMAGE_MIME_TYPES et IMAGE_EXTENSION, et création d'un tableau RESIZABLE_MIME_TYPES sans le pdf
* Dans FileFactory->createInstanceFrom() détermination du fileType en fonction de l'extension (mise à jour de la fonction getFileType et utilisation systématique de celle-ci)
* Ajustements en conséquence de l'affichage  /édition des fichiers en divers endroits de la plateforme

## Pré-requis

`npm run watch`

## Tests
- [ ] Déposer un signalement, mettre une photo en pdf pour un désordre, et dans les photos complémentaires. Mettre aussi des photos "images" et d'autre documents. Vérifier qu'il n'y a pas d'erreurs pendant le dépôt, ni à la validation. Après la validation, dans le BO, vérifier que seules les "images" s'affichent en vignettes et dans l'album-photo. Vérifier que l'image en pdf s'affiche dans la liste des documents avec les bonnes infos.
- [ ] Dans la fiche signalement du BO, ajouter une photo en pdf, et vérifier qu'elle s'affiche bien dans l'onglet Documents, en Documents sur la situation. On peut l'ouvrir dans un nouvel onglet, on peut éditer son type, et on peut la supprimer.
- [ ] Sur un signalement avec visite, faire la démarche pour dire que la visite est passée et ajouter le rapport de visite. Puis, ajouter des photos de visite, en image et en pdf. Dans la modale, vérifier que pour les pdf on n'a pas de vignette. Vérifier ensuite qu'on peut visionner les images, les éditer et les supprimer. Dans l'onglet Documents, vérifier que les photos de visite en pdf apparaissent dans la partie "Documents concernant la procédure"
- [ ] Aller sur la page profil, vérifier qu'on ne peut pas mettre une image pdf pour l'avatar
- [ ] Aller sur la page de suivi, ajouter image png, image pdf et document, vérifier qu'ils sont bien affichés / catégorisés dans la page de suivi, et dans la fiche BO
- [ ] Tester l'ajout de fichier via l'api
