### PR TITLE
[BO - Dashboard] Mauvais compte des partenaires non notifiables sur le widget

### DIFF
--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -142,6 +142,7 @@ class PartnerRepository extends ServiceEntityRepository
         $expr = $queryBuilder->expr();
         $queryBuilder
             ->where('p.email IS NULL') // Pas d'email générique
+            ->andWhere('p.isArchive = 0')
             ->andWhere(
                 $expr->orX(
                     'up.id IS NULL', // Aucun utilisateur lié
@@ -167,7 +168,6 @@ class PartnerRepository extends ServiceEntityRepository
                 ->andWhere('p.territory IN (:territories)')
                 ->setParameter('territories', $territories);
         }
-
         try {
             $count = $queryBuilder->getQuery()->getSingleScalarResult();
         } catch (NonUniqueResultException) {


### PR DESCRIPTION
## Ticket

#3853   

## Description
La requête qui compte les partenaires non notifiables pour le dashboard n'éliminait pas les partenaires archivés

## Changements apportés
* Changement de la requête

## Pré-requis
**A tester sur base de prod**
`make clear-pool pool=--all`

## Tests
- [ ] Sur base de prod, vérifier l'adéquation entre le compte des partenaires non notifiables sur le widget du dashboard et la réalité de la liste (tester en SA dans plusieurs territoires ou en RT)
