### PR TITLE
[BO - Signalement] Ajouter l'info création via BO sur la fiche

### DIFF
--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -133,7 +133,7 @@
         <div class="fr-col-5">
             <div class="fr-mb-4v fr-text--right">
                 Dossier déposé le : {{ signalement.createdAt|date('d/m/Y') }}
-                {% if signalement.createdBy is defined and signalement.createdBy is not null %}
+                {% if signalement.createdBy is not null %}
                      depuis le formulaire pro
                 {% elseif signalement.isImported is same as true %}
                      par import

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -133,6 +133,13 @@
         <div class="fr-col-5">
             <div class="fr-mb-4v fr-text--right">
                 Dossier déposé le : {{ signalement.createdAt|date('d/m/Y') }}
+                {% if signalement.createdBy is defined and signalement.createdBy is not null %}
+                     depuis le formulaire pro
+                {% elseif signalement.isImported is same as true %}
+                     par import
+                {% else %}
+                     depuis le formulaire usager
+                {% endif %}
             </div>
 
             <div class="fr-mb-4v fr-text--right">


### PR DESCRIPTION
## Ticket

#4131   

## Description
Une fois qu'un signalement créé depuis le BO est validé, l'information n'apparaît plus nulle part ce qui peut créer de la confusion, surtout si on a des signalements avec peu d'info
Il faudrait ajouter l'info sur la fiche
Je propose de le mettre dans l'en-tête `Dossier déposé le : dd/mm/yyyy depuis le formulaire pro` | `Dossier déposé le : dd/mm/yyyy depuis le formulaire usager` | `Dossier déposé le : dd/mm/yyyy par import`


## Changements apportés
* Modification du template twig

## Pré-requis

## Tests
- [ ] Ouvrir 3 signalements (importé, créé sur le formu usager, créé sur le form BO) et vérifier la fiche signalement sur le BO
