### PR TITLE
[BO - Mes brouillons] Enlever le hover sur les signalements en attente de validation

### DIFF
--- a/templates/back/signalement_drafts/need_validation_card.html.twig
+++ b/templates/back/signalement_drafts/need_validation_card.html.twig
@@ -1,4 +1,4 @@
-<div class="fr-card fr-my-5v fr-enlarge-link fr-card--grey">
+<div class="fr-card fr-my-5v fr-card--grey">
     <div class="fr-card__body">
         <div class="fr-card__content">
             <div class="fr-grid-row">


### PR DESCRIPTION
## Ticket

#4129   

## Description
Je suis agent
J'ai créé un signalement depuis le BO
Il apparaît dans ma liste de brouillon comme en attente de validation
Quand je passe ma souris dessus, il y a un effet hover et le fond devient plus foncé
Il faudrait retirer ce hover parce que ça donne l'impression qu'il va se passer quelque chose si on clique sur le signalement, alors que non

## Changements apportés
* Suppression d'une classe css dans le template

## Pré-requis

## Tests
- [ ] En agent, faire un signalement via le BO dans le 13
- [ ] Vérifier l'affichage dans la liste `Mes brouillons`
