### PR TITLE
[BO - Signalement] Le bouton d'annulation de refus doit fermer la modale sans valider le formulaire

### DIFF
--- a/templates/_partials/_modal_localisation.html.twig
+++ b/templates/_partials/_modal_localisation.html.twig
@@ -20,7 +20,7 @@
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
-                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-localisation">
+                                <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-localisation">
                                     Fermer
                                 </button>
                             </li>

--- a/templates/_partials/_modal_pick_localisation.html.twig
+++ b/templates/_partials/_modal_pick_localisation.html.twig
@@ -34,7 +34,7 @@
                                 </form>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-pick-localisation">
+                                <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-pick-localisation">
                                     Annuler
                                 </button>
                             </li>

--- a/templates/_partials/_modal_refus_affectation.html.twig
+++ b/templates/_partials/_modal_refus_affectation.html.twig
@@ -50,7 +50,8 @@
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                    <button type="button"
+                                            class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="refus-signalement-modal">
                                         Annuler
                                     </button>

--- a/templates/_partials/_modal_refus_signalement.html.twig
+++ b/templates/_partials/_modal_refus_signalement.html.twig
@@ -49,7 +49,8 @@
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                    <button type="button"
+                                            class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="refus-signalement-modal">
                                         Annuler
                                     </button>

--- a/templates/_partials/_modal_reopen_signalement.html.twig
+++ b/templates/_partials/_modal_reopen_signalement.html.twig
@@ -57,7 +57,8 @@
                                     </button>
                                 </li>
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                    <button type="button"
+                                            class="fr-btn fr-btn--secondary fr-icon-close-line"
                                             aria-controls="reopen{% if all == '1' %}-all{% endif %}-signalement-modal">
                                         Annuler
                                     </button>

--- a/templates/_partials/_modal_user_transfer.html.twig
+++ b/templates/_partials/_modal_user_transfer.html.twig
@@ -35,7 +35,8 @@
                                 </button>
                             </li>
                             <li>
-                                <button class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                <button type="button"
+                                        class="fr-btn fr-btn--secondary fr-icon-close-line"
                                         aria-controls="fr-modal-user-transfer">
                                     Annuler
                                 </button>


### PR DESCRIPTION
## Ticket

#3883   

## Description
Dans les modales de refus de signalement, le bouton d'annulation (qui ferme la modale) n'avait pas de type, et validait donc les formulaires.
Ajout d'un `type="button"` pour éviter ce comportement.

## Tests
- [ ] Ouvrir la modale de refus de signalement, remplir le formulaire et cliquer sur Annuler : le formulaire ne se valide pas
- [ ] Idem pour les affectation
- [ ] Idem pour la réouverture d'un signalement
