### PR TITLE
[Tech] Remplacement de statut utilisateur par enum

### DIFF
--- a/migrations/Version20240625095546.php
+++ b/migrations/Version20240625095546.php
@@ -18,9 +18,9 @@ final class Version20240625095546 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $suffixArchived = User::SUFFIXE_ARCHIVED;
-        $statusActive = User::STATUS_ACTIVE;
-        $statusInactive = User::STATUS_INACTIVE;
-        $statusArchive = User::STATUS_ARCHIVE;
+        $statusActive = 1;
+        $statusInactive = 0;
+        $statusArchive = 2;
 
         $this->addSql("
             UPDATE user

--- a/migrations/Version20240717081056.php
+++ b/migrations/Version20240717081056.php
@@ -19,11 +19,12 @@ final class Version20240717081056 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE user ADD cgu_version_checked VARCHAR(255) DEFAULT NULL');
 
+        $statusActive = 1;
         $this->addSql("
             UPDATE user
             SET cgu_version_checked = '05/06/2024'
             WHERE last_login_at IS NOT NULL
-              AND statut = ".User::STATUS_ACTIVE.'
+              AND statut = ".$statusActive.'
         ');
     }
 

--- a/migrations/Version20240717081056.php
+++ b/migrations/Version20240717081056.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
-use App\Entity\User;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 

--- a/migrations/Version20250505141736.php
+++ b/migrations/Version20250505141736.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Enum\UserStatus;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250505141736 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change user status format';
+    }
+
+    private const OLD_STATUS_TO_NEW_STATUS = [
+        UserStatus::INACTIVE->value => 0,
+        UserStatus::ACTIVE->value => 1,
+        UserStatus::ARCHIVE->value => 2,
+    ];
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user CHANGE statut statut VARCHAR(255) NOT NULL');
+
+        foreach (self::OLD_STATUS_TO_NEW_STATUS as $newStatus => $oldStatus) {
+            $this->addSql('UPDATE `user` SET `statut` = \''.$newStatus.'\' WHERE statut = \''.$oldStatus.'\'');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::OLD_STATUS_TO_NEW_STATUS as $newStatus => $oldStatus) {
+            $this->addSql('UPDATE `user` SET `statut` = \''.$oldStatus.'\' WHERE statut = \''.$newStatus.'\'');
+        }
+
+        $this->addSql('ALTER TABLE user CHANGE statut statut INT NOT NULL');
+    }
+}

--- a/src/Command/CreateApiPartnerUsersCommand.php
+++ b/src/Command/CreateApiPartnerUsersCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Entity\UserPartner;
 use App\Factory\PartnerFactory;
@@ -134,7 +135,7 @@ class CreateApiPartnerUsersCommand extends Command
                 );
                 $password = $this->userManager->getComplexRandomPassword();
                 $passwordHashed = $this->hasher->hashPassword($boUser, $password);
-                $boUser->setStatut(User::STATUS_ACTIVE)->setPassword($passwordHashed);
+                $boUser->setStatut(UserStatus::ACTIVE)->setPassword($passwordHashed);
 
                 $boUserPartner = (new UserPartner())->setPartner($partner)->setUser($boUser);
                 $boUser->addUserPartner($boUserPartner);
@@ -167,7 +168,7 @@ class CreateApiPartnerUsersCommand extends Command
         );
         $password = $this->userManager->getComplexRandomPassword();
         $passwordHashed = $this->hasher->hashPassword($user, $password);
-        $user->setStatut(User::STATUS_ACTIVE)->setPassword($passwordHashed);
+        $user->setStatut(UserStatus::ACTIVE)->setPassword($passwordHashed);
 
         $userPartner = (new UserPartner())->setPartner($partner)->setUser($user);
         $user->addUserPartner($userPartner);

