### PR TITLE
[BO - Export XLS] Nettoyer les champs html (com de cloture, com de visite)

### DIFF
--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -11,6 +11,7 @@ use App\Entity\Intervention;
 use App\Entity\Model\InformationProcedure;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\User;
+use App\Service\HtmlCleaner;
 use App\Service\Signalement\SignalementAffectationHelper;
 use App\Utils\DateHelper;
 
@@ -125,11 +126,11 @@ class SignalementExportFactory
             isOccupantPresentVisite: ($isOccupantPresentVisite && '-' !== $isOccupantPresentVisite) ? self::OUI : ('0' === $isOccupantPresentVisite ? self::NON : ''),
             interventionStatus: $interventionStatus,
             interventionConcludeProcedure: $data['interventionConcludeProcedure'],
-            interventionDetails: strip_tags(html_entity_decode($data['interventionDetails'])),
+            interventionDetails: HtmlCleaner::clean($data['interventionDetails']),
             modifiedAt: $modifiedAt,
             closedAt: $closedAt,
             motifCloture: $motifCloture,
-            comCloture: strip_tags(html_entity_decode($data['comCloture'])),
+            comCloture: HtmlCleaner::clean($data['comCloture']),
             longitude: is_array($geoloc) ? $geoloc['lng'] ?? '' : '',
             latitude: is_array($geoloc) ? $geoloc['lat'] ?? '' : '',
         );

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -126,11 +126,11 @@ class SignalementExportFactory
             isOccupantPresentVisite: ($isOccupantPresentVisite && '-' !== $isOccupantPresentVisite) ? self::OUI : ('0' === $isOccupantPresentVisite ? self::NON : ''),
             interventionStatus: $interventionStatus,
             interventionConcludeProcedure: $data['interventionConcludeProcedure'],
-            interventionDetails: HtmlCleaner::clean($data['interventionDetails']),
+            interventionDetails: $data['interventionDetails'] ? HtmlCleaner::clean($data['interventionDetails']) : '',
             modifiedAt: $modifiedAt,
             closedAt: $closedAt,
             motifCloture: $motifCloture,
-            comCloture: HtmlCleaner::clean($data['comCloture']),
+            comCloture: $data['comCloture'] ? HtmlCleaner::clean($data['comCloture']) : '',
             longitude: is_array($geoloc) ? $geoloc['lng'] ?? '' : '',
             latitude: is_array($geoloc) ? $geoloc['lat'] ?? '' : '',
         );

--- a/src/Factory/SignalementExportFactory.php
+++ b/src/Factory/SignalementExportFactory.php
@@ -125,11 +125,11 @@ class SignalementExportFactory
             isOccupantPresentVisite: ($isOccupantPresentVisite && '-' !== $isOccupantPresentVisite) ? self::OUI : ('0' === $isOccupantPresentVisite ? self::NON : ''),
             interventionStatus: $interventionStatus,
             interventionConcludeProcedure: $data['interventionConcludeProcedure'],
-            interventionDetails: $data['interventionDetails'],
+            interventionDetails: strip_tags(html_entity_decode($data['interventionDetails'])),
             modifiedAt: $modifiedAt,
             closedAt: $closedAt,
             motifCloture: $motifCloture,
-            comCloture: $data['comCloture'],
+            comCloture: strip_tags(html_entity_decode($data['comCloture'])),
             longitude: is_array($geoloc) ? $geoloc['lng'] ?? '' : '',
             latitude: is_array($geoloc) ? $geoloc['lat'] ?? '' : '',
         );

--- a/tests/Unit/Factory/SignalementExportFactoryTest.php
+++ b/tests/Unit/Factory/SignalementExportFactoryTest.php
@@ -79,7 +79,7 @@ class SignalementExportFactoryTest extends TestCase
             'interventionNbVisites' => 2,
             'interventionOccupantPresent' => 1,
             'interventionConcludeProcedure' => 'RSD,INSALUBRITE',
-            'interventionDetails' => 'dossier envoyé pour manquement sanitaire',
+            'interventionDetails' => '<p>dossier envoyé à ARS pour une suspicion d&#039;insalubrité</p>',
         ];
 
         $user = $this->getUserFromRole(User::ROLE_ADMIN);
@@ -119,6 +119,6 @@ class SignalementExportFactoryTest extends TestCase
         $this->assertEquals(VisiteStatus::TERMINEE->value, $signalementExportFactory->interventionStatus);
         $this->assertEquals('RSD,INSALUBRITE', $signalementExportFactory->interventionConcludeProcedure);
         $this->assertEquals('Entre 1 et 2 ans', $signalementExportFactory->debutDesordres);
-        $this->assertEquals('dossier envoyé pour manquement sanitaire', $signalementExportFactory->interventionDetails);
+        $this->assertEquals('dossier envoyé à ARS pour une suspicion d\'insalubrité', $signalementExportFactory->interventionDetails);
     }
 }


### PR DESCRIPTION
## Ticket

#3962

## Description
Retrait des balises et caractères HTML des champs "Commentaire de clôture" et "Comm. de la dernière visite" dans l'export des signalement

## Tests
- [ ] Ajouter un commentaire de visite et un commentaire de cloture contenant du HTML sur  un signalement. Vérifier que l'HTML n’apparaît pas à l'export
