### PR TITLE
[FO - Signalement] Bloquage de la création de signalement quand il existe un doublon de moins de 3 mois

### DIFF
--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -227,6 +227,7 @@ export default defineComponent({
           const link = document.getElementById('fr-modal-already-exists-button')
           formStore.alreadyExists.type = requestResponse.type
           formStore.alreadyExists.signalements = requestResponse.signalements
+          formStore.alreadyExists.hasCreatedRecently = requestResponse.has_created_recently
           formStore.alreadyExists.createdAt = requestResponse.created_at
           formStore.alreadyExists.updatedAt = requestResponse.updated_at
           formStore.alreadyExists.draftExists = requestResponse.draft_exists

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormModalAlreadyExists.vue
@@ -7,9 +7,21 @@
             <div class="fr-modal__header">
               <button type="button" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-already-exists" id="fr-modal-already-exists-close">Fermer</button>
             </div>
-            <div class="fr-modal__content" v-if="formStore.alreadyExists.type==='signalement'">
-              <h1 id="fr-modal-title-modal-already-exists" class="fr-modal__title"><span v-if="formStore.alreadyExists.signalements?.length === 1">Ce signalement existe déjà</span><span v-else>Ces signalements existent déjà</span></h1>
-              <div v-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.alreadyExists.signalements?.length === 1">
+            <div class="fr-modal__content" v-if="formStore.alreadyExists.type === 'signalement'">
+              <h1 id="fr-modal-title-modal-already-exists" class="fr-modal__title">
+                <span v-if="formStore.alreadyExists.signalements?.length === 1">Ce signalement existe déjà</span>
+                <span v-else>Ces signalements existent déjà</span>
+              </h1>
+              <div v-if="formStore.alreadyExists.hasCreatedRecently">
+                <p>
+                  Un signalement existe déjà et est déjà en cours de traitement par les services.
+                  Pour compléter votre dossier ou demander des informations merci de laisser un message directement sur votre page de suivi.
+                </p>
+                <p>
+                  Pour récupérer le lien vers votre page de suivi, cliquez sur le bouton ci-dessous.
+                </p>
+              </div>
+              <div v-else-if="formStore.data.profil === 'bailleur_occupant' || formStore.data.profil === 'locataire' || formStore.alreadyExists.signalements?.length === 1">
                 Il semblerait que vous ayez déjà déposé un signalement pour le logement situé <strong>{{ formStore.data.adresse_logement_adresse }}</strong><div class=""></div>
                 <span v-if="formStore.data.profil !== 'bailleur_occupant' && formStore.data.profil !== 'locataire' && formStore.alreadyExists.signalements" v-html="signalementLabel(formStore.alreadyExists.signalements[0])"></span>
                 Ce signalement est en cours de traitement.<br>
@@ -51,6 +63,7 @@
                 Souhaitez-vous compléter le signalement sélectionné ou en créer un nouveau ?
               </div>
               <SignalementFormWarning
+                v-if="!formStore.alreadyExists.hasCreatedRecently"
                 id="fr-modal-already-exists-info"
                 label="Créer un nouveau signalement pour le même logement risque de ralentir la procédure."
               >
@@ -85,7 +98,7 @@
                     Recevoir mon lien de suivi
                   </button>
                 </li>
-                <li>
+                <li v-if="!formStore.alreadyExists.hasCreatedRecently">
                   <button
                     :class="[ 'fr-btn fr-btn--secondary', isButtonClicked ? 'fr-btn--loading fr-btn--icon-right fr-icon-refresh-line' : '' ]"
                     aria-controls="fr-modal-already-exists"

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -52,6 +52,7 @@ interface FormStore {
     type: string | null
     uuid: string | null
     signalements: any[] | null
+    hasCreatedRecently: boolean | null
     draftExists: boolean | null
     createdAt: string | null
     updatedAt: string | null
@@ -97,6 +98,7 @@ const formStore: FormStore = reactive({
     uuid: null,
     type: null,
     signalements: null,
+    hasCreatedRecently: null,
     draftExists: null,
     createdAt: null,
     updatedAt: null

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1210,6 +1210,8 @@ class SignalementRepository extends ServiceEntityRepository
             return [];
         }
 
+        $city = CommuneHelper::getCommuneFromArrondissement($city);
+
         $qb = $this->createQueryBuilder('s');
         if ($isTiersDeclarant) {
             $qb->andWhere('s.mailDeclarant = :email')->setParameter('email', $email);

--- a/src/Service/Signalement/SignalementDuplicateChecker.php
+++ b/src/Service/Signalement/SignalementDuplicateChecker.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Service\Signalement;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Signalement;
+use App\Manager\SignalementDraftManager;
+use App\Repository\SignalementRepository;
+
+class SignalementDuplicateChecker
+{
+    private const NB_DAYS_RECENTLY_CREATED_SIGNALEMENT = 90;
+
+    public function __construct(
+        private readonly SignalementDraftManager $signalementDraftManager,
+        private readonly SignalementRepository $signalementRepository,
+    ) {
+    }
+
+    public function check(SignalementDraftRequest $signalementDraftRequest): array
+    {
+        $isTiersDeclarant = SignalementDraftHelper::isTiersDeclarant($signalementDraftRequest);
+        $existingSignalements = $this->signalementRepository->findAllForEmailAndAddress(
+            SignalementDraftHelper::getEmailDeclarant($signalementDraftRequest),
+            $signalementDraftRequest->getAdresseLogementAdresseDetailNumero(),
+            $signalementDraftRequest->getAdresseLogementAdresseDetailCodePostal(),
+            $signalementDraftRequest->getAdresseLogementAdresseDetailCommune(),
+            $isTiersDeclarant
+        );
+
+        $existingSignalementDraft = $this->signalementDraftManager->findSignalementDraftByAddressAndMail(
+            $signalementDraftRequest,
+        );
+
+        if (!empty($existingSignalements)) {
+            $signalements = array_map(function (Signalement $existingSignalement) {
+                $todayDate = new \DateTimeImmutable();
+                $durationSinceCreated = $todayDate->diff($existingSignalement->getCreatedAt());
+
+                return [
+                    'uuid' => $existingSignalement->getUuid(),
+                    'created_at' => $existingSignalement->getCreatedAt(),
+                    'has_created_recently' => ($durationSinceCreated->days <= self::NB_DAYS_RECENTLY_CREATED_SIGNALEMENT),
+                    'prenom_occupant' => $existingSignalement->getPrenomOccupant(),
+                    'nom_occupant' => $existingSignalement->getNomOccupant(),
+                    'complement_adresse_occupant' => $existingSignalement->getComplementAdresseOccupant(),
+                ];
+            }, $existingSignalements);
+
+            $hasCreatedRecently = false;
+            foreach ($signalements as $signalement) {
+                $hasCreatedRecently = $hasCreatedRecently || $signalement['has_created_recently'];
+            }
+
+            return [
+                'already_exists' => true,
+                'type' => 'signalement',
+                'signalements' => $signalements,
+                'has_created_recently' => $hasCreatedRecently,
+                'draft_exists' => (bool) $existingSignalementDraft,
+            ];
+        }
+
+        if (null !== $existingSignalementDraft) {
+            return [
+                'already_exists' => true,
+                'type' => 'draft',
+                'draft_exists' => true,
+                'created_at' => $existingSignalementDraft->getCreatedAt(),
+                'updated_at' => $existingSignalementDraft->getUpdatedAt(),
+            ];
+        }
+
+        return [
+            'already_exists' => false,
+            'uuid' => 'waiting_creation',
+        ];
+    }
+}

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Tests\Functional\Controller;
 
-use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\SignalementDraftStatus;
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Signalement;
@@ -296,39 +295,6 @@ class SignalementControllerTest extends WebTestCase
 
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
     }
-
-    /*
-    public function testCheckSignalementOrDraftAlreadyExistsOld(): void
-    {
-        $client = static::createClient();
-
-        /** @var RouterInterface $router *
-        $router = self::getContainer()->get(RouterInterface::class);
-        $url = $router->generate('check_signalement_or_draft_already_exists');
-
-        /** @var EntityManagerInterface $entityManager *
-        $entityManager = self::getContainer()->get('doctrine');
-        /** @var Signalement $signalement *
-        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy([
-            'uuid' => '00000000-0000-0000-2022-000000000008',
-        ]);
-
-        $payloadLocataireSignalement = file_get_contents(__DIR__.'../../../files/post_signalement_draft_payload.json');
-        
-        $payloadLocataireSignalementDecoded = json_decode($payloadLocataireSignalement);
-        $payloadLocataireSignalementDecoded->profil = ProfileDeclarant::LOCATAIRE->name;
-        $payloadLocataireSignalementDecoded->adresse_logement_adresse_detail_numero = $signalement->getAdresseOccupant();
-        $payloadLocataireSignalementDecoded->adresse_logement_adresse_detail_code_postal = $signalement->getCpOccupant();
-        $payloadLocataireSignalementDecoded->adresse_logement_adresse_detail_commune = $signalement->getVilleOccupant();
-        $payloadLocataireSignalementDecoded->vos_coordonnees_occupant_email = $signalement->getMailOccupant();
-
-        $client->request('POST', $url, [], [], [], json_encode($payloadLocataireSignalement));
-
-        $content = $client->getResponse()->getContent();
-        dd($content);
-
-        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-    }*/
 
     public function provideSignalementRequestPayload(): \Generator
     {

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller;
 
+use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\SignalementDraftStatus;
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Signalement;
@@ -295,6 +296,39 @@ class SignalementControllerTest extends WebTestCase
 
         $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
     }
+
+    /*
+    public function testCheckSignalementOrDraftAlreadyExistsOld(): void
+    {
+        $client = static::createClient();
+
+        /** @var RouterInterface $router *
+        $router = self::getContainer()->get(RouterInterface::class);
+        $url = $router->generate('check_signalement_or_draft_already_exists');
+
+        /** @var EntityManagerInterface $entityManager *
+        $entityManager = self::getContainer()->get('doctrine');
+        /** @var Signalement $signalement *
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy([
+            'uuid' => '00000000-0000-0000-2022-000000000008',
+        ]);
+
+        $payloadLocataireSignalement = file_get_contents(__DIR__.'../../../files/post_signalement_draft_payload.json');
+        
+        $payloadLocataireSignalementDecoded = json_decode($payloadLocataireSignalement);
+        $payloadLocataireSignalementDecoded->profil = ProfileDeclarant::LOCATAIRE->name;
+        $payloadLocataireSignalementDecoded->adresse_logement_adresse_detail_numero = $signalement->getAdresseOccupant();
+        $payloadLocataireSignalementDecoded->adresse_logement_adresse_detail_code_postal = $signalement->getCpOccupant();
+        $payloadLocataireSignalementDecoded->adresse_logement_adresse_detail_commune = $signalement->getVilleOccupant();
+        $payloadLocataireSignalementDecoded->vos_coordonnees_occupant_email = $signalement->getMailOccupant();
+
+        $client->request('POST', $url, [], [], [], json_encode($payloadLocataireSignalement));
+
+        $content = $client->getResponse()->getContent();
+        dd($content);
+
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }*/
 
     public function provideSignalementRequestPayload(): \Generator
     {

--- a/tests/Unit/Service/Signalement/SignalementDuplicateCheckerTest.php
+++ b/tests/Unit/Service/Signalement/SignalementDuplicateCheckerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Tests\Unit\Service\Signalement;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Enum\ProfileDeclarant;
+use App\Entity\Signalement;
+use App\Entity\SignalementDraft;
+use App\Repository\SignalementDraftRepository;
+use App\Repository\SignalementRepository;
+use App\Serializer\SignalementDraftRequestSerializer;
+use App\Service\Signalement\SignalementDuplicateChecker;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SignalementDuplicateCheckerTest extends KernelTestCase
+{
+    public function testCheckSignalementOld(): void
+    {
+        $uuid = '00000000-0000-0000-2022-000000000008';
+
+        $signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy([
+            'uuid' => $uuid,
+        ]);
+
+        $serializer = static::getContainer()->get(SignalementDraftRequestSerializer::class);
+        $payloadLocataireSignalement = file_get_contents(__DIR__.'../../../../files/post_signalement_draft_payload.json');
+        /** @var SignalementDraftRequest $signalementDraftRequest */
+        $signalementDraftRequest = $serializer->deserialize(
+            $payloadLocataireSignalement,
+            SignalementDraftRequest::class,
+            'json'
+        );
+
+        $signalementDraftRequest->setProfil(ProfileDeclarant::LOCATAIRE->name);
+        $signalementDraftRequest->setAdresseLogementAdresseDetailNumero($signalement->getAdresseOccupant());
+        $signalementDraftRequest->setAdresseLogementAdresseDetailCodePostal($signalement->getCpOccupant());
+        $signalementDraftRequest->setAdresseLogementAdresseDetailCommune($signalement->getVilleOccupant());
+        $signalementDraftRequest->setVosCoordonneesOccupantEmail($signalement->getMailOccupant());
+
+        $signalementDuplicateChecker = static::getContainer()->get(SignalementDuplicateChecker::class);
+        $result = $signalementDuplicateChecker->check($signalementDraftRequest);
+
+        $this->assertEquals($result['already_exists'], true);
+        $this->assertEquals($result['type'], 'signalement');
+        $this->assertEquals($result['has_created_recently'], false);
+        $this->assertEquals($result['signalements'][0]['uuid'], $uuid);
+    }
+
+    public function testCheckSignalementRecent(): void
+    {
+        $uuid = '00000000-0000-0000-2022-000000000001';
+
+        $signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        /** @var Signalement $signalement */
+        $signalement = $signalementRepository->findOneBy([
+            'uuid' => $uuid,
+        ]);
+
+        $serializer = static::getContainer()->get(SignalementDraftRequestSerializer::class);
+        $payloadLocataireSignalement = file_get_contents(__DIR__.'../../../../files/post_signalement_draft_payload.json');
+        /** @var SignalementDraftRequest $signalementDraftRequest */
+        $signalementDraftRequest = $serializer->deserialize(
+            $payloadLocataireSignalement,
+            SignalementDraftRequest::class,
+            'json'
+        );
+
+        $signalementDraftRequest->setProfil(ProfileDeclarant::TIERS_PRO->name);
+        $signalementDraftRequest->setAdresseLogementAdresseDetailNumero($signalement->getAdresseOccupant());
+        $signalementDraftRequest->setAdresseLogementAdresseDetailCodePostal($signalement->getCpOccupant());
+        $signalementDraftRequest->setAdresseLogementAdresseDetailCommune($signalement->getVilleOccupant());
+        $signalementDraftRequest->setCoordonneesOccupantEmail($signalement->getMailOccupant());
+        $signalementDraftRequest->setVosCoordonneesTiersEmail($signalement->getMailDeclarant());
+
+        $signalementDuplicateChecker = static::getContainer()->get(SignalementDuplicateChecker::class);
+        $result = $signalementDuplicateChecker->check($signalementDraftRequest);
+
+        $this->assertEquals($result['already_exists'], true);
+        $this->assertEquals($result['type'], 'signalement');
+        $this->assertEquals($result['has_created_recently'], true);
+        $this->assertEquals($result['signalements'][0]['uuid'], $uuid);
+    }
+
+    public function testCheckSignalementDraft(): void
+    {
+        $uuid = '00000000-0000-0000-2023-locataire001';
+
+        $signalementDraftRepository = static::getContainer()->get(SignalementDraftRepository::class);
+        /** @var SignalementDraft $signalementDraft */
+        $signalementDraft = $signalementDraftRepository->findOneBy([
+            'uuid' => $uuid,
+        ]);
+
+        $serializer = static::getContainer()->get(SignalementDraftRequestSerializer::class);
+        $payloadLocataireSignalement = file_get_contents(__DIR__.'../../../../files/post_signalement_draft_payload.json');
+        /** @var SignalementDraftRequest $signalementDraftRequest */
+        $signalementDraftRequest = $serializer->deserialize(
+            $payloadLocataireSignalement,
+            SignalementDraftRequest::class,
+            'json'
+        );
+
+        $signalementDraftRequest->setAdresseLogementAdresse($signalementDraft->getAddressComplete());
+        $signalementDraftRequest->setProfil(ProfileDeclarant::LOCATAIRE->name);
+        $signalementDraftRequest->setAdresseLogementAdresseDetailNumero($signalementDraft->getPayload()['adresse_logement_adresse_detail_numero']);
+        $signalementDraftRequest->setAdresseLogementAdresseDetailCodePostal($signalementDraft->getPayload()['adresse_logement_adresse_detail_code_postal']);
+        $signalementDraftRequest->setAdresseLogementAdresseDetailCommune($signalementDraft->getPayload()['adresse_logement_adresse_detail_commune']);
+        $signalementDraftRequest->setVosCoordonneesOccupantEmail($signalementDraft->getPayload()['vos_coordonnees_occupant_email']);
+
+        $signalementDuplicateChecker = static::getContainer()->get(SignalementDuplicateChecker::class);
+        $result = $signalementDuplicateChecker->check($signalementDraftRequest);
+
+        $this->assertEquals($result['already_exists'], true);
+        $this->assertEquals($result['type'], 'draft');
+    }
+}


### PR DESCRIPTION
## Ticket

#3815   

## Description
Lorsqu'un signalement est en doublon depuis moins de 3 mois (90 jours), on modifie la modale pour ne pas permettre de créer de nouveau signalement.

## Changements apportés
* Calcul du nombre de jour de différence entre aujourd'hui et la date de création
* Ajustement de l'algo de calcul de doublon pour les villes avec arrondissements qui n'étaient pas considérées

## Pré-requis
`npm run watch`

## Tests
- [ ] Vérifier la modale avec un signalement actif créé il y a moins de 3 mois
- [ ] Idem avec un signalement actif créé il y a plus de 3 mois
