### PR TITLE
[Tech - Perf] Synchro Esabora 

### DIFF
--- a/migrations/Version20250506093843.php
+++ b/migrations/Version20250506093843.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250506093843 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create index on context column in suivi table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_suivi_context ON suivi (context)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DROP INDEX idx_suivi_context ON suivi
+        SQL);
+    }
+}

--- a/src/Command/Cron/AbstractSynchronizeEsaboraCommand.php
+++ b/src/Command/Cron/AbstractSynchronizeEsaboraCommand.php
@@ -76,8 +76,8 @@ class AbstractSynchronizeEsaboraCommand extends AbstractCronCommand
         $countSyncFailed = 0;
         $count = 0;
         foreach ($affectations as $row) {
-            $affectation = $row[0];
-            $dossierResponse = $esaboraService->getStateDossier($affectation, $row['uuid']);
+            $affectation = $row['affectation'];
+            $dossierResponse = $esaboraService->getStateDossier($affectation, $row['signalement_uuid']);
             if (AbstractEsaboraService::hasSuccess($dossierResponse)) {
                 $this->esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);
                 $io->success($this->printInfo($dossierResponse));

--- a/src/Command/Cron/AbstractSynchronizeEsaboraCommand.php
+++ b/src/Command/Cron/AbstractSynchronizeEsaboraCommand.php
@@ -14,6 +14,7 @@ use App\Service\Interconnection\Esabora\Response\DossierStateSISHResponse;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -29,12 +30,15 @@ use Symfony\Component\Serializer\SerializerInterface;
 )]
 class AbstractSynchronizeEsaboraCommand extends AbstractCronCommand
 {
+    public const int BATCH_SIZE = 100;
+
     public function __construct(
         private readonly EsaboraManager $esaboraManager,
         private readonly AffectationRepository $affectationRepository,
         private readonly SerializerInterface $serializer,
         private readonly NotificationMailerRegistry $notificationMailerRegistry,
         private readonly ParameterBagInterface $parameterBag,
+        private readonly EntityManagerInterface $entityManager,
     ) {
         parent::__construct($this->parameterBag);
     }
@@ -70,8 +74,10 @@ class AbstractSynchronizeEsaboraCommand extends AbstractCronCommand
         );
         $countSyncSuccess = 0;
         $countSyncFailed = 0;
-        foreach ($affectations as $affectation) {
-            $dossierResponse = $esaboraService->getStateDossier($affectation);
+        $count = 0;
+        foreach ($affectations as $row) {
+            $affectation = $row[0];
+            $dossierResponse = $esaboraService->getStateDossier($affectation, $row['uuid']);
             if (AbstractEsaboraService::hasSuccess($dossierResponse)) {
                 $this->esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);
                 $io->success($this->printInfo($dossierResponse));
@@ -80,7 +86,12 @@ class AbstractSynchronizeEsaboraCommand extends AbstractCronCommand
                 $io->error(\sprintf('%s', $this->serializer->serialize($dossierResponse, 'json')));
                 ++$countSyncFailed;
             }
+            ++$count;
+            if (0 === $count % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+            }
         }
+        $this->entityManager->flush();
         $io->table(['Count success', 'Count Failed'], [[$countSyncSuccess, $countSyncFailed]]);
         $this->notify($partnerType, $countSyncSuccess, $countSyncFailed);
     }

