### PR TITLE
[BO - Brouillon Signalement] Onglet coordonnées

### DIFF
--- a/assets/scripts/app-back-bo.ts
+++ b/assets/scripts/app-back-bo.ts
@@ -12,6 +12,7 @@ import './vanilla/services/search_filter_form.js'
 import './vanilla/services/table_sortable.js'
 import './vanilla/services/list_filter_helper.js';
 import './vanilla/services/component_search_checkbox.js';
+import './vanilla/services/component_phone_number_row.js';
 import './vanilla/services/tabs_manager.js';
 import './vanilla/services/modales_helper.js';
 

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -131,7 +131,7 @@ function initBoFormSignalementSubmit(tabName) {
   }
 }
 
-function initRefreshFromRadio(tabName, radioName, listElements) {
+function initRefreshFromRadio(tabName, radioName, listElementsToEnable, valueToEnable = undefined, listElementsToHide = []) {
   const boFormSignalementTab = document?.querySelector('#bo-form-signalement-' + tabName)
 
   const radioInputs = boFormSignalementTab?.querySelectorAll('#' +radioName+ ' input')
@@ -150,37 +150,51 @@ function initRefreshFromRadio(tabName, radioName, listElements) {
       }
     })
 
-    listElements.forEach((elementSelector) => {
-      refreshElementEnable(tabName, elementSelector, (radioInputValue === 'oui' || radioInputValue === '1'))
+    listElementsToEnable.forEach((elementSelector) => {
+      refreshElementEnable('enable', tabName, elementSelector, (radioInputValue === 'oui' || radioInputValue === '1' || (valueToEnable !== undefined && radioInputValue === valueToEnable)))
+    })
+
+    listElementsToHide.forEach((elementSelector) => {
+      refreshElementEnable('show', tabName, elementSelector, (radioInputValue === 'oui' || radioInputValue === '1' || (valueToEnable !== undefined && radioInputValue === valueToEnable)))
     })
   }
 }
 
-function refreshElementEnable(tabName, elementSelector, isEnabled) {
+function refreshElementEnable(action, tabName, elementSelector, isEnabled) {
   const boFormSignalementTab = document?.querySelector('#bo-form-signalement-' + tabName)
   const elementSelected = boFormSignalementTab?.querySelector(elementSelector)
 
   if (isEnabled) {
-    elementSelected.parentElement.classList.remove('fr-input-group--disabled')
-    elementSelected.disabled = false
-    const elementSelectedInputs = elementSelected?.querySelectorAll('input')
-    if (elementSelectedInputs) {
-      elementSelectedInputs.forEach((elementSelectedInput) => {
-        elementSelectedInput.disabled = false
-      })
+    if (action === 'show') {
+      elementSelected.classList.remove('fr-display-none')
+
+    } else {
+      elementSelected.parentElement.classList.remove('fr-input-group--disabled')
+      elementSelected.disabled = false
+      const elementSelectedInputs = elementSelected?.querySelectorAll('input')
+      if (elementSelectedInputs) {
+        elementSelectedInputs.forEach((elementSelectedInput) => {
+          elementSelectedInput.disabled = false
+        })
+      }
     }
 
   } else {
-    elementSelected.parentElement.classList.add('fr-input-group--disabled')
-    if (elementSelected.value) {
-      elementSelected.value = ''
+    if (action === 'show') {
+      elementSelected.classList.add('fr-display-none')
+
+    } else {
+      elementSelected.parentElement.classList.add('fr-input-group--disabled')
+      if (elementSelected.value) {
+        elementSelected.value = ''
+      }
+      elementSelected.disabled = true
+      const elementSelectedInputs = elementSelected?.querySelectorAll('input')
+      elementSelectedInputs.forEach((elementSelectedInput) => {
+        elementSelectedInput.checked = false
+        elementSelectedInput.disabled = true
+      })
     }
-    elementSelected.disabled = true
-    const elementSelectedInputs = elementSelected?.querySelectorAll('input')
-    elementSelectedInputs.forEach((elementSelectedInput) => {
-      elementSelectedInput.checked = false
-      elementSelectedInput.disabled = true
-    })
   }
 }
 
@@ -247,9 +261,9 @@ function initBoFormSignalementLogement() {
       }
     })
 
-    refreshElementEnable('logement', '#signalement_draft_logement_natureLogementAutre', (natureLogementValue === 'autre'))
-    refreshElementEnable('logement', '#signalement_draft_logement_appartementEtage', (natureLogementValue === 'appartement'))
-    refreshElementEnable('logement', '#signalement_draft_logement_appartementAvecFenetres', (natureLogementValue === 'appartement'))
+    refreshElementEnable('enable', 'logement', '#signalement_draft_logement_natureLogementAutre', (natureLogementValue === 'autre'))
+    refreshElementEnable('enable', 'logement', '#signalement_draft_logement_appartementEtage', (natureLogementValue === 'appartement'))
+    refreshElementEnable('enable', 'logement', '#signalement_draft_logement_appartementAvecFenetres', (natureLogementValue === 'appartement'))
   }
 
   const compositionLogementInputs = boFormSignalementLogement?.querySelectorAll('#signalement_draft_logement_pieceUnique input')
@@ -268,7 +282,7 @@ function initBoFormSignalementLogement() {
       }
     })
 
-    refreshElementEnable('logement', '#signalement_draft_logement_nombrePieces', (compositionLogementValue === 'plusieurs_pieces'))
+    refreshElementEnable('enable', 'logement', '#signalement_draft_logement_nombrePieces', (compositionLogementValue === 'plusieurs_pieces'))
   }
 
   const cuisineInputs = boFormSignalementLogement?.querySelectorAll('#signalement_draft_logement_cuisine input')
@@ -299,7 +313,7 @@ function initBoFormSignalementLogement() {
       }
     })
 
-    refreshElementEnable('logement', '#signalement_draft_logement_toilettesCuisineMemePiece', (cuisineValue === 'oui' && toilettesValue === 'oui'))
+    refreshElementEnable('enable', 'logement', '#signalement_draft_logement_toilettesCuisineMemePiece', (cuisineValue === 'oui' && toilettesValue === 'oui'))
   }
 }
 
@@ -401,4 +415,16 @@ window.addEventListener('refreshUploadedFileList', (e) => {
 })
 
 function initBoFormSignalementCoordonnees() {
+  initRefreshFromRadio(
+    'coordonnees',
+    'signalement_draft_coordonnees_typeProprio',
+    [
+      '#signalement_draft_coordonnees_denominationProprio',
+    ],
+    'ORGANISME_SOCIETE',
+    [
+      '#signalement_draft_coordonnees_nomProprio_help',
+      '#signalement_draft_coordonnees_prenomProprio_help',
+    ]
+  )
 }

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -431,4 +431,20 @@ function initBoFormSignalementCoordonnees() {
       '#signalement_draft_coordonnees_prenomProprio_help',
     ]
   )
