### PR TITLE
[BUG - BO] Désarchivage d'un user / [Tech] Staging : désactiver cron de rappel pour les utilisateurs inactifs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   APP_URL: http://localhost:8080
+  APP: 'test'
   CLAMAV_SOCKET: '/tmp/clamd.socket'
   CLAMAV_HOST: 127.0.0.1
   CLAMAV_PORT: 3310

--- a/src/Command/Cron/RemindInactiveUserCommand.php
+++ b/src/Command/Cron/RemindInactiveUserCommand.php
@@ -43,6 +43,12 @@ class RemindInactiveUserCommand extends AbstractCronCommand
     {
         $io = new SymfonyStyle($input, $output);
 
+        if ('histologe' !== getenv('APP') && 'test' !== getenv('APP')) {
+            $io->error('This command is only available on production and test environment');
+
+            return Command::FAILURE;
+        }
+
         /** @var UserRepository $userRepository */
         $userRepository = $this->userManager->getRepository();
         $userList = $userRepository->findInactiveWithNbAffectationPending();

--- a/src/Controller/Back/BackArchivedUsersController.php
+++ b/src/Controller/Back/BackArchivedUsersController.php
@@ -97,6 +97,9 @@ class BackArchivedUsersController extends AbstractController
             foreach ($user->getUserPartners() as $userPartner) {
                 $entityManager->remove($userPartner);
             }
+            // we need to flush the removed userPartners before flushing the new one to prevent a duplicate user_partner because doctrine perform the insert before the delete
+            $entityManager->flush();
+
             $partner = $form->get('tempPartner')->getData();
             $userPartner = (new UserPartner())->setUser($user)->setPartner($partner);
             $user->addUserPartner($userPartner);

--- a/tests/Functional/Command/Cron/RemindInactiveUserCommandTest.php
+++ b/tests/Functional/Command/Cron/RemindInactiveUserCommandTest.php
@@ -10,6 +10,8 @@ class RemindInactiveUserCommandTest extends KernelTestCase
 {
     public function testDisplayMessageSuccessfully(): void
     {
+        putenv('APP=test');
+
         $kernel = self::bootKernel();
         $application = new Application($kernel);
 

--- a/tests/Functional/Controller/BackArchivedUsersControllerTest.php
+++ b/tests/Functional/Controller/BackArchivedUsersControllerTest.php
@@ -107,23 +107,14 @@ class BackArchivedUsersControllerTest extends WebTestCase
         /** @var RouterInterface $router */
         $router = self::getContainer()->get(RouterInterface::class);
 
-        /** @var TerritoryRepository $territoryRepository */
-        $territoryRepository = static::getContainer()->get(TerritoryRepository::class);
-        $territory = $territoryRepository->findOneBy(['zip' => '01']);
-
-        /** @var PartnerRepository $partnerRepository */
-        $partnerRepository = static::getContainer()->get(PartnerRepository::class);
-        $partner = $partnerRepository->findOneBy([
-            'territory' => $territory->getId(),
-            'isArchive' => '0',
-        ]);
-
         $accountEmail = 'user-01-09@signal-logement.fr';
         /** @var User $account */
         $account = $userRepository->findArchivedUserByEmail($accountEmail);
         $route = $router->generate('back_archived_users_reactiver', [
             'id' => $account->getId(),
         ]);
+
+        $partner = $account->getUserPartners()->first()->getPartner();
 
         $crawler = $client->request('GET', $route);
 
@@ -133,7 +124,7 @@ class BackArchivedUsersControllerTest extends WebTestCase
         $form['user[prenom]'] = $faker->name();
         $form['user[nom]'] = $faker->lastName();
         $form['user[email]'] = (string) $account->getEmail();
-        $form['user[territory]'] = (string) $territory->getId();
+        $form['user[territory]'] = (string) $partner->getTerritory()->getId();
         $form['user[tempPartner]'] = (string) $partner->getId();
         $client->submit($form);
 


### PR DESCRIPTION
## Ticket

#4083 
#4084

## Description
- Fix d'un bug au désarchivage d'utilisateur (qui fait suite à l'ajout d'une containte unique `unique_user_partner` en base)
- Désactivation de la commande `app:remind-inactive-user` pour  éviter de dépasser les limitation d'envoi de mail sur staging

## Tests
- [ ] Désarchiver un utilisateur
- [ ] Lancer la commande `app:remind-inactive-user` et vérifier qu'elle ne s’exécute pas 