--- a/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
+++ b/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
@@ -80,15 +80,15 @@ class SynchronizeEsaboraSCHSCommand extends AbstractSynchronizeEsaboraCommand
         $this->existingEvents = $this->suiviRepository->findExistingEventsForSCHS();
         $count = 0;
         foreach ($affectations as $row) {
-            $affectation = $row[0];
+            $affectation = $row['affectation'];
             try {
-                $dossierEvents = $this->esaboraService->getDossierEvents($affectation, $row['uuid']);
+                $dossierEvents = $this->esaboraService->getDossierEvents($affectation, $row['signalement_uuid']);
                 foreach ($dossierEvents->getCollection() as $eventItem) {
                     $this->synchronizeEvent($eventItem, $affectation);
                 }
             } catch (\Throwable $exception) {
                 $msg = sprintf('Error while synchronizing events on signalement %s: %s',
-                    $row['uuid'],
+                    $row['signalement_uuid'],
                     $exception->getMessage()
                 );
                 $this->io->error($msg);

--- a/src/Command/Cron/SynchronizeEsaboraSISHCommand.php
+++ b/src/Command/Cron/SynchronizeEsaboraSISHCommand.php
@@ -7,6 +7,7 @@ use App\Repository\AffectationRepository;
 use App\Service\Interconnection\Esabora\EsaboraManager;
 use App\Service\Interconnection\Esabora\EsaboraSISHService;
 use App\Service\Mailer\NotificationMailerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,6 +28,7 @@ class SynchronizeEsaboraSISHCommand extends AbstractSynchronizeEsaboraCommand
         private readonly SerializerInterface $serializer,
         private readonly NotificationMailerRegistry $notificationMailerRegistry,
         private readonly ParameterBagInterface $parameterBag,
+        private readonly EntityManagerInterface $entityManager,
     ) {
         parent::__construct(
             $this->esaboraManager,
@@ -34,6 +36,7 @@ class SynchronizeEsaboraSISHCommand extends AbstractSynchronizeEsaboraCommand
             $this->serializer,
             $this->notificationMailerRegistry,
             $this->parameterBag,
+            $this->entityManager,
         );
     }
 

--- a/src/Command/Cron/SynchronizeInterventionSISHCommand.php
+++ b/src/Command/Cron/SynchronizeInterventionSISHCommand.php
@@ -73,16 +73,16 @@ class SynchronizeInterventionSISHCommand extends AbstractSynchronizeEsaboraComma
         );
         $count = 0;
         foreach ($affectations as $row) {
-            $affectation = $row[0];
+            $affectation = $row['affectation'];
             /** @var InterventionSISHHandlerInterface $interventionHandler */
             foreach ($this->interventionHandlers as $key => $interventionHandler) {
                 try {
-                    $interventionHandler->handle($affectation, $row['uuid']);
+                    $interventionHandler->handle($affectation, $row['signalement_uuid']);
                     $io->writeln(\sprintf('#%s: %s was executed', $key, $interventionHandler->getServiceName()));
                 } catch (\Throwable $e) {
                     $signalement = $affectation->getSignalement();
                     $message = $interventionHandler->getServiceName()
-                        .' - Signalement '.$row['uuid']
+                        .' - Signalement '.$row['signalement_uuid']
                         .' ('.$signalement->getId().') : '
                         .$e->getMessage();
                     if (!($e instanceof \Exception)) {

--- a/src/Command/PushEsaboraDossierCommand.php
+++ b/src/Command/PushEsaboraDossierCommand.php
@@ -87,7 +87,7 @@ class PushEsaboraDossierCommand extends Command
         }
 
         foreach ($affectations as $row) {
-            $affectation = $row[0];
+            $affectation = $row['affectation'];
             $this->esaboraBus->dispatch($affectation);
             $io->success(\sprintf(
                 '[%s] Dossier %s pushed to esabora',

--- a/src/Command/PushEsaboraDossierCommand.php
+++ b/src/Command/PushEsaboraDossierCommand.php
@@ -86,7 +86,8 @@ class PushEsaboraDossierCommand extends Command
             return Command::FAILURE;
         }
 
-        foreach ($affectations as $affectation) {
+        foreach ($affectations as $row) {
+            $affectation = $row[0];
             $this->esaboraBus->dispatch($affectation);
             $io->success(\sprintf(
                 '[%s] Dossier %s pushed to esabora',

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['type'], name: 'idx_suivi_type')]
 #[ORM\Index(columns: ['created_at'], name: 'idx_suivi_created_at')]
 #[ORM\Index(columns: ['signalement_id', 'type', 'created_at'], name: 'idx_suivi_signalement_type_created_at')]
+#[ORM\Index(columns: ['context'], name: 'idx_suivi_context')]
 class Suivi implements EntityHistoryInterface
 {
     public const int TYPE_AUTO = 1;

--- a/src/Manager/JobEventManager.php
+++ b/src/Manager/JobEventManager.php
@@ -23,6 +23,7 @@ class JobEventManager extends AbstractManager
         ?int $signalementId,
         ?int $partnerId,
         ?PartnerType $partnerType,
+        ?bool $flush = true,
     ): JobEvent {
         $jobEvent = (new JobEvent())
             ->setSignalementId($signalementId)
@@ -35,7 +36,7 @@ class JobEventManager extends AbstractManager
             ->setStatus($status)
             ->setCodeStatus($codeStatus);
 
-        $this->save($jobEvent);
+        $this->save($jobEvent, $flush);
 
         return $jobEvent;
     }

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -108,7 +108,7 @@ class AffectationRepository extends ServiceEntityRepository
         ?Territory $territory = null,
     ): array {
         $qb = $this->createQueryBuilder('a');
-        $qb->select('a', 's.uuid');
+        $qb->select('a AS affectation', 's.uuid AS signalement_uuid');
         $qb = $qb
             ->innerJoin('a.partner', 'p')
             ->innerJoin('a.signalement', 's')

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -99,7 +99,7 @@ class AffectationRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return Affectation[]
+     * @return array[]
      */
     public function findAffectationSubscribedToEsabora(
         PartnerType $partnerType,
@@ -108,6 +108,7 @@ class AffectationRepository extends ServiceEntityRepository
         ?Territory $territory = null,
     ): array {
         $qb = $this->createQueryBuilder('a');
+        $qb->select('a', 's.uuid');
         $qb = $qb
             ->innerJoin('a.partner', 'p')
             ->innerJoin('a.signalement', 's')

--- a/src/Service/Interconnection/Esabora/AbstractEsaboraService.php
+++ b/src/Service/Interconnection/Esabora/AbstractEsaboraService.php
@@ -64,9 +64,9 @@ abstract class AbstractEsaboraService implements EsaboraServiceInterface
         ]))->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE);
     }
 
-    abstract public function getStateDossier(Affectation $affectation): DossierResponseInterface;
+    abstract public function getStateDossier(Affectation $affectation, string $uuidSignalement): DossierResponseInterface;
 
-    public function prepareInterventionPayload(Affectation $affectation, string $serviceName): array
+    public function prepareInterventionPayload(string $uuidSignalement, string $serviceName): array
     {
         return [
             'searchName' => $serviceName,
@@ -74,7 +74,7 @@ abstract class AbstractEsaboraService implements EsaboraServiceInterface
                 [
                     'criterionName' => 'Reference_Dossier',
                     'criterionValueList' => [
-                        $affectation->getSignalement()->getUuid(),
+                        $uuidSignalement,
                     ],
                 ],
                 [

--- a/src/Service/Interconnection/Esabora/EsaboraSCHSService.php
+++ b/src/Service/Interconnection/Esabora/EsaboraSCHSService.php
@@ -50,7 +50,7 @@ class EsaboraSCHSService extends AbstractEsaboraService
         return $this->request($url, $token, $payload, $options);
     }
 
-    public function getStateDossier(Affectation $affectation): DossierStateSCHSResponse
+    public function getStateDossier(Affectation $affectation, string $uuidSignalement): DossierStateSCHSResponse
     {
         list($url, $token) = $affectation->getPartner()->getEsaboraCredential();
         $payload = [
@@ -59,7 +59,7 @@ class EsaboraSCHSService extends AbstractEsaboraService
                 [
                     'criterionName' => 'SAS_Référence',
                     'criterionValueList' => [
-                        $affectation->getSignalement()->getUuid(),
+                        $uuidSignalement,
                     ],
                 ],
             ],
@@ -95,7 +95,7 @@ class EsaboraSCHSService extends AbstractEsaboraService
         );
     }
 
-    public function getDossierEvents(Affectation $affectation): DossierEventsSCHSCollectionResponse
+    public function getDossierEvents(Affectation $affectation, string $uuidSignalement): DossierEventsSCHSCollectionResponse
     {
         list($url, $token) = $affectation->getPartner()->getEsaboraCredential();
         $statusCode = Response::HTTP_SERVICE_UNAVAILABLE;
@@ -105,7 +105,7 @@ class EsaboraSCHSService extends AbstractEsaboraService
                 [
                     'criterionName' => 'SAS_Référence',
                     'criterionValueList' => [
-                        $affectation->getSignalement()->getUuid(),
+                        $uuidSignalement,
                     ],
                 ],
             ],

--- a/src/Service/Interconnection/Esabora/EsaboraSISHService.php
+++ b/src/Service/Interconnection/Esabora/EsaboraSISHService.php
@@ -68,7 +68,7 @@ class EsaboraSISHService extends AbstractEsaboraService
         return $this->getDossierPushResponse($url, $token, $payload, $dossierMessageSISH);
     }
 
-    public function getStateDossier(Affectation $affectation): DossierStateSISHResponse
+    public function getStateDossier(Affectation $affectation, string $uuidSignalement): DossierStateSISHResponse
     {
         list($url, $token) = $affectation->getPartner()->getEsaboraCredential();
         $payload = [
@@ -77,7 +77,7 @@ class EsaboraSISHService extends AbstractEsaboraService
                 [
                     'criterionName' => 'Reference_Dossier',
                     'criterionValueList' => [
-                        $affectation->getSignalement()->getUuid(),
+                        $uuidSignalement,
                     ],
                 ],
             ],
@@ -113,11 +113,11 @@ class EsaboraSISHService extends AbstractEsaboraService
         );
     }
 
-    public function getVisiteDossier(Affectation $affectation): DossierVisiteSISHCollectionResponse
+    public function getVisiteDossier(Affectation $affectation, string $uuidSignalement): DossierVisiteSISHCollectionResponse
     {
         list($url, $token) = $affectation->getPartner()->getEsaboraCredential();
         $statusCode = Response::HTTP_SERVICE_UNAVAILABLE;
-        $payload = $this->prepareInterventionPayload($affectation, self::SISH_VISITES_DOSSIER_SAS);
+        $payload = $this->prepareInterventionPayload($uuidSignalement, self::SISH_VISITES_DOSSIER_SAS);
 
         $options['extra']['job_event_metadata'] = new JobEventMetaData(
             service: self::TYPE_SERVICE,
@@ -147,11 +147,11 @@ class EsaboraSISHService extends AbstractEsaboraService
         );
     }
 
-    public function getArreteDossier(Affectation $affectation): DossierArreteSISHCollectionResponse
+    public function getArreteDossier(Affectation $affectation, string $uuidSignalement): DossierArreteSISHCollectionResponse
     {
         list($url, $token) = $affectation->getPartner()->getEsaboraCredential();
         $statusCode = Response::HTTP_SERVICE_UNAVAILABLE;
-        $payload = $this->prepareInterventionPayload($affectation, self::SISH_ARRETES_DOSSIER_SAS);
+        $payload = $this->prepareInterventionPayload($uuidSignalement, self::SISH_ARRETES_DOSSIER_SAS);
         $options['extra']['job_event_metadata'] = new JobEventMetaData(
             service: self::TYPE_SERVICE,
             action: self::ACTION_SYNC_DOSSIER_ARRETE,

--- a/src/Service/Interconnection/Esabora/EsaboraServiceInterface.php
+++ b/src/Service/Interconnection/Esabora/EsaboraServiceInterface.php
@@ -7,5 +7,5 @@ use App\Service\Interconnection\Esabora\Response\DossierResponseInterface;
 
 interface EsaboraServiceInterface
 {
-    public function getStateDossier(Affectation $affectation): DossierResponseInterface;
+    public function getStateDossier(Affectation $affectation, string $uuidSignalement): DossierResponseInterface;
 }

--- a/src/Service/Interconnection/Esabora/Handler/InterventionArreteServiceHandler.php
+++ b/src/Service/Interconnection/Esabora/Handler/InterventionArreteServiceHandler.php
@@ -18,9 +18,9 @@ class InterventionArreteServiceHandler implements InterventionSISHHandlerInterfa
     ) {
     }
 
-    public function handle(Affectation $affectation): void
+    public function handle(Affectation $affectation, string $uuidSignalement): void
     {
-        $dossierArreteSISHCollectionResponse = $this->esaboraSISHService->getArreteDossier($affectation);
+        $dossierArreteSISHCollectionResponse = $this->esaboraSISHService->getArreteDossier($affectation, $uuidSignalement);
         if (AbstractEsaboraService::hasSuccess($dossierArreteSISHCollectionResponse)) {
             foreach ($dossierArreteSISHCollectionResponse->getCollection() as $dossierArrete) {
                 $this->esaboraManager->createOrUpdateArrete($affectation, $dossierArrete);

--- a/src/Service/Interconnection/Esabora/Handler/InterventionSISHHandlerInterface.php
+++ b/src/Service/Interconnection/Esabora/Handler/InterventionSISHHandlerInterface.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('app.intervention_sish_handler')]
 interface InterventionSISHHandlerInterface
 {
-    public function handle(Affectation $affectation);
+    public function handle(Affectation $affectation, string $uuidSignalement);
 
     public function getServiceName(): string;
 

--- a/src/Service/Interconnection/Esabora/Handler/InterventionVisiteServiceHandler.php
+++ b/src/Service/Interconnection/Esabora/Handler/InterventionVisiteServiceHandler.php
@@ -21,10 +21,10 @@ class InterventionVisiteServiceHandler implements InterventionSISHHandlerInterfa
     /**
      * @throws \Exception
      */
-    public function handle(Affectation $affectation): void
+    public function handle(Affectation $affectation, string $uuidSignalement): void
     {
         $hasDateError = false;
-        $dossierVisiteSISHCollectionResponse = $this->esaboraSISHService->getVisiteDossier($affectation);
+        $dossierVisiteSISHCollectionResponse = $this->esaboraSISHService->getVisiteDossier($affectation, $uuidSignalement);
         if (AbstractEsaboraService::hasSuccess($dossierVisiteSISHCollectionResponse)) {
             foreach ($dossierVisiteSISHCollectionResponse->getCollection() as $dossierVisite) {
                 if (!$dossierVisite->getVisiteDate()) {

--- a/src/Service/Interconnection/JobEventHttpClient.php
+++ b/src/Service/Interconnection/JobEventHttpClient.php
@@ -102,6 +102,7 @@ class JobEventHttpClient implements HttpClientInterface
             signalementId: $jobEventMetaData->getSignalementId(),
             partnerId: $jobEventMetaData->getPartnerId(),
             partnerType: $jobEventMetaData->getPartnerType(),
+            flush: 'esabora' === $jobEventMetaData->getService() ? false : true,
         );
 
         return $response;

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -25,7 +25,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class EsaboraManagerTest extends KernelTestCase
@@ -39,7 +38,6 @@ class EsaboraManagerTest extends KernelTestCase
     private EventDispatcherInterface $eventDispatcher;
     private UserManager $userManager;
     private LoggerInterface $logger;
-    private ParameterBagInterface $parameterBag;
     private ZipHelper $zipHelper;
     private FileScanner $fileScanner;
     private UploadHandlerService $uploadHander;
@@ -58,7 +56,6 @@ class EsaboraManagerTest extends KernelTestCase
         $this->eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $this->userManager = self::getContainer()->get(UserManager::class);
         $this->logger = self::getContainer()->get(LoggerInterface::class);
-        $this->parameterBag = self::getContainer()->get(ParameterBagInterface::class);
         $this->zipHelper = self::getContainer()->get(ZipHelper::class);
         $this->fileScanner = self::getContainer()->get(FileScanner::class);
         $this->uploadHander = self::getContainer()->get(UploadHandlerService::class);
@@ -102,7 +99,6 @@ class EsaboraManagerTest extends KernelTestCase
             $this->eventDispatcher, // @phpstan-ignore-line
             $this->userManager,
             $this->logger,
-            $this->parameterBag,
             $this->entityManager,
             $this->zipHelper,
             $this->fileScanner,
@@ -220,7 +216,6 @@ class EsaboraManagerTest extends KernelTestCase
             $this->eventDispatcher, // @phpstan-ignore-line
             $this->userManager,
             $this->logger,
-            $this->parameterBag,
             $this->entityManager,
             $this->zipHelper,
             $this->fileScanner,

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -26,13 +26,15 @@ class AffectationRepositoryTest extends KernelTestCase
         $affectationRepository = $this->entityManager->getRepository(Affectation::class);
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::ARS);
         $this->assertCount(2, $affectationsSubscribedToEsabora);
-        foreach ($affectationsSubscribedToEsabora as $affectationSubscribedToEsabora) {
+        foreach ($affectationsSubscribedToEsabora as $row) {
+            $affectationSubscribedToEsabora = $row[0];
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }
 
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::COMMUNE_SCHS);
         $this->assertCount(1, $affectationsSubscribedToEsabora);
-        foreach ($affectationsSubscribedToEsabora as $affectationSubscribedToEsabora) {
+        foreach ($affectationsSubscribedToEsabora as $row) {
+            $affectationSubscribedToEsabora = $row[0];
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }
 
@@ -43,6 +45,8 @@ class AffectationRepositoryTest extends KernelTestCase
         );
 
         $this->assertCount(1, $affectationsSubscribedToEsabora);
+        $this->assertInstanceOf(Affectation::class, $affectationsSubscribedToEsabora[0][0]);
+        $this->assertEquals('00000000-0000-0000-2023-000000000012', $affectationsSubscribedToEsabora[0]['uuid']);
     }
 
     public function testUpdateStatusBySignalement(): void

--- a/tests/Functional/Repository/AffectationRepositoryTest.php
+++ b/tests/Functional/Repository/AffectationRepositoryTest.php
@@ -27,14 +27,14 @@ class AffectationRepositoryTest extends KernelTestCase
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::ARS);
         $this->assertCount(2, $affectationsSubscribedToEsabora);
         foreach ($affectationsSubscribedToEsabora as $row) {
-            $affectationSubscribedToEsabora = $row[0];
+            $affectationSubscribedToEsabora = $row['affectation'];
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }
 
         $affectationsSubscribedToEsabora = $affectationRepository->findAffectationSubscribedToEsabora(PartnerType::COMMUNE_SCHS);
         $this->assertCount(1, $affectationsSubscribedToEsabora);
         foreach ($affectationsSubscribedToEsabora as $row) {
-            $affectationSubscribedToEsabora = $row[0];
+            $affectationSubscribedToEsabora = $row['affectation'];
             $this->assertCount(2, $affectationSubscribedToEsabora->getPartner()->getEsaboraCredential());
         }
 
@@ -45,8 +45,8 @@ class AffectationRepositoryTest extends KernelTestCase
         );
 
         $this->assertCount(1, $affectationsSubscribedToEsabora);
-        $this->assertInstanceOf(Affectation::class, $affectationsSubscribedToEsabora[0][0]);
-        $this->assertEquals('00000000-0000-0000-2023-000000000012', $affectationsSubscribedToEsabora[0]['uuid']);
+        $this->assertInstanceOf(Affectation::class, $affectationsSubscribedToEsabora[0]['affectation']);
+        $this->assertEquals('00000000-0000-0000-2023-000000000012', $affectationsSubscribedToEsabora[0]['signalement_uuid']);
     }
 
     public function testUpdateStatusBySignalement(): void

--- a/tests/Unit/Command/Cron/SynchronizeEsaboraSCHSCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeEsaboraSCHSCommandTest.php
@@ -54,7 +54,7 @@ class SynchronizeEsaboraSCHSCommandTest extends KernelTestCase
         $affectationRepositoryMock = $this->createMock(AffectationRepository::class);
 
         $affectations = [
-            [0 => $affectation, 'uuid' => $affectation->getSignalement()->getUuid()],
+            ['affectation' => $affectation, 'signalement_uuid' => $affectation->getSignalement()->getUuid()],
         ];
 
         $affectationRepositoryMock

--- a/tests/Unit/Command/Cron/SynchronizeEsaboraSCHSCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeEsaboraSCHSCommandTest.php
@@ -13,7 +13,6 @@ use App\Service\Interconnection\Esabora\EsaboraSCHSService;
 use App\Service\Interconnection\Esabora\Response\DossierEventsSCHSCollectionResponse;
 use App\Service\Interconnection\Esabora\Response\DossierStateSCHSResponse;
 use App\Service\Mailer\NotificationMailerRegistry;
-use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -54,13 +53,14 @@ class SynchronizeEsaboraSCHSCommandTest extends KernelTestCase
 
         $affectationRepositoryMock = $this->createMock(AffectationRepository::class);
 
-        $collection = (new ArrayCollection());
-        $collection->add($affectation);
+        $affectations = [
+            [0 => $affectation, 'uuid' => $affectation->getSignalement()->getUuid()],
+        ];
 
         $affectationRepositoryMock
             ->expects($this->atLeast(1))
             ->method('findAffectationSubscribedToEsabora')
-            ->willReturn($collection->toArray());
+            ->willReturn($affectations);
 
         $serializerMock = $this->createMock(SerializerInterface::class);
         $notificationMailerRegistry = self::getContainer()->get(NotificationMailerRegistry::class);

--- a/tests/Unit/Command/Cron/SynchronizeEsaboraSISHCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeEsaboraSISHCommandTest.php
@@ -40,7 +40,7 @@ class SynchronizeEsaboraSISHCommandTest extends KernelTestCase
         $affectationRepositoryMock = $this->createMock(AffectationRepository::class);
 
         $affectations = [
-            [0 => $affectation, 'uuid' => $affectation->getUuid()],
+            ['affectation' => $affectation, 'signalement_uuid' => $affectation->getUuid()],
         ];
 
         $affectationRepositoryMock

--- a/tests/Unit/Command/Cron/SynchronizeEsaboraSISHCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeEsaboraSISHCommandTest.php
@@ -10,7 +10,6 @@ use App\Service\Interconnection\Esabora\EsaboraSISHService;
 use App\Service\Interconnection\Esabora\Response\DossierStateSISHResponse;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Tests\FixturesHelper;
-use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -40,13 +39,14 @@ class SynchronizeEsaboraSISHCommandTest extends KernelTestCase
 
         $affectationRepositoryMock = $this->createMock(AffectationRepository::class);
 
-        $collection = (new ArrayCollection());
-        $collection->add($affectation);
+        $affectations = [
+            [0 => $affectation, 'uuid' => $affectation->getUuid()],
+        ];
 
         $affectationRepositoryMock
             ->expects($this->atLeast(1))
             ->method('findAffectationSubscribedToEsabora')
-            ->willReturn($collection->toArray());
+            ->willReturn($affectations);
 
         $serializerMock = $this->createMock(SerializerInterface::class);
         $notificationMailerRegistry = self::getContainer()->get(NotificationMailerRegistry::class);
@@ -61,6 +61,7 @@ class SynchronizeEsaboraSISHCommandTest extends KernelTestCase
             $serializerMock,
             $notificationMailerRegistry,
             $parameterBag,
+            self::getContainer()->get('doctrine')->getManager(),
         ));
 
         $commandTester = new CommandTester($command);

--- a/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
@@ -41,7 +41,7 @@ class SynchronizeInterventionSISHCommandTest extends KernelTestCase
 
         $affectation = $this->getAffectation(PartnerType::ARS);
         $affectations = [
-            [0 => $affectation, 'uuid' => $affectation->getUuid()],
+            ['affectation' => $affectation, 'signalement_uuid' => $affectation->getUuid()],
         ];
         $affectationRepositoryMock
             ->expects($this->atLeast(1))

--- a/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
@@ -12,7 +12,6 @@ use App\Service\Interconnection\Esabora\Handler\InterventionArreteServiceHandler
 use App\Service\Interconnection\Esabora\Handler\InterventionVisiteServiceHandler;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Tests\FixturesHelper;
-use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -40,11 +39,14 @@ class SynchronizeInterventionSISHCommandTest extends KernelTestCase
         $jobEventManagerMock = $this->createMock(JobEventManager::class);
         $jobEventManagerMock->expects($this->once())->method('getRepository')->willReturn($jobEventRepositoryMock);
 
-        $collection = (new ArrayCollection([$this->getAffectation(PartnerType::ARS)]));
+        $affectation = $this->getAffectation(PartnerType::ARS);
+        $affectations = [
+            [0 => $affectation, 'uuid' => $affectation->getUuid()],
+        ];
         $affectationRepositoryMock
             ->expects($this->atLeast(1))
             ->method('findAffectationSubscribedToEsabora')
-            ->willReturn($collection->toArray());
+            ->willReturn($affectations);
 
         $parameterBag = self::getContainer()->get(ParameterBagInterface::class);
         $notificationMailerRegistry = self::getContainer()->get(NotificationMailerRegistry::class);
@@ -58,6 +60,7 @@ class SynchronizeInterventionSISHCommandTest extends KernelTestCase
             $serializerMock,
             $notificationMailerRegistry,
             $parameterBag,
+            self::getContainer()->get('doctrine')->getManager(),
             [$visiteHandler, $arreteHandler],
         ));
 

