### PR TITLE
[BUG] Bloquer la création d'un utilisateur avec même email à l'ajout d'un agent

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -439,7 +439,7 @@ class PartnerController extends AbstractController
                 $userExist->setIsMailingActive($user->getIsMailingActive());
                 $userExist->setHasPermissionAffectation($user->hasPermissionAffectation());
                 $userExist->setStatut(User::STATUS_INACTIVE);
-                $userExist->setRoles($user->getRoles());
+                $userExist->setRoles([$formUserPartner->get('role')->getData()]);
                 $userPartner->setUser($userExist);
                 $user = $userExist;
                 $userManager->sendAccountActivationNotification($user);

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -432,10 +432,18 @@ class PartnerController extends AbstractController
 
                 return $this->json(['content' => $content, 'title' => 'Compte existant sur un autre territoire', 'submitLabel' => 'Ajouter l\'utilisateur']);
             }
-            if ($userExist) {
-                $user->setStatut(User::STATUS_INACTIVE);
-            }
             $user->setRoles([$formUserPartner->get('role')->getData()]);
+            if ($userExist) {
+                $userExist->setNom($user->getNom());
+                $userExist->setPrenom($user->getPrenom());
+                $userExist->setIsMailingActive($user->getIsMailingActive());
+                $userExist->setHasPermissionAffectation($user->hasPermissionAffectation());
+                $userExist->setStatut(User::STATUS_INACTIVE);
+                $userExist->setRoles($user->getRoles());
+                $userPartner->setUser($userExist);
+                $user = $userExist;
+                $userManager->sendAccountActivationNotification($user);
+            }
             $userManager->persist($userPartner);
             $userManager->save($user);
             $message = 'L\'utilisateur a bien été créé. Un e-mail de confirmation a été envoyé à '.$user->getEmail();

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -194,6 +194,7 @@ class PartnerControllerTest extends WebTestCase
             $this->assertArrayHasKey('url', $response);
             $this->assertStringEndsWith('/bo/partenaires/'.$partner->getId().'/voir#agents', $response['url']);
             $this->assertEmailCount(1);
+            $this->assertCount(1, $this->userRepository->findBy(['email' => $email]));
         } else {
             $this->assertArrayHasKey('content', $response);
             $this->assertStringContainsString($expected, $response['content']);


### PR DESCRIPTION
## Ticket

#3924

## Description
Bug faisant suite à la mise en place des agents multi territoires :
Lors de l'ajout d'un agent si un usager avec le même email existe, un nouvel utilisateur est créé plutôt que d'upgrader le role de l'user existant.

- Correction du problème
- Ajout d'un test permettant de s'assurer qu'un doublon n'est pas généré

Pré-requis à la finalisation de #3854

## Tests
- [ ] Ajouter un agent avec l'email `usager-01@histologe.fr` sur un partenaire