### PR TITLE
[QA] TypeError: "App\Repository\NotificationRepository::findUnseenNotificationsBy()

### DIFF
--- a/src/EventSubscriber/SignalementViewedSubscriber.php
+++ b/src/EventSubscriber/SignalementViewedSubscriber.php
@@ -66,6 +66,9 @@ class SignalementViewedSubscriber implements EventSubscriberInterface
         if ($user instanceof SignalementUser) {
             $user = $user->getUser();
         }
+        if (!$user) {
+            return;
+        }
         $notifications = $this->notificationRepository->findUnseenNotificationsBy(
             signalement: $signalement,
             user: $user,

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -213,7 +213,7 @@ class SignalementBoManager
         }
         $signalement->setNumAllocataire($form->get('numeroAllocataire')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsTypeAllocation($form->get('typeAllocation')->getData());
-        $signalement->setMontantAllocation($form->get('montantAllocation')->getData());
+        $signalement->setMontantAllocation((int) $form->get('montantAllocation')->getData());
         $situationFoyer->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireRsa($form->get('beneficiaireRSA')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($form->get('beneficiaireFSL')->getData());


### PR DESCRIPTION
## Ticket

#4180
#4185

## Description
- Lorsqu'un utilisateur FO n'est pas lié a un user (cas d'occupant sans email), on ne rentre pas dans le process manquant les suivi comme lu
- Transformation du champ "MontantAllocation" en int avant de l’injecter dans l'objet signalement pour éviter erreur de typage

## Tests
- [ ] Se connecter en occuapant sur le suivi usager d'un signalement sans emailOccupant et voir que la page s'affiche
- [ ] Remplir un formulaire pro en mettant n'importe quoi dans le champ "Montant de l'allocation"
