### PR TITLE
[Statistiques] Ajout de cache pour optimiser les chargements

### DIFF
--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -6,6 +6,7 @@ use App\Dto\StatisticsFilters;
 use App\Entity\Territory;
 use App\Entity\User;
 use App\Repository\TerritoryRepository;
+use App\Service\Signalement\SearchFilterOptionDataProvider;
 use App\Service\Statistics\FilteredBackAnalyticsProvider;
 use App\Service\Statistics\GlobalBackAnalyticsProvider;
 use App\Service\Statistics\ListCommunesStatisticProvider;
@@ -66,7 +67,8 @@ class BackStatistiquesController extends AbstractController
         $backGlobalStatistics = $this->cache->get(
             $cacheKey,
             function (ItemInterface $item) use ($territory, $partners) {
-                $item->expiresAfter(120); // 2 minutes for global back stats
+                $item->expiresAfter(3600); // 1 hour for global back stats
+                $item->tag([SearchFilterOptionDataProvider::CACHE_TAG.$territory->getZip()]);
 
                 return $this->globalBackAnalyticsProvider->getData($territory, $partners);
             }
@@ -175,11 +177,12 @@ class BackStatistiquesController extends AbstractController
         }
 
         $territoryKey = !empty($territory) ? $territory->getZip() : '';
-        $cacheKey = 'filters-zip-'.$territoryKey;
+        $cacheKey = 'back-statistiques-filters-zip-'.$territoryKey;
         $filterLists = $this->cache->get(
             $cacheKey,
             function (ItemInterface $item) use ($territory) {
-                $item->expiresAfter(120); // 2 minutes for filters
+                $item->expiresAfter(7200); // 2 hours for filters
+                $item->tag([SearchFilterOptionDataProvider::CACHE_TAG.$territory->getZip()]);
 
                 return [
                     'list_communes' => $this->listCommunesStatisticProvider->getData($territory),

--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -18,6 +18,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 #[Route('/bo/statistiques')]
 class BackStatistiquesController extends AbstractController
@@ -31,6 +33,7 @@ class BackStatistiquesController extends AbstractController
         private ListTagsStatisticProvider $listTagStatisticProvider,
         private GlobalBackAnalyticsProvider $globalBackAnalyticsProvider,
         private FilteredBackAnalyticsProvider $filteredBackAnalyticsProvider,
+        private TagAwareCacheInterface $cache,
     ) {
     }
 
@@ -57,13 +60,24 @@ class BackStatistiquesController extends AbstractController
 
         $this->buildFilterLists($territory);
 
-        $globalStatistics = $this->globalBackAnalyticsProvider->getData($territory, $partners);
-        $this->result['count_signalement'] = $globalStatistics['count_signalement'];
-        $this->result['average_criticite'] = $globalStatistics['average_criticite'];
-        $this->result['average_days_validation'] = $globalStatistics['average_days_validation'];
-        $this->result['average_days_closure'] = $globalStatistics['average_days_closure'];
-        $this->result['count_signalement_refuses'] = $globalStatistics['count_signalement_refuses'];
-        $this->result['count_signalement_archives'] = $globalStatistics['count_signalement_archives'];
+        $territoryKey = !empty($territory) ? $territory->getZip() : '';
+        $partnersIds = implode('-', $partners->map(fn ($partner) => $partner->getId())->toArray());
+        $cacheKey = 'backGlobalStatistics-zip-'.$territoryKey.'-partners-'.$partnersIds;
+        $backGlobalStatistics = $this->cache->get(
+            $cacheKey,
+            function (ItemInterface $item) use ($territory, $partners) {
+                $item->expiresAfter(120); // 2 minutes for global back stats
+
+                return $this->globalBackAnalyticsProvider->getData($territory, $partners);
+            }
+        );
+
+        $this->result['count_signalement'] = $backGlobalStatistics['count_signalement'];
+        $this->result['average_criticite'] = $backGlobalStatistics['average_criticite'];
+        $this->result['average_days_validation'] = $backGlobalStatistics['average_days_validation'];
+        $this->result['average_days_closure'] = $backGlobalStatistics['average_days_closure'];
+        $this->result['count_signalement_refuses'] = $backGlobalStatistics['count_signalement_refuses'];
+        $this->result['count_signalement_archives'] = $backGlobalStatistics['count_signalement_archives'];
 
         $statisticsFilters = $this->createFilters($request, $territory, $partners);
         $filteredStatistics = $this->filteredBackAnalyticsProvider->getData($statisticsFilters);
@@ -159,8 +173,24 @@ class BackStatistiquesController extends AbstractController
             $this->result['can_filter_territoires'] = '1';
             $this->result['list_territoires'] = $this->listTerritoryStatisticProvider->getData($user);
         }
-        $this->result['list_communes'] = $this->listCommunesStatisticProvider->getData($territory);
-        $this->result['list_epcis'] = $this->listEpciStatisticProvider->getData($territory);
-        $this->result['list_etiquettes'] = $this->listTagStatisticProvider->getData($territory);
+
+        $territoryKey = !empty($territory) ? $territory->getZip() : '';
+        $cacheKey = 'filters-zip-'.$territoryKey;
+        $filterLists = $this->cache->get(
+            $cacheKey,
+            function (ItemInterface $item) use ($territory) {
+                $item->expiresAfter(120); // 2 minutes for filters
+
+                return [
+                    'list_communes' => $this->listCommunesStatisticProvider->getData($territory),
+                    'list_epcis' => $this->listEpciStatisticProvider->getData($territory),
+                    'list_etiquettes' => $this->listTagStatisticProvider->getData($territory),
+                ];
+            }
+        );
+
+        $this->result['list_communes'] = $filterLists['list_communes'];
+        $this->result['list_epcis'] = $filterLists['list_epcis'];
+        $this->result['list_etiquettes'] = $filterLists['list_etiquettes'];
     }
 }