--- a/tests/Unit/Command/PushEsaboraDossierCommandTest.php
+++ b/tests/Unit/Command/PushEsaboraDossierCommandTest.php
@@ -39,10 +39,9 @@ class PushEsaboraDossierCommandTest extends TestCase
         $affectation1->setIsSynchronized(false);
         $affectation2->setIsSynchronized(false);
 
-        $affectation = $this->getAffectation(PartnerType::ARS);
         $affectations = [
-            [0 => $affectation1, 'uuid' => $affectation1->getUuid()],
-            [0 => $affectation2, 'uuid' => $affectation2->getUuid()],
+            ['affectation' => $affectation1, 'signalement_uuid' => $affectation1->getUuid()],
+            ['affectation' => $affectation2, 'signalement_uuid' => $affectation2->getUuid()],
         ];
 
         $this->territoryRepository
@@ -89,7 +88,7 @@ class PushEsaboraDossierCommandTest extends TestCase
     {
         $affectation = $this->getAffectation(PartnerType::ARS);
         $affectations = [
-            [0 => $affectation, 'uuid' => $affectation->getUuid()],
+            ['affectation' => $affectation, 'signalement_uuid' => $affectation->getUuid()],
         ];
 
         $this->affectationRepository

--- a/tests/Unit/Command/PushEsaboraDossierCommandTest.php
+++ b/tests/Unit/Command/PushEsaboraDossierCommandTest.php
@@ -39,6 +39,12 @@ class PushEsaboraDossierCommandTest extends TestCase
         $affectation1->setIsSynchronized(false);
         $affectation2->setIsSynchronized(false);
 
+        $affectation = $this->getAffectation(PartnerType::ARS);
+        $affectations = [
+            [0 => $affectation1, 'uuid' => $affectation1->getUuid()],
+            [0 => $affectation2, 'uuid' => $affectation2->getUuid()],
+        ];
+
         $this->territoryRepository
             ->expects($this->once())
             ->method('findOneBy')
@@ -54,7 +60,7 @@ class PushEsaboraDossierCommandTest extends TestCase
                 null,
                 (new Territory())->setZip('01')->setIsActive(true)->setName('Ain')
             )
