### PR TITLE
[BO - Formulaire pro] Eviter de créer des références pour les signalements en brouillon

### DIFF
--- a/src/Service/Signalement/ReferenceGenerator.php
+++ b/src/Service/Signalement/ReferenceGenerator.php
@@ -17,10 +17,15 @@ class ReferenceGenerator
      * @throws TransactionRequiredException
      * @throws NonUniqueResultException
      */
-    public function generate(Territory $territory): string
+    public function generate(Territory $territory, bool $isDefinitive = true): string
     {
-        $result = $this->signalementRepository->findLastReferenceByTerritory($territory);
         $todayYear = (new \DateTime())->format('Y');
+
+        if (!$isDefinitive) {
+            return $todayYear.'-TEMPORAIRE';
+        }
+
+        $result = $this->signalementRepository->findLastReferenceByTerritory($territory);
         if (!empty($result)) {
             list($year, $id) = explode('-', $result['reference']);
 
@@ -33,8 +38,7 @@ class ReferenceGenerator
 
             return $year.'-'.$id;
         }
-        $year = (new \DateTime())->format('Y');
 
-        return $year.'-'. 1;
+        return $todayYear.'-'. 1;
     }
 }

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -92,7 +92,7 @@ class SignalementBoManager
         $signalement->setTerritory($territory);
         $signalement->setIsCguAccepted(true);
         if (!$signalement->getReference()) {
-            $signalement->setReference($this->referenceGenerator->generate($territory));
+            $signalement->setReference($this->referenceGenerator->generate($territory, false));
         }
 
         return true;


### PR DESCRIPTION
## Ticket

#4203   

## Description
Eviter de créer des références pour les signalements en brouillon

## Changements apportés
* Enregistrement d'une référence temporaire lorsque le brouillon est créé
* Enregistrement de la vraie référence au moment de la validation

## Tests
- [ ] Créer un signalement en brouillon : dans la BDD, il y a une référence temporaire
- [ ] Valider le brouillon : la référence est écrasée
- [ ] Créer un signalement normal : la référence est créée normalement
