### PR TITLE
[QA - BUG] Crash login quand deux compte avec même email existe

### DIFF
--- a/migrations/Version20250317105914.php
+++ b/migrations/Version20250317105914.php
@@ -16,10 +16,10 @@ final class Version20250317105914 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->skipIf(
+        /*$this->skipIf(
             'histologe' !== getenv('APP'),
             'Cette migration ne s’exécute qu’en environnement de production.'
-        );
+        );*/
         // agents to delete
         $this->addSql('DELETE FROM notification WHERE user_id = 18527');
         $agentsToDelete = [18974, 18975, 18976, 18525, 12063, 15309, 15037, 18527, 17591, 19368, 14755, 19528, 25098, 14907, 67589, 12805, 15918];
@@ -42,6 +42,13 @@ final class Version20250317105914 extends AbstractMigration
             33176 => 69699,
             11094 => 11308,
             67777 => 68418,
+            30663 => 71060,
+            40573 => 71278,
+            69771 => 70685,
+            31611 => 71501,
+            69595 => 70396,
+            64480 => 71730,
+            20389 => 71389,
             // archive
             18324 => 18325,
             14507 => 18986,
@@ -55,7 +62,9 @@ final class Version20250317105914 extends AbstractMigration
             $this->addSql('UPDATE file SET uploaded_by_id = '.$newId.' WHERE uploaded_by_id = '.$oldId);
         }
         $usagersToDelete = [
-            40446, 55271, 52375, 28521, 15766, 42061, 65076, 68110, 28398, 28857, 49670, 21412, 33176, 11094, 67777, 18324, 14507, 5057, 18323,
+            40446, 55271, 52375, 28521, 15766, 42061, 65076, 68110, 28398, 28857, 49670, 21412, 33176, 11094, 67777,
+            30663, 40573, 69771, 31611, 69595, 64480, 20389,
+            18324, 14507, 5057, 18323,
             10355, 25252, 10725, 9107, 11786, 3533, 10782, 17081, 12383, 9548, 13569, 9226, 28287, 65857, 8567, 35788, 9230, 8403, 7312, 29384, 8587, 17232,
         ];
         $this->addSql('DELETE FROM user_partner WHERE user_id IN ('.implode(',', $usagersToDelete).')');

--- a/migrations/Version20250317105914.php
+++ b/migrations/Version20250317105914.php
@@ -17,7 +17,7 @@ final class Version20250317105914 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->skipIf(
-            'prod' !== getenv('APP_ENV'),
+            'histologe' !== getenv('APP'),
             'Cette migration ne s’exécute qu’en environnement de production.'
         );
         // agents to delete

