### PR TITLE
[Sécurité - ClamAV] Correction de la règle YARA pour éviter les faux positifs sur les PDF

### DIFF
--- a/clamav/data/PDF_Malicious_PDF_JS_Heuristics.yar
+++ b/clamav/data/PDF_Malicious_PDF_JS_Heuristics.yar
@@ -28,8 +28,6 @@ rule Malicious_PDF_JS_Heuristics
         $large_encoded = /(\\x[0-9a-fA-F]{2}){10,}/
         $unicode_encoded = /(\\u[0-9a-fA-F]{4}){5,}/
 
-        // Bloc PDF stream
-        $stream = /stream[\r\n]+.{1,10000}endstream/s
     condition:
         $pdf_tag1 in (0..1024) and
         $js_tag and
@@ -37,6 +35,6 @@ rule Malicious_PDF_JS_Heuristics
             $eval, $unescape, $function_ctor, $setTimeout,
             $setInterval, $fromCharCode, $decodeURIComponent,
             $atob, $alert, $response, $execMenu,
-            $large_encoded, $unicode_encoded, $stream
+            $large_encoded, $unicode_encoded
         ))
 }


### PR DESCRIPTION
## Ticket

#4017    

## Description
https://sentry.incubateur.net/organizations/betagouv/issues/169541/?project=61

