### PR TITLE
[Tech - Historisation] Tentative d'optimisation pour les traitement en boucle

### DIFF
--- a/src/DataFixtures/Loader/LoadAffectationData.php
+++ b/src/DataFixtures/Loader/LoadAffectationData.php
@@ -45,7 +45,7 @@ class LoadAffectationData extends Fixture implements OrderedFixtureInterface
             ->setTerritory($this->territoryRepository->findOneBy(['name' => $row['territory']]))
             ->setCreatedAt(new \DateTimeImmutable())
             ->setAffectedBy($this->userRepository->findOneBy(['email' => $row['affected_by']]))
-            ->setAnsweredBy($this->userRepository->findOneBy(['email' => $row['affected_by']]))
+            ->setAnsweredBy($this->userRepository->findOneBy(['email' => $row['answered_by']]))
             ->setAnsweredAt(new \DateTimeImmutable())
             ->setIsSynchronized($row['is_synchronized'] ?? false)
         ;

--- a/src/Entity/HistoryEntry.php
+++ b/src/Entity/HistoryEntry.php
@@ -40,6 +40,8 @@ class HistoryEntry
     #[ORM\JoinColumn(nullable: true)]
     private ?User $user = null;
 
+    private object $entity;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -149,6 +151,18 @@ class HistoryEntry
     public function setSignalement(?Signalement $signalement): self
     {
         $this->signalement = $signalement;
+
+        return $this;
+    }
+
+    public function getEntity(): object
+    {
+        return $this->entity;
+    }
+
+    public function setEntity(object $entity): static
+    {
+        $this->entity = $entity;
 
         return $this;
     }

--- a/src/EventListener/AuthentificationHistoryListener.php
+++ b/src/EventListener/AuthentificationHistoryListener.php
@@ -54,7 +54,6 @@ class AuthentificationHistoryListener
             $historyEntry = $this->historyEntryManager->create(
                 historyEntryEvent: $historyEntryEvent,
                 entityHistory: $user instanceof SignalementUser ? $signalement : $user,
-                flush: false
             );
 
             $source = $this->historyEntryManager->getSource();

--- a/src/EventListener/EntityHistoryListener.php
+++ b/src/EventListener/EntityHistoryListener.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Uid\Uuid;
 
 #[AsDoctrineListener(event: Events::onFlush)]
 class EntityHistoryListener
