### PR TITLE
[BO - Fiche signalement] Ajouter le badge "logement vacant" dans l'en-tête du signalement

### DIFF
--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -42,6 +42,12 @@
                         Bailleur non-averti
                     {% endif %}
                 </span>
+
+                <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">
+                    {% if signalement.isLogementVacant %}
+                        Logement vacant
+                    {% endif %}
+                </span>
                 
                 {% for zone in zones %}
                     <span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon fr-m-1v">{{zone.name}}</span>


### PR DESCRIPTION
## Ticket

#4122   

## Description
Avec le formulaire pro, il est désormais possible de créer des signalements pour des logements vacants
Il faudrait l'indiquer dans le signalement
Quand on coche la case "Logement vacant" dans le form pro
Il faudrait ensuite ajouter un badge Logement vacant dans l'en-tête à côté de ceux disant allocataire / bailleur averti, etc.

## Changements apportés
* Changement du template twif pour ajouter le badge seulement si on sait que c'est un logement vacant

## Pré-requis

## Tests
- [ ] Créer un signalement en logement vacant, et vérifier que c'est indiqué dans la fiche signalement
- [ ] Créer un signalement PAS en logement vacant et vérifier qu'il n'y a pas de badge
- [ ] Vérifier sur des signalements précédents qu'il n'y a pas de badge
