### PR TITLE
[TECH] Spécifier la version de xdebug

### DIFF
--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && pecl bundle -d /usr/src/php/ext apcu \
         && docker-php-ext-install -j2 apcu \
         # Install Xdebug
-        && pecl bundle -d /usr/src/php/ext xdebug-3.4 \
+        && pecl bundle -d /usr/src/php/ext xdebug-3.4.2 \
         && docker-php-ext-install xdebug \
         # Install Redis
         && pecl install redis \

--- a/.docker/php-worker/Dockerfile
+++ b/.docker/php-worker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && pecl bundle -d /usr/src/php/ext apcu \
         && docker-php-ext-install -j2 apcu \
         # Install Xdebug
-        && pecl bundle -d /usr/src/php/ext xdebug-3.4 \
+        && pecl bundle -d /usr/src/php/ext xdebug-3.4.2 \
         && docker-php-ext-install xdebug \
         # Install Redis
         && pecl install redis \


### PR DESCRIPTION
## Ticket

#4200

## Description
La dernière version 3.4.3 de xdebug (date de release 2025-05-14) ayant posé des problème dans l'environnement local d'Hélène et Numa (chargement des fixtures / envoie d'email) : 
- on force la version précédente dans les dockerfile

## Pré-requis
`make build`

## Tests
- [ ] Chargement des fixtures
- [ ] Envoie d'email synchrone (ex ajout de suivi)
- [ ] Envoie d'email asynchrone (ex export PDF)
