### PR TITLE
[BO - Partenaire] Correction de l'ouverture de la modale d'ajout d'utilisateur

### DIFF
--- a/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
+++ b/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
@@ -194,17 +194,18 @@ if (modalPartnerUserCreate) {
   modalPartnerUserCreate.addEventListener('dsfr.conceal', (event) => {
     fetchRefreshUrl()
   })
-}
-fetchRefreshUrl()
+  fetchRefreshUrl()
 
-function fetchRefreshUrl() {
-  const modalPartnerUserCreate = document?.querySelector('#fr-modal-user-create')
-  const refreshUrl = modalPartnerUserCreate.dataset.refreshUrl
-  modalPartnerUserCreate.querySelector('button[type="submit"]').disabled = true
-  fetch(refreshUrl).then(response => {
-    updateModaleFromResponse(response, '#fr-modal-user-create', addEventListenerOnFormUser)
-  })
+  function fetchRefreshUrl() {
+    const modalPartnerUserCreate = document?.querySelector('#fr-modal-user-create')
+    const refreshUrl = modalPartnerUserCreate.dataset.refreshUrl
+    modalPartnerUserCreate.querySelector('button[type="submit"]').disabled = true
+    fetch(refreshUrl).then(response => {
+      updateModaleFromResponse(response, '#fr-modal-user-create', addEventListenerOnFormUser)
+    })
+  }
 }
+
 
 function addEventListenerOnFormUser () {
   if (document.querySelector('#user_partner_role')) {

--- a/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
+++ b/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
@@ -192,11 +192,17 @@ document.querySelectorAll('.btn-edit-partner-user').forEach(swbtn => {
 const modalPartnerUserCreate = document?.querySelector('#fr-modal-user-create')
 if (modalPartnerUserCreate) {
   modalPartnerUserCreate.addEventListener('dsfr.conceal', (event) => {
-    const refreshUrl = event.target.dataset.refreshUrl
-    modalPartnerUserCreate.querySelector('button[type="submit"]').disabled = true
-    fetch(refreshUrl).then(response => {
-      updateModaleFromResponse(response, '#fr-modal-user-create', addEventListenerOnFormUser)
-    })
+    fetchRefreshUrl()
+  })
+}
+fetchRefreshUrl()
+
+function fetchRefreshUrl() {
+  const modalPartnerUserCreate = document?.querySelector('#fr-modal-user-create')
+  const refreshUrl = modalPartnerUserCreate.dataset.refreshUrl
+  modalPartnerUserCreate.querySelector('button[type="submit"]').disabled = true
+  fetch(refreshUrl).then(response => {
+    updateModaleFromResponse(response, '#fr-modal-user-create', addEventListenerOnFormUser)
   })
 }
 

--- a/assets/scripts/vanilla/controllers/back_profil_edit_email/back_profil_edit_email.js
+++ b/assets/scripts/vanilla/controllers/back_profil_edit_email/back_profil_edit_email.js
@@ -119,4 +119,6 @@ modalEditEmail?.addEventListener('submit', (event) => {
   submitEditEmail(formElement)
 })
 
-showStepOne()
+if(modalCodeInputInput){
+  showStepOne()
+}

--- a/assets/scripts/vanilla/controllers/back_profil_edit_email/back_profil_edit_email.js
+++ b/assets/scripts/vanilla/controllers/back_profil_edit_email/back_profil_edit_email.js
@@ -118,3 +118,5 @@ modalEditEmail?.addEventListener('submit', (event) => {
   clearErrors()
   submitEditEmail(formElement)
 })
+
+showStepOne()


### PR DESCRIPTION
## Ticket

#4192   

## Description
Nous nous servons de l'événement `dsfr.conceal` pour détecter les fermetures de modales DSFR.
Historiquement, cet événement était envoyé en ouverture de page.
Ce n'est plus le cas depuis la mise à jour DSFR 1.13.1.
Dans la page Partenaire, pour la modale d'ajout d'utilisateur, nous nous en servons pour mettre à jour le formulaire.

## Changements apportés
* Modification de la méthode pour mettre à jour le formulaire d'ajout d'utilisateur
* Modification de méthode dans la page de profil utilisateur (c'est plus par sécurité, je n'ai pas l'impression que ça posait souci)
* Rien d'autre : normalement les autres fois où cet événement est utilisé, on n'a pas le même souci

## Pré-requis
`npm run watch`

## Tests
- [ ] Tester l'ajout d'un utilisateur
- [ ] Tester la modification d'adresse e-mail dans le profil utilisateur
