### PR TITLE
[Archivage agents] Pouvoir tester la commande à n'importe quelle date

### DIFF
--- a/tests/Functional/Command/Cron/NotifyAndArchiveInactiveAccountCommandTest.php
+++ b/tests/Functional/Command/Cron/NotifyAndArchiveInactiveAccountCommandTest.php
@@ -37,7 +37,7 @@ class NotifyAndArchiveInactiveAccountCommandTest extends KernelTestCase
         $this->assertStringContainsString('0 accounts archived.', $output);
         $this->assertEmailCount(2);
 
-        $mockClock->modify('+15 days');
+        $mockClock->modify('+40 days'); // to ensure matching with fixtures data not based on the mocked clock
 
         $commandTester->execute([]);
         $commandTester->assertCommandIsSuccessful();


### PR DESCRIPTION
## Ticket

#3894

## Description
- Ajout d'une option `--force` à la commande `app:notify-and-archive-inactive-accounts` afin de pouvoir tester l'archivage un autre jours que le 15 du mois
- Corrections afin que le tests de la commande fonctionne dans tous les cas (ajout de la prise en compte de la date d'archivage de l'utilisateur des fixtures en attente d'archivage

## Pré-requis
Ajouter `FEATURE_ARCHIVE_INACTIVE_ACCOUNT=1` dans son `env.test`

## Tests
- [ ] Lancer la commande  `app:notify-and-archive-inactive-accounts --force` et voir que l'archivage se fait bien qu'on ne soit pas le 15 du mois
- [ ] Vérifier que les tests se jouent sans erreur
