### PR TITLE
[BO - Visites] Intervenant Visite - Externe

### DIFF
--- a/assets/scripts/vanilla/controllers/form_visite.js
+++ b/assets/scripts/vanilla/controllers/form_visite.js
@@ -67,7 +67,14 @@ function histoCheckVisiteForms (formType) {
       if (selectVisitePartner) {
         const selectVisitePartnerError = visiteForm.querySelector('#signalement-' + formType + '-visite-partner-double-error')
         selectVisitePartnerError.classList.add('fr-hidden')
-        if (selectVisitePartner.selectedOptions[0].classList.contains('alert-partner')) {
+        if(selectVisitePartner.value === 'extern') {
+          const operatorExternField = visiteForm.querySelector('.visite-external-operator')
+          const operatorNames = JSON.parse(document.getElementById('list-pending-visite-external-operator-names').dataset.list)
+          if(operatorNames.includes(operatorExternField.value)) {
+            selectVisitePartnerError.classList.remove('fr-hidden')
+            stopSubmit = true
+          }
+        }else if (selectVisitePartner.selectedOptions[0].classList.contains('alert-partner')) {
           selectVisitePartnerError.classList.remove('fr-hidden')
           stopSubmit = true
         }

--- a/assets/scripts/vanilla/controllers/form_visite.js
+++ b/assets/scripts/vanilla/controllers/form_visite.js
@@ -12,13 +12,31 @@ dateFields.forEach(dateField => {
   dateField.addEventListener('change', evt => {
     const fieldToToggle = dateField.dataset.fields
 
-    if (dateField.value <= localDateString) {
+    if (dateField.value && dateField.value <= localDateString) {
       document.querySelector('#' + fieldToToggle).classList.remove('fr-hidden')
     } else {
       document.querySelector('#' + fieldToToggle).classList.add('fr-hidden')
     }
   })
+  dateField.dispatchEvent(new Event('change'))
 })
+
+const selectVisitePartner = document.querySelectorAll('.visite-partner-select')
+selectVisitePartner.forEach(partnerSelect => {
+  const operatorExtern = partnerSelect.parentElement.nextElementSibling
+  const operatorExternField = operatorExtern.querySelector('input')
+  partnerSelect.addEventListener('change', evt => {
+    if (evt.currentTarget.value === 'extern') {
+      operatorExtern.classList.remove('fr-hidden')
+      operatorExternField.setAttribute('required', 'required')
+    }else {
+      operatorExtern.classList.add('fr-hidden')
+      operatorExternField.removeAttribute('required')
+    }
+  })
+  partnerSelect.dispatchEvent(new Event('change'))
+})
+
 
 histoCheckVisiteForms('add')
 histoCheckVisiteForms('reschedule')

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -175,7 +175,7 @@ pre {
 }
 
 legend.required::after, label.required::after {
-    color: #F60700;
+    color: var(--text-default-error);
     content: '*';
     position: relative;
     left: 3px;

--- a/migrations/Version20250328162438.php
+++ b/migrations/Version20250328162438.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250328162438 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add external_operator column to intervention table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE intervention ADD external_operator VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE intervention DROP external_operator');
+    }
+}

--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -92,12 +92,14 @@ class SignalementVisitesController extends AbstractController
         $fileName = $this->getUploadedFile($request, 'visite-add', $uploadHandler, $filenameGenerator);
 
         $requestAddData = $request->get('visite-add');
+        $idPartner = 'extern' === $requestAddData['partner'] ? null : $requestAddData['partner'];
         $visiteRequest = new VisiteRequest(
             idIntervention: $requestAddData['intervention'] ?? null,
             date: $requestAddData['date'],
             time: $requestAddData['time'],
             timezone: $timezoneProvider->getTimezone(),
-            idPartner: $requestAddData['partner'],
+            idPartner: $idPartner,
+            externalOperator: $requestAddData['externalOperator'],
             details: $requestAddData['details'] ?? null,
             concludeProcedure: $requestAddData['concludeProcedure'] ?? null,
             isVisiteDone: $requestAddData['visiteDone'] ?? null,
@@ -210,12 +212,14 @@ class SignalementVisitesController extends AbstractController
         $previousDate = $intervention->getScheduledAt();
         $fileName = $this->getUploadedFile($request, 'visite-reschedule', $uploadHandler, $filenameGenerator);
 
+        $idPartner = 'extern' === $requestRescheduleData['partner'] ? null : $requestRescheduleData['partner'];
         $visiteRequest = new VisiteRequest(
             idIntervention: $requestRescheduleData['intervention'],
             date: $requestRescheduleData['date'],
             time: $requestRescheduleData['time'],
             timezone: $timezoneProvider->getTimezone(),
-            idPartner: $requestRescheduleData['partner'] ?? $intervention->getPartner()?->getId(),
+            idPartner: $idPartner,
+            externalOperator: $requestRescheduleData['externalOperator'],
             details: $requestRescheduleData['details'] ?? null,
             concludeProcedure: $requestRescheduleData['concludeProcedure'] ?? null,
             isVisiteDone: $requestRescheduleData['visiteDone'] ?? null,

--- a/src/Dto/Request/Signalement/VisiteRequest.php
+++ b/src/Dto/Request/Signalement/VisiteRequest.php
@@ -4,6 +4,7 @@ namespace App\Dto\Request\Signalement;
 
 use App\Service\TimezoneProvider;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class VisiteRequest
 {
@@ -18,8 +19,8 @@ class VisiteRequest
         #[Assert\DateTime('H:i')]
         private readonly ?string $time = null,
         private readonly ?string $timezone = TimezoneProvider::TIMEZONE_EUROPE_PARIS,
-        #[Assert\NotBlank]
         private readonly ?int $idPartner = null,
+        private readonly ?string $externalOperator = null,
         private readonly ?string $details = null,
         private readonly ?array $concludeProcedure = [],
         private readonly ?bool $isVisiteDone = null,
@@ -28,6 +29,14 @@ class VisiteRequest
         private readonly ?bool $isUsagerNotified = null,
         private readonly ?string $document = null,
     ) {
+    }
+
+    #[Assert\Callback]
+    public function validate(ExecutionContextInterface $context, $payload)
+    {
+        if (null === $this->idPartner && empty(trim((string) $this->externalOperator))) {
+            $context->buildViolation('Le nom de l\'opérateur externe est requis')->atPath('externalOperator')->addViolation();
+        }
     }
 
     public function getIntervention(): ?int
@@ -74,6 +83,11 @@ class VisiteRequest
     public function getPartner(): ?int
     {
         return $this->idPartner;
+    }
+
+    public function getExternalOperator(): ?string
+    {
+        return $this->externalOperator;
     }
 
     public function getDetails(): ?string

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -8,6 +8,7 @@ use App\Entity\Behaviour\TimestampableTrait;
 use App\Entity\Enum\DocumentType;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\Enum\InterventionType;
+use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\ProcedureType;
 use App\Repository\InterventionRepository;
 use App\Service\TimezoneProvider;
@@ -89,6 +90,9 @@ class Intervention implements EntityHistoryInterface, EntitySanitizerInterface
     #[ORM\OneToMany(mappedBy: 'intervention', targetEntity: File::class, cascade: ['persist'])]
     private Collection $files;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $externalOperator = null;
+
     public function __construct()
     {
         $this->files = new ArrayCollection();
@@ -161,6 +165,14 @@ class Intervention implements EntityHistoryInterface, EntitySanitizerInterface
 
     public function getPartner(): ?Partner
     {
+        if (!$this->partner && $this->externalOperator) {
+            $externalPartner = new Partner();
+            $externalPartner->setNom($this->externalOperator);
+            $externalPartner->setType(PartnerType::AUTRE);
+
+            return $externalPartner;
+        }
+
         return $this->partner;
     }
 
@@ -370,5 +382,17 @@ class Intervention implements EntityHistoryInterface, EntitySanitizerInterface
     public function getDescription(): string
     {
         return $this->getDetails() ?? '';
+    }
+
+    public function getExternalOperator(): ?string
+    {
+        return $this->externalOperator;
+    }
+
+    public function setExternalOperator(?string $externalOperator): static
+    {
+        $this->externalOperator = $externalOperator;
+
+        return $this;
     }
 }

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -168,7 +168,7 @@ class Intervention implements EntityHistoryInterface, EntitySanitizerInterface
         if (!$this->partner && $this->externalOperator) {
             $externalPartner = new Partner();
             $externalPartner->setNom($this->externalOperator);
-            $externalPartner->setType(PartnerType::AUTRE);
+            $externalPartner->setType(PartnerType::OPERATEUR_VISITES_ET_TRAVAUX);
 
             return $externalPartner;
         }

--- a/src/Manager/InterventionManager.php
+++ b/src/Manager/InterventionManager.php
@@ -49,22 +49,26 @@ class InterventionManager extends AbstractManager
      */
     public function createVisiteFromRequest(Signalement $signalement, VisiteRequest $visiteRequest): ?Intervention
     {
-        if (!$visiteRequest->getDate() || !$visiteRequest->getPartner()) {
+        if (!$visiteRequest->getDate()) {
             return null;
         }
 
-        $partnerFound = $this->partnerManager->getPartnerIfQualification(
-            $visiteRequest->getPartner(),
-            Qualification::VISITES,
-            $signalement->getTerritory()
-        );
-        if (!$partnerFound) {
-            return null;
+        $partnerFound = null;
+        if ($visiteRequest->getPartner()) {
+            $partnerFound = $this->partnerManager->getPartnerIfQualification(
+                $visiteRequest->getPartner(),
+                Qualification::VISITES,
+                $signalement->getTerritory()
+            );
+            if (!$partnerFound) {
+                return null;
+            }
         }
 
         $intervention = new Intervention();
         $intervention->setSignalement($signalement)
             ->setPartner($partnerFound)
+            ->setExternalOperator($visiteRequest->getExternalOperator())
             ->setScheduledAt(new \DateTimeImmutable($visiteRequest->getDateTimeUTC()))
             ->setType(InterventionType::VISITE)
             ->setStatus(Intervention::STATUS_PLANNED);
@@ -107,7 +111,7 @@ class InterventionManager extends AbstractManager
      */
     public function rescheduleVisiteFromRequest(Signalement $signalement, VisiteRequest $visiteRequest): ?Intervention
     {
-        if (!$visiteRequest->getIntervention() || !$visiteRequest->getDate() || !$visiteRequest->getPartner()) {
+        if (!$visiteRequest->getIntervention() || !$visiteRequest->getDate()) {
             return null;
         }
 
@@ -116,17 +120,21 @@ class InterventionManager extends AbstractManager
             return null;
         }
 
-        $partnerFound = $this->partnerManager->getPartnerIfQualification(
-            $visiteRequest->getPartner(),
-            Qualification::VISITES,
-            $signalement->getTerritory()
-        );
-        if (!$partnerFound) {
-            return null;
+        $partnerFound = null;
+        if ($visiteRequest->getPartner()) {
+            $partnerFound = $this->partnerManager->getPartnerIfQualification(
+                $visiteRequest->getPartner(),
+                Qualification::VISITES,
+                $signalement->getTerritory()
+            );
+            if (!$partnerFound) {
+                return null;
+            }
         }
 
         $intervention
             ->setPartner($partnerFound)
+            ->setExternalOperator($visiteRequest->getExternalOperator())
             ->setScheduledAt(new \DateTimeImmutable($visiteRequest->getDateTimeUTC()));
         $this->save($intervention);
 

--- a/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
@@ -31,45 +31,26 @@
 
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-my-3w">
                                 <div class="fr-col-12 fr-mb-3v">
-                                    <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
-                                        <legend class="fr-fieldset__legend fr-text--regular required">
-                                            Date de la visite
-                                        </legend>
-                                        <p id="signalement-add-visite-date-error" class="fr-error-text fr-hidden fr-my-3v">
-                                            Veuillez préciser la date de la visite.
-                                        </p>
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="visite-add[date]">Date de la visite <span class="fr-text-default--error">*</span></label>
                                         <input type="date"
                                                class="fr-input add-fields-if-past-date"
                                                data-fields="visite-add-past-date-complementary-fields"
                                                name="visite-add[date]" required>
-                                    </fieldset>
+                                    </div>
 
-                                    <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
-                                        <legend class="fr-fieldset__legend fr-text--regular">
-                                            Heure de la visite
-                                        </legend>
-                                        <p id="signalement-add-visite-date-error" class="fr-error-text fr-hidden fr-my-3v">
-                                            Veuillez préciser l'heure de la visite.
-                                        </p>
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="visite-add[time]">Heure de la visite</label>
                                         <input type="time"
                                                class="fr-input"
                                                data-territory-timezone="{{ territory_timezone }}"
                                                data-fields="visite-add-past-date-complementary-fields"
                                                name="visite-add[time]">
-                                    </fieldset>
+                                    </div>
                                     
                                     {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                                        <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
-                                            <legend class="fr-fieldset__legend fr-text--regular required">
-                                                Opérateur de visite
-                                            </legend>
-                                            <p id="signalement-add-visite-partner-error" class="fr-error-text fr-hidden fr-my-3v">
-                                                Veuillez sélectionner le partenaire en charge de la visite
-                                            </p>
-                                            <p id="signalement-add-visite-partner-double-error" class="fr-error-text fr-hidden fr-my-3v">
-                                                Ce partenaire a déjà une visite en cours.
-                                                Veuillez terminer ou annuler la visite ou sélectionner un autre partenaire.
-                                            </p>
+                                        <div class="fr-select-group">
+                                            <label class="fr-label" for="visite-add[partner]">Opérateur de visite <span class="fr-text-default--error">*</span></label>
                                             <select name="visite-add[partner]" class="fr-select visite-partner-select" required>
                                                 <option value=""></option>
                                                 {% for partner in partnersCanVisite %}
@@ -86,8 +67,17 @@
                                                         {{ partner.nom|upper }}
                                                     </option>
                                                 {% endfor %}
+                                                <option value="extern">Opérateur Externe</option>
                                             </select>
-                                        </fieldset>
+                                            <p id="signalement-add-visite-partner-double-error" class="fr-error-text fr-hidden">
+                                                Ce partenaire a déjà une visite en cours.
+                                                Veuillez terminer ou annuler la visite ou sélectionner un autre partenaire.
+                                            </p>
+                                        </div>
+                                        <div class="fr-input-group fr-hidden">
+                                            <label class="fr-label" for="visite-add[externalOperator]">Nom de l'opérateur externe <span class="fr-text-default--error">*</span></label>
+                                            <input type="text" name="visite-add[externalOperator]" maxlength="255" class="fr-input">
+                                        </div>
                                     {% else %}
                                         <input type="hidden" name="visite-add[partner]" value="{{ app.user.partnerInTerritory(signalement.territory).id }}">
                                     {% endif %}

--- a/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-add.html.twig
@@ -76,7 +76,7 @@
                                         </div>
                                         <div class="fr-input-group fr-hidden">
                                             <label class="fr-label" for="visite-add[externalOperator]">Nom de l'opérateur externe <span class="fr-text-default--error">*</span></label>
-                                            <input type="text" name="visite-add[externalOperator]" maxlength="255" class="fr-input">
+                                            <input type="text" name="visite-add[externalOperator]" maxlength="255" class="fr-input visite-external-operator">
                                         </div>
                                     {% else %}
                                         <input type="hidden" name="visite-add[partner]" value="{{ app.user.partnerInTerritory(signalement.territory).id }}">

--- a/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
@@ -65,7 +65,7 @@
                                         </div>
                                         <div class="fr-input-group fr-hidden" id="visite-reschedule-external-operator">
                                             <label class="fr-label" for="visite-reschedule[externalOperator]">Nom de l'opérateur externe <span class="fr-text-default--error">*</span></label>
-                                            <input type="text" name="visite-reschedule[externalOperator]" value="{{intervention.externalOperator}}" maxlength="255" class="fr-input">
+                                            <input type="text" name="visite-reschedule[externalOperator]" value="{{intervention.externalOperator}}" maxlength="255" class="fr-input visite-external-operator">
                                         </div>
                                     {% else %}
                                         <input type="hidden" name="visite-reschedule[partner]" value="{{ app.user.partnerInTerritory(signalement.territory).id }}">

--- a/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
@@ -23,38 +23,19 @@
 
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-my-3w">
                                 <div class="fr-col-12 fr-mb-3v">
-                                    <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
-                                        <legend class="fr-fieldset__legend fr-text--regular required">
-                                            Date de la visite
-                                        </legend>
-                                        <p id="signalement-reschedule-visite-date-error" class="fr-error-text fr-hidden fr-my-3v">
-                                            Veuillez préciser la date de la visite.
-                                        </p>
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="visite-reschedule[date]">Date de la visite <span class="fr-text-default--error">*</span></label>
                                         <input type="date" class="fr-input add-fields-if-past-date" data-fields="visite-reschedule-{{intervention.id}}-past-date-complementary-fields" name="visite-reschedule[date]" value="{{ intervention.scheduledAt.format('Y-m-d') }}" required>
-                                    </fieldset>
+                                    </div>
 
-                                    <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
-                                        <legend class="fr-fieldset__legend fr-text--regular">
-                                            Heure de la visite
-                                        </legend>
-                                        <p id="signalement-reschedule-visite-date-error" class="fr-error-text fr-hidden fr-my-3v">
-                                            Veuillez préciser l'heure de la visite.
-                                        </p>
+                                    <div class="fr-input-group">
+                                        <label class="fr-label" for="visite-reschedule[time]">Heure de la visite</label>
                                         <input type="time" class="fr-input" data-fields="visite-reschedule-past-date-complementary-fields" name="visite-reschedule[time]" value="{{ (intervention.scheduledAt.format('H')) > 0 ? intervention.scheduledAt|date('H:i')  : '' }}">
-                                    </fieldset>
+                                    </div>
                                     
                                     {% if is_granted('ROLE_ADMIN_TERRITORY') %}
-                                        <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
-                                            <legend class="fr-fieldset__legend fr-text--regular required">
-                                                Opérateur de visite
-                                            </legend>
-                                            <p id="signalement-reschedule-visite-partner-error" class="fr-error-text fr-hidden fr-my-3v">
-                                                Veuillez sélectionner le partenaire en charge de la visite
-                                            </p>
-                                            <p id="signalement-reschedule-visite-partner-double-error" class="fr-error-text fr-hidden fr-my-3v">
-                                                Ce partenaire a déjà une visite en cours.
-                                                Veuillez terminer ou annuler la visite ou sélectionner un autre partenaire.
-                                            </p>
+                                        <div class="fr-select-group">
+                                            <label class="fr-label" for="visite-reschedule[partner]">Opérateur de visite <span class="fr-text-default--error">*</span></label>
                                             <select name="visite-reschedule[partner]" class="fr-select visite-partner-select">
                                                 {% for partner in partnersCanVisite %}
                                                     {% set alertPartner = false %}
@@ -75,8 +56,17 @@
                                                         {{ partner.nom|upper }}
                                                     </option>
                                                 {% endfor %}
+                                                <option value="extern" {% if intervention.partner.id is null %}selected="selected"{% endif %}>Opérateur Externe</option>
                                             </select>
-                                        </fieldset>
+                                            <p id="signalement-reschedule-visite-partner-double-error" class="fr-error-text fr-hidden fr-my-3v">
+                                                Ce partenaire a déjà une visite en cours.
+                                                Veuillez terminer ou annuler la visite ou sélectionner un autre partenaire.
+                                            </p>
+                                        </div>
+                                        <div class="fr-input-group fr-hidden" id="visite-reschedule-external-operator">
+                                            <label class="fr-label" for="visite-reschedule[externalOperator]">Nom de l'opérateur externe <span class="fr-text-default--error">*</span></label>
+                                            <input type="text" name="visite-reschedule[externalOperator]" value="{{intervention.externalOperator}}" maxlength="255" class="fr-input">
+                                        </div>
                                     {% else %}
                                         <input type="hidden" name="visite-reschedule[partner]" value="{{ app.user.partnerInTerritory(signalement.territory).id }}">
                                     {% endif %}

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -57,8 +57,10 @@
                 Non renseigné
             {% else %}
                 {{ intervention.partner.nom }}
-                {% if intervention.partner.territory is not same as signalement.territory or intervention.partner.isArchive %}
-                    (partenaire supprimé)
+                {% if intervention.externalOperator %}
+                    <i>(opérateur externe)</i>
+                {% elseif intervention.partner.territory is not same as signalement.territory or intervention.partner.isArchive %}
+                    <i>(partenaire supprimé)</i>
                 {% endif %}
             {% endif %}
         </div>

--- a/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
+++ b/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
@@ -1,59 +1,68 @@
 {% if formType is not same as 'edit' %}
-    <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
+    <fieldset class="fr-fieldset fr-fieldset--inline">
         <legend class="fr-fieldset__legend fr-text--regular required">
             La visite a-t-elle eu lieu ?
         </legend>
-        <p id="signalement-confirm-visite-done-error" class="fr-error-text fr-hidden fr-my-3v">
+        <div class="fr-fieldset__element fr-fieldset__element--inline">
+            <div class="fr-radio-group">
+                <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-1" name="visite-{{ formType }}[visiteDone]" value="1">
+                <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-1">Visite effectuée</label>
+            </div>
+        </div>
+        <div class="fr-fieldset__element fr-fieldset__element--inline">
+            <div class="fr-radio-group">
+                <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-0" name="visite-{{ formType }}[visiteDone]" value="0">
+                <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-0">Visite non effectuée</label>
+            </div>
+        </div>
+        <p id="signalement-confirm-visite-done-error" class="fr-error-text fr-hidden fr-messages-group fr-mt-n1w">
             Veuillez préciser si la visite a eu lieu.
         </p>
-        <div class="fr-radio-group">
-            <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-1" name="visite-{{ formType }}[visiteDone]" value="1">
-            <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-1">Visite effectuée</label>
-        </div>
-        <div class="fr-radio-group">
-            <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-0" name="visite-{{ formType }}[visiteDone]" value="0">
-            <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-confirm-0">Visite non effectuée</label>
-        </div>
     </fieldset>
-    <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
+    <fieldset class="fr-fieldset fr-fieldset--inline">
         <legend class="fr-fieldset__legend fr-text--regular required">
             L'occupant était-il présent ?
         </legend>
-        <p id="signalement-confirm-visite-occupant-present-error" class="fr-error-text fr-hidden fr-my-3v">
+        <div class="fr-fieldset__element fr-fieldset__element--inline">
+            <div class="fr-radio-group">
+                <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-1" name="visite-{{ formType }}[occupantPresent]" value="1">
+                <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-1">Oui</label>
+            </div>
+        </div>
+        <div class="fr-fieldset__element fr-fieldset__element--inline">
+            <div class="fr-radio-group">
+                <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-0" name="visite-{{ formType }}[occupantPresent]" value="0">
+                <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-0">Non</label>
+            </div>
+        </div>
+        <p id="signalement-confirm-visite-occupant-present-error" class="fr-error-text fr-messages-group fr-hidden fr-mt-n1w">
             Veuillez préciser si l'occupant était présent.
         </p>
-        <div class="fr-radio-group">
-            <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-1" name="visite-{{ formType }}[occupantPresent]" value="1">
-            <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-1">Oui</label>
-        </div>
-        <div class="fr-radio-group">
-            <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-0" name="visite-{{ formType }}[occupantPresent]" value="0">
-            <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-occupant-present-0">Non</label>
-        </div>
     </fieldset>
-    <fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
+    <fieldset class="fr-fieldset fr-fieldset--inline">
         <legend class="fr-fieldset__legend fr-text--regular required">
             Le propriétaire était-il présent ?
         </legend>
-        <p id="signalement-confirm-visite-proprietaire-present-error" class="fr-error-text fr-hidden fr-my-3v">
+         <div class="fr-fieldset__element fr-fieldset__element--inline">
+            <div class="fr-radio-group">
+                <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-1" name="visite-{{ formType }}[proprietairePresent]" value="1">
+                <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-1">Oui</label>
+            </div>
+        </div>
+        <div class="fr-fieldset__element fr-fieldset__element--inline">
+            <div class="fr-radio-group">
+                <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-0" name="visite-{{ formType }}[proprietairePresent]" value="0">
+                <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-0">Non</label>
+            </div>
+        </div>
+        <p id="signalement-confirm-visite-proprietaire-present-error" class="fr-error-text fr-messages-group fr-hidden fr-mt-n1w">
             Veuillez préciser si le propriétaire était présent.
         </p>
-        <div class="fr-radio-group">
-            <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-1" name="visite-{{ formType }}[proprietairePresent]" value="1">
-            <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-1">Oui</label>
-        </div>
-        <div class="fr-radio-group">
-            <input type="radio" id="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-0" name="visite-{{ formType }}[proprietairePresent]" value="0">
-            <label for="visite-{{ formType }}-{{ intervention is defined ? intervention.id : '' }}-proprietaire-present-0">Non</label>
-        </div>
     </fieldset>
     <fieldset id="fieldset-conclude-procedure" class="fr-fieldset fr-fieldset--inline fr-mb-5v fr-w-100-left fr-hidden">
         <legend class="fr-fieldset__legend fr-text--regular required">
             Quelle est la conclusion de la visite ?
         </legend>
-        <p id="signalement-confirm-visite-procedure-error" class="fr-error-text fr-hidden fr-my-3v">
-            Veuillez préciser la conclusion de la visite.
-        </p>
         <div class="search-checkbox-container fr-input-group fr-w-100">
             <input id="visite-{{ formType }}[concludeProcedure]_input" type="text" placeholder="Sélectionner une ou plusieurs conclusions" class="fr-input">
             <div class="search-checkbox" class="fr-hidden">
@@ -70,6 +79,9 @@
                 {% endfor %}
             </div>
         </div>
+        <p id="signalement-confirm-visite-procedure-error" class="fr-error-text fr-hidden fr-messages-group fr-mt-n1w">
+            Veuillez préciser la conclusion de la visite.
+        </p>
     </fieldset>
 {% endif %}
 
@@ -94,17 +106,17 @@
 </div>
 {% endif %}
 
-<fieldset class="fr-fieldset fr-fieldset--inline fr-mb-5v">
-    <legend class="fr-fieldset__legend fr-text--regular required">
-        Commentaire de visite
-    </legend>
-    <p id="signalement-confirm-visite-details-error" class="fr-error-text fr-hidden fr-my-3v">
-        Veuillez saisir un commentaire pour la visite.
-    </p>
+<div class="fr-input-group">
+    <label class="fr-label" for="visite-{{ formType }}[details]">
+        Commentaire de visite <span class="fr-text-default--error">*</span>
+    </label>
     <textarea class="fr-input fr-input--no-resize editor field-visite-details" id="visite-{{ formType }}[details]" name="visite-{{ formType }}[details]" minlength="10">{{
         intervention is defined and intervention.details ? intervention.details : ''
     }}</textarea>
-</fieldset>
+    <p id="signalement-confirm-visite-details-error" class="fr-error-text fr-messages-group fr-hidden">
+        Veuillez saisir un commentaire pour la visite.
+    </p>
+</div>
 
 {% if not intervention is defined or intervention.files is empty %}
 <div class="fr-upload-group fr-mb-5v">

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -12,12 +12,17 @@
         {% if is_granted('SIGN_ADD_VISITE', signalement) %}
             {% include 'back/signalement/view/visites/modals/visites-modal-add.html.twig' %}
             {% set displayAddVisiteButton = true %}
+            {% set listPendingVisiteExternalOperatorNames = [] %}
             {% for pendingVisite in pendingVisites %}
                 {% set partner = app.user.partnerInTerritoryOrFirstOne(signalement.territory) %}
                 {% if pendingVisite.partner and pendingVisite.partner.id is same as partner.id %}
                     {% set displayAddVisiteButton = false %}
                 {% endif %}
+                {% if pendingVisite.externalOperator and pendingVisite.partner.id is null %}
+                    {% set listPendingVisiteExternalOperatorNames = listPendingVisiteExternalOperatorNames|merge([pendingVisite.externalOperator]) %}
+                {% endif %}
             {% endfor %}
+            <span id="list-pending-visite-external-operator-names" data-list="{{ listPendingVisiteExternalOperatorNames|json_encode}}"></span>
 
             <div class="fr-my-5v fr-text--right">
                 {% if not signalement.territory.isGrilleVisiteDisabled %}

--- a/tests/Functional/Manager/InterventionManagerTest.php
+++ b/tests/Functional/Manager/InterventionManagerTest.php
@@ -157,7 +157,7 @@ class InterventionManagerTest extends KernelTestCase
         $this->assertTrue($intervention->getScheduledAt() > new \DateTimeImmutable());
         $this->assertEquals('Lala la', $intervention->getPartner()->getNom());
         $this->assertNull($intervention->getPartner()->getId());
-        $this->assertEquals('AUTRE', $intervention->getPartner()->getType()->name);
+        $this->assertEquals('OPERATEUR_VISITES_ET_TRAVAUX', $intervention->getPartner()->getType()->name);
         $this->assertEquals('Lala la', $intervention->getExternalOperator());
         $this->assertEmailCount(0);
     }

--- a/tests/Functional/Manager/InterventionManagerTest.php
+++ b/tests/Functional/Manager/InterventionManagerTest.php
@@ -141,6 +141,30 @@ class InterventionManagerTest extends KernelTestCase
     /**
      * @throws \Exception
      */
+    public function testCreateFutureVisiteFromRequestOnExternalOperator(): void
+    {
+        $signalement = $this->signalementRepository->findOneBy(['reference' => '2023-10']);
+
+        $visiteRequest = new VisiteRequest(
+            date: (new \DateTimeImmutable())->modify('+ 1 month')->format('Y-m-d'),
+            time: '10:00',
+            externalOperator: 'Lala la',
+        );
+
+        $intervention = $this->interventionManager->createVisiteFromRequest($signalement, $visiteRequest);
+        $this->assertInstanceOf(Intervention::class, $intervention);
+        $this->assertEquals(Intervention::STATUS_PLANNED, $intervention->getStatus());
+        $this->assertTrue($intervention->getScheduledAt() > new \DateTimeImmutable());
+        $this->assertEquals('Lala la', $intervention->getPartner()->getNom());
+        $this->assertNull($intervention->getPartner()->getId());
+        $this->assertEquals('AUTRE', $intervention->getPartner()->getType()->name);
+        $this->assertEquals('Lala la', $intervention->getExternalOperator());
+        $this->assertEmailCount(0);
+    }
+
+    /**
+     * @throws \Exception
+     */
     public function testCancelVisiteFromRequest(): void
     {
         $signalement = $this->signalementRepository->findOneBy(['reference' => '2023-9']);


### PR DESCRIPTION
## Ticket

#3742

## Description
Ajout de la possibilité de sélectionner un "Opérateur externe" lors de la création/modification d'une visite

## Changements apportés
* Ajout d'une colonne sur la table intervention pour enregistrer le nom de l'opérateur externe de visite
* Mise au propre du html des modale d'ajout/édition de visites
* Corrections et ajout de tests sur les visites

## Pré-requis
`make execute-migration name=Version20250328162438 direction=up`
`make npm-build`

## Tests
- [ ] Faire quelques tests arbitraire sur ce qui concerne les visites 
