### PR TITLE
[API] Commande pour créer un utilisateur API

### DIFF
--- a/src/Command/CreateApiPartnerUsersCommand.php
+++ b/src/Command/CreateApiPartnerUsersCommand.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Enum\PartnerType;
+use App\Entity\User;
+use App\Entity\UserPartner;
+use App\Factory\PartnerFactory;
+use App\Factory\UserFactory;
+use App\Manager\PartnerManager;
+use App\Manager\UserManager;
+use App\Repository\PartnerRepository;
+use App\Repository\TerritoryRepository;
+use App\Repository\UserRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+#[AsCommand(
+    name: 'app:create-api-partner-users',
+    description: 'Create new partner and users with API connection',
+)]
+class CreateApiPartnerUsersCommand extends Command
+{
+    public function __construct(
+        private readonly TerritoryRepository $territoryRepository,
+        private readonly PartnerRepository $partnerRepository,
+        private readonly PartnerFactory $partnerFactory,
+        private readonly PartnerManager $partnerManager,
+        private readonly UserFactory $userFactory,
+        private readonly UserPasswordHasherInterface $hasher,
+        private readonly UserManager $userManager,
+        private readonly UserRepository $userRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('api_email', null, InputOption::VALUE_REQUIRED, 'E-mail of the user with API connection')
+            ->addOption('partner_id', null, InputOption::VALUE_OPTIONAL, 'ID of an existing partner (for production purpose)')
+            ->addOption('zip', null, InputOption::VALUE_OPTIONAL, 'Territory zip to target (for testing purpose)')
+            ->addOption('partner_name', null, InputOption::VALUE_OPTIONAL, 'Name of a new partner (for testing purpose)')
+            ->addOption('bo_email', null, InputOption::VALUE_OPTIONAL, 'E-mail of the user with BO connection (for testing purpose)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $apiEmail = $input->getOption('api_email');
+
+        if (empty($apiEmail)) {
+            $io->warning('Missing required arguments');
+
+            return Command::INVALID;
+        }
+
+        $foundUserApi = $this->userRepository->findOneBy(['email' => $apiEmail]);
+        if (!empty($foundUserApi)) {
+            $io->warning('User already exists with API e-mail');
+
+            return Command::INVALID;
+        }
+
+        $partnerId = $input->getOption('partner_id');
+        $zip = $input->getOption('zip');
+        $partnerName = $input->getOption('partner_name');
+        $boEmail = $input->getOption('bo_email');
+
+        // Testing purpose: create partner and BO user, and get partner ID
+        if (!empty($zip) && !empty($partnerName) && !empty($boEmail)) {
+            $foundUserBo = $this->userRepository->findOneBy(['email' => $boEmail]);
+            if (!empty($foundUserBo)) {
+                $io->warning('User already exists with BO e-mail');
+
+                return Command::INVALID;
+            }
+
+            $territory = $this->territoryRepository->findOneBy(['zip' => $zip]);
+            $partner = $this->partnerFactory->createInstanceFrom(
+                territory: $territory,
+                name: $partnerName,
+                email: null,
+                type: PartnerType::ARS
+            );
+            $this->partnerManager->save($partner);
+            $partnerId = $partner->getId();
+
+            $boUser = $this->userFactory->createInstanceFrom(
+                roleLabel: 'Agent',
+                firstname: 'Agent',
+                lastname: 'Test',
+                email: $boEmail,
+                isMailActive: false,
+                isActivateAccountNotificationEnabled: false,
+            );
+            $password = $this->userManager->getComplexRandomPassword();
+            $passwordHashed = $this->hasher->hashPassword($boUser, $password);
+            $boUser->setStatut(User::STATUS_ACTIVE)->setPassword($passwordHashed);
+
+            $boUserPartner = (new UserPartner())->setPartner($partner)->setUser($boUser);
+            $boUser->addUserPartner($boUserPartner);
+
+            $this->userManager->persist($boUserPartner);
+            $this->userManager->save($boUser);
+
+            $io->success('BO account was created for '.$boEmail.' with password '.$password);
+        } elseif (empty($partnerId)) {
+            $io->warning('Missing optional argument: we need either a partner ID or a set of zip, partner name, bo e-mail');
+
+            return Command::INVALID;
+        }
+
+        if (empty($partner)) {
+            $partner = $this->partnerRepository->findOneBy(['id' => $partnerId]);
+        }
+
+        $user = $this->userFactory->createInstanceFrom(
+            roleLabel: 'API',
+            firstname: 'API',
+            lastname: 'Test',
+            email: $apiEmail,
+            isMailActive: false,
+            isActivateAccountNotificationEnabled: false,
+        );
+        $password = $this->userManager->getComplexRandomPassword();
+        $passwordHashed = $this->hasher->hashPassword($user, $password);
+        $user->setStatut(User::STATUS_ACTIVE)->setPassword($passwordHashed);
+
+        $userPartner = (new UserPartner())->setPartner($partner)->setUser($user);
+        $user->addUserPartner($userPartner);
+
+        $this->userManager->persist($userPartner);
+        $this->userManager->save($user);
+
+        $io->success('API account was created for '.$apiEmail.' with password '.$password);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/CreateApiPartnerUsersCommand.php
+++ b/src/Command/CreateApiPartnerUsersCommand.php
@@ -61,7 +61,10 @@ class CreateApiPartnerUsersCommand extends Command
             return Command::INVALID;
         }
 
-        $foundUserApi = $this->userRepository->findOneBy(['email' => $apiEmail]);
+        $foundUserApi = $this->userRepository->findOneBy([
+            'email' => $apiEmail,
+            'statut' => User::STATUS_ACTIVE,
+        ]);
         if (!empty($foundUserApi)) {
             $io->warning('User already exists with API e-mail');
 
@@ -75,7 +78,10 @@ class CreateApiPartnerUsersCommand extends Command
 
         // Testing purpose: create partner and BO user, and get partner ID
         if (!empty($zip) && !empty($partnerName) && !empty($boEmail)) {
-            $foundUserBo = $this->userRepository->findOneBy(['email' => $boEmail]);
+            $foundUserBo = $this->userRepository->findOneBy([
+                'email' => $boEmail,
+                'statut' => User::STATUS_ACTIVE,
+            ]);
             if (!empty($foundUserBo)) {
                 $io->warning('User already exists with BO e-mail');
 
@@ -119,6 +125,12 @@ class CreateApiPartnerUsersCommand extends Command
 
         if (empty($partner)) {
             $partner = $this->partnerRepository->findOneBy(['id' => $partnerId]);
+        }
+
+        if (empty($partner)) {
+            $io->error('No partner found');
+
+            return Command::FAILURE;
         }
 
         $user = $this->userFactory->createInstanceFrom(

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -77,6 +77,18 @@ class UserManager extends AbstractManager
         return $user;
     }
 
+    public function getComplexRandomPassword(): string
+    {
+        $keyspace = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_!:()';
+        $password = '';
+        $max = mb_strlen($keyspace, '8bit') - 1;
+        for ($i = 0; $i < 15; ++$i) {
+            $password .= $keyspace[random_int(0, $max)];
+        }
+
+        return $password;
+    }
+
     public function loadUserTokenForUser(User $user, bool $flush = true): User
     {
         $user

--- a/tests/Functional/Command/CreateApiPartnerUsersCommandTest.php
+++ b/tests/Functional/Command/CreateApiPartnerUsersCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\Functional\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CreateApiPartnerUsersCommandTest extends KernelTestCase
+{
+    public function testNewApiUserToExistingPartner(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:create-api-partner-users');
+        // --zip=44 --partner_name=Jambon --bo_email=soupe@soupe.fr"
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--api_email' => 'api-nouveau@histologe.fr',
+            '--partner_id' => 1,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testExistingApiUserToExistingPartner(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:create-api-partner-users');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--api_email' => 'api-01@histologe.fr',
+            '--partner_id' => 1,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('User already exists with API e-mail', $output, $output);
+    }
+
+    public function testNewApiUserToNewPartnerWithNewBoUser(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:create-api-partner-users');
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--api_email' => 'api-nouveau@histologe.fr',
+            '--zip' => 44,
+            '--partner_name' => 'Nouveau partenaire',
+            '--bo_email' => 'bo-nouveau@histologe.fr',
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testNewApiUserToNewPartnerWithExistingBoUser(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:create-api-partner-users');
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--api_email' => 'api-nouveau@histologe.fr',
+            '--zip' => 44,
+            '--partner_name' => 'Nouveau partenaire',
+            '--bo_email' => 'user-13-01@histologe.fr',
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('User already exists with BO e-mail', $output, $output);
+    }
+}

--- a/tests/Functional/Command/CreateApiPartnerUsersCommandTest.php
+++ b/tests/Functional/Command/CreateApiPartnerUsersCommandTest.php
@@ -18,7 +18,7 @@ class CreateApiPartnerUsersCommandTest extends KernelTestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([
-            '--api_email' => 'api-nouveau@histologe.fr',
+            '--api_email' => 'api-nouveau@signal-logement.fr',
             '--partner_id' => 1,
         ]);
 
@@ -34,7 +34,7 @@ class CreateApiPartnerUsersCommandTest extends KernelTestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([
-            '--api_email' => 'api-01@histologe.fr',
+            '--api_email' => 'api-01@signal-logement.fr',
             '--partner_id' => 1,
         ]);
 
@@ -52,10 +52,10 @@ class CreateApiPartnerUsersCommandTest extends KernelTestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([
-            '--api_email' => 'api-nouveau@histologe.fr',
+            '--api_email' => 'api-nouveau@signal-logement.fr',
             '--zip' => 44,
             '--partner_name' => 'Nouveau partenaire',
-            '--bo_email' => 'bo-nouveau@histologe.fr',
+            '--bo_email' => 'bo-nouveau@signal-logement.fr',
         ]);
 
         $commandTester->assertCommandIsSuccessful();
@@ -71,10 +71,10 @@ class CreateApiPartnerUsersCommandTest extends KernelTestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([
-            '--api_email' => 'api-nouveau@histologe.fr',
+            '--api_email' => 'api-nouveau@signal-logement.fr',
             '--zip' => 44,
             '--partner_name' => 'Nouveau partenaire',
-            '--bo_email' => 'user-13-01@histologe.fr',
+            '--bo_email' => 'user-13-01@signal-logement.fr',
         ]);
 
         $output = $commandTester->getDisplay();


### PR DESCRIPTION
## Ticket

#3808   

## Description
Afin de pouvoir utiliser l'API, on donne la possibilité de créer un compte en ligne de commande.
Et pour pouvoir tester sur la plateforme de demo, on donne aussi la possibilité de créer un partenaire de test.

## Tests
- [ ] CI OK
- [ ] Tester la commande qui ajoute un compte API dans un partenaire existant
  - `make console app="create-api-partner-users --api_email=EMAIL_API --partner_id=ID_PARTNER"`
- [ ] Tester la commande qui crée un partenaire, crée un agent qui peut se connecter et crée un compte API
  - `make console app="create-api-partner-users --api_email=EMAIL_API --zip=ZIP --partner_name=NOM_PARTNER --bo_email=EMAIL_AGENT"`
- [ ] Vérifier les commandes avec des paramètres manquants
- [ ] Vérifier les commandes avec des adresses e-mails existantes
