### PR TITLE
[BUG - BO] réinitialiser modale aprés soumission d'un suivi

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -235,6 +235,17 @@ document.querySelectorAll('button[data-cloture-type]').forEach(button => {
   })
 })
 
+let modalAddSuiviHasBeenOpened = false;
+document?.getElementById('fr-modal-add-suivi')?.addEventListener('dsfr.disclose', (event) => {
+  if(modalAddSuiviHasBeenOpened) {
+    return;
+  }
+  modalAddSuiviHasBeenOpened = true;
+  document.getElementById('signalement-add-suivi-notify-usager').checked = false
+  document.getElementById('signalement-add-suivi-notify-usager').dispatchEvent(new Event('change'))
+  tinymce.get('signalement-add-suivi-content').setContent('');
+})
+
 document?.getElementById('signalement-add-suivi-notify-usager')?.addEventListeners('change', (e) => {
   document.getElementById('signalement-add-suivi-submit').textContent = (e.target.checked) ? 'Envoyer le suivi à l\'usager' : 'Enregistrer le suivi interne'
 })


### PR DESCRIPTION
## Ticket

#4171

## Description
Afin qu’après une soumission de suivi depuis le BO, la modale ne garde pas les informations préalablement soumise, on réinitialise ses valeurs à sa première ouverture

## Pré-requis
`make npm-build`

## Tests
- [ ] Soumettre une suivi depuis le BO, puis rouvrir la modale de soumission et s'assurer ques les champs ont bien leu valeurs initiales. 
