### PR TITLE
[Ouverture territoire - Import grille] Ignorer les utilisateurs existants lors de la phase de validation

### DIFF
--- a/src/Service/Import/GridAffectation/GridAffectationLoader.php
+++ b/src/Service/Import/GridAffectation/GridAffectationLoader.php
@@ -144,33 +144,6 @@ class GridAffectationLoader
                     if (\count($violations) > 0) {
                         $errors[] = \sprintf('line %d : E-mail incorrect pour un utilisateur : %s', $numLine, $emailUser);
                     }
-
-                    /** @var User $userToCheck */
-                    $userToCheck = $this->userManager->findOneBy(['email' => $emailUser]);
-                    if (!$isModeUpdate
-                        && null !== $userToCheck
-                        && !\in_array('ROLE_USAGER', $userToCheck->getRoles())
-                    ) {
-                        $territories = '';
-                        foreach ($userToCheck->getPartners() as $partner) {
-                            $territories .= $partner->getTerritory()->getName().', ';
-                        }
-                        $territories = \substr($territories, 0, -2);
-                        $partners = '';
-                        foreach ($userToCheck->getPartners() as $partner) {
-                            $partners .= $partner->getNom().', ';
-                        }
-                        $partners = \substr($partners, 0, -2);
-
-                        $errors[] = \sprintf(
-                            'line %d : Utilisateur déjà existant avec (%s) dans %s, partenaire : %s, rôle : %s',
-                            $numLine,
-                            $emailUser,
-                            $territories,
-                            $partners,
-                            $userToCheck->getRoleLabel()
-                        );
-                    }
                     // store user mail to check duplicates
                     if (!empty($item[GridAffectationHeader::USER_EMAIL])) {
                         $mailUsers[] = $item[GridAffectationHeader::USER_EMAIL];

--- a/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
+++ b/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
@@ -9,6 +9,7 @@ use App\Manager\ManagerInterface;
 use App\Manager\PartnerManager;
 use App\Manager\UserManager;
 use App\Service\Import\GridAffectation\GridAffectationLoader;
+use App\Service\Mailer\NotificationMailerRegistry;
 use App\Tests\FixturesHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Faker\Factory;
@@ -49,7 +50,8 @@ class GridAffectationLoaderTest extends KernelTestCase
             self::getContainer()->get(ManagerInterface::class),
             self::getContainer()->get(ValidatorInterface::class),
             self::getContainer()->get(LoggerInterface::class),
-            $this->entityManager
+            self::getContainer()->get(NotificationMailerRegistry::class),
+            $this->entityManager,
         );
     }
 

--- a/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
+++ b/tests/Functional/Service/Import/GridAffectation/GridAffectationLoaderTest.php
@@ -131,7 +131,6 @@ class GridAffectationLoaderTest extends KernelTestCase
             'line 7 : E-mail partenaire déjà existant dans le territoire avec (partenaire-13-01@signal-logement.fr) dans Bouches-du-Rhône, nom : Partenaire 13-01',
             'line 8 : E-mail manquant pour Margaretta Borer, partenaire ADIL',
             'line 9 : Nom de partenaire manquant',
-            'line 10 : Utilisateur déjà existant avec (user-13-06@signal-logement.fr) dans Bouches-du-Rhône, partenaire : Partenaire 13-06 ESABORA ARS, rôle : Agent',
             'Certains partenaires ont un e-mail en commun ddt-m@signal-logement.fr',
             'Certains utilisateurs ont un e-mail en commun user-ddt@signal-logement.fr',
             'Certains utilisateurs ont un e-mail en commun avec un partenaire ddt-m@signal-logement.fr,user-ddt@signal-logement.fr',


### PR DESCRIPTION
## Ticket

#4114 
#4115

## Description
Lors de l'import d'une grille la méthode de pré validation bloquait sur les utilisateurs déjà existants, alors que la méthode d'insertion à déjà été modifié pour les gérer en multi-territoire. C'est corrigé. Au passage ajout de notification mail pour les cas de multi territoire

## Pré-requis
Se mettre sur une base de prod

## Tests
- [ ] Lancer `make console app="import-grid-affectation 80"`
- [ ] Lancer `make console app="import-grid-affectation 90"`
