### PR TITLE
[BO - Signalement] Ajout d'un bandeau d'info quand le signalement a été créé par formulaire pro 

### DIFF
--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -4,6 +4,7 @@
 
 {% block body %}
     {% include 'back/nav_bo.html.twig' %}
+    {% block notice %}{% endblock %}
     <main id="container-horizontal" class="{{ app.request.get('_route') in ['back_cartographie'] ? '' : 'fr-mb-5v'}}">
         <div class="{{ app.request.get('_route') in ['back_cartographie', 'back_signalements_index', 'back_dashboard'] ? 'fr-container-fluid' : container_class }}">
             <div class="fr-grid-row">

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -3,6 +3,22 @@
 {% set static_picto_yes = '<p class="fr-badge fr-badge--success">Oui</p>' %}
 {% set static_picto_no = '<p class="fr-badge fr-badge--error">Non</p>' %}
 
+{% block notice %}
+    {% if signalement.createdBy and signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION %}
+        <div class="fr-notice fr-notice--info">
+            <div class="fr-container">
+                <div class="fr-notice__body">
+                    <p>
+                        <span class="fr-notice__title">Signalement BO</span>
+                        <span class="fr-notice__desc">Ce signalement a été créé depuis le formulaire pro par {{ signalement.createdBy.prenom }} {{ signalement.createdBy.nom }}, du partenaire {{ signalement.createdBy.getPartnerInTerritory(signalement.territory).nom }}.</span>
+                    </p>
+                    <button title="Masquer le message" onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" id="button-1299" class="fr-btn--close fr-btn">Masquer le message</button>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
     {% if canSeePartnerAffectation and canTogglePartnerAffectation %}
         {% include '_partials/_modal_affectation.html.twig' %}


### PR DESCRIPTION
## Ticket

#3534   

## Description
Ajout d'un bandeau d'information pour les signalements en attente de validation qui ont été créés via le formulaire pro

## Tests
- [ ] Tester avec différents signalements, différents statuts et vérifier que le bandeau n'apparait pas
- [ ] Tester avec un signalement en attente de validation créé par le formulaire pro (dans les fixtures 00000000-0000-0000-2025-000000000005) et vérifier l'affichage du bandeau
