### PR TITLE
Bugfix/3879 bug carto

### DIFF
--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewCarto.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewCarto.vue
@@ -48,7 +48,7 @@ export default defineComponent({
       sharedState: store.state,
       sharedProps: store.props,
       offset: 0,
-      bounds: L.latLngBounds(L.latLng(8, -80), L.latLng(70, 20)),
+      bounds: L.latLngBounds(L.latLng(-90, -180), L.latLng(90, 180)),
       defaultCenter: [47.11, -0.01] as L.LatLngExpression,
       defaultZoom: 5,
       zonesLayer: L.layerGroup()
@@ -72,7 +72,7 @@ export default defineComponent({
       this.map = L.map('map-signalements-view', {
         center: this.defaultCenter,
         maxBounds: this.bounds,
-        minZoom: 5,
+        minZoom: 2,
         maxZoom: 18,
         zoom: this.defaultZoom
       })
@@ -136,15 +136,13 @@ export default defineComponent({
       })
     },
     adjustMapBounds () {
+      this.map?.invalidateSize();
       if (this.sharedState.signalements.list.length === 0){
         this.map?.setView(this.defaultCenter, this.defaultZoom)
       }else{
         const bounds = this.markers.getBounds()
         if (Object.keys(bounds).length !== 0) {
-          this.map?.fitBounds([
-            [bounds.getNorthEast().lat, bounds.getNorthEast().lng],
-            [bounds.getSouthWest().lat, bounds.getSouthWest().lng]
-          ])
+          this.map?.fitBounds(bounds)
         }
       }
     },

--- a/src/Command/UpdateSignalementGeolocalisationCommand.php
+++ b/src/Command/UpdateSignalementGeolocalisationCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Entity\Signalement;
+use App\Manager\HistoryEntryManager;
 use App\Repository\SignalementRepository;
 use App\Repository\TerritoryRepository;
 use App\Service\Signalement\SignalementAddressUpdater;
@@ -27,6 +28,7 @@ class UpdateSignalementGeolocalisationCommand extends Command
         private readonly TerritoryRepository $territoryRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly SignalementAddressUpdater $signalementAddressUpdater,
+        private readonly HistoryEntryManager $historyEntryManager,
     ) {
         parent::__construct();
     }
@@ -35,6 +37,8 @@ class UpdateSignalementGeolocalisationCommand extends Command
     {
         $this
             ->addOption('zip', null, InputOption::VALUE_OPTIONAL, 'Territory zip to target')
+            ->addOption('split', null, InputOption::VALUE_OPTIONAL, 'Split signalements for prevent memory limit', 0)
+            ->addOption('limit', null, InputOption::VALUE_OPTIONAL, 'full or partial')
             ->addOption('uuid', null, InputOption::VALUE_OPTIONAL, 'UUID du signalement')
             ->addOption('from_created_at', null, InputOption::VALUE_OPTIONAL, 'Get signalements data from created_at to 1 month');
     }
@@ -47,6 +51,7 @@ class UpdateSignalementGeolocalisationCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         $zip = $input->getOption('zip');
+        $split = $input->getOption('split');
         $uuid = $input->getOption('uuid');
         $fromCreatedAt = $input->getOption('from_created_at');
         $toCreatedAt = null;
@@ -57,8 +62,9 @@ class UpdateSignalementGeolocalisationCommand extends Command
         if ($uuid) {
             $signalements = $signalementRepository->findBy(['uuid' => $uuid]);
         } elseif (!empty($zip)) {
+            $this->historyEntryManager->removeEntityListeners();
             $territory = $this->territoryRepository->findOneBy(['zip' => $zip]);
-            $signalements = $signalementRepository->findWithNoGeolocalisation($territory);
+            $signalements = $signalementRepository->findSignalementsSplittedCreatedBefore($split, $territory);
         } elseif (!empty($fromCreatedAt)) {
             $fromCreatedAt = \DateTimeImmutable::createFromFormat('Y-m-d', $fromCreatedAt);
             if (false !== $fromCreatedAt) {

--- a/src/Controller/Back/CartographieController.php
+++ b/src/Controller/Back/CartographieController.php
@@ -51,7 +51,7 @@ class CartographieController extends AbstractController
         if (!empty($filters['zones'])) {
             $criteria = ['id' => $filters['zones']];
             if (!$this->isGranted('ROLE_ADMIN')) {
-                $criteria['territories'] = $user->getPartnersTerritories();
+                $criteria['territory'] = $user->getPartnersTerritories();
             }
             $zones = $zoneRepository->findBy($criteria);
             foreach ($zones as $zone) {

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1422,6 +1422,28 @@ class SignalementRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    public function findSignalementsSplittedCreatedBefore(int $split, Territory $territory): array
+    {
+        $qb = $this->createQueryBuilder('s')
+            ->where('s.territory = :territory')
+            ->setParameter('territory', $territory)
+            ->orderBy('s.createdAt', 'ASC');
+
+        if (1 === $split) {
+            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2024-02-01');
+            $qb->andWhere('s.createdAt > :afterDate')->setParameter('afterDate', '2023-01-01');
+        } elseif (2 === $split) {
+            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2023-01-01');
+            $qb->andWhere('s.createdAt > :afterDate')->setParameter('afterDate', '2021-01-01');
+        } elseif (3 === $split) {
+            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2021-01-01');
+        } else {
+            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2024-02-01');
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
     public function findOneForApi(
         User $user,
         ?string $uuid = null,


### PR DESCRIPTION
## Ticket

#3627 
#3879

## Description
- Correction de la requête de recherche avec l'utilisation du filtre zone pour les RT
- Modification de la commande `UpdateSignalementGeolocalisationCommand` afin de pouvoir l’exécuter par territoire sur les signalement antérieurs à mars 2024 
- Correction d'affichage de la carto afin que tous les point apparaissent bien dans la zone et qu'elle fonctionne sur tout le territoire (y compris dans l'hémisphère sud 

Après passage de la commande il reste quelque signalement situé dans un département X qui est enregistré dans le département Y mais c'est un autre problème, il seront à présent facilement visible via la page carto, a voir si on veux les corriger.

Liste des commandes complètes à passer pour traiter tous les territoires avec des signalements mal placés
```
make symfony cmd="app:update-signalement-geolocalisation --zip=02"
make symfony cmd="app:update-signalement-geolocalisation --zip=04"
make symfony cmd="app:update-signalement-geolocalisation --zip=06"
make symfony cmd="app:update-signalement-geolocalisation --zip=08"
make symfony cmd="app:update-signalement-geolocalisation --zip=13 --split=1"
make symfony cmd="app:update-signalement-geolocalisation --zip=13 --split=2"
make symfony cmd="app:update-signalement-geolocalisation --zip=13 --split=3"
make symfony cmd="app:update-signalement-geolocalisation --zip=17"
make symfony cmd="app:update-signalement-geolocalisation --zip=19"
make symfony cmd="app:update-signalement-geolocalisation --zip=2A"
make symfony cmd="app:update-signalement-geolocalisation --zip=29"
make symfony cmd="app:update-signalement-geolocalisation --zip=31"
make symfony cmd="app:update-signalement-geolocalisation --zip=33"
make symfony cmd="app:update-signalement-geolocalisation --zip=35"
make symfony cmd="app:update-signalement-geolocalisation --zip=38"
make symfony cmd="app:update-signalement-geolocalisation --zip=40"
make symfony cmd="app:update-signalement-geolocalisation --zip=43"
make symfony cmd="app:update-signalement-geolocalisation --zip=47"
make symfony cmd="app:update-signalement-geolocalisation --zip=54"
make symfony cmd="app:update-signalement-geolocalisation --zip=59"
make symfony cmd="app:update-signalement-geolocalisation --zip=60"
make symfony cmd="app:update-signalement-geolocalisation --zip=62"
make symfony cmd="app:update-signalement-geolocalisation --zip=63"
make symfony cmd="app:update-signalement-geolocalisation --zip=64"
make symfony cmd="app:update-signalement-geolocalisation --zip=71"
make symfony cmd="app:update-signalement-geolocalisation --zip=73"
make symfony cmd="app:update-signalement-geolocalisation --zip=81"
make symfony cmd="app:update-signalement-geolocalisation --zip=84"
```

## Pré-requis
`make npm-build`

## Tests
- [ ] Se connecter en RT sur un département ayant des zone et filtrer sur une zone
- [ ] Sur une copie de la base de prod, afficher un département de la liste des commande (ex 02, 04, 06...) voir que y'a des petit soucis. Lancer la commande correspondante et vérifier ensuite que tout s'affiche bien

