### PR TITLE
[QA] Modification de la lib de parsing wkt

### DIFF
--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewCarto.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewCarto.vue
@@ -19,7 +19,7 @@ import * as L from 'leaflet'
 import 'leaflet.markercluster'
 import { SignalementMarkerOptions } from '../interfaces/signalementMarkerOptions'
 // @ts-ignore
-import omnivore from '@mapbox/leaflet-omnivore'
+import { parse } from 'wellknown'
 
 // Import des fichiers CSS nécessaires pour Leaflet
 import 'leaflet/dist/leaflet.css'
@@ -105,7 +105,7 @@ export default defineComponent({
       zones.forEach((wkt: string, index: number) => {
         const color = this.getZoneColor(index)
         // @ts-ignore
-        const zone = omnivore.wkt.parse(wkt)
+        const zone = L.geoJson(parse(wkt))
         zone.setStyle({
           color: color,
           fillColor: color,

--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -8,7 +8,7 @@ parameters:
       - "'unsafe-eval'"
       - "https://cdn.matomo.cloud/histologe.matomo.cloud/matomo.js"
       - "https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/"
-      - "https://cdn.jsdelivr.net/npm/@mapbox/leaflet-omnivore@0.3.4/leaflet-omnivore.min.js"
+      - "https://cdn.jsdelivr.net/npm/wellknown@0.5.0/wellknown.js"
       - "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/"
       - "https://cdn.jsdelivr.net/npm/tippy.js@6/dist/"
       - "https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.2",
         "@gouvfr/dsfr": "^1.13.0",
-        "@mapbox/leaflet-omnivore": "^0.3.4",
         "@sentry/browser": "^8.33.0",
         "@sentry/tracing": "^7.99.0",
         "@symfony/webpack-encore": "^5.0.1",
@@ -23,7 +22,8 @@
         "libphonenumber-js": "^1.10.44",
         "vue": "^3.5.13",
         "vue-chartjs": "^4.1.1",
-        "vue-loader": "^17.0.0"
+        "vue-loader": "^17.0.0",
+        "wellknown": "^0.5.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -394,25 +394,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1527,15 +1527,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1571,9 +1571,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -2050,21 +2050,6 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
-    },
-    "node_modules/@mapbox/leaflet-omnivore": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/leaflet-omnivore/-/leaflet-omnivore-0.3.4.tgz",
-      "integrity": "sha512-KHdJXk7EBBygCuErNkI981y51Fd80odYlBmWzsHPtmdzqmvV0D+allIi8uMiTzfW1K3aasOnOw4p6OV0rOs4TQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "brfs": "1.4.3",
-        "corslite": "0.0.7",
-        "csv2geojson": "~5.0.0",
-        "polyline": "0.2.0",
-        "togeojson": "0.13.0",
-        "topojson": "1.6.26",
-        "wellknown": "0.4.2"
-      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.7",
@@ -4006,16 +3991,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "license": "BSD-3-Clause OR MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -4460,21 +4435,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/brfs": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.3.tgz",
-      "integrity": "sha512-fHHsBNkim3FJNT4j5GsfcCEEq5nZAZxKQl2L1haCkh41Q3+Ib0aX23PTCjWOGis/Ywx6IQ/OY/xj31z/k3j4qw==",
-      "license": "MIT",
-      "dependencies": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^1.1.0",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "brfs": "bin/cmd.js"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.24.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
@@ -4504,15 +4464,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/buffer-from": {
@@ -4945,13 +4896,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "node_modules/corslite": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/corslite/-/corslite-0.0.7.tgz",
-      "integrity": "sha512-XJwov1fnFuhJBiBlAdu0eV8dVjif4TAbCPX3CzaG5dyfNvb/3GlyRk0t6yj31wiZOGqMReOTSVOgygaynSn0bg==",
-      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/corslite instead",
-      "license": "BSD"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5288,56 +5232,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/csv2geojson": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/csv2geojson/-/csv2geojson-5.0.2.tgz",
-      "integrity": "sha512-hcO+NVF6CO0ZtjwEJ4D7c/dVdiaEqqWZOpQvmNY7PS5LzQbpSKghQ9TuQTgzPCqlzcmrpfzPsA9rVENb5LRNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "~1.5.1",
-        "d3-dsv": "1.0.1",
-        "optimist": "~0.6.1",
-        "sexagesimal": "0.5.0"
-      },
-      "bin": {
-        "csv2geojson": "csv2geojson"
-      }
-    },
-    "node_modules/d3": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha512-yFk/2idb8OHPKkbAL8QaOaqENNoMhIaSHZerk3oQsECwkObkCpJyjYwCe+OHiq6UEdhe1m8ZGARRRO3ljFjlKg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-dsv": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.1.tgz",
-      "integrity": "sha512-VjRi8bmInbdZsnNr5inlWEEd7GutNcQUb+gXgr4LUyt+8lZjAxU2PBPMNMBBLHCPwosiFcmdwBfnWFpN4/khsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/csv2json",
-        "csv2tsv": "bin/csv2tsv",
-        "tsv2csv": "bin/tsv2csv",
-        "tsv2json": "bin/tsv2json"
-      }
-    },
-    "node_modules/d3-geo-projection": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-0.2.16.tgz",
-      "integrity": "sha512-NB4/NRMnfJnpodvRbNY/nOzuoU17P229ASYf2l1GwjZyfD7l5aIuMylDMbIBF4y42BGZZvGdUwFW8iFM/5UBzg==",
-      "dependencies": {
-        "brfs": "^1.3.0"
-      }
-    },
-    "node_modules/d3-queue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-2.0.3.tgz",
-      "integrity": "sha512-ejbdHqZYEmk9ns/ljSbEcD6VRiuNwAkZMdFf6rsUb3vHROK5iMFd8xewDQnUVr6m/ba2BG63KmR/LySfsluxbg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5716,39 +5610,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
-      "license": "BSD",
-      "dependencies": {
-        "readable-stream": "~1.1.9"
-      }
-    },
-    "node_modules/duplexer2/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5987,54 +5848,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-      "integrity": "sha512-z9FWgKc48wjMlpzF5ymKS1AF8OIgnKLp9VyN7KbdtyrP/9lndwUFqCtMm+TAJmJf7KJFFYc4cFJfVTTGkKEwsA==",
-      "dependencies": {
-        "esprima": "~1.1.1",
-        "estraverse": "~1.5.0",
-        "esutils": "~1.0.0"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.1.33"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-      "integrity": "sha512-FpCjJDfmo3vsc/1zKSeqR5k42tcIhxFIlvq+h9j0fO2q/h2uLKyweq7rYJ+0CoVvrGQOxIS5wyBrW/+vF58BUQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/esutils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-      "integrity": "sha512-x/iYH53X3quDwfHRz4y8rn4XcEwwCJeWsul9pF1zldMbGtgOtMNBEOuYWwB1EQlK2LRa1fev3YAgym/RElp5Cg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
-      "optional": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
       "engines": {
         "node": ">=0.8.0"
       }
@@ -6638,18 +6451,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
-      "integrity": "sha512-qxxB994/7NtERxgXdFgLHIs9M6bhLXc6qtUmWZ3L8+gTQ9qaoyki2887P2IqAYsoENyr8SUbTutStDniOHSDHg==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -6779,31 +6580,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
-    },
-    "node_modules/falafel": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
-      "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "isarray": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/falafel/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -7316,15 +7092,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
-    },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -7883,6 +7650,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -8250,7 +8018,8 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -9177,22 +8946,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "license": "MIT"
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9348,7 +9101,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -9487,15 +9241,6 @@
       "resolved": "https://registry.npmjs.org/point-geometry/-/point-geometry-0.0.0.tgz",
       "integrity": "sha512-tXK8bY2l3/CPkyO7+UbOWbVjCpKoYY4t6uY3AYYy4Bagd4Z942gLeQOgtHICwBwgPf8dI6fw4VqKwzSNgvlw4A==",
       "deprecated": "This module has moved: please install @mapbox/point-geometry instead"