Détection d'un fichier suspect depuis la MEP
![image](https://github.com/user-attachments/assets/826cb957-3e5b-4fb6-bda0-490978223f20)


```
select file.filename, created_at, is_suspicious from file where created_at > '2025-04-28 14:35' and filename  like '%.pdf';
```

```
yara -s clamav/data/PDF_Malicious_PDF_JS_Heuristics.yar scripts/local/pdf/photos-fissure-dans-le-mure-1-Metre-680f9a869642c.pdf
```

```
Malicious_PDF_JS_Heuristics scripts/local/pdf/photos-fissure-dans-le-mure-1-Metre-680f9a869642c.pdf
0x0:$pdf_tag1: %PDF-
0x10c3a7:$js_tag: /JS
0xfc2b7:$stream: stream\x0D\x0Aendobj\x0A2 0 obj\x0A<< /Producer (Adobe Acrobat T5)/Creator (Adobe Acrobat Reader (iOS))/CreationDate (D:20250428165105+02'00')/ModDate (D:20250428165105+02'00')>>\x0D\x0Aendobj\x0A3 0 obj\x0A<< /Type /Page/MediaBox [0 0 4284 5712]/Resources << /XObject << /Im 1 0 R>>\x0D>>\x0D/Contents 4 0 R/Parent 5 0 R>>\x0D\x0Aendobj\x0A4 0 obj\x0A<</Length 32>>\x0Dstream\x0D\x0Aq\x0A4284 0 0 5712 0 0 cm\x0A/Im Do\x0AQ\x0A\x0Dendstream\x0D\x0Aendobj\x0A5 0 obj\x0A<< /Type /Pages/Kids [3 0 R]/Count 1>>\x0D\x0Aendobj\x0A6 0 obj\x0A<< /Type /Catalog/Pages 5 0 R>>\x0D\x0Aendobj\x0A7 0 obj\x0A<</Filter /FlateD
0xfc3fc:$stream: stream\x0D\x0Aq\x0A4284 0 0 5712 0 0 cm\x0A/Im Do\x0AQ\x0A\x0Dendstream\x0D\x0Aendobj\x0A5 0 obj\x0A<< /Type /Pages/Kids [3 0 R]/Count 1>>\x0D\x0Aendobj\x0A6 0 obj\x0A<< /Type /Catalog/Pages 5 0 R>>\x0D\x0Aendobj\x0A7 0 obj\x0A<</Filter /FlateDecode /Length 39/Root 6 0 R/Info 2 0 R/ID [<25A078A935A47AFCF4A00DB30F20D68A> <766E20EA9507E0F48C9078F61A4CAACF>]/Size 8/Type /XRef/W [1 3 2]/Index [0 7]>>\x0Dstream\x0D\x0Ax\x9Cb```\xF8\xFF\x9F\x91\x81A\x90\x81\x81\x91\xFF\xD01\x10y8\x0DL>\x05\x91G\xCC\xC1d\x1E\x03\x03\x00\x00\x00\xFF\xFF\x0Dendstream\x0D\x0Astartxref\x0D\x0A1033374\x0D\x0A%%EOF\x0D\x0A5 0 obj\x0A<</Type/Pages/Kids[ 3 0 R]/Count 1>>\x0Aendobj\x0A6 0 obj\x0A<</Type/Catalog/Pages 5
0xfc428:$stream: stream\x0D\x0Aendobj\x0A5 0 obj\x0A<< /Type /Pages/Kids [3 0 R]/Count 1>>\x0D\x0Aendobj\x0A6 0 obj\x0A<< /Type /Catalog/Pages 5 0 R>>\x0D\x0Aendobj\x0A7 0 obj\x0A<</Filter /FlateDecode /Length 39/Root 6 0 R/Info 2 0 R/ID [<25A078A935A47AFCF4A00DB30F20D68A> <766E20EA9507E0F48C9078F61A4CAACF>]/Size 8/Type /XRef/W [1 3 2]/Index [0 7]>>\x0Dstream\x0D\x0Ax\x9Cb```\xF8\xFF\x9F\x91\x81A\x90\x81\x81\x91\xFF\xD01\x10y8\x0DL>\x05\x91G\xCC\xC1d\x1E\x03\x03\x00\x00\x00\xFF\xFF\x0Dendstream\x0D\x0Astartxref\x0D\x0A1033374\x0D\x0A%%EOF\x0D\x0A5 0 obj\x0A<</Type/Pages/Kids[ 3 0 R]/Count 1>>\x0Aendobj\x0A6 0 obj\x0A<</Type/Catalog/Pages 5 0 R/Version/1.7>>\x0Aendobj\x0A2 0 obj\x0A<</Produce
0xfc553:$stream: stream\x0D\x0Ax\x9Cb```\xF8\xFF\x9F\x91\x81A\x90\x81\x81\x91\xFF\xD01\x10y8\x0DL>\x05\x91G\xCC\xC1d\x1E\x03\x03\x00\x00\x00\xFF\xFF\x0Dendstream\x0D\x0Astartxref\x0D\x0A1033374\x0D\x0A%%EOF\x0D\x0A5 0 obj\x0A<</Type/Pages/Kids[ 3 0 R]/Count 1>>\x0Aendobj\x0A6 0 obj\x0A<</Type/Catalog/Pages 5 0 R/Version/1.7>>\x0Aendobj\x0A2 0 obj\x0A<</Producer(Adobe Acrobat T5)/Creator(Adobe Acrobat Reader (iOS))/CreationDate(D:20250428165105+02'00')/ModDate(D:20250428165458+02'00')>>\x0Aendobj\x0A19 0 obj\x0A<</Type/XRef/Size 20/Prev 1033374/Root 6 0 R/Info 2 0 R/ID[<25A078A935A47AFCF4A00DB30F20D68A><43D42E6D6EB41082F90CBC7C54C6F4A2>]/W[ 1 4 2]/Index[ 2 1 5 2 
0xfc586:$stream: stream\x0D\x0Astartxref\x0D\x0A1033374\x0D\x0A%%EOF\x0D\x0A5 0 obj\x0A<</Type/Pages/Kids[ 3 0 R]/Count 1>>\x0Aendobj\x0A6 0 obj\x0A<</Type/Catalog/Pages 5 0 R/Version/1.7>>\x0Aendobj\x0A2 0 obj\x0A<</Producer(Adobe Acrobat T5)/Creator(Adobe Acrobat Reader (iOS))/CreationDate(D:20250428165105+02'00')/ModDate(D:20250428165458+02'00')>>\x0Aendobj\x0A19 0 obj\x0A<</Type/XRef/Size 20/Prev 1033374/Root 6 0 R/Info 2 0 R/ID[<25A078A935A47AFCF4A00DB30F20D68A><43D42E6D6EB41082F90CBC7C54C6F4A2>]/W[ 1 4 2]/Index[ 2 1 5 2 19 1]/Filter/FlateDecode/Length 29>>\x0Astream\x0D\x0Ax\x9Cbd\xE0?
0xfc778:$stream: stream\x0D\x0Ax\x9Cbd\xE0?&\xC6\xC0\xC0\xC8\xC0\x7Ft%\x84\xBA\x0B\xA6\x8Em``\x00\x00\x00\x00\xFF\xFF\x0Aendstream\x0Aendobj\x0Astartxref\x0A1033904\x0A%%EOF\x0A5 0 obj\x0A<</Type/Pages/Kids[ 3 0 R]/Count 1>>\x0Aendobj\x0A2 0 obj\x0A<</Producer(Adobe Acrobat T5)/Creator(Adobe Acrobat Reader (iOS))/CreationDate(D:20250428165105+02'00')/ModDate(D:20250428165605+02'00')>>\x0Aendobj\x0A30 0 obj\x0A<</Type/XRef/Size 31/Prev 1033904/Root 6 0 R/Info 2 0 R/ID[<25A078A935A47AFCF4A00DB30F20D68A><68B3A23331146CE4D732D342AF5CAFA3>]/W[ 1 4 2]/Index[ 2 1 5 1 30 1]/Filter/FlateDecode/Length 25>>\x0Astream\x0D\x0Ax\x9Cbd\xE0?\xFE\x9B\x81\x81\x11H\x1D\x07S'\xA620
0xfc7a1:$stream: stream\x0Aendobj\x0Astartxref\x0A1033904\x0A%%EOF\x0A5 0 obj\x0A<</Type/Pages/Kids[ 3 0 R]/Count 1>>\x0Aendobj\x0A2 0 obj\x0A<</Producer(Adobe Acrobat T5)/Creator(Adobe Acrobat Reader (iOS))/CreationDate(D:20250428165105+02'00')/ModDate(D:20250428165605+02'00')>>\x0Aendobj\x0A30 0 obj\x0A<</Type/XRef/Size 31/Prev 1033904/Root 6 0 R/Info 2 0 R/ID[<25A078A935A47AFCF4A00DB30F20D68A><68B3A23331146CE4D732D342AF5CAFA3>]/W[ 1 4 2]/Index[ 2 1 5 1 30 1]/Filter/FlateDecode/Length 25>>\x0Astream\x0D\x0Ax\x9Cbd\xE0?\xFE\x9B\x81\x81\x11H\x1D\x07S'\xA620\x00\x00\x00\x00\xFF\xFF\x0Aendstream
0xfc95d:$stream: stream\x0D\x0Ax\x9Cbd\xE0?\xFE\x9B\x81\x81\x11H\x1D\x07S'\xA620\x00\x00\x00\x00\xFF\xFF\x0Aendstream
0x1c5418:$stream: stream\x0Aendobj\x0A37 0 obj\x0A[ 0 0 5707 2848]\x0Aendobj\x0A39 0 obj\x0A<</Length 32>>\x0Astream\x0D\x0Aq\x0A5707 0 0 2848 0 0 cm\x0A/Im Do\x0AQ\x0A\x0Aendstream\x0Aendobj\x0A2 0 obj\x0A<</Producer(Adobe Acrobat T5)/Creator(Adobe Acrobat Reader (iOS))/CreationDate(D:20250428165105+02'00')/ModDate(D:20250428165633+02'00')>>\x0Aendobj\x0A41 0 obj\x0A<</Type/XRef/Size 42/Prev 1034389/Root 6 0 R/Info 2 0 R/ID[<25A078A935A47AFCF4A00DB30F20D68A><E4C19F964CB719ED5B23168BA9C651C5>]/W[ 1 4 2]/Index[ 2 1 5 1 31 3 35 1 37 1 39 1 41 1]/Filter/FlateDecode/Length 45>>\x0Astream\x0D\x0Ax
0x1c545f:$stream: stream\x0D\x0Aq\x0A5707 0 0 2848 0 0 cm\x0A/Im Do\x0AQ\x0A\x0Aendstream\x0Aendobj\x0A2 0 obj\x0A<</Producer(Adobe Acrobat T5)/Creator(Adobe Acrobat Reader (iOS))/CreationDate(D:20250428165105+02'00')/ModDate(D:20250428165633+02'00')>>\x0Aendobj\x0A41 0 obj\x0A<</Type/XRef/Size 42/Prev 1034389/Root 6 0 R/Info 2 0 R/ID[<25A078A935A47AFCF4A00DB30F20D68A><E4C19F964CB719ED5B23168BA9C651C5>]/W[ 1 4 2]/Index[ 2 1 5 1 31 3 35 1 37 1 39 1 41 1]/Filter/FlateDecode/Length 45>>\x0Astream\x0D\x0Ax\x9Cbd\x90\x09\x99\xC9\xC0\xC0\xC8\xC0\x7Fr\x05\x84z\x0C\xA6N9@\xA8\x14\x08\xD5\x0C\xA2dB\xD4 \x94;\x98\x0A5f`\x00\x00\x00\x00\xFF\xFF\x0Aendstream
0x1c548b:$stream: stream\x0Aendobj\x0A2 0 obj\x0A<</Producer(Adobe Acrobat T5)/Creator(Adobe Acrobat Reader (iOS))/CreationDate(D:20250428165105+02'00')/ModDate(D:20250428165633+02'00')>>\x0Aendobj\x0A41 0 obj\x0A<</Type/XRef/Size 42/Prev 1034389/Root 6 0 R/Info 2 0 R/ID[<25A078A935A47AFCF4A00DB30F20D68A><E4C19F964CB719ED5B23168BA9C651C5>]/W[ 1 4 2]/Index[ 2 1 5 1 31 3 35 1 37 1 39 1 41 1]/Filter/FlateDecode/Length 45>>\x0Astream\x0D\x0Ax\x9Cbd\x90\x09\x99\xC9\xC0\xC0\xC8\xC0\x7Fr\x05\x84z\x0C\xA6N9@\xA8\x14\x08\xD5\x0C\xA2dB\xD4 \x94;\x98\x0A5f`\x00\x00\x00\x00\xFF\xFF\x0Aendstream
0x1c560f:$stream: stream\x0D\x0Ax\x9Cbd\x90\x09\x99\xC9\xC0\xC0\xC8\xC0\x7Fr\x05\x84z\x0C\xA6N9@\xA8\x14\x08\xD5\x0C\xA2dB\xD4 \x94;\x98\x0A5f`\x00\x00\x00\x00\xFF\xFF\x0Aendstream
````

- Créé avec : Adobe Acrobat Reader sur iOS (iPhone ou iPad).
- Producteur/Writer PDF : Adobe Acrobat T5 (T5 = moteur interne de génération PDF d'Adobe pour certaines plateformes mobiles).

Analyse de ChatGPT suite à ce faux positif
> Le motif $stream peut correspondre à des blocs de données présents dans les fichiers PDF créés par Adobe Reader ou d'autres outils standards. Ainsi, la présence d'un stream n'indique en rien un comportement malveillant.
La détection réellement pertinente repose uniquement sur la présence explicite de /JavaScript dans le document, combinée à l'apparition de patterns suspects dans le code JavaScript.


## Changements apportés
* Suppression de stream

## Pré-requis



## Tests local

```shell
sudo apt update && sudo apt install yara
yara -s clamav/data/PDF_Malicious_PDF_JS_Heuristics.yar scripts/local/pdf/test_pdf_js.pdf
```
*Output*
```
Malicious_PDF_JS_Heuristics scripts/local/pdf/test_pdf_js.pdf
0x0:$pdf_tag1: %PDF-
0xa3:$js_tag: /JavaScript
0x17a:$js_tag: /JavaScript
0x186:$js_tag: /JS
0x1ca:$eval: eval
0x196:$alert: alert

```

## Tests
https://histologe-staging-pr4018.osc-fr1.scalingo.io/

### Tests à faire sur dépôt de signalement, fiche usager et BO
- [ ] Ajouter le **PDF valide** faux positif et vérifier qu'il passe

### TNR
- [ ] Ajouter un **PDF avec JavaScript suspect** (déclenchant la **règle YARA**)  et vérifier que :
  - [ ] le fichier est bien **ajouté**,
  - [ ] le champ  `is_suspicious` dans la table `file` est bien à true
  - [ ] le fichier n’est **pas visualisable** sur le BO,
  - [ ] le fichier n’est **pas visualisable** sur la fiche usager.
