### PR TITLE
[Interventions] comparaison d'intervention pour esabora

### DIFF
--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -131,6 +131,7 @@ class AffectationRepository extends ServiceEntityRepository
         if (null !== $territory) {
             $qb->andWhere('a.territory = :territory')->setParameter('territory', $territory);
         }
+        $qb->setMaxResults(100);
 
         return $qb->getQuery()->getResult();
     }

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -131,7 +131,6 @@ class AffectationRepository extends ServiceEntityRepository
         if (null !== $territory) {
             $qb->andWhere('a.territory = :territory')->setParameter('territory', $territory);
         }
-        $qb->setMaxResults(100);
 
         return $qb->getQuery()->getResult();
     }

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class EsaboraManagerTest extends KernelTestCase
@@ -46,6 +47,7 @@ class EsaboraManagerTest extends KernelTestCase
     private UrlGeneratorInterface $UrlGeneratorInterface;
     private FileFactory $fileFactory;
     private SignalementQualificationUpdater $signalementQualificationUpdater;
+    private HtmlSanitizerInterface $htmlSanitizerInterface;
 
     protected function setUp(): void
     {
@@ -64,6 +66,7 @@ class EsaboraManagerTest extends KernelTestCase
         $this->UrlGeneratorInterface = self::getContainer()->get('router');
         $this->fileFactory = self::getContainer()->get(FileFactory::class);
         $this->signalementQualificationUpdater = self::getContainer()->get(SignalementQualificationUpdater::class);
+        $this->htmlSanitizerInterface = self::getContainer()->get('html_sanitizer.sanitizer.app.message_sanitizer');
     }
 
     /**
@@ -107,7 +110,8 @@ class EsaboraManagerTest extends KernelTestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
-            $this->signalementQualificationUpdater
+            $this->signalementQualificationUpdater,
+            $this->htmlSanitizerInterface
         );
 
         $esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);
@@ -224,7 +228,8 @@ class EsaboraManagerTest extends KernelTestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
-            $this->signalementQualificationUpdater
+            $this->signalementQualificationUpdater,
+            $this->htmlSanitizerInterface
         );
 
         $esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -23,13 +23,14 @@ use App\Service\UploadHandlerService;
 use App\Tests\FixturesHelper;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class EsaboraManagerTest extends TestCase
+class EsaboraManagerTest extends KernelTestCase
 {
     use FixturesHelper;
     protected const CREATE_ACTION = 'create';
@@ -50,6 +51,7 @@ class EsaboraManagerTest extends TestCase
     private MockObject|UrlGeneratorInterface $UrlGeneratorInterface;
     private MockObject|FileFactory $fileFactory;
     private MockObject|SignalementQualificationUpdater $signalementQualificationUpdater;
+    private HtmlSanitizerInterface $htmlSanitizerInterface;
 
     protected function setUp(): void
     {
@@ -68,6 +70,7 @@ class EsaboraManagerTest extends TestCase
         $this->UrlGeneratorInterface = $this->createMock(UrlGeneratorInterface::class);
         $this->fileFactory = $this->createMock(FileFactory::class);
         $this->signalementQualificationUpdater = $this->createMock(SignalementQualificationUpdater::class);
+        $this->htmlSanitizerInterface = self::getContainer()->get('html_sanitizer.sanitizer.app.message_sanitizer');
     }
 
     /**
@@ -125,7 +128,8 @@ class EsaboraManagerTest extends TestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
-            $this->signalementQualificationUpdater
+            $this->signalementQualificationUpdater,
+            $this->htmlSanitizerInterface
         );
         $esaboraManager->createOrUpdateVisite($this->getAffectation(PartnerType::ARS), $dossierVisite);
     }
@@ -206,7 +210,8 @@ class EsaboraManagerTest extends TestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
-            $this->signalementQualificationUpdater
+            $this->signalementQualificationUpdater,
+            $this->htmlSanitizerInterface
         );
     }
 
@@ -254,7 +259,8 @@ class EsaboraManagerTest extends TestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
-            $this->signalementQualificationUpdater
+            $this->signalementQualificationUpdater,
+            $this->htmlSanitizerInterface
         );
 
         $reflector = new \ReflectionClass($esaboraManager);
@@ -311,7 +317,9 @@ class EsaboraManagerTest extends TestCase
             $this->imageManipulationHandler,
             $this->UrlGeneratorInterface,
             $this->fileFactory,
-            $this->signalementQualificationUpdater);
+            $this->signalementQualificationUpdater,
+            $this->htmlSanitizerInterface
+        );
 
         $reflector = new \ReflectionClass($esaboraManager);
         $method = $reflector->getMethod('updateFromDossierVisite');


### PR DESCRIPTION
## Ticket

#4183

## Description
- Correction des comparaison trop stricte de `updateFromDossierArrete` qui provoqué une mise à jour à chaque appel

## Tests
- [ ] Lancer la commande `app:sync-esabora-sish-intervention` sur une signalement en erreur de ce matin ou de façon partielle et voir que les suivi d'arété ne sont plus crées