+  initRefreshFromRadio(
+    'coordonnees',
+    'signalement_draft_coordonnees_profileDeclarantTiers',
+    [
+      '#signalement_draft_coordonnees_lienDeclarantOccupant',
+    ],
+    'TIERS_PARTICULIER'
+  )
+  initRefreshFromRadio(
+    'coordonnees',
+    'signalement_draft_coordonnees_profileDeclarantTiers',
+    [
+      '#signalement_draft_coordonnees_isProTiersDeclarant_0',
+    ],
+    'TIERS_PRO'
+  )
 }

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -117,7 +117,6 @@ function initBoFormSignalementSubmit(tabName) {
 
   switch (tabName) {
     case 'adresse':
-      initBoFormSignalementAdresse()
       break
     case 'logement':
       initBoFormSignalementLogement()
@@ -198,6 +197,8 @@ function refreshElementEnable(action, tabName, elementSelector, isEnabled) {
   }
 }
 
+initComponentsAdress()
+
 if (document?.querySelector('#bo-form-signalement-adresse')) {
   initBoFormSignalementSubmit('adresse')
 }
@@ -211,36 +212,39 @@ if (document?.querySelector('#bo-form-signalement-coordonnees')) {
   initBoFormSignalementSubmit('coordonnees')
 }
 
-function initBoFormSignalementAdresse() {
-  const inputAdresse = document?.querySelector('#signalement_draft_address_adresseCompleteOccupant')
-  attacheAutocompleteAddressEvent(inputAdresse)
-
-  const manualAddressSwitcher = document?.querySelector('#bo-signalement-manual-address-switcher')
-  const manualAddressContainer = document?.querySelector('#bo-form-signalement-manual-address-container')
-  const manualAddressAddress = document?.querySelector('#signalement_draft_address_adresseOccupant')
-  const manualAddressInputs = document.querySelectorAll('.bo-form-signalement-manual-address');
-  const hasManualAddressValues = Array.from(manualAddressInputs).some(input => input.value !== '')
-
-  manualAddressSwitcher?.addEventListener('click', (event) => {
-    event.preventDefault()
-    if (manualAddressContainer.classList.contains('fr-hidden')) {
-      manualAddressContainer.classList.remove('fr-hidden')
-      manualAddressSwitcher.textContent = 'Rechercher une adresse'
-      inputAdresse.value = ''
-      inputAdresse.disabled = true
-      manualAddressAddress.focus()
-    } else {
-      manualAddressContainer.classList.add('fr-hidden')
-      manualAddressSwitcher.textContent = 'Saisir une adresse manuellement'
-      manualAddressInputs.forEach(input => input.value = '');
-      inputAdresse.disabled = false
-      inputAdresse.focus()
+function initComponentsAdress() {
+  const addressInputs = document.querySelectorAll('[data-fr-adresse-autocomplete]')
+  addressInputs.forEach((addressInput) => {
+    attacheAutocompleteAddressEvent(addressInput)
+  
+    const addressInputParent = addressInput.parentElement.parentElement.parentElement
+    const manualAddressSwitcher = addressInputParent?.querySelector('.bo-signalement-manual-address-switcher')
+    const manualAddressContainer = addressInputParent?.querySelector('.bo-form-signalement-manual-address-container')
+    const manualAddressAddress = addressInputParent?.querySelector('.bo-form-signalement-manual-address-input')
+    const manualAddressInputs = addressInputParent?.querySelectorAll('.bo-form-signalement-manual-address');
+    const hasManualAddressValues = Array.from(manualAddressInputs).some(input => input.value !== '')
+  
+    manualAddressSwitcher?.addEventListener('click', (event) => {
+      event.preventDefault()
+      if (manualAddressContainer.classList.contains('fr-hidden')) {
+        manualAddressContainer.classList.remove('fr-hidden')
+        manualAddressSwitcher.textContent = 'Rechercher une adresse'
+        addressInput.value = ''
+        addressInput.disabled = true
+        manualAddressAddress.focus()
+      } else {
+        manualAddressContainer.classList.add('fr-hidden')
+        manualAddressSwitcher.textContent = 'Saisir une adresse manuellement'
+        manualAddressInputs.forEach(input => input.value = '');
+        addressInput.disabled = false
+        addressInput.focus()
+      }
+    })
+  
+    if(addressInput.value == '' && hasManualAddressValues) {
+      manualAddressSwitcher.click()
     }
   })
-
-  if(inputAdresse.value == '' && hasManualAddressValues) {
-    manualAddressSwitcher.click()
-  }
 }
 
 function initBoFormSignalementLogement() {

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -465,4 +465,6 @@ function initBoFormSignalementCoordonnees() {
       proTiersMail.value = ''
     }
   })
+
+  window.dispatchEvent(new Event('refreshPhoneNumberEvent'))
 }

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -125,6 +125,9 @@ function initBoFormSignalementSubmit(tabName) {
     case 'situation':
       initBoFormSignalementSituation()
       break
+    case 'coordonnees':
+      initBoFormSignalementCoordonnees()
+      break
   }
 }
 
@@ -189,6 +192,9 @@ if (document?.querySelector('#bo-form-signalement-logement')) {
 }
 if (document?.querySelector('#bo-form-signalement-situation')) {
   initBoFormSignalementSubmit('situation')
+}
+if (document?.querySelector('#bo-form-signalement-coordonnees')) {
+  initBoFormSignalementSubmit('coordonnees')
 }
 
 function initBoFormSignalementAdresse() {
@@ -393,3 +399,6 @@ function reloadDeleteFileList() {
 window.addEventListener('refreshUploadedFileList', (e) => {
   reloadFileList()
 })
+
+function initBoFormSignalementCoordonnees() {
+}

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -117,6 +117,7 @@ function initBoFormSignalementSubmit(tabName) {
 
   switch (tabName) {
     case 'adresse':
+      initComponentAdress('#signalement_draft_address_adresseCompleteOccupant')
       break
     case 'logement':
       initBoFormSignalementLogement()
@@ -126,6 +127,8 @@ function initBoFormSignalementSubmit(tabName) {
       break
     case 'coordonnees':
       initBoFormSignalementCoordonnees()
+      initComponentAdress('#signalement_draft_coordonnees_adresseCompleteProprio')
+      initComponentAdress('#signalement_draft_coordonnees_adresseCompleteAgence')
       break
   }
 }
@@ -197,8 +200,6 @@ function refreshElementEnable(action, tabName, elementSelector, isEnabled) {
   }
 }
 
-initComponentsAdress()
-
 if (document?.querySelector('#bo-form-signalement-adresse')) {
   initBoFormSignalementSubmit('adresse')
 }
@@ -212,39 +213,37 @@ if (document?.querySelector('#bo-form-signalement-coordonnees')) {
   initBoFormSignalementSubmit('coordonnees')
 }
 
-function initComponentsAdress() {
-  const addressInputs = document.querySelectorAll('[data-fr-adresse-autocomplete]')
-  addressInputs.forEach((addressInput) => {
-    attacheAutocompleteAddressEvent(addressInput)
-  
-    const addressInputParent = addressInput.parentElement.parentElement.parentElement
-    const manualAddressSwitcher = addressInputParent?.querySelector('.bo-signalement-manual-address-switcher')
-    const manualAddressContainer = addressInputParent?.querySelector('.bo-form-signalement-manual-address-container')
-    const manualAddressAddress = addressInputParent?.querySelector('.bo-form-signalement-manual-address-input')
-    const manualAddressInputs = addressInputParent?.querySelectorAll('.bo-form-signalement-manual-address');
-    const hasManualAddressValues = Array.from(manualAddressInputs).some(input => input.value !== '')
-  
-    manualAddressSwitcher?.addEventListener('click', (event) => {
-      event.preventDefault()
-      if (manualAddressContainer.classList.contains('fr-hidden')) {
-        manualAddressContainer.classList.remove('fr-hidden')
-        manualAddressSwitcher.textContent = 'Rechercher une adresse'
-        addressInput.value = ''
-        addressInput.disabled = true
-        manualAddressAddress.focus()
-      } else {
-        manualAddressContainer.classList.add('fr-hidden')
-        manualAddressSwitcher.textContent = 'Saisir une adresse manuellement'
-        manualAddressInputs.forEach(input => input.value = '');
-        addressInput.disabled = false
-        addressInput.focus()
-      }
-    })
-  
-    if(addressInput.value == '' && hasManualAddressValues) {
-      manualAddressSwitcher.click()
+function initComponentAdress(id) {
+  const addressInput = document.querySelector(id)
+  attacheAutocompleteAddressEvent(addressInput)
+
+  const addressInputParent = addressInput.parentElement.parentElement.parentElement
+  const manualAddressSwitcher = addressInputParent?.querySelector('.bo-signalement-manual-address-switcher')
+  const manualAddressContainer = addressInputParent?.querySelector('.bo-form-signalement-manual-address-container')
+  const manualAddressAddress = addressInputParent?.querySelector('.bo-form-signalement-manual-address-input')
+  const manualAddressInputs = addressInputParent?.querySelectorAll('.bo-form-signalement-manual-address');
+  const hasManualAddressValues = Array.from(manualAddressInputs).some(input => input.value !== '')
+
+  manualAddressSwitcher?.addEventListener('click', (event) => {
+    event.preventDefault()
+    if (manualAddressContainer.classList.contains('fr-hidden')) {
+      manualAddressContainer.classList.remove('fr-hidden')
+      manualAddressSwitcher.textContent = 'Rechercher une adresse'
+      addressInput.value = ''
+      addressInput.disabled = true
+      manualAddressAddress.focus()
+    } else {
+      manualAddressContainer.classList.add('fr-hidden')
+      manualAddressSwitcher.textContent = 'Saisir une adresse manuellement'
+      manualAddressInputs.forEach(input => input.value = '');
+      addressInput.disabled = false
+      addressInput.focus()
     }
   })
+
+  if(addressInput.value == '' && hasManualAddressValues) {
+    manualAddressSwitcher.click()
+  }
 }
 
 function initBoFormSignalementLogement() {
@@ -447,4 +446,23 @@ function initBoFormSignalementCoordonnees() {
     ],
     'TIERS_PRO'
   )
+
+  const checkIsProTiersDeclarant = document.querySelector('#signalement_draft_coordonnees_isProTiersDeclarant_0')
+  checkIsProTiersDeclarant.addEventListener('change', (event) => {
+    const proTiersStructure = document.querySelector('#signalement_draft_coordonnees_structureDeclarant')
+    const proTiersNom = document.querySelector('#signalement_draft_coordonnees_nomDeclarant')
+    const proTiersPrenom = document.querySelector('#signalement_draft_coordonnees_prenomDeclarant')
+    const proTiersMail = document.querySelector('#signalement_draft_coordonnees_mailDeclarant')
+    if (event.target.checked) {
+      proTiersStructure.value = checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userStructure
+      proTiersNom.value = checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userNom
+      proTiersPrenom.value = checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userPrenom
+      proTiersMail.value = checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userMail
+    } else {
+      proTiersStructure.value = ''
+      proTiersNom.value = ''
+      proTiersPrenom.value = ''
+      proTiersMail.value = ''
+    }
+  })
 }

--- a/assets/scripts/vanilla/services/component_phone_number_row.js
+++ b/assets/scripts/vanilla/services/component_phone_number_row.js
@@ -1,0 +1,21 @@
+document.querySelectorAll('.phone-number-row-container').forEach((containerPhoneNumber) => {
+  initContainerPhoneNumber(containerPhoneNumber)
+})
+
+function initContainerPhoneNumber (containerPhoneNumber) {
+  const selectCode = containerPhoneNumber.querySelector('.fr-select')
+  const inputNumber = containerPhoneNumber.querySelector('.fr-input')
+  selectCode.addEventListener('change', (event) => {
+    refreshInputHidden(containerPhoneNumber)
+  })
+  inputNumber.addEventListener('input', (event) => {
+    refreshInputHidden(containerPhoneNumber)
+  })
+}
+
+function refreshInputHidden(containerPhoneNumber) {
+  const selectCode = containerPhoneNumber.querySelector('.fr-select')
+  const inputNumber = containerPhoneNumber.querySelector('.fr-input')
+  const inputHidden = containerPhoneNumber.querySelector('[type=hidden]')
+  inputHidden.value = selectCode.value + inputNumber.value
+}

--- a/assets/scripts/vanilla/services/component_phone_number_row.js
+++ b/assets/scripts/vanilla/services/component_phone_number_row.js
@@ -1,5 +1,7 @@
-document.querySelectorAll('.phone-number-row-container').forEach((containerPhoneNumber) => {
-  initContainerPhoneNumber(containerPhoneNumber)
+window.addEventListener('refreshPhoneNumberEvent', (e) => {
+  document.querySelectorAll('.phone-number-row-container').forEach((containerPhoneNumber) => {
+    initContainerPhoneNumber(containerPhoneNumber)
+  })
 })
 
 function initContainerPhoneNumber (containerPhoneNumber) {
@@ -17,5 +19,10 @@ function refreshInputHidden(containerPhoneNumber) {
   const selectCode = containerPhoneNumber.querySelector('.fr-select')
   const inputNumber = containerPhoneNumber.querySelector('.fr-input')
   const inputHidden = containerPhoneNumber.querySelector('[type=hidden]')
-  inputHidden.value = selectCode.value + inputNumber.value
+  inputHidden.value = ''
+  if (selectCode.value !== '' && inputNumber.value !== '') {
+    inputHidden.value = selectCode.value + inputNumber.value
+  }
 }
+
+window.dispatchEvent(new Event('refreshPhoneNumberEvent'))

--- a/assets/scripts/vanilla/services/component_search_address.js
+++ b/assets/scripts/vanilla/services/component_search_address.js
@@ -26,6 +26,10 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
   }
 
   let selectionIndex = -1
+  let suffix = ''
+  if (inputAdresse.dataset.suffix !== undefined && inputAdresse.dataset.suffix !== '') {
+    suffix = '-' + inputAdresse.dataset.suffix
+  }
   const addressGroup = document?.querySelector(inputAdresse.dataset.autocompleteQuerySelector)
   const apiAdresse = 'https://api-adresse.data.gouv.fr/search/?q='
   inputAdresse.addEventListener('input', (e) => {
@@ -53,7 +57,7 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
                 'fr-adresse-suggestion'
               )
               suggestion.innerHTML = feature.properties.label
-              attachAddressSuggestionEvent(inputAdresse, suggestion, feature)
+              attachAddressSuggestionEvent(inputAdresse, suggestion, feature, suffix)
               addressGroup.appendChild(suggestion)
             }
           })
@@ -62,17 +66,17 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
     if (adresse.length === 0) {
       addressGroup.innerHTML = ''
       const idForm = inputAdresse.closest('form').id
-      if (document?.querySelector('#' + idForm + ' [data-autocomplete-addresse]')) {
-        document.querySelector('#' + idForm + ' [data-autocomplete-addresse]').value = ''
+      if (document?.querySelector('#' + idForm + ' [data-autocomplete-addresse'+suffix+']')) {
+        document.querySelector('#' + idForm + ' [data-autocomplete-addresse'+suffix+']').value = ''
       }
-      if (document?.querySelector('#' + idForm + ' [data-autocomplete-codepostal]')) {
-        document.querySelector('#' + idForm + ' [data-autocomplete-codepostal]').value = ''
+      if (document?.querySelector('#' + idForm + ' [data-autocomplete-codepostal'+suffix+']')) {
+        document.querySelector('#' + idForm + ' [data-autocomplete-codepostal'+suffix+']').value = ''
       }
-      if (document?.querySelector('#' + idForm + ' [data-autocomplete-ville]')) {
-        document.querySelector('#' + idForm + ' [data-autocomplete-ville]').value = ''
+      if (document?.querySelector('#' + idForm + ' [data-autocomplete-ville'+suffix+']')) {
+        document.querySelector('#' + idForm + ' [data-autocomplete-ville'+suffix+']').value = ''
       }
-      if (document?.querySelector('#' + idForm + ' [data-autocomplete-insee]')) {
-        document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = ''
+      if (document?.querySelector('#' + idForm + ' [data-autocomplete-insee'+suffix+']')) {
+        document.querySelector('#' + idForm + ' [data-autocomplete-insee'+suffix+']').value = ''
       }
     }
   })
@@ -115,27 +119,27 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
   })
 }
 
-function attachAddressSuggestionEvent (inputAdresse, suggestion, feature) {
+function attachAddressSuggestionEvent (inputAdresse, suggestion, feature, suffix) {
   suggestion.addEventListener('click', (e) => {
     const idForm = inputAdresse.closest('form').id
     inputAdresse.value = feature.properties.label
-    if (document?.querySelector('#' + idForm + ' [data-autocomplete-addresse]')) {
-      document.querySelector('#' + idForm + ' [data-autocomplete-addresse]').value = feature.properties.name
+    if (document?.querySelector('#' + idForm + ' [data-autocomplete-addresse'+suffix+']')) {
+      document.querySelector('#' + idForm + ' [data-autocomplete-addresse'+suffix+']').value = feature.properties.name
     }
-    if (document?.querySelector('#' + idForm + ' [data-autocomplete-codepostal]')) {
-      document.querySelector('#' + idForm + ' [data-autocomplete-codepostal]').value = feature.properties.postcode
+    if (document?.querySelector('#' + idForm + ' [data-autocomplete-codepostal'+suffix+']')) {
+      document.querySelector('#' + idForm + ' [data-autocomplete-codepostal'+suffix+']').value = feature.properties.postcode
     }
-    if (document?.querySelector('#' + idForm + ' [data-autocomplete-ville]')) {
-      document.querySelector('#' + idForm + ' [data-autocomplete-ville]').value = feature.properties.city
+    if (document?.querySelector('#' + idForm + ' [data-autocomplete-ville'+suffix+']')) {
+      document.querySelector('#' + idForm + ' [data-autocomplete-ville'+suffix+']').value = feature.properties.city
     }
-    if (document?.querySelector('#' + idForm + ' [data-autocomplete-manual]')) {
-      document.querySelector('#' + idForm + ' [data-autocomplete-manual]').value = 0
+    if (document?.querySelector('#' + idForm + ' [data-autocomplete-manual'+suffix+']')) {
+      document.querySelector('#' + idForm + ' [data-autocomplete-manual'+suffix+']').value = 0
     }
-    if (document?.querySelector('#' + idForm + ' [data-autocomplete-need-reset-insee]')) {
-      document.querySelector('#' + idForm + ' [data-autocomplete-need-reset-insee]').value = 0
+    if (document?.querySelector('#' + idForm + ' [data-autocomplete-need-reset-insee'+suffix+']')) {
+      document.querySelector('#' + idForm + ' [data-autocomplete-need-reset-insee'+suffix+']').value = 0
     }
-    if (document?.querySelector('#' + idForm + ' [data-autocomplete-insee]')) {
-      document.querySelector('#' + idForm + ' [data-autocomplete-insee]').value = feature.properties.citycode
+    if (document?.querySelector('#' + idForm + ' [data-autocomplete-insee'+suffix+']')) {
+      document.querySelector('#' + idForm + ' [data-autocomplete-insee'+suffix+']').value = feature.properties.citycode
     }
     const addressGroup = document?.querySelector(inputAdresse.dataset.autocompleteQuerySelector)
     addressGroup.innerHTML = ''

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -19,6 +19,7 @@ twig:
         feature_sites_faciles: '%env(bool:FEATURE_SITES_FACILES)%'
         feature_banner_histologe: '%env(bool:FEATURE_BANNER_HISTOLOGE)%'
         sites_faciles_url: '%env(resolve:SITES_FACILES_URL)%'
+        feature_bo_signalement_create: '%env(bool:FEATURE_BO_SIGNALEMENT_CREATE)%'
     paths:
         # point this wherever your images live
         '%kernel.project_dir%/public/img': images

--- a/migrations/Version20250319142447.php
+++ b/migrations/Version20250319142447.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250319142447 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'separate nom and denomination from proprio';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement ADD denomination_proprio VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP denomination_proprio');
+    }
+}

--- a/migrations/Version20250324150108.php
+++ b/migrations/Version20250324150108.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250324150108 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add agence fields to signalement';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement ADD nom_agence VARCHAR(255) DEFAULT NULL, ADD denomination_agence VARCHAR(255) DEFAULT NULL, ADD prenom_agence VARCHAR(255) DEFAULT NULL, ADD adresse_agence VARCHAR(255) DEFAULT NULL, ADD code_postal_agence VARCHAR(5) DEFAULT NULL, ADD ville_agence VARCHAR(255) DEFAULT NULL, ADD tel_agence VARCHAR(128) DEFAULT NULL, ADD tel_agence_secondaire VARCHAR(128) DEFAULT NULL, ADD mail_agence VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP nom_agence, DROP denomination_agence, DROP prenom_agence, DROP adresse_agence, DROP code_postal_agence, DROP ville_agence, DROP tel_agence, DROP tel_agence_secondaire, DROP mail_agence');
+    }
+}

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -302,12 +302,12 @@ class SignalementCreateController extends AbstractController
                 $this->addFlash('success', 'Le brouillon est bien enregistré, n\'oubliez pas de le terminer !');
                 $url = $this->generateUrl('back_signalement_drafts', [], UrlGeneratorInterface::ABSOLUTE_URL);
             } else {
-                $url = $this->generateUrl('back_signalement_edit_draft', ['uuid' => $signalement->getUuid(), '_fragment' => 'desordres'], UrlGeneratorInterface::ABSOLUTE_URL);
+                $url = '';
             }
 
             $tabContent = $this->renderView('back/signalement_create/tabs/tab-coordonnees.html.twig', ['formCoordonnees' => $form, 'signalement' => $signalement]);
 
-            return $this->json(['redirect' => true, 'tabContent' => $tabContent]);
+            return $this->json(['redirect' => true, 'tabContent' => $tabContent, 'url' => $url]);
         }
 
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-coordonnees.html.twig', ['formCoordonnees' => $form, 'signalement' => $signalement]);

--- a/src/DataFixtures/Files/signalement_draft_payload/locataire.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/locataire.json
@@ -52,7 +52,7 @@
   "bail_dpe_etat_des_lieux": "oui",
   "bail_dpe_invariant": "abcd12ef34",
   "adresse_logement_adresse": "33 Rue des phoceens 13002 Marseille",
-  "coordonnees_bailleur_nom": "13 Habitat",
+  "coordonnees_bailleur_nom": "13 HABITAT",
   "coordonnees_bailleur_prenom": "Sandrine",
   "coordonnees_bailleur_email": "sandrine@signal-logement.fr",
   "coordonnees_bailleur_tel": "0644784516",

--- a/src/Dto/Request/Signalement/CoordonneesAgenceRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesAgenceRequest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Dto\Request\Signalement;
+
+use App\Validator as AppAssert;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Constraints\Email;
+
+class CoordonneesAgenceRequest implements RequestInterface
+{
+    public function __construct(
+        #[Assert\Length(max: 255, maxMessage: 'La dénomination de l\'agence ne doit pas dépasser {{ limit }} caractères.')]
+        private readonly ?string $denomination = null,
+        #[Assert\Length(max: 255, maxMessage: 'Le nom de l\'agence ne doit pas dépasser {{ limit }} caractères.')]
+        private readonly ?string $nom = null,
+        #[Assert\Length(max: 255, maxMessage: 'Le prénom de l\'agence ne doit pas dépasser {{ limit }} caractères.')]
+        private readonly ?string $prenom = null,
+        #[Email(mode: Email::VALIDATION_MODE_STRICT)]
+        #[Assert\Length(max: 255, maxMessage: 'L\'email de l\'agence ne doit pas dépasser {{ limit }} caractères.')]
+        private readonly ?string $mail = null,
+        #[AppAssert\TelephoneFormat]
+        private readonly ?string $telephone = null,
+        #[AppAssert\TelephoneFormat]
+        private readonly ?string $telephoneBis = null,
+        #[Assert\Length(max: 255, maxMessage: 'L\'adresse de l\'agence ne doit pas dépasser {{ limit }} caractères.')]
+        private readonly ?string $adresse = null,
+        #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal doit être composé de 5 chiffres.')]
+        private readonly ?string $codePostal = null,
+        #[Assert\Length(max: 255, maxMessage: 'La ville de l\'agence ne doit pas dépasser {{ limit }} caractères.')]
+        private readonly ?string $ville = null,
+    ) {
+    }
+
+    public function getDenomination(): ?string
+    {
+        return $this->denomination;
+    }
+
+    public function getNom(): ?string
+    {
+        return $this->nom;
+    }
+
+    public function getPrenom(): ?string
+    {
+        return $this->prenom;
+    }
+
+    public function getMail(): ?string
+    {
+        return $this->mail;
+    }
+
+    public function getTelephone(): ?string
+    {
+        return $this->telephone;
+    }
+
+    public function getTelephoneBis(): ?string
+    {
+        return $this->telephoneBis;
+    }
+
+    public function getAdresse(): ?string
+    {
+        return $this->adresse;
+    }
+
+    public function getCodePostal(): ?string
+    {
+        return $this->codePostal;
+    }
+
+    public function getVille(): ?string
+    {
+        return $this->ville;
+    }
+}

--- a/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesBailleurRequest.php
@@ -13,6 +13,10 @@ class CoordonneesBailleurRequest implements RequestInterface
     use DateNaissanceValidatorTrait;
 
     public function __construct(
+        #[Assert\Choice(choices: ['ORGANISME_SOCIETE', 'PARTICULIER'], message: 'Le type de propriétaire est incorrect.')]
+        private readonly ?string $typeProprio = null,
+        #[Assert\Length(max: 255, maxMessage: 'La dénomination du bailleur ne doit pas dépasser {{ limit }} caractères.')]
+        private readonly ?string $denomination = null,
         #[Assert\NotBlank(
             message: 'Merci de saisir le nom du bailleur.',
             groups: ['LOCATAIRE', 'BAILLEUR_OCCUPANT', 'BAILLEUR', 'TIERS_PARTICULIER', 'TIERS_PRO'])]
@@ -56,6 +60,16 @@ class CoordonneesBailleurRequest implements RequestInterface
     public function validate(ExecutionContextInterface $context): void
     {
         $this->validateDateNaissance($this->dateNaissance, 'dateNaissance', $context);
+    }
+
+    public function getTypeProprio(): ?string
+    {
+        return $this->typeProprio;
+    }
+
+    public function getDenomination(): ?string
+    {
+        return $this->denomination;
     }
 
     public function getNom(): ?string

--- a/src/Entity/Enum/Api/PersonneType.php
+++ b/src/Entity/Enum/Api/PersonneType.php
@@ -7,4 +7,5 @@ enum PersonneType: string
     case DECLARANT = 'DECLARANT';
     case OCCUPANT = 'OCCUPANT';
     case PROPRIETAIRE = 'PROPRIETAIRE';
+    case AGENCE = 'AGENCE';
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -132,6 +132,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     private ?string $telProprioSecondaire = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Email(mode: Email::VALIDATION_MODE_STRICT, message: 'L\'adresse e-mail du bailleur n\'est pas valide.', groups: ['Default', 'bo_step_coordonnees'])]
     private ?string $mailProprio = null;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
@@ -169,7 +170,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     private ?string $telDeclarantSecondaire = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    #[Email(mode: Email::VALIDATION_MODE_STRICT, message: 'L\'adresse e-mail du déclarant n\'est pas valide.')]
+    #[Email(mode: Email::VALIDATION_MODE_STRICT, message: 'L\'adresse e-mail du déclarant n\'est pas valide.', groups: ['Default', 'bo_step_coordonnees'])]
     private ?string $mailDeclarant = null;
 
     #[ORM\Column(type: 'string', length: 200, nullable: true)]
@@ -193,7 +194,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     private ?string $telOccupant = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    #[Email(mode: Email::VALIDATION_MODE_STRICT, message: 'L\'adresse e-mail de l\'occupant n\'est pas valide.')]
+    #[Email(mode: Email::VALIDATION_MODE_STRICT, message: 'L\'adresse e-mail de l\'occupant n\'est pas valide.', groups: ['Default', 'bo_step_coordonnees'])]
     private ?string $mailOccupant = null;
 
     #[ORM\Column(type: 'string', length: 100, nullable: true)]
@@ -243,6 +244,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     private ?string $telAgenceSecondaire = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Email(mode: Email::VALIDATION_MODE_STRICT, message: 'L\'adresse e-mail de l\'agence n\'est pas valide.', groups: ['Default', 'bo_step_coordonnees'])]
     private ?string $mailAgence = null;
 
     #[ORM\Column(type: 'boolean')]

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -212,6 +212,39 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
     private ?string $banIdOccupant = null;
 
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Assert\Length(max: 255)]
+    private ?string $nomAgence = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Assert\Length(max: 255)]
+    private ?string $denominationAgence = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Assert\Length(max: 255)]
+    private ?string $prenomAgence = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $adresseAgence = null;
+
+    #[ORM\Column(type: 'string', length: 5, nullable: true)]
+    #[Assert\Regex(pattern: '/^[0-9]{5}$/', message: 'Le code postal être composé de 5 chiffres.')]
+    private ?string $codePostalAgence = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $villeAgence = null;
+
+    #[ORM\Column(type: 'string', length: 128, nullable: true)]
+    #[AppAssert\TelephoneFormat]
+    private ?string $telAgence = null;
+
+    #[ORM\Column(type: 'string', length: 128, nullable: true)]
+    #[AppAssert\TelephoneFormat]
+    private ?string $telAgenceSecondaire = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $mailAgence = null;
+
     #[ORM\Column(type: 'boolean')]
     private ?bool $isCguAccepted = null;
 
@@ -1133,6 +1166,114 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function setBanIdOccupant(?string $banIdOccupant): self
     {
         $this->banIdOccupant = $banIdOccupant;
+
+        return $this;
+    }
+
+    public function getNomAgence(): ?string
+    {
+        return $this->nomAgence;
+    }
+
+    public function setNomAgence(?string $nomAgence): self
+    {
+        $this->nomAgence = $nomAgence;
+
+        return $this;
+    }
+
+    public function getDenominationAgence(): ?string
+    {
+        return $this->denominationAgence;
+    }
+
+    public function setDenominationAgence(?string $denominationAgence): self
+    {
+        $this->denominationAgence = $denominationAgence;
+
+        return $this;
+    }
+
+    public function getPrenomAgence(): ?string
+    {
+        return $this->prenomAgence;
+    }
+
+    public function setPrenomAgence(?string $prenomAgence): self
+    {
+        $this->prenomAgence = $prenomAgence;
+
+        return $this;
+    }
+
+    public function getAdresseAgence(): ?string
+    {
+        return $this->adresseAgence;
+    }
+
+    public function setAdresseAgence(?string $adresseAgence): self
+    {
+        $this->adresseAgence = $adresseAgence;
+
+        return $this;
+    }
+
+    public function getCodePostalAgence(): ?string
+    {
+        return $this->codePostalAgence;
+    }
+
+    public function setCodePostalAgence(?string $codePostalAgence): self
+    {
+        $this->codePostalAgence = $codePostalAgence;
+
+        return $this;
+    }
+
+    public function getVilleAgence(): ?string
+    {
+        return $this->villeAgence;
+    }
+
+    public function setVilleAgence(?string $villeAgence): self
+    {
+        $this->villeAgence = $villeAgence;
+
+        return $this;
+    }
+
+    public function getTelAgence(): ?string
+    {
+        return $this->telAgence;
+    }
+
+    public function setTelAgence(?string $telAgence): self
+    {
+        $this->telAgence = $telAgence;
+
+        return $this;
+    }
+
+    public function getTelAgenceSecondaire(): ?string
+    {
+        return $this->telAgenceSecondaire;
+    }
+
+    public function setTelAgenceSecondaire(?string $telAgenceSecondaire): self
+    {
+        $this->telAgenceSecondaire = $telAgenceSecondaire;
+
+        return $this;
+    }
+
+    public function getMailAgence(): ?string
+    {
+        return $this->mailAgence;
+    }
+
+    public function setMailAgence(?string $mailAgence): self
+    {
+        $this->mailAgence = $mailAgence;
 
         return $this;
     }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -1247,6 +1247,11 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         return $this->telAgence;
     }
 
+    public function getTelAgenceDecoded(?bool $national = false): ?string
+    {
+        return Phone::format($this->telAgence, $national);
+    }
+
     public function setTelAgence(?string $telAgence): self
     {
         $this->telAgence = $telAgence;
@@ -1257,6 +1262,11 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function getTelAgenceSecondaire(): ?string
     {
         return $this->telAgenceSecondaire;
+    }
+
+    public function getTelAgenceSecondaireDecoded(?bool $national = false): ?string
+    {
+        return Phone::format($this->telAgenceSecondaire, $national);
     }
 
     public function setTelAgenceSecondaire(?string $telAgenceSecondaire): self

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -107,6 +107,10 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Assert\Length(max: 255)]
+    private ?string $denominationProprio = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Assert\Length(max: 255)]
     private ?string $prenomProprio = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
@@ -794,16 +798,28 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function getNomProprio(): ?string
     {
-        if ($this->bailleur) {
-            return $this->bailleur->getName();
-        }
-
         return $this->nomProprio;
     }
 
     public function setNomProprio(?string $nomProprio): self
     {
         $this->nomProprio = $nomProprio;
+
+        return $this;
+    }
+
+    public function getDenominationProprio(): ?string
+    {
+        if ($this->bailleur) {
+            return $this->bailleur->getName();
+        }
+
+        return $this->denominationProprio;
+    }
+
+    public function setDenominationProprio(?string $denominationProprio): self
+    {
+        $this->denominationProprio = $denominationProprio;
 
         return $this;
     }

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -14,6 +14,7 @@ use App\Entity\Enum\Api\PersonneType;
 use App\Entity\Enum\DesordreCritereZone;
 use App\Entity\Enum\EtageType;
 use App\Entity\Enum\InterventionType;
+use App\Entity\Enum\ProprioType;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Service\Signalement\SignalementDesordresProcessor;
@@ -246,6 +247,7 @@ readonly class SignalementResponseFactory
             return new Personne(
                 personneType: $personneType,
                 precisionTypeSiBailleur: $signalement->getTypeProprio(),
+                structure: ProprioType::ORGANISME_SOCIETE === $signalement->getTypeProprio() ? $signalement->getDenominationProprio() : '',
                 nom: $signalement->getNomProprio(),
                 prenom: $signalement->getPrenomProprio(),
                 email: $signalement->getMailProprio(),

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -19,6 +19,7 @@ use App\Entity\Signalement;
 use App\Entity\User;
 use App\Service\Signalement\SignalementDesordresProcessor;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 readonly class SignalementResponseFactory
 {
@@ -26,6 +27,7 @@ readonly class SignalementResponseFactory
         PersonneType::OCCUPANT,
         PersonneType::DECLARANT,
         PersonneType::PROPRIETAIRE,
+        PersonneType::AGENCE,
     ];
 
     public function __construct(
@@ -33,6 +35,7 @@ readonly class SignalementResponseFactory
         private FileFactory $fileFactory,
         private VisiteFactory $visiteFactory,
         private Security $security,
+        private ParameterBagInterface $parameterBag,
     ) {
     }
 
@@ -257,6 +260,25 @@ readonly class SignalementResponseFactory
                 revenuFiscal: $signalement->getInformationComplementaire()?->getInformationsComplementairesSituationBailleurRevenuFiscal(),
                 beneficiaireRsa: $this->stringToBool($signalement->getInformationComplementaire()?->getInformationsComplementairesSituationBailleurBeneficiaireRsa()),
                 beneficiaireFsl: $this->stringToBool($signalement->getInformationComplementaire()?->getInformationsComplementairesSituationBailleurBeneficiaireFsl()),
+                adresse: $adresse
+            );
+        }
+
+        if (PersonneType::AGENCE === $personneType && !empty($signalement->getDenominationAgence()) && $this->parameterBag->get('feature_bo_signalement_create')) {
+            $adresse = new Adresse(
+                adresse: $signalement->getAdresseAgence(),
+                codePostal: $signalement->getCodePostalAgence(),
+                ville: $signalement->getVilleAgence(),
+            );
+
+            return new Personne(
+                personneType: $personneType,
+                structure: $signalement->getDenominationAgence(),
+                nom: $signalement->getNomAgence(),
+                prenom: $signalement->getPrenomAgence(),
+                email: $signalement->getMailAgence(),
+                telephone: $signalement->getTelAgence(),
+                telephoneSecondaire: $signalement->getTelAgenceSecondaire(),
                 adresse: $adresse
             );
         }

