### PR TITLE
[Sécurité - Audit] Faille XSS avec fichier pdf contenant du javascript

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/Scalingo/wkhtmltopdf-buildpack
-https://github.com/Scalingo/clamav-buildpack#feat/yara
+https://github.com/Scalingo/clamav-buildpack
 https://github.com/Scalingo/php-buildpack

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/Scalingo/wkhtmltopdf-buildpack
-https://github.com/Scalingo/clamav-buildpack#341b560e9afef5aa90f9300ea7f61427145aaac7
+https://github.com/Scalingo/clamav-buildpack#feat/yara
 https://github.com/Scalingo/php-buildpack

--- a/clamav/data/PDF_Containing_JavaScript.yar
+++ b/clamav/data/PDF_Containing_JavaScript.yar
@@ -1,0 +1,22 @@
+rule PDF_Containing_JavaScript
+{
+    meta:
+        author         = "InQuest Labs"
+		description    = "This signature detects a PDF file that contains JavaScript. JavaScript can be used to customize PDFs by implementing objects, methods, and properties. While not inherently malicious, embedding JavaScript inside of a PDF is often used for malicious purposes such as malware delivery or exploitation."
+        created_date   = "2022-03-15"
+        updated_date   = "2022-03-15"
+        blog_reference = "www.sans.org/security-resources/malwarefaq/pdf-overview.php"
+        labs_reference = "N/A"
+        labs_pivot     = "N/A"
+        samples        = "c82e29dcaed3c71e05449cb9463f3efb7114ea22b6f45b16e09eae32db9f5bef"
+
+	strings:
+			
+		$pdf_tag1 = /\x25\x50\x44\x46\x2d/
+		$js_tag1  = "/JavaScript" fullword
+		$js_tag2  = "/JS"		  fullword
+	condition:
+			
+		$pdf_tag1 in (0..1024) and ($js_tag1 or $js_tag2)
+
+}

--- a/config/packages/clamav.yaml
+++ b/config/packages/clamav.yaml
@@ -1,5 +1,5 @@
 sineflow_clam_av:
     strategy: '%env(CLAMAV_STRATEGY)%'
     host: '%env(CLAMAV_HOST)%'
-    socket: "/app/run/clamd.sock"
+    socket: "/app/clamav/run/clamd.sock"
     port: 3310

--- a/scalingo.json
+++ b/scalingo.json
@@ -17,11 +17,5 @@
       "description": "When set to false, this environment variable instructs the application to NOT check virus in files.",
       "value": "false"
     }
-  },
-  "formation": {
-    "web": {
-      "amount": 2,
-      "size": "XL"
-    }
   }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -17,5 +17,11 @@
       "description": "When set to false, this environment variable instructs the application to NOT check virus in files.",
       "value": "false"
     }
+  },
+  "formation": {
+    "postdeploy": {
+      "amount": 1,
+      "size": "2XL"
+    }
   }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -17,5 +17,11 @@
       "description": "When set to false, this environment variable instructs the application to NOT check virus in files.",
       "value": "false"
     }
+  },
+  "formation": {
+    "web": {
+      "amount": 2,
+      "size": "XL"
+    }
   }
 }

--- a/src/Controller/Back/BackTerritoryController.php
+++ b/src/Controller/Back/BackTerritoryController.php
@@ -69,7 +69,7 @@ class BackTerritoryController extends AbstractController
             }
             if ($file) {
                 if (!$fileScanner->isClean($file->getPathname())) {
-                    $this->addFlash('error', 'Le fichier est infecté.');
+                    $this->addFlash('error', 'Par mesure de sécurité, le fichier '.$file->getClientOriginalName().' a été rejeté car il contient du code exécutable.');
 
                     return $this->redirectToRoute('back_territory_edit', ['territory' => $territory->getId()]);
                 }

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -402,7 +402,11 @@ class SignalementController extends AbstractController
             try {
                 foreach ($files as $key => $file) {
                     if (!$fileScanner->isClean($file->getPathname())) {
-                        return $this->json(['error' => 'Le fichier est infecté'], 400);
+                        if ('application/pdf' === $file->getMimeType()) {
+                            return $this->json(['error' => 'Par mesure de sécurité, le fichier '.$file->getClientOriginalName().' a été rejeté car il contient du code exécutable.'], 400);
+                        }
+
+                        return $this->json(['error' => 'Le fichier est infecté par un virus.'], 400);
                     }
                     $res = $uploadHandlerService->toTempFolder($file, $key);
                     if (\is_array($res) && isset($res['error'])) {

--- a/src/Service/Signalement/SignalementFileProcessor.php
+++ b/src/Service/Signalement/SignalementFileProcessor.php
@@ -47,7 +47,11 @@ class SignalementFileProcessor
             if ($file instanceof UploadedFile) {
                 try {
                     if (!$this->fileScanner->isClean($file->getPathname())) {
-                        $message = 'Le fichier '.$file->getClientOriginalName().' est infecté par un virus.';
+                        if ('application/pdf' === $file->getMimeType()) {
+                            $message = 'Par mesure de sécurité, le fichier '.$file->getClientOriginalName().' a été rejeté car il contient du code exécutable.';
+                        } else {
+                            $message = 'Le fichier '.$file->getClientOriginalName().' est infecté par un virus.';
+                        }
                         $this->errors[] = $message;
                         $this->logger->error($message);
                         continue;


### PR DESCRIPTION
## Ticket

#3562    

## Description
Ajout de Yara pour détecter les pdf contenant du javascript.

## Changements apportés
* Utilisation d'un buildpack clamav contenant Yara
* Ajout d'une yara rule

## Pré-requis

Se procurer un pdf avec du js : https://community.adobe.com/havfw69955/attachments/havfw69955/acrobat-sdk/86720/1/JSCollectionDemo.pdf

Tests à faire sur la reviewApp https://histologe-staging-pr3901.osc-fr1.scalingo.io/

## Tests
- [ ] Sur un signalement ajouter un pdf "normal", et vérifier qu'il s'ajoute
- [ ] Ajouter un pdf avec du js et vérifier qu'on a un message de virus
