### PR TITLE
[BO - Partenaires] Ajouter la compétences Visites par défaut aux partenaires Opérateurs visites et travaux

### DIFF
--- a/config/app/competences.yaml
+++ b/config/app/competences.yaml
@@ -61,5 +61,6 @@ parameters:
     - !php/enum App\Entity\Enum\Qualification::ACCOMPAGNEMENT_TRAVAUX
     - !php/enum App\Entity\Enum\Qualification::CONCILIATION
     - !php/enum App\Entity\Enum\Qualification::NON_DECENCE_ENERGETIQUE
+    - !php/enum App\Entity\Enum\Qualification::VISITES
     PREFECTURE:
     - !php/enum App\Entity\Enum\Qualification::DALO

--- a/tests/Unit/Factory/PartnerFactoryTest.php
+++ b/tests/Unit/Factory/PartnerFactoryTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Unit\Factory;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\Qualification;
 use App\Entity\Partner;
 use App\Entity\Territory;
 use App\Factory\PartnerFactory;
@@ -64,5 +65,27 @@ class PartnerFactoryTest extends KernelTestCase
         $this->assertEquals($partner->getIsArchive(), false);
         $this->assertEquals($partner->getIsCommune(), true);
         $this->assertContains('99000', $partner->getInsee());
+    }
+
+    public function testCreatePartnerInstanceWhenIsOperator(): void
+    {
+        $partner = (new PartnerFactory($this->parameterBag))->createInstanceFrom(
+            territory: new Territory(),
+            name: 'HTL',
+            email: 'htl@example.com',
+            type: PartnerType::OPERATEUR_VISITES_ET_TRAVAUX,
+            insee: '99000, 99001'
+        );
+
+        /** @var ConstraintViolationList $errors */
+        $errors = $this->validator->validate($partner);
+        $this->assertEmpty($errors, (string) $errors);
+
+        $this->assertInstanceOf(Partner::class, $partner);
+
+        $this->assertEquals($partner->getIsArchive(), false);
+        $this->assertEquals($partner->getIsCommune(), false);
+        $this->assertContains('99000', $partner->getInsee());
+        $this->assertContains(Qualification::VISITES, $partner->getCompetence());
     }
 }


### PR DESCRIPTION
## Ticket

#3819    

## Description
Ajouter la compétence VISITE par défaut aux partenaire de type OPERATEURS

## Changements apportés
* Modification de competences.yaml
* ajout d'un test

## Pré-requis

## Tests
- [ ] CI OK
- [ ] Charger une grille d'affectation avec des opérateurs et vérifier les compétences
