### PR TITLE
[SISH] Décalage sur les dates de visites sans heures

### DIFF
--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -314,7 +314,10 @@ class EsaboraManager
     private function updateFromDossierVisite(Intervention $intervention, DossierVisiteSISH $dossierVisiteSISH): void
     {
         $intervention
-            ->setScheduledAt(DateParser::parse($dossierVisiteSISH->getVisiteDate()))
+            ->setScheduledAt(DateParser::parse(
+                $dossierVisiteSISH->getVisiteDate(),
+                $intervention->getSignalement()->getTimezone())
+            )
             ->setDoneBy($visitePar = $dossierVisiteSISH->getVisitePar());
 
         if ('ARS' !== $visitePar) {

--- a/src/Service/Interconnection/Esabora/Response/Model/DossierVisiteSISH.php
+++ b/src/Service/Interconnection/Esabora/Response/Model/DossierVisiteSISH.php
@@ -4,13 +4,13 @@ namespace App\Service\Interconnection\Esabora\Response\Model;
 
 class DossierVisiteSISH
 {
-    public const SAS_LOGICIEL_PROVENANCE = 0;
-    public const REFERENCE_DOSSIER = 1;
-    public const DOSS_NUM = 2;
-    public const VISITE_DATE = 3;
-    public const VISITE_NUM = 4;
-    public const VISITE_TYPE = 5;
-    public const VISITE_PAR = 6;
+    public const int SAS_LOGICIEL_PROVENANCE = 0;
+    public const int REFERENCE_DOSSIER = 1;
+    public const int DOSS_NUM = 2;
+    public const int VISITE_DATE = 3;
+    public const int VISITE_NUM = 4;
+    public const int VISITE_TYPE = 5;
+    public const int VISITE_PAR = 6;
 
     private ?int $visiteId = null;
     private ?string $sasLogicielProvenance = null;

--- a/tests/Unit/Service/Esabora/DateParserTest.php
+++ b/tests/Unit/Service/Esabora/DateParserTest.php
@@ -25,7 +25,9 @@ class DateParserTest extends TestCase
     {
         $date = '04/05/2023';
         $parsedDate = DateParser::parse($date, 'Europe/Paris');
-        $this->assertEquals(new \DateTimeImmutable('2023-05-04 00:00'), $parsedDate);
+        $this->assertEquals(new \DateTimeImmutable('2023-05-04 00:00', new \DateTimeZone('UTC')),
+            $parsedDate);
+
         $this->assertSame('00:00:00', $parsedDate->format('H:i:s'));
     }
 }

--- a/tests/Unit/Service/Esabora/DateParserTest.php
+++ b/tests/Unit/Service/Esabora/DateParserTest.php
@@ -7,19 +7,25 @@ use PHPUnit\Framework\TestCase;
 
 class DateParserTest extends TestCase
 {
+    /**
+     * @throws \Exception
+     */
     public function testParseWithDateTimeFormat(): void
     {
         $date = '03/05/2023 10:16';
-        $expected = \DateTimeImmutable::createFromFormat('d/m/Y H:i', $date);
-        $this->assertEquals($expected, DateParser::parse($date));
+        $this->assertEquals(
+            new \DateTimeImmutable('2023-05-03 08:16', new \DateTimeZone('UTC')),
+            DateParser::parse($date, 'Europe/Paris'));
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testParseWithDateFormat(): void
     {
         $date = '04/05/2023';
-        $parsedDate = DateParser::parse($date);
-        $expected = \DateTimeImmutable::createFromFormat('d/m/Y H:i:s', $date.' 00:00:00');
-        $this->assertEquals($expected, $parsedDate);
+        $parsedDate = DateParser::parse($date, 'Europe/Paris');
+        $this->assertEquals(new \DateTimeImmutable('2023-05-04 00:00'), $parsedDate);
         $this->assertSame('00:00:00', $parsedDate->format('H:i:s'));
     }
 }

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Service\Esabora;
 
+use App\Entity\Enum\InterventionType;
 use App\Entity\Enum\PartnerType;
 use App\Entity\Intervention;
 use App\Entity\User;
@@ -67,14 +68,20 @@ class EsaboraManagerTest extends TestCase
         $this->signalementQualificationUpdater = $this->createMock(SignalementQualificationUpdater::class);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testCreateVisite(): void
     {
         $dossierVisiteCollection = $this->getDossierVisiteSISHCollectionResponse()->getCollection();
         $dossierVisite = $dossierVisiteCollection[0];
-        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::CREATE_ACTION);
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::CREATE_ACTION, InterventionType::VISITE);
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testFailureCreateVisite(): void
     {
         $dossierVisiteCollection = $this->getDossierVisiteSISHCollectionWithDossierResponse()->getCollection();
@@ -121,36 +128,51 @@ class EsaboraManagerTest extends TestCase
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testUpdateVisite(): void
     {
         $dossierVisiteCollection = $this->getDossierVisiteSISHCollectionResponse()->getCollection();
         $dossierVisite = $dossierVisiteCollection[0];
-        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::UPDATE_ACTION);
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::UPDATE_ACTION, InterventionType::VISITE);
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testCreateArrete(): void
     {
         $dossierArreteCollection = $this->getDossierArreteSISHCollectionResponse()->getCollection();
         $dossierArrete = $dossierArreteCollection[0];
-        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::CREATE_ACTION);
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::CREATE_ACTION, InterventionType::ARRETE_PREFECTORAL);
         $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testUpdateArrete(): void
     {
         $dossierArreteCollection = $this->getDossierArreteSISHCollectionResponse()->getCollection();
         $dossierArrete = $dossierArreteCollection[0];
-        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::UPDATE_ACTION);
+        $esaboraManager = $this->provideEsaboraManagerForIntervention(self::UPDATE_ACTION, InterventionType::ARRETE_PREFECTORAL);
         $esaboraManager->createOrUpdateArrete($this->getAffectation(PartnerType::ARS), $dossierArrete);
     }
 
-    public function provideEsaboraManagerForIntervention(string $action): EsaboraManager
+    public function provideEsaboraManagerForIntervention(string $action, InterventionType $interventionType): EsaboraManager
     {
         $this->interventionRepository
             ->expects($this->once())
             ->method('findOneBy')
-            ->willReturn(self::CREATE_ACTION === $action ? null : new Intervention());
+            ->willReturn(self::CREATE_ACTION === $action
+                ? null
+                : $this->getIntervention(
+                    $interventionType,
+                    new \DateTimeImmutable('2024-01-20'),
+                    Intervention::STATUS_DONE)
+            );
 
         $this->interventionRepository
             ->expects($this->once())


### PR DESCRIPTION
## Ticket

#4106   

## Description
La date de mise à jour via Esabora est enregistré au format local en base, elle devrait être au format UTC

## Changements apportés
* Mise à jour EsaboraManager

## Pré-requis
make mock-stop && make mock-start

## Tests
- [ ] Executer make sync-sish et vérifier que sur le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012 les dates sont bien enregistré au format UTC
- [ ] A chaque mise à jour du mock => make mock-stop && make mock-start
- [ ] Faire une maj sur le signalement tools/wiremock/src/Resources/Esabora/sish/ws_visites_dossier_sas_en_cours.json et faire plusieurs mises à jour dont une sans heure. Vérifier que les dates sont toujours en UTC en base et au format locale sur le tableau de bord 
