### PR TITLE
[BO - Profile] Afficher l'e-mail des RT pour les agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ S3_URL_BUCKET=
 | Bouches-du-Rhône | Agent Partenaire 13   | user-13-01@signal-logement.fr             | ROLE_USER_PARTNER    |
 | Ain              | Agent Partenaire 01   | user-01-01@signal-logement.fr             | ROLE_USER_PARTNER    |
 
-> Pour les mails générique partenaire, la nomenclature est la suivante : partenaire-[zip]-[index]
+> Pour les mails de contact partenaire, la nomenclature est la suivante : partenaire-[zip]-[index]
 
 ## API
 

--- a/migrations/Version20250428102700.php
+++ b/migrations/Version20250428102700.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250428102700 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add email_notifiable column to partner table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE partner ADD email_notifiable TINYINT(1) NOT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE partner SET email_notifiable = 1 WHERE email IS NOT NULL AND email != ''
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE partner DROP email_notifiable
+        SQL);
+    }
+}

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\HasLifecycleCallbacks()]
 #[UniqueEntity(
     fields: ['email', 'territory', 'isArchive'],
-    message: 'L\'e-mail générique existe déjà pour ce territoire. Veuillez saisir un autre e-mail partenaire.',
+    message: 'L\'e-mail de contact existe déjà pour ce territoire. Veuillez saisir un autre e-mail partenaire.',
     errorPath: 'email',
     ignoreNull: true)
 ]
@@ -57,6 +57,9 @@ class Partner implements EntityHistoryInterface
     #[Assert\Email]
     #[Assert\Length(max: 255)]
     private ?string $email = null;
+
+    #[ORM\Column]
+    private ?bool $emailNotifiable = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Assert\Url]
@@ -125,6 +128,7 @@ class Partner implements EntityHistoryInterface
         $this->zones = new ArrayCollection();
         $this->userPartners = new ArrayCollection();
         $this->excludedZones = new ArrayCollection();
+        $this->emailNotifiable = true;
     }
 
     public function getId(): ?int
@@ -247,9 +251,21 @@ class Partner implements EntityHistoryInterface
         return $this;
     }
 
