### PR TITLE
[BO - Signalement] Activation de l'onglet Activité PDLHI même si le RT n'a pas encore validé le signalement

### DIFF
--- a/templates/back/signalement/view/tabs.html.twig
+++ b/templates/back/signalement/view/tabs.html.twig
@@ -1,13 +1,14 @@
 <div class="fr-tabs">
     <ul class="fr-tabs__list" role="tablist" aria-label="Informations du signalement">
         <li role="presentation">
-            <button id="tabpanel-activite" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left"
-                tabindex="0" role="tab" aria-selected="false" aria-controls="tabpanel-activite-panel"
-                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION %}disabled{% endif %}
-                >Activité PDLHI</button>
+            <button id="tabpanel-activite" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="0" role="tab"
+                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION %}aria-selected="false"{% else %}aria-selected="true"{% endif %}
+                aria-controls="tabpanel-activite-panel">Activité PDLHI ({{ signalement.suivis|length }})</button>
         </li>
         <li role="presentation">
-            <button id="tabpanel-situation" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-situation-panel">Situation</button>
+            <button id="tabpanel-situation" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="-1" role="tab"
+                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION %}aria-selected="true"{% else %}aria-selected="false"{% endif %}
+                aria-controls="tabpanel-situation-panel">Situation</button>
         </li>
         <li role="presentation">
             <button id="tabpanel-foyer" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-foyer-panel">Foyer</button>
@@ -19,11 +20,9 @@
             <button id="tabpanel-documents" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-documents-panel">Documents</button>
         </li>
     </ul>
-    {% if signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION %}
     <div id="tabpanel-activite-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-activite" tabindex="0">
         {% include 'back/signalement/view/tabs/tab-activite.html.twig' %}
     </div>
-    {% endif %}
     <div id="tabpanel-situation-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-situation" tabindex="0">
         {% include 'back/signalement/view/tabs/tab-situation.html.twig' %}
     </div>


### PR DESCRIPTION
## Ticket

#3874   

## Description
Activation de l'onglet Activité PDLHI même si le RT n'a pas encore validé le signalement
Ajout du nombre de suivi entre parenthèses dans le nom de l'onglet

## Tests
- [ ] Vérifier différents signalements avec différents statuts, avec différents rôles utilisateurs
