### PR TITLE
[Import - Grille affectation] Prise en compte partenaire déjà existant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,13 @@ help:
 	@grep -E '(^[a-zA-Z0-9_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}{printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
 
 ## Service management
-build: ## Install local environement
-	@bash -l -c 'make .check .env .destroy .setup run .sleep composer create-db npm-install npm-build mock-stop mock-start'
-
+build: ## Install local environment (use SKIP_NPM_BUILD=1 to skip npm-build step)
+	@if [ "$(SKIP_NPM_BUILD)" = "1" ]; then \
+		echo "Skipping npm-build step"; \
+		bash -l -c 'make .check .env .destroy .setup run .sleep composer create-db create-db-test npm-install mock-stop mock-start'; \
+	else \
+		bash -l -c 'make .check .env .destroy .setup run .sleep composer create-db create-db-test npm-install npm-build mock-stop mock-start'; \
+	fi
 run: ## Start containers
 	@echo -e '\e[1;32mStart containers\032'
 	@bash -l -c '$(DOCKER_COMP) up -d'

--- a/src/Command/ImportGridAffectationCommand.php
+++ b/src/Command/ImportGridAffectationCommand.php
@@ -11,6 +11,7 @@ use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\UploadHandlerService;
+use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -28,20 +29,20 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 )]
 class ImportGridAffectationCommand extends Command
 {
-    private const PARAM_TERRITORY_ZIP = 'territory_zip';
-    private const PARAM_IGNORE_NOTIFICATION_ALL_PARTNER = 'ignore-notification-all';
-    private const PARAM_IGNORE_NOTIFICATION_PARTNER = 'ignore-notification-partners';
-    private const PARAM_FILE_VERSION = 'file-version';
+    private const string PARAM_TERRITORY_ZIP = 'territory_zip';
+    private const string PARAM_IGNORE_NOTIFICATION_ALL_PARTNER = 'ignore-notification-all';
+    private const string PARAM_IGNORE_NOTIFICATION_PARTNER = 'ignore-notification-partners';
+    private const string PARAM_FILE_VERSION = 'file-version';
 
     public function __construct(
-        private FilesystemOperator $fileStorage,
-        private ParameterBagInterface $parameterBag,
-        private CsvParser $csvParser,
-        private TerritoryManager $territoryManager,
-        private GridAffectationLoader $gridAffectationLoader,
-        private UploadHandlerService $uploadHandlerService,
-        private NotificationMailerRegistry $notificationMailerRegistry,
-        private UrlGeneratorInterface $urlGenerator,
+        private readonly FilesystemOperator $fileStorage,
+        private readonly ParameterBagInterface $parameterBag,
+        private readonly CsvParser $csvParser,
+        private readonly TerritoryManager $territoryManager,
+        private readonly GridAffectationLoader $gridAffectationLoader,
+        private readonly UploadHandlerService $uploadHandlerService,
+        private readonly NotificationMailerRegistry $notificationMailerRegistry,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
         parent::__construct();
     }
@@ -69,6 +70,9 @@ class ImportGridAffectationCommand extends Command
         ;
     }
 
+    /**
+     * @throws FilesystemException
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
@@ -180,6 +184,9 @@ class ImportGridAffectationCommand extends Command
         return Command::SUCCESS;
     }
 
+    /**
+     * @throws FilesystemException
+     */
     private function canExecute(
         SymfonyStyle $io,
         bool $isModeUpdate,

--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -65,6 +65,7 @@ class GridAffectationLoader
 
     /**
      * @param array<array<string, mixed>> $data Un tableau de données du fichier CSV à valider
+     *
      * @return string[] Liste des messages d'erreur
      */
     public function validate(array $data, Territory $territory, bool $isModeUpdate = false): array
@@ -212,8 +213,8 @@ class GridAffectationLoader
     }
 
     /**
-     * @param array<array<string, mixed>> $data Un tableau de données du fichier CSV
-     * @param string[] $ignoreNotifPartnerTypes
+     * @param array<array<string, mixed>> $data                    Un tableau de données du fichier CSV
+     * @param string[]                    $ignoreNotifPartnerTypes
      */
     public function load(
         Territory $territory,
@@ -346,11 +347,13 @@ class GridAffectationLoader
 
     /**
      * @param string[] $emails Liste des emails à vérifier
+     *
      * @return array<string, int> Tableau associatif des emails en doublon
      */
     private function checkIfDuplicates(array $emails): array
     {
         $occurrencesEmails = array_count_values($emails);
+
         return array_filter($occurrencesEmails, function ($value) {
             return $value > 1;
         });


### PR DESCRIPTION
## Ticket

#4058   

## Description
Ne pas créer le partenaire quand il existe en base

## Changements apportés
* Mise à jour `GridAffectationLoader`

## Pré-requis
```
 update territory set is_active = 0 where id=27;
```

## Tests
- [ ] Exécuter  `make console app="import-grid-affectation 26"` et vérifier que tout s'est bien passé avec ARS, DDETS, CAF
- [ ] Exécuter  `make console app="import-grid-affectation 26 --file-version=1"` et vérifier qu'aucun partenaire en doublon s'est crée dont ARS, DDETS, CAF
