### PR TITLE
[BO - Signalement] Ajout du champ Logement vacant

### DIFF
--- a/src/Dto/Api/Response/SignalementResponse.php
+++ b/src/Dto/Api/Response/SignalementResponse.php
@@ -177,6 +177,7 @@ class SignalementResponse
         nullable: true
     )]
     public ?bool $constructionAvant1949;
+
     #[OA\Property(
         description: 'Nombre d\'étages dans le logement.',
         format: 'int',
@@ -461,6 +462,18 @@ class SignalementResponse
         nullable: true
     )]
     public ?float $loyer;
+
+    #[OA\Property(
+        description: 'Indique si un logement est actuellement vacant.<br>
+        <ul>
+           <li>`true` pour "oui"</li>
+           <li>`false` pour "non"</li>
+           <li>`nsp` pour "Je ne sais pas".</li>
+        </ul>',
+        example: true,
+        nullable: true
+    )]
+    public bool|string|null $logementVacant;
 
     #[OA\Property(
         description: 'Indique si un bail est actuellement en cours.<br>

--- a/src/Dto/Api/Response/SignalementResponse.php
+++ b/src/Dto/Api/Response/SignalementResponse.php
@@ -468,24 +468,22 @@ class SignalementResponse
         <ul>
            <li>`true` pour "oui"</li>
            <li>`false` pour "non"</li>
-           <li>`nsp` pour "Je ne sais pas".</li>
         </ul>',
         example: true,
         nullable: true
     )]
-    public bool|string|null $logementVacant;
+    public ?bool $logementVacant;
 
     #[OA\Property(
         description: 'Indique si un bail est actuellement en cours.<br>
         <ul>
            <li>`true` pour "oui"</li>
            <li>`false` pour "non"</li>
-           <li>`nsp` pour "Je ne sais pas".</li>
         </ul>',
         example: true,
         nullable: true
     )]
-    public bool|string|null $bailEnCours;
+    public ?bool $bailEnCours;
 
     #[OA\Property(
         description: 'Indique si un bail existe.<br>

--- a/src/Dto/Request/Signalement/InformationsLogementRequest.php
+++ b/src/Dto/Request/Signalement/InformationsLogementRequest.php
@@ -27,6 +27,8 @@ class InformationsLogementRequest implements RequestInterface
         #[Assert\NotBlank(message: 'Merci d\'indiquer si un bail existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR'])]
         #[Assert\Choice(choices: ['oui', 'non', 'nsp'], message: 'Le champ "bail" est incorrect.')]
         private readonly ?string $bailDpeBail = null,
+        #[Assert\Choice(choices: ['oui', 'non'], message: 'Le champ "logement vacant" est incorrect.')]
+        private readonly ?string $logementVacant = null,
         #[Assert\Length(max: 12, maxMessage: 'L\'invariant fiscal ne doit pas dépasser {{ limit }} caractères.')]
         private readonly ?string $bailDpeInvariant = null,
         #[Assert\NotBlank(message: 'Merci d\'indiquer si un état des lieux existe (ou a été fourni).', groups: ['LOCATAIRE', 'BAILLEUR'])]
@@ -75,6 +77,11 @@ class InformationsLogementRequest implements RequestInterface
     public function getBailDpeBail(): ?string
     {
         return $this->bailDpeBail;
+    }
+
+    public function getLogementVacant(): ?string
+    {
+        return $this->logementVacant;
     }
 
     public function getBailDpeInvariant(): ?string

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -113,6 +113,7 @@ readonly class SignalementResponseFactory
         $signalementResponse->reponseProprietaire = $signalement->getInformationProcedure()?->getInfoProcedureBailReponse();
         $signalementResponse->numeroReclamationProprietaire = $signalement->getInformationProcedure()?->getInfoProcedureBailNumero();
         $signalementResponse->loyer = $signalement->getLoyer();