-    },
-    "node_modules/polyline": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/polyline/-/polyline-0.2.0.tgz",
-      "integrity": "sha512-rCJSkIHWZ/HOUoEWgjZ1DrRjLpTeTjgaktyJV0yhm8PugM5sKoavNjUHtI/amjsTn/Tq+Q3IIAuBD/dUSsWwxQ==",
-      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/polyline instead",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -10083,7 +9828,8 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
@@ -10160,20 +9906,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/quote-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
-      "integrity": "sha512-kKr2uQ2AokadPjvTyKJQad9xELbZwYzWlNfI3Uz2j/ib5u6H9lDP7fUUR//rMycd0gv4Z5P1qXMfXR8YpIxrjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal": "0.0.1",
-        "minimist": "^1.1.3",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "quote-stream": "bin/cmd.js"
-      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -10414,6 +10146,7 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -10553,12 +10286,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -10944,16 +10671,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
     },
-    "node_modules/sexagesimal": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/sexagesimal/-/sexagesimal-0.5.0.tgz",
-      "integrity": "sha512-xwbZEEGr5SQxON2PskNQQmPjrir+rnkaAoZqeHEDQ29fElSgpOh2rA5tBmZZd07NyBgUpU5/budc6wWm2Wjy+w==",
-      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/sexagesimal instead",
-      "license": "BSD",
-      "bin": {
-        "sexagesimal": "bin/sexagesimal"
-      }
-    },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -10965,52 +10682,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shallow-copy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw==",
-      "license": "MIT"
-    },
-    "node_modules/shapefile": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/shapefile/-/shapefile-0.3.1.tgz",
-      "integrity": "sha512-BZoPvnq4ULce0pyKiZUU4D8CdPl0Z1fpE73AeCkwyMbD2hpUeVA0s7jIE/wX8uWNruVeJV6e+rznPHBwuH5J6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-queue": "1",
-        "iconv-lite": "0.2",
-        "optimist": "0.3"
-      },
-      "bin": {
-        "dbfcat": "bin/dbfcat",
-        "shp2json": "bin/shp2json",
-        "shpcat": "bin/shpcat"
-      }
-    },
-    "node_modules/shapefile/node_modules/d3-queue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-1.2.3.tgz",
-      "integrity": "sha512-m6KtxX4V5pmVf1PqhH4SkQVMshSJfyCLM2vf2oFPi9FWFVT3+rtbCGerk766b/JXymHQDU3oqXHaZoiQ/e8yUQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/shapefile/node_modules/iconv-lite": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-      "integrity": "sha512-KhmFWgaQZY83Cbhi+ADInoUQ8Etn6BG5fikM9syeOjQltvR45h7cRKJ/9uvQEuD61I3Uju77yYce0/LhKVClQw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/shapefile/node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
       }
     },
     "node_modules/shebang-command": {
@@ -11202,203 +10873,6 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
     },
