### PR TITLE
wip add desordres #3647

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -18,7 +18,7 @@ function saveCurrentTab(event) {
   const currentTab = document?.querySelector('.fr-tabs__panel.fr-tabs__panel--selected')
   currentTab.classList.add('fr-tabs__panel--saving')
   const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
-
+  
   let formData = null
   let formAction = null
   if (event.type === 'submit') {
@@ -105,7 +105,6 @@ function initBoFormSignalementSubmit(tabName) {
       boFormSignalementCurrentTabIsDirty = true
     })
   })
-
   switch (tabName) {
     case 'adresse':
       initBoFormSignalementAdresse()
@@ -115,6 +114,9 @@ function initBoFormSignalementSubmit(tabName) {
       break
     case 'situation':
       initBoFormSignalementSituation()
+      break
+    case 'desordres':
+      initBoFormSignalementDesordres()
       break
   }
 }
@@ -180,6 +182,114 @@ if (document?.querySelector('#bo-form-signalement-logement')) {
 }
 if (document?.querySelector('#bo-form-signalement-situation')) {
   initBoFormSignalementSubmit('situation')
+}
+if (document?.querySelector('#bo-form-signalement-desordres')) {
+  initBoFormSignalementSubmit('desordres')
+}
+
+function initBoFormSignalementDesordres() {
+  console.log('initBoFormSignalementDesordres')
+
+
+  // Gestion de la fermeture des modales de sélection des critères
+  document.querySelectorAll(".valid-add-critere").forEach(openModalBtn => {
+    openModalBtn.addEventListener("click", function () {
+      updateSelectedCriteres(openModalBtn.closest('dialog'));
+    });
+  });
+
+  // Gestion de la fermeture des modales d'édition des précisions
+  document.querySelectorAll(".valid-edit-precisions").forEach(openModalBtn => {
+    openModalBtn.addEventListener("click", function () {
+      updateSelectedPrecisions(openModalBtn.closest('dialog'));
+    });
+  });
+
+  function updateSelectedCriteres(modal) {
+    console.log("Mise à jour des critères sélectionnés");
+    let zone = modal.dataset.zone
+    let listCriteres = document.querySelector(`#list-critere-${zone}`)
+
+    // Vider les encarts existants
+    document.querySelectorAll(`.item-critere-${zone}`).forEach(container => {
+      container.remove(); 
+    });
+
+    let nbCriteres = 0
+    // Récupérer les critères sélectionnés
+    modal.querySelectorAll("input[type='checkbox']:checked").forEach(checkbox => {
+      nbCriteres++
+      let critereLabel = checkbox.labels[0].innerText
+      let critereId = checkbox.value
+      console.log(critereId)
+
+      // Créer un encart pour le critère sélectionné
+      let encart = document.createElement("div");
+      encart.classList.add("fr-grid-row", "fr-p-3v", "fr-mb-3v", "fr-grid-row--top", "fr-border--grey", `item-critere-${zone}`);
+      encart.id = `item-critere-${critereId}`
+      // TODO : changer la couleur de la bordure et mettre un warning, si précision pas choisie alors que devrait 
+      encart.innerHTML = `
+        <div class="fr-col-12 fr-col-md-8">
+          ${critereLabel}
+        </div>`
+      let modalId = `modal-precisions-signalement_draft_desordres_precisions_${critereId}`
+      let modalElement = document.getElementById(modalId);
+      if (modalElement) {
+        encart.innerHTML += `<div class="fr-col-12 fr-col-md-4 fr-text--right">
+            <a href="#" aria-controls="modal-precisions-signalement_draft_desordres_precisions_${critereId}" data-fr-opened="false" 
+                class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
+                title="Editer les détails" data-fr-js-modal-button="true">
+                    Editer les détails
+            </a>  
+          </div>
+          <div class="fr-col-12">
+            <ul class="fr-list" data-precisions="${checkbox.value}">
+              <!-- Les précisions seront injectées ici -->
+            </ul>
+          </div>
+        `;
+      }
+
+      // Ajouter l'encart dans la bonne colonne (Logement ou Bâtiment)
+      listCriteres
+        .appendChild(encart);
+      if (modalElement) {
+        updateSelectedPrecisions(modalElement)
+      }
+
+    });
+    console.log(nbCriteres)
+    if (nbCriteres > 0 ){
+      listCriteres.classList.remove("fr-hidden")
+    } else {
+      listCriteres.classList.add("fr-hidden")
+    }
+  }
+
+  function updateSelectedPrecisions(modal) {
+    console.log("Mise à jour des précisions sélectionnées");
+    console.log(modal)
+    let critereId = modal.dataset.critereid
+    let precisionContainer = document.querySelector(`#item-critere-${critereId}`);
+
+    let ulElement = precisionContainer ? precisionContainer.querySelector("ul") : null;
+
+    if (ulElement) {
+      ulElement.innerHTML = ""; // Vider les précisions existantes
+      let checkboxes = modal.querySelectorAll("input[type='checkbox']");
+      checkboxes.forEach(checkbox => {
+        if (checkbox.checked) { // Vérifier l'état checked manuellement
+          let precisionLabel = checkbox.labels[0].textContent;
+          let precisionId = checkbox.value;
+          let precisionItem = document.createElement("li");
+          precisionItem.textContent = precisionLabel;
+          ulElement.appendChild(precisionItem);
+        }
+      });
+    }
+  }
+  updateSelectedCriteres(document.getElementById("fr-modal-desordres-batiment-add"))
+  updateSelectedCriteres(document.getElementById("fr-modal-desordres-logement-add"))
 }
 
 function initBoFormSignalementAdresse() {

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -152,6 +152,10 @@ pre {
     border: 1px solid #000091;
 }
 
+.fr-border--grey {
+    border: 1px solid #dddddd;
+}
+
 .fr-border--bottom--orange {
     border-bottom: 3px solid #FF9940;
 }

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -7,6 +7,7 @@ use App\Entity\Signalement;
 use App\Entity\User;
 use App\Form\SearchDraftType;
 use App\Form\SignalementDraftAddressType;
+use App\Form\SignalementDraftDesordresType;
 use App\Form\SignalementDraftLogementType;
 use App\Form\SignalementDraftSituationType;
 use App\Manager\SignalementManager;
@@ -14,6 +15,7 @@ use App\Repository\FileRepository;
 use App\Repository\SignalementRepository;
 use App\Service\ListFilters\SearchDraft;
 use App\Service\Signalement\SignalementBoManager;
+use App\Service\Signalement\SignalementDesordresProcessor;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -106,6 +108,7 @@ class SignalementCreateController extends AbstractController
     #[Route('/brouillon/editer/{uuid:signalement}', name: 'back_signalement_edit_draft', methods: ['GET'])]
     public function editSignalement(
         Signalement $signalement,
+        SignalementDesordresProcessor $signalementDesordresProcessor,
     ): Response {
         $this->denyAccessUnlessGranted('SIGN_EDIT_DRAFT', $signalement);
         $formAddress = $this->createForm(SignalementDraftAddressType::class, $signalement, [
@@ -117,13 +120,62 @@ class SignalementCreateController extends AbstractController
         $formSituation = $this->createForm(SignalementDraftSituationType::class, $signalement, [
             'action' => $this->generateUrl('back_signalement_draft_form_situation_edit', ['uuid' => $signalement->getUuid()]),
         ]);
+        $formDesordres = $this->createForm(SignalementDraftDesordresType::class, $signalement, [
+            'action' => $this->generateUrl('back_signalement_draft_form_desordres_edit', ['uuid' => $signalement->getUuid()]),
+        ]);
+
+        $criteresByZone = $signalementDesordresProcessor->processDesordresByZone($signalement);
 
         return $this->render('back/signalement_create/index.html.twig', [
+            'criteresByZone' => $criteresByZone,
             'formAddress' => $formAddress,
             'formLogement' => $formLogement,
             'formSituation' => $formSituation,
+            'formDesordres' => $formDesordres,
             'signalement' => $signalement,
         ]);
+    }
+
+    #[Route('/bo-form-desordres/{uuid:signalement}', name: 'back_signalement_draft_form_desordres_edit', methods: ['POST'])]
+    public function editFormDesordres(
+        Signalement $signalement,
+        Request $request,
+        EntityManagerInterface $entityManager,
+        SignalementDesordresProcessor $signalementDesordresProcessor,
+    ): Response {
+        $this->denyAccessUnlessGranted('SIGN_EDIT_DRAFT', $signalement);
+
+        $entityManager->beginTransaction();
+        $action = $this->generateUrl('back_signalement_draft_form_desordres_edit', ['uuid' => $signalement->getUuid()]);
+        $form = $this->createForm(SignalementDraftDesordresType::class, $signalement, ['action' => $action]);
+        $form->handleRequest($request);
+        $criteresByZone = $signalementDesordresProcessor->processDesordresByZone($signalement);
+        if ($form->isSubmitted() && $form->isValid() && $this->signalementBoManager->formDesordresManager($form, $signalement)) {
+            $this->signalementManager->save($signalement);
+            $entityManager->commit();
+            if ($form->get('draft')->isClicked()) { // @phpstan-ignore-line
+                $this->addFlash('success', 'Le brouillon est bien enregistré, n\'oubliez pas de le terminer !');
+                $url = $this->generateUrl('back_signalement_drafts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+            } else {
+                $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'coordonnees'], UrlGeneratorInterface::ABSOLUTE_URL);
+            }
+
+            $tabContent = $this->renderView('back/signalement_create/tabs/tab-desordres.html.twig', [
+                'formDesordres' => $form,
+                'signalement' => $signalement,
+                'criteresByZone' => $criteresByZone,
+            ]);
+
+            return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
+        }
+
+        $tabContent = $this->renderView('back/signalement_create/tabs/tab-desordres.html.twig', [
+            'formDesordres' => $form,
+            'signalement' => $signalement,
+            'criteresByZone' => $criteresByZone,
+        ]);
+
+        return $this->json(['tabContent' => $tabContent]);
     }
 
     #[Route('/brouillon/{uuid:signalement}/liste-fichiers', name: 'back_signalement_create_file_list', methods: ['GET'])]

--- a/src/Form/SignalementDraftDesordresType.php
+++ b/src/Form/SignalementDraftDesordresType.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\DesordreCritere;
+use App\Entity\DesordrePrecision;
+use App\Entity\Signalement;
+use App\Form\Type\SearchCheckboxType;
+use App\Repository\DesordreCritereRepository;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SignalementDraftDesordresType extends AbstractType
+{
+    private DesordreCritereRepository $desordreCritereRepository;
+
+    public function __construct(DesordreCritereRepository $desordreCritereRepository)
+    {
+        $this->desordreCritereRepository = $desordreCritereRepository;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var Signalement $signalement */
+        $signalement = $builder->getData();
+        $details = $signalement->getDetails();
+
+        // Récupération des critères et regroupement par zoneCategorie -> labelCategorie
+        // TODO : vérifier s'il peut y avoir des critères archivés pour ne pas les prendre en compte
+        $desordreCriteres = $this->desordreCritereRepository->findAll();
+        $groupedCriteria = [];
+
+        foreach ($desordreCriteres as $critere) {
+            $zone = $critere->getZoneCategorie()->value;
+            $labelCategorie = $critere->getLabelCategorie();
+
+            $groupedCriteria[$zone][$labelCategorie][] = $critere;
+        }
+
+        $builder
+            ->add('details', TextareaType::class, [
+                'label' => 'Description du problème',
+                'help' => 'Saisissez ici la description du problème tel que présenté par le déclarant ainsi que toutes les informations nécessaires au traitement du dossier.',
+                'required' => false,
+                'mapped' => false,
+                'data' => $details,
+            ]);
+
+        foreach ($groupedCriteria as $zone => $categories) {
+            foreach ($categories as $labelCategorie => $criteres) {
+                $firstCritereId = $criteres[0]->getId();
+                // TODO : voir avec Mathilde si on garde la catégorie Type et composition du logement, ou si on la calcule à la volée comme pour le front
+                $builder->add("desordres_{$zone}_{$firstCritereId}", SearchCheckboxType::class, [
+                    'class' => DesordreCritere::class,
+                    'query_builder' => function (DesordreCritereRepository $repo) use ($zone, $labelCategorie) {
+                        return $repo->createQueryBuilder('c')
+                            ->where('c.zoneCategorie = :zone')
+                            ->andWhere('c.labelCategorie = :labelCategorie')
+                            ->setParameter('zone', $zone)
+                            ->setParameter('labelCategorie', $labelCategorie)
+                            ->orderBy('c.labelCritere', 'ASC');
+                    },
+                    'label' => $labelCategorie, // TODO : pour la catégorie Humidité, les 3 critères ont le même label, à retravailler  pour ajouter la pièce
+                    'choice_label' => 'labelCritere',
+                    'noselectionlabel' => 'Sélectionner une ou plusieurs options',
+                    'nochoiceslabel' => 'Aucun critère disponible',
+                    'mapped' => false,
+                    'required' => false,
+                ]);
+            }
+        }
+
+        // Récupérer les critères sélectionnés
+        $signalementCriteres = $signalement ? $signalement->getDesordreCriteres() : [];
+
+        // TODO : vérifier l'ajout des précisions à la volée lors du choix d'un critère
+        foreach ($signalementCriteres as $signalementCritere) {
+            if ($signalementCritere->getDesordrePrecisions()->count() > 1) {
+                // TODO : est-ce qu'on met toutes les précisions sous forme de case à cocher ou on essaie de se rapprocher de ce qu'a fait MAthilde ? --> Mathilde OK pour cases à cocher
+                // TODO : gérer le <span>
+                // TODO : si besoin de préciser via champ texte (autre type de nuisible)
+                $builder->add('precisions_'.$signalementCritere->getId(), ChoiceType::class, [
+                    'label' => $signalementCritere->getLabelCritere(),
+                    'choices' => $this->getPrecisionsChoices($signalementCritere),
+                    'expanded' => true,
+                    'multiple' => true,
+                    'required' => false,
+                    'mapped' => false,
+                ]);
+            }
+        }
+
+        $builder
+            ->add('forceSave', HiddenType::class, ['mapped' => false])
+            ->add('previous', SubmitType::class, [
+                'label' => 'Précédent',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ])
+            ->add('draft', SubmitType::class, [
+                'label' => 'Finir plus tard',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline'],
+            ])
+            ->add('save', SubmitType::class, [
+                'label' => 'Suivant',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'validation_groups' => ['bo_step_desordres'],
+        ]);
+    }
+
+    private function getPrecisionsChoices(DesordreCritere $critere): array
+    {
+        $choices = [];
+
+        /** @var DesordrePrecision $precision */
+        foreach ($critere->getDesordrePrecisions() as $precision) {
+            $choices[$precision->getLabel()] = $precision;
+        }
+
+        return $choices;
+    }
+}

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -2,6 +2,8 @@
 
 namespace App\Service\Signalement;
 
+use App\Entity\DesordreCritere;
+use App\Entity\DesordrePrecision;
 use App\Entity\Enum\EtageType;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\SignalementStatus;
@@ -11,6 +13,7 @@ use App\Entity\Model\SituationFoyer;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\Signalement;
 use App\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
@@ -221,6 +224,41 @@ class SignalementBoManager
         $signalement->setInformationComplementaire($informationComplementaire);
         $signalement->setSituationFoyer($situationFoyer);
         $signalement->setInformationProcedure($informationProcedure);
+
+        return true;
+    }
+
+    public function formDesordresManager(FormInterface $form, Signalement $signalement): bool
+    {
+        $signalement->setDetails($form->get('details')->getData());
+
+        // Parcours des champs du formulaire
+        foreach ($form->all() as $field) {
+            $fieldName = $field->getName();
+            $fieldData = $field->getData();
+            if (empty($fieldData) || ($fieldData instanceof ArrayCollection && $fieldData->isEmpty())) {
+                continue;
+            }
+
+            // TODO : retirer un éventuel critère existant et déselectionné
+            if (str_starts_with($fieldName, 'desordres_LOGEMENT') || str_starts_with($fieldName, 'desordres_BATIMENT')) {
+                /** @var DesordreCritere $desordreCritere */
+                foreach ($fieldData as $desordreCritere) {
+                    $signalement->addDesordreCritere($desordreCritere);
+                    $signalement->addDesordreCategory($desordreCritere->getDesordreCategorie());
+                    if ($desordreCritere->getDesordrePrecisions()->count() < 2) {
+                        $signalement->addDesordrePrecision($desordreCritere->getDesordrePrecisions()->first());
+                    }
+                }
+            }
+            // TODO : retirer une éventuelle précision existante et déselectionnée
+            if (str_starts_with($fieldName, 'precisions_')) {
+                /** @var DesordrePrecision $desordrePrecision */
+                foreach ($fieldData as $desordrePrecision) {
+                    $signalement->addDesordrePrecision($desordrePrecision);
+                }
+            }
+        }
 
         return true;
     }

--- a/src/Service/Signalement/SignalementDesordresProcessor.php
+++ b/src/Service/Signalement/SignalementDesordresProcessor.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Signalement;
 
+use App\Entity\Enum\DesordreCritereZone;
 use App\Entity\Signalement;
 
 class SignalementDesordresProcessor
@@ -68,5 +69,27 @@ class SignalementDesordresProcessor
             array_merge($photos[$key], PhotoHelper::getPhotosBySlug($signalement, $slug)),
             \SORT_REGULAR
         );
