### PR TITLE
[Tech] Correction de boucle clock pour améliorer gestion des tâches asynchrones

### DIFF
--- a/src/Command/Clock/ScheduledTaskCommand.php
+++ b/src/Command/Clock/ScheduledTaskCommand.php
@@ -62,15 +62,17 @@ class ScheduledTaskCommand extends Command
             $report = $cron->run();
 
             while ($cron->isRunning()) {
-                $this->logger->info(\sprintf('[CRON] %d tasks has been executed', \count($report->getReports())));
+            }
 
-                foreach ($report->getReports() as $jobReport) {
-                    $output = $jobReport->getOutput();
-                    foreach ($output as $line) {
-                        $this->logger->info(\sprintf('[CRON] %s', $line));
-                    }
+            $this->logger->info(\sprintf('[CRON] %d tasks has been executed', \count($report->getReports())));
+
+            foreach ($report->getReports() as $jobReport) {
+                $output = $jobReport->getOutput();
+                foreach ($output as $line) {
+                    $this->logger->info(\sprintf('[CRON] %s', $line));
                 }
             }
+
             sleep($sleepInterval);
         }
 


### PR DESCRIPTION
## Ticket

#3989   

## Description
La commande qui gère l'horloge Scalingo a été mal copiée et lançait les logs en boucle.
La boucle `while ($cron->isRunning())` devait être vide
Voir https://doc.scalingo.com/platform/app/task-scheduling/custom-clock-processes#implementing-custom-clock-processes

## Tests
- [ ] Relire...