--- a/src/Form/SignalementDraftAddressType.php
+++ b/src/Form/SignalementDraftAddressType.php
@@ -50,7 +50,7 @@ class SignalementDraftAddressType extends AbstractType
             ->add('adresseOccupant', null, [
                 'label' => 'Numéro et voie ',
                 'attr' => [
-                    'class' => 'bo-form-signalement-manual-address',
+                    'class' => 'bo-form-signalement-manual-address bo-form-signalement-manual-address-input',
                 ],
                 'empty_data' => '',
             ])

--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -8,12 +8,9 @@ use App\Entity\Enum\ProprioType;
 use App\Entity\Signalement;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,6 +27,7 @@ class SignalementDraftCoordonneesType extends AbstractType
         /** @var Signalement $signalement */
         $signalement = $builder->getData();
         $adresseCompleteProprio = trim($signalement->getAdresseProprio().' '.$signalement->getCodePostalProprio().' '.$signalement->getVilleProprio());
+        $adresseCompleteAgence = trim($signalement->getAdresseAgence().' '.$signalement->getCodePostalAgence().' '.$signalement->getVilleAgence());
         $profilesTiersList = [
             ProfileDeclarant::TIERS_PARTICULIER,
             ProfileDeclarant::TIERS_PRO,
@@ -42,29 +40,6 @@ class SignalementDraftCoordonneesType extends AbstractType
         }
 
         $builder
