### PR TITLE
[Import - Grille affectation] Prise en compte du multi territoire

### DIFF
--- a/migrations/Version20250505105401.php
+++ b/migrations/Version20250505105401.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250505105401 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout d\'une contrainte unique sur user_id et partner_id dans la table user_partner.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE partner RENAME INDEX fk_312b3e1657b5d0a2 TO IDX_312B3E1657B5D0A2
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE user RENAME INDEX uniq_8d93d64961f0bb97 TO UNIQ_8D93D64921CADBFB
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX unique_user_partner ON user_partner (user_id, partner_id)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE partner RENAME INDEX idx_312b3e1657b5d0a2 TO FK_312B3E1657B5D0A2
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE user RENAME INDEX uniq_8d93d64921cadbfb TO UNIQ_8D93D64961F0BB97
+        SQL);
+        $this->addSql(<<<'SQL'
+            DROP INDEX unique_user_partner ON user_partner
+        SQL);
+    }
+}

--- a/src/Command/ImportGridAffectationCommand.php
+++ b/src/Command/ImportGridAffectationCommand.php
@@ -127,9 +127,11 @@ class ImportGridAffectationCommand extends Command
             $io->warning($error);
         }
 
-        $io->success(\sprintf('%d partner(s) created, %d user(s) created',
+        $io->success(\sprintf(
+            '%d partner(s) created, %d user(s) created, %d multi-territory user(s)',
             $metadata['nb_partners'],
-            $metadata['nb_users_created']
+            $metadata['nb_users_created'],
+            $metadata['nb_users_multi_territory'],
         ));
 
         if (0 === $metadata['nb_partners'] && 0 === $metadata['nb_users_created']) {

--- a/src/Entity/UserPartner.php
+++ b/src/Entity/UserPartner.php
@@ -8,6 +8,7 @@ use App\Repository\UserPartnerRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: UserPartnerRepository::class)]
+#[ORM\UniqueConstraint(name: 'unique_user_partner', columns: ['user_id', 'partner_id'])]
 class UserPartner implements EntityHistoryInterface
 {
     #[ORM\Id]

--- a/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
+++ b/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
@@ -20,20 +20,20 @@ class GridAffectationLoaderTest extends KernelTestCase
 {
     use FixturesHelper;
 
-    public const FIXTURE_PARTNER_DDT = 'DDT/M';
-    public const FIXTURE_PARTNER_ARS = 'ARS';
-    public const FIXTURE_PARTNER_SCHS = 'Commune / SCHS';
-    public const FIXTURE_PARTNER_ADIL = 'ADIL';
-    public const FIXTURE_PARTNER_EPCI = 'EPCI';
-    public const FIXTURE_PARTNER_FAKE = 'Random Type';
+    public const string FIXTURE_PARTNER_DDT = 'DDT/M';
+    public const string FIXTURE_PARTNER_ARS = 'ARS';
+    public const string FIXTURE_PARTNER_SCHS = 'Commune / SCHS';
+    public const string FIXTURE_PARTNER_ADIL = 'ADIL';
+    public const string FIXTURE_PARTNER_EPCI = 'EPCI';
+    public const string FIXTURE_PARTNER_FAKE = 'Random Type';
 
-    public const FIXTURE_PARTNER_DDT_EMAIL = 'ddt-m@signal-logement.fr';
-    public const FIXTURE_PARTNER_ARS_EMAIL = 'ars@signal-logement.fr';
+    public const string FIXTURE_PARTNER_DDT_EMAIL = 'ddt-m@signal-logement.fr';
+    public const string FIXTURE_PARTNER_ARS_EMAIL = 'ars@signal-logement.fr';
 
-    public const FIXTURE_USER_EMAIL_DUPLICATE = 'user-ddt@signal-logement.fr';
-    public const FIXTURE_ROLE_RT = 'Resp. Territoire';
-    public const FIXTURE_ROLE_PARTNER = 'Admin. partenaire';
-    public const FIXTURE_ROLE_USER = 'Agent';
+    public const string FIXTURE_USER_EMAIL_DUPLICATE = 'user-ddt@signal-logement.fr';
+    public const string FIXTURE_ROLE_RT = 'Resp. Territoire';
+    public const string FIXTURE_ROLE_PARTNER = 'Admin. partenaire';
+    public const string FIXTURE_ROLE_USER = 'Agent';
 
     private GridAffectationLoader $gridAffectationLoader;
     private EntityManagerInterface $entityManager;

--- a/tests/Unit/Command/ImportGridAffectationCommandTest.php
+++ b/tests/Unit/Command/ImportGridAffectationCommandTest.php
@@ -65,7 +65,7 @@ class ImportGridAffectationCommandTest extends KernelTestCase
         $this->gridAffectationLoader
             ->expects($this->once())
             ->method('getMetaData')
-            ->willReturn(['nb_partners' => 10, 'nb_users_created' => 55, 'errors' => []]);
+            ->willReturn(['nb_partners' => 10, 'nb_users_created' => 55, 'nb_users_multi_territory' => 2, 'errors' => []]);
 
         $this->uploadHandlerServiceMock
             ->expects($this->once())
@@ -118,7 +118,7 @@ class ImportGridAffectationCommandTest extends KernelTestCase
         $this->gridAffectationLoader
             ->expects($this->once())
             ->method('getMetaData')
-            ->willReturn(['nb_partners' => 1, 'nb_users_created' => 1, 'errors' => []]);
+            ->willReturn(['nb_partners' => 1, 'nb_users_created' => 1, 'nb_users_multi_territory' => 0, 'errors' => []]);
 
         $command = $application->add(new ImportGridAffectationCommand(
             $this->fileStorage,


### PR DESCRIPTION
## Ticket

#4048    

## Description
Prise en compte du multi-territoire afin d'importer la Drome avec 4 utilisateurs qui sont sur un partenaire en Ardèche
![image](https://github.com/user-attachments/assets/a26ca0f6-826e-48cb-b518-49c1dac7393c)

## Changements apportés
* Mise à jour du GridAffectationLoader 
* Ajout d'une contrainte DB d'unicité sur le couple (user_id, partner_id)

## Pré-requis
```
make load-data
make mysql
>  update territory set is_active = 1 where id = 27;
> exit
```

## Tests
- [ ] Exécuter `make console app="import-grid-affectation 26 --file-version=1"`
- [ ] Vérifier que les 4 utilisateurs concernés par le multi ont bien été ajoutés à leur nouveau partenaire
- [ ] TNR : Les autres utilisateurs ont été ajoutés 
