### PR TITLE
[API] Améliorer le monitoring des requêtes et réponses

### DIFF
--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -11,6 +11,12 @@ monolog:
             path: php://stderr
             level: debug
             formatter: monolog.formatter.json
+        stdout:
+            type: stream
+            path: php://stdout
+            level: info
+            formatter: monolog.formatter.json
+            channels: [ "!event", "!doctrine", "!console" ]
         console:
             type: console
             process_psr_3_messages: false

--- a/config/packages/test/monolog.yaml
+++ b/config/packages/test/monolog.yaml
@@ -1,12 +1,5 @@
 monolog:
     handlers:
         main:
-            type: fingers_crossed
-            action_level: error
-            handler: nested
-            excluded_http_codes: [404, 405]
-            channels: ["!event"]
-        nested:
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            type: test
             level: debug

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -99,7 +99,7 @@ services:
 
     App\EventListener\MaintenanceListener:
         tags:
-            - { name: 'kernel.event_listener', event: 'kernel.request' }
+            - { name: 'kernel.event_listener', event: 'kernel.request', priority: 10 }
 
     App\EventListener\EntitySanitizerListener:
         arguments:

--- a/src/EventListener/MaintenanceListener.php
+++ b/src/EventListener/MaintenanceListener.php
@@ -4,7 +4,9 @@ namespace App\EventListener;
 
 use App\Entity\User;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -24,6 +26,11 @@ class MaintenanceListener
     public function onKernelRequest(RequestEvent $requestEvent): void
     {
         if ($this->maintenanceEnable) {
+            $request = $requestEvent->getRequest();
+            if (str_starts_with($request->getPathInfo(), '/api') && !str_starts_with($request->getPathInfo(), '/api/doc')) {
+                $this->jsonResponse($requestEvent);
+            }
+
             if ($this->shouldLogout()) {
                 $this->redirect('app_logout', $requestEvent);
             }
@@ -55,6 +62,12 @@ class MaintenanceListener
     {
         $route = $this->router->generate($routeName);
         $response = new RedirectResponse($route);
+        $requestEvent->setResponse($response);
+    }
+
+    private function jsonResponse(RequestEvent $requestEvent): void
+    {
+        $response = new JsonResponse(['error' => 'Service indisponible', 'message' => 'Maintenance en cours'], Response::HTTP_SERVICE_UNAVAILABLE);
         $requestEvent->setResponse($response);
     }
 }

--- a/src/EventSubscriber/ApiRequestIdSubscriber.php
+++ b/src/EventSubscriber/ApiRequestIdSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Service\ApiLogger;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ApiRequestIdSubscriber implements EventSubscriberInterface
+{
+    public const REQUEST_API_ID_KEY = 'api_request_id';
+    public const REQUEST_START_TIME = 'api_request_start_time';
+
+    public function __construct(
+        private readonly ApiLogger $apiLogger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 20],
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if (!str_starts_with($request->getPathInfo(), '/api') || str_starts_with($request->getPathInfo(), '/api/doc')) {
+            return;
+        }
+
+        $requestId = uniqid('', true);
+        $request->attributes->set(self::REQUEST_API_ID_KEY, $requestId);
+        $request->attributes->set(self::REQUEST_START_TIME, microtime(true));
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if (!str_starts_with($request->getPathInfo(), '/api') || str_starts_with($request->getPathInfo(), '/api/doc')) {
+            return;
+        }
+
+        $requestId = $request->attributes->get(self::REQUEST_API_ID_KEY);
+        $response = $event->getResponse();
+        $response->headers->set('X-Request-ID', $requestId);
+        $this->apiLogger->logApiCall($request, $response);
+    }
+}

