### PR TITLE
[BUG - FO] Login usager carractère accentué

### DIFF
--- a/src/Security/Authenticator/CodeSuiviLoginAuthenticator.php
+++ b/src/Security/Authenticator/CodeSuiviLoginAuthenticator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
+use function Symfony\Component\String\u;
 
 class CodeSuiviLoginAuthenticator extends AbstractLoginFormAuthenticator
 {
@@ -56,8 +57,8 @@ class CodeSuiviLoginAuthenticator extends AbstractLoginFormAuthenticator
         }
 
         $visitorType = $request->request->get('visitor-type');
-        $firstLetterPrenom = mb_strtoupper($request->request->get('login-first-letter-prenom'));
-        $firstLetterNom = mb_strtoupper($request->request->get('login-first-letter-nom'));
+        $firstLetterPrenom = $request->request->get('login-first-letter-prenom');
+        $firstLetterNom = $request->request->get('login-first-letter-nom');
         $codePostal = $request->request->get('login-code-postal');
 
         if (ProfileDeclarant::LOCATAIRE !== $signalement->getProfileDeclarant()
@@ -97,22 +98,25 @@ class CodeSuiviLoginAuthenticator extends AbstractLoginFormAuthenticator
         string $inputCodePostal,
         ?string $visitorType,
     ): void {
+        $inputFirstLetterPrenom = u($inputFirstLetterPrenom)->ascii()->upper()->toString();
+        $inputFirstLetterNom = u($inputFirstLetterNom)->ascii()->upper()->toString();
+
         $testOccupant = false;
         if (ProfileDeclarant::LOCATAIRE === $signalement->getProfileDeclarant()
             || ProfileDeclarant::BAILLEUR_OCCUPANT === $signalement->getProfileDeclarant()
             || 'occupant' === $visitorType
         ) {
             if (!empty($signalement->getPrenomOccupant()) && !empty($signalement->getNomOccupant())) {
-                $firstLetterPrenomToCheck = mb_strtoupper(substr($signalement->getPrenomOccupant(), 0, 1));
-                $firstLetterNomToCheck = mb_strtoupper(substr($signalement->getNomOccupant(), 0, 1));
+                $firstLetterPrenomToCheck = u(mb_substr($signalement->getPrenomOccupant(), 0, 1))->ascii()->upper()->toString();
+                $firstLetterNomToCheck = u(mb_substr($signalement->getNomOccupant(), 0, 1))->ascii()->upper()->toString();
                 $testOccupant = $firstLetterPrenomToCheck === $inputFirstLetterPrenom && $firstLetterNomToCheck === $inputFirstLetterNom;
             }
         }
         $testDeclarant = false;
         if (!$testOccupant && 'declarant' === $visitorType) {
             if (!empty($signalement->getPrenomDeclarant()) && !empty($signalement->getNomDeclarant())) {
-                $firstLetterPrenomToCheck = mb_strtoupper(substr($signalement->getPrenomDeclarant(), 0, 1));
-                $firstLetterNomToCheck = mb_strtoupper(substr($signalement->getNomDeclarant(), 0, 1));
+                $firstLetterPrenomToCheck = u(mb_substr($signalement->getPrenomDeclarant(), 0, 1))->ascii()->upper()->toString();
+                $firstLetterNomToCheck = u(mb_substr($signalement->getNomDeclarant(), 0, 1))->ascii()->upper()->toString();
                 $testDeclarant = $firstLetterPrenomToCheck === $inputFirstLetterPrenom && $firstLetterNomToCheck === $inputFirstLetterNom;
             }
         }

--- a/tests/Unit/Security/Authenticator/CodeSuiviLoginAuthenticatorTest.php
+++ b/tests/Unit/Security/Authenticator/CodeSuiviLoginAuthenticatorTest.php
@@ -103,6 +103,75 @@ class CodeSuiviLoginAuthenticatorTest extends TestCase
                 'roles' => 'ROLE_DECLARANT',
             ],
         ];
+        yield 'occupant accentué minuscule' => [
+            (new self())->getMockSignalement(
+                ProfileDeclarant::LOCATAIRE,
+                'Morin',
+                'Édith',
+                '30100',
+                '123456789',
+                'edith.morin@example.com'
+            ),
+            [
+                'code' => '13121312',
+                'visitor-type' => 'occupant',
+                'login-first-letter-prenom' => 'é',
+                'login-first-letter-nom' => 'm',
+                'login-code-postal' => '30100',
+                '_csrf_token' => 'token789',
+            ],
+            [
+                'identifier' => '13121312:occupant',
+                'email' => 'edith.morin@example.com',
+                'roles' => 'ROLE_OCCUPANT',
+            ],
+        ];
+        yield 'occupant accentué majuscule' => [
+            (new self())->getMockSignalement(
+                ProfileDeclarant::LOCATAIRE,
+                'Morin',
+                'Édith',
+                '30100',
+                '123456789',
+                'edith.morin@example.com'
+            ),
+            [
+                'code' => '13121312',
+                'visitor-type' => 'occupant',
+                'login-first-letter-prenom' => 'É',
+                'login-first-letter-nom' => 'M',
+                'login-code-postal' => '30100',
+                '_csrf_token' => 'token789',
+            ],
+            [
+                'identifier' => '13121312:occupant',
+                'email' => 'edith.morin@example.com',
+                'roles' => 'ROLE_OCCUPANT',
+            ],
+        ];
+        yield 'occupant accentué sans accentuation' => [
+            (new self())->getMockSignalement(
+                ProfileDeclarant::LOCATAIRE,
+                'Morin',
+                'Édith',
+                '30100',
+                '123456789',
+                'edith.morin@example.com'
+            ),
+            [
+                'code' => '13121312',
+                'visitor-type' => 'occupant',
+                'login-first-letter-prenom' => 'e',
+                'login-first-letter-nom' => 'm',
+                'login-code-postal' => '30100',
+                '_csrf_token' => 'token789',
+            ],
+            [
+                'identifier' => '13121312:occupant',
+                'email' => 'edith.morin@example.com',
+                'roles' => 'ROLE_OCCUPANT',
+            ],
+        ];
     }
 
     public function testAuthenticateWithInvalidCodeThrowsException()


### PR DESCRIPTION
## Ticket

#4202

## Description
Le login utilisateur ne fonctionnait pas si la première lettre du nom ou prénom était accentué.
- Correction de ce cas d'usage
- Mise en place d'un controle sans prise en compte de l'accentuation (ex : on peux mettre "e" quand le prénom commence par "é")
- Ajout de tests

## Tests
- [ ] Tester le login user avec et sans caractères accentués
