### PR TITLE
[QA] Correction de la gestion des étages vides dans l'API

### DIFF
--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -85,7 +85,9 @@ readonly class SignalementResponseFactory
         $signalementResponse->anneeConstruction = $signalement->getInformationComplementaire()?->getInformationsComplementairesLogementAnneeConstruction() ?? $signalement->getAnneeConstruction();
         $signalementResponse->constructionAvant1949 = $signalement->getIsConstructionAvant1949();
         $signalementResponse->nbNiveaux = $signalement->getInformationComplementaire()?->getInformationsComplementairesLogementNombreEtages() ?? $signalement->getNbNiveauxLogement();
-        $signalementResponse->etage = EtageType::tryFrom($signalement->getTypeCompositionLogement()?->getTypeLogementAppartementEtage());
+        if (!empty($signalement->getTypeCompositionLogement()?->getTypeLogementAppartementEtage())) {
+            $signalementResponse->etage = EtageType::tryFrom($signalement->getTypeCompositionLogement()?->getTypeLogementAppartementEtage());
+        }
         $signalementResponse->avecFenetres = $signalement->getTypeCompositionLogement()?->getTypeLogementAppartementAvecFenetres();
         $signalementResponse->pieceAVivreSuperieureA9m = $this->stringToBool($signalement->getTypeCompositionLogement()?->getTypeLogementCommoditesPieceAVivre9m());
         $signalementResponse->cuisine = $this->stringToBool($signalement->getTypeCompositionLogement()?->getTypeLogementCommoditesCuisine());

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -86,7 +86,7 @@ readonly class SignalementResponseFactory
         $signalementResponse->constructionAvant1949 = $signalement->getIsConstructionAvant1949();
         $signalementResponse->nbNiveaux = $signalement->getInformationComplementaire()?->getInformationsComplementairesLogementNombreEtages() ?? $signalement->getNbNiveauxLogement();
         if (!empty($signalement->getTypeCompositionLogement()?->getTypeLogementAppartementEtage())) {
-            $signalementResponse->etage = EtageType::tryFrom($signalement->getTypeCompositionLogement()?->getTypeLogementAppartementEtage());
+            $signalementResponse->etage = EtageType::tryFrom($signalement->getTypeCompositionLogement()->getTypeLogementAppartementEtage());
         }
         $signalementResponse->avecFenetres = $signalement->getTypeCompositionLogement()?->getTypeLogementAppartementAvecFenetres();
         $signalementResponse->pieceAVivreSuperieureA9m = $this->stringToBool($signalement->getTypeCompositionLogement()?->getTypeLogementCommoditesPieceAVivre9m());


### PR DESCRIPTION
## Ticket

#4169   

## Description
Correction de la gestion des étages vides dans l'API

## Tests
- [ ] Faire un appel sur un signalement de l'API avec étage et vérifier que tout est ok
- [ ] Idem sur un logement sans étage
