### PR TITLE
[BUG - Filtre Signalement] La date de dernier suivi écrase la date de dépot

### DIFF
--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -25,6 +25,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
+use function Symfony\Component\String\u;
 
 class SearchFilter
 {
@@ -538,13 +539,15 @@ class SearchFilter
     private function addFilterDate(QueryBuilder $qb, string $columnDbField, array $dates): QueryBuilder
     {
         if (!empty($dates['on'])) {
-            $qb->andWhere($columnDbField.' >= :date_in')->setParameter('date_in', $dates['on']);
+            $paramName = 'date_in_'.u($columnDbField)->snake();
+            $qb->andWhere($columnDbField.' >= :'.$paramName)->setParameter($paramName, $dates['on']);
         }
 
         if (!empty($dates['off'])) {
             $endDate = new \DateTime($dates['off']);
             $endDate->add(new \DateInterval('P1D'));
-            $qb->andWhere($columnDbField.' <= :date_off')->setParameter('date_off', $endDate->format('Y-m-d'));
+            $paramName = 'date_off_'.u($columnDbField)->snake();
+            $qb->andWhere($columnDbField.' <= :'.$paramName)->setParameter($paramName, $endDate->format('Y-m-d'));
         }
 
         return $qb;

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -80,6 +80,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Zones' => [['isImported' => 'oui', 'zones' => [1, 2, 3]], 5];
         yield 'Search by Zones on Territory 34' => [['isImported' => 'oui', 'zones' => [1, 2, 3], 'territoire' => '35'], 1];
         yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 7];
+        yield 'Search by dates depot and dates of last suivi' => [['isImported' => 'oui', 'dateDepotDebut' => '2023-01-01', 'dateDepotFin' => '2023-03-31', 'dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-12-31'], 3];
     }
 
     /**


### PR DESCRIPTION
## Ticket

#4104

## Description
La recherche de signalements sur des plage de date de création de signalement ET de date du dernier suivi ne fonctionnait pas correctement. En effet la même fonction gérant les deux date avec les même paramètre nommé, seule la date de dernier suivi etait prise en compte pour les deux filtres.

Correction de la fonction et ajout d'un tests

## Tests
- [ ] Filtrer sur deux plage de dates différentes et s'assurer que la requête généré contient bien ls deux plage de dates différentes.
