### PR TITLE
[BUG] Fix banner changement de nom

### DIFF
--- a/.env
+++ b/.env
@@ -76,6 +76,7 @@ SITES_FACILES_URL=
 FEATURE_SITES_FACILES=0
 PLATFORM_NAME='Signal Logement'
 PLATFORM_LOGO='logo-signal-logement.svg'
+FEATURE_BANNER_HISTOLOGE=1
 ### signal-logement ###
 
 ### object storage S3 ###

--- a/assets/scripts/vanilla/services/maintenance_banner.js
+++ b/assets/scripts/vanilla/services/maintenance_banner.js
@@ -21,3 +21,15 @@ if (maintenanceBannerElement !== null) {
     maintenanceBannerElement.classList.remove('fr-hidden')
   }
 }
+
+const changeNameBannerElement = document.getElementById('change-name-banner')
+if (changeNameBannerElement !== null) {
+
+  const closeButtonElement = document.querySelector('#change-name-banner .fr-btn--close')
+
+  closeButtonElement.addEventListener('click', (event) => {
+    const notice = event.target.parentNode.parentNode.parentNode
+    notice.parentNode.removeChild(notice)
+  })
+
+}

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -18,6 +18,7 @@ twig:
         mise_en_berne: '%env(MISE_EN_BERNE_ENABLE)%'
         feature_multi_territories: '%env(bool:FEATURE_MULTI_TERRITORIES)%'
         feature_sites_faciles: '%env(bool:FEATURE_SITES_FACILES)%'
+        feature_banner_histologe: '%env(bool:FEATURE_BANNER_HISTOLOGE)%'
         sites_faciles_url: '%env(resolve:SITES_FACILES_URL)%'
     paths:
         # point this wherever your images live

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -51,6 +51,7 @@ parameters:
     feature_bo_signalement_create: '%env(bool:FEATURE_BO_SIGNALEMENT_CREATE)%'
     send_error_email_token: '%env(SEND_ERROR_EMAIL_TOKEN)%'
     feature_sites_faciles: '%env(bool:FEATURE_SITES_FACILES)%'
+    feature_banner_histologe: '%env(bool:FEATURE_BANNER_HISTOLOGE)%'
 
 services:
     # default configuration for services in *this* file

--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -189,24 +189,19 @@
             </div>
         </div>
     </header>
+{% endif %}
 
-    {% if platform.name is same as 'Signal Logement' %}
-        <div class="fr-notice fr-notice--warning">
-            <div class="fr-container">
-                <div class="fr-notice__body">
-                    <p class="fr-notice__desc">
-                        <strong>Histologe devient Signal Logement !</strong>  Un nouveau nom et un nouveau site pour mieux refléter notre mission : lutter contre le mal logement !
-                    </p>
-                    <button
-                            class="fr-btn--close fr-btn"
-                            title="Masquer le message"
-                            onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)"
-                    >
-                        Masquer le message
-                    </button>
-                </div>
+{% if feature_banner_histologe and platform.name is same as 'Signal Logement' %}
+    <div id="change-name-banner" class="fr-notice fr-notice--warning">
+        <div class="fr-container">
+            <div class="fr-notice__body">
+                <p class="fr-notice__desc">
+                    <strong>Histologe devient Signal Logement !</strong> Un nouveau nom et un nouveau site pour mieux refléter notre mission : lutter contre le mal logement !
+                </p>
+                <button class="fr-btn--close fr-btn" title="Masquer le message">
+                    Masquer le message
+                </button>
             </div>
         </div>
-    {% endif %}
-
+    </div>
 {% endif %}


### PR DESCRIPTION
## Ticket

#3933

## Description
- Ajout de la var d'env `FEATURE_BANNER_HISTOLOGE` pour pouvoir désactiver la banniere du changement de nom quand on le souhaite
- Correction de l'affichage de la banière qui n'apparaissait plus avec la var `FEATURE_SITES_FACILES=1`
- Déplacement du JS permettant de fermer la banière afin qu'il ne soit plus bloqué

## Pré-requis
`make npm-build`
