### PR TITLE
[BUG - FO] Page suivi d'un signalement archivé

### DIFF
--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -21,6 +21,7 @@
 	{% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').ARCHIVED %}
 		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
 			<p>Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.</p>
+		</div>
 	{% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').DRAFT %}
 		<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
 			<p>Votre signalement est un brouillon, vous ne pouvez pas encore envoyer de messages.</p>


### PR DESCRIPTION
## Ticket

#4079   

## Description
Le premier onglet s’étend vers le bas sans raison et le second n'est pas cliquable

## Changements apportés
* Fermeture de balise du twig

## Pré-requis

## Tests
- [ ] Ouvrir la page de suivi d'un signalement archivé, et vérifier que la page s'affiche et que le 2è onglet est accessible
