### PR TITLE
[BO] Optimisation de la commande d’archivage des comptes inactifs avec batchs

### DIFF
--- a/tests/Functional/Command/Cron/NotifyAndArchiveInactiveAccountCommandTest.php
+++ b/tests/Functional/Command/Cron/NotifyAndArchiveInactiveAccountCommandTest.php
@@ -10,6 +10,10 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class NotifyAndArchiveInactiveAccountCommandTest extends KernelTestCase
 {
+    /**
+     * @throws \DateMalformedStringException
+     * @throws \DateInvalidTimeZoneException
+     */
     public function testDisplayMessageSuccessfully(): void
     {
         $kernel = self::bootKernel();


### PR DESCRIPTION
## Ticket

#3985    

## Description
La commande rencontrait des arrêts inattendus en raison des effets de bord liés à l’historisation. 
Un traitement en mode batch pourrais éviter ces effets de bord à condition de trouver le bon nombre (ni trop grand et ni trop petit nécessite des tests supplémentaire) 

Le plus efficace est de supprimer l'historisation pour l'instant. 

## Changements apportés
* Désactivons de l'historisation 

## Pré-requis
```
make load-data
```
## Tests
- [ ] Exécuter la commande `make console app="notify-and-archive-inactive-accounts`