-        /*
-            ->add('dateEntreeLogement', DateType::class, [
-                'label' => 'Date d\'entrée dans le logement',
-                'required' => false,
-                'placeholder' => false,
-                'mapped' => false,
-                'data' => $dateEntreeLogement,
-            ])
-            ->add('montantLoyer', NumberType::class, [
-                'label' => 'Montant du loyer',
-                'help' => 'Format attendu : saisir un nombre entier',
-                'required' => false,
-                'mapped' => false,
-                'data' => $montantLoyer,
-            ])
-            ->add('reponseProprietaire', TextareaType::class, [
-                'label' => 'Réponse du bailleur / propriétaire',
-                'help' => 'Format attendu : 10 caractères minimum',
-                'required' => false,
-                'mapped' => false,
-                'data' => $reponseProprietaire,
-            ])
-                */
             ->add('nomOccupant', TextType::class, [
                 'label' => 'Nom de famille',
                 'required' => false,
@@ -130,13 +105,13 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'attr' => [
                     'autocomplete' => 'off',
                     'data-fr-adresse-autocomplete' => 'true',
-                    'data-autocomplete-query-selector' => '#bo-form-signalement-coordonnees .fr-address-group',
+                    'data-autocomplete-query-selector' => '#bo-form-signalement-coordonnees .fr-address-proprio-group',
                 ],
             ])
             ->add('adresseProprio', null, [
                 'label' => 'Numéro et voie ',
                 'attr' => [
-                    'class' => 'bo-form-signalement-manual-address',
+                    'class' => 'bo-form-signalement-manual-address bo-form-signalement-manual-address-input',
                 ],
                 'empty_data' => '',
             ])
@@ -215,6 +190,63 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'label' => 'Téléphone',
                 'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
                 'required' => false,
