### PR TITLE
[Suivis] Commande pour supprimer les suivis et notifications créés en trop

### DIFF
--- a/src/Command/DeleteUselessSuivisAndNotifications.php
+++ b/src/Command/DeleteUselessSuivisAndNotifications.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Suivi;
+use App\Repository\NotificationRepository;
+use App\Repository\SuiviRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(
+    name: 'app:delete-useless-suivis-notifications',
+    description: 'Delete useless suivis and notifications'
+)]
+class DeleteUselessSuivisAndNotifications extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly SuiviRepository $suiviRepository,
+        private readonly NotificationRepository $notificationRepository,
+        private readonly ParameterBagInterface $parameterBag,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        // See https://symfony.com/doc/current/console/style.html
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $userCreatedBy = $this->userRepository->findOneBy(['email' => $this->parameterBag->get('user_system_email')]);
+
+        $connection = $this->entityManager->getConnection();
+        $sql = 'SELECT s.id
+                FROM suivi s
+                WHERE s.created_by_id = :created_by
+                AND s.context = :context
+                AND DATE_FORMAT(s.created_at, \'%Y-%m-%d\') = :created_at';
+        $statement = $connection->prepare($sql);
+        $parameters = [
+            'created_by' => $userCreatedBy->getId(),
+            'context' => Suivi::CONTEXT_INTERVENTION,
+            'created_at' => '2025-06-03',
+        ];
+
+        $suivis = $statement->executeQuery($parameters)->fetchFirstColumn();
+        $count = \count($suivis);
+
+        $this->notificationRepository->deleteBySuiviIds($suivis);
+        $this->suiviRepository->deleteBySuiviIds($suivis);
+
+        $this->io->success(\sprintf('%s suivis were successfully deleted.', $count));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/NotificationRepository.php
+++ b/src/Repository/NotificationRepository.php
@@ -268,6 +268,16 @@ class NotificationRepository extends ServiceEntityRepository implements EntityCl
         $qb->getQuery()->execute();
     }
 
+    public function deleteBySuiviIds(array $suiviIds): void
+    {
+        $qb = $this->createQueryBuilder('n')
+            ->delete()
+            ->where('n.suivi in (:suivis)')
+            ->setParameter('suivis', $suiviIds);
+
+        $qb->getQuery()->execute();
+    }
+
     public function findWaitingSummaryForUser(User $user): array
     {
         return $this->createQueryBuilder('n')

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -476,4 +476,14 @@ class SuiviRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getOneOrNullResult();
     }
+
+    public function deleteBySuiviIds(array $suiviIds): void
+    {
+        $qb = $this->createQueryBuilder('s')
+            ->delete()
+            ->where('s.id in (:suivis)')
+            ->setParameter('suivis', $suiviIds);
+
+        $qb->getQuery()->execute();
+    }
 }


### PR DESCRIPTION
## Ticket

#4184   

## Description
Suite à un souci de décalage de dates UTC, des suivis (et notifications associées) ont été créés en trop.

## Changements apportés
* Création d'une commande qui permet de les supprimer

## Tests
- [ ] Récupérer le dernier backup du jour, et l'utiliser
- [ ] Vérifier la liste des suivis correspondants 
- [ ] `make console app="delete-useless-suivis-notifications"`
- [ ] Vérifier que ces suivis ont disparu
