### PR TITLE
[TECH - CI] Corriger le test de soumission de message depuis la fiche signalement FO

### DIFF
--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -7,6 +7,8 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\Signalement;
 use App\Entity\SignalementDraft;
 use App\Entity\Suivi;
+use App\Manager\UserManager;
+use App\Security\User\SignalementUser;
 use App\Tests\SessionHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -151,20 +153,23 @@ class SignalementControllerTest extends WebTestCase
             'code' => $codeSuivi = $signalement->getCodeSuivi(),
         ]);
 
+        $signalementUser = new SignalementUser(
+            $signalement->getCodeSuivi().':'.UserManager::OCCUPANT,
+            $signalement->getMailOccupant(),
+        );
+
+        $client->loginUser($signalementUser, 'code_suivi');
+
         $crawler = $client->request('POST', $urlSuiviSignalementUserResponse, [
-            '_csrf_token' => $this->generateCsrfToken($client, 'authenticate'),
-            'visitor-type' => 'occupant',
-            'login-first-letter-prenom' => mb_substr($signalement->getPrenomOccupant(), 0, 1),
-            'login-first-letter-nom' => mb_substr($signalement->getNomOccupant(), 0, 1),
-            'login-code-postal' => $signalement->getCpOccupant(),
+            '_token' => $this->generateCsrfToken($client, 'signalement_front_response_'.$signalement->getUuid()),
+            'signalement_front_response' => [
+                'email' => $emailOccupant = $signalement->getMailOccupant(),
+                'type' => UserManager::OCCUPANT,
+                'content' => 'Lorem Ipsum is simply dummy text of the printing and typesetting industry',
+            ],
         ]);
-        if ($status !== SignalementStatus::ACTIVE->value && $client->getResponse()->isRedirect()) {
-            $crawler = $client->followRedirect();
-        }
         if (SignalementStatus::ACTIVE->value === $status) {
-            $this->assertResponseRedirects('/suivre-mon-signalement/'.$codeSuivi);
-        } elseif (SignalementStatus::DRAFT->value === $status || SignalementStatus::DRAFT_ARCHIVED->value === $status) {
-            $this->assertEquals('Le lien utilisé est expiré ou invalide.', $crawler->filter('.fr-alert p')->text());
+            $this->assertResponseRedirects('/suivre-mon-signalement/'.$codeSuivi.'?from='.$emailOccupant);
         } else {
             $this->assertEquals('Vous n\'avez pas les droits pour effectuer cette action.', $crawler->filter('.fr-alert p')->text());
         }


### PR DESCRIPTION
## Ticket

#4089   

## Description
Authentification explicite d’un usager : correction de la régression liée à l’envoi de message, raison initiale de l’existence du test.

## Changements apportés
* Rollback sur la version 3.2.1 et ajout d'une authentification explicite

## Pré-requis

## Tests
- [ ] CI OK et test locale OK 
