### PR TITLE
[BO - Interconnexion SI-SH] Ajouter date et partenaire (nom agent + nom partenaire) au suivi 

### DIFF
--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -42,27 +42,27 @@ class Suivi implements EntityHistoryInterface
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    private $createdAt;
+    private ?\DateTimeImmutable $createdAt = null;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'suivis')]
     #[ORM\JoinColumn(nullable: true)]
-    private $createdBy;
+    private ?User $createdBy = null;
 
     #[ORM\Column(type: 'text')]
-    private $description;
+    private ?string $description = null;
 
     #[ORM\Column(type: 'boolean')]
-    private $isPublic;
+    private ?bool $isPublic = null;
 
     #[ORM\Column(type: 'integer')]
-    private $type;
+    private ?int $type = null;
 
     #[ORM\ManyToOne(targetEntity: Signalement::class, inversedBy: 'suivis')]
     #[ORM\JoinColumn(nullable: false)]
-    private Signalement $signalement;
+    private ?Signalement $signalement = null;
 
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $context = null;
@@ -70,11 +70,11 @@ class Suivi implements EntityHistoryInterface
     private bool $sendMail = true;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
-    private $deletedAt;
+    private ?\DateTimeImmutable $deletedAt = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: true)]
-    private $deletedBy;
+    private ?User $deletedBy = null;
 
     #[ORM\Column(nullable: true)]
     private ?array $originalData = null;

--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -250,7 +250,10 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
     {
         $suivis = $this->suiviRepository->findAllSuiviBy($signalement, Suivi::TYPE_PARTNER);
         $cleanedSuivis = array_map(function (Suivi $suivi) {
-            return HtmlCleaner::clean($suivi->getDescription(false));
+            $mention = 'Par '.$suivi->getCreatedByLabel().', le '.$suivi->getCreatedAt()->format('d/m/Y');
+            $cleanSuivi = HtmlCleaner::clean($suivi->getDescription(false));
+
+            return $mention.\PHP_EOL.$cleanSuivi;
         }, $suivis);
         $separator = str_repeat('-', 50);
 

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -148,16 +148,24 @@ trait FixturesHelper
             ->setType(Suivi::TYPE_PARTNER)
             ->setDescription($description)
             ->setCreatedAt(new \DateTimeImmutable())
-            ->setCreatedBy(new User());
+            ->setCreatedBy($this->getUser([User::ROLE_USER_PARTNER]));
     }
 
     public function getSuiviPartnerList(): array
     {
         return [
-            $this->getSuiviPartner('Problèmes de condensation et de moisissure'),
-            $this->getSuiviPartner('Problèmes d\'humidité dans le logement'),
-            $this->getSuiviPartner('Absence de chauffage'),
-            $this->getSuiviPartner('Ventilation défectueuse'),
+            $this
+                ->getSuiviPartner('Problèmes de condensation et de moisissure')
+                ->setSignalement($this->getSignalement($this->getTerritory())),
+            $this
+                ->getSuiviPartner('Problèmes d\'humidité dans le logement')
+                ->setSignalement($this->getSignalement($this->getTerritory())),
+            $this
+                ->getSuiviPartner('Absence de chauffage')
+                ->setSignalement($this->getSignalement($this->getTerritory())),
+            $this
+                ->getSuiviPartner('Ventilation défectueuse')
+                ->setSignalement($this->getSignalement($this->getTerritory())),
         ];
     }
 

--- a/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
@@ -74,7 +74,11 @@ class DossierMessageSISHFactoryTest extends TestCase
         $this->assertNotNull($dossierMessage->getLocalisationVille());
         $this->assertEquals('H', $dossierMessage->getSasLogicielProvenance());
         $this->assertEquals(75, $dossierMessage->getSitLogementSuperficie());
-        $this->assertCount(4, explode(\PHP_EOL.str_repeat('-', 50).\PHP_EOL, $dossierMessage->getSignalementCommentaire()));
+        $suivis = explode(\PHP_EOL.str_repeat('-', 50).\PHP_EOL, $dossierMessage->getSignalementCommentaire());
+        foreach ($suivis as $suivi) {
+            $this->assertStringContainsString('Par ARS : John Doe, le', $suivi);
+        }
+        $this->assertCount(4, $suivis);
         $this->assertEquals(
             AbstractEsaboraService::SIGNALEMENT_ORIGINE,
             $dossierMessage->getSignalementOrigine()


### PR DESCRIPTION
## Ticket

#4062   

## Description
Suite à #4040 il manque la personne (dont le nom du partenaire) qui a soumis le commentaire et la date 

## Changements apportés
* Ajout typage Suivi 
* Ajout des infos partenaire via la méthode `getCreatedByLabel` déjà existantes

## Pré-requis
``` 
make mock-stop && make mock-start
make worker-stop && make worker-start
```

## Tests
- [ ] Se connecter en tant qu'agent du signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012
- [ ] Ajouter plusieurs suivis partenaire sur ce signalement 
- [ ] Se connecter en tant que RT13 ou Super Admin, désaffecter puis réaffecter le partenaire ARS afin de déclencher l'envoi.
- [ ] Vérifier dans la table job_event que les commentaires sont bien séparé par des tiret et saut de ligne

![image](https://github.com/user-attachments/assets/688a69c0-371d-46d4-bc10-ce62012839b8)
