### PR TITLE
[FO - Mot de passe] Tabulation sur le bouton d'affichage du mot de passe

### DIFF
--- a/templates/back/profil/_modal_profil_password.html.twig
+++ b/templates/back/profil/_modal_profil_password.html.twig
@@ -17,14 +17,16 @@
                                     Mot de passe actuel
                                 </label>
                                 <input class="fr-input fr-col-11" type="password" id="login-password-current" name="password-current" required autocomplete="password">
-                                <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                                <button class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
+                                    type="button" title="Afficher/Cacher le mot de passe"></button>
                             </div>
                             <div class="fr-input-group fr-input-group-password fr-grid-row fr-grid-row--middle fr-mt-5v">
                                 <label class="fr-label fr-col-12" for="login-password">
                                     Nouveau mot de passe
                                 </label>
                                 <input class="fr-input fr-col-11" type="password" id="login-password" name="password" required minlength="12" autocomplete="new-password">
-                                <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                                <button class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
+                                    type="button" title="Afficher/Cacher le mot de passe"></button>
                                 <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
                                     <p class="fr-message">Votre mot de passe doit contenir :</p>
                                     <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">12 caractères minimum</p>
@@ -39,7 +41,8 @@
                                     Confirmer le nouveau mot de passe
                                 </label>
                                 <input class="fr-input fr-col-11" type="password" id="login-password-repeat" name="password-repeat" required minlength="12" autocomplete="new-password">
-                                <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                                <button class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
+                                    type="button" title="Afficher/Cacher le mot de passe"></button>
                                 <p id="password-match-error" class="fr-error-text fr-hidden fr-col-12">
                                     Les mots de passe ne correspondent pas.
                                 </p>

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -43,8 +43,8 @@
                     </label>
                     <input class="fr-input fr-col-11" aria-describedby="login-password-error-desc-error" type="password"
                            id="login-password" name="password" required>
-                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
-                          title="Afficher/Cacher le mot de passe"></span>
+                    <button class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
+                        type="button" title="Afficher/Cacher le mot de passe"></button>
                     <p id="login-password-error-desc-error" class="fr-error-text fr-hidden fr-col-12">
                         Veuillez saisir votre mot de passe.
                     </p>

--- a/templates/security/reset_password_new.html.twig
+++ b/templates/security/reset_password_new.html.twig
@@ -67,7 +67,8 @@
                         <span class="fr-hint-text">Choisissez un mot de passe <u>fort et unique</u></span>
                     </label>
                     <input class="fr-input fr-col-11" type="password" id="login-password" name="password" required minlength="12">
-                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                    <button class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
+                        type="button" title="Afficher/Cacher le mot de passe"></button>
                     <div class="fr-messages-group" id="password-input-messages" aria-live="assertive">
                         <p class="fr-message">Votre mot de passe doit contenir :</p>
                         <p class="message-password fr-message fr-message--info" id="password-input-message-info-length">12 caractères minimum</p>
@@ -83,7 +84,8 @@
                         <span class="fr-hint-text">Saisissez à nouveau votre mot de passe</span>
                     </label>
                     <input class="fr-input fr-col-11" type="password" id="login-password-repeat" name="password-repeat" required minlength="12">
-                    <span class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle" title="Afficher/Cacher le mot de passe"></span>
+                    <button class="fr-btn fr-fi-eye-off-fill fr-col-1 fr-mt-2v fr-password-toggle"
+                        type="button" title="Afficher/Cacher le mot de passe"></button>
                     <p id="password-match-error" class="fr-error-text fr-hidden fr-col-12">
                         Les mots de passe ne correspondent pas.
                     </p>


### PR DESCRIPTION
## Ticket

#3978   

## Description
Le bouton qui permet d'afficher ou masquer la saisie de mot de passe n'était pas accessible via tabulation.

## Tests
- [ ] Vérifier sur page de connexion
- [ ] Vérifier sur page d'activation de compte
- [ ] Vérifier sur le profil, dans la modale de modification de mot de passe
