### PR TITLE
[Signalements] Correction des espaces de début et fin de chaine de données mail, prénom et nom

### DIFF
--- a/src/Command/TrimSignalementFieldsCommand.php
+++ b/src/Command/TrimSignalementFieldsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\SignalementRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:trim-signalement-fields',
+    description: 'Trim signalement fields'
+)]
+class TrimSignalementFieldsCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private SignalementRepository $signalementRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        // See https://symfony.com/doc/current/console/style.html
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->signalementRepository->trimFields();
+
+        $this->io->success('Signalement fields were successfully fixed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -842,7 +842,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setNomProprio(?string $nomProprio): self
     {
-        $this->nomProprio = $nomProprio;
+        $this->nomProprio = \trim($nomProprio); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -899,7 +899,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setMailProprio(?string $mailProprio): self
     {
-        $this->mailProprio = $mailProprio;
+        $this->mailProprio = \trim($mailProprio); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -991,7 +991,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setNomDeclarant(?string $nomDeclarant): self
     {
-        $this->nomDeclarant = $nomDeclarant;
+        $this->nomDeclarant = \trim($nomDeclarant); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -1003,7 +1003,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setPrenomDeclarant(?string $prenomDeclarant): self
     {
-        $this->prenomDeclarant = $prenomDeclarant;
+        $this->prenomDeclarant = \trim($prenomDeclarant); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -1032,7 +1032,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setMailDeclarant(?string $mailDeclarant): self
     {
-        $this->mailDeclarant = $mailDeclarant;
+        $this->mailDeclarant = \trim($mailDeclarant); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -1070,7 +1070,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setNomOccupant(?string $nomOccupant): self
     {
-        $this->nomOccupant = $nomOccupant;
+        $this->nomOccupant = \trim($nomOccupant); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -1082,7 +1082,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setPrenomOccupant(?string $prenomOccupant): self
     {
-        $this->prenomOccupant = $prenomOccupant;
+        $this->prenomOccupant = \trim($prenomOccupant); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -1111,7 +1111,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setMailOccupant($mailOccupant): self
     {
-        $this->mailOccupant = $mailOccupant;
+        $this->mailOccupant = \trim($mailOccupant); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }
@@ -2316,7 +2316,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function setPrenomProprio(?string $prenomProprio): self
     {
-        $this->prenomProprio = $prenomProprio;
+        $this->prenomProprio = \trim($prenomProprio); // Replace with mb_trim($name); when php 8.4
 
         return $this;
     }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1560,4 +1560,22 @@ class SignalementRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function trimFields(): void
+    {
+        $connection = $this->getEntityManager()->getConnection();
+        // Replace unbreakable spaces, and then trim
+        $sql = 'UPDATE signalement SET
+            mail_occupant = TRIM(REPLACE(mail_occupant, UNHEX("C2A0"), " ")),
+            prenom_occupant = TRIM(REPLACE(prenom_occupant, UNHEX("C2A0"), " ")),
+            nom_occupant = TRIM(REPLACE(nom_occupant, UNHEX("C2A0"), " ")),
+            mail_declarant = TRIM(REPLACE(mail_declarant, UNHEX("C2A0"), " ")),
+            prenom_declarant = TRIM(REPLACE(prenom_declarant, UNHEX("C2A0"), " ")),
+            nom_declarant = TRIM(REPLACE(nom_declarant, UNHEX("C2A0"), " ")),
+            mail_proprio = TRIM(REPLACE(mail_proprio, UNHEX("C2A0"), " ")),
+            prenom_proprio = TRIM(REPLACE(prenom_proprio, UNHEX("C2A0"), " ")),
+            nom_proprio = TRIM(REPLACE(nom_proprio, UNHEX("C2A0"), " "))';
+
+        $connection->prepare($sql)->executeStatement();
+    }
 }


### PR DESCRIPTION
## Ticket

#4032   

## Description
Avec le nouveau formulaire de sécurité d'accès aux fiches de suivi, on vérifie la première lettre du prénom et du nom des usagers.
Dans certains cas, il y a des espaces en premier caractère.

## Changements apportés
* Migration pour supprimer les espaces de début et fin de chaine
* Suppression des espaces à l'enregistrement

## Pré-requis
Utilisation base de prod

## Tests
- [ ] Vérifier la présence de signalements avec par exemple cette requête `SELECT * FROM `signalement` WHERE prenom_occupant LIKE ' %' AND prenom_occupant != ''`
- [ ] Exécuter la commande `make console app="trim-signalement-fields"`
- [ ] Vérifier la correction des signalements récupérés plus tôt
- [ ] Modifier un signalement en ajoutant des espaces en début ou fin de chaine, et vérifier que les espaces ne sont pas enregistrés
