### PR TITLE
[Sécurité] Correction double authentification compatible CSP

### DIFF
--- a/.env
+++ b/.env
@@ -80,6 +80,7 @@ PLATFORM_LOGO='logo-signal-logement.svg'
 FEATURE_BANNER_HISTOLOGE=1
 FEATURE_SECURE_UUID_URL=0
 FEATURE_EMAIL_RECAP=0
+TRUSTED_PROXIES=0.0.0.0/0
 ### signal-logement ###
 
 ### object storage S3 ###

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -23,7 +23,6 @@ framework:
         default_uuid_version: 7
         time_based_uuid_version: 7
 
-
     #esi: true
     #fragments: true
     php_errors:
@@ -34,6 +33,8 @@ when@prod:
         session:
             cookie_secure: true
             cookie_httponly: true
+    trusted_proxies: '%env(TRUSTED_PROXIES)%'
+    trusted_headers: [ "x-forwarded-for", "x-forwarded-proto", "x-forwarded-port", "x-forwarded-host" ]
 
 when@test:
     framework:

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -33,8 +33,8 @@ when@prod:
         session:
             cookie_secure: true
             cookie_httponly: true
-    trusted_proxies: '%env(TRUSTED_PROXIES)%'
-    trusted_headers: [ "x-forwarded-for", "x-forwarded-proto", "x-forwarded-port", "x-forwarded-host" ]
+        trusted_proxies: '%env(TRUSTED_PROXIES)%'
+        trusted_headers: [ "x-forwarded-for", "x-forwarded-proto", "x-forwarded-port", "x-forwarded-host" ]
 
 when@test:
     framework:

--- a/config/routes/scheb_2fa.yaml
+++ b/config/routes/scheb_2fa.yaml
@@ -1,7 +1,9 @@
 2fa_login:
     path: /2fa
+    schemes: [https]
     defaults:
         _controller: "scheb_two_factor.form_controller::form"
 
 2fa_login_check:
     path: /2fa_check
+    schemes: [https]

--- a/src/Service/Security/TwoFactorCondition.php
+++ b/src/Service/Security/TwoFactorCondition.php
@@ -23,6 +23,7 @@ class TwoFactorCondition implements TwoFactorConditionInterface
         if (!$this->isLocalEnvironment()) {
             $this->requestContext->setScheme('https');
         }
+
         return $this->feature2faEmailEnabled;
     }
 

--- a/src/Service/Security/TwoFactorCondition.php
+++ b/src/Service/Security/TwoFactorCondition.php
@@ -5,17 +5,29 @@ namespace App\Service\Security;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Condition\TwoFactorConditionInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Routing\RequestContext;
 
 class TwoFactorCondition implements TwoFactorConditionInterface
 {
     public function __construct(
+        private readonly RequestContext $requestContext,
         #[Autowire(env: 'FEATURE_2FA_EMAIL_ENABLED')]
         private bool $feature2faEmailEnabled,
+        #[Autowire(env: 'APP_URL')]
+        private readonly string $appUrl,
     ) {
     }
 
     public function shouldPerformTwoFactorAuthentication(AuthenticationContextInterface $context): bool
     {
+        if (!$this->isLocalEnvironment()) {
+            $this->requestContext->setScheme('https');
+        }
         return $this->feature2faEmailEnabled;
+    }
+
+    private function isLocalEnvironment(): bool
+    {
+        return str_contains($this->appUrl, 'localhost');
     }
 }

--- a/src/Service/Security/TwoFactorCondition.php
+++ b/src/Service/Security/TwoFactorCondition.php
@@ -5,30 +5,17 @@ namespace App\Service\Security;
 use Scheb\TwoFactorBundle\Security\TwoFactor\AuthenticationContextInterface;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Condition\TwoFactorConditionInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Routing\RequestContext;
 
 class TwoFactorCondition implements TwoFactorConditionInterface
 {
     public function __construct(
-        private readonly RequestContext $requestContext,
         #[Autowire(env: 'FEATURE_2FA_EMAIL_ENABLED')]
         private bool $feature2faEmailEnabled,
-        #[Autowire(env: 'APP_URL')]
-        private readonly string $appUrl,
     ) {
     }
 
     public function shouldPerformTwoFactorAuthentication(AuthenticationContextInterface $context): bool
     {
-        if (!$this->isLocalEnvironment()) {
-            $this->requestContext->setScheme('https');
-        }
-
         return $this->feature2faEmailEnabled;
-    }
-
-    private function isLocalEnvironment(): bool
-    {
-        return str_contains($this->appUrl, 'localhost');
     }
 }


### PR DESCRIPTION
## Ticket

#2779

## Description
Modification de la configuration pour permettre l'authentification 2FA.

## Explications ChatGPT

### .env
`trusted_proxies` permet à Symfony de comprendre qu’il doit faire confiance à `X-Forwarded-Proto: https`.
Sinon Symfony croit qu’il est en http même si ton utilisateur utilise https.
Ce mauvais schéma est utilisé pour les redirections automatiques, dont celle de `/2fa`.

### scheb_2fa.yaml
`schemes: [https]` indique à Symfony que cette route ne doit répondre qu'en HTTPS.
Si un utilisateur arrive dessus en HTTP (par accident ou mauvaise config), Symfony lui renverra une redirection automatique en HTTPS.
Ça rend ta sécurité beaucoup plus stricte et plus conforme à ta politique CSP.

## Tests
- [ ] Se rendre sur la Review App et tester différents logins sur différents navigateurs
