### PR TITLE
[Suivi usager] Revue de la page d'authentification

### DIFF
--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -1,5 +1,34 @@
 import { disableHeaderAndFooterButtonOfModal, enableHeaderAndFooterButtonOfModal } from '../../services/modales_helper'
 
+const fieldsetVisitorType = document?.querySelector('#fieldset-visitor-type')
+if (fieldsetVisitorType) {
+  document.querySelectorAll('#radio-visitor-type-occupant, #radio-visitor-type-declarant').forEach(element => {
+    element.addEventListener('change', (event) => {
+      refreshLoginFields()
+    })
+  })
+
+  function refreshLoginFields() {
+    const listVisibleOccupant = document.querySelectorAll('.visible-if-occupant')
+    const listVisibleDeclarant = document.querySelectorAll('.visible-if-declarant')
+    if (document.querySelector('#radio-visitor-type-occupant').checked) {
+      listVisibleOccupant.forEach(element => {
+        element.classList.remove('fr-hidden')
+      })
+      listVisibleDeclarant.forEach(element => {
+        element.classList.add('fr-hidden')
+      })
+    } else {
+      listVisibleOccupant.forEach(element => {
+        element.classList.add('fr-hidden')
+      })
+      listVisibleDeclarant.forEach(element => {
+        element.classList.remove('fr-hidden')
+      })
+    }
+  }
+}
+
 const modalUploadFiles = document?.querySelector('#fr-modal-upload-files-usager')
 if (modalUploadFiles) {
   const dropArea = document.querySelector('.modal-upload-drop-section')

--- a/templates/security/login_suivi_signalement.html.twig
+++ b/templates/security/login_suivi_signalement.html.twig
@@ -4,62 +4,116 @@
 
 {% block body %}
     <main class="fr-container fr-py-5w" id="content">
-        <section class="fr-grid-row fr-grid-row--center">
-            <header class="fr-callout bg-light fr-col-12">
-                <p class="fr-callout__title">Suivre mon signalement</p>
-                <p class="fr-callout__text fr-mb-5v">
-                    Saisissez les informations suivantes pour accéder au signalement.
-                </p>
-                <em class="fr-fi-information-line fr-text--light fr-text-label--blue-france disabled-link"
-                    >Toutes les informations sont obligatoires</em>
-            </header>
-            <form class="needs-validation fr-mt-5v fr-col-md-6" name="login-form" method="POST" novalidate="">
-                {% if error %}
-                    <div role="alert" class="fr-alert fr-alert--error fr-alert--sm fr-mb-5w">
-                        <p class="fr-alert__title">Connexion impossible</p>
-                        <p>{{ error.messageKey|trans(error.messageData, 'security') }}</p>
+        <h1>Suivre mon signalement</h1>
+        <div class="fr-notice fr-notice--info fr-mb-5v">
+            <div class="fr-container">
+                <div class="fr-notice__body">
+                    <p>
+                        <span class="fr-notice__desc">Pour renforcer la sécurité de vos données, vous devez désormais répondre à quelques questions pour accéder à votre page de suivi.</span>
+                    </p>
+                    <button title="Masquer le message" onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" id="button-1299" class="fr-btn--close fr-btn">Masquer le message</button>
+                </div>
+            </div>
+        </div>
+        <p class="fr-mb-5v">Répondez à ces quelques questions de sécurité pour accéder au dossier !</p>
+        <p>
+            <em>Tous les champs sont obligatoires</em>
+        </p>
+        <form class="needs-validation fr-mt-10v" name="login-form" method="POST" novalidate="">
+            {% if error %}
+                <div role="alert" class="fr-alert fr-alert--error fr-alert--sm fr-col-12 fr-mb-5w">
+                    <p class="fr-alert__title">Connexion impossible</p>
+                    <p>{{ error.messageKey|trans(error.messageData, 'security') }}</p>
+                </div>
+            {% endif %}
+            {% if signalement.profileDeclarant
+                and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT
+                and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').LOCATAIRE
+            %}
+                <fieldset class="fr-fieldset fr-grid-row fr-grid-row--gutters fr-mb-10v" id="fieldset-visitor-type" aria-labelledby="fieldset-visitor-type-legend">
+                    <legend class="fr-fieldset__legend" id="fieldset-visitor-type-legend">
+                        Qui êtes-vous ?
+                    </legend>
+                    <div class="fr-fieldset__element">
+                        <div class="fr-radio-group">
+                            <input type="radio" id="radio-visitor-type-occupant" name="visitor-type" value="occupant">
+                            <label class="fr-label" for="radio-visitor-type-occupant">
+                                La personne qui vit dans le logement (occupant)
+                            </label>
+                        </div>
                     </div>
-                {% endif %}
-                <div class="fr-input-group">
-                    <label class="fr-label" for="login-first-letter-prenom">
-                        Initiale du prénom du déclarant ou de l'occupant
-                        <span class="fr-hint-text">Première lettre du prénom de la personne qui a déclaré le signalement ou de celle qui occupe le logement</span>
-                    </label>
-                    <input class="fr-input" aria-describedby="login-first-letter-prenom-error-desc-error" type="text" maxlength="1"
-                           id="login-first-letter-prenom" name="login-first-letter-prenom" required>
-                    <p id="login-first-letter-prenom-error-desc-error" class="fr-error-text fr-hidden">
-                        Veuillez saisir une lettre.
-                    </p>
+                    <div class="fr-fieldset__element">
+                        <div class="fr-radio-group">
+                            <input type="radio" id="radio-visitor-type-declarant" name="visitor-type" value="declarant">
+                            <label class="fr-label" for="radio-visitor-type-declarant">
+                                La personne qui a déposé le signalement (tiers déclarant)
+                            </label>
+                        </div>
+                    </div>
+                </fieldset>
+            {% endif %}
+            <fieldset class="fr-fieldset fr-grid-row fr-grid-row--gutters" id="fieldset-identity" aria-labelledby="fieldset-identity-legend">
+                <legend class="fr-fieldset__legend" id="fieldset-identity-legend">
+                    Confirmez votre identité
+                </legend>
+                <div class="fr-fieldset__element fr-col-12 fr-col-md-6">
+                    <div class="fr-input-group">
+                        <label class="fr-label" for="login-first-letter-prenom">
+                            Première lettre de votre prénom
+                            <span class="fr-hint-text visible-if-occupant fr-hidden">Première lettre du prénom de la personne vivant dans le logement</span>
+                            {% if signalement.profileDeclarant
+                                and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT
+                                and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').LOCATAIRE
+                            %}
+                            <span class="fr-hint-text visible-if-declarant fr-hidden">Première lettre du prénom de la personne qui a déposé le dossier</span>
+                            {% endif %}
+                        </label>
+                        <input class="fr-input" aria-describedby="login-first-letter-prenom-error-desc-error" type="text" maxlength="1"
+                                id="login-first-letter-prenom" name="login-first-letter-prenom" required>
+                        <p id="login-first-letter-prenom-error-desc-error" class="fr-error-text fr-hidden">
+                            Veuillez saisir une lettre.
+                        </p>
+                    </div>
                 </div>
-                <div class="fr-input-group">
-                    <label class="fr-label" for="login-first-letter-nom">
-                        Initiale du nom de famille du déclarant ou de l'occupant
-                        <span class="fr-hint-text">Première lettre du nom de famille de la personne qui a déclaré le signalement ou de celle qui occupe le logement</span>
-                    </label>
-                    <input class="fr-input" aria-describedby="login-first-letter-nom-error-desc-error" type="text" maxlength="1"
-                           id="login-first-letter-nom" name="login-first-letter-nom" required>
-                    <p id="login-first-letter-nom-error-desc-error" class="fr-error-text fr-hidden">
-                        Veuillez saisir une lettre.
-                    </p>
+                <div class="fr-fieldset__element fr-col-12 fr-col-md-6">
+                    <div class="fr-input-group">
+                        <label class="fr-label" for="login-first-letter-nom">
+                            Première lettre de votre nom de famille
+                            <span class="fr-hint-text visible-if-occupant fr-hidden">Première lettre du nom de famille de la personne vivant dans le logement</span>
+                            {% if signalement.profileDeclarant
+                                and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT
+                                and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').LOCATAIRE
+                            %}
+                            <span class="fr-hint-text visible-if-declarant fr-hidden">Première lettre du nom de famille de la personne qui a déposé le dossier</span>
+                            {% endif %}
+                        </label>
+                        <input class="fr-input" aria-describedby="login-first-letter-nom-error-desc-error" type="text" maxlength="1"
+                                id="login-first-letter-nom" name="login-first-letter-nom" required>
+                        <p id="login-first-letter-nom-error-desc-error" class="fr-error-text fr-hidden">
+                            Veuillez saisir une lettre.
+                        </p>
+                    </div>
                 </div>
-                <div class="fr-input-group">
-                    <label class="fr-label" for="login-code-postal">
-                        Code postal du logement
-                    </label>
-                    <input class="fr-input" aria-describedby="login-code-postal-error-desc-error" type="text" maxlength="5"
-                           id="login-code-postal" name="login-code-postal" required>
-                    <p id="login-code-postal-error-desc-error" class="fr-error-text fr-hidden">
-                        Veuillez saisir un code postal.
-                    </p>
+                <div class="fr-fieldset__element fr-col-12 fr-col-md-6">
+                    <div class="fr-input-group">
+                        <label class="fr-label" for="login-code-postal">
+                            Code postal du logement
+                        </label>
+                        <input class="fr-input" aria-describedby="login-code-postal-error-desc-error" type="text" maxlength="5"
+                                id="login-code-postal" name="login-code-postal" required>
+                        <p id="login-code-postal-error-desc-error" class="fr-error-text fr-hidden">
+                            Veuillez saisir un code postal.
+                        </p>
+                    </div>
                 </div>
-                <input type="hidden" name="from_email" value="{{ fromEmail }}">
-                <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-                <div class="fr-form-group">
-                    <button class="fr-btn fr-icon-checkbox-circle-fill fr-btn--icon-right" aria-label="Accéder au signalement">
-                        Accéder au signalement
-                    </button>
-                </div>
-            </form>
-        </section>
+            </fieldset>
+            <input type="hidden" name="from_email" value="{{ fromEmail }}">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+            <div class="fr-form-group fr-mt-3v">
+                <button class="fr-btn fr-btn--icon-left fr-icon-check-line" aria-label="Accéder au signalement">
+                    Accéder au signalement
+                </button>
+            </div>
+        </form>
     </main>
 {% endblock %}


### PR DESCRIPTION
## Ticket

#4008   

## Description
Revue de la page d'authentification de la page de suivi usager (en se basant sur la capture fournie dans le ticket)

## Changements apportés
* Ajout d'un bandeau pour prévenir les usagers
* Si le signalement a un déclarant de type locataire ou bailleur occupant, on demande les infos de l'occupant directement
* Sinon, on donne le choix avec des boutons radio

## Pré-requis
`npm run watch`

## Tests
- [ ] Tester l'authentification de la page de suivi pour un signalement de type locataire ou bailleur occupant
- [ ] Tester l'authentification de la page de suivi pour un signalement d'un autre type