-            ->willReturn([$affectation1, $affectation2]);
+            ->willReturn($affectations);
 
         $this->affectationRepository
             ->expects($this->atMost(3))
@@ -82,6 +88,9 @@ class PushEsaboraDossierCommandTest extends TestCase
     public function testExecuteWithUuidOption(): void
     {
         $affectation = $this->getAffectation(PartnerType::ARS);
+        $affectations = [
+            [0 => $affectation, 'uuid' => $affectation->getUuid()],
+        ];
 
         $this->affectationRepository
             ->expects($this->once())
@@ -91,7 +100,7 @@ class PushEsaboraDossierCommandTest extends TestCase
                 null,
                 $this->equalTo('00000000-0000-0000-2023-000000000010')
             )
-            ->willReturn([$affectation]);
+            ->willReturn($affectations);
 
         $this->affectationRepository
             ->expects($this->atMost(2))

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -23,7 +23,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -40,7 +39,6 @@ class EsaboraManagerTest extends TestCase
     protected MockObject|EventDispatcherInterface $eventDispatcher;
     protected MockObject|UserManager $userManager;
     private MockObject|LoggerInterface $logger;
-    private MockObject|ParameterBagInterface $parameterBag;
     private MockObject|EntityManager $entityManager;
     private MockObject|ZipHelper $zipHelper;
     private MockObject|FileScanner $fileScanner;
