### PR TITLE
[BO - Interconnexion SI-SH] Evolutions suivi et visites

### DIFF
--- a/migrations/Version20250502060650.php
+++ b/migrations/Version20250502060650.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250502060650 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Esabora - Mise à jour de la colonne external_operator dans la table intervention';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE intervention
+            SET external_operator = done_by
+            WHERE provider_name = 'esabora'
+            AND type LIKE 'VISITE%'
+            AND done_by NOT LIKE 'ARS'
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE intervention
+            SET external_operator = NULL
+            WHERE provider_name = 'esabora'
+            AND type LIKE 'VISITE%'
+            AND done_by NOT LIKE 'ARS'
+        ");
+    }
+}

--- a/src/Entity/Enum/InterventionType.php
+++ b/src/Entity/Enum/InterventionType.php
@@ -8,7 +8,7 @@ enum InterventionType: string
     case VISITE_CONTROLE = 'VISITE_CONTROLE';
     case ARRETE_PREFECTORAL = 'ARRETE_PREFECTORAL';
 
-    public const INTERVENTION_TYPE_LABEL = [
+    public const array INTERVENTION_TYPE_LABEL = [
         'VISITE' => 'Visite',
         'VISITE_CONTROLE' => 'Visite de contrôle',
         'ARRETE_PREFECTORAL' => 'Arrêté préfectoral',

--- a/src/Factory/InterventionFactory.php
+++ b/src/Factory/InterventionFactory.php
@@ -34,6 +34,14 @@ class InterventionFactory
             ->setDetails($details)
             ->setAdditionalInformation($additionalInformation);
 
+        if ('ARS' === $doneBy) {
+            $intervention->setPartner($affectation->getPartner());
+        } else {
+            $intervention
+                ->setExternalOperator($doneBy)
+                ->setPartner(null);
+        }
+
         if (!empty($concludeProcedures)) {
             $intervention->setConcludeProcedure($concludeProcedures);
         }

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -435,17 +435,16 @@ class SuiviRepository extends ServiceEntityRepository
     /**
      * @throws NonUniqueResultException
      */
-    public function findFirstSuiviBy(Signalement $signalement, int $typeSuivi): ?Suivi
+    public function findAllSuiviBy(Signalement $signalement, int $typeSuivi): array
     {
         $qb = $this->createQueryBuilder('s');
         $qb->where('s.signalement = :signalement')
             ->andWhere('s.type = :type')
             ->orderBy('s.createdAt', 'ASC')
-            ->setMaxResults(1)
             ->setParameter('signalement', $signalement)
             ->setParameter('type', $typeSuivi);
 
-        return $qb->getQuery()->getOneOrNullResult();
+        return $qb->getQuery()->getResult();
     }
 
     public function findExistingEventsForSCHS(): array

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -316,7 +316,13 @@ class EsaboraManager
     {
         $intervention
             ->setScheduledAt(DateParser::parse($dossierVisiteSISH->getVisiteDate()))
-            ->setDoneBy($dossierVisiteSISH->getVisitePar());
+            ->setDoneBy($visitePar = $dossierVisiteSISH->getVisitePar());
+
+        if ('ARS' !== $visitePar) {
+            $intervention
+                ->setExternalOperator($visitePar)
+                ->setPartner(null);
+        }
 
         $this->interventionRepository->save($intervention, true);
     }

--- a/src/Service/Intervention/InterventionDescriptionGenerator.php
+++ b/src/Service/Intervention/InterventionDescriptionGenerator.php
@@ -26,7 +26,7 @@ class InterventionDescriptionGenerator
     public static function buildDescriptionVisiteCreated(Intervention $intervention): string
     {
         $labelVisite = strtolower($intervention->getType()->label());
-        $partnerName = $intervention->getPartner() ? $intervention->getPartner()->getNom() : 'Non renseigné';
+        $partnerName = $intervention->getExternalOperator() ?? $intervention->getPartner()?->getNom() ?? 'Non renseigné';
         $today = new \DateTimeImmutable();
         $isInPast = $today > $intervention->getScheduledAt()
             && Intervention::STATUS_DONE === $intervention->getStatus();

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -142,13 +142,23 @@ trait FixturesHelper
         return (new Affectation())->setSignalement($signalement)->setPartner($partner);
     }
 
-    public function getSuiviPartner(): Suivi
+    public function getSuiviPartner(string $description = 'Problèmes de condensation et de moisissures'): Suivi
     {
         return (new Suivi())
             ->setType(Suivi::TYPE_PARTNER)
-            ->setDescription('Problèmes de condensation et de moisissures')
+            ->setDescription($description)
             ->setCreatedAt(new \DateTimeImmutable())
             ->setCreatedBy(new User());
+    }
+
+    public function getSuiviPartnerList(): array
+    {
+        return [
+            $this->getSuiviPartner('Problèmes de condensation et de moisissure'),
+            $this->getSuiviPartner('Problèmes d\'humidité dans le logement'),
+            $this->getSuiviPartner('Absence de chauffage'),
+            $this->getSuiviPartner('Ventilation défectueuse'),
+        ];
     }
 
     public function getAdditionalInformationArrete(): array

--- a/tests/Functional/Repository/SuiviRepositoryTest.php
+++ b/tests/Functional/Repository/SuiviRepositoryTest.php
@@ -6,7 +6,6 @@ use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Repository\SuiviRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class SuiviRepositoryTest extends KernelTestCase
@@ -21,18 +20,6 @@ class SuiviRepositoryTest extends KernelTestCase
 
         $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
         $this->suiviRepository = $this->entityManager->getRepository(Suivi::class);
-    }
-
-    /**
-     * @throws NonUniqueResultException
-     */
-    public function testFindFirstSuiviBy(): void
-    {
-        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-        $signalement = $signalementRepository->findOneBy(['reference' => '2023-15']);
-        $firstSuivi = $this->suiviRepository->findFirstSuiviBy($signalement, Suivi::TYPE_PARTNER);
-
-        $this->assertStringContainsString('le premier suivi de partenaire 13-01', $firstSuivi->getDescription());
     }
 
     public function testFindSignalementsForThirdRelance(): void

--- a/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
@@ -29,8 +29,8 @@ class DossierMessageSISHFactoryTest extends TestCase
         $suiviRepositoryMock = $this->createMock(SuiviRepository::class);
         $suiviRepositoryMock
             ->expects($this->once())
-            ->method('findFirstSuiviBy')
-            ->willReturn($this->getSuiviPartner());
+            ->method('findAllSuiviBy')
+            ->willReturn($this->getSuiviPartnerList());
 
         $uploadHandlerServiceMock = $this->createMock(UploadHandlerService::class);
         $uploadHandlerServiceMock
@@ -74,6 +74,7 @@ class DossierMessageSISHFactoryTest extends TestCase
         $this->assertNotNull($dossierMessage->getLocalisationVille());
         $this->assertEquals('H', $dossierMessage->getSasLogicielProvenance());
         $this->assertEquals(75, $dossierMessage->getSitLogementSuperficie());
+        $this->assertCount(4, explode(\PHP_EOL.str_repeat('-', 50).\PHP_EOL, $dossierMessage->getSignalementCommentaire()));
         $this->assertEquals(
             AbstractEsaboraService::SIGNALEMENT_ORIGINE,
             $dossierMessage->getSignalementOrigine()


### PR DESCRIPTION
## Ticket

#4006
#4007    

## Description
Évolutions demandées lors du dernier point technico-fonctionnelle

## Changements apportés
* Ajout d'une migration pour mettre à jour l'opération externe si non ARS
* Remplacer la récupération du dernier suivi partenaire par tous les suivi partenaires
* Mise à jour EsaboraManager pour la gestion de l'opérateur externe

## Pré-requis
``` 
make create-db
make worker-stop && make worker-start
make mock-stop && make mock-start
```

## Tests

####  [[BO - Interconnexion SI-SH] Le partenaire de visite peut être un partenaire différent de l'ARS #4006](https://github.com/MTES-MCT/histologe/issues/4006)

- [ ] Se rentre sur http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012 afin de simuler une sychro de visite. 
- [ ] Exécuter `make sync-sish` et constater que la visite avec le partenaire externe est bien ajouté 
![image](https://github.com/user-attachments/assets/c95f9679-e6a8-4fd6-8a4b-3f0413a3b49a)
- [ ] Tester la migration en récupérant la base de prod 

#### [[BO - Interconnexion SI-SH] Remplacer le dernier suivi partenaire envoyé par la liste des suivis partenaire #4007](https://github.com/MTES-MCT/histologe/issues/4007)

- [ ] Se connecter en tant qu'agent du signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012
- [ ] Ajouter plusieurs suivis partenaire sur ce signalement 
- [ ] Se connecter en tant que RT13 ou Super Admin, désaffecter puis réaffecter le partenaire ARS afin de déclencher l'envoi.
- [ ] Vérifier dans la table job_event que les commentaires sont bien séparé par des tiret et saut de ligne

![image](https://github.com/user-attachments/assets/a5c1d762-cdfc-47c8-b677-dd6448bc1e75)

![image](https://github.com/user-attachments/assets/b10a3977-b9ef-434b-b9e7-53be60d81299)
