### PR TITLE
[BUG - Création agent] Impossible de sélectionner "Non" sur "Recevoir les e-mails

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -416,10 +416,14 @@ class PartnerController extends AbstractController
                 return $this->json(['content' => $content, 'title' => 'Compte existant sur un autre territoire', 'submitLabel' => 'Ajouter l\'utilisateur']);
             }
             $user->setRoles([$formUserPartner->get('role')->getData()]);
+            if (null === $user->getIsMailingSummary()) {
+                $user->setIsMailingSummary(true);
+            }
             if ($userExist) {
                 $userExist->setNom($user->getNom());
                 $userExist->setPrenom($user->getPrenom());
                 $userExist->setIsMailingActive($user->getIsMailingActive());
+                $userExist->setIsMailingSummary($user->getIsMailingSummary());
                 $userExist->setHasPermissionAffectation($user->hasPermissionAffectation());
                 $userExist->setStatut(User::STATUS_INACTIVE);
                 $userExist->setRoles([$formUserPartner->get('role')->getData()]);

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -553,7 +553,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         return $this;
     }
 
-    public function getIsMailingSummary(): bool
+    public function getIsMailingSummary(): ?bool
     {
         return $this->isMailingSummary;
     }

--- a/src/Form/UserPartnerType.php
+++ b/src/Form/UserPartnerType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -20,6 +21,8 @@ class UserPartnerType extends AbstractType
 
     public function __construct(
         private readonly Security $security,
+        #[Autowire(env: 'FEATURE_EMAIL_RECAP')]
+        private readonly bool $featureEmailRecap,
     ) {
         $this->roles = [];
         if ($security->isGranted('ROLE_ADMIN')) {
@@ -96,7 +99,7 @@ class UserPartnerType extends AbstractType
                 'label' => 'Recevoir les e-mails ?',
                 'help' => 'Si vous cochez oui, des e-mails concernant les signalements seront envoyés à cette adresse.',
             ]);
-        if (!$user->getId()) {
+        if (!$user->getId() && $this->featureEmailRecap) {
             $builder->add('isMailingSummary', ChoiceType::class, [
                 'choices' => [
                     'Un e-mail récapitulatif par jour' => true,

--- a/templates/_partials/_modal_user_create_form.html.twig
+++ b/templates/_partials/_modal_user_create_form.html.twig
@@ -21,15 +21,17 @@
     <div class="fr-col-12">
         {{ form_row(formUserPartner.isMailingActive) }}
     </div>
-    <div class="fr-col-12">
-        {{ form_row(formUserPartner.isMailingSummary) }}
-        <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-n3w">
-            <p>
-                Une fois son compte validé, seul l'agent pourra mettre à jour ses préférences en matière d'e-mail (tous les e-mails ou récapitulatif). 
-                L'agent ne pourra pas désactiver ses e-mails, seulement un responsable de territoire pourra le faire.
-            </p>
+    {% if feature_email_recap %}
+        <div class="fr-col-12">
+            {{ form_row(formUserPartner.isMailingSummary) }}
+            <div class="fr-alert fr-alert--info fr-alert--sm fr-mt-n3w">
+                <p>
+                    Une fois son compte validé, seul l'agent pourra mettre à jour ses préférences en matière d'e-mail (tous les e-mails ou récapitulatif). 
+                    L'agent ne pourra pas désactiver ses e-mails, seulement un responsable de territoire pourra le faire.
+                </p>
+            </div>
         </div>
-    </div>
+    {% endif %}
     {% if formUserPartner.hasPermissionAffectation is defined %}
         <div class="fr-col-12">
             <label class="fr-label fr-pb-1w">Droits d'affectation</label>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -241,7 +241,7 @@
                             <td>
                                 <span class="fr-badge fr-badge--blue-ecume fr-mb-1v">
                                     {% if user.isMailingActive %}
-                                        {{ user.isMailingSummary ? 'Récap' : 'Oui' }}
+                                        {{ user.isMailingSummary and feature_email_recap ? 'Récap' : 'Oui' }}
                                     {% else %}
                                         Non
                                     {% endif %}


### PR DESCRIPTION
## Ticket

#4021

## Description
- Correction du bug empêchant l'ajout d'un agent sans notification mail
- Correction du feature flipping email de recap (création d'agent, badge "Récap" dans la liste des agents du partenaire)

## Tests
- [ ] Tester la création d'agent avec et sans notification email, que ce soit avec ou sans `FEATURE_EMAIL_RECAP`
