### PR TITLE
[BO - Auth] Ne pas proposer le 2FA pour un utilisateur ProConnect

### DIFF
--- a/config/routes/scheb_2fa.yaml
+++ b/config/routes/scheb_2fa.yaml
@@ -1,9 +1,20 @@
 2fa_login:
     path: /2fa
-    schemes: [https]
+    schemes: [http]
     defaults:
         _controller: "scheb_two_factor.form_controller::form"
 
 2fa_login_check:
     path: /2fa_check
-    schemes: [https]
+    schemes: [http]
+
+when@prod:
+    2fa_login:
+        path: /2fa
+        schemes: [https]
+        defaults:
+            _controller: "scheb_two_factor.form_controller::form"
+
+    2fa_login_check:
+        path: /2fa_check
+        schemes: [https]

--- a/src/Controller/Security/ProConnectController.php
+++ b/src/Controller/Security/ProConnectController.php
@@ -70,6 +70,7 @@ class ProConnectController extends AbstractController
                     $this->entityManager->flush();
                 }
 
+                $user->setIsAuthenticatedViaProConnect(true);
                 $this->security->login(
                     $user,
                     FormLoginAuthenticator::class,

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -181,6 +181,8 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[Assert\Length(max: 50, groups: ['user_partner', 'Default'])]
     private ?string $fonction = null;
 
+    private bool $isAuthenticatedViaProConnect = false;
+
     public function __construct()
     {
         $this->suivis = new ArrayCollection();
@@ -780,7 +782,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
 
     public function isEmailAuthEnabled(): bool
     {
-        return $this->isSuperAdmin();
+        return $this->isSuperAdmin() && !$this->isAuthenticatedViaProConnect;
     }
 
     public function getEmailAuthRecipient(): string
@@ -910,5 +912,15 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         $this->fonction = $fonction;
 
         return $this;
+    }
+
+    public function isAuthenticatedViaProConnect(): bool
+    {
+        return $this->isAuthenticatedViaProConnect;
+    }
+
+    public function setIsAuthenticatedViaProConnect(bool $isAuthenticatedViaProConnect): void
+    {
+        $this->isAuthenticatedViaProConnect = $isAuthenticatedViaProConnect;
     }
 }


### PR DESCRIPTION
## Ticket

#4147   

## Description
Ne plus proposer le 2FA au super admin si l’authentification se fait via ProConnect

## Changements apportés
* Mise à jour condition 2FA

## Pré-requis
Donner le rôle ROLE_ADMIN à proconnect@signal-logement.fr
Définir un mot de passe pour proconnect@signal-logement.fr
```
FEATURE_2FA_EMAIL_ENABLED=1
```
## Tests
- [ ] Se connecter avec le bouton proConnnect et vérifier que 2FA n'est pas proposé
- [ ] Se connecter avec le même email proConnnect et le mot de passe défini et vérifier que 2FA est proposé
- [ ] Se connecter avec un autre utilisateur super admin et vérifier que 2FA est proposé