--- a/src/Command/Cron/NotifyAndArchiveInactiveAccountCommand.php
+++ b/src/Command/Cron/NotifyAndArchiveInactiveAccountCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command\Cron;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMail;
@@ -134,7 +135,7 @@ class NotifyAndArchiveInactiveAccountCommand extends AbstractCronCommand
 
         foreach ($users as $user) {
             $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
-            $user->setStatut(User::STATUS_ARCHIVE);
+            $user->setStatut(UserStatus::ARCHIVE);
             $user->setArchivingScheduledAt(null);
 
             ++$count;

--- a/src/Command/ReinitAdminPasswordsCommand.php
+++ b/src/Command/ReinitAdminPasswordsCommand.php
@@ -2,7 +2,7 @@
 
 namespace App\Command;
 
-use App\Entity\User;
+use App\Entity\Enum\UserStatus;
 use App\Manager\UserManager;
 use App\Repository\UserRepository;
 use App\Service\Mailer\NotificationMail;
@@ -46,7 +46,7 @@ class ReinitAdminPasswordsCommand extends Command
 
         foreach ($users as $user) {
             /* @var User $user */
-            $user->setPassword('')->setStatut(User::STATUS_INACTIVE);
+            $user->setPassword('')->setStatut(UserStatus::INACTIVE);
             $this->userManager->loadUserTokenForUser($user, false);
 
             /** @var ConstraintViolationList $errors */

--- a/src/Controller/Back/BackArchivedUsersController.php
+++ b/src/Controller/Back/BackArchivedUsersController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Back;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Entity\UserPartner;
 use App\Form\SearchArchivedUserType;
@@ -63,7 +64,7 @@ class BackArchivedUsersController extends AbstractController
     ): Response {
         $isUserUnlinked = $user->getPartners()->isEmpty();
 
-        if ((User::STATUS_ARCHIVE !== $user->getStatut() && !$isUserUnlinked) || $user->getAnonymizedAt()) {
+        if ((UserStatus::ARCHIVE !== $user->getStatut() && !$isUserUnlinked) || $user->getAnonymizedAt()) {
             $this->addFlash('error', 'Ce compte ne peut pas être réactivé.');
 
             return $this->redirect($this->generateUrl('back_archived_users_index'));
@@ -90,7 +91,7 @@ class BackArchivedUsersController extends AbstractController
         }
 
         if (!$userExist && !$partnerExist && $form->isSubmitted() && $form->isValid()) {
-            $user->setStatut(User::STATUS_ACTIVE);
+            $user->setStatut(UserStatus::ACTIVE);
             $user->setEmail($untaggedEmail);
             // tempPartner is not mapped, so we need to set the partner manually
             foreach ($user->getUserPartners() as $userPartner) {

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -6,6 +6,7 @@ use App\Entity\Affectation;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\PartnerType as EnumPartnerType;
 use App\Entity\Enum\Qualification;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Intervention;
 use App\Entity\Partner;
 use App\Entity\User;
@@ -284,7 +285,7 @@ class PartnerController extends AbstractController
                     }
                 } else {
                     $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
-                    $user->setStatut(User::STATUS_ARCHIVE);
+                    $user->setStatut(UserStatus::ARCHIVE);
                     $entityManager->persist($user);
                     $notificationMailerRegistry->send(
                         new NotificationMail(
@@ -425,7 +426,7 @@ class PartnerController extends AbstractController
                 $userExist->setIsMailingActive($user->getIsMailingActive());
                 $userExist->setIsMailingSummary($user->getIsMailingSummary());
                 $userExist->setHasPermissionAffectation($user->hasPermissionAffectation());
-                $userExist->setStatut(User::STATUS_INACTIVE);
+                $userExist->setStatut(UserStatus::INACTIVE);
                 $userExist->setRoles([$formUserPartner->get('role')->getData()]);
                 $userPartner->setUser($userExist);
                 $user = $userExist;
@@ -542,7 +543,7 @@ class PartnerController extends AbstractController
         }
 
         $this->denyAccessUnlessGranted('USER_DELETE', $user);
-        if (User::STATUS_ARCHIVE === $user->getStatut()) {
+        if (UserStatus::ARCHIVE === $user->getStatut()) {
             $this->addFlash('error', 'Cet utilisateur est déjà supprimé.');
 
             return $this->redirectToRoute('back_partner_view', ['id' => $partner->getId()], Response::HTTP_SEE_OTHER);
@@ -577,7 +578,7 @@ class PartnerController extends AbstractController
             )
         );
         $user->setEmail(Sanitizer::tagArchivedEmail($user->getEmail()));
-        $user->setStatut(User::STATUS_ARCHIVE);
+        $user->setStatut(UserStatus::ARCHIVE);
         $user->setProConnectUserId(null);
         $userManager->save($user);
         $this->addFlash('success', 'L\'utilisateur a bien été supprimé.');

--- a/src/Controller/Security/ProConnectController.php
+++ b/src/Controller/Security/ProConnectController.php
@@ -3,7 +3,6 @@
 namespace App\Controller\Security;
 
 use App\Entity\Enum\UserStatus;
-use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Security\FormLoginAuthenticator;
 use App\Service\Gouv\ProConnect\ProConnectAuthentication;

--- a/src/Controller/Security/ProConnectController.php
+++ b/src/Controller/Security/ProConnectController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Security;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Security\FormLoginAuthenticator;
@@ -64,8 +65,8 @@ class ProConnectController extends AbstractController
             if ($user) {
                 if ($user->getProConnectUserId() !== $proConnectUser->sub) {
                     $user->setProConnectUserId($proConnectUser->sub);
-                    if (User::STATUS_INACTIVE === $user->getStatut()) {
-                        $user->setStatut(User::STATUS_ACTIVE);
+                    if (UserStatus::INACTIVE === $user->getStatut()) {
+                        $user->setStatut(UserStatus::ACTIVE);
                     }
                     $this->entityManager->flush();
                 }

--- a/src/Controller/Security/UserAccountController.php
+++ b/src/Controller/Security/UserAccountController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller\Security;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Manager\UserManager;
 use App\Repository\UserRepository;
@@ -42,7 +43,7 @@ class UserAccountController extends AbstractController
                 ]);
             }
 
-            $user = $userRepository->findAgentByEmail($email, User::STATUS_INACTIVE);
+            $user = $userRepository->findAgentByEmail($email, UserStatus::INACTIVE);
             if ($user) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
@@ -88,7 +89,7 @@ class UserAccountController extends AbstractController
             }
 
             $user = $userRepository->findAgentByEmail($email);
-            if ($user && User::STATUS_ACTIVE === $user->getStatut()) {
+            if ($user && UserStatus::ACTIVE === $user->getStatut()) {
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_LOST_PASSWORD,

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -3,135 +3,135 @@ users:
     email: api-01@signal-logement.fr
     roles: "[\"ROLE_API_USER\"]"
     partner: "Partenaire 13-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: api-02@signal-logement.fr
     roles: "[\"ROLE_API_USER\"]"
     partner: "Alès Agglomération"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: admin-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN\"]"
     partner: "Administrateurs Signal-logement"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: admin-02@signal-logement.fr
     roles: "[\"ROLE_ADMIN\"]"
     partner: "Administrateurs Signal-logement"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 1
   -
     email: admin-03@signal-logement.fr
     roles: "[\"ROLE_ADMIN\"]"
     partner: "Administrateurs Signal-logement"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: admin-territoire-13-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 13-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
     is_mailing_summary: 0
   -
     email: admin-territoire-13-02@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 13-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: admin-territoire-01-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 01-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: admin-territoire-63-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 63-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-89-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT 89"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-06-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 06-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-59-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 59-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-69-mdl@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "EMHA - Métropole de Lyon"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-69-cor@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "COR"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-69205-mdl@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Commune 69-03 MDL"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-69054-cor@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Commune 69-04 COR"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-69-05@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 69-05"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-69-06@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 69-06"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-partenaire-13-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_PARTNER\"]"
     partner: "Partenaire 13-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-partenaire-01-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_PARTNER\"]"
     partner: "Partenaire 01-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-13-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-02"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
     last_login_at: '-1 year'
   -
     email: user-13-02@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-03"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
     is_mailing_summary: 0
     last_login_at: '-2 year'
@@ -139,279 +139,279 @@ users:
     email: user-13-03@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-04"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 1
   -
     email: user-13-04@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-03"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 0
   -
     email: user-13-05@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-05 ESABORA SCHS"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-13-06@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-06 ESABORA ARS"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-13-07@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-07"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 1
   -
     email: user-13-08@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-01"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 1
     anonymized: true
   -
     email: user-13-09@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-01"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 1
     last_login_at: '-2 year'
   -
     email: user-13-10@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-08"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-13-11@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-08"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 1
   -
     email: user-13-12@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-09 Non Notifiable"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-13-13@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 13-09 Non Notifiable"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 0
   -
     email: user-2A-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 2A-01"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 0
   -
     email: user-974-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 974-01"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 1
   -
     email: user-01-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-04"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-01-02@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 1
     token: 00000000-0000-0000-0000-000000000001
   -
     email: user-01-03@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-01-04@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 1
   -
     email: user-01-05@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 1
   -
     email: user-01-06@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-02"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-01-06@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 0
   -
     email: user-01-07@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 0
   -
     email: user-01-08@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-02"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 0
   -
     email: user-01-09@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 0
   -
     email: user-01-10@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 01-03"
-    statut: 2
+    statut: "ARCHIVE"
     is_mailing_active: 0
   -
     email: user-63-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ADIL 63"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-63-02@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ALF (OPAH)"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 1
   -
     email: user-63-03@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "API"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-63-04@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "CAF 63"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 1
   -
     email: user-89-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ADIL 89"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-89-02@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "CAF 89"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-89-03@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ARS 89"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-89-04@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Mairie de Tonnerre"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-unlinked@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: admin-territoire-38-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT 38"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: user-38-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 38-02"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: admin-territoire-62-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 62-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-62-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire 62-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-93-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Mairie de Saint-Denis"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: usager-01@signal-logement.fr
     roles: "[\"ROLE_USAGER\"]"
-    statut: 0
+    statut: "INACTIVE"
     is_mailing_active: 0
     last_login_at: '-5 year'
   -
     email: admin-territoire-972-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT_M 972"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-972-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "DDT_M 972"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-972-02@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "ARS 972"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-34-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire Zone Agde"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-34-02@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire Hors Zone Agde"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-partenaire-34-01@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Partenaire Zone Agde"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
     archiving_scheduled: 1
   -
     email: user-partenaire-34-02@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "CAF 34"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
     is_mailing_summary: 0
   -
@@ -420,7 +420,7 @@ users:
     partners: 
       - "Partenaire 13-01"
       - "Partenaire 01-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-partenaire-multi-ter-34-30@signal-logement.fr
@@ -428,14 +428,14 @@ users:
     partners: 
       - "CAF 34"
       - "CAF 30"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-partenaire-30@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partners: 
       - "CAF 30"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
     has_permission_affectation: 1
   -
@@ -443,36 +443,36 @@ users:
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partners: 
       - "CAF 30"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: admin-territoire-44-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "DDT Loire-Atlantique"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-44-02@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "SDIS 44"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-44-03@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Mairie de Saint-Mars du Désert"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: user-44-04@signal-logement.fr
     roles: "[\"ROLE_USER_PARTNER\"]"
     partner: "Cocoland"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
   -
     email: proconnect@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"
     partner: "Partenaire 13-01"
-    statut: 1
+    statut: "ACTIVE"
     is_mailing_active: 1
     is_mailing_summary: 0

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -12,6 +12,7 @@ use App\Entity\Enum\ProprioType;
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\QualificationStatus;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\Enum\UserStatus;
 use App\Entity\File;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\Signalement;
@@ -172,7 +173,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             $signalement
                 ->setMotifCloture(MotifCloture::tryFrom($row['motif_cloture']))
                 ->setClosedAt(new \DateTimeImmutable())
-                ->setClosedBy($this->userRepository->findOneBy(['statut' => User::STATUS_ACTIVE]));
+                ->setClosedBy($this->userRepository->findOneBy(['statut' => UserStatus::ACTIVE]));
         }
 
         if (SignalementStatus::REFUSED->value === $row['statut']) {
@@ -414,7 +415,7 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
             $signalement
                 ->setMotifCloture(MotifCloture::tryFrom($row['motif_cloture']))
                 ->setClosedAt(new \DateTimeImmutable())
-                ->setClosedBy($this->userRepository->findOneBy(['statut' => User::STATUS_ACTIVE]));
+                ->setClosedBy($this->userRepository->findOneBy(['statut' => UserStatus::ACTIVE]));
         }
 
         if (SignalementStatus::REFUSED->value === $row['statut']) {

--- a/src/DataFixtures/Loader/LoadUserData.php
+++ b/src/DataFixtures/Loader/LoadUserData.php
@@ -2,6 +2,7 @@
 
 namespace App\DataFixtures\Loader;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\User;
 use App\Entity\UserPartner;
@@ -62,7 +63,7 @@ class LoadUserData extends Fixture implements OrderedFixtureInterface
         $faker = Factory::create();
         $user = (new User())
             ->setRoles(json_decode($row['roles'], true))
-            ->setStatut($row['statut'])
+            ->setStatut(UserStatus::from($row['statut']))
             ->setIsMailingActive($row['is_mailing_active'])
             ->setPrenom($faker->firstName())
             ->setNom($faker->lastName());
@@ -71,7 +72,7 @@ class LoadUserData extends Fixture implements OrderedFixtureInterface
             $user->setHasPermissionAffectation($row['has_permission_affectation']);
         }
 
-        if (User::STATUS_ARCHIVE === $row['statut']) {
+        if (UserStatus::ARCHIVE->value === $row['statut']) {
             $user->setEmail(Sanitizer::tagArchivedEmail($row['email']));
         } else {
             $user->setEmail($row['email']);
@@ -132,7 +133,7 @@ class LoadUserData extends Fixture implements OrderedFixtureInterface
             isMailActive: false,
         );
         $password = $this->hasher->hashPassword($user, self::APP_PLAIN_PASSWORD);
-        $user->setStatut(User::STATUS_ACTIVE)->setPassword($password);
+        $user->setStatut(UserStatus::ACTIVE)->setPassword($password);
         $manager->persist($user);
 
         $partner = $this->partnerRepository->findOneBy(['nom' => Partner::DEFAULT_PARTNER]);

--- a/src/Entity/Enum/UserStatus.php
+++ b/src/Entity/Enum/UserStatus.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Entity\Enum;
+
+use App\Entity\Behaviour\EnumTrait;
+
+enum UserStatus: string
+{
+    use EnumTrait;
+
+    case INACTIVE = 'INACTIVE';
+    case ACTIVE = 'ACTIVE';
+    case ARCHIVE = 'ARCHIVE';
+
+    public static function getLabelList(): array
+    {
+        return [
+            self::INACTIVE->name => 'Inactif',
+            self::ACTIVE->name => 'Actif',
+            self::ARCHIVE->name => 'Archivé',
+        ];
+    }
+
+    public static function getLabel(self $value): string
+    {
+        return match ($value) {
+            self::INACTIVE => 'Inactif',
+            self::ACTIVE => 'Actif',
+            self::ARCHIVE => 'Archivé',
+        };
+    }
+}

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -7,6 +7,7 @@ use App\Entity\Behaviour\TimestampableTrait;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\Qualification;
+use App\Entity\Enum\UserStatus;
 use App\Repository\PartnerRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -161,7 +162,7 @@ class Partner implements EntityHistoryInterface
     public function getUserPartners(): Collection
     {
         return $this->userPartners->filter(function (UserPartner $userPartner) {
-            return User::STATUS_ARCHIVE !== $userPartner->getUser()->getStatut();
+            return UserStatus::ARCHIVE !== $userPartner->getUser()->getStatut();
         });
     }
 
@@ -272,7 +273,7 @@ class Partner implements EntityHistoryInterface
             if ($excludeUser && $user->getId() === $excludeUser->getId()) {
                 continue;
             }
-            if (User::STATUS_ACTIVE === $user->getStatut() && $user->getIsMailingActive()) {
+            if (UserStatus::ACTIVE === $user->getStatut() && $user->getIsMailingActive()) {
                 return true;
             }
         }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -506,11 +506,6 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         return $this;
     }
 
-    public function getStatutLabel(): string
-    {
-        return $this->statut->label();
-    }
-
     public function getLastLoginAt(): ?\DateTimeImmutable
     {
         return $this->lastLoginAt;

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace App\Factory;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 
 class UserFactory
@@ -20,7 +21,7 @@ class UserFactory
             ->setPrenom($firstname)
             ->setNom($lastname)
             ->setEmail($email)
-            ->setStatut(User::STATUS_INACTIVE)
+            ->setStatut(UserStatus::INACTIVE)
             ->setIsMailingActive($isMailActive)
             ->setIsActivateAccountNotificationEnabled($isActivateAccountNotificationEnabled)
             ->setHasPermissionAffectation($hasPermissionAffectation);

--- a/src/Form/SearchUserType.php
+++ b/src/Form/SearchUserType.php
@@ -3,6 +3,7 @@
 namespace App\Form;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\Territory;
 use App\Entity\User;
@@ -86,8 +87,8 @@ class SearchUserType extends AbstractType
         });
         $builder->add('statut', ChoiceType::class, [
             'choices' => [
-                'Activé' => 'ACTIVE',
-                'Non activé' => 'INACTIVE',
+                'Activé' => UserStatus::ACTIVE->value,
+                'Non activé' => UserStatus::INACTIVE->value,
             ],
             'required' => false,
             'placeholder' => 'Tous les statuts',

--- a/src/Form/SearchUserType.php
+++ b/src/Form/SearchUserType.php
@@ -86,8 +86,8 @@ class SearchUserType extends AbstractType
         });
         $builder->add('statut', ChoiceType::class, [
             'choices' => [
-                'Activé' => 1,
-                'Non activé' => 0,
+                'Activé' => 'ACTIVE',
+                'Non activé' => 'INACTIVE',
             ],
             'required' => false,
             'placeholder' => 'Tous les statuts',

--- a/src/Manager/PopNotificationManager.php
+++ b/src/Manager/PopNotificationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Manager;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\PopNotification;
 use App\Entity\User;
@@ -21,7 +22,7 @@ class PopNotificationManager extends Manager
         string $type,
         Partner $partner,
     ): ?PopNotification {
-        if (User::STATUS_ACTIVE !== $user->getStatut()) {
+        if (UserStatus::ACTIVE !== $user->getStatut()) {
             return null;
         }
         if ($user->getPopNotifications()->count()) {

--- a/src/Manager/UserManager.php
+++ b/src/Manager/UserManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Manager;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -60,7 +61,7 @@ class UserManager extends AbstractManager
     {
         // if the user is not active yet, he is activating his account, so he just saw the cgu
         $currentCguVersion = $this->parameterBag->get('cgu_current_version');
-        if (User::STATUS_ACTIVE !== $user->getStatut()) {
+        if (UserStatus::ACTIVE !== $user->getStatut()) {
             $user->setCguVersionChecked($currentCguVersion);
         }
 
@@ -68,7 +69,7 @@ class UserManager extends AbstractManager
         $user
             ->setPassword($password)
             ->setToken(null)
-            ->setStatut(User::STATUS_ACTIVE)
+            ->setStatut(UserStatus::ACTIVE)
             ->setTokenExpiredAt(null);
 
         $this->save($user);
@@ -180,7 +181,7 @@ class UserManager extends AbstractManager
     public function sendAccountActivationNotification(User $user): void
     {
         if (!\in_array('ROLE_USAGER', $user->getRoles())
-            && User::STATUS_ARCHIVE !== $user->getStatut()
+            && UserStatus::ARCHIVE !== $user->getStatut()
         ) {
             $this->notificationMailerRegistry->send(
                 new NotificationMail(

--- a/src/Repository/ApiUserTokenRepository.php
+++ b/src/Repository/ApiUserTokenRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\ApiUserToken;
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\Behaviour\EntityCleanerRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -31,7 +32,7 @@ class ApiUserTokenRepository extends ServiceEntityRepository implements EntityCl
             ->andWhere('a.token = :token')
             ->andWhere('a.expiresAt > :now')
             ->setParameter('role_api', '%'.User::ROLE_API_USER.'%')
-            ->setParameter('statut_active', User::STATUS_ACTIVE)
+            ->setParameter('statut_active', UserStatus::ACTIVE)
             ->setParameter('token', $token)
             ->setParameter('now', new \DateTimeImmutable())
             ->setMaxResults(1);

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -6,6 +6,7 @@ use App\Dto\CountPartner;
 use App\Entity\Affectation;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\Qualification;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Territory;
@@ -83,7 +84,7 @@ class PartnerRepository extends ServiceEntityRepository
                     JOIN up2.user u2
                     WHERE up2.partner = p
                     AND u2.email IS NOT NULL
-                    AND u2.statut = 1
+                    AND u2.statut LIKE \''.UserStatus::ACTIVE->value.'\'
                     AND u2.isMailingActive = 1
                 ) THEN 1
                 ELSE 0

--- a/src/Security/FormLoginAuthenticator.php
+++ b/src/Security/FormLoginAuthenticator.php
@@ -2,6 +2,7 @@
 
 namespace App\Security;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -49,7 +50,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
 
         $passport = new Passport(
             new UserBadge($email, function (string $email) {
-                return $this->userRepository->findAgentByEmail(email: $email, userStatus: User::STATUS_ACTIVE, acceptRoleApi: false);
+                return $this->userRepository->findAgentByEmail(email: $email, userStatus: UserStatus::ACTIVE, acceptRoleApi: false);
             }),
             new PasswordCredentials($request->request->get('password', '')),
             [

--- a/src/Security/JsonLoginAuthenticator.php
+++ b/src/Security/JsonLoginAuthenticator.php
@@ -3,6 +3,7 @@
 namespace App\Security;
 
 use App\Entity\ApiUserToken;
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use Random\RandomException;
@@ -55,7 +56,7 @@ class JsonLoginAuthenticator extends AbstractAuthenticator
             new UserBadge($email, function (string $email) {
                 $user = $this->userRepository->findOneBy([
                     'email' => $email,
-                    'statut' => User::STATUS_ACTIVE,
+                    'statut' => UserStatus::ACTIVE,
                 ]);
 
                 if (null === $user || !in_array(User::ROLE_API_USER, $user->getRoles(), true)) {

--- a/src/Service/ListFilters/SearchUser.php
+++ b/src/Service/ListFilters/SearchUser.php
@@ -3,6 +3,7 @@
 namespace App\Service\ListFilters;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Territory;
 use App\Entity\User;
 use App\Service\Behaviour\SearchQueryTrait;
@@ -20,7 +21,7 @@ class SearchUser
     private ?Territory $territory = null;
     private Collection $partners;
     private ?PartnerType $partnerType = null;
-    private ?int $statut = null;
+    private ?string $statut = null;
     private ?string $role = null;
     private ?string $permissionAffectation = null;
     private ?string $orderType = null;
@@ -79,12 +80,12 @@ class SearchUser
         $this->partnerType = $partnerType;
     }
 
-    public function getStatut(): ?int
+    public function getStatut(): ?string
     {
         return $this->statut;
     }
 
-    public function setStatut(?int $statut): void
+    public function setStatut(?string $statut): void
     {
         $this->statut = $statut;
     }
@@ -150,7 +151,7 @@ class SearchUser
             $filters['Type de partenaire'] = $this->partnerType->label();
         }
         if (null !== $this->statut) {
-            $filters['Statut'] = User::STATUS_LABELS[$this->statut];
+            $filters['Statut'] = UserStatus::from($this->statut)->label();
         }
         if ($this->role) {
             $filters['Rôle'] = array_search($this->role, User::ROLES);

--- a/src/Service/Mailer/Mail/Account/AccountNewTerritoryMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountNewTerritoryMailer.php
@@ -3,7 +3,6 @@
 namespace App\Service\Mailer\Mail\Account;
 
 use App\Entity\Enum\UserStatus;
-use App\Entity\User;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;

--- a/src/Service/Mailer/Mail/Account/AccountNewTerritoryMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountNewTerritoryMailer.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
@@ -32,7 +33,7 @@ class AccountNewTerritoryMailer extends AbstractNotificationMailer
     public function getMailerParamsFromNotification(NotificationMail $notificationMail): array
     {
         $user = $notificationMail->getUser();
-        if (User::STATUS_ACTIVE === $user->getStatut()) {
+        if (UserStatus::ACTIVE === $user->getStatut()) {
             $btntext = 'Me connecter à Signal Logement';
             $link = $this->generateLink('back_dashboard', []);
         } else {

--- a/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Mailer\Mail\Account;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
@@ -33,16 +34,16 @@ class AccountTransferMailer extends AbstractNotificationMailer
     {
         $user = $notificationMail->getUser();
         $this->userManager->loadUserTokenForUser($user);
-        if (User::STATUS_ACTIVE === $user->getStatut()) {
+        if (UserStatus::ACTIVE === $user->getStatut()) {
             $link = $this->generateLink('back_dashboard', []);
         } else {
             $link = $this->generateLink('activate_account', ['uuid' => $user->getUuid(), 'token' => $user->getToken()]);
         }
 
         return [
-            'btntext' => User::STATUS_ACTIVE === $user->getStatut() ? 'Accéder à mon compte' : 'Activer mon compte',
+            'btntext' => UserStatus::ACTIVE === $user->getStatut() ? 'Accéder à mon compte' : 'Activer mon compte',
             'link' => $link,
-            'user_status' => $user->getStatut(),
+            'user_status' => $user->getStatut()->value,
             'partner_name' => $notificationMail->getParams()['partner_name'],
             'territory_name' => $notificationMail->getTerritory()->getName(),
         ];

--- a/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
+++ b/src/Service/Mailer/Mail/Account/AccountTransferMailer.php
@@ -3,7 +3,6 @@
 namespace App\Service\Mailer\Mail\Account;
 
 use App\Entity\Enum\UserStatus;
-use App\Entity\User;
 use App\Manager\UserManager;
 use App\Service\Mailer\Mail\AbstractNotificationMailer;
 use App\Service\Mailer\NotificationMail;

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -5,6 +5,7 @@ namespace App\Service;
 use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\NotificationType;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
@@ -295,7 +296,7 @@ class NotificationAndMailSender
             $suiviPartner = $this->suivi->getCreatedBy()?->getPartnerInTerritory($this->suivi->getSignalement()->getTerritory());
         }
 
-        return User::STATUS_ACTIVE === $user->getStatut()
+        return UserStatus::ACTIVE === $user->getStatut()
             && !$user->isSuperAdmin() && !$user->isTerritoryAdmin()
             && (!empty($this->affectation) || ($this->suivi->getCreatedBy() && $partner !== $suiviPartner));
     }

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -171,7 +171,7 @@ class NotificationAndMailSender
             $recipients->removeElement($this->suivi->getCreatedBy()?->getEmail());
             foreach ($recipients as $recipient) {
                 if ($this->signalement->isTiersDeclarant() && $recipient === $this->signalement->getMailDeclarant()) {
-                    $agentExist = $this->userRepository->findAgentByEmail(email: $recipient, userStatus: User::STATUS_ACTIVE, acceptRoleApi: false);
+                    $agentExist = $this->userRepository->findAgentByEmail(email: $recipient, userStatus: UserStatus::ACTIVE, acceptRoleApi: false);
                     if ($agentExist) {
                         continue;
                     }

--- a/src/Service/Token/ActivationTokenGenerator.php
+++ b/src/Service/Token/ActivationTokenGenerator.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Token;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 
@@ -26,13 +27,13 @@ class ActivationTokenGenerator extends AbstractTokenGenerator
     {
         return null !== $user
             && new \DateTimeImmutable() < $user->getTokenExpiredAt()
-            && User::STATUS_INACTIVE === $user->getStatut();
+            && UserStatus::INACTIVE === $user->getStatut();
     }
 
     private function canUpdatePassword(?User $user): bool
     {
         return null !== $user
             && new \DateTimeImmutable() < $user->getTokenExpiredAt()
-            && User::STATUS_ACTIVE === $user->getStatut();
+            && UserStatus::ACTIVE === $user->getStatut();
     }
 }

--- a/src/Service/UserExportLoader.php
+++ b/src/Service/UserExportLoader.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Service\ListFilters\SearchUser;
@@ -67,7 +68,7 @@ readonly class UserExportLoader
                     'partner' => $partners,
                     'partnerType' => $partnerTypes,
                     'createdAt' => $user->getCreatedAt()->format('d/m/Y'),
-                    'statut' => User::STATUS_ACTIVE === $user->getStatut() ? 'Activé' : 'Non activé',
+                    'statut' => UserStatus::ACTIVE === $user->getStatut() ? 'Activé' : 'Non activé',
                     'lastLoginAt' => $user->getLastLoginAt() ? $user->getLastLoginAt()->format('d/m/Y') : '',
                     'role' => $user->getRoleLabel(),
                     'permissionAffectation' => $user->isSuperAdmin() || $user->isTerritoryAdmin() || $user->hasPermissionAffectation() ? 'oui' : 'non',

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -247,13 +247,13 @@
                                     {% endif %}
                                 </span>
                             </td>
-                            <td>{% if user.statut == 0 %}
+                            <td>{% if user.statut is same as enum('App\\Entity\\Enum\\UserStatus').INACTIVE %}
                                     {% set classe = 'fr-badge--orange-terre-battue' %}
                                     {% set label = 'INACTIF' %}
-                                {% elseif user.statut == 1 %}
+                                {% elseif user.statut is same as enum('App\\Entity\\Enum\\UserStatus').ACTIVE %}
                                     {% set classe = 'fr-badge--green-emeraude' %}
                                     {% set label = 'ACTIF' %}
-                                {% elseif user.statut == 2 %}
+                                {% elseif user.statut is same as enum('App\\Entity\\Enum\\UserStatus').ARCHIVE %}
                                     {% set classe = 'fr-badge--blue-ecume' %}
                                     {% set label = 'ARCHIVE' %}
                                 {% endif %}

--- a/templates/back/user/inactive-accounts.html.twig
+++ b/templates/back/user/inactive-accounts.html.twig
@@ -80,7 +80,7 @@
                         {% elseif user.statut is same as enum('App\\Entity\\Enum\\UserStatus').ACTIVE %}
                             <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
                         {% else %}
-                            {{ user.statutLabel }}
+                            {{ user.statut.label }}
                         {% endif %}
                     </td>
                     <td>{{ user.createdAt|date('d/m/Y') }}</td>

--- a/templates/back/user/inactive-accounts.html.twig
+++ b/templates/back/user/inactive-accounts.html.twig
@@ -75,9 +75,9 @@
                         {% endfor %}
                     </td>
                     <td>
-                        {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE') %}
+                        {% if user.statut is same as enum('App\\Entity\\Enum\\UserStatus').INACTIVE %}
                             <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>
-                        {% elseif user.statut is same as constant('App\\Entity\\User::STATUS_ACTIVE') %}
+                        {% elseif user.statut is same as enum('App\\Entity\\Enum\\UserStatus').ACTIVE %}
                             <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
                         {% else %}
                             {{ user.statutLabel }}

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -131,9 +131,9 @@
                         {% endfor %}
                     </td>
                     <td>
-                        {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE') %}
+                        {% if user.statut is same as enum('App\\Entity\\Enum\\UserStatus').INACTIVE %}
                             <span class="fr-badge fr-badge--no-icon fr-badge--error">Non activé</span>
-                        {% elseif user.statut is same as constant('App\\Entity\\User::STATUS_ACTIVE') %}
+                        {% elseif user.statut is same as enum('App\\Entity\\Enum\\UserStatus').ACTIVE %}
                             <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
                         {% else %}
                             {{ user.statutLabel }}

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -136,7 +136,7 @@
                         {% elseif user.statut is same as enum('App\\Entity\\Enum\\UserStatus').ACTIVE %}
                             <span class="fr-badge fr-badge--no-icon fr-badge--success">Activé</span>
                         {% else %}
-                            {{ user.statutLabel }}
+                            {{ user.statut.label }}
                         {% endif %}
                     </td>
                     <td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}</td>

--- a/templates/emails/transfer_account_email.html.twig
+++ b/templates/emails/transfer_account_email.html.twig
@@ -2,14 +2,14 @@
 
 {% block body %}
     <p>Bonjour,</p>
-    {% if user_status == 1 %}
+    {% if user_status is same as 'ACTIVE' %}
         <p>Votre compte a été transféré vers le partenaire {{ partner_name }} sur votre plateforme {{ platform.name }}
             - {{ territory_name }}. </p>
         <p>Vous pouvez désormais traiter et assurer le suivi des signalements du partenaire {{ partner_name }}. <p>
         <p> Votre adresse de connexion et mot de passe ne changent pas. <br/>
             Cliquez ci-dessous pour vous connecter à votre compte.</p>
     {% endif %}
-    {% if user_status == 0 %}
+    {% if user_status is same as 'INACTIVE' %}
         <p>Votre compte a été transféré vers le partenaire {{ partner_name }} sur votre plateforme {{ platform.name }}
             - {{ territory_name }}.</p>
         <p>Vous devez activer votre compte pour traiter les signalements du partenaire {{ partner_name }}. <br/>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -8,7 +8,7 @@
         <section class="fr-grid-row fr-grid-row--center">
             <header class="fr-callout bg-light fr-col-12">
                 <p class="fr-callout__title">Création de votre mot de passe</p>
-                {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE')  %}
+                {% if user.statut is same as enum('App\\Entity\\Enum\\UserStatus').ACTIVE %}
                     <p class="fr-callout__text fr-mb-5v">
                         Vous avez demandé l'activation de votre compte
                     </p>
@@ -91,7 +91,7 @@
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('create_password_'~ user.uuid) }}">
                 <div class="fr-form-group">
                     <button class="fr-btn fr-icon-checkbox-circle-fill fr-btn--icon-right" disabled
-                            {% if user.statut is same as constant('App\\Entity\\User::STATUS_INACTIVE')  %}
+                            {% if user.statut is same as enum('App\\Entity\\Enum\\UserStatus').INACTIVE %}
                             aria-controls="fr-modal-cgu-bo" data-fr-opened="false" type="button"
                             {% else %}
                             type="submit" 

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -9,6 +9,7 @@ use App\Entity\Criticite;
 use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Enum\UserStatus;
 use App\Entity\File;
 use App\Entity\Intervention;
 use App\Entity\Partner;
@@ -371,7 +372,7 @@ trait FixturesHelper
             ->setNom('Doe')
             ->setPrenom('John')
             ->setRoles($roles)
-            ->setStatut(User::STATUS_ACTIVE);
+            ->setStatut(UserStatus::ACTIVE);
         $userPartner = (new UserPartner())->setPartner($this->getPartner())->setUser($user);
         $user->addUserPartner($userPartner);
 

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -38,7 +38,7 @@ class BackUserControllerTest extends WebTestCase
         yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 22];
         yield 'Search with territory 13' => [['territory' => 13], 16];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];
-        yield 'Search with status 0' => [['statut' => 0], 10];
+        yield 'Search with status INACTIVE' => [['statut' => 'INACTIVE'], 10];
         yield 'Search with role ROLE_ADMIN' => [['role' => 'ROLE_ADMIN'], 3];
         yield 'Search with role ROLE_ADMIN and territory 13' => [['role' => 'ROLE_ADMIN', 'territory' => 13], 0];
         yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 14];
@@ -70,9 +70,9 @@ class BackUserControllerTest extends WebTestCase
         yield 'Search without params' => [[], 15];
         yield 'Search with queryUser user' => [['queryUser' => 'user'], 10];
         yield 'Search with partner 6 and 7' => [['partners' => [2]], 5];
-        yield 'Search with status 1' => [['statut' => 1], 11];
+        yield 'Search with status ACTIVE' => [['statut' => 'ACTIVE'], 11];
         yield 'Search with role ROLE_USER_PARTNER' => [['role' => 'ROLE_USER_PARTNER'], 10];
-        yield 'Search with role ROLE_USER_PARTNER and status 1' => [['role' => 'ROLE_USER_PARTNER', 'statut' => 1], 6];
+        yield 'Search with role ROLE_USER_PARTNER and status ACTIVE' => [['role' => 'ROLE_USER_PARTNER', 'statut' => 'ACTIVE'], 6];
         yield 'Search with territory 13 and partnerType Autre' => [['territory' => 13, 'partnerType' => 'AUTRE'], 15];
         yield 'Search with partnerType Ars' => [['partnerType' => 'ARS'], 1];
     }

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Controller\Back;
 
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Suivi;
 use App\Entity\User;
 use App\Repository\UserRepository;
@@ -107,7 +108,7 @@ class SignalementListControllerTest extends WebTestCase
     {
         /** @var UserRepository $userRepository */
         $userRepository = static::getContainer()->get(UserRepository::class);
-        $users = $userRepository->findBy(['statut' => User::STATUS_ACTIVE]);
+        $users = $userRepository->findBy(['statut' => UserStatus::ACTIVE]);
         $users = array_filter($users, function (User $user) {
             return !in_array('ROLE_API_USER', $user->getRoles(), true);
         });

--- a/tests/Functional/Controller/BackArchivedUsersControllerTest.php
+++ b/tests/Functional/Controller/BackArchivedUsersControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\PartnerRepository;
 use App\Repository\TerritoryRepository;
@@ -138,7 +139,7 @@ class BackArchivedUsersControllerTest extends WebTestCase
 
         /** @var User $account */
         $account = $userRepository->findOneBy(['email' => $accountEmail]);
-        $this->assertEquals(User::STATUS_ACTIVE, $account->getStatut());
+        $this->assertEquals(UserStatus::ACTIVE, $account->getStatut());
         $this->assertResponseRedirects('/bo/comptes-archives/');
     }
 
@@ -188,7 +189,7 @@ class BackArchivedUsersControllerTest extends WebTestCase
 
         /** @var User $account */
         $account = $userRepository->findArchivedUserByEmail($accountEmail);
-        $this->assertEquals(User::STATUS_ARCHIVE, $account->getStatut());
+        $this->assertEquals(UserStatus::ARCHIVE, $account->getStatut());
     }
 
     public function testAccountReactivateError(): void
@@ -226,7 +227,7 @@ class BackArchivedUsersControllerTest extends WebTestCase
 
         /** @var User $account */
         $account = $userRepository->findArchivedUserByEmail($accountEmail);
-        $this->assertEquals(User::STATUS_ARCHIVE, $account->getStatut());
+        $this->assertEquals(UserStatus::ARCHIVE, $account->getStatut());
     }
 
     public function testAccountReactivateAnonymizedUser(): void
@@ -301,7 +302,7 @@ class BackArchivedUsersControllerTest extends WebTestCase
 
         /** @var User $account */
         $account = $userRepository->findOneBy(['email' => $accountEmail]);
-        $this->assertEquals(User::STATUS_ACTIVE, $account->getStatut());
+        $this->assertEquals(UserStatus::ACTIVE, $account->getStatut());
         $this->assertResponseRedirects('/bo/comptes-archives/');
     }
 }

--- a/tests/Functional/Controller/CartographieControllerTest.php
+++ b/tests/Functional/Controller/CartographieControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -49,7 +50,7 @@ class CartographieControllerTest extends WebTestCase
     {
         /** @var UserRepository $userRepository */
         $userRepository = static::getContainer()->get(UserRepository::class);
-        $users = $userRepository->findBy(['statut' => User::STATUS_ACTIVE]);
+        $users = $userRepository->findBy(['statut' => UserStatus::ACTIVE]);
         /** @var User $user */
         foreach ($users as $user) {
             if ($user->getFirstTerritory()) {

--- a/tests/Functional/Controller/PartnerControllerTest.php
+++ b/tests/Functional/Controller/PartnerControllerTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Functional\Controller;
 
 use App\Entity\Enum\PartnerType;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\User;
 use App\Repository\PartnerRepository;
@@ -150,10 +151,10 @@ class PartnerControllerTest extends WebTestCase
         $this->assertStringStartsWith($mailBeforArchive.User::SUFFIXE_ARCHIVED, $partner->getEmail());
         foreach ($partnerUsers as $user) {
             if ('admin-partenaire-multi-ter-13-01@signal-logement.fr' === $user->getEmail()) {
-                $this->assertEquals(User::STATUS_ACTIVE, $user->getStatut());
+                $this->assertEquals(UserStatus::ACTIVE, $user->getStatut());
                 $this->assertCount(1, $user->getPartners());
             } else {
-                $this->assertEquals(User::STATUS_ARCHIVE, $user->getStatut());
+                $this->assertEquals(UserStatus::ARCHIVE, $user->getStatut());
                 $this->assertStringContainsString(User::SUFFIXE_ARCHIVED, $user->getEmail());
             }
         }
@@ -489,7 +490,7 @@ class PartnerControllerTest extends WebTestCase
             '_token' => $this->generateCsrfToken($this->client, 'partner_user_delete'),
         ]);
 
-        $this->assertEquals(2, $user->getStatut());
+        $this->assertEquals(UserStatus::ARCHIVE, $user->getStatut());
         $this->assertStringContainsString(User::SUFFIXE_ARCHIVED, $user->getEmail());
         $this->assertEmailCount(1);
     }
@@ -504,7 +505,7 @@ class PartnerControllerTest extends WebTestCase
             '_token' => $this->generateCsrfToken($this->client, 'partner_user_delete'),
         ]);
 
-        $this->assertEquals(1, $user->getStatut());
+        $this->assertEquals(UserStatus::ACTIVE, $user->getStatut());
         $this->assertEmailCount(1);
         $this->assertCount(1, $user->getPartners());
     }
@@ -532,7 +533,7 @@ class PartnerControllerTest extends WebTestCase
             '_token' => $this->generateCsrfToken($this->client, 'bad_csrf'),
         ]);
 
-        $this->assertNotEquals(2, $user->getStatut());
+        $this->assertNotEquals(UserStatus::ARCHIVE, $user->getStatut());
         $this->assertStringNotContainsString(User::SUFFIXE_ARCHIVED, $user->getEmail());
         $this->assertResponseRedirects('/bo/partenaires/');
     }

--- a/tests/Functional/Controller/Security/ProConnectControllerTest.php
+++ b/tests/Functional/Controller/Security/ProConnectControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller\Security;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Service\Gouv\ProConnect\Model\ProConnectUser;
@@ -43,7 +44,7 @@ class ProConnectControllerTest extends WebTestCase
         $em = $container->get('doctrine.orm.entity_manager');
         $user = (new User())
             ->setEmail($proConnectUser->email)
-            ->setStatut(User::STATUS_ACTIVE);
+            ->setStatut(UserStatus::ACTIVE);
         $em->persist($user);
 
         $userRepositoryMock = $this->createMock(UserRepository::class);

--- a/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Functional\EventSubscriber;
 
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\NotificationType;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Notification;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -46,7 +47,7 @@ class SignalementClosedSubscriberTest extends KernelTestCase
         /** @var Signalement $signalementClosed */
         $signalementClosed = $this->signalementRepository->findOneBy(['reference' => '2024-08']);
 
-        $user = $this->userRepository->findOneBy(['statut' => User::STATUS_ACTIVE]);
+        $user = $this->userRepository->findOneBy(['statut' => UserStatus::ACTIVE]);
 
         $securityMock = $this->createMock(Security::class);
         $securityMock->expects($this->once())->method('getUser')->willReturn($user);

--- a/tests/Functional/Service/NotificationAndMailSenderTest.php
+++ b/tests/Functional/Service/NotificationAndMailSenderTest.php
@@ -6,6 +6,7 @@ use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\NotificationType;
+use App\Entity\Enum\UserStatus;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
@@ -165,7 +166,7 @@ class NotificationAndMailSenderTest extends KernelTestCase
                 }
 
                 foreach ($partner->getUsers() as $user) {
-                    if (User::STATUS_ACTIVE === $user->getStatut()) {
+                    if (UserStatus::ACTIVE === $user->getStatut()) {
                         if ($user->getIsMailingActive() && !$user->getIsMailingSummary()) {
                             $expectedAdress[] = $user->getEmail();
                         }

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Entity;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Tests\FixturesHelper;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -57,7 +58,7 @@ class UserTest extends KernelTestCase
         $user->anonymize();
         $this->assertNull($user->getAnonymizedAt());
 
-        $user->setStatut(User::STATUS_ARCHIVE);
+        $user->setStatut(UserStatus::ARCHIVE);
         $user->anonymize();
         $this->assertNotNull($user->getAnonymizedAt());
         $this->assertEquals(User::ANONYMIZED_PRENOM, $user->getPrenom());

--- a/tests/Unit/Factory/UserFactoryTest.php
+++ b/tests/Unit/Factory/UserFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Factory;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\User;
 use App\Entity\UserPartner;
@@ -43,7 +44,7 @@ class UserFactoryTest extends KernelTestCase
         $this->assertInstanceOf(User::class, $user);
 
         $this->assertEquals($user->getIsMailingActive(), true);
-        $this->assertEquals($user->getStatut(), User::STATUS_INACTIVE);
+        $this->assertEquals($user->getStatut(), UserStatus::INACTIVE);
     }
 
     public function testCreateUserAdminInstanceWithoutPartnerAndTerritory(): void
@@ -62,7 +63,7 @@ class UserFactoryTest extends KernelTestCase
         $this->assertInstanceOf(User::class, $user);
 
         $this->assertEquals($user->getIsMailingActive(), true);
-        $this->assertEquals($user->getStatut(), User::STATUS_INACTIVE);
+        $this->assertEquals($user->getStatut(), UserStatus::INACTIVE);
         $this->assertEquals($user->getFirstTerritory(), null);
         $this->assertEquals($user->getPartners()->count(), 0);
     }
@@ -90,7 +91,7 @@ class UserFactoryTest extends KernelTestCase
         $this->assertInstanceOf(User::class, $user);
 
         $this->assertEquals($user->getIsMailingActive(), true);
-        $this->assertEquals($user->getStatut(), User::STATUS_INACTIVE);
+        $this->assertEquals($user->getStatut(), UserStatus::INACTIVE);
         $this->assertEquals($user->getFirstTerritory(), $partner->getTerritory());
         $this->assertEquals($user->getPartners()->first(), $partner);
     }

--- a/tests/Unit/Security/JsonLoginAuthenticatorTest.php
+++ b/tests/Unit/Security/JsonLoginAuthenticatorTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Unit\Security;
 
 use App\Entity\ApiUserToken;
+use App\Entity\Enum\UserStatus;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Security\JsonLoginAuthenticator;
@@ -53,7 +54,7 @@ class JsonLoginAuthenticatorTest extends TestCase
         $user = new User();
         $user->setEmail('user@example.com');
         $user->setRoles([User::ROLE_API_USER]);
-        $user->setStatut(User::STATUS_ACTIVE);
+        $user->setStatut(UserStatus::ACTIVE);
 
         $request = Request::create('/api/login', 'POST', [], [], [], [], json_encode(['email' => 'user@example.com', 'password' => 'password']));
         $passport = $this->authenticator->authenticate($request);
@@ -71,7 +72,7 @@ class JsonLoginAuthenticatorTest extends TestCase
         $user = new User();
         $user->setEmail('user@example.com');
         $user->setRoles([User::ROLE_API_USER]);
-        $user->setStatut(User::STATUS_ACTIVE);
+        $user->setStatut(UserStatus::ACTIVE);
 
         $apiUserToken = new ApiUserToken();
         $user->addApiUserToken($apiUserToken);

--- a/tests/UserHelper.php
+++ b/tests/UserHelper.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests;
 
+use App\Entity\Enum\UserStatus;
 use App\Entity\Partner;
 use App\Entity\Territory;
 use App\Entity\User;
@@ -39,7 +40,7 @@ trait UserHelper
     {
         return (new User())
             ->setEmail('proconnect@signal-logement.fr')
-            ->setStatut(User::STATUS_ACTIVE)
+            ->setStatut(UserStatus::ACTIVE)
             ->setRoles([User::ROLE_ADMIN_TERRITORY])
             ->setProConnectUserId('1234');
     }


### PR DESCRIPTION
## Ticket

#3963   

## Description
Remplacement de la donnée statut des utilisateurs par un enum

## Changements apportés
* Remplacement du `int` existant par un `enum`

## Tests
- [ ] CI OK
- [ ] Sur base de prod : `make execute-migration name=Version20250418112346 direction=up`
- [ ] Faire quelques tests (recherche utilisateur, affectation, liste signalement, connexion, activation...)