--- a/src/Controller/Back/BackStatistiquesController.php
+++ b/src/Controller/Back/BackStatistiquesController.php
@@ -68,7 +68,9 @@ class BackStatistiquesController extends AbstractController
             $cacheKey,
             function (ItemInterface $item) use ($territory, $partners) {
                 $item->expiresAfter(3600); // 1 hour for global back stats
-                $item->tag([SearchFilterOptionDataProvider::CACHE_TAG.$territory->getZip()]);
+                if (!empty($territory)) {
+                    $item->tag([SearchFilterOptionDataProvider::CACHE_TAG.$territory->getZip()]);
+                }
 
                 return $this->globalBackAnalyticsProvider->getData($territory, $partners);
             }
@@ -182,7 +184,9 @@ class BackStatistiquesController extends AbstractController
             $cacheKey,
             function (ItemInterface $item) use ($territory) {
                 $item->expiresAfter(7200); // 2 hours for filters
-                $item->tag([SearchFilterOptionDataProvider::CACHE_TAG.$territory->getZip()]);
+                if (!empty($territory)) {
+                    $item->tag([SearchFilterOptionDataProvider::CACHE_TAG.$territory->getZip()]);
+                }
 
                 return [
                     'list_communes' => $this->listCommunesStatisticProvider->getData($territory),

--- a/src/Controller/Back/TagController.php
+++ b/src/Controller/Back/TagController.php
@@ -75,6 +75,7 @@ class TagController extends AbstractController
             $entityManager->persist($tag);
             $entityManager->flush();
             $cache->invalidateTags([SearchFilterOptionDataProvider::CACHE_TAG, SearchFilterOptionDataProvider::CACHE_TAG.$tag->getTerritory()->getZip()]);
+
             $this->addFlash('success', 'L\'étiquette a bien été ajoutée.');
         }
         if ($form->isSubmitted() && !$form->isValid()) {


### PR DESCRIPTION
## Ticket

#3949   

## Description
Le ticket d'origine parlait d'ajouter du cache sur les stats publiques. Sur Matomo, il y a entre 10 et 15 visites par jour. Ce n'est pas énorme. Mise en place de cache de 2h.

Mise en place de cache de quelques minutes sur les stats BO. En analysant Matomo, c'est encore moins utile (à peu près le même nombre de visiteur). J'aurais du vérifier avant...

Pas convaincu de l'utilité de cette PR :)

## Tests
- [ ] Vérifier avec différents utilisateurs qu'il n'y a pas de problème de valeurs affichées
