### PR TITLE
[ProConnect] Limiter la récupération aux données essentiels (sub, uid, email) 

### DIFF
--- a/src/Service/Gouv/ProConnect/Model/ProConnectUser.php
+++ b/src/Service/Gouv/ProConnect/Model/ProConnectUser.php
@@ -9,22 +9,18 @@ class ProConnectUser
     public string $uid;
     public string $sub;
     public string $email;
-    public string $givenName;
-    public string $usualName;
 
     /**
      * @throws \Exception
      */
     public function __construct(array $data)
     {
-        if (!isset($data['sub'], $data['uid'], $data['email'], $data['given_name'], $data['usual_name'])) {
+        if (!isset($data['sub'], $data['uid'], $data['email'])) {
             throw new ProConnectException('Les informations de l\'utilisateur ProConnect sont incomplètes');
         }
 
         $this->sub = $data['sub'];
         $this->uid = $data['uid'];
         $this->email = $data['email'];
-        $this->givenName = $data['given_name'];
-        $this->usualName = $data['usual_name'];
     }
 }

--- a/src/Service/Gouv/ProConnect/Request/AuthorizationRequest.php
+++ b/src/Service/Gouv/ProConnect/Request/AuthorizationRequest.php
@@ -11,7 +11,7 @@ class AuthorizationRequest
         public string $nonce,
         public string $responseType = 'code',
         public string $acrValues = 'eidas1',
-        public string $scope = 'openid given_name usual_name email uid',
+        public string $scope = 'openid email uid',
     ) {
     }
 

--- a/tests/Functional/Controller/Security/ProConnectControllerTest.php
+++ b/tests/Functional/Controller/Security/ProConnectControllerTest.php
@@ -34,9 +34,6 @@ class ProConnectControllerTest extends WebTestCase
             'uid' => '1234',
             'sub' => '1234',
             'email' => 'test@proconnect.fr',
-            'given_name' => 'Jean',
-            'family_name' => 'Dupont',
-            'usual_name' => 'JD',
         ]);
 
         /** @var \Doctrine\ORM\EntityManagerInterface $em */

--- a/tests/Unit/Service/Gouv/ProConnect/ProConnectAuthenticationTest.php
+++ b/tests/Unit/Service/Gouv/ProConnect/ProConnectAuthenticationTest.php
@@ -64,8 +64,6 @@ class ProConnectAuthenticationTest extends KernelTestCase
             'sub' => '1234',
             'uid' => '1234',
             'email' => 'proconnect@signal-logement.fr',
-            'given_name' => 'Proconnect',
-            'usual_name' => 'Proconnect',
         ];
         $httpClient
             ->expects(self::once())
@@ -90,8 +88,6 @@ class ProConnectAuthenticationTest extends KernelTestCase
         $user = $proConnectAuthentication->authenticateFromCallback(new CallbackRequest('valid_code', 'valid_state'));
         $this->assertSame('1234', $user->uid);
         $this->assertSame('proconnect@signal-logement.fr', $user->email);
-        $this->assertSame('Proconnect', $user->givenName);
-        $this->assertSame('Proconnect', $user->usualName);
     }
 
     /**

--- a/tests/Unit/Service/Gouv/ProConnect/ProConnectJwtParserTest.php
+++ b/tests/Unit/Service/Gouv/ProConnect/ProConnectJwtParserTest.php
@@ -25,11 +25,5 @@ class ProConnectJwtParserTest extends TestCase
 
         $this->assertArrayHasKey('uid', $claims);
         $this->assertSame('7855', $claims['uid']);
-
-        $this->assertArrayHasKey('given_name', $claims);
-        $this->assertSame('Proconnect', $claims['given_name']);
-
-        $this->assertArrayHasKey('family_name', $claims);
-        $this->assertSame('P', $claims['family_name']);
     }
 }


### PR DESCRIPTION
## Ticket

#4050    

## Description
Ne pas récupérer ces infos car il ne seront pas envoyé

## Changements apportés
* Supprimer la récupérations des données inutiles

## Pré-requis
```
make mock-stop && make mock-start
````
## Tests
- [ ] Se connecter avec ProConnect Mock (ça suffira)