### PR TITLE
[BUG - Suivi] Voir pourquoi on crée des suivi TYPE_AUTO complétement vide

### DIFF
--- a/migrations/Version20250527143737.php
+++ b/migrations/Version20250527143737.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250527143737 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Delete suivi entries with type AUTO and empty description';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DELETE FROM suivi WHERE type = 1 AND description = ''
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -37,6 +37,7 @@ class AffectationManager extends Manager
         int $status,
         ?string $motifRefus = null,
         ?string $message = null,
+        ?bool $dispatchAffectationAnsweredEvent = true,
     ): Affectation {
         $affectation
             ->setStatut($status)
@@ -52,7 +53,9 @@ class AffectationManager extends Manager
         }
 
         $this->save($affectation);
-        $this->dispatchAffectationAnsweredEvent($affectation, $user, $status, $affectation->getMotifRefus(), $message);
+        if ($dispatchAffectationAnsweredEvent) {
+            $this->dispatchAffectationAnsweredEvent($affectation, $user, $status, $affectation->getMotifRefus(), $message);
+        }
 
         return $affectation;
     }

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -117,7 +117,12 @@ class EsaboraManager
                 break;
             case EsaboraStatus::ESABORA_REJECTED->value:
                 if (Affectation::STATUS_REFUSED !== $currentStatus) {
-                    $this->affectationManager->updateAffectation($affectation, $user, Affectation::STATUS_REFUSED);
+                    $this->affectationManager->updateAffectation(
+                        affectation: $affectation,
+                        user: $user,
+                        status: Affectation::STATUS_REFUSED,
+                        dispatchAffectationAnsweredEvent: false
+                    );
                     $description = \sprintf(
                         'refusé via '.$dossierResponse->getNameSI().' pour motif suivant: %s',
                         $dossierResponse->getSasCauseRefus()


### PR DESCRIPTION
## Ticket

#4157

## Description
Description de la modification apportée

## Changements apportés
* Ajout d'une migration pour supprimer ces suivis vides
* Dans le cas d'un refus d'affectation via esabora retrait de l'appel au `dispatchAffectationAnsweredEvent` générant le suivi problèmatique

## Pré-requis
- Se mettre sur un copie base de prod
- Commenter le passage qui bloque les appel à esabora en local (chercher `url must contain "signal_logement_wiremock" when on localhost.`)
- Prendre un signalement avec un suivi vide (avec `SELECT s.id, s.created_at, s.is_public, s.type, s.context, si.id, si.uuid FROM `suivi` s inner join signalement si ON s.signalement_id = si.id where s.description = '' and type =1 ORDER BY s.created_at DESC; `)

## Tests
- [ ] Ouvrir le signalement et voir le suivi vide
- [ ] `make execute-migration name=Version20250527143737 direction=up` et voir qu'il n'y à plus de suivi vide
- [ ] Passer en base l'affectation esabora refusé (ayant crée le suivi vide) en statut en attente (0)
- [ ] Lancer `app:sync-esabora-sish [UUID DU SUIVI]` et voir que le suivi vide n'est plus crée
