### PR TITLE
[Etude][Sécurité - Audit] Faille XSS avec fichier pdf contenant du javascript

### DIFF
--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -1,4 +1,6 @@
 FROM php:8.3-fpm
+
+# Mise à jour et installation des dépendances nécessaires
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         curl \
@@ -13,9 +15,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         sqlite3 \
         libxslt1-dev \
         wkhtmltopdf \
+        # Installation de Yara
+        yara \
         && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash \
         && apt-get install -y  nodejs \
-         # Install intl
+        # Install intl
         && docker-php-ext-configure intl \
         && docker-php-ext-install -j2 intl \
         # Install apcu
@@ -39,5 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN sed -E -i -e 's/memory_limit = 128M/memory_limit = 512M/' "$PHP_INI_DIR/php.ini" \
     && sed -E -i -e 's/post_max_size = 8M/post_max_size = 75M/' "$PHP_INI_DIR/php.ini" \
     && sed -E -i -e 's/upload_max_filesize = 2M/upload_max_filesize = 75M/' "$PHP_INI_DIR/php.ini"
+
+COPY ./yara_rules/PDF_Containing_JavaScript.yar /etc/yara/rules/
 
 WORKDIR /app/

--- a/.docker/php-fpm/yara_rules/PDF_Containing_JavaScript.yar
+++ b/.docker/php-fpm/yara_rules/PDF_Containing_JavaScript.yar
@@ -1,0 +1,22 @@
+rule PDF_Containing_JavaScript
+{
+    meta:
+        author         = "InQuest Labs"
+		description    = "This signature detects a PDF file that contains JavaScript. JavaScript can be used to customize PDFs by implementing objects, methods, and properties. While not inherently malicious, embedding JavaScript inside of a PDF is often used for malicious purposes such as malware delivery or exploitation."
+        created_date   = "2022-03-15"
+        updated_date   = "2022-03-15"
+        blog_reference = "www.sans.org/security-resources/malwarefaq/pdf-overview.php"
+        labs_reference = "N/A"
+        labs_pivot     = "N/A"
+        samples        = "c82e29dcaed3c71e05449cb9463f3efb7114ea22b6f45b16e09eae32db9f5bef"
+
+	strings:
+			
+		$pdf_tag1 = /\x25\x50\x44\x46\x2d/
+		$js_tag1  = "/JavaScript" fullword
+		$js_tag2  = "/JS"		  fullword
+	condition:
+			
+		$pdf_tag1 in (0..1024) and ($js_tag1 or $js_tag2)
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN}
     volumes:
       - .:/app/
+      - ./.docker/php-fpm/yara_rules:/etc/yara/rules
 
   histologe_phpworker:
     build: .docker/php-worker

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "histologe",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Ticket

#3562    

## Description
Ajout de Yara pour détecter les pdf contenant du javascript.

**2 questions à se poser avant un quelconque déploiement :** 

- [ ] Est-ce qu'on veut vraiment faire ça ? (sachant que vu la galère pour trouver/générer un pdf contenant du javascript, ça ne doit pas être si courant que ça. On peut faire des pdf avec des formulaires, des macros etc. sans que ce soit du javascript)
- [ ] Si on le fait, est-ce qu'on laisse comme actuellement le message "`virus`", ou est-ce qu'on met un message plus explicite, genre "`Ce fichier pdf contient du javascript, pour des raisons de sécurité nous ne pouvons pas l'accepter.`" ? 

## Changements apportés
* Ajout de Yara et d'une yara rules via Docker
* Modification du service FileScanner pour executer yara sur les fichiers afin de détecter s'il y a du javascript dans le pdf

## Pré-requis
`make build`

Se procurer un pdf avec du js : https://community.adobe.com/havfw69955/attachments/havfw69955/acrobat-sdk/86720/1/JSCollectionDemo.pdf

Mettre la var d'env `CLAMAV_SCAN_ENABLE` à 1

## Tests
- [ ] Sur un signalement ajouter un pdf "normal", et vérifier qu'il s'ajoute
- [ ] Ajouter un pdf avec du js et vérifier qu'on a un message de virus
