### PR TITLE
[BO - Export signalements] Ajouter la colonne commentaire de clôture

### DIFF
--- a/migrations/Version20250401111532.php
+++ b/migrations/Version20250401111532.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250401111532 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add com_cloture column to signalement table and populate it with data from suivi table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement ADD com_cloture LONGTEXT DEFAULT NULL');
+        $list = $this->getSuiviCloturePourTous();
+        foreach ($list as $item) {
+            $exploded = explode('</strong>', $item['description']);
+            $comCloture = $exploded[count($exploded) - 1];
+            $this->addSql('UPDATE signalement SET com_cloture = ? WHERE id = ?', [$comCloture, $item['signalement_id']]);
+        }
+    }
+
+    private function getSuiviCloturePourTous(): array
+    {
+        $query = 'SELECT signalement_id, description FROM suivi WHERE description LIKE "Le signalement a été cloturé pour tous les partenaires avec le motif suivant%"';
+
+        return $this->connection->fetchAllAssociative($query);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement DROP com_cloture');
+    }
+}

--- a/migrations/Version20250401111532.php
+++ b/migrations/Version20250401111532.php
@@ -19,7 +19,7 @@ final class Version20250401111532 extends AbstractMigration
         $this->addSql('ALTER TABLE signalement ADD com_cloture LONGTEXT DEFAULT NULL');
         $list = $this->getSuiviCloturePourTous();
         foreach ($list as $item) {
-            $exploded = explode('</strong>', $item['description']);
+            $exploded = explode('<strong>Desc. : </strong>', $item['description']);
             $comCloture = $exploded[count($exploded) - 1];
             $this->addSql('UPDATE signalement SET com_cloture = ? WHERE id = ?', [$comCloture, $item['signalement_id']]);
         }

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -135,7 +135,8 @@ class SignalementController extends AbstractController
                 $eventParams['subject'] = 'tous les partenaires';
                 $entity = $signalement = $signalementManager->closeSignalementForAllPartners(
                     $signalement,
-                    $eventParams['motif_cloture']
+                    $eventParams['motif_cloture'],
+                    $eventParams['motif_suivi']
                 );
                 $reference = $signalement->getReference();
                 $eventDispatcher->dispatch(new SignalementClosedEvent($entity, $eventParams), SignalementClosedEvent::NAME);

--- a/src/Dto/SignalementExport.php
+++ b/src/Dto/SignalementExport.php
@@ -60,6 +60,7 @@ class SignalementExport
         public ?string $modifiedAt = null,
         public ?string $closedAt = null,
         public ?string $motifCloture = null,
+        public ?string $comCloture = null,
         public ?string $longitude = null,
         public ?string $latitude = null,
     ) {

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -23,6 +23,7 @@ use App\Utils\Phone;
 use App\Validator as AppAssert;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -443,6 +444,9 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     #[ORM\Column(type: 'boolean', nullable: true)]
     private ?bool $hasSeenDesordres = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $comCloture = null;
 
     public function __construct()
     {
@@ -2543,6 +2547,18 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function setHasSeenDesordres(?bool $hasSeenDesordres): static
     {
         $this->hasSeenDesordres = $hasSeenDesordres;
+
+        return $this;
+    }
+
+    public function getComCloture(): ?string
+    {
+        return $this->comCloture;
+    }
+
+    public function setComCloture(?string $comCloture): static
+    {
+        $this->comCloture = $comCloture;
 
         return $this;
     }

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -129,6 +129,7 @@ class SignalementExportFactory
             modifiedAt: $modifiedAt,
             closedAt: $closedAt,
             motifCloture: $motifCloture,
+            comCloture: $data['comCloture'],
             longitude: is_array($geoloc) ? $geoloc['lng'] ?? '' : '',
             latitude: is_array($geoloc) ? $geoloc['lat'] ?? '' : '',
         );

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -595,6 +595,7 @@ class SignalementRepository extends ServiceEntityRepository
             s.modifiedAt,
             s.closedAt,
             s.motifCloture,
+            s.comCloture,
             s.geoloc,
             s.typeCompositionLogement,
             s.informationProcedure,

--- a/src/Service/Signalement/Export/SignalementExportHeader.php
+++ b/src/Service/Signalement/Export/SignalementExportHeader.php
@@ -62,6 +62,7 @@ class SignalementExportHeader
             'Dernière MAJ le',
             'Clôturé le',
             'Motif de clôture',
+            'Commentaire de clôture',
             'Longitude',
             'Latitude',
         ];

