### PR TITLE
[FO - Suivi usager] Pas de bouton de suppression d'image/doc

### DIFF
--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -413,7 +413,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 							data-id={{ photo.id }} 
 							title="Voir la photo {{ photo.filename }} - ouvre une nouvelle fenêtre"
 						></a>
-						{% if is_granted('FRONT_FILE_DELETE', { 'file': photo, 'email': email }) %}
+						{% if is_granted('FRONT_FILE_DELETE', photo) %}
 							<button class="fr-btn fr-btn--sm fr-btn--secondary fr-background--white fr-fi-delete-line btn-signalement-file-delete"
 								id="file_delete_{{ photo.id }}" 
 								title="Supprimer la photo {{ photo.filename }}"
@@ -482,7 +482,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 					<a href="{{ path('show_file', {uuid: doc.uuid}) }}"
 						class="fr-btn fr-btn--sm fr-icon-eye-fill img-box" title="Afficher le document {{ doc.filename }} - ouvre une nouvelle fenêtre"
 						target="_blank" rel="noopener"></a>    
-					{% if is_granted('FRONT_FILE_DELETE', { 'file': doc, 'email': email }) %}
+					{% if is_granted('FRONT_FILE_DELETE', doc) %}
 						<button class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line btn-signalement-file-delete"
 							id="file_delete_{{ doc.id }}" 
 							title="Supprimer le document {{ doc.filename }}"


### PR DESCRIPTION
## Ticket

#3857    

## Description
Retour de test de Mathilde, les boutons de suppression de fichier sur la page de suivi usager n'apparaissent pas

## Changements apportés
* Correction de l'appel au voter FRONT_FILE_DELETE dans le twig

## Pré-requis

## Tests
- [ ] Prendre un signalement avec des photos/docs usager. En tant que partenaire, ajouter aussi des photos/docs. Aller sur la page usager, et vérifier que l'usager peut bien supprimer ses fichiers (et pas ceux du partenaire)