-    "node_modules/static-eval": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
-      "integrity": "sha512-6dWWPfa/0+1zULdQi7ssT5EQZHsGK8LygBzhE/HdafNCo4e/Ibt7vLPfxBw9VcdVV+t0ARtN4ZAJKtApVc0A5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "escodegen": "~0.0.24"
-      }
-    },
-    "node_modules/static-eval/node_modules/escodegen": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
-      "integrity": "sha512-6ioQhg16lFs5c7XJlJFXIDxBjO4yRvXC9yK6dLNNGuhI3a/fJukHanPF6qtpjGDgAFzI8Wuq3PSIarWmaOq/5A==",
-      "dependencies": {
-        "esprima": "~1.0.2",
-        "estraverse": "~1.3.0"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      },
-      "optionalDependencies": {
-        "source-map": ">= 0.1.2"
-      }
-    },
-    "node_modules/static-eval/node_modules/esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha512-rp5dMKN8zEs9dfi9g0X1ClLmV//WRyk/R15mppFNICIFRG5P92VP7Z04p8pk++gABo9W2tY+kHyu6P1mEHgmTA==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/static-eval/node_modules/estraverse": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
-      "integrity": "sha512-OkbCPVUu8D9tbsLcUR+CKFRBbhZlogmkbWaP3BPERlkqzWL5Q6IdTz6eUk+b5cid2MTaCqJb2nNRGoJ8TpfPrg==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/static-module": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
-      "integrity": "sha512-XTj7pQOHT33l77lK/Pu8UXqzI44C6LYAqwAc9hLTTESHRqJAFudBpReuopFPpoRr5CtOoSmGfFQC6FPlbDnyCw==",
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "~1.6.0",
-        "duplexer2": "~0.0.2",
-        "escodegen": "~1.3.2",
-        "falafel": "^2.1.0",
-        "has": "^1.0.0",
-        "object-inspect": "~0.4.0",
-        "quote-stream": "~0.0.0",
-        "readable-stream": "~1.0.27-1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "~0.2.0",
-        "through2": "~0.4.1"
-      }
-    },
-    "node_modules/static-module/node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/static-module/node_modules/concat-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/static-module/node_modules/concat-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/static-module/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/object-inspect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-      "integrity": "sha512-8WvkvUZiKAjjsy/63rJjA7jw9uyF0CLVLjBKEfnPHE3Jxvs1LgwqL2OmJN+LliIX1vrzKW+AAu02Cc+xv27ncQ==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/quote-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
-      "integrity": "sha512-m4VtvjAMx00wgAS6eOy50ZDat1EBQeFKBIrtF/oxUt0MenEI33y7runJcRiOihc+JBBIt2aFFJhILIh4e9shJA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "0.0.8",
-        "through2": "~0.4.1"
-      }
-    },
-    "node_modules/static-module/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/static-module/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/through2": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.0.17",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/static-module/node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -11568,6 +11042,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11830,52 +11305,6 @@
         "tslib": "^2"
       }
     },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -11919,65 +11348,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/togeojson": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/togeojson/-/togeojson-0.13.0.tgz",