+            ])
+
+            ->add('denominationAgence', TextType::class, [
+                'label' => 'Dénomination',
+                'required' => false,
+            ])
+            ->add('nomAgence', TextType::class, [
+                'label' => 'Nom de famille',
+                'required' => false,
+            ])
+            ->add('prenomAgence', TextType::class, [
+                'label' => 'Prénom',
+                'required' => false,
+            ])
+            ->add('mailAgence', TextType::class, [
+                'label' => 'Adresse e-mail',
+                'help' => 'Format attendu : nom@domaine.fr',
+                'required' => false,
+            ])
+            ->add('telAgence', TextType::class, [
+                'label' => 'Téléphone',
+                'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+                'required' => false,
+            ])
+            ->add('adresseCompleteAgence', null, [
+                'label' => false,
+                'help' => 'Format attendu : Tapez l\'adresse puis sélectionnez-la dans la liste. Si elle n\'apparaît pas, cliquez sur saisir une adresse manuellement.',
+                'mapped' => false,
+                'data' => $adresseCompleteAgence,
+                'attr' => [
+                    'autocomplete' => 'off',
+                    'data-fr-adresse-autocomplete' => 'true',
+                    'data-autocomplete-query-selector' => '#bo-form-signalement-coordonnees .fr-address-agence-group',
+                ],
+            ])
+            ->add('adresseAgence', null, [
+                'label' => 'Numéro et voie ',
+                'attr' => [
+                    'class' => 'bo-form-signalement-manual-address bo-form-signalement-manual-address-input',
+                ],
+                'empty_data' => '',
+            ])
+            ->add('codePostalAgence', null, [
+                'label' => 'Code postal',
+                'required' => false,
+                'attr' => [
+                    'class' => 'bo-form-signalement-manual-address',
+                ],
+                'empty_data' => '',
+            ])
+            ->add('villeAgence', null, [
+                'label' => 'Ville',
+                'required' => false,
+                'attr' => [
+                    'class' => 'bo-form-signalement-manual-address',
+                ],
+                'empty_data' => '',
             ])
 
             ->add('forceSave', HiddenType::class, [

--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Enum\ProprioType;
+use App\Entity\Signalement;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SignalementDraftCoordonneesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var Signalement $signalement */
+        $signalement = $builder->getData();
+        $adresseCompleteProprio = trim($signalement->getAdresseProprio().' '.$signalement->getCodePostalProprio().' '.$signalement->getVilleProprio());
+
+        $builder
+        /*
+            ->add('bail', ChoiceType::class, [
+                'label' => 'Contrat de location (bail)',
+                'choices' => [
+                    'Oui' => 'oui',
+                    'Non' => 'non',
+                ],
+                'expanded' => true,
+                'multiple' => false,
+                'required' => false,
+                'placeholder' => false,
+                'mapped' => false,
+                'data' => $bail,
+            ])
+            ->add('dateEntreeLogement', DateType::class, [
+                'label' => 'Date d\'entrée dans le logement',
+                'required' => false,
+                'placeholder' => false,
+                'mapped' => false,
+                'data' => $dateEntreeLogement,
+            ])
+            ->add('montantLoyer', NumberType::class, [
+                'label' => 'Montant du loyer',
+                'help' => 'Format attendu : saisir un nombre entier',
+                'required' => false,
+                'mapped' => false,
+                'data' => $montantLoyer,
+            ])
+            ->add('reponseProprietaire', TextareaType::class, [
+                'label' => 'Réponse du bailleur / propriétaire',
+                'help' => 'Format attendu : 10 caractères minimum',
+                'required' => false,
+                'mapped' => false,
+                'data' => $reponseProprietaire,
+            ])
+                */
+            ->add('nomOccupant', TextType::class, [
+                'label' => 'Nom de famille',
+                'required' => false,
+            ])
+            ->add('prenomOccupant', TextType::class, [
+                'label' => 'Prénom',
+                'required' => false,
+            ])
+            ->add('mailOccupant', TextType::class, [
+                'label' => 'Adresse e-mail',
+                'help' => 'Format attendu : nom@domaine.fr',
+                'required' => false,
+            ])
+            ->add('telOccupant', TextType::class, [
+                'label' => 'Téléphone',
+                'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+                'required' => false,
+            ])
+
+            ->add('typeProprio', EnumType::class, [
+                'label' => 'Type de bailleur',
+                'class' => ProprioType::class,
+                'choice_label' => function ($choice) {
+                    return $choice->label();
+                },
+                'expanded' => true,
+                'multiple' => false,
+                'required' => false,
+                'placeholder' => false,
+            ])
+            ->add('denominationProprio', TextType::class, [
+                'label' => 'Dénomination',
+                'required' => false,
+            ])
+            ->add('nomProprio', TextType::class, [
+                'label' => 'Nom de famille',
+                'help' => 'Saisissez le nom du ou de la représentante de la société',
+                'required' => false,
+            ])
+            ->add('prenomProprio', TextType::class, [
+                'label' => 'Prénom de famille',
+                'help' => 'Saisissez le prénom du ou de la représentante de la société',
+                'required' => false,
+            ])
+            ->add('mailProprio', TextType::class, [
+                'label' => 'Adresse e-mail',
+                'help' => 'Format attendu : nom@domaine.fr',
+                'required' => false,
+            ])
+            ->add('telProprio', TextType::class, [
+                'label' => 'Téléphone',
+                'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+                'required' => false,
+            ])
+            ->add('adresseCompleteProprio', null, [
+                'label' => false,
+                'help' => 'Format attendu : Tapez l\'adresse puis sélectionnez-la dans la liste. Si elle n\'apparaît pas, cliquez sur saisir une adresse manuellement.',
+                'mapped' => false,
+                'data' => $adresseCompleteProprio,
+                'attr' => [
+                    'autocomplete' => 'off',
+                    'data-fr-adresse-autocomplete' => 'true',
+                    'data-autocomplete-query-selector' => '#bo-form-signalement-coordonnees .fr-address-group',
+                ],
+            ])
+            ->add('adresseProprio', null, [
+                'label' => 'Numéro et voie ',
+                'attr' => [
+                    'class' => 'bo-form-signalement-manual-address',
+                ],
+                'empty_data' => '',
+            ])
+            ->add('codePostalProprio', null, [
+                'label' => 'Code postal',
+                'required' => false,
+                'attr' => [
+                    'class' => 'bo-form-signalement-manual-address',
+                ],
+                'empty_data' => '',
+            ])
+            ->add('villeProprio', null, [
+                'label' => 'Ville',
+                'required' => false,
+                'attr' => [
+                    'class' => 'bo-form-signalement-manual-address',
+                ],
+                'empty_data' => '',
+            ])
+
+            ->add('forceSave', HiddenType::class, [
+                'mapped' => false,
+            ])
+            ->add('previous', SubmitType::class, [
+                'label' => 'Précédent',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-left-line fr-btn--icon-left fr-btn--secondary', 'data-target' => 'situation'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ])
+            ->add('draft', SubmitType::class, [
+                'label' => 'Finir plus tard',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline'],
+            ])
+            ->add('save', SubmitType::class, [
+                'label' => 'Suivant',
+                'attr' => ['class' => 'fr-btn fr-icon-arrow-right-line fr-btn--icon-right', 'data-target' => 'desordres'],
+                'row_attr' => ['class' => 'fr-ml-2w'],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'validation_groups' => ['bo_step_coordonnees'],
+        ]);
+    }
+}

--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -7,6 +7,7 @@ use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\ProprioType;
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Form\Type\PhoneType;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -66,9 +67,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
             ])
-            ->add('telOccupant', TextType::class, [
-                'label' => 'Téléphone',
-                'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+            ->add('telOccupant', PhoneType::class, [
                 'required' => false,
             ])
 
@@ -105,9 +104,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
             ])
-            ->add('telProprio', TextType::class, [
-                'label' => 'Téléphone',
-                'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+            ->add('telProprio', PhoneType::class, [
                 'required' => false,
             ])
             ->add('adresseCompleteProprio', null, [
@@ -209,9 +206,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
             ])
-            ->add('telDeclarant', TextType::class, [
-                'label' => 'Téléphone',
-                'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+            ->add('telDeclarant', PhoneType::class, [
                 'required' => false,
             ])
 
@@ -232,9 +227,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
             ])
-            ->add('telAgence', TextType::class, [
-                'label' => 'Téléphone',
-                'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+            ->add('telAgence', PhoneType::class, [
                 'required' => false,
             ])
             ->add('adresseCompleteAgence', null, [

--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -12,7 +12,6 @@ use App\Validator\TelephoneFormat;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -86,7 +85,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'label' => 'Prénom',
                 'required' => false,
             ])
