### PR TITLE
[BO - Visite] Reprogrammation sur opérateur externe impossible

### DIFF
--- a/assets/scripts/vanilla/controllers/form_visite.js
+++ b/assets/scripts/vanilla/controllers/form_visite.js
@@ -70,7 +70,7 @@ function histoCheckVisiteForms (formType) {
         if(selectVisitePartner.value === 'extern') {
           const operatorExternField = visiteForm.querySelector('.visite-external-operator')
           const operatorNames = JSON.parse(document.getElementById('list-pending-visite-external-operator-names').dataset.list)
-          if(operatorNames.includes(operatorExternField.value)) {
+          if(operatorNames.includes(operatorExternField.value) && formType != 'reschedule') {
             selectVisitePartnerError.classList.remove('fr-hidden')
             stopSubmit = true
           }


### PR DESCRIPTION
## Ticket

#4144   

## Description
Si je veux reprogrammer une visite existante (juste changer la date) qui est sur un opérateur externe, on me dit que c'est impossible car l'opérateur a déjà une visite. 

## Changements apportés
* Changement du js

## Pré-requis

## Tests
- [ ] Planifier une visite sur un opérateur externe
- [ ] Vérifier qu'on peut changer sa date
- [ ] Planifier une visite sur un partenaire existant
- [ ] Vérifier qu'on peut changer la date
- [ ] Vérifier qu'on ne peut pas créer une deuxième visite sur un opérateur externe qui en a déjà une
