### PR TITLE
[ProConnect] Déconnexion - Ne pas appeler ProConnect pour un utilisateur ProConnect connecté via login/mot de passe

### DIFF
--- a/tests/Unit/EventSubscriber/LogoutSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/LogoutSubscriberTest.php
@@ -30,6 +30,11 @@ class LogoutSubscriberTest extends TestCase
 
         $request = new Request();
         $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('has')
+            ->with('proconnect_id_token')
+            ->willReturn(true);
         $request->setSession($session);
 
         $event = new LogoutEvent($request, $token);


### PR DESCRIPTION
## Ticket

#4067    

## Description
Appeler la déconnexion ProConnect s'il a une session ProConnect en cours

## Changements apportés
* Vérifier l'existence de la session ProConnect 

## Pré-requis
Test avec mock 
```
make mock-stop && make mock-start
```
Pour TNR avec le vrai service mettre à jour les variables d'environnements

## Tests
- [ ] Se Connecter avec utilisateur ProConnect pour avoir l'id proconnect et se déconnecter 
- [ ] Se Connecter avec ce même utilisateur mais avec login mot de passe et vérifier qu'il n’ait pas d'erreur dans les logs `tail -f var/log/dev.log | grep "ERROR"`
