### PR TITLE
[BO - Partenaires] Filtre partenaire non notifiable ne fonctionne pas depuis le widget

### DIFF
--- a/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
+++ b/src/Service/DashboardWidget/WidgetDataKpiBuilder.php
@@ -177,6 +177,12 @@ class WidgetDataKpiBuilder
             $widgetParams['params']['territoire'] = 1 === count($this->territories) ? reset($this->territories)->getId() : null;
             if ('cardPartenairesNonNotifiables' !== $key) {
                 $widgetParams['params']['isImported'] = 'oui';
+            } else {
+                /** @var User $user */
+                $user = $this->security->getUser();
+                if (0 === count($this->territories) || $user->isTerritoryAdmin()) {
+                    unset($widgetParams['params']['territoire']);
+                }
             }
             $parameters = array_merge($linkParameters, $widgetParams['params'] ?? []);
             $widgetCard = $this->widgetCardFactory->createInstance($label, $count, $link, $parameters);


### PR DESCRIPTION
## Ticket

#3853    

## Description
Je suis RT du 06
Je vais sur mon dashboard
Je clique sur le widget pour afficher la liste des partenaires non notifiables
J'arrive sur la liste
La liste est affichée, l'interrupteur pour afficher uniquement les partenaires non-notifiables est actif mais la liste n'est pas filtrée + un il a une erreur

## Changements apportés
* Suppression du territoire dans l'url si pas admin ou pas de territoire choisi

## Pré-requis
`make clear-pool pool=--all`
## Tests
- [ ] Tester le lien widget du dashboard en RT -> on arrive sur la liste bien filtrée sans erreur de formType
- [ ] Tester le lien widget du dashboard en SA en choisissant un territoire -> on arrive sur la liste bien filtrée sans erreur de formType
- [ ] Tester le lien widget du dashboard en SA sans choisir de territoire -> on arrive sur la liste NON filtrée sans erreur de formType