-            ->add('mailOccupant', EmailType::class, [
+            ->add('mailOccupant', TextType::class, [
                 'label' => 'Adresse e-mail',
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
@@ -125,11 +124,11 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'required' => false,
             ])
             ->add('prenomProprio', TextType::class, [
-                'label' => 'Prénom de famille',
+                'label' => 'Prénom',
                 'help' => 'Saisissez le prénom du ou de la représentante de la société',
                 'required' => false,
             ])
-            ->add('mailProprio', EmailType::class, [
+            ->add('mailProprio', TextType::class, [
                 'label' => 'Adresse e-mail',
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
@@ -216,10 +215,10 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'required' => false,
             ])
             ->add('prenomDeclarant', TextType::class, [
-                'label' => 'Prénom de famille',
+                'label' => 'Prénom',
                 'required' => false,
             ])
-            ->add('mailDeclarant', EmailType::class, [
+            ->add('mailDeclarant', TextType::class, [
                 'label' => 'Adresse e-mail',
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
@@ -246,7 +245,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'label' => 'Prénom',
                 'required' => false,
             ])
-            ->add('mailAgence', EmailType::class, [
+            ->add('mailAgence', TextType::class, [
                 'label' => 'Adresse e-mail',
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,

--- a/src/Form/Type/PhoneType.php
+++ b/src/Form/Type/PhoneType.php
@@ -53,9 +53,11 @@ class PhoneType extends AbstractType
                     $view->vars['selectedCode'] = '+'.$phoneNumber->getCountryCode();
                     $view->vars['inputNumber'] = str_pad('', $phoneNumber->getNumberOfLeadingZeros(), '0');
                     $view->vars['inputNumber'] .= $phoneNumber->getNationalNumber();
+                } else {
+                    $view->vars['inputNumber'] = substr($phoneNumberStr, 3); // Bad numbers re-parsed with french format
                 }
             } catch (\Exception $e) {
-                return;
+                $view->vars['inputNumber'] = substr($phoneNumberStr, 3); // Bad numbers re-parsed with french format
             }
         }
     }

--- a/src/Form/Type/PhoneType.php
+++ b/src/Form/Type/PhoneType.php
@@ -47,11 +47,15 @@ class PhoneType extends AbstractType
         $phoneNumberStr = $form->getNormData();
         if (!empty($phoneNumberStr)) {
             $phoneNumberUtil = PhoneNumberUtil::getInstance();
-            $phoneNumber = $phoneNumberUtil->parse($phoneNumberStr);
-            if ($phoneNumberUtil->isPossibleNumber($phoneNumber)) {
-                $view->vars['selectedCode'] = '+'.$phoneNumber->getCountryCode();
-                $view->vars['inputNumber'] = str_pad('', $phoneNumber->getNumberOfLeadingZeros(), '0');
-                $view->vars['inputNumber'] .= $phoneNumber->getNationalNumber();
+            try {
+                $phoneNumber = $phoneNumberUtil->parse($phoneNumberStr);
+                if ($phoneNumberUtil->isPossibleNumber($phoneNumber)) {
+                    $view->vars['selectedCode'] = '+'.$phoneNumber->getCountryCode();
+                    $view->vars['inputNumber'] = str_pad('', $phoneNumber->getNumberOfLeadingZeros(), '0');
+                    $view->vars['inputNumber'] .= $phoneNumber->getNationalNumber();
+                }
+            } catch (\Exception $e) {
+                return;
             }
         }
     }

--- a/src/Form/Type/PhoneType.php
+++ b/src/Form/Type/PhoneType.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Form\Type;
+
+use libphonenumber\PhoneNumberUtil;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TelType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PhoneType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $phoneNumberUtil = PhoneNumberUtil::getInstance();
+        $supportedRegions = $phoneNumberUtil->getSupportedRegions();
+        $countryCallingCodes = [];
+        foreach ($supportedRegions as $region) {
+            $country = \Locale::getDisplayRegion('-'.$region, 'en');
+            $label = $country.' (+'.$phoneNumberUtil->getCountryCodeForRegion($region).')';
+            $countryCallingCodes['+'.$phoneNumberUtil->getCountryCodeForRegion($region)] = $label;
+        }
+        array_multisort($countryCallingCodes);
+
+        $resolver->setDefaults([
+            'expanded' => true,
+            'multiple' => true,
+            'attr' => ['class' => 'phone-input'],
+            'label' => 'Téléphone',
+            'help' => 'Format attendu : Veuillez sélectionner le pays pour obtenir l\'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l\'indicatif). Exemple pour la France : 0702030405.',
+            'countryCodes' => $countryCallingCodes,
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return TelType::class;
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['countryCodes'] = $options['countryCodes'];
+        $view->vars['selectedCode'] = '+33';
+        $view->vars['inputNumber'] = '';
+
+        $phoneNumberStr = $form->getNormData();
+        if (!empty($phoneNumberStr)) {
+            $phoneNumberUtil = PhoneNumberUtil::getInstance();
+            $phoneNumber = $phoneNumberUtil->parse($phoneNumberStr);
+            if ($phoneNumberUtil->isPossibleNumber($phoneNumber)) {
+                $view->vars['selectedCode'] = '+'.$phoneNumber->getCountryCode();
+                $view->vars['inputNumber'] = str_pad('', $phoneNumber->getNumberOfLeadingZeros(), '0');
+                $view->vars['inputNumber'] .= $phoneNumber->getNationalNumber();
+            }
+        }
+    }
+}

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -4,6 +4,7 @@ namespace App\Manager;
 
 use App\Dto\Request\Signalement\AdresseOccupantRequest;
 use App\Dto\Request\Signalement\CompositionLogementRequest;
+use App\Dto\Request\Signalement\CoordonneesAgenceRequest;
 use App\Dto\Request\Signalement\CoordonneesBailleurRequest;
 use App\Dto\Request\Signalement\CoordonneesFoyerRequest;
 use App\Dto\Request\Signalement\CoordonneesTiersRequest;
@@ -456,6 +457,28 @@ class SignalementManager extends AbstractManager
         $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'Les coordonnées du bailleur ont été modifiées par ',
+        );
+    }
+
+    public function updateFromCoordonneesAgenceRequest(
+        Signalement $signalement,
+        CoordonneesAgenceRequest $coordonneesAgenceRequest,
+    ): void {
+        $signalement
+            ->setDenominationAgence($coordonneesAgenceRequest->getDenomination())
+            ->setNomAgence($coordonneesAgenceRequest->getNom())
+            ->setPrenomAgence($coordonneesAgenceRequest->getPrenom())
+            ->setMailAgence($coordonneesAgenceRequest->getMail())
+            ->setTelAgence($coordonneesAgenceRequest->getTelephone())
+            ->setTelAgenceSecondaire($coordonneesAgenceRequest->getTelephoneBis())
+            ->setAdresseAgence($coordonneesAgenceRequest->getAdresse())
+            ->setCodePostalAgence($coordonneesAgenceRequest->getCodePostal())
+            ->setVilleAgence($coordonneesAgenceRequest->getVille());
+
+        $this->save($signalement);
+        $this->suiviManager->addSuiviIfNeeded(
+            signalement: $signalement,
+            description: 'Les coordonnées de l\'agence ont été modifiées par ',
         );
     }
 

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -385,7 +385,8 @@ class SignalementManager extends AbstractManager
                     ? ProprioType::from($coordonneesFoyerRequest->getTypeProprio())
                     : null
                 )
-                ->setStructureDeclarant($coordonneesFoyerRequest->getNomStructure());
+                ->setStructureDeclarant($coordonneesFoyerRequest->getNomStructure())
+                ->setDenominationProprio($coordonneesFoyerRequest->getNomStructure());
         }
         $signalement
             ->setCiviliteOccupant($coordonneesFoyerRequest->getCivilite())
@@ -407,14 +408,20 @@ class SignalementManager extends AbstractManager
         CoordonneesBailleurRequest $coordonneesBailleurRequest,
     ): void {
         $bailleur = null;
-        if ($signalement->getIsLogementSocial() && $coordonneesBailleurRequest->getNom()) {
+        if ($signalement->getIsLogementSocial() && $coordonneesBailleurRequest->getDenomination()) {
             $bailleur = $this->bailleurRepository->findOneBailleurBy(
-                $coordonneesBailleurRequest->getNom(),
+                $coordonneesBailleurRequest->getDenomination(),
                 $this->zipcodeProvider->getTerritoryByInseeCode($signalement->getInseeOccupant())
             );
         }
 
         $signalement->setBailleur($bailleur)
+            ->setTypeProprio(
+                $coordonneesBailleurRequest->getTypeProprio()
+                ? ProprioType::from($coordonneesBailleurRequest->getTypeProprio())
+                : null
+            )
+            ->setDenominationProprio($coordonneesBailleurRequest->getDenomination())
             ->setNomProprio($coordonneesBailleurRequest->getNom())
             ->setPrenomProprio($coordonneesBailleurRequest->getPrenom())
             ->setMailProprio($coordonneesBailleurRequest->getMail())

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -224,4 +224,11 @@ class SignalementBoManager
 
         return true;
     }
+
+    public function formCoordonneesManager(FormInterface $form, Signalement $signalement): bool
+    {
+        $signalement->setNomOccupant($form->get('nomOccupant')->getData());
+
+        return true;
+    }
 }

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -227,7 +227,9 @@ class SignalementBoManager
 
     public function formCoordonneesManager(FormInterface $form, Signalement $signalement): bool
     {
-        $signalement->setNomOccupant($form->get('nomOccupant')->getData());
+        $profileDeclarant = ProfileDeclarant::tryFrom($form->get('profileDeclarantTiers')->getData());
+        $signalement->setProfileDeclarant($profileDeclarant);
+        $signalement->setLienDeclarantOccupant($form->get('lienDeclarantOccupant')->getData());
 
         return true;
     }

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -397,6 +397,9 @@ class SignalementBuilder
                         $this->signalementDraftRequest->getSignalementConcerneProfilDetailBailleurProprietaire()
                     ))
                 );
+            if (ProprioType::ORGANISME_SOCIETE === $this->signalement->getTypeProprio()) {
+                $this->signalement->setDenominationProprio($this->signalement->getNomProprio());
+            }
         } elseif ($this->isBailleur()) {
             $this->signalement
                 ->setStructureDeclarant($this->signalementDraftRequest->getVosCoordonneesTiersNomOrganisme())
@@ -410,6 +413,9 @@ class SignalementBuilder
                         $this->signalementDraftRequest->getSignalementConcerneProfilDetailBailleurBailleur()
                     ))
                 );
+            if (ProprioType::ORGANISME_SOCIETE === $this->signalement->getTypeProprio()) {
+                $this->signalement->setDenominationProprio($this->signalement->getNomProprio());
+            }
         } else {
             $this->signalement
                 ->setAdresseProprio($this->signalementDraftRequest->getCoordonneesBailleurAdresseDetailNumero())
@@ -431,6 +437,7 @@ class SignalementBuilder
                 if (null !== $bailleur) {
                     $this->signalement->setBailleur($bailleur);
                 }
+                $this->signalement->setDenominationProprio($bailleurNom);
             }
         }
     }

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-agence.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-agence.html.twig
@@ -1,0 +1,146 @@
+<dialog aria-labelledby="fr-modal-title-modal-edit-coordonnees-agence" id="fr-modal-edit-coordonnees-agence" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">                
+                    <form method="POST" id="form-edit-coordonnees-agence" enctype="application/json" action="{{ path('back_signalement_edit_coordonnees_agence',{uuid:signalement.uuid}) }}">
+                        <div class="fr-modal__header">
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-coordonnees-agence">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h1 id="fr-modal-title-modal-edit-coordonnees-agence" class="fr-modal__title">
+                                Modifier les coordonnées de l'agence
+                            </h1>
+                            <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesAgenceDenomination">Dénomination
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesAgenceRequest',
+                                        'denomination',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input"
+                                       type="text"
+                                       id="coordonneesAgenceDenomination"
+                                       name="denomination"
+                                       value="{{ signalement.denominationAgence }}"
+                                       maxlength="255"
+                                       autocomplete="off"
+                                >
+                                <ul class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-list">
+                                </ul>
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesAgenceNom">Nom
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesAgenceRequest',
+                                        'nom',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input"
+                                       type="text"
+                                       id="coordonneesAgenceNom"
+                                       name="nom"
+                                       value="{{ signalement.nomAgence }}"
+                                       maxlength="255"
+                                       autocomplete="off"
+                                >
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesAgencePrenom">Prénom
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesAgenceRequest',
+                                        'prenom',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="text" id="coordonneesAgencePrenom" name="prenom" value="{{ signalement.prenomAgence }}" maxlength="255">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesAgenceMail">Courriel
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesAgenceRequest',
+                                        'mail',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="text" id="coordonneesAgenceMail" name="mail" value="{{ signalement.mailAgence }}">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesAgenceTelephone">Téléphone
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesAgenceRequest',
+                                        'telephone',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input" type="text" id="coordonneesAgenceTelephone" name="telephone" value="{{ signalement.telAgenceDecoded }}">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesAgenceTelephoneBis">Téléphone sec. (facultatif)</label>
+                                <input class="fr-input" type="text" id="coordonneesAgenceTelephoneBis" name="telephoneBis" value="{{ signalement.telAgenceSecondaireDecoded }}">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="edit-coordonnees-agence-search">
+                                    Adresse {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesAgenceRequest',
+                                        'adresse',
+                                        signalement.profileDeclarant)
+                                    }}
+                                    <span class="fr-hint-text">Tapez l'adresse et sélectionnez-la dans la liste</span>
+                                </label>
+                                <input class="fr-input search-address-autocomplete" type="text" id="edit-coordonnees-agence-search"
+                                    data-fr-adresse-autocomplete="true" 
+                                    data-autocomplete-query-selector="#form-edit-coordonnees-agence .fr-address-group-bo"
+                                    data-form-id="form-edit-coordonnees-agence">                                        
+                                <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group-bo">
+                                </div>
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="form-edit-coordonnees-agence-adresse">Numéro et voie</label>
+                                <input class="fr-input" id="form-edit-coordonnees-agence-adresse" type="text" name="adresse" value="{{ signalement.adresseAgence }}" data-autocomplete-addresse="true">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="form-edit-coordonnees-agence-codepostal">Code postal</label>
+                                <input class="fr-input" id="form-edit-coordonnees-agence-codepostal" type="text" name="codePostal" value="{{ signalement.codePostalAgence }}" data-autocomplete-codepostal="true">
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="form-edit-coordonnees-agence-ville">Commune</label>
+                                <input class="fr-input" id="form-edit-coordonnees-agence-ville" type="text" name="ville" value="{{ signalement.villeAgence }}" data-autocomplete-ville="true">
+                            </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('signalement_edit_coordonnees_agence_'~signalement.id) }}">
+                        </div>
+                        
+                        <div class="fr-modal__footer">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-icon-check-line" type="submit">
+                                        Valider
+                                    </button>
+                                </li>
+                                <li>
+                                    <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                            aria-controls="fr-modal-edit-coordonnees-agence">
+                                        Annuler
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -38,7 +38,7 @@
                                        value="{{ signalement.denominationProprio }}"
                                        maxlength="255"
                                        autocomplete="off"
-                                        {% if signalement.isLogementSocial  %}
+                                        {% if signalement.isLogementSocial %}
                                             data-autocomplete-bailleur-url="{{ path('app_bailleur', {'inseecode': signalement.inseeOccupant}) }}"
                                         {% endif %}
                                 >

--- a/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-coordonnees-bailleur.html.twig
@@ -12,6 +12,40 @@
                                 Modifier les coordonnées du bailleur
                             </h1>
                             <p>Tous les champs sont obligatoires, sauf mention contraire.</p>