@@ -59,7 +57,6 @@ class EsaboraManagerTest extends TestCase
         $this->userManager = $this->createMock(UserManager::class);
         $this->eventDispatcher = new EventDispatcher();
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->parameterBag = $this->createMock(ParameterBagInterface::class);
         $this->entityManager = $this->createMock(EntityManager::class);
         $this->zipHelper = $this->createMock(ZipHelper::class);
         $this->fileScanner = $this->createMock(FileScanner::class);
@@ -99,6 +96,11 @@ class EsaboraManagerTest extends TestCase
             ->expects($this->once())
             ->method('error');
 
+        $this->userManager
+            ->expects($this->once())
+            ->method('getSystemUser')
+            ->willReturn($this->getUser([User::ROLE_ADMIN]));
+
         $esaboraManager = new EsaboraManager(
             $this->affectationManager,
             $this->suiviManager,
@@ -107,7 +109,6 @@ class EsaboraManagerTest extends TestCase
             $this->eventDispatcher, // @phpstan-ignore-line
             $this->userManager,
             $this->logger,
-            $this->parameterBag,
             $this->entityManager,
             $this->zipHelper,
             $this->fileScanner,
@@ -174,7 +175,6 @@ class EsaboraManagerTest extends TestCase
             $this->eventDispatcher, // @phpstan-ignore-line
             $this->userManager,
             $this->logger,
-            $this->parameterBag,
             $this->entityManager,
             $this->zipHelper,
             $this->fileScanner,

--- a/tests/Unit/Service/Esabora/EsaboraSCHSServiceTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraSCHSServiceTest.php
@@ -77,8 +77,10 @@ class EsaboraSCHSServiceTest extends KernelTestCase
 
         $mockHttpClient = new MockHttpClient($mockResponse);
         $esaboraService = new EsaboraSCHSService($mockHttpClient, $this->logger, $this->uploadHandlerService);
+        $affectation = $this->getAffectation(PartnerType::COMMUNE_SCHS);
         $dossierResponse = $esaboraService->getStateDossier(
-            $this->getAffectation(PartnerType::COMMUNE_SCHS)
+            $affectation,
+            $affectation->getSignalement()->getUuid()
         );
 
         $this->assertInstanceOf(DossierStateSCHSResponse::class, $dossierResponse);
@@ -95,8 +97,10 @@ class EsaboraSCHSServiceTest extends KernelTestCase
         });
 
         $esaboraService = new EsaboraSCHSService($mockHttpClient, $this->logger, $this->uploadHandlerService);
