### PR TITLE
[BO - Liste signalements] Correction filtre Bailleur social pour agent

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -532,11 +532,9 @@ class SignalementRepository extends ServiceEntityRepository
             }
         }
 
-        if ($user->isSuperAdmin() || $user->isTerritoryAdmin()) {
-            if (!empty($options['bailleurSocial'])) {
-                $qb->andWhere('s.bailleur = :bailleur')
-                ->setParameter('bailleur', $options['bailleurSocial']);
-            }
+        if (!empty($options['bailleurSocial'])) {
+            $qb->andWhere('s.bailleur = :bailleur')
+            ->setParameter('bailleur', $options['bailleurSocial']);
         }
         $qb->setParameter('statusList', [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED]);
         $qb = $this->searchFilter->applyFilters($qb, $options, $user);


### PR DESCRIPTION
## Ticket

#3847   

## Description
Dans la liste des signalements, le filtre sur les bailleurs sociaux fonctionne pour RT et SA, mais pas pour les agents, alors que le filtre est bien disponible pour tout le monde.
On rétablit donc son fonctionnement.

## Tests
- [ ] Tester le filtre avec différents profils