+
+                            <div class="fr-select-group">
+                                <label class="fr-label" for="coordonneesBailleurTypeProprio">Type</label>
+                                <select class="fr-select" id="coordonneesBailleurTypeProprio" name="typeProprio">
+                                    <option value="" disabled hidden>Sélectionnez un choix</option>
+                                    <option value="" {{ signalement.typeProprio is same as '' ? 'selected' : '' }}>N/C</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE.label }}</option>
+                                    <option value="{{ enum('App\\Entity\\Enum\\ProprioType').PARTICULIER.name }}" {{ signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').PARTICULIER ? 'selected' : '' }}>{{ enum('App\\Entity\\Enum\\ProprioType').PARTICULIER.label }}</option>
+                                </select>
+                            </div>
+
+                            <div class="fr-input-group">
+                                <label class="fr-label" for="coordonneesBailleurDenomination">Dénomination
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\CoordonneesBailleurRequest',
+                                        'denomination',
+                                        signalement.profileDeclarant)
+                                    }}
+                                </label>
+                                <input class="fr-input"
+                                       type="text"
+                                       id="coordonneesBailleurDenomination"
+                                       name="denomination"
+                                       value="{{ signalement.denominationProprio }}"
+                                       maxlength="255"
+                                       autocomplete="off"
+                                        {% if signalement.isLogementSocial  %}
+                                            data-autocomplete-bailleur-url="{{ path('app_bailleur', {'inseecode': signalement.inseeOccupant}) }}"
+                                        {% endif %}
+                                >
+                                <ul class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-list">
+                                </ul>
+                            </div>
+
                             <div class="fr-input-group">
                                 <label class="fr-label" for="coordonneesBailleurNom">Nom
                                     {{ show_label_facultatif(
@@ -27,9 +61,6 @@
                                        value="{{ signalement.nomProprio }}"
                                        maxlength="255"
                                        autocomplete="off"
-                                        {% if signalement.isLogementSocial  %}
-                                            data-autocomplete-bailleur-url="{{ path('app_bailleur', {'inseecode': signalement.inseeOccupant}) }}"
-                                        {% endif %}
                                 >
                                 <ul class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-list">
                                 </ul>

--- a/templates/back/signalement/view/information/information-agence.html.twig
+++ b/templates/back/signalement/view/information/information-agence.html.twig
@@ -1,0 +1,47 @@
+{% if canEditSignalement %}
+    {% include 'back/signalement/view/edit-modals/edit-coordonnees-agence.html.twig' %}
+{% endif %}
+<div class="fr-grid-row">
+    <div class="fr-col-12 fr-col-md-8">
+        <h4 class="fr-h6">Informations sur l'agence</h4>
+    </div>
+    <div class="fr-col-12 fr-col-md-4 fr-text--right">
+        {% if canEditSignalement %}
+        <button href="#" data-fr-opened="false" aria-controls="fr-modal-edit-coordonnees-agence"
+            class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">Modifier</button>
+        {% endif %}
+    </div>
+    <div class="fr-col-12 fr-col-md-12">
+        <strong>Dénomination :</strong> {{ signalement.denominationAgence }}
+    </div>
+    <div class="fr-col-12 fr-col-md-6">
+        <strong>Nom :</strong> {{ signalement.nomAgence }}
+    </div>
+    <div class="fr-col-12 fr-col-md-6">
+        <strong>Prénom :</strong> {{ signalement.prenomAgence }}
+    </div>
+    <div class="fr-col-12">
+        <strong>Courriel :</strong>
+        {% if signalement.mailAgence %}
+            <a href="mailto:{{ signalement.mailAgence }}">{{ signalement.mailAgence }}</a>
+            {% if show_email_alert(signalement.mailAgence) %}
+                <p class="fr-badge fr-badge--error">Format non valide</p>
+            {% endif %}
+        {% endif %}
+    </div>
+    <div class="fr-col-12 fr-col-md-6">
+        <strong>Tél. :</strong>
+        {% if signalement.telAgence %}
+            <a href="mailto:{{ signalement.telAgenceDecoded }}">{{ signalement.telAgenceDecoded|phone }}</a>
+        {% endif %}
+    </div>
+    <div class="fr-col-12 fr-col-md-6">
+        <strong>Tél. sec. :</strong>
+        {% if signalement.telAgenceSecondaire %}
+            <a href="mailto:{{ signalement.telAgenceSecondaireDecoded }}">{{ signalement.telAgenceSecondaireDecoded|phone }}</a>
+        {% endif %}
+    </div>
+    <div class="fr-col-12">
+        <strong>Adresse :</strong> {{ signalement.adresseAgence ? signalement.adresseAgence ~ ', ' ~ signalement.codePostalAgence ~ ' ' ~ signalement.villeAgence}}
+    </div>
+</div>

--- a/templates/back/signalement/view/information/information-bailleur.html.twig
+++ b/templates/back/signalement/view/information/information-bailleur.html.twig
@@ -11,11 +11,24 @@
             class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">Modifier</button>
         {% endif %}
     </div>
+    <div class="fr-col-12 fr-col-md-12">
+        <strong>Type :</strong>
+        {% if signalement.typeProprio is not same as null %}
+            {{ signalement.typeProprio.label }}
+        {% else %}
+            N/C
+        {% endif %}
+    </div>
+    {% if signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
+    <div class="fr-col-12 fr-col-md-12">
+        <strong>Dénomination :</strong> {{ signalement.denominationProprio }}
+    </div>
+    {% endif %}
     <div class="fr-col-12 fr-col-md-6">
-        <strong>Nom :</strong> {{ signalement.nomProprio}}
+        <strong>Nom :</strong> {{ signalement.nomProprio }}
     </div>
     <div class="fr-col-12 fr-col-md-6">
-        <strong>Prénom :</strong> {{ signalement.prenomProprio}}
+        <strong>Prénom :</strong> {{ signalement.prenomProprio }}
     </div>
     <div class="fr-col-12">
         <strong>Courriel :</strong>

--- a/templates/back/signalement/view/tabs/tab-situation.html.twig
+++ b/templates/back/signalement/view/tabs/tab-situation.html.twig
@@ -58,5 +58,11 @@
 <hr class="fr-mt-3w fr-hr">
 {% endif %}
 
+{% if feature_bo_signalement_create %}
+{% include 'back/signalement/view/information/information-agence.html.twig' %}
+
+<hr class="fr-mt-3w fr-hr">
+{% endif %}
+
 {% include 'back/signalement/view/information/information-procedure.html.twig' %}
 </div>

--- a/templates/back/signalement_create/tabs/_partial_facultative.html.twig
+++ b/templates/back/signalement_create/tabs/_partial_facultative.html.twig
@@ -1,0 +1,1 @@
+<p>Sauf mention contraire, toutes les réponses sont <strong>facultatives</strong>. Essayez de compléter le dossier au mieux !</p>

--- a/templates/back/signalement_create/tabs/tab-adresse.html.twig
+++ b/templates/back/signalement_create/tabs/tab-adresse.html.twig
@@ -15,10 +15,10 @@
                     </div>
                 </div>
                 <div class="fr-mt-n2w">
-                    <a href="#" id="bo-signalement-manual-address-switcher" class="fr-link fr-icon-edit-line fr-link--icon-left">Saisir une adresse manuellement</a>
+                    <a href="#" class="fr-link fr-icon-edit-line fr-link--icon-left bo-signalement-manual-address-switcher">Saisir une adresse manuellement</a>
                 </div>
             </div>
-            <div id="bo-form-signalement-manual-address-container" class="fr-hidden fr-w-100" >
+            <div class="fr-hidden fr-w-100 bo-form-signalement-manual-address-container">
                 <div class="fr-fieldset__element">
                     {{ form_row(form.adresseOccupant) }}
                 </div>

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -57,7 +57,7 @@
                 <h2 class="fr-h4">Adresse postale</h2>
             </legend>
             <div class="fr-fieldset__element">
-                {{ form_row(form.adresseCompleteProprio) }}
+                {{ form_row(formCoordonnees.adresseCompleteProprio) }}
                 <div class="fr-address-group-container">
                     <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
                     </div>
@@ -68,13 +68,13 @@
             </div>
             <div id="bo-form-signalement-manual-address-container" class="fr-hidden fr-w-100" >
                 <div class="fr-fieldset__element">
-                    {{ form_row(form.adresseProprio) }}
+                    {{ form_row(formCoordonnees.adresseProprio) }}
                 </div>
                 <div class="fr-fieldset__element">
-                    {{ form_row(form.codePostalProprio) }}
+                    {{ form_row(formCoordonnees.codePostalProprio) }}
                 </div>
                 <div class="fr-fieldset__element">
-                    {{ form_row(form.villeProprio) }}
+                    {{ form_row(formCoordonnees.villeProprio) }}
                 </div>
             </div>
         </fieldset>

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -1,1 +1,102 @@
 <h2 class="fr-h4">Coordonnées</h2>
+{% include 'back/signalement_create/tabs/_partial_facultative.html.twig' %}
+
+<div class="fr-alert fr-alert--warning fr-alert--sm fr-mb-5v">
+    <p>Renseigner l'adresse e-mail de la personne occupant le logement ou d'un tiers est recommandé pour un meilleur suivi du dossier.</p>
+</div>
+
+{% form_theme formCoordonnees 'form/dsfr_theme.html.twig' %}
+{{ form_start(formCoordonnees, {'attr': {'id': 'bo-form-signalement-coordonnees'}}) }}
+{{ form_errors(formCoordonnees) }}
+<div class="fr-grid-row fr-grid-row--gutters">
+
+    <div class="fr-col-12 fr-col-md-6">
+        <fieldset class="fr-fieldset">
+            <legend>
+                <h3 class="fr-h5">Occupant</h3>
+            </legend>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.nomOccupant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.prenomOccupant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.mailOccupant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.telOccupant) }}
+            </div>
+        </fieldset>
+
+        <fieldset class="fr-fieldset">
+            <legend>
+                <h3 class="fr-h5">Bailleur</h3>
+            </legend>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.typeProprio) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.denominationProprio) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.nomProprio) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.prenomProprio) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.mailProprio) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.telProprio) }}
+            </div>
+        </fieldset>
+        <fieldset class="fr-fieldset">
+            <legend>
+                <h2 class="fr-h4">Adresse postale</h2>
+            </legend>
+            <div class="fr-fieldset__element">
+                {{ form_row(form.adresseCompleteProprio) }}
+                <div class="fr-address-group-container">
+                    <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
+                    </div>
+                </div>
+                <div class="fr-mt-n2w">
+                    <a href="#" id="bo-signalement-manual-address-switcher" class="fr-link fr-icon-edit-line fr-link--icon-left">Saisir une adresse manuellement</a>
+                </div>
+            </div>
+            <div id="bo-form-signalement-manual-address-container" class="fr-hidden fr-w-100" >
+                <div class="fr-fieldset__element">
+                    {{ form_row(form.adresseProprio) }}
+                </div>
+                <div class="fr-fieldset__element">
+                    {{ form_row(form.codePostalProprio) }}
+                </div>
+                <div class="fr-fieldset__element">
+                    {{ form_row(form.villeProprio) }}
+                </div>
+            </div>
+        </fieldset>
+    </div>
+
+    <div class="fr-col-12 fr-col-md-6">
+        <fieldset class="fr-fieldset">
+        </fieldset>
+    </div>
+
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--left">
+            {{ form_row(formCoordonnees.previous) }}
+        </div>
+    </div>
+    <div class="fr-col-6">
+        <div class="fr-grid-row fr-grid-row--right">
+            {{ form_row(formCoordonnees.forceSave) }}
+            {{ form_row(formCoordonnees.draft) }}
+            {{ form_row(formCoordonnees.save) }}
+        </div>
+    </div>
+
+</div>
+{{ form_end(formCoordonnees) }}

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -39,6 +39,8 @@
             <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.denominationProprio) }}
             </div>
+            <ul class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-autocomplete-list">
+            </ul>
             <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.nomProprio) }}
             </div>
@@ -54,7 +56,7 @@
         </fieldset>
         <fieldset class="fr-fieldset">
             <legend>
-                <h2 class="fr-h4">Adresse postale</h2>
+                <h4 class="fr-h6">Adresse postale</h4>
             </legend>
             <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.adresseCompleteProprio) }}
@@ -82,6 +84,33 @@
 
     <div class="fr-col-12 fr-col-md-6">
         <fieldset class="fr-fieldset">