-      "integrity": "sha512-d8qA5mSUpnqYBQDuq0Lhgl1rMUOWwrHh50Qy00qkk3SuwjYnaxZR2h8pXMOrMGa6d/7m1YmStOI4CMRa14K46A==",
-      "deprecated": "This module has moved: please install @mapbox/togeojson instead",
-      "license": "BSD",
-      "dependencies": {
-        "concat-stream": "~1.4.5",
-        "minimist": "0.0.8",
-        "xmldom": "~0.1.19"
-      },
-      "bin": {
-        "togeojson": "togeojson"
-      }
-    },
-    "node_modules/togeojson/node_modules/concat-stream": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
-      "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.1",
-        "readable-stream": "~1.1.9",
-        "typedarray": "~0.0.5"
-      }
-    },
-    "node_modules/togeojson/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
-    "node_modules/togeojson/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
-      "license": "MIT"
-    },
-    "node_modules/togeojson/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/togeojson/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -11985,28 +11355,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/topojson": {
-      "version": "1.6.26",
-      "resolved": "https://registry.npmjs.org/topojson/-/topojson-1.6.26.tgz",
-      "integrity": "sha512-W0B6UMeC9ZzH6OQ4vWG8tGb6ITis7/gDG0nNq13GL/ysy1LKU07HM0GtjQMrecQ/Q8S5EP7sjpjBjoKiz6P3nQ==",
-      "deprecated": "Use topojson-client, topojson-server or topojson-simplify directly.",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3": "3",
-        "d3-geo-projection": "0.2",
-        "d3-queue": "2",
-        "optimist": "0.3",
-        "rw": "1",
-        "shapefile": "0.3"
-      },
-      "bin": {
-        "topojson": "bin/topojson",
-        "topojson-geojson": "bin/topojson-geojson",
-        "topojson-group": "bin/topojson-group",
-        "topojson-merge": "bin/topojson-merge",
-        "topojson-svg": "bin/topojson-svg"
       }
     },
     "node_modules/topojson-client": {
@@ -12026,15 +11374,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/topojson/node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
-      }
     },
     "node_modules/tree-dump": {
       "version": "1.0.2",
@@ -13219,23 +12558,16 @@
       }
     },
     "node_modules/wellknown": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.4.2.tgz",
