### PR TITLE
[Fo - Suivi usager] Ne pas afficher les messages de l'usager sur la carte du dashboard

### DIFF
--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -587,6 +587,7 @@ class SignalementController extends AbstractController
                     'error' => $error,
                 ]);
             }
+            $user = $currentUser->getUser();
         }
 
         $demandeLienSignalement = new DemandeLienSignalement();
@@ -595,7 +596,7 @@ class SignalementController extends AbstractController
         ]);
 
         if ($this->featureSuiviAction) {
-            $lastSuiviPublic = $suiviRepository->findLastPublicSuivi($signalement);
+            $lastSuiviPublic = $suiviRepository->findLastPublicSuivi($signalement, $user);
             $suiviCategory = null;
             if (!$lastSuiviPublic && SignalementStatus::CLOSED === $signalement->getStatut()) {
                 $suiviCategory = $suiviCategorizerService->getSuiviCategoryFromEnum(SuiviCategory::SIGNALEMENT_IS_CLOSED);

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -7,6 +7,7 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\Territory;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Exception;
@@ -464,14 +465,18 @@ class SuiviRepository extends ServiceEntityRepository
         return $indexed;
     }
 
-    public function findLastPublicSuivi(Signalement $signalement): ?Suivi
+    public function findLastPublicSuivi(Signalement $signalement, ?User $userToExclude = null): ?Suivi
     {
         $qb = $this->createQueryBuilder('s');
         $qb->where('s.signalement = :signalement')
             ->andWhere('s.isPublic = 1')
             ->andWhere('s.deletedBy IS NULL')
-            ->orderBy('s.createdAt', 'DESC')
-            ->setParameter('signalement', $signalement)
+            ->setParameter('signalement', $signalement);
+        if(null !== $userToExclude) {
+            $qb->andWhere('s.createdBy != :userToExclude')
+                ->setParameter('userToExclude', $userToExclude);
+        }
+        $qb->orderBy('s.createdAt', 'DESC')
             ->setMaxResults(1);
 
         return $qb->getQuery()->getOneOrNullResult();

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -472,7 +472,7 @@ class SuiviRepository extends ServiceEntityRepository
             ->andWhere('s.isPublic = 1')
             ->andWhere('s.deletedBy IS NULL')
             ->setParameter('signalement', $signalement);
-        if(null !== $userToExclude) {
+        if (null !== $userToExclude) {
             $qb->andWhere('s.createdBy != :userToExclude')
                 ->setParameter('userToExclude', $userToExclude);
         }


### PR DESCRIPTION
## Ticket

#4194   

## Description
Sur la carte Accès rapide du nouveau dashboard usager, il ne faudrait pas afficher les messages usagers
car c'est un peu bizarre en termes de parcours qu'on mette ton propre message en avant comme "nouveau"

## Changements apportés
* Modification de la requête pour exclure un suivi créé par l'usager du dernier suivi public retourné

## Pré-requis

## Tests
- [ ] Aller sur le nouveau dashboard usager d'un signalement, ajouter un suivi usager et vérifier qu'il n'est pas considéré comme "nouveau" dans la carte accès rapide de l'accueil. Faire plusieurs actions sur le signalement, dont des suivis visibles usager d'agents, et vérifier que cette carte se comporte normalement
