### PR TITLE
[BO - Formulaire] Etendre la détection de doublon aux brouillons

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -108,6 +108,7 @@ function saveCurrentTab(event) {
             const modaleDuplicateOpenLink = document.querySelector('#fr-modal-duplicate-open-duplicates')
             modaleDuplicateContainer.innerHTML = response.duplicateContent
             modaleDuplicateOpenLink.href = response.linkDuplicates
+            modaleDuplicateOpenLink.textContent = response.labelBtnDuplicates
             dsfr(modaleDuplicate).modal.disclose();
           } else {
             const errorAlertStr = '<div class="fr-alert fr-alert--sm fr-alert--error fr-mb-2v" role="alert"><p class="fr-alert__title">Merci de corriger les champs où des erreurs sont signalées.</p></div>'

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -38,6 +38,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\ORM\TransactionRequiredException;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @method Signalement|null find($id, $lockMode = null, $lockVersion = null)
@@ -1547,6 +1548,7 @@ class SignalementRepository extends ServiceEntityRepository
         Signalement $signalement,
         array $exclusiveStatus = [SignalementStatus::NEED_VALIDATION, SignalementStatus::ACTIVE],
         array $excludedStatus = [],
+        ?UserInterface $exclusiveCreatedBy = null,
     ): array {
         $qb = $this->createQueryBuilder('s')
             ->where('s.adresseOccupant = :address')
@@ -1568,6 +1570,11 @@ class SignalementRepository extends ServiceEntityRepository
         if (null !== $signalement->getId()) {
             $qb->andWhere('s.id != :id')
             ->setParameter('id', $signalement->getId());
+        }
+
+        if (null !== $exclusiveCreatedBy) {
+            $qb->andWhere('s.createdBy = :user')
+            ->setParameter('user', $exclusiveCreatedBy);
         }
 
         return $qb->getQuery()->getResult();

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -94,7 +94,6 @@ class SignalementBoManager
         if (!$signalement->getReference()) {
             $signalement->setReference($this->referenceGenerator->generate($territory));
         }
-
         return true;
     }
 

--- a/templates/back/signalement_create/_modal_duplicate_draft_content.html.twig
+++ b/templates/back/signalement_create/_modal_duplicate_draft_content.html.twig
@@ -1,0 +1,9 @@
+{% set lastDuplicate = duplicates|last %}
+<p>
+    Vous avez déjà un brouillon de signalement à cette adresse postale.
+    <br>
+    Il s'agit du brouillon du {{ lastDuplicate.createdAt|date('d/m/Y') }} créé à {{ lastDuplicate.createdAt|date('H:i') }}
+</p>
+<p>
+    Avant de poursuivre la création de ce signalement, nous vous invitons à vérifier qu'il en s'agit pas d'un doublon !
+</p>


### PR DESCRIPTION
## Ticket

#4125   

## Description
Je suis RT
J'ai des brouillons de signalements
Je saisis un nouveau signalement à la même adresse qu'un brouillon existant
Je peux le saisir sans problème
Afin d'éviter de créer plusieurs fois le brouillon pour un même signalement, je propose qu'on fasse la détection de doublons potentiels sur la liste des brouillons du user en cours également
Au même titre que sur les signalements en cours :
Il faudrait mettre un truc du genre :

```
Doublon possible !
Vous avez déjà un brouillon de signalement à cette adresse postale.
Il s'agit du brouillon du dd/mm/yyyy crée à hh:mm

Avant de poursuivre la création de ce signalement, nous vous invitons à vérifier qu'il en s'agit pas d'un doublon !

Boutons : Voir mes brouillons
Continuer ma saisie
```

⚠ Si on a un doublon dans les signalements en cours + dans les brouillons, on affiche la modale pour les signalements en cours
(normalement ce cas ne devrait pas arriver)

Idéalement, il faudrait la détection sur les brouillons pour les agents aussi pour qu'ils évitent de créer plusieurs fois le même !

## Changements apportés
* Modifier SignalementCreateController pour chercher des doublons de brouillon à l'adresse (créés par l'utilisateur en cours) s'il n'y a pas déjà de brouillon de signalement
* Ajout d'un template de modale de doublon de brouillon

## Pré-requis
`npm run watch`

## Tests
- [ ] Créer un brouillon de signalement
- [ ] Essayer de créer un 2è brouillon de signalement à la même adresse, vérifier qu'on a bien la nouvelle modale
- [ ] Créer quand même ce 2 signalement et le valider
- [ ] Essayer de créer un 3è signalement à la même adresse, et vérifier qu'on a cette fois la modale de signalement existant
