### PR TITLE
[Fichiers] Ajout d'un attribut extension pour remplacer le fileType à terme

### DIFF
--- a/migrations/Version20250516083935.php
+++ b/migrations/Version20250516083935.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250516083935 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add extension to File entity';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file ADD extension VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file DROP extension');
+    }
+}

--- a/src/Command/InitFilesExtensionCommand.php
+++ b/src/Command/InitFilesExtensionCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\FileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:init-files-extension',
+    description: 'Init files extension',
+)]
+class InitFilesExtensionCommand extends Command
+{
+    public const int BATCH_TOTAL_SIZE = 5000;
+    public const int BATCH_FLUSH_SIZE = 500;
+
+    public function __construct(
+        private readonly FileRepository $fileRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $files = $this->fileRepository->findBy(['extension' => null], ['createdAt' => 'DESC'], self::BATCH_TOTAL_SIZE);
+        $i = 0;
+        $total = \count($files);
+        foreach ($files as $file) {
+            ++$i;
+            $ext = pathinfo($file->getFilename(), \PATHINFO_EXTENSION);
+            $file->setExtension($ext);
+            $io->info('File "'.$i.'/'.$total.'": '.$file->getFilename().' extension has been set with success');
+            if (0 === $i % self::BATCH_FLUSH_SIZE) {
+                $this->entityManager->flush();
+            }
+        }
+        $this->entityManager->flush();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/InitFilesExtensionCommand.php
+++ b/src/Command/InitFilesExtensionCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command;
 
+use App\Manager\HistoryEntryManager;
 use App\Repository\FileRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -16,18 +17,21 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class InitFilesExtensionCommand extends Command
 {
-    public const int BATCH_TOTAL_SIZE = 5000;
-    public const int BATCH_FLUSH_SIZE = 500;
+    public const int BATCH_TOTAL_SIZE = 50000;
+    public const int BATCH_FLUSH_SIZE = 5000;
 
     public function __construct(
         private readonly FileRepository $fileRepository,
         private readonly EntityManagerInterface $entityManager,
+        private readonly HistoryEntryManager $historyEntryManager,
     ) {
         parent::__construct();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->historyEntryManager->removeEntityListeners();
+
         $io = new SymfonyStyle($input, $output);
 
         $files = $this->fileRepository->findBy(['extension' => null], ['createdAt' => 'DESC'], self::BATCH_TOTAL_SIZE);

--- a/src/Controller/Api/SignalementFileUpdateController.php
+++ b/src/Controller/Api/SignalementFileUpdateController.php
@@ -111,6 +111,7 @@ class SignalementFileUpdateController extends AbstractController
             $file->setFileType(File::FILE_TYPE_DOCUMENT);
             $file->setDescription(null);
         }
+        $file->setExtension($ext);
         $file->setDocumentType($documentType);
         $this->entityManager->flush();
 

--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -178,13 +178,12 @@ class SignalementFileController extends AbstractController
         } elseif ($this->isCsrfTokenValid('signalement_delete_file_'.$signalement->getId(), $request->get('_token'))
         ) {
             $filename = $file->getFilename();
-            $type = $file->getFileType();
             if ($uploadHandlerService->deleteFile($file)) {
                 if (!$this->isGranted('ROLE_ADMIN') && SignalementStatus::CLOSED !== $signalement->getStatut()) {
                     /** @var User $user */
                     $user = $this->getUser();
                     $description = $user->getNomComplet().' a supprimé ';
-                    $description .= File::FILE_TYPE_DOCUMENT === $type ? 'le document suivant :' : 'la photo suivante :';
+                    $description .= $file->isTypeDocument() ? 'le document suivant :' : 'la photo suivante :';
                     $description .= '<ul><li>'.$filename.'</li></ul>';
                     $suiviManager->createSuivi(
                         user: $user,
@@ -195,7 +194,7 @@ class SignalementFileController extends AbstractController
                 }
 
                 if ('1' !== $request->get('is_draft')) {
-                    if (File::FILE_TYPE_DOCUMENT === $type) {
+                    if ($file->isTypeDocument()) {
                         $this->addFlash('success', 'Le document a bien été supprimé.');
                     } else {
                         $this->addFlash('success', 'La photo a bien été supprimée.');
@@ -304,7 +303,7 @@ class SignalementFileController extends AbstractController
         if ($request->isXmlHttpRequest()) {
             return $this->json(['response' => 'success']);
         }
-        if ('document' === $file->getFileType()) {
+        if ($file->isTypeDocument()) {
             $this->addFlash('success', 'Le document a bien été modifié.');
         } else {
             $this->addFlash('success', 'La photo a bien été modifiée.');

--- a/src/Controller/SignalementFileController.php
+++ b/src/Controller/SignalementFileController.php
@@ -131,10 +131,9 @@ class SignalementFileController extends AbstractController
         if (null === $file) {
             $this->addFlash('error', 'Ce fichier n\'existe plus');
         } elseif ($this->isCsrfTokenValid('signalement_delete_file_'.$signalement->getId(), $request->get('_token'))) {
-            $type = $file->getFileType();
             $filename = $file->getFilename();
             if ($uploadHandlerService->deleteFile($file)) {
-                $description = File::FILE_TYPE_DOCUMENT === $type ? 'Document supprimé ' : 'Photo supprimée ';
+                $description = $file->isTypeDocument() ? 'Document supprimé ' : 'Photo supprimée ';
                 $description .= 'par l\'usager :';
                 $description .= '<ul><li>'.$filename.'</li></ul>';
                 $suiviManager->createSuivi(
@@ -143,7 +142,7 @@ class SignalementFileController extends AbstractController
                     description: $description,
                     type: Suivi::TYPE_AUTO,
                 );
-                $message = (File::FILE_TYPE_DOCUMENT === $type) ? 'Le document a bien été supprimé.' : 'La photo a bien été supprimée.';
+                $message = $file->isTypeDocument() ? 'Le document a bien été supprimé.' : 'La photo a bien été supprimée.';
                 $this->addFlash('success', $message);
             } else {
                 $this->addFlash('error', 'Le fichier n\'a pas été supprimé.');

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -89,6 +89,9 @@ class File implements EntityHistoryInterface
     #[ORM\Column(length: 32, options: ['comment' => 'Value possible photo or document'])]
     private ?string $fileType = null;
 
+    #[ORM\Column(length: 255)]
+    private ?string $extension = null;
+
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $createdAt = null;
 
@@ -230,6 +233,18 @@ class File implements EntityHistoryInterface
         return $this;
     }
 
+    public function getExtension(): ?string
+    {
+        return $this->extension;
+    }
+
+    public function setExtension(?string $extension): self
+    {
+        $this->extension = $extension;
+
+        return $this;
+    }
+
     public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
@@ -345,17 +360,28 @@ class File implements EntityHistoryInterface
 
     public function isTypePhoto(): bool
     {
-        return $this::FILE_TYPE_PHOTO === $this->fileType;
+        if (empty($this->getExtension())) {
+            return $this::FILE_TYPE_PHOTO === $this->fileType;
+        }
+
+        return (self::FILE_TYPE_PHOTO === $this->getDocumentType()->mapFileType() || DocumentType::AUTRE === $this->getDocumentType())
+            && \in_array($this->getExtension(), self::IMAGE_EXTENSION)
+            && 'pdf' !== $this->getExtension()
+        ;
     }
 
     public function isTypeDocument(): bool
     {
-        return $this::FILE_TYPE_DOCUMENT === $this->fileType;
+        if (empty($this->getExtension())) {
+            return $this::FILE_TYPE_DOCUMENT === $this->fileType;
+        }
+
+        return !$this->isTypePhoto();
     }
 
     public function isSituationPhoto(): bool
     {
-        return $this->fileType === $this::FILE_TYPE_PHOTO
+        return $this->isTypePhoto()
         && \array_key_exists($this->documentType->value, DocumentType::getOrderedSituationList())
         && null === $this->intervention;
     }

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -361,7 +361,7 @@ class File implements EntityHistoryInterface
     public function isTypePhoto(): bool
     {
         if (empty($this->getExtension())) {
-            return $this::FILE_TYPE_PHOTO === $this->fileType;
+            return self::FILE_TYPE_PHOTO === $this->fileType;
         }
 
         return (self::FILE_TYPE_PHOTO === $this->getDocumentType()->mapFileType() || DocumentType::AUTRE === $this->getDocumentType())
@@ -373,7 +373,7 @@ class File implements EntityHistoryInterface
     public function isTypeDocument(): bool
     {
         if (empty($this->getExtension())) {
-            return $this::FILE_TYPE_DOCUMENT === $this->fileType;
+            return self::FILE_TYPE_DOCUMENT === $this->fileType;
         }
 
         return !$this->isTypePhoto();

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -343,6 +343,16 @@ class File implements EntityHistoryInterface
         return $this;
     }
 
+    public function isTypePhoto(): bool
+    {
+        return $this::FILE_TYPE_PHOTO === $this->fileType;
+    }
+
+    public function isTypeDocument(): bool
+    {
+        return $this::FILE_TYPE_DOCUMENT === $this->fileType;
+    }
+
     public function isSituationPhoto(): bool
     {
         return $this->fileType === $this::FILE_TYPE_PHOTO

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -54,6 +54,12 @@ class File implements EntityHistoryInterface
         'image/png',
         'image/gif',
     ];
+    public const array RESIZABLE_EXTENSION = [
+        'jpeg',
+        'jpg',
+        'png',
+        'gif',
+    ];
     public const array IMAGE_MIME_TYPES = [
         'image/jpeg',
         'image/png',
@@ -221,11 +227,17 @@ class File implements EntityHistoryInterface
         return $this;
     }
 
+    /**
+     * @deprecated  Cette méthode est obsolete et doit être remplacée par isTypePhoto ou isTypeDocument
+     */
     public function getFileType(): ?string
     {
         return $this->fileType;
     }
 
+    /**
+     * @deprecated  Cette méthode est obsolete et doit être remplacée par isTypePhoto ou isTypeDocument
+     */
     public function setFileType(?string $fileType): self
     {
         $this->fileType = $fileType;
@@ -365,8 +377,7 @@ class File implements EntityHistoryInterface
         }
 
         return (self::FILE_TYPE_PHOTO === $this->getDocumentType()->mapFileType() || DocumentType::AUTRE === $this->getDocumentType())
-            && \in_array($this->getExtension(), self::IMAGE_EXTENSION)
-            && 'pdf' !== $this->getExtension()
+            && \in_array($this->getExtension(), self::RESIZABLE_EXTENSION)
         ;
     }
 

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2209,7 +2209,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function getPhotos(): Collection
     {
         return $this->files->filter(function (File $file) {
-            return 'photo' === $file->getFiletype() && !$file->isTemp() && !$file->isIsWaitingSuivi();
+            return $file->isTypePhoto() && !$file->isTemp() && !$file->isIsWaitingSuivi();
         });
     }
 
@@ -2219,7 +2219,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function getDocuments(): Collection
     {
         return $this->files->filter(function (File $file) {
-            return 'document' === $file->getFiletype() && !$file->isTemp() && !$file->isIsWaitingSuivi();
+            return $file->isTypeDocument() && !$file->isTemp() && !$file->isIsWaitingSuivi();
         });
     }
 

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -26,12 +26,22 @@ class FileFactory
         ?bool $isVariantsGenerated = false,
         ?bool $isSuspicious = false,
     ): ?File {
+        $extension = strtolower(pathinfo($filename, \PATHINFO_EXTENSION));
         $file = (new File())
             ->setFilename($filename)
             ->setTitle($title)
-            ->setFileType($this->getFileType($filename, $documentType ?? DocumentType::AUTRE))
+            ->setExtension($extension)
             ->setIsWaitingSuivi($isWaitingSuivi)
             ->setIsTemp($isTemp);
+
+        if (null !== $documentType) {
+            $file->setDocumentType($documentType);
+        } else {
+            $file->setDocumentType(DocumentType::AUTRE);
+        }
+
+        $file->setFileType($file->isTypePhoto() ? File::FILE_TYPE_PHOTO : File::FILE_TYPE_DOCUMENT);
+
         if (null !== $signalement) {
             $file->setSignalement($signalement);
         }
@@ -42,12 +52,6 @@ class FileFactory
 
         if (null !== $intervention) {
             $file->setIntervention($intervention);
-        }
-
-        if (null !== $documentType) {
-            $file->setDocumentType($documentType);
-        } else {
-            $file->setDocumentType(DocumentType::AUTRE);
         }
 
         if (null !== $desordreSlug) {
@@ -100,18 +104,5 @@ class FileFactory
             desordreSlug: $desordreSlug,
             description: $fileDescription,
         );
-    }
-
-    private function getFileType(string $filename, DocumentType $documentType)
-    {
-        $ext = strtolower(pathinfo($filename, \PATHINFO_EXTENSION));
-        if ((File::FILE_TYPE_PHOTO === $documentType->mapFileType() || DocumentType::AUTRE === $documentType)
-            && \in_array($ext, File::IMAGE_EXTENSION)
-            && 'pdf' !== $ext
-        ) {
-            return File::FILE_TYPE_PHOTO;
-        }
-
-        return File::FILE_TYPE_DOCUMENT;
     }
 }

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -92,8 +92,9 @@ class SuiviManager extends Manager
 
         /** @var ?Intervention $intervention */
         $intervention = null;
+        /** @var File $file */
         foreach ($files as $file) {
-            if (File::FILE_TYPE_PHOTO === $file->getFileType()) {
+            if ($file->isTypePhoto()) {
                 ++$nbPhotos;
             } else {
                 ++$nbDocs;

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -48,10 +48,8 @@ class FileRepository extends ServiceEntityRepository
             ->select('f')
             ->innerJoin('f.signalement', 's')
             ->where('f.extension IN :extensionsImage')
-            ->andWhere('f.extension != :extensionPdf')
             ->andWhere('f.isVariantsGenerated = false')
-            ->setParameter('extensionsImage', File::IMAGE_EXTENSION)
-            ->setParameter('extensionPdf', 'pdf');
+            ->setParameter('extensionsImage', File::RESIZABLE_EXTENSION);
         if ($territory) {
             $qb->andWhere('s.territory = :territory')->setParameter('territory', $territory);
         }

--- a/src/Repository/FileRepository.php
+++ b/src/Repository/FileRepository.php
@@ -47,9 +47,11 @@ class FileRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('f')
             ->select('f')
             ->innerJoin('f.signalement', 's')
-            ->where('f.fileType = :type')
+            ->where('f.extension IN :extensionsImage')
+            ->andWhere('f.extension != :extensionPdf')
             ->andWhere('f.isVariantsGenerated = false')
-            ->setParameter('type', File::FILE_TYPE_PHOTO);
+            ->setParameter('extensionsImage', File::IMAGE_EXTENSION)
+            ->setParameter('extensionPdf', 'pdf');
         if ($territory) {
             $qb->andWhere('s.territory = :territory')->setParameter('territory', $territory);
         }

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -71,7 +71,7 @@
 {% if 'photo' in filesType and (filesFilter is same as 'situation' or filesFilter is same as 'visite') %}
     <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
         {% for index, photo in signalement.files|filter(
-            photo => photo.fileType == 'photo' and (
+            photo => photo.isTypePhoto and (
                 (filesFilter is same as 'situation' and photo.isSituationPhoto) or
                 (filesFilter is same as 'visite' and photo.intervention is not null and photo.intervention.id is same as interventionId)
             )) %}
@@ -129,7 +129,7 @@
 
 {% if 'document' in filesType %}
 {% for index, doc in signalement.files|filter(
-    doc => doc.fileType == 'document'
+    doc => doc.isTypeDocument
         and (
             (filesFilter is same as 'situation' 
             and doc.documentType.label() in  DocumentType.getOrderedSituationList)

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -81,7 +81,7 @@
 
 <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
     {% for index, photo in signalement.files|filter(
-        photo => photo.fileType == 'photo'
+        photo => photo.isTypePhoto
                 and photo.intervention is not null
                 and photo.intervention.id is same as intervention.id
         ) %}
@@ -140,7 +140,7 @@
 <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
     <div class="fr-col-12">
         {% for index, doc in signalement.files|filter(
-            doc => doc.fileType == 'document'
+            doc => doc.isTypeDocument
                     and doc.documentType.name == 'PHOTO_VISITE'
                     and doc.intervention is not null
                     and doc.intervention.id is same as intervention.id

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -179,7 +179,7 @@
                     text: 'Partager un document',
                     fetch: function (callback) {
                         let items = [
-                            {% for doc in signalement.files|filter(doc => doc.fileType == 'document' and not doc.isSuspicious) %}
+                            {% for doc in signalement.files|filter(doc => doc.isTypeDocument and not doc.isSuspicious) %}
                             {
                                 type: 'menuitem',
                                 text: '{{ doc.title }}',

--- a/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_infos.html.twig
@@ -397,13 +397,13 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 <h4 class="fr-mb-2v">Vos photos</h4>
 <div class="fr-mb-4v">
     	{% include '_partials/_modal_file_delete.html.twig' %}
-	{% if signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile)|length %}
+	{% if signalement.files|filter(photo => photo.isTypePhoto and photo.isUsagerFile)|length %}
 		Les photos que vous avez ajoutées.
 		<br>
 		Cliquez sur la photo pour l'ouvrir dans un nouvel onglet.
 		<br>
 			<div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
-			{% for photo in signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile) %}
+			{% for photo in signalement.files|filter(photo => photo.isTypePhoto and photo.isUsagerFile) %}
 				<div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
 					<div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center"
 						style="background: url('{{ sign_url(path('show_file', {uuid: photo.uuid, variant: 'thumb'})) }}')no-repeat center center/cover"
@@ -433,7 +433,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 	{% endif %}
 </div>
 
-{% if signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile is same as(false))|length %}
+{% if signalement.files|filter(photo => photo.isTypePhoto and photo.isUsagerFile is same as(false))|length %}
 	<h4 class="fr-mb-2v">Photos supplémentaires</h4>
 	<div class="fr-mb-4v">
 		Les photos ajoutées à votre dossier par l'administration.
@@ -441,7 +441,7 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 		Cliquez sur la photo pour l'ouvrir dans un nouvel onglet.
 		<br>
 		<div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">
-			{% for photo in signalement.files|filter(photo => photo.fileType == 'photo' and photo.isUsagerFile is same as(false)) %}
+			{% for photo in signalement.files|filter(photo => photo.isTypePhoto and photo.isUsagerFile is same as(false)) %}
 				<div class="fr-col-6 fr-col-md-2 fr-rounded signalement-file-item">
 					<div class="fr-px-5w fr-py-8w fr-rounded fr-border fr-text--center"
 						style="background: url('{{ sign_url(path('show_file', {uuid: photo.uuid, variant: 'thumb'})) }}')no-repeat center center/cover"
@@ -460,10 +460,10 @@ and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\Profile
 
 <h4 class="fr-mb-2v">Documents</h4>
 <div class="fr-mb-4v">
-	{% if signalement.files|filter(doc => doc.fileType == 'document' and doc.isUsagerFile)|length %}
+	{% if signalement.files|filter(doc => doc.isTypeDocument and doc.isUsagerFile)|length %}
 		Cliquez sur le document pour l'ouvrir dans un nouvel onglet.
 		<br>
-		{% for doc in signalement.files|filter(doc => doc.fileType == 'document' and doc.isUsagerFile) %}			
+		{% for doc in signalement.files|filter(doc => doc.isTypeDocument and doc.isUsagerFile) %}			
 			<div class="fr-grid-row fr-grid-row--middle fr-background-alt--grey fr-rounded fr-p-3v signalement-file-item">
 				<div class="fr-col-9">
 					<div class="fr-grid-row">

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -625,7 +625,7 @@
 
     <section>
         <div class="page">
-        {% for index, photo in signalement.files|filter(photo => photo.fileType == 'photo') %}
+        {% for index, photo in signalement.files|filter(photo => photo.isTypePhoto) %}
                 <div style="page-break-inside: avoid;margin-top: 25px;">
                     <h2>Photo : {{ photo.title }}</h2>
                     <small>Ajouté par {{ photo.username ?? 'N/R' }}</small><br>

--- a/tests/FixturesHelper.php
+++ b/tests/FixturesHelper.php
@@ -457,6 +457,7 @@ trait FixturesHelper
         return (new File())
             ->setFilename('document.pdf')
             ->setTitle('Doc')
+            ->setExtension('pdf')
             ->setFileType(File::FILE_TYPE_DOCUMENT)
             ->setCreatedAt(new \DateTimeImmutable('2022-12-02'));
     }
@@ -466,6 +467,7 @@ trait FixturesHelper
         return (new File())
             ->setFilename('photo.jpg')
             ->setTitle('Photo')
+            ->setExtension('jpg')
             ->setFileType(File::FILE_TYPE_PHOTO)
             ->setCreatedAt(new \DateTimeImmutable('2022-12-02'));
     }

--- a/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementFileUpdateControllerTest.php
@@ -31,7 +31,7 @@ class SignalementFileUpdateControllerTest extends WebTestCase
     {
         $signalement = self::getContainer()->get(SignalementRepository::class)->find(1);
         $file = $signalement->getFiles()->filter(function (File $file) {
-            return 'photo' === $file->getFileType();
+            return $file->isTypePhoto();
         })->current();
 
         $payload = [
@@ -55,7 +55,7 @@ class SignalementFileUpdateControllerTest extends WebTestCase
     {
         $signalement = self::getContainer()->get(SignalementRepository::class)->find(1);
         $file = $signalement->getFiles()->filter(function (File $file) {
-            return 'photo' === $file->getFileType();
+            return $file->isTypePhoto();
         })->current();
 
         $payload = [

--- a/tests/Functional/Manager/FileManagerTest.php
+++ b/tests/Functional/Manager/FileManagerTest.php
@@ -30,6 +30,7 @@ class FileManagerTest extends KernelTestCase
 
         $this->assertEquals('blank.pdf', $file->getFilename());
         $this->assertEquals('Blank', $file->getTitle());
+        $this->assertEquals('pdf', $file->getExtension());
         $this->assertTrue($file->isTypeDocument());
         $this->assertEquals($signalement->getReference(), $file->getSignalement()->getReference());
         $this->assertEquals(DocumentType::AUTRE, $file->getDocumentType());
@@ -48,17 +49,17 @@ class FileManagerTest extends KernelTestCase
         $file = $fileManager->createOrUpdate(
             filename: 'blank.jpg',
             title: 'Blank',
-            type: File::FILE_TYPE_PHOTO,
             signalement: $signalement = $signalementRepository->findOneBy(['reference' => '2023-12']),
             description: $desc,
-            documentType: DocumentType::PROCEDURE_RAPPORT_DE_VISITE
+            documentType: DocumentType::PHOTO_VISITE
         );
 
         $this->assertEquals('blank.jpg', $file->getFilename());
         $this->assertEquals('Blank', $file->getTitle());
+        $this->assertEquals('jpg', $file->getExtension());
         $this->assertTrue($file->isTypePhoto());
         $this->assertEquals($signalement->getReference(), $file->getSignalement()->getReference());
         $this->assertEquals($desc, $file->getDescription());
-        $this->assertEquals(DocumentType::PROCEDURE_RAPPORT_DE_VISITE, $file->getDocumentType());
+        $this->assertEquals(DocumentType::PHOTO_VISITE, $file->getDocumentType());
     }
 }

--- a/tests/Functional/Manager/FileManagerTest.php
+++ b/tests/Functional/Manager/FileManagerTest.php
@@ -30,7 +30,7 @@ class FileManagerTest extends KernelTestCase
 
         $this->assertEquals('blank.pdf', $file->getFilename());
         $this->assertEquals('Blank', $file->getTitle());
-        $this->assertEquals('document', $file->getFileType());
+        $this->assertTrue($file->isTypeDocument());
         $this->assertEquals($signalement->getReference(), $file->getSignalement()->getReference());
         $this->assertEquals(DocumentType::AUTRE, $file->getDocumentType());
     }
@@ -56,7 +56,7 @@ class FileManagerTest extends KernelTestCase
 
         $this->assertEquals('blank.jpg', $file->getFilename());
         $this->assertEquals('Blank', $file->getTitle());
-        $this->assertEquals('photo', $file->getFileType());
+        $this->assertTrue($file->isTypePhoto());
         $this->assertEquals($signalement->getReference(), $file->getSignalement()->getReference());
         $this->assertEquals($desc, $file->getDescription());
         $this->assertEquals(DocumentType::PROCEDURE_RAPPORT_DE_VISITE, $file->getDocumentType());

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -25,7 +25,6 @@ class FileFactoryTest extends TestCase
         $this->assertEquals('sample-123.jpg', $file->getFilename());
         $this->assertEquals('sample.jpg', $file->getTitle());
         $this->assertTrue($file->isTypePhoto());
-        $this->assertTrue($file->isTypePhoto());
         $this->assertInstanceOf(Signalement::class, $file->getSignalement());
         $this->assertInstanceOf(User::class, $file->getUploadedBy());
         $this->assertInstanceOf(\DateTimeImmutable::class, $file->getCreatedAt());

--- a/tests/Unit/Factory/FileFactoryTest.php
+++ b/tests/Unit/Factory/FileFactoryTest.php
@@ -24,8 +24,8 @@ class FileFactoryTest extends TestCase
         );
         $this->assertEquals('sample-123.jpg', $file->getFilename());
         $this->assertEquals('sample.jpg', $file->getTitle());
-        $this->assertEquals('photo', $file->getFileType());
-        $this->assertEquals(File::FILE_TYPE_PHOTO, $file->getFileType());
+        $this->assertTrue($file->isTypePhoto());
+        $this->assertTrue($file->isTypePhoto());
         $this->assertInstanceOf(Signalement::class, $file->getSignalement());
         $this->assertInstanceOf(User::class, $file->getUploadedBy());
         $this->assertInstanceOf(\DateTimeImmutable::class, $file->getCreatedAt());


### PR DESCRIPTION
## Ticket

#3843   

## Description
Afin de remplacer l'attribut `fileType` de l'entité `File`, mise en place de l'attribut extension qui doit permettre de séparer les fichiers selon l'endroit où on souhaite l'afficher.
Dans cette PR, le fonctionnement métier ne doit pas changer.

## Changements apportés
* Ajout d'une colonne extension
* Remplacement de toutes les comparaisons sur le `fileType` par `isTypePhoto` ou `isTypeDocument`
* Conservation de `fileType` pour l'instant, au cas où un retour arrière est nécessaire
* Création d'une commande qui initialise la colonne `extension` pour les fichiers

## Pré-requis
`make execute-migration name=Version20250516083935 direction=up`

## Tests
- [ ] TNR Sans avoir exécuté la commande d'initialisation, vérifier que le site fonctionne
- [ ] Si ajout de fichier (fo signalement, fo suivi, bo signalement), l'extension est définie
- [ ] `make console app="init-files-extension"`
- [ ] Les extensions des différents sont bien définies, mais le fonctionnement actuel ne change pas
