### PR TITLE
[BO - Signalement] Edition type fichier sur Signalement en attente de validation

### DIFF
--- a/src/Security/Voter/FileVoter.php
+++ b/src/Security/Voter/FileVoter.php
@@ -52,6 +52,9 @@ class FileVoter extends Voter
         if (SignalementStatus::DRAFT === $file->getSignalement()->getStatut() && $file->getSignalement()->getCreatedBy() === $user) {
             return true;
         }
+        if (SignalementStatus::NEED_VALIDATION === $file->getSignalement()->getStatut() && $user->isSuperAdmin()) {
+            return true;
+        }
         if (SignalementStatus::ACTIVE !== $file->getSignalement()->getStatut()) {
             return false;
         }


### PR DESCRIPTION
## Ticket

#4107    

## Description
Si je vais sur un signalement en attente de validation en tant qu'admin, je peux ajouter un fichier.
Par contre, quand je l'édite, l'accès est refusé.
Donc quand je sélectionne le type de document, celui-ci n'est pas enregistré.

C'est lié au voter FILE_EDIT qui vérifie le statut du signalement.

## Changements apportés
* Modification du FileVoter

## Pré-requis

## Tests
- [ ] En tant que SA, aller sur un signalement en attente, ajouter un document en précisant son type, et vérifier que le type est pris en compte
