### PR TITLE
[PDF signalement] La description occupant y est 2 fois

### DIFF
--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -464,10 +464,6 @@
             </table>
         </section>
         <section>
-            <h3>Description par l'occupant</h3>
-            <text>{{ signalement.details|nl2br }}</text>
-        </section>
-        <section>
             <h2>Prise en charge partenaire</h2>
             <table style="width: 100%;text-align: center;" class="border">
                 <tr>


### PR DESCRIPTION
## Ticket

#3987    

## Description
Description en double

## Changements apportés
* Suppression de la description la plus récente

## Pré-requis

`make worker-stop && make worker-start`

## Tests
- [ ] Faire un export et vérifier la description par l'occupant