### PR TITLE
[Logout - QA] Gestion deconnexion Usager

### DIFF
--- a/src/EventSubscriber/LogoutSubscriber.php
+++ b/src/EventSubscriber/LogoutSubscriber.php
@@ -3,6 +3,7 @@
 namespace App\EventSubscriber;
 
 use App\Entity\User;
+use App\Security\User\SignalementUser;
 use App\Service\Gouv\ProConnect\ProConnectAuthentication;
 use App\Service\Gouv\ProConnect\ProConnectContext;
 use Psr\Log\LoggerInterface;
@@ -44,6 +45,20 @@ readonly class LogoutSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $session = $request->getSession();
         $logoutUrl = null;
+
+        if ($user instanceof SignalementUser) {
+            $this->logger->info('App usager logout');
+            $this->clearSession($session);
+            $response = new RedirectResponse(
+                $this->urlGenerator->generate(
+                    'home',
+                )
+            );
+            $event->setResponse($response);
+
+            return;
+        }
+
         try {
             if ($user?->getProConnectUserId() && $session->has(ProConnectContext::SESSION_KEY_ID_TOKEN)) {
                 $logoutUrl = $this->proConnectAuthentication->getLogoutUrl();


### PR DESCRIPTION
## Ticket

#4117 

## Description
Bien que l'erreur soit intercepté, il faudrait vérifier si c'est un usager avant de vérifier si c'est un utilisateur proconnect.
Traitement en dehors des bloc try/catch

## Changements apportés
* Ajout condition subscriber
* Mise à jour test

## Pré-requis

tail -f var/log/dev.log | grep "app."

## Tests
- [ ] Se déconnecter en tant qu'usager  et vérifier qu'aucun log d'erreur n'est affiché
