### PR TITLE
[Tech - Migration] mise au propre de profileDeclarant

### DIFF
--- a/migrations/Version20250505092515.php
+++ b/migrations/Version20250505092515.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250505092515 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update profile_declarant for signalement where created_from_id and profile_declarant IS NULL';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $baseWhere = 'WHERE created_from_id IS NULL AND profile_declarant IS NULL';
+        $this->addSql('UPDATE signalement SET profile_declarant = \'LOCATAIRE\' '.$baseWhere.' AND is_not_occupant = 0');
+        $this->addSql('UPDATE signalement SET profile_declarant = \'TIERS_PRO\' '.$baseWhere.' AND lien_declarant_occupant IN (\'PROFESSIONNEL\', \'pro\', \'assistante sociale\', \'curatrice\')');
+        $this->addSql('UPDATE signalement SET profile_declarant = \'TIERS_PARTICULIER\' '.$baseWhere.'');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2277,20 +2277,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function getProfileDeclarant(): ?ProfileDeclarant
     {
-        // TODO : faire une migration pour eviter ce code ?
-        if ($this->isV2()) {
-            return $this->profileDeclarant;
-        }
-
-        if (false === $this->isNotOccupant) {
-            return ProfileDeclarant::LOCATAIRE;
-        }
-
-        if (\in_array($this->lienDeclarantOccupant, ['PROFESSIONNEL', 'pro', 'assistante sociale', 'curatrice'])) {
-            return ProfileDeclarant::TIERS_PRO;
-        }
-
-        return ProfileDeclarant::TIERS_PARTICULIER;
+        return $this->profileDeclarant;
     }
 
     public function setProfileDeclarant(?ProfileDeclarant $profileDeclarant): self

--- a/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
+++ b/src/Factory/Interconnection/Oilhi/DossierMessageFactory.php
@@ -5,7 +5,6 @@ namespace App\Factory\Interconnection\Oilhi;
 use App\Controller\FileController;
 use App\Entity\Affectation;
 use App\Entity\Criticite;
-use App\Entity\Enum\OccupantLink;
 use App\Entity\Enum\Qualification;
 use App\Entity\Intervention;
 use App\Entity\Signalement;
@@ -45,7 +44,7 @@ class DossierMessageFactory implements DossierMessageFactoryInterface
         $signalement = $affectation->getSignalement();
         $partner = $affectation->getPartner();
         $interventionData = $this->buildInterventionData($signalement);
-        $typeDeclarant = $this->getTypeDeclarant($signalement);
+        $typeDeclarant = $signalement->getProfileDeclarant()->label();
 
         return (new DossierMessage())
             ->setAction(HookZapierService::ACTION_PUSH_DOSSIER)
@@ -151,22 +150,6 @@ class DossierMessageFactory implements DossierMessageFactoryInterface
         }
 
         return $desordres;
-    }
-
-    private function getTypeDeclarant(Signalement $signalement): ?string
-    {
-        $typeDeclarant = null;
-        if ($signalement->isV2()) {
-            $typeDeclarant = $signalement->getProfileDeclarant()->label();
-        }
-
-        if (!$signalement->getIsNotOccupant()) {
-            $typeDeclarant = $signalement->getLienDeclarantOccupant()
-            ? strtoupper($signalement->getLienDeclarantOccupant())
-            : OccupantLink::AUTRE->label();
-        }
-
-        return $typeDeclarant;
     }
 
     private function getRapportVisite(Intervention $intervention): ?string

--- a/tests/Unit/Entity/SignalementTest.php
+++ b/tests/Unit/Entity/SignalementTest.php
@@ -52,30 +52,7 @@ class SignalementTest extends KernelTestCase
     public function testGetProfileDeclarant(): void
     {
         $signalement = $this->getSignalement($this->getTerritory('Pas-de-calais', '62'));
-        $this->assertEquals(ProfileDeclarant::TIERS_PARTICULIER, $signalement->getProfileDeclarant());
-    }
-
-    /** @dataProvider provideProfileDeclarant */
-    public function testResolveProfileDeclarant(
-        bool $isNotOccupant,
-        ProfileDeclarant $profileDeclarant,
-        ?string $lienDeclarant = null,
-    ): void {
-        $signalement = $this->getSignalement($this->getTerritory('Pas-de-calais', '62'));
-        $signalement->setIsNotOccupant($isNotOccupant);
-        $signalement->setLienDeclarantOccupant($lienDeclarant);
-
-        $this->assertEquals($profileDeclarant, $signalement->getProfileDeclarant());
-    }
-
-    public function provideProfileDeclarant(): \Generator
-    {
-        yield 'isOccupant LOCATION' => [false, ProfileDeclarant::LOCATAIRE];
-        yield 'isNotOccupant TIERS PROFESSIONNEL' => [true, ProfileDeclarant::TIERS_PRO, 'PROFESSIONNEL'];
-        yield 'isNotOccupant TIERS PRO' => [true, ProfileDeclarant::TIERS_PRO, 'pro'];
-        yield 'isNotOccupant TIERS assistance sociale' => [true, ProfileDeclarant::TIERS_PRO, 'assistante sociale'];
-        yield 'isNotOccupant TIERS curatrice' => [true, ProfileDeclarant::TIERS_PRO, 'curatrice'];
-        yield 'isNotOccupant PARTICULIER' => [true, ProfileDeclarant::TIERS_PARTICULIER];
+        $this->assertEquals(ProfileDeclarant::LOCATAIRE, $signalement->getProfileDeclarant());
     }
 
     /** @dataProvider provideProfile */


### PR DESCRIPTION
## Ticket

#4029

## Description
Migration des valeur profile_declarant afin que ce qui était retourné par le getProfileDeclarant soient ce qu'on a en base. 
Pas de modification des valeurs existantes.

## Pré-requis
`make execute-migration name=Version20250505092515 direction=up`

## Tests
- [ ] ??
