### PR TITLE
[BO - Stats] Signalements refuses et archives sont à 0

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -152,7 +152,7 @@ class SignalementRepository extends ServiceEntityRepository
         $qb->select('COUNT(s.id) as count')
             ->addSelect('s.statut')
             ->andWhere('s.statut NOT IN (:statutList)')
-            ->setParameter('statutList', [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED]);
+            ->setParameter('statutList', [SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED]);
 
         if ($removeImported) {
             $qb->andWhere('s.isImported IS NULL OR s.isImported = 0');

--- a/src/Service/Statistics/GlobalBackAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalBackAnalyticsProvider.php
@@ -31,10 +31,10 @@ class GlobalBackAnalyticsProvider
         $countByStatus = $this->signalementRepository->countByStatus($territories, $partners, null, true);
         foreach ($countByStatus as $countByStatusItem) {
             switch ($countByStatusItem['statut']) {
-                case SignalementStatus::ARCHIVED->value:
+                case SignalementStatus::ARCHIVED:
                     $data['count_signalement_archives'] = $countByStatusItem['count'];
                     break;
-                case SignalementStatus::REFUSED->value:
+                case SignalementStatus::REFUSED:
                     $data['count_signalement_refuses'] = $countByStatusItem['count'];
                     break;
                 default:

--- a/tests/Functional/Service/Statistics/GlobalBackAnalyticsProviderTest.php
+++ b/tests/Functional/Service/Statistics/GlobalBackAnalyticsProviderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Functional\Service\Statistics;
+
+use App\Repository\SignalementRepository;
+use App\Repository\TerritoryRepository;
+use App\Service\Statistics\GlobalBackAnalyticsProvider;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GlobalBackAnalyticsProviderTest extends KernelTestCase
+{
+    public function testGetData(): void
+    {
+        self::bootKernel();
+        /** @var TerritoryRepository $territoryRepository */
+        $territoryRepository = self::getContainer()->get(TerritoryRepository::class);
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = self::getContainer()->get(SignalementRepository::class);
+        $data = (new GlobalBackAnalyticsProvider($signalementRepository))->getData(null, new ArrayCollection());
+
+        $this->assertEquals(6, \count($data));
+        $this->assertArrayHasKey('count_signalement', $data);
+        $this->assertEquals(51, $data['count_signalement']);
+        $this->assertArrayHasKey('average_criticite', $data);
+        $this->assertArrayHasKey('average_days_validation', $data);
+        $this->assertArrayHasKey('average_days_closure', $data);
+        $this->assertArrayHasKey('count_signalement_archives', $data);
+        $this->assertEquals(3, $data['count_signalement_archives']);
+        $this->assertArrayHasKey('count_signalement_refuses', $data);
+        $this->assertEquals(1, $data['count_signalement_refuses']);
+    }
+}


### PR DESCRIPTION
## Ticket

#3920   

## Description
Correction du GlobalBackAnalyticsProvider pour les signalements refusés et archivés

## Changements apportés
* Correction du GlobalBackAnalyticsProvider
* Ajout d'un test

## Pré-requis

## Tests
- [ ] Aller dans les stats back et vérifier qu'on a des données pour les signalements refusés et archivés
