### PR TITLE
[BO - Formulaire pro - onglet coordonnées] Ajouter la civilité pour l'occupant

### DIFF
--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -78,6 +78,17 @@ class SignalementDraftCoordonneesType extends AbstractType
         }
 
         $builder
+            ->add('civiliteOccupant', ChoiceType::class, [
+                'label' => 'Civilité',
+                'choices' => [
+                    'Mme' => 'mme',
+                    'Mr' => 'mr',
+                ],
+                'expanded' => true,
+                'multiple' => false,
+                'required' => false,
+                'placeholder' => false,
+            ])
             ->add('nomOccupant', TextType::class, [
                 'label' => 'Nom de famille',
                 'required' => false,

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -16,6 +16,9 @@
                 <h3 class="fr-h5">Occupant</h3>
             </legend>
             <div class="fr-fieldset__element">
+                {{ form_row(formCoordonnees.civiliteOccupant) }}
+            </div>
+            <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.nomOccupant) }}
             </div>
             <div class="fr-fieldset__element">


### PR DESCRIPTION
## Ticket

#4128   

## Description
dans l'onglet coordonnées
Il faut ajouter le champ Civilité avec bouton radio Madame et Monsieur

## Changements apportés
* Modification du formType et du template twig

## Pré-requis

## Tests
- [ ] Faire un signalement et vérifier que la civilité de l'occupant est bien enregistré