### PR TITLE
[Albert API] Correction des reqûetes et modèles proposés

### DIFF
--- a/src/Form/SuiviSummariesType.php
+++ b/src/Form/SuiviSummariesType.php
@@ -67,13 +67,9 @@ class SuiviSummariesType extends AbstractType
             // Commented languages are listed in Albert doc, but don't work when used
             ->add('model', ChoiceType::class, [
                 'choices' => [
-                    'meta-llama/Meta-Llama-3.1-8B-Instruct' => 'meta-llama/Meta-Llama-3.1-8B-Instruct',
-                    // 'mistralai/Mixtral-8x7B-Instruct-v0.1' => 'mistralai/Mixtral-8x7B-Instruct-v0.1',
-                    'AgentPublic/llama3-instruct-8b' => 'AgentPublic/llama3-instruct-8b',
-                    // 'BAAI/bge-m3' => 'BAAI/bge-m3',
-                    'AgentPublic/llama3-instruct-guillaumetell' => 'AgentPublic/llama3-instruct-guillaumetell',
-                    // 'intfloat/multilingual-e5-large' => 'intfloat/multilingual-e5-large',
-                    'google/gemma-2-9b-it' => 'google/gemma-2-9b-it',
+                    'albert-large' => 'albert-large',
+                    'albert-small' => 'albert-small',
+                    'neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8' => 'neuralmagic/Meta-Llama-3.1-70B-Instruct-FP8',
                 ],
                 'placeholder' => 'Choisissez un modèle de langage',
                 'multiple' => false,

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1504,7 +1504,7 @@ class SignalementRepository extends ServiceEntityRepository
         $statement = $connexion->prepare($sql);
 
         return $statement->executeQuery([
-            'statusSignalement' => SignalementStatus::ACTIVE,
+            'statusSignalement' => SignalementStatus::ACTIVE->value,
             'territoryId' => $territory->getId(),
             'suiviTypeTechnical' => Suivi::TYPE_TECHNICAL,
             'suiviTypeUsager' => Suivi::TYPE_USAGER,
@@ -1534,7 +1534,7 @@ class SignalementRepository extends ServiceEntityRepository
         $statement = $connexion->prepare($sql);
 
         return $statement->executeQuery([
-            'statusSignalement' => SignalementStatus::ACTIVE,
+            'statusSignalement' => SignalementStatus::ACTIVE->value,
             'territoryId' => $territory->getId(),
             'suiviTypePartner' => Suivi::TYPE_PARTNER,
             'nbDays' => $nbDays,

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -205,4 +205,24 @@ class SignalementRepositoryTest extends KernelTestCase
         yield 'Search all for user partner multi territories' => ['user-partenaire-multi-ter-34-30@signal-logement.fr', [], 2];
         yield 'Search in Hérault for user partner multi territories' => ['user-partenaire-multi-ter-34-30@signal-logement.fr', ['territories' => 35], 1];
     }
+
+    public function testfindSignalementsLastSuiviWithSuiviAuto(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
+
+        $signalements = $signalementRepository->findSignalementsLastSuiviWithSuiviAuto($territory, 10);
+        $this->assertCount(0, $signalements);
+    }
+
+    public function testfindSignalementsLastSuiviByPartnerOlderThan(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
+
+        $signalements = $signalementRepository->findSignalementsLastSuiviByPartnerOlderThan($territory, 10, 0);
+        $this->assertCount(2, $signalements);
+    }
 }


### PR DESCRIPTION
## Ticket

#4043

## Description
- Correction de la liste des modèles proposé par l'API Albert (qui ont évolué)
- Correction des requêtes pour récupérer les suivies a résumé (KO depuis la mise en place de l'enum `SignalementStatus`
- Ajout de tests sur ces reqûetes

## Pré-requis
- Modifier la clé Albert API dans la var d'env `ALBERT_API_KEY` (voir mattermost)

## Tests
- [ ] Tester un résumé de suivi
