### PR TITLE
[BO - Visites] Réorganisation par date de visite

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -243,6 +243,7 @@ class SignalementController extends AbstractController
             'listQualificationStatusesLabelsCheck' => $listQualificationStatusesLabelsCheck,
             'listConcludeProcedures' => $listConcludeProcedures,
             'partnersCanVisite' => $partnerVisite,
+            'visites' => $interventionRepository->getOrderedVisitesForSignalement($signalement),
             'pendingVisites' => $interventionRepository->getPendingVisitesForSignalement($signalement),
             'allPhotosOrdered' => $allPhotosOrdered,
             'canTogglePartnerAffectation' => $this->isGranted(AffectationVoter::TOGGLE, $signalement),

--- a/src/Messenger/MessageHandler/PdfExportMessageHandler.php
+++ b/src/Messenger/MessageHandler/PdfExportMessageHandler.php
@@ -4,6 +4,7 @@ namespace App\Messenger\MessageHandler;
 
 use App\Entity\Intervention;
 use App\Messenger\Message\PdfExportMessage;
+use App\Repository\InterventionRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
@@ -24,6 +25,7 @@ class PdfExportMessageHandler
         private readonly SignalementExportPdfGenerator $signalementExportPdfGenerator,
         private readonly Environment $twig,
         private readonly SignalementRepository $signalementRepository,
+        private readonly InterventionRepository $interventionRepository,
         private readonly ParameterBagInterface $parameterBag,
         private readonly UploadHandlerService $uploadHandlerService,
         private readonly SignalementDesordresProcessor $signalementDesordresProcessor,
@@ -60,11 +62,14 @@ class PdfExportMessageHandler
                 return $concludeProcedure->label();
             }, $listConcludeProcedures));
 
+            $visites = $this->interventionRepository->getOrderedVisitesForSignalement($signalement);
+
             $htmlContent = $this->twig->render('pdf/signalement.html.twig', [
                 'signalement' => $signalement,
                 'situations' => $infoDesordres['criticitesArranged'],
                 'listConcludeProcedures' => $listConcludeProcedures,
                 'listQualificationStatusesLabelsCheck' => $listQualificationStatusesLabelsCheck,
+                'visites' => $visites,
                 'isForUsager' => $pdfExportMessage->isForUsager(),
             ]);
 

--- a/src/Repository/InterventionRepository.php
+++ b/src/Repository/InterventionRepository.php
@@ -69,6 +69,20 @@ class InterventionRepository extends ServiceEntityRepository
         return $this->getVisitsToNotify(self::NB_DAYS_DELAY_NOTIFICATION_VISIT_PAST);
     }
 
+    public function getOrderedVisitesForSignalement(Signalement $signalement): array
+    {
+        $queryBuilder = $this->createQueryBuilder('i');
+
+        return $queryBuilder
+            ->andWhere('i.type IN (:visiteTypes)')
+            ->setParameter('visiteTypes', [InterventionType::VISITE->name, InterventionType::VISITE_CONTROLE->name])
+            ->andWhere('i.signalement = :signalement')
+            ->setParameter('signalement', $signalement)
+            ->orderBy('i.scheduledAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function getPendingVisitesForSignalement(Signalement $signalement): array
     {
         $queryBuilder = $this->createQueryBuilder('i');

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -45,12 +45,12 @@
 {% if signalement.interventions is empty %}
     {% include 'back/signalement/view/visites/visite-item.html.twig' with { 'isForBO': true } %}
 {% else %}
-    {% for intervention in signalement.interventions | filter(intervention => intervention.type != enum('App\\Entity\\Enum\\InterventionType').ARRETE_PREFECTORAL) %}
+    {% for intervention in visites %}
         <div class="fr-background-alt--grey fr-p-5v fr-mb-5v">
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-col-md-6 fr-h6 fr-mb-3v">
-                    Visite #{{loop.index}}
-                    {% if signalement.interventions is not empty or intervention.scheduledAt is not empty %}
+                    Visite
+                    {% if visites is not empty or intervention.scheduledAt is not empty %}
                         du {{ intervention.scheduledAt|date('d/m/Y') }}
                     {% endif %}
                 </div>

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -513,12 +513,12 @@
 
             <section>
                 <h2>Visites</h2>            
-                {% for intervention in signalement.interventions | filter(intervention => intervention.type != enum('App\\Entity\\Enum\\InterventionType').ARRETE_PREFECTORAL) %}
+                {% for intervention in visites %}
                     <div class="fr-background-alt--grey fr-p-5v fr-mb-5v">
                         <div class="fr-grid-row">
                             <div class="fr-col-12 fr-col-md-6 fr-h6 fr-mb-3v">
-                                Visite #{{loop.index}}
-                                {% if signalement.interventions is not empty or intervention.scheduledAt is not empty %}
+                                Visite
+                                {% if visites is not empty or intervention.scheduledAt is not empty %}
                                     du {{ intervention.scheduledAt|date('d/m/Y') }}
                                 {% endif %}
                             </div>

--- a/tests/Unit/Service/Signalement/Export/SignalementExportPdfTest.php
+++ b/tests/Unit/Service/Signalement/Export/SignalementExportPdfTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Unit\Service\Signalement\Export;
 
+use App\Repository\InterventionRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\Export\SignalementExportPdfGenerator;
 use Knp\Snappy\Pdf;
@@ -19,15 +20,21 @@ class SignalementExportPdfTest extends KernelTestCase
         $signalementExportPdfGenerator = new SignalementExportPdfGenerator($pdf, $parameterBag);
 
         $twig = static::getContainer()->get(Environment::class);
+        /** @var SignalementRepository $signalementRepository */
         $signalementRepository = static::getContainer()->get(SignalementRepository::class);
 
         $signalement = $signalementRepository->findOneBy(['reference' => '2023-1']);
+
+        /** @var InterventionRepository $interventionRepository */
+        $interventionRepository = static::getContainer()->get(InterventionRepository::class);
+        $visites = $interventionRepository->getOrderedVisitesForSignalement($signalement);
 
         $html = $twig->render('pdf/signalement.html.twig', [
             'listConcludeProcedures' => [],
             'signalement' => $signalement,
             'situations' => [],
             'listQualificationStatusesLabelsCheck' => [],
+            'visites' => $visites,
             'isForUsager' => false,
         ]);
         $options = static::getContainer()->getParameter('export_options');


### PR DESCRIPTION
## Ticket

#4085   

## Description
Réorganisation des visites par date

## Tests
- [ ] Créer une visite dans le future, puis une visite dans le passé
- [ ] Fiche signalement : Vérifier que la visite dans le passé s'affiche avant la visite dans le futur
- [ ] Vérifier que c'est appliqué à l'export PDF
