### PR TITLE
[BO - Liste signalements] Mettre en valeur les nouvelles affectations

### DIFF
--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -49,7 +49,7 @@ class SignalementAffectationHelper
         }
 
         $signalementStatus = null;
-        if (!empty($statusAffectation)) {
+        if (!empty($statusAffectation) || 0 === $statusAffectation) {
             $signalementStatus = AffectationStatus::tryFrom($statusAffectation)?->mapSignalementStatus();
         }
 

--- a/src/Service/Signalement/SignalementAffectationHelper.php
+++ b/src/Service/Signalement/SignalementAffectationHelper.php
@@ -26,11 +26,12 @@ class SignalementAffectationHelper
             }
         }
 
-        if (empty($statusAffectation)) {
-            return '';
+        $affectationStatusLabel = '';
+        if (!empty($statusAffectation) || 0 === $statusAffectation) {
+            $affectationStatusLabel = AffectationStatus::tryFrom($statusAffectation)?->label();
         }
 
-        return AffectationStatus::tryFrom($statusAffectation)?->label();
+        return $affectationStatusLabel;
     }
 
     public static function getStatusAndAffectationFrom(User $user, array $data): array


### PR DESCRIPTION
## Ticket

#3884   

## Description
Dans la liste des signalements, le statut d'affectation en attente n'était pas bien retourné, et les nouvelles affectations n'était donc pas mises en avant.

## Tests
- [ ] Se connecter en agent et vérifier l'affichage des nouvelles affectations dans la liste