+    public function isEmailNotifiable(): ?bool
+    {
+        return $this->emailNotifiable;
+    }
+
+    public function setEmailNotifiable(bool $emailNotifiable): static
+    {
+        $this->emailNotifiable = $emailNotifiable;
+
+        return $this;
+    }
+
     public function receiveEmailNotifications(?User $excludeUser = null): bool
     {
-        if ($this->email) {
+        if ($this->email && $this->emailNotifiable) {
             return true;
         }
         foreach ($this->getUsers() as $user) {

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ChoiceList;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -65,6 +66,15 @@ class PartnerType extends AbstractType
                     'class' => 'fr-input',
                 ],
                 'required' => false,
+            ])
+            ->add('emailNotifiable', ChoiceType::class, [
+                'choices' => [
+                    'Oui' => true,
+                    'Non' => false,
+                ],
+                'expanded' => true,
+                'label' => 'Notifier l\'adresse e-mail de contact ?',
+                'help' => 'Est-ce que les e-mails concernant les signalements du partenaire doivent être envoyés à cette adresse ?',
             ])
             ->add('type', EnumType::class, [
                 'class' => EnumPartnerType::class,

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -76,7 +76,7 @@ class PartnerRepository extends ServiceEntityRepository
 
         $queryBuilder->addSelect(
             '(CASE
-                WHEN p.email IS NOT NULL THEN 1
+                WHEN (p.email IS NOT NULL AND p.email != \'\' AND p.emailNotifiable = 1) THEN 1
                 WHEN EXISTS (
                     SELECT 1
                     FROM '.UserPartner::class.' up2
@@ -141,7 +141,7 @@ class PartnerRepository extends ServiceEntityRepository
         // Filtre sur les partenaires non notifiables
         $expr = $queryBuilder->expr();
         $queryBuilder
-            ->where('p.email IS NULL') // Pas d'email générique
+            ->where('(p.email IS NULL OR p.email = \'\' OR p.emailNotifiable = 0)')
             ->andWhere('p.isArchive = 0')
             ->andWhere(
                 $expr->orX(

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -236,7 +236,7 @@ class NotificationAndMailSender
     private function getRecipientsPartner(Partner $partner): ArrayCollection
     {
         $recipients = new ArrayCollection();
-        if ($partner->getEmail()) {
+        if ($partner->getEmail() && $partner->isEmailNotifiable()) {
             $recipients->add($partner);
         }
 

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -23,11 +23,14 @@
 			<div class="fr-fieldset__element">
 				<div class="fr-input-group">
 					<label for="{{ form.email.vars.id }}" class="fr-label">
-						E-mail générique (facultatif)
-						<span class="fr-hint-text">Des e-mails concernant les signalements du partenaire seront envoyés à cette adresse.</span>
+						E-mail de contact (facultatif)
+						<span class="fr-hint-text">S'il y a des responsables de territoire au sein du partenaire, cette adresse e-mail sera visible par les agents du territoire.</span>
 					</label>
 					{{ form_widget(form.email) }}
 				</div>
+			</div>
+			<div class="fr-fieldset__element fr-mb-n1v">
+				{{ form_row(form.emailNotifiable) }}
 			</div>
 			<div class="fr-fieldset__element">
 				<div class="fr-select-group">

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -34,7 +34,7 @@
         {% if partner.receiveEmailNotifications is same as false %}  
             <div class="fr-alert fr-alert--warning">
                 <h3 class="fr-alert__title">Ce partenaire n'est pas notifiable.</h3>
-                <p>Cela signifie qu'il n'a pas d'adresse e-mail générique et qu'aucun utilisateur ne reçoit de notifications par e-mail.</p>
+                <p>Cela signifie qu'il n'a pas d'adresse e-mail de contact ou qu'elle n'est pas notifiable et qu'aucun utilisateur ne reçoit de notifications par e-mail.</p>
             </div>     
         {% endif %}
     </section>
@@ -69,7 +69,7 @@
                     <div><b>Territoire :</b> {{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : ''}}</div>
                 </div>
                 <div class="fr-col-6">
-                    <div><b>E-mail générique :</b> {{ partner.email }}</div>
+                    <div><b>E-mail de contact :</b> {{ partner.email }}</div>
                 </div>
                 <div class="fr-col-6">
                     <div><b>Type :</b> {{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'N/A') }}</div>

--- a/templates/back/profil/index.html.twig
+++ b/templates/back/profil/index.html.twig
@@ -69,7 +69,13 @@
                         </p>
                         <ul>
                             {% for userAdmin in activeTerritoryAdminsByTerritory[partner.territory.id] %}
-                            <li>{{ userAdmin.prenom }} {{ userAdmin.nom }} du partenaire {{ userAdmin.getPartnerInTerritoryOrFirstOne(partner.territory).nom }}</li>
+                            {% set partner = userAdmin.getPartnerInTerritoryOrFirstOne(partner.territory) %}
+                            <li>
+                                {{ userAdmin.prenom }} {{ userAdmin.nom }} du partenaire {{ partner.nom }}
+                                {% if partner.email %}
+                                    - {{ partner.email }}
+                                {% endif %}
+                            </li>
                             {% endfor %}
                         </ul>
                     </div>

--- a/templates/front/cgu_agents.html.twig
+++ b/templates/front/cgu_agents.html.twig
@@ -114,7 +114,7 @@
                 <ul>
                     <li>Le territoire ;</li>
                     <li>Le nom du partenaire ;</li>
-                    <li>L’e-mail générique (facultatif) ;</li>
+                    <li>L’e-mail de contact (facultatif) ;</li>
                     <li>Le type de partenaire ;</li>
                     <li>Les compétences du partenaire (facultatif) ;</li>
                     <li>Le ou les codes INSEE.</li>

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -125,7 +125,7 @@ class PartnerControllerTest extends WebTestCase
                 'partner[type]' => $partner->getType()->value,
             ]
         );
-        $this->assertSelectorNotExists('.fr-alert--error', 'E-mail générique manquant: Il faut obligatoirement qu\'un compte utilisateur accepte de recevoir les e-mails.');
+        $this->assertSelectorNotExists('.fr-alert--error', 'E-mail de contact manquant: Il faut obligatoirement qu\'un compte utilisateur accepte de recevoir les e-mails.');
     }
 
     public function testDeletePartner()


### PR DESCRIPTION
## Ticket

#3984

## Description
- Sur la page de profil d'un utilisateur on affiche en plus du nom/prénom et nom du partenaire de ses RT, l'email de contact du partenaire.
- A la création/modification d'un partenaire on demande l'email de contact et si il doit être notifié.

## Changements apportés
* Ajout du champ `emailNotifiable` sur `Partner`
* Adaptation des contrôle pour la feature "Partenaire non notifiable"

## Pré-requis
`make execute-migration name=Version20250428102700 direction=up`

## Tests
- [ ] Vérifier l'affichage du mail de contact sur la page de profil
- [ ] Vérifier le fonctionnement du widget et liste des "Partenaire non notifiable"
- [ ] Vérifier que l'envoi des notification au mail du partenaire prend bien en compte le choix notifiable ou non notifiable