+    }
+
+    public function processDesordresByZone(
+        Signalement $signalement,
+    ): array {
+        $criteres = [];
+        $criteres[DesordreCritereZone::BATIMENT->value] = [];
+        $criteres[DesordreCritereZone::LOGEMENT->value] = [];
+        foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
+            $zone = $desordreCritere->getZoneCategorie();
+            $desordrePrecisionsSelected = $signalement->getDesordrePrecisions()->filter(function ($desordrePrecision) use ($desordreCritere) {
+                return $desordrePrecision->getDesordreCritere() == $desordreCritere;
+            });
+            $desordrePrecisionsLinked = $desordreCritere->getDesordrePrecisions();
+            $criteres[$zone->value][] = [
+                'desordreCritere' => $desordreCritere,
+                'desordrePrecisionsSelected' => $desordrePrecisionsSelected,
+                'desordrePrecisionsLinked' => $desordrePrecisionsLinked,
+            ];
+        }
+
+        return $criteres;
     }
 }

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -10,44 +10,6 @@
 {{ form_start(formDesordres, {'attr': {'id': 'bo-form-signalement-desordres'}}) }}
 {{ form_errors(formDesordres) }}
 
-{% set desordres_logement = [] %}
-{% set desordres_batiment = [] %}
-
-{% for field in formDesordres %}
-    {% if field.vars.name starts with 'desordres_LOGEMENT' and not field.rendered %}
-        {% set desordres_logement = desordres_logement|merge([field]) %}
-    {% elseif field.vars.name starts with 'desordres_BATIMENT' and not field.rendered %}
-        {% set desordres_batiment = desordres_batiment|merge([field]) %}
-    {% endif %}
-    {% if field.vars.name starts with 'precisions_' and not field.rendered %}
-        <dialog aria-labelledby="fr-modal-title-{{ field.vars.id }}" id="modal-precisions-{{ field.vars.id }}" class="fr-modal">
-            <div class="fr-container fr-container--fluid fr-container-md">
-                <div class="fr-grid-row fr-grid-row--center">
-                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                        <div class="fr-modal__body">
-                            <div class="fr-modal__header">
-                                <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ field.vars.id }}">Fermer</button>
-                            </div>
-                            <div class="fr-modal__content">
-                                <h1 id="fr-modal-title-{{ field.vars.id }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
-                                <p>Renseignez les détails du désordre</p>
-                                {{ form_widget(field) }} 
-                            </div>
-                            <div class="fr-modal__footer">
-                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                    {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
-                                    <button class="fr-btn fr-icon-check-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Valider</button>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Annuler</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </dialog>
-    {% endif %}
-{% endfor %}
-
 <div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
     <div class="fr-col-12">
         <fieldset class="fr-fieldset">
@@ -62,7 +24,7 @@
         <span>Désordres déclarés dans le logement</span>
         <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
         <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
-            title="Sélectionner les désordres"
+            title="Sélectionner les désordres" type="button"
             data-fr-opened="false" aria-controls="fr-modal-desordres-logement-add"
             >
             Sélectionner les désordres
@@ -73,15 +35,18 @@
         <span>Désordres déclarés dans le bâtiment</span>
         <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
         <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
-            title="Sélectionner les désordres"
+            title="Sélectionner les désordres" type="button"
             data-fr-opened="false" aria-controls="fr-modal-desordres-batiment-add"
             >
             Sélectionner les désordres
         </button>
     </div>
 
-    {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
-    {{ _self.display_criteres('BATIMENT', criteresByZone['BATIMENT']) }}
+    <div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
+        {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
+        {{ _self.display_criteres('BATIMENT', criteresByZone['BATIMENT']) }}
+    </div>
+
 
     <div class="fr-col-6">
         <div class="fr-grid-row fr-grid-row--left">
@@ -97,46 +62,63 @@
     </div>
 
 </div>
-{% macro display_criteres(zone, criteres) %}
-    {% if criteres|length > 0 %}
-        <div class="fr-col-6">
-            <h3 class="fr-h5">Désordres sélectionnés</h3>
-            {% for critere in criteres %}
-                <div>
-                    {# TODO : changer la couleur de la bordure et mettre un warning, si précision pas choisie alors que devrait #}
-                    <div class="fr-grid-row fr-p-3v fr-mb-3v fr-grid-row--top fr-border--grey">
-                        <div class="fr-col-12 fr-col-md-8">
-                            {{ critere['desordreCritere'].labelCritere }}
-                        </div>
-                        <div class="fr-col-12 fr-col-md-4 fr-text--right">
-                            {% if critere['desordrePrecisionsLinked'] and critere['desordrePrecisionsLinked']|length > 1 %}
-                                <a href="#" aria-controls="modal-precisions-signalement_draft_desordres_precisions_{{ critere['desordreCritere'].id }}" data-fr-opened="false" 
-                                class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
-                                title="Editer les détails" data-fr-js-modal-button="true">
-                                    Editer les détails
-                                </a>                                
-                            {% endif %}
-                        </div>
-                        <div class="fr-col-12">
-                            {% if critere['desordrePrecisionsSelected'] %}
-                                <ul class="fr-list fr-list--none">   
-                                {% for desordrePrecision in critere['desordrePrecisionsSelected'] %}
-                                    <li>
-                                        {{ desordrePrecision.label|raw }}
-                                    </li>                                    
-                                {% endfor %}    
-                                </ul>                       
-                            {% endif %}
+
+{% set desordres_logement = [] %}
+{% set desordres_batiment = [] %}
+
+{% for field in formDesordres %}
+    {% if field.vars.name starts with 'desordres_LOGEMENT' and not field.rendered %}
+        {% set desordres_logement = desordres_logement|merge([field]) %}
+    {% elseif field.vars.name starts with 'desordres_BATIMENT' and not field.rendered %}
+        {% set desordres_batiment = desordres_batiment|merge([field]) %}
+    {% endif %}
+    {% if field.vars.name starts with 'precisions_' and not field.rendered %}
+        {% set critereId = field.vars.id|replace({'signalement_draft_desordres_precisions_': ''}) %}
+        <dialog aria-labelledby="fr-modal-title-{{ critereId }}" id="modal-precisions-{{ field.vars.id }}" class="fr-modal" data-critereId={{ critereId }}>
+            <div class="fr-container fr-container--fluid fr-container-md">
+                <div class="fr-grid-row fr-grid-row--center">
+                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                        <div class="fr-modal__body">
+                            <div class="fr-modal__header">
+                                <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ critereId }}">Fermer</button>
+                            </div>
+                            <div class="fr-modal__content">
+                                <h1 id="fr-modal-title-{{ field.vars.id }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
+                                <p>Renseignez les détails du désordre</p>
+                                {% for child in field %}
+                                    <fieldset class="fr-fieldset">
+                                        <div class="fr-fieldset__element">
+                                            <div class="fr-checkbox-group">
+                                                {{ form_widget(child) }}
+                                                <label class="fr-label" for="{{ child.vars.id }}">{{ child.vars.label|raw }}</label>
+                                            </div>
+                                        </div>
+                                    </fieldset>
+                                {% endfor %}
+
+                            </div>
+                            <div class="fr-modal__footer">
+                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    <button class="fr-btn fr-icon-check-line valid-edit-precisions" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Valider</button>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Annuler</button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
-            {% endfor %}
-        </div>
+            </div>
+        </dialog>
     {% endif %}
+{% endfor %}
+{% macro display_criteres(zone, criteres) %}
+    <div class="fr-col-6 fr-hidden" id="list-critere-{{zone}}">
+        <h3 class="fr-h5">Désordres sélectionnés</h3>
+        {# Le reste est ajouté en js  #}
+    </div>
 {% endmacro %}
 
-{% macro modal_add_criteres(id, title, desordres) %}
-    <dialog aria-labelledby="fr-modal-title-{{ id }}" id="fr-modal-{{ id }}" class="fr-modal">
+{% macro modal_add_criteres(id, title, desordres, zone) %}
+    <dialog aria-labelledby="fr-modal-title-{{ id }}" id="fr-modal-{{ id }}" class="fr-modal" data-zone={{ zone }}>
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
@@ -153,8 +135,7 @@
                         </div>
                         <div class="fr-modal__footer">
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
-                                <button class="fr-btn fr-icon-check-line" type="button" aria-controls="fr-modal-{{ id }}">Valider</button>
+                                <button class="fr-btn fr-icon-check-line valid-add-critere" type="button" aria-controls="fr-modal-{{ id }}">Valider</button>
                                 <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-{{ id }}">Annuler</button>
                             </div>
                         </div>
@@ -165,8 +146,8 @@
     </dialog>
 {% endmacro %}
 
-{{ _self.modal_add_criteres('desordres-batiment-add', 'Désordres dans le bâtiment', desordres_batiment) }}
-{{ _self.modal_add_criteres('desordres-logement-add', 'Désordres dans le logement', desordres_logement) }}
+{{ _self.modal_add_criteres('desordres-batiment-add', 'Désordres dans le bâtiment', desordres_batiment, 'BATIMENT') }}
+{{ _self.modal_add_criteres('desordres-logement-add', 'Désordres dans le logement', desordres_logement, 'LOGEMENT') }}
 
 
 {{ form_end(formDesordres) }}

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -1,1 +1,172 @@
 <h2 class="fr-h4">Désordres</h2>
+<p>Renseignez ici les désordres déclarés dans le logement. Vous devez renseigner au moins 1 désordre.</p>
+<div class="fr-alert fr-alert--warning">
+	<p>
+		Vous ne pourrez plus ajouter de désordres après l'enregistrement du signalement ! Veuillez renseigner <u>tous</u> les désordres.
+	</p>
+</div>
+
+{% form_theme formDesordres 'form/dsfr_theme.html.twig' %}
+{{ form_start(formDesordres, {'attr': {'id': 'bo-form-signalement-desordres'}}) }}
+{{ form_errors(formDesordres) }}
+
+{% set desordres_logement = [] %}
+{% set desordres_batiment = [] %}
+
+{% for field in formDesordres %}
+    {% if field.vars.name starts with 'desordres_LOGEMENT' and not field.rendered %}
+        {% set desordres_logement = desordres_logement|merge([field]) %}
+    {% elseif field.vars.name starts with 'desordres_BATIMENT' and not field.rendered %}
+        {% set desordres_batiment = desordres_batiment|merge([field]) %}
+    {% endif %}
+    {% if field.vars.name starts with 'precisions_' and not field.rendered %}
+        <dialog aria-labelledby="fr-modal-title-{{ field.vars.id }}" id="modal-precisions-{{ field.vars.id }}" class="fr-modal">
+            <div class="fr-container fr-container--fluid fr-container-md">
+                <div class="fr-grid-row fr-grid-row--center">
+                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                        <div class="fr-modal__body">
+                            <div class="fr-modal__header">
+                                <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ field.vars.id }}">Fermer</button>
+                            </div>
+                            <div class="fr-modal__content">
+                                <h1 id="fr-modal-title-{{ field.vars.id }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
+                                <p>Renseignez les détails du désordre</p>
+                                {{ form_widget(field) }} 
+                            </div>
+                            <div class="fr-modal__footer">
+                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
+                                    <button class="fr-btn fr-icon-check-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Valider</button>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Annuler</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </dialog>
+    {% endif %}
+{% endfor %}
+
+<div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
+    <div class="fr-col-12">
+        <fieldset class="fr-fieldset">
+            <div class="fr-fieldset__element">
+                {{ form_row(formDesordres.details) }}
+            </div>
+        </fieldset>
+    </div>
+
+    <div class="fr-col-6">
+        <h3 class="fr-h5">Logement</h3>
+        <span>Désordres déclarés dans le logement</span>
+        <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
+        <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
+            title="Sélectionner les désordres"
+            data-fr-opened="false" aria-controls="fr-modal-desordres-logement-add"
+            >
+            Sélectionner les désordres
+        </button>
+    </div>
+    <div class="fr-col-6">
+        <h3 class="fr-h5">Bâtiment</h3>
+        <span>Désordres déclarés dans le bâtiment</span>
+        <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
+        <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
+            title="Sélectionner les désordres"
+            data-fr-opened="false" aria-controls="fr-modal-desordres-batiment-add"
+            >
+            Sélectionner les désordres
+        </button>
+    </div>
+
+    {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
+    {{ _self.display_criteres('BATIMENT', criteresByZone['BATIMENT']) }}
+
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--left">
+            {{ form_row(formDesordres.previous) }}
+        </div>
+    </div>
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--right">
+            {{ form_row(formDesordres.forceSave) }}
+            {{ form_row(formDesordres.draft) }}
+            {{ form_row(formDesordres.save) }}
+        </div>
+    </div>
+
+</div>
+{% macro display_criteres(zone, criteres) %}
+    {% if criteres|length > 0 %}
+        <div class="fr-col-6">
+            <h3 class="fr-h5">Désordres sélectionnés</h3>
+            {% for critere in criteres %}
+                <div>
+                    {# TODO : changer la couleur de la bordure et mettre un warning, si précision pas choisie alors que devrait #}
+                    <div class="fr-grid-row fr-p-3v fr-mb-3v fr-grid-row--top fr-border--grey">
+                        <div class="fr-col-12 fr-col-md-8">
+                            {{ critere['desordreCritere'].labelCritere }}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-4 fr-text--right">
+                            {% if critere['desordrePrecisionsLinked'] and critere['desordrePrecisionsLinked']|length > 1 %}
+                                <a href="#" aria-controls="modal-precisions-signalement_draft_desordres_precisions_{{ critere['desordreCritere'].id }}" data-fr-opened="false" 
+                                class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
+                                title="Editer les détails" data-fr-js-modal-button="true">
+                                    Editer les détails
+                                </a>                                
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12">
+                            {% if critere['desordrePrecisionsSelected'] %}
+                                <ul class="fr-list fr-list--none">   
+                                {% for desordrePrecision in critere['desordrePrecisionsSelected'] %}
+                                    <li>
+                                        {{ desordrePrecision.label|raw }}
+                                    </li>                                    
+                                {% endfor %}    
+                                </ul>                       
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro modal_add_criteres(id, title, desordres) %}
+    <dialog aria-labelledby="fr-modal-title-{{ id }}" id="fr-modal-{{ id }}" class="fr-modal">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-{{ id }}">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h1 id="fr-modal-title-{{ id }}" class="fr-modal__title">{{ title }}</h1>
+                            <p>Sélectionnez un ou plusieurs désordres dans la liste ci-dessous. Les détails des désordres seront à saisir dans un second temps.</p>
+                            {% for field in desordres %}
+                                {{ form_row(field) }}
+                            {% endfor %}
+                        </div>
+                        <div class="fr-modal__footer">
+                            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
+                                <button class="fr-btn fr-icon-check-line" type="button" aria-controls="fr-modal-{{ id }}">Valider</button>
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-{{ id }}">Annuler</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
+{% endmacro %}
+
+{{ _self.modal_add_criteres('desordres-batiment-add', 'Désordres dans le bâtiment', desordres_batiment) }}
+{{ _self.modal_add_criteres('desordres-logement-add', 'Désordres dans le logement', desordres_logement) }}
+
+
+{{ form_end(formDesordres) }}


### PR DESCRIPTION
## Ticket

#3647    

## Description
Proposition d'archi pour l'ajout de l'onglet Désordres.
**A noter : Mathilde est OK pour simplifier les modales d'édition de critères, pour qu'on liste les précisions liées avec des cases à cocher plutôt que de poser des questions avec des réponses multiples.** cf https://github.com/MTES-MCT/histologe/issues/3647#issuecomment-2730210043

Fait : 

- [x] Affichage de l'onglet avec champ texte
- [x] Choix des critères dans des popups liées à la zone (bâtiment/logement) et classés par catégorie
- [x] Enregistrement des critères (et de la catégorié liée, et de la précision s'il n'y en a qu'une)
- [x] Affichage des critères choisisLes 3 label
- [x] Edition des critères avec plusieurs précisions
- [x] Enregistrement des précisions choisies
- [x] Affichage des précisions choisies

Reste à faire : 

- [x] Gestion de la réactivité de la page et du formType (à discuter)
- [ ] Les 3 labels identiques des critères de la catégorie Humidité (ajout de la pièce)
- [ ] Affichage ou non de la catégorie Type et composition du logement (si oui, redondant avec l'onglet Logement, si non, désordres à calculer à la volée)
- [ ] Affichage en rouge avec warning des critères à plusieurs précisions dont la précision n'est pas choisie
- [x] Gérer le code html dans la modale de choix de précision
- [ ] Certaines précision nécéssitent un champ texte (par exemple autre type de nuisibles)
- [ ] Désenregistrement des critères et/ou précisions préalablement enregistrées et déselectionnées

## Changements apportés
* Pour le choix des critères dans les modales Bâtiment et Logement, on a un formType `SignalementDraftDesordresType` qui récupère tous les `désordresCritere` et génère des selectbox à la volée. Ce formType ajoute aussi des checkbox de `desordrePrecision` pour les `desordreCritere` déjà enregistrés (à améliorer pour la réactivité, sauf si on enregistre et recharge la page à chaque validation de modale
* Dans `src/Controller/Back/SignalementCreateController.php` ajout du formType dans editSignalement, ainsi que d'un tableau de criteres classés par zone. Et ajout d'une route `back_signalement_draft_form_desordres_edit`
* Enregistrement des critères et précisions dans `SignalementBoManager` dans une fonction `formDesordresManager`
* Dans `src/Service/Signalement/SignalementDesordresProcessor.php` création d'une fonction `processDesordresByZone` pour envoyer les critères classés au twig
* Gestion des modales dans le twig `templates/back/signalement_create/tabs/tab-desordres.html.twig` (arborescence à revoir, mais j'ai tout centralisé pour que ce soit plus simple à relire)

## Pré-requis

## Tests
- [ ] Ouvrir une modale pour choisir des critères
- [ ] eLa page redirige vers le json, revenir en arrière dans le navigateur
- [ ] Choisir des critères et cliquer sur Suivant pour enregistrer
- [ ] Recharger la page pour voir les critères enregistrés
- [ ] Ouvrir une modale d'édition de critères pour choisir précisions (et rebelote ça redirige vers le json etc.) 
