### PR TITLE
[BO - Partenaires] A la création d'un partenaire, rediriger vers sa fiche

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -102,7 +102,9 @@ class PartnerController extends AbstractController
             $entityManager->flush();
             $this->addFlash('success', 'Le partenaire a bien été créé.');
 
-            return $this->redirectToRoute('back_partner_index', [], Response::HTTP_SEE_OTHER);
+            return $this->redirectToRoute('back_partner_view', [
+                'id' => $partner->getId(),
+            ]);
         }
 
         $this->displayErrors($form);

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -60,17 +60,21 @@ class PartnerControllerTest extends WebTestCase
         $route = $this->router->generate('back_partner_new');
         $this->client->request('GET', $route);
 
+        $name = $this->faker->company();
         $this->client->submitForm(
             'Créer le partenaire',
             [
                 'partner[territory]' => 1,
-                'partner[nom]' => $this->faker->company(),
+                'partner[nom]' => $name,
                 'partner[email]' => $this->faker->companyEmail(),
                 'partner[type]' => PartnerType::ARS->value,
             ]
         );
 
-        $this->assertResponseRedirects('/bo/partenaires/');
+        /** @var Partner $partner */
+        $partner = $this->partnerRepository->findOneBy(['nom' => $name]);
+
+        $this->assertResponseRedirects('/bo/partenaires/'.$partner->getId().'/voir');
     }
 
     public function testPartnerSuccessfullyDisplay()


### PR DESCRIPTION
## Ticket

#3833    

## Description
Lors de la création d'un partenaire, on redirige vers sa fiche pour ne pas avoir à le chercher dans la liste afin d'y ajouter des agents.

## Changements apportés
* Modification du PartnerController

## Pré-requis

## Tests
- [ ] Créer un partenaire, et vérifier qu'on est bien redirigé vers sa fiche