--- a/migrations/Version20250317105914.php
+++ b/migrations/Version20250317105914.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250317105914 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'remove duplicate users emails';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /*$this->skipIf(
+            'prod' !== getenv('APP_ENV'),
+            'Cette migration ne s’exécute qu’en environnement de production.'
+        );*/
+        // agents to delete
+        $this->addSql('DELETE FROM notification WHERE user_id = 18527');
+        $agentsToDelete = [18974, 18975, 18976, 18525, 12063, 15309, 15037, 18527, 17591, 19368, 14755, 19528, 25098, 14907, 67589, 12805, 15918];
+        $this->addSql('DELETE FROM user_partner WHERE user_id IN ('.implode(',', $agentsToDelete).')');
+        $this->addSql('DELETE FROM user WHERE id IN ('.implode(',', $agentsToDelete).')');
+        // usagers and archived agents to delete
+        $replacements = [
+            40446 => 69447,
+            55271 => 47392,
+            52375 => 69318,
+            28521 => 68280,
+            15766 => 68641,
+            42061 => 29521,
+            65076 => 68576,
+            68110 => 68474,
+            28398 => 28403,
+            28857 => 28858,
+            49670 => 51920,
+            21412 => 69320,
+            33176 => 69699,
+            11094 => 11308,
+            67777 => 68418,
+            // archive
+            18324 => 18325,
+            14507 => 18986,
+            5057 => 5061,
+            18323 => 18325,
+        ];
+        foreach ($replacements as $oldId => $newId) {
+            $this->addSql('UPDATE signalement_usager SET declarant_id = '.$newId.' WHERE declarant_id = '.$oldId);
+            $this->addSql('UPDATE signalement_usager SET occupant_id  = '.$newId.' WHERE occupant_id = '.$oldId);
+            $this->addSql('UPDATE suivi SET created_by_id = '.$newId.' WHERE created_by_id = '.$oldId);
+            $this->addSql('UPDATE file SET uploaded_by_id = '.$newId.' WHERE uploaded_by_id = '.$oldId);
+        }
+        $usagersToDelete = [
+            40446, 55271, 52375, 28521, 15766, 42061, 65076, 68110, 28398, 28857, 49670, 21412, 33176, 11094, 67777, 18324, 14507, 5057, 18323,
+            10355, 25252, 10725, 9107, 11786, 3533, 10782, 17081, 12383, 9548, 13569, 9226, 28287, 65857, 8567, 35788, 9230, 8403, 7312, 29384, 8587, 17232,
+        ];
+        $this->addSql('DELETE FROM user_partner WHERE user_id IN ('.implode(',', $usagersToDelete).')');
+        $this->addSql('DELETE FROM user WHERE id IN ('.implode(',', $usagersToDelete).')');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version20250317105914.php
+++ b/migrations/Version20250317105914.php
@@ -16,39 +16,41 @@ final class Version20250317105914 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->skipIf(
+        /*$this->skipIf(
             'histologe' !== getenv('APP'),
             'Cette migration ne s’exécute qu’en environnement de production.'
-        );
+        );*/
         // agents to delete
-        $this->addSql('DELETE FROM notification WHERE user_id = 18527');
         $agentsToDelete = [18974, 18975, 18976, 18525, 12063, 15309, 15037, 18527, 17591, 19368, 14755, 19528, 25098, 14907, 67589, 12805, 15918];
+        $this->addSql('DELETE FROM notification WHERE user_id IN ('.implode(',', $agentsToDelete).')');
         $this->addSql('DELETE FROM user_partner WHERE user_id IN ('.implode(',', $agentsToDelete).')');
         $this->addSql('DELETE FROM user WHERE id IN ('.implode(',', $agentsToDelete).')');
         // usagers and archived agents to delete
         $replacements = [
-            40446 => 69447,
+            69447 => 40446,
             55271 => 47392,
-            52375 => 69318,
-            28521 => 68280,
-            15766 => 68641,
+            69318 => 52375,
+            68280 => 28521,
+            68641 => 15766,
             42061 => 29521,
-            65076 => 68576,
+            68576 => 65076,
             68110 => 68474,
             28398 => 28403,
             28857 => 28858,
-            49670 => 51920,
-            21412 => 69320,
-            33176 => 69699,
+            51920 => 49670,
+            69320 => 21412,
+            69699 => 33176,
             11094 => 11308,
-            67777 => 68418,
-            30663 => 71060,
-            40573 => 71278,
+            68418 => 67777,
+            71060 => 30663,
+            71278 => 40573,
             69771 => 70685,
-            31611 => 71501,
-            69595 => 70396,
-            64480 => 71730,
-            20389 => 71389,
+            71501 => 31611,
+            70396 => 69595,
+            71730 => 64480,
+            71389 => 20389,
+            13569 => 13568,
+            72270 => 72271,
             // archive
             18324 => 18325,
             14507 => 18986,
@@ -60,13 +62,16 @@ final class Version20250317105914 extends AbstractMigration
             $this->addSql('UPDATE signalement_usager SET occupant_id  = '.$newId.' WHERE occupant_id = '.$oldId);
             $this->addSql('UPDATE suivi SET created_by_id = '.$newId.' WHERE created_by_id = '.$oldId);
             $this->addSql('UPDATE file SET uploaded_by_id = '.$newId.' WHERE uploaded_by_id = '.$oldId);
+            $this->addSql('UPDATE notification SET user_id = '.$newId.' WHERE user_id = '.$oldId);
+            $this->addSql('UPDATE affectation SET answered_by_id = '.$newId.' WHERE answered_by_id = '.$oldId);
         }
         $usagersToDelete = [
-            40446, 55271, 52375, 28521, 15766, 42061, 65076, 68110, 28398, 28857, 49670, 21412, 33176, 11094, 67777,
-            30663, 40573, 69771, 31611, 69595, 64480, 20389,
+            69447, 55271, 69318, 68280, 68641, 42061, 68576, 68110, 28398, 28857, 51920, 69320, 69699, 11094, 68418,
+            71060, 71278, 69771, 71501, 70396, 71730, 71389, 13569, 72270,
             18324, 14507, 5057, 18323,
-            10355, 25252, 10725, 9107, 11786, 3533, 10782, 17081, 12383, 9548, 13569, 9226, 28287, 65857, 8567, 35788, 9230, 8403, 7312, 29384, 8587, 17232,
+            10355, 25252, 10725, 9107, 11786, 3533, 10782, 17081, 12383, 9548, 9226, 28287, 65857, 8567, 35788, 9230, 8403, 7312, 29384, 8587, 17232,
         ];
+        $this->addSql('DELETE FROM history_entry WHERE user_id IN ('.implode(',', $usagersToDelete).')');
         $this->addSql('DELETE FROM user_partner WHERE user_id IN ('.implode(',', $usagersToDelete).')');
         $this->addSql('DELETE FROM user WHERE id IN ('.implode(',', $usagersToDelete).')');
     }

