### PR TITLE
[QA] Nettoyage des textes de descriptions des visites

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -101,6 +101,13 @@ services:
         tags:
             - { name: 'kernel.event_listener', event: 'kernel.request' }
 
+    App\EventListener\EntitySanitizerListener:
+        arguments:
+            $htmlSanitizer: '@html_sanitizer.sanitizer.app.message_sanitizer'
+            $logger: '@logger'
+        tags:
+            - { name: doctrine.orm.entity_listener }
+
     Aws\S3\S3Client:
         arguments:
             - endpoint: '%env(resolve:S3_ENDPOINT)%'

--- a/src/Entity/Behaviour/EntitySanitizerInterface.php
+++ b/src/Entity/Behaviour/EntitySanitizerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Entity\Behaviour;
+
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+
+interface EntitySanitizerInterface
+{
+    public function sanitizeDescription(HtmlSanitizerInterface $htmlSanitizer): void;
+
+    public function getDescription(): ?string;
+}

--- a/src/EventListener/EntitySanitizerListener.php
+++ b/src/EventListener/EntitySanitizerListener.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Behaviour\EntitySanitizerInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Events;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+
+#[AsDoctrineListener(event: Events::prePersist)]
+#[AsDoctrineListener(event: Events::preUpdate)]
+readonly class EntitySanitizerListener
+{
+    public function __construct(
+        #[Autowire(service: 'html_sanitizer.sanitizer.app.message_sanitizer')]
+        private HtmlSanitizerInterface $htmlSanitizer,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function prePersist(LifecycleEventArgs $eventArgs): void
+    {
+        $entity = $eventArgs->getObject();
+        if ($entity instanceof EntitySanitizerInterface) {
+            $this->sanitize($entity, 'prePersist');
+        }
+    }
+
+    public function preUpdate(LifecycleEventArgs $eventArgs): void
+    {
+        $entity = $eventArgs->getObject();
+        if ($entity instanceof EntitySanitizerInterface) {
+            $this->sanitize($entity, 'preUpdate');
+        }
+    }
+
+    private function sanitize(EntitySanitizerInterface $entity, string $eventType): void
+    {
+        $this->logger->info('[$eventType] Before sanitization', [
+            'class' => $entity::class,
+            'description' => $entity->getDescription(),
+        ]);
+
+        $entity->sanitizeDescription($this->htmlSanitizer);
+
+        $this->logger->info('[$eventType] After sanitization', [
+            'class' => $entity::class,
+            'description' => $entity->getDescription(),
+        ]);
+    }
+}

--- a/src/Repository/InterventionRepository.php
+++ b/src/Repository/InterventionRepository.php
@@ -18,8 +18,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class InterventionRepository extends ServiceEntityRepository
 {
-    private const NB_DAYS_DELAY_NOTIFICATION_VISIT_PAST = 2;
-    private const NB_DAYS_DELAY_NOTIFICATION_VISIT_FUTURE = -2;
+    private const int NB_DAYS_DELAY_NOTIFICATION_VISIT_PAST = 2;
+    private const int NB_DAYS_DELAY_NOTIFICATION_VISIT_FUTURE = -2;
 
     public function __construct(ManagerRegistry $registry)
     {
@@ -92,5 +92,14 @@ class InterventionRepository extends ServiceEntityRepository
             ->setParameter('arrete', InterventionType::ARRETE_PREFECTORAL->name)
             ->getQuery()
             ->getResult();
+    }
+
+    public function getInterventionsWithDescription(): array
+    {
+        return $this
+            ->createQueryBuilder('i')
+            ->andWhere('i.details IS NOT NULL')
+            ->orderBy('i.createdAt', 'DESC')
+            ->getQuery()->getResult();
     }
 }

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -70,7 +70,7 @@
             {% if signalement.interventions is empty or intervention.details is empty %}
                 Non renseigné
             {% else %}
-                {{ intervention.details|sanitize_html('app.message_sanitizer') }}
+                {{ intervention.details|raw }}
             {% endif %}
             </p>
         </div>


### PR DESCRIPTION
## Ticket

#3839    

## Description
Retour de @numew 
> On autorise le HTML dans les description de visite, nous utilisons pour cette description un sanitizer html uniquement à l'affichage (dans twig) il faudrait le faire à l'insertion (comme pour les suivis, voir https://github.com/MTES-MCT/histologe/pull/3587). Autrement cela signifie que l'on est capable de retourner dans le payload GET de l'intervention du contenu malicieux. (il vaut sûrement mieux créer un ticket dédié pour ça)

La description peut être édité contrairement au suivi

## Changements apportés
* Ajout d'un nouveau listener pour nettoyer une entité qui implémente EntitySanitizerInterface
* Ajout d'une commande pour nettoyer les description des visites

## Pré-requis

## Tests
- [ ]  Créer une intervention en copiant-collant des image en base64 et vérifier qu'elle sont bien nettoyé à l'enregistrement et à l'éditon
