### PR TITLE
[BO - Formulaire pro] Gérer la perte de token

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -43,6 +43,15 @@ function saveCurrentTab(event) {
 
   fetch(formAction, {method: 'POST', body: formData}).then(response => {
     if (response.ok) {
+
+      const contentType = response.headers.get('Content-Type') || '';
+      
+      if (!contentType.includes('application/json') && response.redirected) {
+        window.location.href = response.url;
+        window.location.reload()
+        return;
+      }
+
       response.json().then((response) => {
         currentTab.classList.remove('fr-tabs__panel--saving')
         


### PR DESCRIPTION
## Ticket

#3950    

## Description
Quand on reste trop longtemps sur un onglet avant de valider, et qu'on perd le token, on n'est pas redirigé vers l'onglet de connexion, mais on reste bloqué sur "Sauvegarde en cours" sans comprendre ce qui se passe

## Changements apportés
* Si la réponse n'est pas du json, mais une redirection, bah on redirige

## Pré-requis

## Tests
- [ ] Créer un signalement, et rester sur un onglet jusqu'à la fin du token avant de valider, vérifier qu'on est redirigé sur l'écran de connexion