+        $affectation = $this->getAffectation(PartnerType::COMMUNE_SCHS);
         $dossierResponse = $esaboraService->getStateDossier(
-            $this->getAffectation(PartnerType::COMMUNE_SCHS)
+            $affectation,
+            $affectation->getSignalement()->getUuid()
         );
         $this->assertEquals(Response::HTTP_SERVICE_UNAVAILABLE, $dossierResponse->getStatusCode());
     }
@@ -131,8 +135,10 @@ class EsaboraSCHSServiceTest extends KernelTestCase
 
         $mockHttpClient = new MockHttpClient([$mockResponse, $mockResponseEventFiles]);
         $esaboraService = new EsaboraSCHSService($mockHttpClient, $this->logger, $this->uploadHandlerService);
+        $affectation = $this->getAffectation(PartnerType::COMMUNE_SCHS);
         $dossierEvents = $esaboraService->getDossierEvents(
-            $this->getAffectation(PartnerType::COMMUNE_SCHS)
+            $affectation,
+            $affectation->getSignalement()->getUuid(),
         );
         $this->assertEquals('27207', $dossierEvents->getSearchId());
         $affectation = $this->getAffectation(PartnerType::COMMUNE_SCHS);

--- a/tests/Unit/Service/Esabora/EsaboraSISHServiceTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraSISHServiceTest.php
@@ -72,8 +72,8 @@ class EsaboraSISHServiceTest extends KernelTestCase
 
         $mockHttpClient = new MockHttpClient($mockResponse);
         $esaboraService = new EsaboraSISHService($mockHttpClient, $this->logger, $this->uploadHandlerService);