--- a/migrations/Version20250317105914.php
+++ b/migrations/Version20250317105914.php
@@ -16,10 +16,10 @@ final class Version20250317105914 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        /*$this->skipIf(
+        $this->skipIf(
             'prod' !== getenv('APP_ENV'),
             'Cette migration ne s’exécute qu’en environnement de production.'
-        );*/
+        );
         // agents to delete
         $this->addSql('DELETE FROM notification WHERE user_id = 18527');
         $agentsToDelete = [18974, 18975, 18976, 18525, 12063, 15309, 15037, 18527, 17591, 19368, 14755, 19528, 25098, 14907, 67589, 12805, 15918];

--- a/migrations/Version20250317105914.php
+++ b/migrations/Version20250317105914.php
@@ -16,10 +16,10 @@ final class Version20250317105914 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        /*$this->skipIf(
+        $this->skipIf(
             'histologe' !== getenv('APP'),
             'Cette migration ne s’exécute qu’en environnement de production.'
-        );*/
+        );
         // agents to delete
         $this->addSql('DELETE FROM notification WHERE user_id = 18527');
         $agentsToDelete = [18974, 18975, 18976, 18525, 12063, 15309, 15037, 18527, 17591, 19368, 14755, 19528, 25098, 14907, 67589, 12805, 15918];

--- a/migrations/Version20250317145302.php
+++ b/migrations/Version20250317145302.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250317145302 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add unique index on user email';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649E7927C74 ON user (email)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_8D93D649E7927C74 ON user');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -69,7 +69,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[ORM\Column(type: Types::GUID)]
     private $uuid;
 
-    #[ORM\Column(type: 'string', length: 180, unique: false)]
+    #[ORM\Column(type: 'string', length: 180, unique: true)]
     #[Email(mode: Email::VALIDATION_MODE_STRICT, groups: ['registration'])]
     #[Assert\NotBlank(message: 'Merci de saisir une adresse e-mail.')]
     #[Assert\Length(max: 255, groups: ['user_partner', 'Default'])]

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -212,7 +212,7 @@ class PartnerControllerTest extends WebTestCase
         yield 'Email existing for non-admin API user' => ['api-02@signal-logement.fr', 'Un utilisateur API existe déjà avec cette adresse e-mail.'];
 
         yield 'New user' => ['new.email@test.com', 'redirect'];
-        yield 'New user from usager' => ['usager-01@signal-logement.fr', 'redirect'];
+        yield 'New user from usager' => ['usager-02@signal-logement.fr', 'redirect'];
         yield 'Email ok to multi territories' => ['user-44-02@signal-logement.fr', 'Ce compte agent existe déjà dans :'];
     }
 
@@ -263,7 +263,7 @@ class PartnerControllerTest extends WebTestCase
         yield 'Email existing for non-admin API user' => ['api-02@signal-logement.fr', 'Un utilisateur API existe déjà avec cette adresse e-mail.'];
 
         yield 'New user' => ['new.email@test.com', 'Agent introuvable avec cette adresse e-mail.'];
-        yield 'New user from usager' => ['usager-01@signal-logement.fr', 'Agent introuvable avec cette adresse e-mail.'];
+        yield 'New user from usager' => ['usager-02@signal-logement.fr', 'Agent introuvable avec cette adresse e-mail.'];
         yield 'Email ok to multi territories' => ['user-44-02@signal-logement.fr', 'redirect'];
     }
 


### PR DESCRIPTION
## Ticket

#3825

## Description
Mise en place d'une contrainte unique sur le champs email de la table user afin fin d'éviter quelques problèmes  (le dernier soucis en date étant celui-ci https://sentry.incubateur.net/organizations/betagouv/issues/155480/?environment=prod&project=61&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=17)

Pour cela il fallait supprimer les utilisateurs dupliqués, j'ai utilisé la requête suivante pour les détecter : 
`SELECT email, COUNT(id) as nombre_occurrences, 
GROUP_CONCAT(id ORDER BY id) as liste_ids, 
GROUP_CONCAT(statut ORDER BY id) as liste_statut, 
GROUP_CONCAT(roles ORDER BY id) as liste_roles 
FROM user GROUP BY email HAVING COUNT(id) > 1 ORDER BY nombre_occurrences DESC, email ASC;
`

J'ai ensuite géré un par un les différent cas : 
- Doublons de compte agents, avec un seul compte actif (on garde et on supprime les autres)
- Doublon de compte entre agents et usager, migrations des données du compte usager vers le compte agents et suppression du compte usager
- Doublon de compte agents archivés migration des données du premier vers le second et suppression du premier


## Changements apportés
* Ajout d'une migration afin de supprimer les compte doublons
* Ajout d'une migrations afin d'ajouter la contrainte unique sur le champ email

## Pré-requis
`make load-data`
commenter la partie `$this->skipIf` de la migrations `Version20250317105914`

## Tests
- [ ] Utiliser la requête présente en description et voir les doublons
- [ ] Exécuter make load-migrations (en ayant commenter le `$this->skipIf` de la migrations `Version20250317105914`)
- [ ] S'assurer que les deux migrations sont exécutés sans erreur et que la requête ne retourne plus de doublons 
