### PR TITLE
[BUG] Filtre détection doublon adresse / Synchro IDOSS en cas de fichier inexistant

### DIFF
--- a/src/Service/Interconnection/Idoss/IdossService.php
+++ b/src/Service/Interconnection/Idoss/IdossService.php
@@ -223,7 +223,12 @@ class IdossService
         ];
         $dataparts = [];
         foreach ($files as $file) {
-            $dataparts[] = ['file' => DataPart::fromPath($this->imageManipulationHandler->getFilePath($file))];
+            try {
+                $filePath = $this->imageManipulationHandler->getFilePath($file);
+                $dataparts[] = ['file' => DataPart::fromPath($filePath)];
+            } catch (\Exception $e) {
+                $this->logger->error('IdossService getFilesPayload on signalement uuid "'.$signalement->getUuid().'" and file id "'.$file->getId().'" throw : '.$e->getMessage());
+            }
         }
 
         return array_merge($payload, $dataparts);

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -132,7 +132,7 @@
                         {% endif %}
                         {% if is_granted('ROLE_ADMIN_TERRITORY') and signalementOnSameAddress|length > 0 %}
                             <li>
-                                <a href="{{ path('back_signalements_index', { 'searchTerms': signalement.adresseOccupant, 'communes[]': signalement.cpOccupant }) }}" class="fr-btn fr-icon-alarm-warning-line">
+                                <a href="{{ path('back_signalements_index', { 'isImported': 'oui', 'searchTerms': signalement.adresseOccupant, 'communes[]': signalement.cpOccupant }) }}" class="fr-btn fr-icon-alarm-warning-line">
                                     {{ signalementOnSameAddress|length > 1 ? signalementOnSameAddress|length ~ ' signalements à la même adresse' : signalementOnSameAddress|length ~  ' signalement à la même adresse' }}
                                 </a>
                             </li>


### PR DESCRIPTION
## Ticket

#4190 
#4191 

## Description
- Correction du lien vers la page des signalement filtré du bouton "signalement à la même adresse" : Ajout du paramètre `isImported=oui`
- Ajout d'un bloc try catch sur l'appel à `getFilePath` dans la fonction `getFilesPayload` afin de ne plus crasher la commande `app:synchronize-idoss` quand un fichier n'existe pas

## Tests
- [ ] Créer un signalement à la même adresse qu'un signalement importé et voir que le lien du bouton "signalement à la même adresse" rammène sur la liste correctement filtré.
- [ ] Lancer la commande `app:synchronize-idoss` et voir que l'erreur  "The file does not exist" ne lève plus d'erreur fatale