-
-        $dossierStateSISHResponse = $esaboraService->getStateDossier($this->getAffectation(PartnerType::ARS));
+        $affectation = $this->getAffectation(PartnerType::ARS);
+        $dossierStateSISHResponse = $esaboraService->getStateDossier($affectation, $affectation->getSignalement()->getUuid());
 
         $this->assertEquals(200, $dossierStateSISHResponse->getStatusCode());
         $this->assertNull($dossierStateSISHResponse->getErrorReason());
@@ -86,7 +86,8 @@ class EsaboraSISHServiceTest extends KernelTestCase
 
         $mockHttpClient = new MockHttpClient($mockResponse);
         $esaboraService = new EsaboraSISHService($mockHttpClient, $this->logger, $this->uploadHandlerService);
-        $dossierVisiteSISHCollectionResponse = $esaboraService->getVisiteDossier($this->getAffectation(PartnerType::ARS));
+        $affectation = $this->getAffectation(PartnerType::ARS);
+        $dossierVisiteSISHCollectionResponse = $esaboraService->getVisiteDossier($affectation, $affectation->getSignalement()->getUuid());
 
         $this->assertEquals(200, $dossierVisiteSISHCollectionResponse->getStatusCode());
         $this->assertNull($dossierVisiteSISHCollectionResponse->getErrorReason());
