### PR TITLE
[BO - Signalement] perte de message quand temps d'attente trop long

### DIFF
--- a/assets/scripts/vanilla/controllers/form_modal_handler.js
+++ b/assets/scripts/vanilla/controllers/form_modal_handler.js
@@ -54,8 +54,8 @@ async function submitPayload (formElement) {
         }
       })
     }
-    if (response.redirected) {
-      window.location.href = response.url
+    if (response.redirected && response.url.endsWith('/connexion')) {
+      alert('Votre session a expiré. Veuillez vous reconnecter en rechargeant la page.')
     } else if (response.redirected) {
       window.location.href = response.url
     } else if (response.ok) {
@@ -67,7 +67,7 @@ async function submitPayload (formElement) {
       const submitElement = document.querySelector('.fr-modal--opened [type="submit"]')
       let firstErrorElement = true
       for (const property in errors) {
-        const inputElement = document.querySelector(`.fr-modal--opened [name="${property}"]`) || document.querySelector('.fr-modal--opened input')
+        const inputElement = document.querySelector(`.fr-modal--opened [name="${property}"]`) || document.querySelector('.fr-modal--opened .no-field-errors') || document.querySelector('.fr-modal--opened input')
         inputElement.setAttribute('aria-describedby', `${property}-desc-error`)
         inputElement.parentElement.classList.add('fr-input-group--error')
 

--- a/templates/_partials/signalement/add_suivi.html.twig
+++ b/templates/_partials/signalement/add_suivi.html.twig
@@ -12,14 +12,17 @@
                         </h1>
                         <form method="POST" name="signalement-add-suivi" id="signalement-add-suivi-form" class="tinyCheck"
                                 action="{{ path('back_signalement_add_suivi',{uuid:signalement.uuid}) }}">
+                            <div class="fr-input-group">
+                                <span class="no-field-errors"></span>
+                            </div>
                             <div class="fr-fieldset fr-fieldset--inline fr-mb-5v">
                                 {% if show_email_alert(signalement.mailDeclarant) and show_email_alert(signalement.mailOccupant) %}
                                     <p class="fr-badge fr-badge--error">L'adresse e-mail de l'usager n'est pas valide. Vous ne pouvez pas lui envoyer le suivi.</p>
-                                    <input type="hidden" name="signalement-add-suivi[notifyUsager]" value="0">
+                                    <input type="hidden" name="notifyUsager" value="0">
                                 {% else %}
                                 <div class="fr-fieldset__content">
                                     <div class="fr-toggle fr-col-12">
-                                        <input type="checkbox" class="fr-toggle__input" aria-describedby="toggle-698-hint-text" id="signalement-add-suivi-notify-usager" name="signalement-add-suivi[notifyUsager]" value="1">
+                                        <input type="checkbox" class="fr-toggle__input" aria-describedby="toggle-698-hint-text" id="signalement-add-suivi-notify-usager" name="notifyUsager" value="1">
                                         <label class="fr-toggle__label" for="signalement-add-suivi-notify-usager">En cochant cette case, le suivi sera envoyé à l'usager</label>
                                     </div>
                                 </div>
@@ -33,8 +36,7 @@
                                         <sup class="fr-text-default--error">*</sup>
                                     </span>
                                 </label>
-                                <textarea class="fr-input fr-input--no-resize editor" id="signalement-add-suivi-content"
-                                        name="signalement-add-suivi[content]" minlength="10"></textarea>
+                                <textarea class="fr-input fr-input--no-resize editor" id="signalement-add-suivi-content" name="content" minlength="10"></textarea>
                                 <p class="fr-error-text fr-hidden">
                                     Merci de proposer une rapide description (minimum 10 caractères).
                                 </p>

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -8,7 +8,9 @@
         is_granted('COMMENT_CREATE', signalement)
         and not isClosedForMe
         %}
-        {% include '_partials/signalement/add_suivi.html.twig' %}
+        <div data-ajax-form>
+            {% include '_partials/signalement/add_suivi.html.twig' %}
+        </div>
         <div class="fr-col-3 fr-col-md-6 fr-text--right">
             <button class="fr-btn fr-btn--icon-left fr-icon-quote-line" data-fr-opened="false"
                     aria-controls="fr-modal-add-suivi">

--- a/tests/Functional/Controller/Back/SignalementActionControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementActionControllerTest.php
@@ -85,17 +85,13 @@ class SignalementActionControllerTest extends WebTestCase
             'POST',
             $route,
             [
-                'signalement-add-suivi' => [
-                    'content' => 'La procédure avance bien, nous vous tiendrons informé de la suite, bon courage !',
-                    'notifyUsager' => '1',
-                ],
+                'content' => 'La procédure avance bien, nous vous tiendrons informé de la suite, bon courage !',
+                'notifyUsager' => '1',
                 '_token' => $this->generateCsrfToken($this->client, 'signalement_add_suivi_'.$signalement->getId()),
             ]
         );
-
-        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid().'#suivis');
-        $this->client->followRedirect();
-        $this->assertSelectorTextContains('.fr-alert--success p', 'Suivi publié avec succès !');
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+        $this->assertResponseStatusCodeSame(200);
     }
 
     public function testAddSuiviSignalementError(): void
@@ -106,17 +102,14 @@ class SignalementActionControllerTest extends WebTestCase
             'POST',
             $route,
             [
-                'signalement-add-suivi' => [
-                    'content' => 'Je v',
-                    'notifyUsager' => '1',
-                ],
+                'content' => 'Je v',
+                'notifyUsager' => '1',
                 '_token' => $this->generateCsrfToken($this->client, 'signalement_add_suivi_'.$signalement->getId()),
             ]
         );
 
-        $this->assertResponseRedirects('/bo/signalements/'.$signalement->getUuid());
-        $this->client->followRedirect();
-        $this->assertSelectorTextContains('.fr-alert--error p', 'Le contenu du suivi doit faire au moins 10 caractères !');
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+        $this->assertStringContainsString('Le contenu du suivi doit faire au moins 10 caract\u00e8res !', $this->client->getResponse()->getContent());
     }
 
     public function testDeleteSuivi(): void


### PR DESCRIPTION
## Ticket

#3875

## Description
- Passage de la soumission du formulaire d'ajout de suivi BO en ajax (via le système `data-ajax-form`)
- En cas de token invalide affichage du message d'erreur et demande de rechargement de la page (sans fermeture de la modale)
![Screenshot 2025-03-26 at 17-47-27 #2025-04 Signalement - Histologe](https://github.com/user-attachments/assets/c88f74c6-bbb3-424f-a3f0-4cf0df3063fc)
- En cas de déconnexion interception de la redirection afin d'afficher une alerte sans fermeture de la modale (généralisé pour toutes les modales utilisant le système `data-ajax-form`)
![Capture d’écran 2025-03-26 174536](https://github.com/user-attachments/assets/8469e42c-918a-4577-9e5e-2745517d2b11)

De cette façon les message ne devrait plus pouvoir être perdu, malgré le rechargement de page nécéssaire.

## Pré-requis
`make npm-build`

## Tests
- [ ] S'assurer que l'ajout de suivi via le BO fonctionne correctement