+            <legend>
+                <h3 class="fr-h5">Tiers</h3>
+            </legend>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.profileDeclarantTiers) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.lienDeclarantOccupant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.isProTiersDeclarant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.structureDeclarant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.nomDeclarant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.prenomDeclarant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.mailDeclarant) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.telDeclarant) }}
+            </div>
         </fieldset>
     </div>
 

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -65,10 +65,10 @@
                     </div>
                 </div>
                 <div class="fr-mt-n2w">
-                    <a href="#" id="bo-signalement-manual-address-switcher" class="fr-link fr-icon-edit-line fr-link--icon-left">Saisir une adresse manuellement</a>
+                    <a href="#" class="fr-link fr-icon-edit-line fr-link--icon-left bo-signalement-manual-address-switcher">Saisir une adresse manuellement</a>
                 </div>
             </div>
-            <div id="bo-form-signalement-manual-address-container" class="fr-hidden fr-w-100" >
+            <div class="fr-hidden fr-w-100 bo-form-signalement-manual-address-container">
                 <div class="fr-fieldset__element">
                     {{ form_row(formCoordonnees.adresseProprio) }}
                 </div>
@@ -110,6 +110,58 @@
             </div>
             <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.telDeclarant) }}
+            </div>
+        </fieldset>
+
+        <fieldset class="fr-fieldset">
+            <legend>
+                <h3 class="fr-h5">Gestionnaire / agence</h3>
+            </legend>
+            <div class="fr-fieldset__element fr-mb-5v">
+                <div class="fr-alert fr-alert--info fr-alert--sm">
+                    <p>Si le logement est géré par une agence, renseignez les coordonnées de l'agence.</p>
+                </div>
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.denominationAgence) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.nomAgence) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.prenomAgence) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.mailAgence) }}
+            </div>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.telAgence) }}
+            </div>
+        </fieldset>
+        <fieldset class="fr-fieldset">
+            <legend>
+                <h4 class="fr-h6">Adresse postale</h4>
+            </legend>
+            <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.adresseCompleteAgence) }}
+                <div class="fr-address-group-container">
+                    <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-agence-group">
+                    </div>
+                </div>
+                <div class="fr-mt-n2w">
+                    <a href="#" class="fr-link fr-icon-edit-line fr-link--icon-left bo-signalement-manual-address-switcher">Saisir une adresse manuellement</a>
+                </div>
+            </div>
+            <div class="fr-hidden fr-w-100 bo-form-signalement-manual-address-container">
+                <div class="fr-fieldset__element">
+                    {{ form_row(formCoordonnees.adresseAgence) }}
+                </div>
+                <div class="fr-fieldset__element">
+                    {{ form_row(formCoordonnees.codePostalAgence) }}
+                </div>
+                <div class="fr-fieldset__element">
+                    {{ form_row(formCoordonnees.villeAgence) }}
+                </div>
             </div>
         </fieldset>
     </div>

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -61,7 +61,7 @@
             <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.adresseCompleteProprio) }}
                 <div class="fr-address-group-container">
-                    <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
+                    <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-proprio-group">
                     </div>
                 </div>
                 <div class="fr-mt-n2w">

--- a/templates/back/signalement_create/tabs/tab-logement.html.twig
+++ b/templates/back/signalement_create/tabs/tab-logement.html.twig
@@ -1,5 +1,5 @@
 <h2 class="fr-h4">Description du logement</h2>
-<p>Sauf mention contraire, toutes les réponses sont <strong>facultatives</strong>. Essayez de compléter le dossier au mieux !</p>
+{% include 'back/signalement_create/tabs/_partial_facultative.html.twig' %}
 
 {% form_theme formLogement 'form/dsfr_theme.html.twig' %}
 {{ form_start(formLogement, {'attr': {'id': 'bo-form-signalement-logement'}}) }}

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -1,5 +1,5 @@
 <h2 class="fr-h4">Situation du foyer et du bail</h2>
-<p>Sauf mention contraire, toutes les réponses sont <strong>facultatives</strong>. Essayez de compléter le dossier au mieux !</p>
+{% include 'back/signalement_create/tabs/_partial_facultative.html.twig' %}
 
 {% form_theme formSituation 'form/dsfr_theme.html.twig' %}
 {{ form_start(formSituation, {'attr': {'id': 'bo-form-signalement-situation'}}) }}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -181,3 +181,35 @@
         {{ block('form_errors') }}
     </div>
 {% endblock %}
+
+{% block phone_row %}
+    <div class="phone-input-container fr-input-group {% if errors|length > 0 %}fr-select-group--error{% endif %}">   
+        <div class="fr-input-group fr-mb-0">
+            {% if label is not same as(false) %}
+                <label for="{{ id }}_input" class="fr-label">
+                    {{ label }}
+                    {% if help is not same as(false) %}
+                        <span id="{{ id }}_help" class="fr-hint-text">{{ help }}</span>
+                    {% endif %}
+                </label>
+            {% endif %}
+
+            <div class="fr-grid-row fr-grid-row--gutters fr-mt-1v phone-number-row-container">
+                <div class="fr-col-12 fr-col-md-4">
+                    <select class="fr-select" id="{{ id }}_select" title="Indicatif national">
+                        {% for region, label in countryCodes  %}
+                        <option value="{{ region }}" {% if region is same as selectedCode %}selected="selected"{% endif %}>{{ label }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="fr-col-12 fr-col-md-8">
+                    <div class="fr-input-wrap fr-icon-phone-line">
+                        <input type="tel" id="{{ id }}_input" class="fr-input" value="{{ inputNumber }}">
+                    </div>
+                </div>
+                <input type="hidden" name="{{form.vars.full_name}}" value="{{ data }}">
+            </div>
+        </div>
+        {{ block('form_errors') }}
+    </div>
+{% endblock %}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -183,7 +183,7 @@
 {% endblock %}
 
 {% block phone_row %}
-    <div class="phone-input-container fr-input-group {% if errors|length > 0 %}fr-select-group--error{% endif %}">   
+    <div class="phone-input-container fr-input-group {% if errors|length > 0 %}fr-input-group--error fr-select-group--error{% endif %}">   
         <div class="fr-input-group fr-mb-0">
             {% if label is not same as(false) %}
                 <label for="{{ id }}_input" class="fr-label">

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -240,6 +240,9 @@
                         <h3 style="margin-bottom: 0">Informations sur le bailleur</h3>
                         <ul style="list-style:none; margin-left:0px;padding-left:0px;">
                             <li>
+                                {% if signalement.typeProprio is same as enum('App\\Entity\\Enum\\ProprioType').ORGANISME_SOCIETE %}
+                                <b>Dénomination :</b> {{ signalement.denominationProprio }}<br>
+                                {% endif %}
                                 <b>Nom :</b> {{ signalement.nomProprio ?? 'N/R' }}
                                 {% if signalement.prenomProprio %}
                                 - <b>Prénom :</b> {{ signalement.prenomProprio }}

--- a/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
@@ -8,6 +8,7 @@ use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 
 class SignalementCreateControllerTest extends WebTestCase
 {
@@ -101,13 +102,20 @@ class SignalementCreateControllerTest extends WebTestCase
         ];
     }
 
-    public function testEditAddress()
+    private function getCrawler(): Crawler
     {
         $user = $this->userRepository->findOneBy(['email' => 'admin-territoire-44-01@signal-logement.fr']);
         $this->client->loginUser($user);
 
         $crawler = $this->client->request('GET', '/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002');
         $this->assertResponseIsSuccessful();
+
+        return $crawler;
+    }
+
+    public function testEditAddress()
+    {
+        $crawler = $this->getCrawler();
 
         $form = $crawler->filter('#bo-form-signalement-adresse')->form();
         $form->setValues([
@@ -142,11 +150,7 @@ class SignalementCreateControllerTest extends WebTestCase
 
     public function testEditAddressOnOtherTerritory()
     {
-        $user = $this->userRepository->findOneBy(['email' => 'admin-territoire-44-01@signal-logement.fr']);
-        $this->client->loginUser($user);
-
-        $crawler = $this->client->request('GET', '/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002');
-        $this->assertResponseIsSuccessful();
+        $crawler = $this->getCrawler();
 
         $form = $crawler->filter('#bo-form-signalement-adresse')->form();
         $form->setValues([
@@ -164,11 +168,7 @@ class SignalementCreateControllerTest extends WebTestCase
 
     public function testEditLogement()
     {
-        $user = $this->userRepository->findOneBy(['email' => 'admin-territoire-44-01@signal-logement.fr']);
-        $this->client->loginUser($user);
-
-        $crawler = $this->client->request('GET', '/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002');
-        $this->assertResponseIsSuccessful();
+        $crawler = $this->getCrawler();
 
         $form = $crawler->filter('#bo-form-signalement-logement')->form();
         $form->setValues([
@@ -194,11 +194,7 @@ class SignalementCreateControllerTest extends WebTestCase
 
     public function testEditSituation()
     {
-        $user = $this->userRepository->findOneBy(['email' => 'admin-territoire-44-01@signal-logement.fr']);
-        $this->client->loginUser($user);
-
-        $crawler = $this->client->request('GET', '/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002');
-        $this->assertResponseIsSuccessful();
+        $crawler = $this->getCrawler();
 
         $form = $crawler->filter('#bo-form-signalement-situation')->form();
         $form->setValues([
@@ -226,11 +222,7 @@ class SignalementCreateControllerTest extends WebTestCase
 
     public function testEditCoordonnees()
     {
-        $user = $this->userRepository->findOneBy(['email' => 'admin-territoire-44-01@histologe.fr']);
-        $this->client->loginUser($user);
-
-        $crawler = $this->client->request('GET', '/bo/signalement/brouillon/editer/00000000-0000-0000-2025-000000000002');
-        $this->assertResponseIsSuccessful();
+        $crawler = $this->getCrawler();
 
         $form = $crawler->filter('#bo-form-signalement-coordonnees')->form();
         $form->setValues([

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -54,7 +54,7 @@ class SignalementEditControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful();
 
         $this->assertEquals('13 HABITAT', $signalement->getBailleur()->getName());
-        $this->assertEquals('13 HABITAT', $signalement->getNomProprio());
+        $this->assertEquals('13 HABITAT', $signalement->getDenominationProprio());
     }
 
     public function testEditCoordonneesBailleurWithCustomBailleur(): void
@@ -70,7 +70,7 @@ class SignalementEditControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
         $this->assertNull($signalement->getBailleur());
-        $this->assertEquals('Habitat Social Solidaire', $signalement->getNomProprio());
+        $this->assertEquals('Habitat Social Solidaire', $signalement->getDenominationProprio());
     }
 
     /**
@@ -129,7 +129,8 @@ class SignalementEditControllerTest extends WebTestCase
     private function getPayloadCoordonneesBailleur(string $bailleurName, int $signalementId): array
     {
         return [
-            'nom' => $bailleurName,
+            'denomination' => $bailleurName,
+            'nom' => 'Bernard',
             'prenom' => '',
             'mail' => 'contact@13habitat.fr',
             'telephone' => '0611000000',


### PR DESCRIPTION
## Ticket

#3773   

## Description
Mise en place de l'onglet Coordonnées du formulaire de création de signalement BO

## Changements apportés
* Nouveau composant Numéro de téléphone
* Entité Signalement : ajout de la dénomination du bailleur (séparé du nom, pour les propriétaires de type Organisme)
  * Modification de la fiche côté BO, de l'export PDF et de l'API en conséquence
* Entité Signalement : ajout de données qui concernent l'agence
  * Modification de la fiche côté BO et de l'API en conséquence

## Pré-requis
`make execute-migration name=Version20250319142447 direction=up`
`make execute-migration name=Version20250324150108 direction=up`
`npm run watch-bo`

## Tests
- [ ] Si bailleur social, auto-complétion sur les noms des bailleurs
- [ ] Tester l'enregistrement des différents champs
- [ ] Tester l'édition de signalement dans le BO