--- a/src/Service/ApiLogger.php
+++ b/src/Service/ApiLogger.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use App\EventSubscriber\ApiRequestIdSubscriber;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiLogger
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly Security $security,
+    ) {
+    }
+
+    public function logApiCall(Request $request, Response $response): void
+    {
+        $requestId = $request->attributes->get(ApiRequestIdSubscriber::REQUEST_API_ID_KEY);
+        $startTime = $request->attributes->get(ApiRequestIdSubscriber::REQUEST_START_TIME);
+        $executionTime = round(microtime(true) - $startTime, 2);
+        $method = $request->getMethod();
+        $pathInfo = $request->getPathInfo();
+        /** @var User|null $user */
+        $user = $this->security->getUser();
+        $userId = $user?->getId();
+
+        $data = [
+            'request_id' => $requestId,
+            'execution_time' => $executionTime,
+            'user_id' => $userId,
+            'method' => $method,
+            'path_info' => $pathInfo,
+            'query' => $request->query->all(),
+            'request' => $this->sanitizeSensitiveData(json_decode($request->getContent(), true)),
+            'files' => $this->extractUploadedFiles($request),
+            'response' => $this->sanitizeSensitiveData(json_decode($response->getContent(), true)),
+            'response_status' => $response->getStatusCode(),
+        ];
+
+        $this->logger->info('API Request '.$method.' '.$pathInfo.' ('.$requestId.')', $data);
+    }
+
+    private function extractUploadedFiles(Request $request): array
+    {
+        $uploadedFiles = [];
+        foreach ($request->files as $fileInfo) {
+            foreach ($fileInfo as $subFile) {
+                if ($subFile instanceof UploadedFile) {
+                    $uploadedFiles[] = [
+                        'original_name' => $subFile->getClientOriginalName(),
+                        'mime_type' => $subFile->getClientMimeType(),
+                        'size' => $subFile->getSize(),
+                    ];
+                }
+            }
+        }
+
+        return $uploadedFiles;
+    }
+
+    private function sanitizeSensitiveData(?array $data): ?array
+    {
+        if (null === $data) {
+            return null;
+        }
+        foreach ($data as $key => $unused) {
+            if (in_array($key, ['password', 'token'])) {
+                $data[$key] = '['.$key.']';
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/ApiHelper.php
+++ b/tests/ApiHelper.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Tests;
+
+use Monolog\Handler\TestHandler;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+trait ApiHelper
+{
+    public function hasXrequestIdHeaderAndOneApiRequestLog(KernelBrowser $client): void
+    {
+        $this->responseHasXRequestIdHeader($client);
+        $this->hasOneApiRequestLog();
+    }
+
+    private function responseHasXRequestIdHeader(KernelBrowser $client): void
+    {
+        /** @var Response $response */
+        $response = $client->getResponse();
+        $requestId = $response->headers->get('X-Request-ID');
+        $this->assertNotEmpty($requestId);
+    }
+
+    private function hasOneApiRequestLog(): void
+    {
+        /** @var TestHandler $testHandler */
+        $testHandler = static::getContainer()->get('monolog.handler.main');
+        $this->assertInstanceOf(TestHandler::class, $testHandler);
+
+        $records = $testHandler->getRecords();
+        $apiLogs = array_filter($records, function ($record) {
+            return str_starts_with($record['message'], 'API Request');
+        });
+
+        $this->assertCount(1, $apiLogs, 'Il devrait y avoir exactement un log API Request');
+    }
+}

--- a/tests/Functional/Controller/Api/AffectationUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/AffectationUpdateControllerTest.php
@@ -6,6 +6,7 @@ use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;
 use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
+use App\Tests\ApiHelper;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -13,6 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AffectationUpdateControllerTest extends WebTestCase
 {
+    use ApiHelper;
     private KernelBrowser $client;
     private SignalementRepository $signalementRepository;
 
@@ -48,6 +50,7 @@ class AffectationUpdateControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $this->assertEquals($statut, AffectationStatus::mapNewStatus($affectation->getStatut())->value);
         $this->assertEmailCount($mailSent);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     /** @dataProvider provideUnvalidData */
@@ -68,6 +71,7 @@ class AffectationUpdateControllerTest extends WebTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertEquals($httpCodeStatus, $this->client->getResponse()->getStatusCode());
         $this->assertStringContainsString($errorMessage, $response['message']);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     private function patchAffectation(?string $affectationUuid, array $payload): void

--- a/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
@@ -4,12 +4,14 @@ namespace App\Tests\Functional\Controller\Api;
 
 use App\Entity\User;
 use App\Repository\SignalementRepository;
+use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Routing\RouterInterface;
 
 class ArreteCreateControllerTest extends WebTestCase
 {
+    use ApiHelper;
     private KernelBrowser $client;
     private RouterInterface $router;
 
@@ -48,6 +50,7 @@ class ArreteCreateControllerTest extends WebTestCase
         }
         $this->assertEmailCount(1);
         $this->assertEquals(201, $this->client->getResponse()->getStatusCode());
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     /** @dataProvider providePayloadFailure */
@@ -63,6 +66,7 @@ class ArreteCreateControllerTest extends WebTestCase
         );
 
         $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     public function providePayloadFailure(): \Generator

--- a/tests/Functional/Controller/Api/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementControllerTest.php
@@ -3,10 +3,13 @@
 namespace App\Tests\Functional\Controller\Api;
 
 use App\Entity\User;
+use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class SignalementControllerTest extends WebTestCase
 {
+    use ApiHelper;
+
     public function testGetSignalementList(): void
     {
         $client = static::createClient();
@@ -19,6 +22,7 @@ class SignalementControllerTest extends WebTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertCount(6, $response);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
     public function testGetSignalementListWithLimit(): void
@@ -33,6 +37,7 @@ class SignalementControllerTest extends WebTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertCount(2, $response);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
     public function testGetSignalementByUuid(): void
@@ -48,6 +53,7 @@ class SignalementControllerTest extends WebTestCase
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('desordres', $response);
         $this->assertCount(7, $response['desordres']);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
     public function testGetOldSignalementByUuid(): void
@@ -63,6 +69,7 @@ class SignalementControllerTest extends WebTestCase
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('desordres', $response);
         $this->assertCount(3, $response['desordres']);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
     /**
@@ -83,6 +90,7 @@ class SignalementControllerTest extends WebTestCase
         $this->assertArrayHasKey('property', current($response['errors']));
         $this->assertArrayHasKey('message', current($response['errors']));
         $this->assertArrayHasKey('invalidValue', current($response['errors']));
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
     public function provideQueryParameters(): \Generator

--- a/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
@@ -5,12 +5,14 @@ namespace App\Tests\Functional\Controller\Api;
 use App\Entity\File;
 use App\Entity\User;
 use App\Repository\SignalementRepository;
+use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Routing\RouterInterface;
 
 class SignalementFileUpdateControllerTest extends WebTestCase
 {
+    use ApiHelper;
     private KernelBrowser $client;
     private RouterInterface $router;
 
@@ -46,6 +48,7 @@ class SignalementFileUpdateControllerTest extends WebTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertResponseIsSuccessful();
         $this->assertEquals($payload['documentType'], $response['documentType']);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     public function testUpdateSignalementFileWithFileTypeUpdated(): void
@@ -70,6 +73,7 @@ class SignalementFileUpdateControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $this->assertNull($response['description']);
         $this->assertEquals('PROCEDURE_ARRETE_PREFECTORAL', $response['documentType']);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     public function testUpdateSignalementFileWithFileNotFound(): void
@@ -85,5 +89,6 @@ class SignalementFileUpdateControllerTest extends WebTestCase
         );
 
         $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 }

--- a/tests/Functional/Controller/Api/SignalementFileUploadControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementFileUploadControllerTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional\Controller\Api;
 use App\Entity\User;
 use App\Service\ImageManipulationHandler;
 use App\Service\UploadHandlerService;
+use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -13,6 +14,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class SignalementFileUploadControllerTest extends WebTestCase
 {
+    use ApiHelper;
     private KernelBrowser $client;
     private RouterInterface $router;
 
@@ -59,6 +61,7 @@ class SignalementFileUploadControllerTest extends WebTestCase
         $this->postRequest($uuid, [$imageFile, $documentFile]);
 
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     /**
@@ -68,6 +71,7 @@ class SignalementFileUploadControllerTest extends WebTestCase
     {
         $this->postRequest($uuid, []);
         $this->assertEquals($codeHttpStatus, $this->client->getResponse()->getStatusCode());
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     public function provideErrorInput(): \Generator

--- a/tests/Functional/Controller/Api/SuiviCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/SuiviCreateControllerTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional\Controller\Api;
 use App\Entity\Suivi;
 use App\Entity\User;
 use App\Repository\SignalementRepository;
+use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
@@ -12,6 +13,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class SuiviCreateControllerTest extends WebTestCase
 {
+    use ApiHelper;
     private KernelBrowser $client;
     private RouterInterface $router;
 
@@ -62,6 +64,7 @@ class SuiviCreateControllerTest extends WebTestCase
         } else {
             $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
         }
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     public function provideData(): \Generator

--- a/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Functional\Controller\Api;
 
 use App\Entity\User;
 use App\Repository\SignalementRepository;
+use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
@@ -11,6 +12,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class VisiteCreateControllerTest extends WebTestCase
 {
+    use ApiHelper;
     public const string UUID_SIGNALEMENT = '00000000-0000-0000-2023-000000000026';
 
     private KernelBrowser $client;
@@ -53,6 +55,7 @@ class VisiteCreateControllerTest extends WebTestCase
             $links = $crawler->filter('a.fr-link');
             $this->assertCount(2, $links, 'Il doit y avoir exactement 2 liens dans le contenu HTML.');
         }
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     /** @dataProvider provideDataForPendingVisite */
@@ -70,6 +73,7 @@ class VisiteCreateControllerTest extends WebTestCase
         $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
         $message = json_decode($this->client->getResponse()->getContent(), true)['message'];
         $this->assertStringContainsString($signalement->getInterventions()->first()->getUuid(), $message);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     /** @dataProvider provideDataForPendingVisite */
@@ -87,6 +91,7 @@ class VisiteCreateControllerTest extends WebTestCase
         $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
         $message = json_decode($this->client->getResponse()->getContent(), true)['message'];
         $this->assertStringContainsString($signalement->getInterventions()->first()->getUuid(), $message);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     /** @dataProvider  provideDataErrorPayload */
@@ -104,6 +109,7 @@ class VisiteCreateControllerTest extends WebTestCase
         $errors = array_map(function ($error) { return $error['property']; }, $errors);
         $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
         $this->assertEquals($fieldsErrors, $errors);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     public function provideDataForNotification(): \Generator

--- a/tests/Functional/Controller/Api/VisiteUploadDocumentsControllerTest.php
+++ b/tests/Functional/Controller/Api/VisiteUploadDocumentsControllerTest.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Repository\SignalementRepository;
 use App\Service\ImageManipulationHandler;
 use App\Service\UploadHandlerService;
+use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class VisiteUploadDocumentsControllerTest extends WebTestCase
 {
+    use ApiHelper;
     private KernelBrowser $client;
     private RouterInterface $router;
 
@@ -70,6 +72,7 @@ class VisiteUploadDocumentsControllerTest extends WebTestCase
         );
 
         $this->assertCount(1, $files);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
     private function postRequest(string $uuid, array $files = [], ?string $typeDocumentVisite = null): false|string

--- a/tests/Functional/Controller/SecurityControllerTest.php
+++ b/tests/Functional/Controller/SecurityControllerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Controller;
 
 use App\Repository\UserRepository;
+use App\Tests\ApiHelper;
 use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -10,6 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SecurityControllerTest extends WebTestCase
 {
+    use ApiHelper;
     use SessionHelper;
 
     /** @dataProvider provideJsonLogin  */
@@ -22,6 +24,7 @@ class SecurityControllerTest extends WebTestCase
         ];
         $client->request('POST', '/api/login', [], [], [], json_encode($payload));
         $this->assertResponseStatusCodeSame($status);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
     public function provideJsonLogin(): \Generator

--- a/tests/Functional/EventListener/MaintenanceListenerTest.php
+++ b/tests/Functional/EventListener/MaintenanceListenerTest.php
@@ -13,6 +13,19 @@ class MaintenanceListenerTest extends WebTestCase
         self::ensureKernelShutdown();
     }
 
+    public function testMaintenanceForApiRoutes()
+    {
+        $client = static::createClient();
+        $_ENV['MAINTENANCE_ENABLE'] = '1';
+        /** @var UrlGeneratorInterface $generatorUrl */
+        $generatorUrl = static::getContainer()->get(UrlGeneratorInterface::class);
+        $client->request('POST', $generatorUrl->generate('api_login'));
+
+        $this->assertSame(503, $client->getResponse()->getStatusCode());
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertSame('Maintenance en cours', $response['message']);
+    }
+
     /**
      * @dataProvider provideRoutes
      */


### PR DESCRIPTION
## Ticket

#3817

## Description
 Pour chaque appel à l'API : 
- Ajout d'un identifiant unique pour la requête que l'on retourne en tant que `X-Request-ID` dans le header de la réponse afin que l'utilisateur final puisse nous le transmettre.
- Ajout d'une ligne de log contenant toutes les informations concernant la requête et sa réponse ainsi que l'identifiant unique de la requête, l'id user et le temps d'exécution de la requête. (les données sensibles telles que le mot de passe et le token ne sont pas concervés en log)

Modification du `MaintenanceListener` afin de retourner un message de maintenance au format json pour les appels API si la feature est activé.

## Pré-requis **(EDIT)**

1. Configurer le projet en environnements de prod  afin de voir si les logs s'affichent bien en prod
`composer dump-env prod` 

2. Sur les routes API à tester supprimer les attributs `When` et vider le cache de prod
```
#[When('dev')]
#[When('test')]
#[Route('/api')]
class SignalementFileUploadController extends AbstractController
{
```



## Tests
- [ ] Effectuer des appel API en succés et en échec et vérifier que le header `X-Request-ID` est bien retourné est qu'un log est enregistré
![Capture d’écran 2025-03-19 142050](https://github.com/user-attachments/assets/754a78f7-9411-4d9e-af04-12ee127b8eda)
![Screenshot 2025-03-19 at 14-21-48 Symfony Profiler](https://github.com/user-attachments/assets/43e396ef-9826-4582-b2ff-a4b46d5d6008)

**EDIT**
- [ ] Vérifier que les logs INFO s'affichent bien en prod via `make logs` (logs dans docker)