+        $signalementResponse->logementVacant = $signalement->getIsLogementVacant();
         $signalementResponse->bailEnCours = $signalement->getIsBailEnCours();
         $signalementResponse->bailExistant = $this->stringToBool($signalement->getTypeCompositionLogement()?->getBailDpeBail());
         $signalementResponse->invariantFiscal = $signalement->getTypeCompositionLogement()?->getBailDpeInvariant();

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -504,6 +504,14 @@ class SignalementManager extends AbstractManager
             $signalement->setDateEntree(null);
         }
 
+        if ('oui' === $informationsLogementRequest->getLogementVacant()) {
+            $signalement->setIsLogementVacant(true);
+        } elseif ('non' === $informationsLogementRequest->getLogementVacant()) {
+            $signalement->setIsLogementVacant(false);
+        } else {
+            $signalement->setIsLogementVacant(null);
+        }
+
         $typeCompositionLogement = new TypeCompositionLogement();
         if (!empty($signalement->getTypeCompositionLogement())) {
             $typeCompositionLogement = clone $signalement->getTypeCompositionLogement();

--- a/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-informations-logement.html.twig
@@ -116,6 +116,22 @@
                                 </select>
                             </div>
 
+                            <div class="fr-select-group">
+                                <label class="fr-label" for="informationLogementVacant">Logement vacant
+                                    {{ show_label_facultatif(
+                                        'App\\Dto\\Request\\Signalement\\InformationsLogementRequest',
+                                        'logementVacant',
+                                        signalement.profileDeclarant,
+                                        signalement.isV2)
+                                    }}
+                                </label>
+                                <select class="fr-select" id="informationLogementVacant" name="logementVacant">
+                                    <option value="" {{ signalement.isLogementVacant not in [true, false] ? 'selected' : '' }}></option>
+                                    <option value="oui" {{ signalement.isLogementVacant is same as true ? 'selected' : '' }}>Oui</option>
+                                    <option value="non" {{ signalement.isLogementVacant is same as false ? 'selected' : '' }}>Non</option>
+                                </select>
+                            </div>
+
                             <div class="fr-input-group">
                                 {% set bailDpeInvariant = signalement.typeCompositionLogement ? signalement.typeCompositionLogement.bailDpeInvariant : null %}
                                 <label class="fr-label" for="informationLogementBailDpeInvariant">Invariant fiscal (facultatif)</label>

--- a/templates/back/signalement/view/information/information-logement.html.twig
+++ b/templates/back/signalement/view/information/information-logement.html.twig
@@ -72,6 +72,14 @@
         {% endif %}
     </div>
     <div class="fr-col-12 fr-col-md-6">
+        <strong>Logement vacant :</strong>
+        {% if signalement.isLogementVacant is same as true %}
+            {{ static_picto_yes|raw }}
+        {% elseif signalement.isLogementVacant is same as false %}
+            {{ static_picto_no|raw }}
+        {% endif %}
+    </div>
+    <div class="fr-col-12 fr-col-md-6">
         <strong>Invariant fiscal :</strong>
         {% if signalement.typeCompositionLogement %}
             {{ signalement.typeCompositionLogement.bailDpeInvariant}}

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -379,6 +379,14 @@
                                 </li>
                             {% endif %}
                             <li>
+                                <b>Logement vacant :</b>
+                                {% if signalement.isLogementVacant is same as true %}
+                                    {{ picto_yes|raw }}
+                                {% elseif signalement.isLogementVacant is same as false %}
+                                    {{ picto_no|raw }}
+                                {% endif %}
+                            </li>
+                            <li>
                                 <b>Logement social :</b>
                                 {% if signalement.isLogementSocial %}
                                     {{ picto_yes|raw }}


### PR DESCRIPTION
## Ticket

#3895   

## Description
Dans le nouveau formulaire BO, on a ajouté le champ Logement vacant.
Mais il n'était pas affiché dans le BO (ni éditable), pas envoyé via l'API, pas affiché dans les PDFs

## Tests
- [ ] Vérifier l'affichage de la valeur dans la fiche signalement
- [ ] Vérifier que l'édition est correcte
- [ ] Modifier la valeur dans différents signalements et récupérer dans l'API
- [ ] Vérifier dans les exports PDFs
