### PR TITLE
[Interventions] Mettre à jour la date des interventions de type arrêté avec la date UTC

### DIFF
--- a/src/Command/UpdateTimezoneArreteDateSISHCommand.php
+++ b/src/Command/UpdateTimezoneArreteDateSISHCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\InterventionRepository;
+use App\Service\Interconnection\Esabora\AbstractEsaboraService;
+use App\Service\Interconnection\Esabora\DateParser;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:update-timezone-arrete-date-sish',
+    description: 'One-time command to fix arrete date',
+)]
+class UpdateTimezoneArreteDateSISHCommand extends Command
+{
+    public const int BATCH_SIZE = 20;
+
+    public function __construct(
+        private readonly InterventionRepository $interventionRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $interventions = $this->interventionRepository->findBy([
+            'providerName' => 'esabora',
+            'type' => 'ARRETE_PREFECTORAL',
+        ]);
+
+        $count = 0;
+        $i = 0;
+        $progressBar = new ProgressBar($output, \count($interventions));
+        $progressBar->start();
+
+        foreach ($interventions as $intervention) {
+            $scheduledAt = $intervention->getScheduledAt();
+            $signalement = $intervention->getSignalement();
+
+            if (!$scheduledAt || !$signalement) {
+                continue;
+            }
+
+            $timezone = $signalement->getTimezone() ?? 'Europe/Paris'; // fallback
+            $parsedScheduledAt = DateParser::parse($scheduledAt->format(AbstractEsaboraService::FORMAT_DATE_TIME), $timezone);
+
+            $intervention->setScheduledAt($parsedScheduledAt);
+            ++$count;
+            if (0 === $i % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+            }
+            ++$i;
+            $progressBar->advance();
+        }
+
+        $this->entityManager->flush();
+        $progressBar->finish();
+        $io->newLine();
+        $io->success("$count intervention(s) mise(s) à jour avec la bonne timezone.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -212,7 +212,10 @@ class EsaboraManager
             $intervention = $this->interventionFactory->createInstanceFrom(
                 affectation: $affectation,
                 type: InterventionType::ARRETE_PREFECTORAL,
-                scheduledAt: DateParser::parse($dossierArreteSISH->getArreteDate()),
+                scheduledAt: DateParser::parse(
+                    $dossierArreteSISH->getArreteDate(),
+                    $affectation->getSignalement()->getTimezone()
+                ),
                 registeredAt: new \DateTimeImmutable(),
                 status: Intervention::STATUS_DONE,
                 providerName: InterfacageType::ESABORA->value,
@@ -368,8 +371,12 @@ class EsaboraManager
             $hasChanged = true;
         }
 
-        $scheduledAt = DateParser::parse($dossierArreteSISH->getArreteDate());
-        if ($intervention->getScheduledAt() != $scheduledAt) {
+        $scheduledAt = DateParser::parse(
+            $dossierArreteSISH->getArreteDate(),
+            $intervention->getSignalement()->getTimezone()
+        );
+        if ($intervention->getScheduledAt()?->getTimestamp() !== $scheduledAt->getTimestamp()) {
+            $intervention->setPreviousScheduledAt($intervention->getScheduledAt());
             $intervention->setScheduledAt($scheduledAt);
             $hasChanged = true;
         }


### PR DESCRIPTION
## Ticket

#4183   

## Description
Description de la modification apportée

## Changements apportés
* Création d'une commande "jetable" pour réenregistrer la date des interventions de type arrêtés créés par esabora au format UTC
* Modification d'EsaboraManager pour enregistrer les arrêtés en date UTC et pour comparer lors de mise à jour en date UTC

## Pré-requis
Se mettre sur la base de prod

## Tests
- [ ] Lancer 2 fois la commande `sync-esabora-sish-intervention` sur un signalement (`uuid_signalement`) synchronisé avec SISH. Vérifier que 2 suivis sont créés
- [ ] Lancer la commande `update-timezone-arrete-date-sish`, vérifier que les interventions concernées sont bien mises à jour
- [ ] Relancer la commande `sync-esabora-sish-intervention` sur le même signalement, et vérifier qu'un nouveau suivi n'est pas créé
