### PR TITLE
[BUG - QA] Call to a member function modify() on null

### DIFF
--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -104,9 +104,9 @@ class SignalementVoter extends Voter
             && SignalementStatus::DRAFT_ARCHIVED !== $signalement->getStatut()
         ) {
             if (SignalementStatus::CLOSED === $signalement->getStatut()) {
-                $datePostCloture = $signalement->getClosedAt()->modify('+ 30days');
+                $datePostCloture = $signalement->getClosedAt()?->modify('+ 30days');
                 $today = new \DateTimeImmutable();
-                if ($today < $datePostCloture && !$signalement->hasSuiviUsagePostCloture()) {
+                if ($signalement->getClosedAt() && $today < $datePostCloture && !$signalement->hasSuiviUsagePostCloture()) {
                     return true;
                 }
             } else {


### PR DESCRIPTION
## Ticket

#4103    

## Description
Des signalements au statut fermés mais sans date de cloture provoquent un bug si on essaie d'accéder à leur page de suivi. Cela est du au SignalementVoter, et à la vérification de date de cloture pour savoir s'il est possible de faire un suivi post-cloture.
1856 signalements sont concernés, ce sont des signalements importés, principalement d'Isère, et il y en a quelques-uns du 62 et du 81 
https://histologe-metabase.osc-fr1.scalingo.io/question/1598-signalement-clos-sans-date-de-cloture

## Changements apportés
* Correction du voter pour ne pas permettre d'ajouter un suivi post-cloture si on n'a pas la date de cloture

## Pré-requis
En base, supprimer la date de clorture sur un signalement fermé

## Tests
- [ ] Aller sur la page de suivi de ce signalement, vérifier qu'on n'a pas d'erreur pour y accéder, mais qu'on ne peut pas ajouter de suivi post cloture
