### PR TITLE
[QA - BUG] Crash d'affichage de certains signalements

### DIFF
--- a/templates/_partials/signalement/signalement-typecomposition-etage.html.twig
+++ b/templates/_partials/signalement/signalement-typecomposition-etage.html.twig
@@ -3,7 +3,7 @@
     {% set etage = signalement.typeCompositionLogement.typeLogementAppartementEtage ?? 
         (signalement.typeCompositionLogement.typeLogementRdc == 'oui' ? EtageType.RDC.value : 
         (signalement.typeCompositionLogement.typeLogementDernierEtage == 'oui' ? EtageType.DERNIER_ETAGE.value : 
-        (signalement.typeCompositionLogement.typeLogementSousSolSansFenetre == 'oui' ? EtageType.SOUS_SOL.value : 
+        (signalement.typeCompositionLogement.typeLogementSousSolSansFenetre == 'oui' ? EtageType.SOUSSOL.value : 
         EtageType.AUTRE.value))) %}
 
     {{ EtageType.from(etage).label }}


### PR DESCRIPTION
## Ticket

#3892

## Description
Les signalement enregistré sur l'étage "SOUSOL" provoque une erreur en prod suite une typo, correction.

## Tests
- [ ] Afficher un signalement dans le BO dont l'`etageType`= 'SOUSSOL'