--- a/src/Service/Signalement/Export/SignalementExportSelectableColumns.php
+++ b/src/Service/Signalement/Export/SignalementExportSelectableColumns.php
@@ -41,6 +41,7 @@ class SignalementExportSelectableColumns
         'DERNIERE_MAJ' => ['name' => 'Dernière MAJ le', 'description' => 'La date de la dernière mise à jour du signalement', 'export' => 'modifiedAt'],
         'DATE_CLOTURE' => ['name' => 'Fermé le', 'description' => 'La date de clôture du signalement', 'export' => 'closedAt'],
         'MOTIF_CLOTURE' => ['name' => 'Motif de clôture', 'description' => 'Le motif de clôture du signalement', 'export' => 'motifCloture'],
+        'COM_CLOTURE' => ['name' => 'Commentaire de clôture', 'description' => 'Le commentaire de clôture du signalement', 'export' => 'comCloture'],
         'GEOLOCALISATION' => ['name' => 'Géolocalisation', 'description' => 'Les coordonnées GPS du logement', 'export' => 'geoloc'],
         'DEBUT_DESORDRES' => ['name' => 'Début des désordres', 'description' => 'Début des désordres', 'export' => 'debutDesordres'],
     ];

--- a/tests/Functional/Service/Signalement/PhotoHelperTest.php
+++ b/tests/Functional/Service/Signalement/PhotoHelperTest.php
@@ -23,6 +23,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 class PhotoHelperTest extends KernelTestCase
 {
@@ -44,6 +45,7 @@ class PhotoHelperTest extends KernelTestCase
     private SignalementAddressUpdater $signalementAddressUpdater;
     private AffectationRepository $affectationRepository;
     private ZipcodeProvider $zipcodeProvider;
+    private HtmlSanitizerInterface $htmlSanitizerInterface;
 
     protected function setUp(): void
     {
@@ -67,6 +69,7 @@ class PhotoHelperTest extends KernelTestCase
         $this->signalementAddressUpdater = static::getContainer()->get(SignalementAddressUpdater::class);
         $this->affectationRepository = static::getContainer()->get(AffectationRepository::class);
         $this->zipcodeProvider = static::getContainer()->get(ZipcodeProvider::class);
+        $this->htmlSanitizerInterface = self::getContainer()->get('html_sanitizer.sanitizer.app.message_sanitizer');
 
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
@@ -85,7 +88,8 @@ class PhotoHelperTest extends KernelTestCase
             $this->bailleurRepository,
             $this->affectationRepository,
             $this->signalementAddressUpdater,
-            $this->zipcodeProvider
+            $this->zipcodeProvider,
+            $this->htmlSanitizerInterface
         );
     }
 

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -67,6 +67,7 @@ class SignalementExportFactoryTest extends TestCase
             'modifiedAt' => new \DateTimeImmutable(),
             'closedAt' => new \DateTimeImmutable(),
             'motifCloture' => MotifCloture::INSALUBRITE,
+            'comCloture' => null,
             'familleSituation' => "l'état et propreté du logement|l'état et propreté du logement|",
             'desordres' => "Les sols sont humides.|Les installations électriques ne sont pas en bon état.|
                 Les murs ont des fissures.|De l'eau s’infiltre dans mon logement.|Il y a des trace ",


### PR DESCRIPTION
## Ticket

#3880

## Description
Possibilité de rajouter le "Commentaire de cloture" dans l'export des signalements

## Changements apportés
* Ajout d'une colonne "com_cloture" sur la table signalement
* Enregistrement de cette colonne pour les signalements existant en base (à partir du suivi correspondant)
* Enregistrement de cette colonne à la cloture pour tous d'un signalement
* Ajout de la colonne sur l'export

## Pré-requis
make execute-migration name=Version20250401111532 direction=up

## Tests
- [ ] Clôturer un signalement pour tous et l'exporter en cochant la colonne "Commentaire de cloture"
