### PR TITLE
[BO - Formulaire pro] Impossible d'uploader un document en agent

### DIFF
--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -64,7 +64,11 @@ class SignalementFileController extends AbstractController
         EntityManagerInterface $entityManager,
         SignalementFileProcessor $signalementFileProcessor,
     ): Response {
-        $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
+        if (SignalementStatus::DRAFT === $signalement->getStatut()) {
+            $this->denyAccessUnlessGranted('SIGN_EDIT_DRAFT', $signalement);
+        } else {
+            $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
+        }
         if (!$this->isCsrfTokenValid('signalement_add_file_'.$signalement->getId(), $request->get('_token')) || !$files = $request->files->get('signalement-add-file')) {
             if ($request->isXmlHttpRequest()) {
                 return $this->json(['response' => 'Token CSRF invalide ou paramètre manquant, veuillez rechargez la page'], Response::HTTP_BAD_REQUEST);


### PR DESCRIPTION
## Ticket

#4126   

## Description
Seuls les SA pouvaient uploader des documents en créant un signalement

## Changements apportés
* Appel du bon Voter si le signalement est au statut DRAFT

## Pré-requis

## Tests
- [ ] Créer un signalement avec différents utilisateurs/rôles
- [ ] Vérifier qu'on peut ajouter des fichiers
