### PR TITLE
[BO - Formulaire pro] Modifier redirection pour les RT

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -161,12 +161,14 @@ function initBoFormSignalementSubmit(tabName) {
       const occupationLogementBailleurOccupant = document.querySelector('#signalement_draft_address_occupationLogement_1')
       const profileBailleurOccupant = document.querySelector('#signalement_draft_coordonnees_profileDeclarantTiers_4')
     
-      if (occupationLogementBailleurOccupant.checked && profileBailleurOccupant) {
-        profileBailleurOccupant.checked = true
-      } else {
-        profileBailleurOccupant.checked = false
+      if (profileBailleurOccupant) {
+        if (occupationLogementBailleurOccupant.checked) {
+          profileBailleurOccupant.checked = true
+        } else {
+          profileBailleurOccupant.checked = false
+        }
+        handleChangeOnProfileBailleurOccupant()
       }
-      handleChangeOnProfileBailleurOccupant()
       break
     case 'logement':
       initBoFormSignalementLogement()
@@ -758,11 +760,13 @@ function handleChangeOnProfileBailleurOccupant() {
   const occupationLogementBailleurOccupant = document.querySelector('#signalement_draft_address_occupationLogement_1')
   const profileBailleurOccupant = document.querySelector('#signalement_draft_coordonnees_profileDeclarantTiers_4')
   const warningProfileBailleurOccupant = document.querySelector('#warning_profile_declarant_bailleur_occupant')
-  if (profileBailleurOccupant.checked) {
-    occupationLogementBailleurOccupant.checked = true
-    warningProfileBailleurOccupant.classList.remove('fr-hidden')
-  } else {
-    occupationLogementBailleurOccupant.checked = false
-    warningProfileBailleurOccupant.classList.add('fr-hidden')
+  if (profileBailleurOccupant) {
+    if (profileBailleurOccupant.checked) {
+      occupationLogementBailleurOccupant.checked = true
+      warningProfileBailleurOccupant.classList.remove('fr-hidden')
+    } else {
+      occupationLogementBailleurOccupant.checked = false
+      warningProfileBailleurOccupant.classList.add('fr-hidden')
+    }
   }
 }

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -446,12 +446,14 @@ class SignalementCreateController extends AbstractController
                 $signalement->setIsNotOccupant(true);
             }
 
-            $route = 'back_signalements_index';
+            $route = 'back_signalement_view';
+            $params = ['uuid' => $signalement->getUuid()];
             if (count($assignablePartners)) {
                 $autoAssigner->assign($signalement);
                 $this->addFlash('success', 'Le signalement a bien été créé et validé. Il a été affecté aux partenaires définis par l\'auto-affectation');
                 if (!$this->isGranted('ROLE_ADMIN_TERRITORY')) {
                     $route = 'back_signalement_drafts';
+                    $params = [];
                 }
             } elseif ($this->isGranted('ROLE_ADMIN_TERRITORY') && !empty($partnerIds)) {
                 $partnersList = explode(',', $partnerIds);
@@ -473,10 +475,11 @@ class SignalementCreateController extends AbstractController
 
                 $this->addFlash('success', 'Le signalement a bien été créé. Il doit être validé par les responsables de territoire. Si ce signalement est affecté à votre partenaire, il sera visible dans la liste des signalements.');
                 $route = 'back_signalement_drafts';
+                $params = [];
             }
             $signalementManager->flush();
 
-            return $this->json(['redirect' => true, 'url' => $this->generateUrl($route, [], UrlGeneratorInterface::ABSOLUTE_URL)]);
+            return $this->json(['redirect' => true, 'url' => $this->generateUrl($route, $params, UrlGeneratorInterface::ABSOLUTE_URL)]);
         }
 
         $tabContent = $this->renderView('back/signalement_create/tabs/tab-validation.html.twig', [

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -451,7 +451,14 @@ class SignalementCreateController extends AbstractController
             if (count($assignablePartners)) {
                 $autoAssigner->assign($signalement);
                 $this->addFlash('success', 'Le signalement a bien été créé et validé. Il a été affecté aux partenaires définis par l\'auto-affectation');
-                if (!$this->isGranted('ROLE_ADMIN_TERRITORY')) {
+                $hasAssignable = $user->getPartners()->exists(function ($key, $partner) use ($assignablePartners) {
+                    return in_array($partner, $assignablePartners, true);
+                });
+
+                if (
+                    !$this->isGranted('ROLE_ADMIN_TERRITORY')
+                    && !$hasAssignable
+                ) {
                     $route = 'back_signalement_drafts';
                     $params = [];
                 }

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -997,3 +997,54 @@ signalements:
     information_procedure: "[]"
     information_complementaire: "[]"
     motif_cloture: "REFUS_DE_VISITE"
+  -     
+    territory: "Loire-Atlantique"
+    uuid: "00000000-0000-0000-2025-000000000008"
+    reference: "2025-08"
+    details: "Le locataire nous a informé de fortes dégradations dans son logement"
+    is_proprio_averti: 1
+    is_allocataire: "0"
+    nature_logement: "maison"
+    superficie: 32
+    loyer: null
+    date_entree: "2019-12-01"
+    nom_proprio: "HabitatMarsien"
+    type_proprio: "ORGANISME_SOCIETE"
+    is_logement_social: 0
+    civilite_occupant: "mme"
+    nom_occupant: "Colbert"
+    prenom_occupant: "Maud"
+    tel_occupant: "+330240556977"
+    phone_number: "+330240556977"
+    mail_occupant: "maudcolbert@yopmail.com"
+    adresse_occupant: "Route des Funeries"
+    cp_occupant: "44850"
+    ville_occupant: "Le Cellier"
+    statut: "DRAFT"
+    created_by: "user-44-02@signal-logement.fr"
+    geoloc: "{\"lat\": 47.338819, \"lng\": -1.361458}"
+    insee_occupant: "44028"
+    nb_pieces_logement: 3
+    nb_occupants_logement: 1
+    score: 35.194711538462
+    type_composition_logement: "{\"bail_dpe_dpe\": \"oui\", \"bail_dpe_bail\": \"oui\", \"type_logement_rdc\": null, \"type_logement_nature\": \"maison\", \"bail_dpe_etat_des_lieux\": \"oui\", \"bail_dpe_date_emmenagement\": \"2019-12-01\", \"type_logement_commodites_wc\": \"oui\", \"type_logement_dernier_etage\": null, \"composition_logement_enfants\": \"oui\", \"composition_logement_hauteur\": \"oui\", \"composition_logement_nb_pieces\": \"5\", \"composition_logement_superficie\": \"67\", \"type_logement_commodites_cuisine\": \"oui\", \"composition_logement_piece_unique\": \"plusieurs_pieces\", \"type_logement_commodites_wc_cuisine\": \"non\", \"type_logement_sous_sol_sans_fenetre\": null, \"composition_logement_nombre_personnes\": \"4\", \"type_logement_commodites_salle_de_bain\": \"oui\", \"type_logement_commodites_wc_collective\": null, \"type_logement_sous_comble_sans_fenetre\": null, \"type_logement_commodites_piece_a_vivre_9m\": \"oui\", \"type_logement_commodites_cuisine_collective\": null, \"type_logement_commodites_salle_de_bain_collective\": null}"
+    situation_foyer: "{\"logement_social_allocation\": \"non\", \"logement_social_date_naissance\": null, \"logement_social_allocation_caisse\": null, \"travailleur_social_accompagnement\": \"non\", \"logement_social_demande_relogement\": \"non\", \"logement_social_montant_allocation\": null, \"logement_social_numero_allocataire\": null, \"travailleur_social_quitte_logement\": \"non\", \"travailleur_social_accompagnement_declarant\": null}"
+    information_procedure: "{\"utilisation_service_ok_visite\": true, \"utilisation_service_ok_cgu\": true, \"info_procedure_bailleur_prevenu\": \"oui\", \"info_procedure_reponse_assurance\": null, \"info_procedure_assurance_contactee\": \"non\", \"info_procedure_depart_apres_travaux\": \"oui\", \"utilisation_service_ok_demande_logement\": true, \"utilisation_service_ok_prevenir_bailleur\": true}"
+    information_complementaire: "{\"informations_complementaires_logement_montant_loyer\": null, \"informations_complementaires_logement_nombre_etages\": null, \"informations_complementaires_logement_annee_construction\": null, \"informations_complementaires_situation_bailleur_revenu_fiscal\": null, \"informations_complementaires_situation_occupants_loyers_payes\": null, \"informations_complementaires_situation_bailleur_date_naissance\": null, \"informations_complementaires_situation_occupants_date_naissance\": null, \"informations_complementaires_situation_bailleur_beneficiaire_fsl\": null, \"informations_complementaires_situation_bailleur_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_beneficiaire_fsl\": null, \"informations_complementaires_situation_occupants_beneficiaire_rsa\": null, \"informations_complementaires_situation_occupants_date_emmenagement\": null, \"informations_complementaires_situation_occupants_demande_relogement\": null}"
+    score_logement: 13.990384615385
+    score_batiment: 50
+    desordre_categorie:
+      - "Sécurite risques particuliers"
+      - "Structure du bâti"
+    desordre_critere:
+      - "desordres_batiment_securite_elements_toit"
+      - "desordres_batiment_securite_toit"
+      - "desordres_batiment_securite_murs_fissures"
+      - "desordres_batiment_securite_balcons"
+      - "desordres_batiment_incendie_odeur_gaz"
+    desordre_precision:
+      - "desordres_batiment_securite_elements_toit"
+      - "desordres_batiment_securite_toit"
+      - "desordres_batiment_securite_murs_fissures_details_mur_porteur_oui"
+      - "desordres_batiment_securite_balcons"
+      - "desordres_batiment_incendie_odeur_gaz"


### PR DESCRIPTION
## Ticket

#4077   

## Description
APrès la validation d'un brouillon de signalement par un RT, la règle de redirection change, on redirige directement sur le signalement créé.
Les agents sont toujours redirigés vers la liste des brouillons

## Changements apportés
* Changement de la redirection dans le controller pour les RT
* Ajout d'une fixture de brouillon de signalement fait par un agent
* Ajout de test

## Pré-requis

## Tests
- [ ] Faire un signalement via le BO, avec un RT, sur un territoire en autoaffectation -> on est redirigé vers la fiche signalement
- [ ] Faire un signalement via le BO, avec un RT, sur un territoire en affectation manuelle -> on est redirigé vers la fiche signalement
- [ ] Faire un signalement via le BO, avec un agent, sur un territoire en autoaffectation -> on est redirigé vers la liste des brouillons
- [ ] Faire un signalement via le BO, avec un agent, sur un territoire en affectation manuelle -> on est redirigé vers la liste des brouillons