-      "integrity": "sha512-ivKT+rEy/GKU3q4Yi0dT/OnkMPXmUJF0SoPwthcCh2cr4PFeEeFjIENV3kB2WF7KgLakl2J0kbkcEMDl3WXSUA==",
-      "license": "BSD",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.5.0.tgz",
+      "integrity": "sha512-za5vTLuPF9nmrVOovYQwNEWE/PwJCM+yHMAj4xN1WWUvtq9OElsvKiPL0CR9rO8xhrYqL7NpI7IknqR8r6eYOg==",
       "dependencies": {
         "concat-stream": "~1.5.0",
-        "minimist": "~1.1.2"
+        "minimist": "~1.2.0"
       },
       "bin": {
         "wellknown": "cli.js"
       }
-    },
-    "node_modules/wellknown/node_modules/minimist": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-      "integrity": "sha512-2RbeLaM/Hbo9vJ1+iRrxzfDnX9108qb2m923U+s+Ot2eMey0IYGdSjzHmvtg2XsxoCuMnzOMw7qc573RvnLgwg==",
-      "license": "MIT"
     },
     "node_modules/whatwg-fetch": {
       "version": "2.0.4",
@@ -13358,15 +12690,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
@@ -13395,25 +12718,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "license": "(LGPL-2.0 or MIT)",
-      "engines": {
-        "node": ">=0.1"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.2",
     "@gouvfr/dsfr": "^1.13.0",
-    "@mapbox/leaflet-omnivore": "^0.3.4",
     "@sentry/browser": "^8.33.0",
     "@sentry/tracing": "^7.99.0",
     "@symfony/webpack-encore": "^5.0.1",
@@ -18,7 +17,8 @@
     "libphonenumber-js": "^1.10.44",
     "vue": "^3.5.13",
     "vue-chartjs": "^4.1.1",
-    "vue-loader": "^17.0.0"
+    "vue-loader": "^17.0.0",
+    "wellknown": "^0.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/public/js/zone_map.js
+++ b/public/js/zone_map.js
@@ -13,7 +13,7 @@ L.Icon.Default.mergeOptions({
 })
 
 var zoneWkt = document.getElementById('info_zone_map').getAttribute('data-zone');
-const zoneGeoJson = omnivore.wkt.parse(zoneWkt);
+const zoneGeoJson = L.geoJson(wellknown.parse(zoneWkt));
 map.fitBounds(zoneGeoJson.getBounds());
 zoneGeoJson.addTo(map);
 

--- a/templates/back/zone/show.html.twig
+++ b/templates/back/zone/show.html.twig
@@ -82,7 +82,7 @@
 {% endblock %}
 
 {% block javascripts %}
-	<script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js" ></script> 
-    <script src="https://cdn.jsdelivr.net/npm/@mapbox/leaflet-omnivore@0.3.4/leaflet-omnivore.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js" ></script>
+    <script src="https://cdn.jsdelivr.net/npm/wellknown@0.5.0/wellknown.js"></script>
     <script src="{{ asset('js/zone_map.js') }}" ></script>
 {% endblock %}


### PR DESCRIPTION
## Ticket

#3951   

## Description
La lib de parsing wkt que nous utilisions utilisait des lib avec vulnérabilités et n'était plus mise à jour. Elle était d'ailleurs un peu lourde pour l'utilisation que nous en avions.
Remplacement par une lib plus simple :
- en Vue pour la page de Cartographie
- en Vanilla pour les pages de visualisation de zone individuelle

## Pré-requis
`npm run watch-bo`

## Tests avec les zones de la prod
- [ ] Cartographie BO
- [ ] Page d'une zone individuelle 
