### PR TITLE
[BO - Partenaires] Ajout de bandeau d'information pour la gestion des accès aux RT

### DIFF
--- a/docs/EXPLOITATION.md
+++ b/docs/EXPLOITATION.md
@@ -72,7 +72,12 @@ Voir le document de [Procédure de gestion des incidents de sécurité](https://
 
 ## Sécurité Opérationnelle
 
-### Gestion des Accès et Authentification
+### Gestion des Accès
+Une revue des accès et des habilitations et faite plusieurs fois par an par l'équipe technique.
+
+Les agents de type Administrateur territoire (voir plus bas) sont chargés de vérifier régulièrement l'utilité du maintien ou non des comptes des autres agents.
+
+### Authentification
 Les mots de passe comportent au moins 12 caractères, dont 1 minuscule, 1 majuscule, 1 signe spécial et 1 chiffre.
 
 #### Comptes administrateurs
@@ -86,7 +91,7 @@ En cas de départ, l'accès est annulé et le compte est conservé mais archivé
 Un compte d'agent a accès au back-office de la plateforme.
 Trois rôles existent donnant accès à un éventail différent de fonctionnalités : agent, administrateur partenaire, administrateur territoire.
 
-En cas de compte non-utilisé pendant plus de 2 ans, le compte est anonymisé et archivé.
+Si un compte n'est pas utilisé pendant plus de 1 an, l'utilisateur est averti. 15 jours plus tard, sans action de l'utilisateur, le compte est anonymisé et archivé.
 
 ### Sauvegardes et Restaurations
 Voir le document de [Procédure de gestion des incidents de sécurité](https://github.com/MTES-MCT/histologe/wiki/Gestion-des-incidents-de-s%C3%A9curit%C3%A9)

--- a/docs/EXPLOITATION.md
+++ b/docs/EXPLOITATION.md
@@ -73,7 +73,7 @@ Voir le document de [Procédure de gestion des incidents de sécurité](https://
 ## Sécurité Opérationnelle
 
 ### Gestion des Accès
-Une revue des accès et des habilitations et faite plusieurs fois par an par l'équipe technique.
+Une revue des accès et des habilitations des comptes administrateurs est faite plusieurs fois par an par l'équipe technique.
 
 Les agents de type Administrateur territoire (voir plus bas) sont chargés de vérifier régulièrement l'utilité du maintien ou non des comptes des autres agents.
 

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -12,6 +12,23 @@
             'level3Title': 'Partenaires',
             'level3Link': '',
         } %}
+
+        {% if is_granted('ROLE_ADMIN_TERRITORY') and not is_granted('ROLE_ADMIN') %}
+        <div class="fr-notice fr-notice--warning fr-mb-3v">
+            <div class="fr-container">
+                <div class="fr-notice__body">
+                    <p>
+                        <span class="fr-notice__desc">
+                            Les responsables de territoire sont en charge de la gestion des utilisateurs.
+                            Pour des raisons de sécurité, nous vous recommandons de vérifier régulièrement les comptes inutilisés et de les supprimer le cas échéant.
+                        </span>
+                    </p>
+                    <button title="Masquer le message" onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" id="button-1305" class="fr-btn--close fr-btn">Masquer le message</button>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-6 fr-text--left">


### PR DESCRIPTION
## Ticket

#3993
#3994

## Description
Ajout d'un bandeau dans la liste des partenaires spécialement pour les RT pour leur demander d'être attentifs aux comptes utilisateurs.
Ajout d'information dans le document `EXPLOITATION.md` pour mettre en place le processus de vérification des accès par l'équipe qui exploite la plateforme.

## Tests
- [ ] Vérifier le contenu de EXPLOITATION.md
- [ ] Se connecter en RT et vérifier le bandeau sur la liste des partenaires
- [ ] Se connecter avec un autre rôle : le bandeau n'apparait pas