@@ -147,8 +148,9 @@ class EntityHistoryListener
         array $changes,
     ): void {
         try {
-            $historyKey = $entity::class.'_'.$entity->getId().'_'.$event->value;
-            if (isset($this->historyEntryBuffer->pendingHistoryEntries[$historyKey])) {
+            $id = $entity->getId() ?? Uuid::v4();
+            $historyKey = $entity::class.'_'.$id.'_'.$event->value;
+            if (HistoryEntryEvent::CREATE !== $event && isset($this->historyEntryBuffer->pendingHistoryEntries[$historyKey])) {
                 $oldChanges = $this->historyEntryBuffer->pendingHistoryEntries[$historyKey]->getChanges();
                 $this->historyEntryBuffer->pendingHistoryEntries[$historyKey]->setChanges(array_merge($oldChanges, $changes));
             } else {

--- a/src/EventListener/EntityHistoryListener.php
+++ b/src/EventListener/EntityHistoryListener.php
@@ -150,16 +150,15 @@ class EntityHistoryListener
         try {
             $id = $entity->getId() ?? Uuid::v4();
             $historyKey = $entity::class.'_'.$id.'_'.$event->value;
-            if (HistoryEntryEvent::CREATE !== $event && isset($this->historyEntryBuffer->pendingHistoryEntries[$historyKey])) {
-                $oldChanges = $this->historyEntryBuffer->pendingHistoryEntries[$historyKey]->getChanges();
-                $this->historyEntryBuffer->pendingHistoryEntries[$historyKey]->setChanges(array_merge($oldChanges, $changes));
+            if (HistoryEntryEvent::CREATE !== $event && $this->historyEntryBuffer->exist($historyKey)) {
+                $this->historyEntryBuffer->update($historyKey, $changes);
             } else {
                 $historyEntry = $this->historyEntryManager->create(
                     historyEntryEvent: $event,
                     entityHistory: $entity,
                     changes: $changes,
                 );
-                $this->historyEntryBuffer->pendingHistoryEntries[$historyKey] = $historyEntry;
+                $this->historyEntryBuffer->add($historyKey, $historyEntry);
             }
         } catch (\Throwable $exception) {
             $this->logger->error($exception->getMessage());

--- a/src/EventListener/EntityHistoryListener.php
+++ b/src/EventListener/EntityHistoryListener.php
@@ -7,18 +7,20 @@ use App\Entity\Behaviour\EntityHistoryInterface;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Manager\HistoryEntryManager;
 use App\Service\History\EntityComparator;
+use App\Service\History\HistoryEntryBuffer;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\PersistentCollection;
+use Doctrine\ORM\UnitOfWork;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-#[AsDoctrineListener(event: Events::postPersist)]
-#[AsDoctrineListener(event: Events::postUpdate)]
-#[AsDoctrineListener(event: Events::preRemove)]
-readonly class EntityHistoryListener
+#[AsDoctrineListener(event: Events::onFlush)]
+class EntityHistoryListener
 {
+    private UnitOfWork $uow;
+
     public const array FIELDS_TO_IGNORE = [
         'lastLoginAt',
         'updatedAt',
@@ -28,59 +30,68 @@ readonly class EntityHistoryListener
     ];
 
     public function __construct(
-        private HistoryEntryManager $historyEntryManager,
-        private EntityManagerInterface $entityManager,
-        private EntityComparator $entityComparator,
-        private LoggerInterface $logger,
+        private readonly HistoryEntryManager $historyEntryManager,
+        private readonly EntityComparator $entityComparator,
+        private readonly LoggerInterface $logger,
+        private readonly HistoryEntryBuffer $historyEntryBuffer,
         #[Autowire(env: 'HISTORY_TRACKING_ENABLE')]
-        private string $historyTrackingEnable,
+        private readonly string $historyTrackingEnable,
     ) {
     }
 
-    public function postPersist(LifecycleEventArgs $eventArgs): void
+    public function onFlush(OnFlushEventArgs $eventArgs)
     {
-        try {
-            $this->processEntity($eventArgs, HistoryEntryEvent::CREATE);
-        } catch (\Throwable $exception) {
-            $this->logger->error($exception->getMessage());
+        if (!$this->historyTrackingEnable) {
+            return;
         }
-    }
-
-    public function postUpdate(LifecycleEventArgs $eventArgs): void
-    {
-        try {
-            $this->processEntity($eventArgs, HistoryEntryEvent::UPDATE);
-            $this->processCollection(HistoryEntryEvent::UPDATE);
-        } catch (\Throwable $exception) {
-            $this->logger->error($exception->getMessage());
+        $this->uow = $eventArgs->getObjectManager()->getUnitOfWork();
+        foreach ($this->uow->getScheduledEntityInsertions() as $entity) {
+            try {
+                $this->processEntity($entity, HistoryEntryEvent::CREATE);
+            } catch (\Throwable $exception) {
+                $this->logger->error($exception->getMessage());
+            }
         }
-    }
 
-    public function preRemove(LifecycleEventArgs $eventArgs): void
-    {
-        try {
-            $this->processEntity($eventArgs, HistoryEntryEvent::DELETE);
-        } catch (\Throwable $e) {
-            $this->logger->error($e->getMessage());
+        foreach ($this->uow->getScheduledEntityUpdates() as $entity) {
+            try {
+                $this->processEntity($entity, HistoryEntryEvent::UPDATE);
+            } catch (\Throwable $exception) {
+                $this->logger->error($exception->getMessage());
+            }
+        }
+
+        foreach ($this->uow->getScheduledEntityDeletions() as $entity) {
+            try {
+                $this->processEntity($entity, HistoryEntryEvent::DELETE);
+            } catch (\Throwable $exception) {
+                $this->logger->error($exception->getMessage());
+            }
+        }
+
+        foreach ($this->uow->getScheduledCollectionUpdates() as $col) {
+            try {
+                if ($col instanceof PersistentCollection) {
+                    $this->processCollection($col, HistoryEntryEvent::UPDATE);
+                }
+            } catch (\Throwable $exception) {
+                $this->logger->error($exception->getMessage());
+            }
         }
     }
 
     /**
      * @throws \ReflectionException
      */
-    protected function processEntity(LifecycleEventArgs $eventArgs, HistoryEntryEvent $event): void
+    protected function processEntity(object $entity, HistoryEntryEvent $event): void
     {
-        $entity = $eventArgs->getObject();
-        if (!$this->historyTrackingEnable
-            || !$entity instanceof EntityHistoryInterface
-            || !in_array($event, $entity->getHistoryRegisteredEvent())) {
+        if (!$entity instanceof EntityHistoryInterface || !in_array($event, $entity->getHistoryRegisteredEvent())) {
             return;
         }
 
         $changes = [];
         if (HistoryEntryEvent::UPDATE === $event) {
-            $unitOfWork = $this->entityManager->getUnitOfWork();
-            foreach ($unitOfWork->getEntityChangeSet($entity) as $field => $changed) {
+            foreach ($this->uow->getEntityChangeSet($entity) as $field => $changed) {
                 if (in_array($field, self::FIELDS_TO_IGNORE)) {
                     continue;
                 }
@@ -111,27 +122,22 @@ readonly class EntityHistoryListener
         $this->saveEntityHistory($event, $entity, $changes);
     }
 
-    public function processCollection(HistoryEntryEvent $event): void
+    public function processCollection(PersistentCollection $collection, HistoryEntryEvent $event): void
     {
-        $unitOfWork = $this->entityManager->getUnitOfWork();
         $changes = [];
-        foreach ($unitOfWork->getScheduledCollectionUpdates() as $collection) {
-            $ownerEntity = $collection->getOwner();
-            $fieldName = $collection->getMapping()['fieldName'];
-            if ($ownerEntity instanceof EntityHistoryCollectionInterface
-                && in_array($fieldName, $ownerEntity->getManyToManyFieldsToTrack())
-            ) {
-                foreach ($collection->getInsertDiff() as $insertItem) {
-                    /* @var EntityHistoryInterface $insertItem */
-                    $changes[$fieldName]['new'][] = $insertItem->getId();
-                }
-
-                foreach ($collection->getDeleteDiff() as $deleteItem) {
-                    /* @var EntityHistoryInterface $deleteItem */
-                    $changes[$fieldName]['old'][] = $deleteItem->getId();
-                }
-                $this->saveEntityHistory($event, $ownerEntity, $changes); // @phpstan-ignore-line
+        $ownerEntity = $collection->getOwner();
+        $fieldName = $collection->getMapping()['fieldName'];
+        if ($ownerEntity instanceof EntityHistoryCollectionInterface && in_array($fieldName, $ownerEntity->getManyToManyFieldsToTrack())) {
+            foreach ($collection->getInsertDiff() as $insertItem) {
+                /* @var EntityHistoryInterface $insertItem */
+                $changes[$fieldName]['new'][] = $insertItem->getId();
             }
+
+            foreach ($collection->getDeleteDiff() as $deleteItem) {
+                /* @var EntityHistoryInterface $deleteItem */
+                $changes[$fieldName]['old'][] = $deleteItem->getId();
+            }
+            $this->saveEntityHistory($event, $ownerEntity, $changes); // @phpstan-ignore-line
         }
     }
 
@@ -141,11 +147,18 @@ readonly class EntityHistoryListener
         array $changes,
     ): void {
         try {
-            $this->historyEntryManager->create(
-                historyEntryEvent: $event,
-                entityHistory: $entity,
-                changes: $changes
-            );
+            $historyKey = $entity::class.'_'.$entity->getId().'_'.$event->value;
+            if (isset($this->historyEntryBuffer->pendingHistoryEntries[$historyKey])) {
+                $oldChanges = $this->historyEntryBuffer->pendingHistoryEntries[$historyKey]->getChanges();
+                $this->historyEntryBuffer->pendingHistoryEntries[$historyKey]->setChanges(array_merge($oldChanges, $changes));
+            } else {
+                $historyEntry = $this->historyEntryManager->create(
+                    historyEntryEvent: $event,
+                    entityHistory: $entity,
+                    changes: $changes,
+                );
+                $this->historyEntryBuffer->pendingHistoryEntries[$historyKey] = $historyEntry;
+            }
         } catch (\Throwable $exception) {
             $this->logger->error($exception->getMessage());
         }

--- a/src/EventSubscriber/HistoryEntryFlushSubscriber.php
+++ b/src/EventSubscriber/HistoryEntryFlushSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Service\History\HistoryEntryBuffer;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class HistoryEntryFlushSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly HistoryEntryBuffer $historyEntryBuffer,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::TERMINATE => 'onKernelTerminate',
+            ConsoleEvents::TERMINATE => 'onConsoleTerminate',
+        ];
+    }
+
+    public function onKernelTerminate(TerminateEvent $event): void
+    {
+        $this->historyEntryBuffer->flushPendingHistoryEntries();
+    }
+
+    public function onConsoleTerminate(): void
+    {
+        $this->historyEntryBuffer->flushPendingHistoryEntries();
+    }
+}

--- a/src/EventSubscriber/HistoryEntryFlushSubscriber.php
+++ b/src/EventSubscriber/HistoryEntryFlushSubscriber.php
@@ -5,6 +5,7 @@ namespace App\EventSubscriber;
 use App\Service\History\HistoryEntryBuffer;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -18,10 +19,16 @@ class HistoryEntryFlushSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
+            // KernelEvents::RESPONSE => 'onKernelResponse',
             KernelEvents::TERMINATE => 'onKernelTerminate',
             ConsoleEvents::TERMINATE => 'onConsoleTerminate',
         ];
     }
+
+    /*public function onKernelResponse(ResponseEvent $event): void
+    {
+        $this->historyEntryBuffer->flushPendingHistoryEntries();
+    }*/
 
     public function onKernelTerminate(TerminateEvent $event): void
     {

--- a/src/EventSubscriber/HistoryEntryFlushSubscriber.php
+++ b/src/EventSubscriber/HistoryEntryFlushSubscriber.php
@@ -19,7 +19,7 @@ class HistoryEntryFlushSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            // KernelEvents::RESPONSE => 'onKernelResponse',
+            // KernelEvents::RESPONSE => 'onKernelResponse', // decommenter avec la fonction onKernelResponse si besoin de suivre les requetes doctrine dans le profiler symfony pour aide au debug
             KernelEvents::TERMINATE => 'onKernelTerminate',
             ConsoleEvents::TERMINATE => 'onConsoleTerminate',
         ];

--- a/src/Factory/HistoryEntryFactory.php
+++ b/src/Factory/HistoryEntryFactory.php
@@ -25,6 +25,7 @@ readonly class HistoryEntryFactory
         $user = $this->security->getUser();
         $historyEntry = (new HistoryEntry())
             ->setEvent($historyEntryEvent)
+            ->setEntity($entityHistory)
             ->setEntityId($entityHistory->getId())
             ->setEntityName(str_replace(self::ENTITY_PROXY_PREFIX, '', $entityHistory::class))
             ->setUser($user);

--- a/src/Manager/HistoryEntryManager.php
+++ b/src/Manager/HistoryEntryManager.php
@@ -113,7 +113,7 @@ class HistoryEntryManager extends AbstractManager
         $this->removeListeners(
             $eventManager,
             EntityHistoryListener::class,
-            [Events::postPersist, Events::postUpdate, Events::preRemove]
+            [Events::onFlush]
         );
     }
 

--- a/src/Manager/HistoryEntryManager.php
+++ b/src/Manager/HistoryEntryManager.php
@@ -52,7 +52,6 @@ class HistoryEntryManager extends AbstractManager
         HistoryEntryEvent $historyEntryEvent,
         EntityHistoryInterface|Collection $entityHistory,
         array $changes = [],
-        bool $flush = true,
     ): ?HistoryEntry {
         $historyEntry = $this->historyEntryFactory->createInstanceFrom(
             historyEntryEvent: $historyEntryEvent,
@@ -63,8 +62,6 @@ class HistoryEntryManager extends AbstractManager
         $historyEntry
             ->setChanges($changes)
             ->setSource($source);
-
-        $this->save($historyEntry, $flush);
 
         return $historyEntry;
     }

--- a/src/Service/History/HistoryEntryBuffer.php
+++ b/src/Service/History/HistoryEntryBuffer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Service\History;
+
+use App\Entity\Signalement;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+class HistoryEntryBuffer
+{
+    public array $pendingHistoryEntries = [];
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function flushPendingHistoryEntries(): void
+    {
+        foreach ($this->pendingHistoryEntries as $entry) {
+            if (!$entry->getEntityId() && $entry->getEntity()?->getId()) {
+                $entry->setEntityId($entry->getEntity()->getId());
+            }
+            // for prevent errors in fixtures loading
+            if ($entry->getSignalement() && !$this->entityManager->contains($entry->getSignalement())) {
+                $signalement = $this->entityManager->getRepository(Signalement::class)->find($entry->getSignalement()->getId());
+                $entry->setSignalement($signalement);
+            }
+            if ($entry->getUser() && !$this->entityManager->contains($entry->getUser())) {
+                $user = $this->entityManager->getRepository(User::class)->find($entry->getUser()->getId());
+                $entry->setUser($user);
+            }
+
+            $this->entityManager->persist($entry);
+        }
+        $this->entityManager->flush();
+        $this->pendingHistoryEntries = [];
+    }
+}

--- a/src/Service/History/HistoryEntryBuffer.php
+++ b/src/Service/History/HistoryEntryBuffer.php
@@ -17,11 +17,12 @@ class HistoryEntryBuffer
 
     public function flushPendingHistoryEntries(): void
     {
+        // for prevent flushing invalid entities
+        $this->entityManager->clear();
         foreach ($this->pendingHistoryEntries as $entry) {
             if (!$entry->getEntityId() && $entry->getEntity()?->getId()) {
                 $entry->setEntityId($entry->getEntity()->getId());
             }
-            // for prevent errors in fixtures loading
             if ($entry->getSignalement() && !$this->entityManager->contains($entry->getSignalement())) {
                 $signalement = $this->entityManager->getRepository(Signalement::class)->find($entry->getSignalement()->getId());
                 $entry->setSignalement($signalement);

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -168,7 +168,7 @@ class HistoryEntryManagerTest extends WebTestCase
         $changes['statut'] = [];
         $changes['statut']['new'] = Affectation::STATUS_ACCEPTED;
         $changes['statut']['old'] = $affectations[0]->getStatut();
-        $historyEntry = $this->historyEntryManager->create(HistoryEntryEvent::UPDATE, $affectations[0], $changes, true);
+        $historyEntry = $this->historyEntryManager->create(HistoryEntryEvent::UPDATE, $affectations[0], $changes);
         $source = $this->historyEntryManager->getSource();
         $historyEntry->setSource($source);
         $this->historyEntryManager->save($historyEntry);

--- a/tests/Unit/Service/History/HistoryEntryBufferTest.php
+++ b/tests/Unit/Service/History/HistoryEntryBufferTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Tests\Unit\Service\History;
+
+use App\Entity\HistoryEntry;
+use App\Entity\User;
+use App\Service\History\HistoryEntryBuffer;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class HistoryEntryBufferTest extends KernelTestCase
+{
+    public function testFlushEmpty(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $entityManager->expects($this->never())->method('clear');
+        $historyEntryBuffer = new HistoryEntryBuffer($entityManager);
+
+        $historyEntryBuffer->flushPendingHistoryEntries();
+    }
+
+    public function testFlushNotEmpty(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $entityManager->expects($this->once())->method('clear');
+        $entityManager->expects($this->exactly(2))->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $historyEntryBuffer = new HistoryEntryBuffer($entityManager);
+        $historyEntry1 = new HistoryEntry();
+        $historyEntry1->setEntity(new User());
+        $historyEntry2 = new HistoryEntry();
+        $historyEntry2->setEntity(new User());
+
+        $historyEntryBuffer->add('un', $historyEntry1);
+        $historyEntryBuffer->add('deux', $historyEntry2);
+
+        $historyEntryBuffer->flushPendingHistoryEntries();
+    }
+
+    public function testExistAndUpdate(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $entityManager->expects($this->once())->method('clear');
+        $entityManager->expects($this->exactly(1))->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $historyEntryBuffer = new HistoryEntryBuffer($entityManager);
+        $historyEntry1 = new HistoryEntry();
+        $historyEntry1->setChanges(['key1' => 'value1']);
+        $historyEntry1->setEntity(new User());
+
+        $historyEntryBuffer->add('un', $historyEntry1);
+        $this->assertTrue($historyEntryBuffer->exist('un'));
+
+        $historyEntryBuffer->update('un', ['key2' => 'value2']);
+        $this->assertTrue($historyEntryBuffer->exist('un'));
+
+        $historyEntryBuffer->flushPendingHistoryEntries();
+        $this->assertFalse($historyEntryBuffer->exist('un'));
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], $historyEntry1->getChanges());
+    }
+}


### PR DESCRIPTION
## Ticket

#4031

## Description
Nouvelle version du fonctionnement de l'historisation afin d'accélérer les traitement.
Les entité d'historisation sont enregistré au cours du process et persisté et sauvegardé uniquement en fin de traitement (commande / http request) cela évite les flush intempestif que chaque historisation déclenché jusqu’à présent.

Par exemple sur la commande d'archivage des utilisateur (base de prod) 
- Archivage d'env 3000 user, **durée inférieure à 30 seconde pour le total** (en retirant le flush intermédiaire via `BATCH_SIZE`)
- Dans la version précédente durée **supérieure à 8 minutes pour 50% du même traitement** 

## Pré-requis
`make load-fixtures`

## Tests
- [ ] Faire des tests divers d'utilisation de l'app pour voir si pas d'effet de bord sur le fonctionnement.
- [ ] Tester sur des traitement long (clock_process)
