### PR TITLE
[BO - Signalement] SA doit pouvoir editer un signalement à tout moment

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -160,12 +160,11 @@ class SignalementController extends AbstractController
         }
         $infoDesordres = $signalementDesordresProcessor->process($signalement);
 
-        $canEditSignalement = false;
-        if (SignalementStatus::ACTIVE === $signalement->getStatut()) {
+        $canEditSignalement = $this->isGranted('ROLE_ADMIN');
+        if (!$canEditSignalement && SignalementStatus::ACTIVE === $signalement->getStatut()) {
             $canEditSignalement = $this->isGranted('ROLE_ADMIN_TERRITORY') || $isAffectationAccepted;
         }
-        $canEditClosedSignalement = SignalementStatus::CLOSED === $signalement->getStatut()
-            && $this->isGranted('ROLE_ADMIN_TERRITORY');
+        $canEditClosedSignalement = SignalementStatus::CLOSED === $signalement->getStatut() && $this->isGranted('ROLE_ADMIN_TERRITORY');
 
         $signalementQualificationNDE = $signalementQualificationRepository->findOneBy([
             'signalement' => $signalement,


### PR DESCRIPTION
## Ticket

#3872

## Description
Correction afin que les bouton d'édition du signalement apparaissent pour les SA quelque soit le statut du signalement

## Tests
- [ ] Se connecter en SA et éditer les informations d'un nouveau signalement
