### PR TITLE
[BO - Formulaire pro] Faire l'onglet Désordres

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -247,6 +247,7 @@ function initBoFormSignalementDesordres() {
     window.dispatchEvent(new Event('refreshSearchCheckboxContainerEvent'))
     const zone = modal.dataset.zone
     const listCriteres = document.querySelector(`#list-critere-${zone}`)
+    const heading = listCriteres.querySelector("h3");
 
     // Vider les encarts existants
     document.querySelectorAll(`.item-critere-${zone}`).forEach(container => {
@@ -315,7 +316,9 @@ function initBoFormSignalementDesordres() {
         encart.remove();
 
         if (listCriteres.querySelectorAll(".fr-grid-row").length === 0) {
-          listCriteres.classList.add("fr-hidden");
+          heading.classList.add("fr-hidden");
+        } else {
+          heading.classList.remove("fr-hidden");
         }
 
         window.dispatchEvent(new Event('refreshSearchCheckboxContainerEvent'));
@@ -323,9 +326,9 @@ function initBoFormSignalementDesordres() {
 
     });
     if (nbCriteres > 0 ){
-      listCriteres.classList.remove("fr-hidden")
+      heading.classList.remove("fr-hidden")
     } else {
-      listCriteres.classList.add("fr-hidden")
+      heading.classList.add("fr-hidden")
     }
   }
 

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -358,8 +358,10 @@ function initBoFormSignalementDesordres() {
       if ('' != inputTextElement.value) {
         detailsCritereElement.innerHTML = 'Commentaire : <i>'+inputTextElement.value+'</i>'      
         if ('desordres_batiment_nuisibles_autres' == modal.dataset.critereslug){
-          hasPrecisionsChosen = true;
+          hasPrecisionsChosen = true; // ce désordre doit automatiquement avoir un commentaire
         }
+      } else if ('desordres_logement_nuisibles_autres' == modal.dataset.critereslug) {
+        hasPrecisionsChosen = false; // ce désordre doit automatiquement avoir un commentaire + une précision (géré ligne 338)
       }
     }
 

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -264,20 +264,25 @@ function initBoFormSignalementDesordres() {
       let encart = document.createElement("div");
       encart.classList.add("fr-grid-row", "fr-p-3v", "fr-mb-3v", "fr-grid-row--top", "fr-border--grey", `item-critere-${zone}`);
       encart.id = `item-critere-${critereId}`
-      // TODO : changer la couleur de la bordure et mettre un warning, si précision pas choisie alors que devrait 
       encart.innerHTML = `
         <div class="fr-col-12 fr-col-md-8">
           ${critereLabel}
         </div>`
       let modalId = `modal-precisions-${critereId}`
       let modalElement = document.getElementById(modalId) ;
+      const buttonDeleteCritereHtml = `<button class="fr-a-edit fr-btn--icon-left fr-icon-delete-line delete-critere-btn" 
+                title="Supprimer le désordre">
+                    Supprimer
+            </button>`;
       if (modalElement) {
-        encart.innerHTML += `<div class="fr-col-12 fr-col-md-4 fr-text--right">
+        encart.innerHTML += `
+          <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <a href="#" aria-controls="${modalId}" data-fr-opened="false" 
                 class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
                 title="Editer les détails" data-fr-js-modal-button="true">
                     Editer les détails
-            </a>  
+            </a>  <br> 
+            ${buttonDeleteCritereHtml}
           </div>
           <div class="fr-col-12">
             <ul class="fr-list" data-precisions="${checkbox.value}">
@@ -287,6 +292,8 @@ function initBoFormSignalementDesordres() {
             <p class="fr-hidden fr-error-text"></p>
           </div>
         `;
+      }else{
+        encart.innerHTML += `<div class="fr-col-12 fr-col-md-4 fr-text--right">${buttonDeleteCritereHtml}</div>`;
       }
 
       // Ajouter l'encart dans la bonne colonne (Logement ou Bâtiment)
@@ -295,6 +302,23 @@ function initBoFormSignalementDesordres() {
       if (modalElement) {
         updateSelectedPrecisions(modalElement)
       }
+      
+      const deleteCritereBtn = encart.querySelector(`.delete-critere-btn`);
+      deleteCritereBtn.addEventListener("click", function (e) {
+        e.preventDefault();
+        
+        if (checkbox) checkbox.checked = false;
+        if (modalElement) {
+          modalElement.querySelectorAll("input[type='checkbox']").forEach(cb => cb.checked = false);
+        }
+        encart.remove();
+
+        if (listCriteres.querySelectorAll(".fr-grid-row").length === 0) {
+          listCriteres.classList.add("fr-hidden");
+        }
+
+        window.dispatchEvent(new Event('refreshSearchCheckboxContainerEvent'));
+      });
 
     });
     if (nbCriteres > 0 ){

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -244,6 +244,7 @@ function initBoFormSignalementDesordres() {
   });
 
   function updateSelectedCriteres(modal) {
+    window.dispatchEvent(new Event('refreshSearchCheckboxContainerEvent'))
     let zone = modal.dataset.zone
     let listCriteres = document.querySelector(`#list-critere-${zone}`)
 
@@ -314,10 +315,10 @@ function initBoFormSignalementDesordres() {
       let checkboxes = modal.querySelectorAll("input[type='checkbox']");
       checkboxes.forEach(checkbox => {
         if (checkbox.checked) {
-          let precisionLabel = checkbox.labels[0].textContent;
+          let precisionLabel = checkbox.labels[0].innerHTML;
           let precisionId = checkbox.value;
           let precisionItem = document.createElement("li");
-          precisionItem.textContent = precisionLabel;
+          precisionItem.innerHTML = precisionLabel;
           ulElement.appendChild(precisionItem);
           hasPrecisionsChosen = true;
         }

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -27,7 +27,7 @@ function saveCurrentTab(event) {
   const currentTab = document?.querySelector('.fr-tabs__panel.fr-tabs__panel--selected')
   currentTab.classList.add('fr-tabs__panel--saving')
   const currentTabName = currentTab.id.substring(9, currentTab.id.length - 6)
-
+  
   let formData = null
   let formAction = null
   if (event.type === 'submit') {
@@ -123,7 +123,6 @@ function initBoFormSignalementSubmit(tabName) {
       boFormSignalementCurrentTabIsDirty = true
     })
   })
-
   switch (tabName) {
     case 'adresse':
       initComponentAdress('#signalement_draft_address_adresseCompleteOccupant')
@@ -138,6 +137,9 @@ function initBoFormSignalementSubmit(tabName) {
       initBoFormSignalementCoordonnees()
       initComponentAdress('#signalement_draft_coordonnees_adresseCompleteProprio')
       initComponentAdress('#signalement_draft_coordonnees_adresseCompleteAgence')
+      break
+    case 'desordres':
+      initBoFormSignalementDesordres()
       break
   }
 }
@@ -220,6 +222,115 @@ if (document?.querySelector('#bo-form-signalement-situation')) {
 }
 if (document?.querySelector('#bo-form-signalement-coordonnees')) {
   initBoFormSignalementSubmit('coordonnees')
+}
+
+if (document?.querySelector('#bo-form-signalement-desordres')) {
+  initBoFormSignalementSubmit('desordres')
+}
+
+function initBoFormSignalementDesordres() {
+  console.log('initBoFormSignalementDesordres')
+
+
+  // Gestion de la fermeture des modales de sélection des critères
+  document.querySelectorAll(".valid-add-critere").forEach(openModalBtn => {
+    openModalBtn.addEventListener("click", function () {
+      updateSelectedCriteres(openModalBtn.closest('dialog'));
+    });
+  });
+
+  // Gestion de la fermeture des modales d'édition des précisions
+  document.querySelectorAll(".valid-edit-precisions").forEach(openModalBtn => {
+    openModalBtn.addEventListener("click", function () {
+      updateSelectedPrecisions(openModalBtn.closest('dialog'));
+    });
+  });
+
+  function updateSelectedCriteres(modal) {
+    console.log("Mise à jour des critères sélectionnés");
+    let zone = modal.dataset.zone
+    let listCriteres = document.querySelector(`#list-critere-${zone}`)
+
+    // Vider les encarts existants
+    document.querySelectorAll(`.item-critere-${zone}`).forEach(container => {
+      container.remove(); 
+    });
+
+    let nbCriteres = 0
+    // Récupérer les critères sélectionnés
+    modal.querySelectorAll("input[type='checkbox']:checked").forEach(checkbox => {
+      nbCriteres++
+      let critereLabel = checkbox.labels[0].innerText
+      let critereId = checkbox.value
+      console.log(critereId)
+
+      // Créer un encart pour le critère sélectionné
+      let encart = document.createElement("div");
+      encart.classList.add("fr-grid-row", "fr-p-3v", "fr-mb-3v", "fr-grid-row--top", "fr-border--grey", `item-critere-${zone}`);
+      encart.id = `item-critere-${critereId}`
+      // TODO : changer la couleur de la bordure et mettre un warning, si précision pas choisie alors que devrait 
+      encart.innerHTML = `
+        <div class="fr-col-12 fr-col-md-8">
+          ${critereLabel}
+        </div>`
+      let modalId = `modal-precisions-signalement_draft_desordres_precisions_${critereId}`
+      let modalElement = document.getElementById(modalId);
+      if (modalElement) {
+        encart.innerHTML += `<div class="fr-col-12 fr-col-md-4 fr-text--right">
+            <a href="#" aria-controls="modal-precisions-signalement_draft_desordres_precisions_${critereId}" data-fr-opened="false" 
+                class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
+                title="Editer les détails" data-fr-js-modal-button="true">
+                    Editer les détails
+            </a>  
+          </div>
+          <div class="fr-col-12">
+            <ul class="fr-list" data-precisions="${checkbox.value}">
+              <!-- Les précisions seront injectées ici -->
+            </ul>
+          </div>
+        `;
+      }
+
+      // Ajouter l'encart dans la bonne colonne (Logement ou Bâtiment)
+      listCriteres
+        .appendChild(encart);
+      if (modalElement) {
+        updateSelectedPrecisions(modalElement)
+      }
+
+    });
+    console.log(nbCriteres)
+    if (nbCriteres > 0 ){
+      listCriteres.classList.remove("fr-hidden")
+    } else {
+      listCriteres.classList.add("fr-hidden")
+    }
+  }
+
+  function updateSelectedPrecisions(modal) {
+    console.log("Mise à jour des précisions sélectionnées");
+    console.log(modal)
+    let critereId = modal.dataset.critereid
+    let precisionContainer = document.querySelector(`#item-critere-${critereId}`);
+
+    let ulElement = precisionContainer ? precisionContainer.querySelector("ul") : null;
+
+    if (ulElement) {
+      ulElement.innerHTML = ""; // Vider les précisions existantes
+      let checkboxes = modal.querySelectorAll("input[type='checkbox']");
+      checkboxes.forEach(checkbox => {
+        if (checkbox.checked) { // Vérifier l'état checked manuellement
+          let precisionLabel = checkbox.labels[0].textContent;
+          let precisionId = checkbox.value;
+          let precisionItem = document.createElement("li");
+          precisionItem.textContent = precisionLabel;
+          ulElement.appendChild(precisionItem);
+        }
+      });
+    }
+  }
+  updateSelectedCriteres(document.getElementById("fr-modal-desordres-batiment-add"))
+  updateSelectedCriteres(document.getElementById("fr-modal-desordres-logement-add"))
 }
 
 function initComponentAdress(id) {

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -229,9 +229,6 @@ if (document?.querySelector('#bo-form-signalement-desordres')) {
 }
 
 function initBoFormSignalementDesordres() {
-  console.log('initBoFormSignalementDesordres')
-
-
   // Gestion de la fermeture des modales de sélection des critères
   document.querySelectorAll(".valid-add-critere").forEach(openModalBtn => {
     openModalBtn.addEventListener("click", function () {
@@ -247,7 +244,6 @@ function initBoFormSignalementDesordres() {
   });
 
   function updateSelectedCriteres(modal) {
-    console.log("Mise à jour des critères sélectionnés");
     let zone = modal.dataset.zone
     let listCriteres = document.querySelector(`#list-critere-${zone}`)
 
@@ -262,7 +258,6 @@ function initBoFormSignalementDesordres() {
       nbCriteres++
       let critereLabel = checkbox.labels[0].innerText
       let critereId = checkbox.value
-      console.log(critereId)
 
       // Créer un encart pour le critère sélectionné
       let encart = document.createElement("div");
@@ -273,11 +268,11 @@ function initBoFormSignalementDesordres() {
         <div class="fr-col-12 fr-col-md-8">
           ${critereLabel}
         </div>`
-      let modalId = `modal-precisions-signalement_draft_desordres_precisions_${critereId}`
-      let modalElement = document.getElementById(modalId);
+      let modalId = `modal-precisions-${critereId}`
+      let modalElement = document.getElementById(modalId) ;
       if (modalElement) {
         encart.innerHTML += `<div class="fr-col-12 fr-col-md-4 fr-text--right">
-            <a href="#" aria-controls="modal-precisions-signalement_draft_desordres_precisions_${critereId}" data-fr-opened="false" 
+            <a href="#" aria-controls="${modalId}" data-fr-opened="false" 
                 class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
                 title="Editer les détails" data-fr-js-modal-button="true">
                     Editer les détails
@@ -287,6 +282,8 @@ function initBoFormSignalementDesordres() {
             <ul class="fr-list" data-precisions="${checkbox.value}">
               <!-- Les précisions seront injectées ici -->
             </ul>
+            <span></span>
+            <p class="fr-hidden fr-error-text"></p>
           </div>
         `;
       }
@@ -299,7 +296,6 @@ function initBoFormSignalementDesordres() {
       }
 
     });
-    console.log(nbCriteres)
     if (nbCriteres > 0 ){
       listCriteres.classList.remove("fr-hidden")
     } else {
@@ -308,25 +304,50 @@ function initBoFormSignalementDesordres() {
   }
 
   function updateSelectedPrecisions(modal) {
-    console.log("Mise à jour des précisions sélectionnées");
-    console.log(modal)
     let critereId = modal.dataset.critereid
     let precisionContainer = document.querySelector(`#item-critere-${critereId}`);
 
+    let hasPrecisionsChosen = false;
     let ulElement = precisionContainer ? precisionContainer.querySelector("ul") : null;
-
     if (ulElement) {
-      ulElement.innerHTML = ""; // Vider les précisions existantes
+      ulElement.innerHTML = "";
       let checkboxes = modal.querySelectorAll("input[type='checkbox']");
       checkboxes.forEach(checkbox => {
-        if (checkbox.checked) { // Vérifier l'état checked manuellement
+        if (checkbox.checked) {
           let precisionLabel = checkbox.labels[0].textContent;
           let precisionId = checkbox.value;
           let precisionItem = document.createElement("li");
           precisionItem.textContent = precisionLabel;
           ulElement.appendChild(precisionItem);
+          hasPrecisionsChosen = true;
         }
       });
+    }
+
+    if ('desordres_batiment_nuisibles_autres' == modal.dataset.critereslug
+      || 'desordres_logement_nuisibles_autres' == modal.dataset.critereslug
+    ){
+      let spanElement = precisionContainer ? precisionContainer.querySelector("span") : null;
+      spanElement.innerHTML = ''
+      let inputTextElement = modal.querySelector("input[type='text']");
+      if ('' != inputTextElement.value) {
+        spanElement.innerHTML = 'Commentaire : <i>'+inputTextElement.value+'</i>'      
+        if ('desordres_batiment_nuisibles_autres' == modal.dataset.critereslug){
+          hasPrecisionsChosen = true;
+        }
+      }
+    }
+
+    let errorElement = precisionContainer ? precisionContainer.querySelector("p") : null;
+    if (hasPrecisionsChosen) {
+      precisionContainer.classList.add('fr-border--grey')
+      precisionContainer.classList.remove('fr-border--red')
+      errorElement.classList.add('fr-hidden')
+    } else {
+      precisionContainer.classList.remove('fr-border--grey')
+      precisionContainer.classList.add('fr-border--red')
+      errorElement.innerHTML = 'Veuillez renseigner les détails du désordre'  
+      errorElement.classList.remove('fr-hidden')
     }
   }
   updateSelectedCriteres(document.getElementById("fr-modal-desordres-batiment-add"))

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -247,7 +247,7 @@ function initBoFormSignalementDesordres() {
     window.dispatchEvent(new Event('refreshSearchCheckboxContainerEvent'))
     const zone = modal.dataset.zone
     const listCriteres = document.querySelector(`#list-critere-${zone}`)
-    const heading = listCriteres.querySelector("h3");
+    const heading = listCriteres.querySelector("h4");
 
     // Vider les encarts existants
     document.querySelectorAll(`.item-critere-${zone}`).forEach(container => {

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -245,8 +245,8 @@ function initBoFormSignalementDesordres() {
 
   function updateSelectedCriteres(modal) {
     window.dispatchEvent(new Event('refreshSearchCheckboxContainerEvent'))
-    let zone = modal.dataset.zone
-    let listCriteres = document.querySelector(`#list-critere-${zone}`)
+    const zone = modal.dataset.zone
+    const listCriteres = document.querySelector(`#list-critere-${zone}`)
 
     // Vider les encarts existants
     document.querySelectorAll(`.item-critere-${zone}`).forEach(container => {
@@ -257,8 +257,8 @@ function initBoFormSignalementDesordres() {
     // Récupérer les critères sélectionnés
     modal.querySelectorAll("input[type='checkbox']:checked").forEach(checkbox => {
       nbCriteres++
-      let critereLabel = checkbox.labels[0].innerText
-      let critereId = checkbox.value
+      const critereLabel = checkbox.labels[0].innerText
+      const critereId = checkbox.value
 
       // Créer un encart pour le critère sélectionné
       let encart = document.createElement("div");
@@ -268,8 +268,8 @@ function initBoFormSignalementDesordres() {
         <div class="fr-col-12 fr-col-md-8">
           ${critereLabel}
         </div>`
-      let modalId = `modal-precisions-${critereId}`
-      let modalElement = document.getElementById(modalId) ;
+      const modalId = `modal-precisions-${critereId}`
+      const modalElement = document.getElementById(modalId) ;
       const buttonDeleteCritereHtml = `<button class="fr-a-edit fr-btn--icon-left fr-icon-delete-line delete-critere-btn" 
                 title="Supprimer le désordre">
                     Supprimer
@@ -288,7 +288,7 @@ function initBoFormSignalementDesordres() {
             <ul class="fr-list" data-precisions="${checkbox.value}">
               <!-- Les précisions seront injectées ici -->
             </ul>
-            <span></span>
+            <span id="details-critere"></span>
             <p class="fr-hidden fr-error-text"></p>
           </div>
         `;
@@ -310,6 +310,7 @@ function initBoFormSignalementDesordres() {
         if (checkbox) checkbox.checked = false;
         if (modalElement) {
           modalElement.querySelectorAll("input[type='checkbox']").forEach(cb => cb.checked = false);
+          modalElement.querySelectorAll("input[type='text']").forEach(inputTextElement => inputTextElement.value = null);
         }
         encart.remove();
 
@@ -329,19 +330,18 @@ function initBoFormSignalementDesordres() {
   }
 
   function updateSelectedPrecisions(modal) {
-    let critereId = modal.dataset.critereid
-    let precisionContainer = document.querySelector(`#item-critere-${critereId}`);
+    const critereId = modal.dataset.critereid
+    const precisionContainer = document.querySelector(`#item-critere-${critereId}`);
 
     let hasPrecisionsChosen = false;
-    let ulElement = precisionContainer ? precisionContainer.querySelector("ul") : null;
+    const ulElement = precisionContainer ? precisionContainer.querySelector("ul") : null;
     if (ulElement) {
       ulElement.innerHTML = "";
-      let checkboxes = modal.querySelectorAll("input[type='checkbox']");
+      const checkboxes = modal.querySelectorAll("input[type='checkbox']");
       checkboxes.forEach(checkbox => {
         if (checkbox.checked) {
-          let precisionLabel = checkbox.labels[0].innerHTML;
-          let precisionId = checkbox.value;
-          let precisionItem = document.createElement("li");
+          const precisionLabel = checkbox.labels[0].innerHTML;
+          const precisionItem = document.createElement("li");
           precisionItem.innerHTML = precisionLabel;
           ulElement.appendChild(precisionItem);
           hasPrecisionsChosen = true;
@@ -352,18 +352,18 @@ function initBoFormSignalementDesordres() {
     if ('desordres_batiment_nuisibles_autres' == modal.dataset.critereslug
       || 'desordres_logement_nuisibles_autres' == modal.dataset.critereslug
     ){
-      let spanElement = precisionContainer ? precisionContainer.querySelector("span") : null;
-      spanElement.innerHTML = ''
-      let inputTextElement = modal.querySelector("input[type='text']");
+      const detailsCritereElement = precisionContainer ? precisionContainer.querySelector("#details-critere") : null;
+      detailsCritereElement.innerHTML = ''
+      const inputTextElement = modal.querySelector("input[type='text']");
       if ('' != inputTextElement.value) {
-        spanElement.innerHTML = 'Commentaire : <i>'+inputTextElement.value+'</i>'      
+        detailsCritereElement.innerHTML = 'Commentaire : <i>'+inputTextElement.value+'</i>'      
         if ('desordres_batiment_nuisibles_autres' == modal.dataset.critereslug){
           hasPrecisionsChosen = true;
         }
       }
     }
 
-    let errorElement = precisionContainer ? precisionContainer.querySelector("p") : null;
+    const errorElement = precisionContainer ? precisionContainer.querySelector("p") : null;
     if (hasPrecisionsChosen) {
       precisionContainer.classList.add('fr-border--grey')
       precisionContainer.classList.remove('fr-border--red')

--- a/assets/scripts/vanilla/services/component_search_checkbox.js
+++ b/assets/scripts/vanilla/services/component_search_checkbox.js
@@ -1,63 +1,67 @@
-document.querySelectorAll('.search-checkbox-container')?.forEach(element => {
-  searchCheckboxCompleteInputValue(element)
-  const input = element.querySelector('input[type="text"]')
-  const checkboxesContainer = element.querySelector('.search-checkbox')
-  // init values
-  const initialValues = []
-  checkboxesContainer.querySelectorAll('input[type="checkbox"]:checked').forEach((checkbox) => {
-    initialValues.push(checkbox.value)
-  })
-  // init order
-  checkboxesContainer.querySelectorAll('.fr-fieldset__element').forEach((checkbox, index) => {
-    checkbox.setAttribute('data-order', index)
-  })
-  // show choices on focus
-  input.addEventListener('focus', function () {
-    const elements = checkboxesContainer.querySelectorAll('.fr-fieldset__element')
-    if (!elements.length) {
-      checkboxesContainer.style.display = 'block'
-      return
-    }
-    elements.forEach((checkbox) => {
-      checkbox.style.display = ''
+
+window.addEventListener('refreshSearchCheckboxContainerEvent', (e) => {
+  document.querySelectorAll('.search-checkbox-container')?.forEach(element => {
+    searchCheckboxCompleteInputValue(element)
+    const input = element.querySelector('input[type="text"]')
+    const checkboxesContainer = element.querySelector('.search-checkbox')
+    // init values
+    const initialValues = []
+    checkboxesContainer.querySelectorAll('input[type="checkbox"]:checked').forEach((checkbox) => {
+      initialValues.push(checkbox.value)
     })
-    checkboxesContainer.style.display = 'block'
-    checkboxesContainer.scrollTop = 0
-    searchCheckboxOrderCheckboxes(element)
-    input.value = ''
-  })
-  // filter choices on input keyup
-  input.addEventListener('keyup', function () {
-    const value = input.value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
-    checkboxesContainer.querySelectorAll('.fr-fieldset__element').forEach((checkbox) => {
-      const text = checkbox.querySelector('label').textContent.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
-      if (text.includes(value)) {
+    // init order
+    checkboxesContainer.querySelectorAll('.fr-fieldset__element').forEach((checkbox, index) => {
+      checkbox.setAttribute('data-order', index)
+    })
+    // show choices on focus
+    input.addEventListener('focus', function () {
+      const elements = checkboxesContainer.querySelectorAll('.fr-fieldset__element')
+      if (!elements.length) {
+        checkboxesContainer.style.display = 'block'
+        return
+      }
+      elements.forEach((checkbox) => {
         checkbox.style.display = ''
-      } else {
-        checkbox.style.display = 'none'
+      })
+      checkboxesContainer.style.display = 'block'
+      checkboxesContainer.scrollTop = 0
+      searchCheckboxOrderCheckboxes(element)
+      input.value = ''
+    })
+    // filter choices on input keyup
+    input.addEventListener('keyup', function () {
+      const value = input.value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+      checkboxesContainer.querySelectorAll('.fr-fieldset__element').forEach((checkbox) => {
+        const text = checkbox.querySelector('label').textContent.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+        if (text.includes(value)) {
+          checkbox.style.display = ''
+        } else {
+          checkbox.style.display = 'none'
+        }
+      })
+    })
+    // hide choices on click outside
+    document.addEventListener('click', function (event) {
+      if (!input.contains(event.target) && !checkboxesContainer.contains(event.target)) {
+        checkboxesContainer.style.display = 'none'
+        searchCheckboxCompleteInputValue(element)
+        searchCheckboxTriggerChange(element, initialValues)
       }
     })
-  })
-  // hide choices on click outside
-  document.addEventListener('click', function (event) {
-    if (!input.contains(event.target) && !checkboxesContainer.contains(event.target)) {
-      checkboxesContainer.style.display = 'none'
-      searchCheckboxCompleteInputValue(element)
-      searchCheckboxTriggerChange(element, initialValues)
-    }
-  })
-  element.addEventListener('click', function (event) {
-    event.stopPropagation()
-  })
-  // reorder on uncheck
-  checkboxesContainer.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
-    checkbox.addEventListener('change', function () {
-      if (!checkbox.checked && checkbox.closest('.fr-fieldset__element').classList.contains('topped')) {
-        searchCheckboxOrderCheckboxes(element)
-      }
+    element.addEventListener('click', function (event) {
+      event.stopPropagation()
+    })
+    // reorder on uncheck
+    checkboxesContainer.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+      checkbox.addEventListener('change', function () {
+        if (!checkbox.checked && checkbox.closest('.fr-fieldset__element').classList.contains('topped')) {
+          searchCheckboxOrderCheckboxes(element)
+        }
+      })
     })
   })
 })
+window.dispatchEvent(new Event('refreshSearchCheckboxContainerEvent'))
 
 function searchCheckboxCompleteInputValue (element) {
   const input = element.querySelector('input[type="text"]')

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -156,6 +156,10 @@ pre {
     border: 1px solid #dddddd;
 }
 
+.fr-border--red {
+    border: 1px solid #ce0500;
+}
+
 .fr-border--bottom--orange {
     border-bottom: 3px solid #FF9940;
 }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -609,6 +609,10 @@ hr.blue-border {
     z-index: 1;
 }
 
+.fr-zindex-100 {
+    z-index: 100 !important;
+}
+
 #signalement_dateNaissanceOccupant_day, #signalement_dateNaissanceOccupant_month {
     border-right: 1px solid black;
 }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -152,6 +152,10 @@ pre {
     border: 1px solid #000091;
 }
 
+.fr-border--grey {
+    border: 1px solid #dddddd;
+}
+
 .fr-border--bottom--orange {
     border-bottom: 3px solid #FF9940;
 }

--- a/migrations/Version20250331141709.php
+++ b/migrations/Version20250331141709.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250331141709 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add label for 2 DesordrePrecision';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE desordre_precision SET label = "Le logement n\'est pas sous un toit" WHERE desordre_precision_slug = "desordres_batiment_isolation_dernier_etage_toit_sous_toit_non"');
+        $this->addSql('UPDATE desordre_precision SET label = "Le logement est à un étage supérieur" WHERE desordre_precision_slug = "desordres_batiment_isolation_infiltration_eau_au_sol_non"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE desordre_precision SET label = "" WHERE desordre_precision_slug = "desordres_batiment_isolation_dernier_etage_toit_sous_toit_non"');
+        $this->addSql('UPDATE desordre_precision SET label = "" WHERE desordre_precision_slug = "desordres_batiment_isolation_infiltration_eau_au_sol_non"');
+    }
+}

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -141,48 +141,6 @@ class SignalementCreateController extends AbstractController
         ]);
     }
 
-    #[Route('/bo-form-desordres/{uuid:signalement}', name: 'back_signalement_draft_form_desordres_edit', methods: ['POST'])]
-    public function editFormDesordres(
-        Signalement $signalement,
-        Request $request,
-        EntityManagerInterface $entityManager,
-        SignalementDesordresProcessor $signalementDesordresProcessor,
-    ): Response {
-        $this->denyAccessUnlessGranted('SIGN_EDIT_DRAFT', $signalement);
-
-        $entityManager->beginTransaction();
-        $action = $this->generateUrl('back_signalement_draft_form_desordres_edit', ['uuid' => $signalement->getUuid()]);
-        $form = $this->createForm(SignalementDraftDesordresType::class, $signalement, ['action' => $action]);
-        $form->handleRequest($request);
-        $criteresByZone = $signalementDesordresProcessor->processDesordresByZone($signalement);
-        if ($form->isSubmitted() && $form->isValid() && $this->signalementBoManager->formDesordresManager($form, $signalement)) {
-            $this->signalementManager->save($signalement);
-            $entityManager->commit();
-            if ($form->get('draft')->isClicked()) { // @phpstan-ignore-line
-                $this->addFlash('success', 'Le brouillon est bien enregistré, n\'oubliez pas de le terminer !');
-                $url = $this->generateUrl('back_signalement_drafts', [], UrlGeneratorInterface::ABSOLUTE_URL);
-            } else {
-                $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'coordonnees'], UrlGeneratorInterface::ABSOLUTE_URL);
-            }
-
-            $tabContent = $this->renderView('back/signalement_create/tabs/tab-desordres.html.twig', [
-                'formDesordres' => $form,
-                'signalement' => $signalement,
-                'criteresByZone' => $criteresByZone,
-            ]);
-
-            return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
-        }
-
-        $tabContent = $this->renderView('back/signalement_create/tabs/tab-desordres.html.twig', [
-            'formDesordres' => $form,
-            'signalement' => $signalement,
-            'criteresByZone' => $criteresByZone,
-        ]);
-
-        return $this->json(['tabContent' => $tabContent]);
-    }
-
     #[Route('/brouillon/{uuid:signalement}/liste-fichiers', name: 'back_signalement_create_file_list', methods: ['GET'])]
     public function getSignalementFileList(
         Signalement $signalement,
@@ -363,6 +321,48 @@ class SignalementCreateController extends AbstractController
         }
 
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-coordonnees.html.twig', ['formCoordonnees' => $form, 'signalement' => $signalement]);
+
+        return $this->json(['tabContent' => $tabContent]);
+    }
+    
+    #[Route('/bo-form-desordres/{uuid:signalement}', name: 'back_signalement_draft_form_desordres_edit', methods: ['POST'])]
+    public function editFormDesordres(
+        Signalement $signalement,
+        Request $request,
+        EntityManagerInterface $entityManager,
+        SignalementDesordresProcessor $signalementDesordresProcessor,
+    ): Response {
+        $this->denyAccessUnlessGranted('SIGN_EDIT_DRAFT', $signalement);
+
+        $entityManager->beginTransaction();
+        $action = $this->generateUrl('back_signalement_draft_form_desordres_edit', ['uuid' => $signalement->getUuid()]);
+        $form = $this->createForm(SignalementDraftDesordresType::class, $signalement, ['action' => $action]);
+        $form->handleRequest($request);
+        $criteresByZone = $signalementDesordresProcessor->processDesordresByZone($signalement);
+        if ($form->isSubmitted() && $form->isValid() && $this->signalementBoManager->formDesordresManager($form, $signalement)) {
+            $this->signalementManager->save($signalement);
+            $entityManager->commit();
+            if ($form->get('draft')->isClicked()) { // @phpstan-ignore-line
+                $this->addFlash('success', 'Le brouillon est bien enregistré, n\'oubliez pas de le terminer !');
+                $url = $this->generateUrl('back_signalement_drafts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+            } else {
+                $url = '';
+            }
+
+            $tabContent = $this->renderView('back/signalement_create/tabs/tab-desordres.html.twig', [
+                'formDesordres' => $form,
+                'signalement' => $signalement,
+                'criteresByZone' => $criteresByZone,
+            ]);
+
+            return $this->json(['redirect' => true, 'url' => $url, 'tabContent' => $tabContent]);
+        }
+
+        $tabContent = $this->renderView('back/signalement_create/tabs/tab-desordres.html.twig', [
+            'formDesordres' => $form,
+            'signalement' => $signalement,
+            'criteresByZone' => $criteresByZone,
+        ]);
 
         return $this->json(['tabContent' => $tabContent]);
     }

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -324,7 +324,7 @@ class SignalementCreateController extends AbstractController
 
         return $this->json(['tabContent' => $tabContent]);
     }
-    
+
     #[Route('/bo-form-desordres/{uuid:signalement}', name: 'back_signalement_draft_form_desordres_edit', methods: ['POST'])]
     public function editFormDesordres(
         Signalement $signalement,

--- a/src/DataFixtures/Files/DesordrePrecision.yml
+++ b/src/DataFixtures/Files/DesordrePrecision.yml
@@ -83,7 +83,7 @@ desordre_precision:
     desordre_critere_slug: "desordres_batiment_isolation_dernier_etage_toit" 
     coef: 2
     is_danger: 0
-    label: ""
+    label: "Le logement n'est pas sous un toit"
     qualification: ['NON_DECENCE', 'RSD', 'MISE_EN_SECURITE_PERIL']
     desordre_precision_slug: "desordres_batiment_isolation_dernier_etage_toit_sous_toit_non"
     is_suroccupation: 0
@@ -115,7 +115,7 @@ desordre_precision:
     desordre_critere_slug: "desordres_batiment_isolation_infiltration_eau" 
     coef: 2
     is_danger: 0
-    label: ""
+    label: "Le logement est à un étage supérieur"
     qualification: ['NON_DECENCE', 'RSD']
     desordre_precision_slug: "desordres_batiment_isolation_infiltration_eau_au_sol_non"
     is_suroccupation: 0

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2471,6 +2471,13 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         return $this;
     }
 
+    public function removeAllDesordreCategory(): self
+    {
+        $this->desordreCategories->clear();
+
+        return $this;
+    }
+
     /**
      * @return Collection<int, DesordreCritere>
      */
@@ -2495,6 +2502,13 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         return $this;
     }
 
+    public function removeAllDesordreCritere(): self
+    {
+        $this->desordreCriteres->clear();
+
+        return $this;
+    }
+
     /**
      * @return Collection<int, DesordrePrecision>
      */
@@ -2515,6 +2529,13 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function removeDesordrePrecision(DesordrePrecision $desordrePrecision): self
     {
         $this->desordrePrecisions->removeElement($desordrePrecision);
+
+        return $this;
+    }
+
+    public function removeAllDesordrePrecision(): self
+    {
+        $this->desordrePrecisions->clear();
 
         return $this;
     }

--- a/src/Form/SignalementDraftDesordresType.php
+++ b/src/Form/SignalementDraftDesordresType.php
@@ -134,16 +134,16 @@ class SignalementDraftDesordresType extends AbstractType
             ->add('forceSave', HiddenType::class, ['mapped' => false])
             ->add('previous', SubmitType::class, [
                 'label' => 'Précédent',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary', 'data-target' => 'coordonnees', 'value' => 'previous'],
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
             ->add('draft', SubmitType::class, [
                 'label' => 'Finir plus tard',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline', 'value' => 'later'],
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Suivant',
-                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right'],
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right', 'data-target' => 'validation', 'value' => 'next'],
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ]);
     }
@@ -163,6 +163,8 @@ class SignalementDraftDesordresType extends AbstractType
         foreach ($critere->getDesordrePrecisions() as $precision) {
             $choices[$precision->getLabel()] = $precision;
         }
+
+        ksort($choices);
 
         return $choices;
     }

--- a/src/Form/SignalementDraftDesordresType.php
+++ b/src/Form/SignalementDraftDesordresType.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\DesordreCritere;
+use App\Entity\DesordrePrecision;
+use App\Entity\Signalement;
+use App\Form\Type\SearchCheckboxType;
+use App\Repository\DesordreCritereRepository;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SignalementDraftDesordresType extends AbstractType
+{
+    private DesordreCritereRepository $desordreCritereRepository;
+
+    public function __construct(DesordreCritereRepository $desordreCritereRepository)
+    {
+        $this->desordreCritereRepository = $desordreCritereRepository;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var Signalement $signalement */
+        $signalement = $builder->getData();
+        $details = $signalement->getDetails();
+
+        // Récupération des critères et regroupement par zoneCategorie -> labelCategorie
+        // TODO : vérifier s'il peut y avoir des critères archivés pour ne pas les prendre en compte
+        $desordreCriteres = $this->desordreCritereRepository->findAll();
+        $groupedCriteria = [];
+
+        foreach ($desordreCriteres as $critere) {
+            $zone = $critere->getZoneCategorie()->value;
+            $labelCategorie = $critere->getLabelCategorie();
+
+            $groupedCriteria[$zone][$labelCategorie][] = $critere;
+        }
+
+        $builder
+            ->add('details', TextareaType::class, [
+                'label' => 'Description du problème',
+                'help' => 'Saisissez ici la description du problème tel que présenté par le déclarant ainsi que toutes les informations nécessaires au traitement du dossier.',
+                'required' => false,
+                'mapped' => false,
+                'data' => $details,
+            ]);
+
+        foreach ($groupedCriteria as $zone => $categories) {
+            foreach ($categories as $labelCategorie => $criteres) {
+                $firstCritereId = $criteres[0]->getId();
+                // TODO : voir avec Mathilde si on garde la catégorie Type et composition du logement, ou si on la calcule à la volée comme pour le front
+                $builder->add("desordres_{$zone}_{$firstCritereId}", SearchCheckboxType::class, [
+                    'class' => DesordreCritere::class,
+                    'query_builder' => function (DesordreCritereRepository $repo) use ($zone, $labelCategorie) {
+                        return $repo->createQueryBuilder('c')
+                            ->where('c.zoneCategorie = :zone')
+                            ->andWhere('c.labelCategorie = :labelCategorie')
+                            ->setParameter('zone', $zone)
+                            ->setParameter('labelCategorie', $labelCategorie)
+                            ->orderBy('c.labelCritere', 'ASC');
+                    },
+                    'label' => $labelCategorie, // TODO : pour la catégorie Humidité, les 3 critères ont le même label, à retravailler  pour ajouter la pièce
+                    'choice_label' => 'labelCritere',
+                    'noselectionlabel' => 'Sélectionner une ou plusieurs options',
+                    'nochoiceslabel' => 'Aucun critère disponible',
+                    'mapped' => false,
+                    'required' => false,
+                ]);
+            }
+        }
+
+        // Récupérer les critères sélectionnés
+        $signalementCriteres = $signalement ? $signalement->getDesordreCriteres() : [];
+
+        // TODO : vérifier l'ajout des précisions à la volée lors du choix d'un critère
+        foreach ($signalementCriteres as $signalementCritere) {
+            if ($signalementCritere->getDesordrePrecisions()->count() > 1) {
+                // TODO : est-ce qu'on met toutes les précisions sous forme de case à cocher ou on essaie de se rapprocher de ce qu'a fait MAthilde ? --> Mathilde OK pour cases à cocher
+                // TODO : gérer le <span>
+                // TODO : si besoin de préciser via champ texte (autre type de nuisible)
+                $builder->add('precisions_'.$signalementCritere->getId(), ChoiceType::class, [
+                    'label' => $signalementCritere->getLabelCritere(),
+                    'choices' => $this->getPrecisionsChoices($signalementCritere),
+                    'expanded' => true,
+                    'multiple' => true,
+                    'required' => false,
+                    'mapped' => false,
+                ]);
+            }
+        }
+
+        $builder
+            ->add('forceSave', HiddenType::class, ['mapped' => false])
+            ->add('previous', SubmitType::class, [
+                'label' => 'Précédent',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ])
+            ->add('draft', SubmitType::class, [
+                'label' => 'Finir plus tard',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline'],
+            ])
+            ->add('save', SubmitType::class, [
+                'label' => 'Suivant',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'validation_groups' => ['bo_step_desordres'],
+        ]);
+    }
+
+    private function getPrecisionsChoices(DesordreCritere $critere): array
+    {
+        $choices = [];
+
+        /** @var DesordrePrecision $precision */
+        foreach ($critere->getDesordrePrecisions() as $precision) {
+            $choices[$precision->getLabel()] = $precision;
+        }
+
+        return $choices;
+    }
+}

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -236,7 +236,7 @@ class SignalementBoManager
 
         return true;
     }
-    
+
     public function formDesordresManager(FormInterface $form, Signalement $signalement): bool
     {
         $signalement->setDetails($form->get('details')->getData());

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -244,8 +244,14 @@ class SignalementBoManager
         $signalement->removeAllDesordreCategory();
         $signalement->removeAllDesordreCritere();
         $signalement->removeAllDesordrePrecision();
+        $jsonContent = $signalement->getJsonContent();
+        if (array_key_exists('desordres_batiment_nuisibles_autres', $jsonContent)) {
+            unset($jsonContent['desordres_batiment_nuisibles_autres']);
+        }
+        if (array_key_exists('desordres_logement_nuisibles_autres', $jsonContent)) {
+            unset($jsonContent['desordres_logement_nuisibles_autres']);
+        }
 
-        // Parcours des champs du formulaire
         foreach ($form->all() as $field) {
             $fieldName = $field->getName();
             $fieldData = $field->getData();
@@ -265,10 +271,8 @@ class SignalementBoManager
             }
             if (str_starts_with($fieldName, 'precisions_')) {
                 if (str_ends_with($fieldName, 'details_type_nuisibles')) {
-                    $jsonContent = $signalement->getJsonContent();
                     $idJsonData = $this->extractCritere($fieldName);
                     $jsonContent[$idJsonData] = $fieldData;
-                    $signalement->setJsonContent($jsonContent);
                 } else {
                     /** @var DesordrePrecision $desordrePrecision */
                     foreach ($fieldData as $desordrePrecision) {
@@ -277,6 +281,8 @@ class SignalementBoManager
                 }
             }
         }
+
+        $signalement->setJsonContent($jsonContent);
 
         return true;
     }
@@ -288,6 +294,6 @@ class SignalementBoManager
             return $matches[1];
         }
 
-        return null; // Si la correspondance échoue
+        return null;
     }
 }

--- a/src/Service/Signalement/SignalementDesordresProcessor.php
+++ b/src/Service/Signalement/SignalementDesordresProcessor.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Signalement;
 
+use App\Entity\Enum\DesordreCritereZone;
 use App\Entity\Signalement;
 
 class SignalementDesordresProcessor
@@ -68,5 +69,27 @@ class SignalementDesordresProcessor
             array_merge($photos[$key], PhotoHelper::getPhotosBySlug($signalement, $slug)),
             \SORT_REGULAR
         );
+    }
+
+    public function processDesordresByZone(
+        Signalement $signalement,
+    ): array {
+        $criteres = [];
+        $criteres[DesordreCritereZone::BATIMENT->value] = [];
+        $criteres[DesordreCritereZone::LOGEMENT->value] = [];
+        foreach ($signalement->getDesordreCriteres() as $desordreCritere) {
+            $zone = $desordreCritere->getZoneCategorie();
+            $desordrePrecisionsSelected = $signalement->getDesordrePrecisions()->filter(function ($desordrePrecision) use ($desordreCritere) {
+                return $desordrePrecision->getDesordreCritere() == $desordreCritere;
+            });
+            $desordrePrecisionsLinked = $desordreCritere->getDesordrePrecisions();
+            $criteres[$zone->value][] = [
+                'desordreCritere' => $desordreCritere,
+                'desordrePrecisionsSelected' => $desordrePrecisionsSelected,
+                'desordrePrecisionsLinked' => $desordrePrecisionsLinked,
+            ];
+        }
+
+        return $criteres;
     }
 }

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -10,44 +10,6 @@
 {{ form_start(formDesordres, {'attr': {'id': 'bo-form-signalement-desordres'}}) }}
 {{ form_errors(formDesordres) }}
 
-{% set desordres_logement = [] %}
-{% set desordres_batiment = [] %}
-
-{% for field in formDesordres %}
-    {% if field.vars.name starts with 'desordres_LOGEMENT' and not field.rendered %}
-        {% set desordres_logement = desordres_logement|merge([field]) %}
-    {% elseif field.vars.name starts with 'desordres_BATIMENT' and not field.rendered %}
-        {% set desordres_batiment = desordres_batiment|merge([field]) %}
-    {% endif %}
-    {% if field.vars.name starts with 'precisions_' and not field.rendered %}
-        <dialog aria-labelledby="fr-modal-title-{{ field.vars.id }}" id="modal-precisions-{{ field.vars.id }}" class="fr-modal">
-            <div class="fr-container fr-container--fluid fr-container-md">
-                <div class="fr-grid-row fr-grid-row--center">
-                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                        <div class="fr-modal__body">
-                            <div class="fr-modal__header">
-                                <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ field.vars.id }}">Fermer</button>
-                            </div>
-                            <div class="fr-modal__content">
-                                <h1 id="fr-modal-title-{{ field.vars.id }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
-                                <p>Renseignez les détails du désordre</p>
-                                {{ form_widget(field) }} 
-                            </div>
-                            <div class="fr-modal__footer">
-                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                    {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
-                                    <button class="fr-btn fr-icon-check-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Valider</button>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Annuler</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </dialog>
-    {% endif %}
-{% endfor %}
-
 <div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
     <div class="fr-col-12">
         <fieldset class="fr-fieldset">
@@ -62,7 +24,7 @@
         <span>Désordres déclarés dans le logement</span>
         <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
         <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
-            title="Sélectionner les désordres"
+            title="Sélectionner les désordres" type="button"
             data-fr-opened="false" aria-controls="fr-modal-desordres-logement-add"
             >
             Sélectionner les désordres
@@ -73,15 +35,18 @@
         <span>Désordres déclarés dans le bâtiment</span>
         <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
         <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
-            title="Sélectionner les désordres"
+            title="Sélectionner les désordres" type="button"
             data-fr-opened="false" aria-controls="fr-modal-desordres-batiment-add"
             >
             Sélectionner les désordres
         </button>
     </div>
 
-    {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
-    {{ _self.display_criteres('BATIMENT', criteresByZone['BATIMENT']) }}
+    <div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
+        {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
+        {{ _self.display_criteres('BATIMENT', criteresByZone['BATIMENT']) }}
+    </div>
+
 
     <div class="fr-col-6">
         <div class="fr-grid-row fr-grid-row--left">
@@ -97,46 +62,63 @@
     </div>
 
 </div>
-{% macro display_criteres(zone, criteres) %}
-    {% if criteres|length > 0 %}
-        <div class="fr-col-6">
-            <h3 class="fr-h5">Désordres sélectionnés</h3>
-            {% for critere in criteres %}
-                <div>
-                    {# TODO : changer la couleur de la bordure et mettre un warning, si précision pas choisie alors que devrait #}
-                    <div class="fr-grid-row fr-p-3v fr-mb-3v fr-grid-row--top fr-border--grey">
-                        <div class="fr-col-12 fr-col-md-8">
-                            {{ critere['desordreCritere'].labelCritere }}
-                        </div>
-                        <div class="fr-col-12 fr-col-md-4 fr-text--right">
-                            {% if critere['desordrePrecisionsLinked'] and critere['desordrePrecisionsLinked']|length > 1 %}
-                                <a href="#" aria-controls="modal-precisions-signalement_draft_desordres_precisions_{{ critere['desordreCritere'].id }}" data-fr-opened="false" 
-                                class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
-                                title="Editer les détails" data-fr-js-modal-button="true">
-                                    Editer les détails
-                                </a>                                
-                            {% endif %}
-                        </div>
-                        <div class="fr-col-12">
-                            {% if critere['desordrePrecisionsSelected'] %}
-                                <ul class="fr-list fr-list--none">   
-                                {% for desordrePrecision in critere['desordrePrecisionsSelected'] %}
-                                    <li>
-                                        {{ desordrePrecision.label|raw }}
-                                    </li>                                    
-                                {% endfor %}    
-                                </ul>                       
-                            {% endif %}
+
+{% set desordres_logement = [] %}
+{% set desordres_batiment = [] %}
+
+{% for field in formDesordres %}
+    {% if field.vars.name starts with 'desordres_LOGEMENT' and not field.rendered %}
+        {% set desordres_logement = desordres_logement|merge([field]) %}
+    {% elseif field.vars.name starts with 'desordres_BATIMENT' and not field.rendered %}
+        {% set desordres_batiment = desordres_batiment|merge([field]) %}
+    {% endif %}
+    {% if field.vars.name starts with 'precisions_' and not field.rendered %}
+        {% set critereId = field.vars.id|replace({'signalement_draft_desordres_precisions_': ''}) %}
+        <dialog aria-labelledby="fr-modal-title-{{ critereId }}" id="modal-precisions-{{ field.vars.id }}" class="fr-modal" data-critereId={{ critereId }}>
+            <div class="fr-container fr-container--fluid fr-container-md">
+                <div class="fr-grid-row fr-grid-row--center">
+                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                        <div class="fr-modal__body">
+                            <div class="fr-modal__header">
+                                <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ critereId }}">Fermer</button>
+                            </div>
+                            <div class="fr-modal__content">
+                                <h1 id="fr-modal-title-{{ field.vars.id }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
+                                <p>Renseignez les détails du désordre</p>
+                                {% for child in field %}
+                                    <fieldset class="fr-fieldset">
+                                        <div class="fr-fieldset__element">
+                                            <div class="fr-checkbox-group">
+                                                {{ form_widget(child) }}
+                                                <label class="fr-label" for="{{ child.vars.id }}">{{ child.vars.label|raw }}</label>
+                                            </div>
+                                        </div>
+                                    </fieldset>
+                                {% endfor %}
+
+                            </div>
+                            <div class="fr-modal__footer">
+                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    <button class="fr-btn fr-icon-check-line valid-edit-precisions" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Valider</button>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Annuler</button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
-            {% endfor %}
-        </div>
+            </div>
+        </dialog>
     {% endif %}
+{% endfor %}
+{% macro display_criteres(zone, criteres) %}
+    <div class="fr-col-6 fr-hidden" id="list-critere-{{zone}}">
+        <h3 class="fr-h5">Désordres sélectionnés</h3>
+        {# Le reste est ajouté en js  #}
+    </div>
 {% endmacro %}
 
-{% macro modal_add_criteres(id, title, desordres) %}
-    <dialog aria-labelledby="fr-modal-title-{{ id }}" id="fr-modal-{{ id }}" class="fr-modal">
+{% macro modal_add_criteres(id, title, desordres, zone) %}
+    <dialog aria-labelledby="fr-modal-title-{{ id }}" id="fr-modal-{{ id }}" class="fr-modal" data-zone={{ zone }}>
         <div class="fr-container fr-container--fluid fr-container-md">
             <div class="fr-grid-row fr-grid-row--center">
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
@@ -153,8 +135,7 @@
                         </div>
                         <div class="fr-modal__footer">
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
-                                <button class="fr-btn fr-icon-check-line" type="button" aria-controls="fr-modal-{{ id }}">Valider</button>
+                                <button class="fr-btn fr-icon-check-line valid-add-critere" type="button" aria-controls="fr-modal-{{ id }}">Valider</button>
                                 <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-{{ id }}">Annuler</button>
                             </div>
                         </div>
@@ -165,8 +146,8 @@
     </dialog>
 {% endmacro %}
 
-{{ _self.modal_add_criteres('desordres-batiment-add', 'Désordres dans le bâtiment', desordres_batiment) }}
-{{ _self.modal_add_criteres('desordres-logement-add', 'Désordres dans le logement', desordres_logement) }}
+{{ _self.modal_add_criteres('desordres-batiment-add', 'Désordres dans le bâtiment', desordres_batiment, 'BATIMENT') }}
+{{ _self.modal_add_criteres('desordres-logement-add', 'Désordres dans le logement', desordres_logement, 'LOGEMENT') }}
 
 
 {{ form_end(formDesordres) }}

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -72,19 +72,51 @@
     {% elseif field.vars.name starts with 'desordres_BATIMENT' and not field.rendered %}
         {% set desordres_batiment = desordres_batiment|merge([field]) %}
     {% endif %}
+    {% set nuisibles_autres_critere = '_details_type_nuisibles' %}
+    {% set nuisibles_logement_autres_critere = '_desordres_logement_nuisibles_autres' %}
+
     {% if field.vars.name starts with 'precisions_' and not field.rendered %}
         {% set critereId = field.vars.id|replace({'signalement_draft_desordres_precisions_': ''}) %}
-        <dialog aria-labelledby="fr-modal-title-{{ critereId }}" id="modal-precisions-{{ field.vars.id }}" class="fr-modal" data-critereId={{ critereId }}>
+        {% set critereId = critereId|replace({'_details_type_nuisibles': ''}) %}
+        {% set critereId = critereId|replace({'_desordres_logement_nuisibles_autres': ''}) %}
+        {% set critereId = critereId|replace({'_desordres_batiment_nuisibles_autres': ''}) %}
+        <dialog 
+            aria-labelledby="fr-modal-title-{{ critereId }}" 
+            id="modal-precisions-{{ critereId }}" 
+            class="fr-modal" 
+            data-critereId={{ critereId }}
+            data-critereSlug={{ field.vars.attr['data-slug-critere'] }}
+        >
             <div class="fr-container fr-container--fluid fr-container-md">
                 <div class="fr-grid-row fr-grid-row--center">
-                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6"> 
                         <div class="fr-modal__body">
                             <div class="fr-modal__header">
                                 <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ critereId }}">Fermer</button>
                             </div>
                             <div class="fr-modal__content">
-                                <h1 id="fr-modal-title-{{ field.vars.id }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
+                                <h1 id="fr-modal-title-{{ critereId }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
                                 <p>Renseignez les détails du désordre</p>
+                                
+                                {# Vérification si le champ texte existe pour le critère nuisibles #}
+                                {% set detailsFieldName = field.vars.name ~ nuisibles_logement_autres_critere ~ nuisibles_autres_critere %}
+                                {% if field.vars.name ends with nuisibles_autres_critere or (formDesordres and attribute(formDesordres, detailsFieldName) is defined) %}
+                                    <fieldset class="fr-fieldset">
+                                        <div class="fr-fieldset__element">
+                                            <div class="fr-input-group">
+                                                <label class="fr-label" for="{{ field.vars.id }}">
+                                                    Précisez le type de nuisible
+                                                </label>
+                                                {% if formDesordres and attribute(formDesordres, detailsFieldName) is defined %}
+                                                    {{ form_widget(attribute(formDesordres, detailsFieldName)) }}
+                                                    {% else %}
+                                                {{ form_widget(field) }}
+                                                {% endif %}
+                                            </div>
+                                        </div>
+                                    </fieldset>
+                                {% endif %}
+
                                 {% for child in field %}
                                     <fieldset class="fr-fieldset">
                                         <div class="fr-fieldset__element">
@@ -95,12 +127,12 @@
                                         </div>
                                     </fieldset>
                                 {% endfor %}
-
                             </div>
                             <div class="fr-modal__footer">
                                 <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                    <button class="fr-btn fr-icon-check-line valid-edit-precisions" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Valider</button>
-                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Annuler</button>
+                                    <button class="fr-btn fr-icon-check-line valid-edit-precisions" type="button" aria-controls="modal-precisions-{{ critereId }}">Valider</button>
+                                    {# todo comment gérer l'annulation ?  #}
+                                    {# <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ critereId }}">Annuler</button> #}
                                 </div>
                             </div>
                         </div>

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -8,7 +8,6 @@
 
 {% form_theme formDesordres 'form/dsfr_theme.html.twig' %}
 {{ form_start(formDesordres, {'attr': {'id': 'bo-form-signalement-desordres'}}) }}
-{{ form_errors(formDesordres) }}
 
 <div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
     <div class="fr-col-12">

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -28,6 +28,7 @@
             >
             Sélectionner les désordres
         </button>
+        {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
     </div>
     <div class="fr-col-6">
         <h3 class="fr-h5">Bâtiment</h3>
@@ -39,13 +40,8 @@
             >
             Sélectionner les désordres
         </button>
-    </div>
-
-    <div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
-        {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
         {{ _self.display_criteres('BATIMENT', criteresByZone['BATIMENT']) }}
     </div>
-
 
     <div class="fr-col-6">
         <div class="fr-grid-row fr-grid-row--left">
@@ -142,8 +138,8 @@
     {% endif %}
 {% endfor %}
 {% macro display_criteres(zone, criteres) %}
-    <div class="fr-col-6 fr-hidden" id="list-critere-{{zone}}">
-        <h3 class="fr-h5">Désordres sélectionnés</h3>
+    <div class="fr-col-12" id="list-critere-{{zone}}">
+        <h3 class="fr-h5 fr-hidden">Désordres sélectionnés</h3>
         {# Le reste est ajouté en js  #}
     </div>
 {% endmacro %}

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -139,7 +139,7 @@
 {% endfor %}
 {% macro display_criteres(zone, criteres) %}
     <div class="fr-col-12" id="list-critere-{{zone}}">
-        <h3 class="fr-h5 fr-hidden">Désordres sélectionnés</h3>
+        <h4 class="fr-h6 fr-mt-5v fr-hidden">Désordres sélectionnés</h4>
         {# Le reste est ajouté en js  #}
     </div>
 {% endmacro %}

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -1,1 +1,172 @@
 <h2 class="fr-h4">Désordres</h2>
+<p>Renseignez ici les désordres déclarés dans le logement. Vous devez renseigner au moins 1 désordre.</p>
+<div class="fr-alert fr-alert--warning">
+	<p>
+		Vous ne pourrez plus ajouter de désordres après l'enregistrement du signalement ! Veuillez renseigner <u>tous</u> les désordres.
+	</p>
+</div>
+
+{% form_theme formDesordres 'form/dsfr_theme.html.twig' %}
+{{ form_start(formDesordres, {'attr': {'id': 'bo-form-signalement-desordres'}}) }}
+{{ form_errors(formDesordres) }}
+
+{% set desordres_logement = [] %}
+{% set desordres_batiment = [] %}
+
+{% for field in formDesordres %}
+    {% if field.vars.name starts with 'desordres_LOGEMENT' and not field.rendered %}
+        {% set desordres_logement = desordres_logement|merge([field]) %}
+    {% elseif field.vars.name starts with 'desordres_BATIMENT' and not field.rendered %}
+        {% set desordres_batiment = desordres_batiment|merge([field]) %}
+    {% endif %}
+    {% if field.vars.name starts with 'precisions_' and not field.rendered %}
+        <dialog aria-labelledby="fr-modal-title-{{ field.vars.id }}" id="modal-precisions-{{ field.vars.id }}" class="fr-modal">
+            <div class="fr-container fr-container--fluid fr-container-md">
+                <div class="fr-grid-row fr-grid-row--center">
+                    <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                        <div class="fr-modal__body">
+                            <div class="fr-modal__header">
+                                <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ field.vars.id }}">Fermer</button>
+                            </div>
+                            <div class="fr-modal__content">
+                                <h1 id="fr-modal-title-{{ field.vars.id }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
+                                <p>Renseignez les détails du désordre</p>
+                                {{ form_widget(field) }} 
+                            </div>
+                            <div class="fr-modal__footer">
+                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
+                                    <button class="fr-btn fr-icon-check-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Valider</button>
+                                    <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="modal-precisions-{{ field.vars.id }}">Annuler</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </dialog>
+    {% endif %}
+{% endfor %}
+
+<div class="fr-grid-row fr-grid-row--gutters fr-mt-3v">
+    <div class="fr-col-12">
+        <fieldset class="fr-fieldset">
+            <div class="fr-fieldset__element">
+                {{ form_row(formDesordres.details) }}
+            </div>
+        </fieldset>
+    </div>
+
+    <div class="fr-col-6">
+        <h3 class="fr-h5">Logement</h3>
+        <span>Désordres déclarés dans le logement</span>
+        <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
+        <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
+            title="Sélectionner les désordres"
+            data-fr-opened="false" aria-controls="fr-modal-desordres-logement-add"
+            >
+            Sélectionner les désordres
+        </button>
+    </div>
+    <div class="fr-col-6">
+        <h3 class="fr-h5">Bâtiment</h3>
+        <span>Désordres déclarés dans le bâtiment</span>
+        <span class="fr-hint-text">Sélectionnez au moins 1 désordre dans la liste</span>
+        <button class="fr-btn fr-btn--icon-left fr-icon-add-line"
+            title="Sélectionner les désordres"
+            data-fr-opened="false" aria-controls="fr-modal-desordres-batiment-add"
+            >
+            Sélectionner les désordres
+        </button>
+    </div>
+
+    {{ _self.display_criteres('LOGEMENT', criteresByZone['LOGEMENT']) }}
+    {{ _self.display_criteres('BATIMENT', criteresByZone['BATIMENT']) }}
+
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--left">
+            {{ form_row(formDesordres.previous) }}
+        </div>
+    </div>
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--right">
+            {{ form_row(formDesordres.forceSave) }}
+            {{ form_row(formDesordres.draft) }}
+            {{ form_row(formDesordres.save) }}
+        </div>
+    </div>
+
+</div>
+{% macro display_criteres(zone, criteres) %}
+    {% if criteres|length > 0 %}
+        <div class="fr-col-6">
+            <h3 class="fr-h5">Désordres sélectionnés</h3>
+            {% for critere in criteres %}
+                <div>
+                    {# TODO : changer la couleur de la bordure et mettre un warning, si précision pas choisie alors que devrait #}
+                    <div class="fr-grid-row fr-p-3v fr-mb-3v fr-grid-row--top fr-border--grey">
+                        <div class="fr-col-12 fr-col-md-8">
+                            {{ critere['desordreCritere'].labelCritere }}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-4 fr-text--right">
+                            {% if critere['desordrePrecisionsLinked'] and critere['desordrePrecisionsLinked']|length > 1 %}
+                                <a href="#" aria-controls="modal-precisions-signalement_draft_desordres_precisions_{{ critere['desordreCritere'].id }}" data-fr-opened="false" 
+                                class="fr-a-edit fr-btn--icon-left fr-icon-edit-line edit-precisions-btn" 
+                                title="Editer les détails" data-fr-js-modal-button="true">
+                                    Editer les détails
+                                </a>                                
+                            {% endif %}
+                        </div>
+                        <div class="fr-col-12">
+                            {% if critere['desordrePrecisionsSelected'] %}
+                                <ul class="fr-list fr-list--none">   
+                                {% for desordrePrecision in critere['desordrePrecisionsSelected'] %}
+                                    <li>
+                                        {{ desordrePrecision.label|raw }}
+                                    </li>                                    
+                                {% endfor %}    
+                                </ul>                       
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro modal_add_criteres(id, title, desordres) %}
+    <dialog aria-labelledby="fr-modal-title-{{ id }}" id="fr-modal-{{ id }}" class="fr-modal">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-{{ id }}">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h1 id="fr-modal-title-{{ id }}" class="fr-modal__title">{{ title }}</h1>
+                            <p>Sélectionnez un ou plusieurs désordres dans la liste ci-dessous. Les détails des désordres seront à saisir dans un second temps.</p>
+                            {% for field in desordres %}
+                                {{ form_row(field) }}
+                            {% endfor %}
+                        </div>
+                        <div class="fr-modal__footer">
+                            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                {# <button class="fr-btn fr-icon-check-line" form="bo-form-signalement-desordres" type="submit">Valider</button> #}
+                                <button class="fr-btn fr-icon-check-line" type="button" aria-controls="fr-modal-{{ id }}">Valider</button>
+                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-{{ id }}">Annuler</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
+{% endmacro %}
+
+{{ _self.modal_add_criteres('desordres-batiment-add', 'Désordres dans le bâtiment', desordres_batiment) }}
+{{ _self.modal_add_criteres('desordres-logement-add', 'Désordres dans le logement', desordres_logement) }}
+
+
+{{ form_end(formDesordres) }}

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -92,7 +92,7 @@
                     <div class="fr-col-12 fr-col-md-8 fr-col-lg-6"> 
                         <div class="fr-modal__body">
                             <div class="fr-modal__header">
-                                <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ critereId }}">Fermer</button>
+                                <button class="fr-btn--close fr-btn" type="button" title="Fermer la fenêtre modale" aria-controls="modal-precisions-{{ critereId }}">Fermer</button>
                             </div>
                             <div class="fr-modal__content">
                                 <h1 id="fr-modal-title-{{ critereId }}" class="fr-modal__title">Editer les détails du désordre : {{ field.vars.label }}</h1>
@@ -122,7 +122,7 @@
                                         <div class="fr-fieldset__element">
                                             <div class="fr-checkbox-group">
                                                 {{ form_widget(child) }}
-                                                <label class="fr-label" for="{{ child.vars.id }}">{{ child.vars.label|raw }}</label>
+                                                <label class="fr-label" for="{{ child.vars.id }}"><span>{{ child.vars.label|raw }}</span></label>
                                             </div>
                                         </div>
                                     </fieldset>
@@ -156,19 +156,19 @@
                 <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-{{ id }}">Fermer</button>
+                            <button class="fr-btn--close fr-btn" type="button" title="Fermer la fenêtre modale" aria-controls="fr-modal-{{ id }}">Fermer</button>
                         </div>
-                        <div class="fr-modal__content">
+                        <div class="fr-modal__content fr-pb-32v">
                             <h1 id="fr-modal-title-{{ id }}" class="fr-modal__title">{{ title }}</h1>
                             <p>Sélectionnez un ou plusieurs désordres dans la liste ci-dessous. Les détails des désordres seront à saisir dans un second temps.</p>
                             {% for field in desordres %}
                                 {{ form_row(field) }}
                             {% endfor %}
                         </div>
-                        <div class="fr-modal__footer">
+                        <div class="fr-modal__footer fr-zindex-100">
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <button class="fr-btn fr-icon-check-line valid-add-critere" type="button" aria-controls="fr-modal-{{ id }}">Valider</button>
-                                <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-{{ id }}">Annuler</button>
+                                {# <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-{{ id }}">Annuler</button> #}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Ticket

#3647    
#3646

## Description
Gestion de l'onglet Désordres
**A noter : Mathilde est OK pour simplifier les modales d'édition de critères, pour qu'on liste les précisions liées avec des cases à cocher plutôt que de poser des questions avec des réponses multiples.** cf https://github.com/MTES-MCT/histologe/issues/3647#issuecomment-2730210043

Fait : 

- [x] Affichage de l'onglet avec champ texte
- [x] Choix des critères dans des popups liées à la zone (bâtiment/logement) et classés par catégorie
- [x] Enregistrement des critères (et de la catégorié liée, et de la précision s'il n'y en a qu'une)
- [x] Affichage des critères choisis
- [x] Edition des critères avec plusieurs précisions
- [x] Enregistrement des précisions choisies
- [x] Affichage des précisions choisies
- [x] Les 3 labels identiques des critères de la catégorie Humidité (ajout de la pièce)
- [x] Affichage en rouge avec warning des critères à plusieurs précisions dont la précision n'est pas choisie
- [x] Gérer le code html dans la modale de choix de précision
- [x] Certaines précision nécéssitent un champ texte (par exemple autre type de nuisibles)
- [x] Désenregistrement des critères et/ou précisions préalablement enregistrées et déselectionnées

Reste à faire : 

- [ ] Affichage ou non de la catégorie Type et composition du logement (si oui, redondant avec l'onglet Logement, si non, désordres à calculer à la volée)

## Changements apportés
* Pour le choix des critères dans les modales Bâtiment et Logement, on a un formType `SignalementDraftDesordresType` qui récupère tous les `desordreCritere` et génère des selectbox à la volée. Ce formType ajoute aussi des checkbox de `desordrePrecision` pour les `desordreCritere` qui en ont plus d'une
* Dans `src/Controller/Back/SignalementCreateController.php` ajout du formType dans editSignalement, ainsi que d'un tableau de criteres classés par zone. Et ajout d'une route `back_signalement_draft_form_desordres_edit`
* Enregistrement des critères et précisions dans `SignalementBoManager` dans une fonction `formDesordresManager`
* Dans `src/Service/Signalement/SignalementDesordresProcessor.php` création d'une fonction `processDesordresByZone` pour envoyer les critères classés au twig
* Gestion des modales dans le twig `templates/back/signalement_create/tabs/tab-desordres.html.twig` 
* Ajout d'une fonction `initBoFormSignalementDesordres` dans `back_signalement_form_js` pour gérer la création des modales de précisions, et la gestion des critères sélectionnés

## Pré-requis
`npm run watch`

## Tests
- [ ] Créer un brouillon
- [ ] Choisir des désordres, et pour les désordres choisis, sélectionner des précisions
- [ ] Valider la page, revenir dessus et vérifier que c'est enregistré
- [ ] Modifier des choses (supprimer des critères ou des précisions), vérifier que l'enregistrement est ok
- [ ] Vérifier que pour la catégorie Humidité on a bien 3 critères avec des labels différents
- [ ] Choisir un désordre nuisibles/autres, et vérifier qu'on peut bien préciser/enregistrer le type de nuisible (dans logement ou batiment)
- [ ] Vérifier que pour un critère ayant plusieurs précisions l'encart est en rouge avec un message tant qu'on n'a pas choisi une précision