@@ -100,7 +101,8 @@ class EsaboraSISHServiceTest extends KernelTestCase
 
         $mockHttpClient = new MockHttpClient($mockResponse);
         $esaboraService = new EsaboraSISHService($mockHttpClient, $this->logger, $this->uploadHandlerService);
-        $dossierArreteSISHCollectionResponse = $esaboraService->getArreteDossier($this->getAffectation(PartnerType::ARS));
+        $affectation = $this->getAffectation(PartnerType::ARS);
+        $dossierArreteSISHCollectionResponse = $esaboraService->getArreteDossier($affectation, $affectation->getSignalement()->getUuid());
 
         $this->assertEquals(200, $dossierArreteSISHCollectionResponse->getStatusCode());
         $this->assertNull($dossierArreteSISHCollectionResponse->getErrorReason());

--- a/tests/Unit/Service/Esabora/Handler/InterventionArreteServiceHandlerTest.php
+++ b/tests/Unit/Service/Esabora/Handler/InterventionArreteServiceHandlerTest.php
@@ -62,7 +62,7 @@ class InterventionArreteServiceHandlerTest extends TestCase
             $this->esaboraManager,
         );
 
-        $this->handler->handle($this->affectation);
+        $this->handler->handle($this->affectation, $this->affectation->getSignalement()->getUuid());
         $this->assertEquals(1, $this->handler->getCountSuccess());
         $this->assertEquals(0, $this->handler->getCountFailed());
     }

--- a/tests/Unit/Service/Esabora/Handler/InterventionVisiteServiceHandlerTest.php
+++ b/tests/Unit/Service/Esabora/Handler/InterventionVisiteServiceHandlerTest.php
@@ -87,7 +87,7 @@ class InterventionVisiteServiceHandlerTest extends TestCase
             $this->esaboraManager,
         );
 
-        $this->handler->handle($this->affectation);
+        $this->handler->handle($this->affectation, $this->affectation->getSignalement()->getUuid());
         $this->assertEquals(1, $this->handler->getCountSuccess());
         $this->assertEquals(0, $this->handler->getCountFailed());
     }


### PR DESCRIPTION
## Ticket

#4051

## Description
Optimisation des commandes de synchronisation Esabora via la réduction du nombre de requêtes et du nombre de flush opérés. 

La synchro SISH tourne actuellement sur un peu plus de 7000 affectations 
Test en condition réelle sur les 1000 première  : durée environ 15 minutes. (dont 99% de temps appel API)
![esabora-sish-x1000-v2-15minutes](https://github.com/user-attachments/assets/783f31fc-b4ae-4524-b742-956b141b3e97)

Test en condition réelle sur les 1000 première en version précédente  : durée environ 23 minutes. (+50%)
![Screenshot 2025-05-06 at 16-03-22 Symfony Profiler](https://github.com/user-attachments/assets/469cb818-14c4-44d0-a8e1-5b4ecccbc96c)

Les performances s’applique sur les différente commandes : 
`app:sync-esabora-sish`
`app:sync-esabora-schs`
`app:sync-esabora-sish-intervention`

Ajout d'un index au passage, permettant de faire passer la requête `findExistingEventsForSCHS` de quelque seconde a quelque micro secondes

## Pré-requis
`make execute-migration name=Version20250506093843 direction=up`

## Tests
- [ ] S'assurer que les différente commande de synchronisation esabora fonctionne correctement
