### PR TITLE
[Tests - E2E] Initialisation de Playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,157 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  APP_URL: http://localhost:8080
+  APP_ENV: dev
+  APP_SECRET: test_secret_key_for_github_actions
+  MAILER_DSN: smtp://signal_logement_mailer:1025
+  DATABASE_URL: mysql://signal_logement:signal_logement@signal_logement_mysql:3307/signal_logement_db
+  CORS_ALLOW_ORIGIN: '^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+  WKHTMLTOPDF_PATH: wkhtmltopdf
+  WKHTMLTOIMAGE_PATH: wkhtmltoimage
+  ADMIN_EMAIL: support@signal-logement.beta.gouv.fr
+  NOTIFICATIONS_EMAIL: notifications@signal-logement.beta.gouv.fr
+  CONTACT_EMAIL: formulaire-contact@signal-logement.beta.gouv.fr
+  USER_SYSTEM_EMAIL: admin@signal-logement.beta.gouv.fr
+  WIDGET_DATA_KPI_CACHE_EXPIRED_AFTER: 3600
+  WIDGET_AFFECTATION_PARTNER_CACHE_EXPIRED_AFTER: 30
+  WIDGET_SIGNALEMENT_ACCEPTED_NO_SUIVI_CACHE_EXPIRED_AFTER: 30
+  WIDGET_SIGNALEMENT_TERRITOIRE_CACHE_EXPIRED_AFTER: 30
+  WIDGET_ESABORA_EVENTS_CACHE_EXPIRED_AFTER: 3600
+  FEATURE_OILHI_ENABLE: 0
+  FEATURE_BO_SIGNALEMENT_CREATE: 1
+  CRON_ENABLE: 0
+  MAIL_ENABLE: 0
+  MAIL_TEST_ENABLE: 0
+  MAIL_TEST_EMAIL:
+  CSP_ENABLE: 1
+  MATOMO_ENABLE: 0
+  MAINTENANCE_ENABLE: 0
+  MAINTENANCE_BANNER_ENABLE: 0
+  MAINTENANCE_BANNER_MESSAGE: 'Une opération de maintenance est en cours'
+  AXIOS_TIMEOUT: 30000
+  LIMIT_DAILY_RELANCES_BY_REQUEST: 275
+  FORMS_SUBMIT_LIMITER_LIMIT: 10
+  FORMS_SUBMIT_LIMITER_INTERVAL: '20 minutes'
+  API_LIMITER_LIMIT: 60
+  API_LIMITER_INTERVAL: '1 minute'
+  FEATURE_2FA_EMAIL_ENABLED: 1
+  MISE_EN_BERNE_ENABLE: 0
+  CLAMAV_SCAN_ENABLE: 0
+  HISTORY_TRACKING_ENABLE: 1
+  DELAY_MIN_CHECK_NEW_SIGNALEMENT_FILES: 30
+  SITES_FACILES_URL: https://signal-logement.beta.gouv.fr/
+  FEATURE_SITES_FACILES: 1
+  PLATFORM_NAME: "Signal Logement"
+  PLATFORM_LOGO: logo-signal-logement.svg
+  FEATURE_BANNER_HISTOLOGE: 1
+  FEATURE_SECURE_UUID_URL: 1
+  FEATURE_PROCONNECT: 0
+  PROCONNECT_SCHEME_PROTOCOL:
+  PROCONNECT_DOMAIN:
+  PROCONNECT_CLIENT_ID:
+  PROCONNECT_CLIENT_SECRET:
+  FEATURE_EMAIL_RECAP: 1
+  FEATURE_SUIVI_ACTION: 1
+  FEATURE_ACCUSE_LECTURE: 1
+  TRUSTED_PROXIES: 0.0.0.0/0
+  S3_ENDPOINT:
+  S3_KEY:
+  S3_SECRET:
+  S3_BUCKET:
+  S3_URL_BUCKET:
+  SENTRY_DSN:
+  SENTRY_DSN_FRONT:
+  SENTRY_ENVIRONMENT:
+  SENTRY_TRACES_SAMPLE_RATE:
+  WIREMOCK_HOSTNAME: signal_logement_wiremock
+  WIREMOCK_PORT: 8080
+  MESSENGER_TRANSPORT_DSN: doctrine://default
+  REDIS_URL: redis://signal_logement_redis:6379
+  LOCK_DSN: flock
+  SIGNATURE_KEY: change_me
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg
+          sudo install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          sudo chmod a+r /etc/apt/keyrings/docker.gpg
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y docker-compose-plugin
+
+      - name: Build Docker containers
+        run: docker compose build
+
+      - name: Generate .env file safely
+        run: |
+          env | grep -E '^(APP_URL|APP_ENV|APP_SECRET|MAILER_DSN|DATABASE_URL|CORS_ALLOW_ORIGIN|WKHTMLTOPDF_PATH|WKHTMLTOIMAGE_PATH|ADMIN_EMAIL|NOTIFICATIONS_EMAIL|CONTACT_EMAIL|USER_SYSTEM_EMAIL|WIDGET_DATA_KPI_CACHE_EXPIRED_AFTER|WIDGET_AFFECTATION_PARTNER_CACHE_EXPIRED_AFTER|WIDGET_SIGNALEMENT_ACCEPTED_NO_SUIVI_CACHE_EXPIRED_AFTER|WIDGET_SIGNALEMENT_TERRITOIRE_CACHE_EXPIRED_AFTER|WIDGET_ESABORA_EVENTS_CACHE_EXPIRED_AFTER|FEATURE_OILHI_ENABLE|FEATURE_BO_SIGNALEMENT_CREATE|CRON_ENABLE|MAIL_ENABLE|MAIL_TEST_ENABLE|MAIL_TEST_EMAIL|CSP_ENABLE|MATOMO_ENABLE|MAINTENANCE_ENABLE|MAINTENANCE_BANNER_ENABLE|MAINTENANCE_BANNER_MESSAGE|AXIOS_TIMEOUT|LIMIT_DAILY_RELANCES_BY_REQUEST|FORMS_SUBMIT_LIMITER_LIMIT|FORMS_SUBMIT_LIMITER_INTERVAL|API_LIMITER_LIMIT|API_LIMITER_INTERVAL|FEATURE_2FA_EMAIL_ENABLED|MISE_EN_BERNE_ENABLE|CLAMAV_SCAN_ENABLE|HISTORY_TRACKING_ENABLE|DELAY_MIN_CHECK_NEW_SIGNALEMENT_FILES|SITES_FACILES_URL|FEATURE_SITES_FACILES|PLATFORM_NAME|PLATFORM_LOGO|FEATURE_BANNER_HISTOLOGE|FEATURE_SECURE_UUID_URL|FEATURE_PROCONNECT|PROCONNECT_SCHEME_PROTOCOL|PROCONNECT_DOMAIN|PROCONNECT_CLIENT_ID|PROCONNECT_CLIENT_SECRET:|FEATURE_EMAIL_RECAP|FEATURE_SUIVI_ACTION|FEATURE_ACCUSE_LECTURE|TRUSTED_PROXIES|S3_ENDPOINT|S3_KEY|S3_SECRET|S3_BUCKET|S3_URL_BUCKET|SENTRY_DSN|SENTRY_DSN_FRONT|SENTRY_ENVIRONMENT|SENTRY_TRACES_SAMPLE_RATE|WIREMOCK_HOSTNAME|WIREMOCK_PORT|MESSENGER_TRANSPORT_DSN|REDIS_URL|LOCK_DSN|SIGNATURE_KEY)=' \
+          | while IFS='=' read -r key value; do
+              safe_value=$(printf "%s" "$value" | sed 's/"/\\"/g')
+              echo "${key}=\"${safe_value}\""
+            done > .env
+
+      - name: Start Docker containers
+        run: docker compose up -d
+
+      - name: Wait for PHP container to be ready
+        run: |
+          docker compose exec -T signal_logement_phpfpm bash -c 'until php -v > /dev/null; do sleep 1; done'
+
+      - name: Install PHP dependencies
+        run: |
+          docker compose exec -T signal_logement_phpfpm composer install --no-interaction --optimize-autoloader
+          docker compose exec -T signal_logement_phpfpm composer install --working-dir=tools/php-cs-fixer --no-interaction --optimize-autoloader
+          docker compose exec -T signal_logement_phpfpm composer install --working-dir=tools/wiremock --no-interaction --optimize-autoloader
+          docker compose exec -T signal_logement_phpfpm composer require symfony/redis-messenger --no-interaction
+
+      - name: Build frontend assets
+        run: |
+          docker compose exec -T signal_logement_phpfpm npm ci
+          docker compose exec -T signal_logement_phpfpm npm run build
+
+      - name: Cache clear & warmup
+        run: |
+          docker compose exec -T signal_logement_phpfpm php bin/console cache:clear --env=dev --no-warmup
+          docker compose exec -T signal_logement_phpfpm php bin/console cache:warmup --env=dev
+
+      - name: Init database
+        run: |
+          docker compose exec -T signal_logement_phpfpm php bin/console doctrine:database:drop --force --no-interaction || true
+          docker compose exec -T signal_logement_phpfpm php bin/console doctrine:database:create --no-interaction
+          docker compose exec -T signal_logement_phpfpm php bin/console messenger:setup-transports --no-interaction
+          docker compose exec -T signal_logement_phpfpm php bin/console doctrine:migrations:migrate --no-interaction
+          docker compose exec -T signal_logement_phpfpm php bin/console doctrine:fixtures:load --no-interaction
+
+      - name: Install Node.js for Playwright
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install Playwright dependencies
+        working-directory: tests/e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        working-directory: tests/e2e
+        run: npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ tmp/*
 src/DataFixtures/Images/sample-target.png
 /metabase-data/
 metabase-data/*
+/test-results/
+/tests/e2e/test-results/

--- a/Makefile
+++ b/Makefile
@@ -195,8 +195,11 @@ test-all: ## Run all tests
 test-coverage: ## Generate phpunit coverage report in html
 	@$(DOCKER_COMP) exec signal_logement_phpfpm sh -c "XDEBUG_MODE=coverage $(PHPUNIT) --coverage-html coverage -d memory_limit=-1"
 
-e2e: ## Run E2E tests
-	@$(NPX) cypress open
+test-e2e: ## Run E2E tests
+	@$(NPX) playwright test
+
+open-test-e2e: ## Open Playwright
+	@$(NPX) playwright open
 
 stan: ## Run PHPStan
 	@$(DOCKER_COMP) exec -it signal_logement_phpfpm composer stan

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ test-coverage: ## Generate phpunit coverage report in html
 	@$(DOCKER_COMP) exec signal_logement_phpfpm sh -c "XDEBUG_MODE=coverage $(PHPUNIT) --coverage-html coverage -d memory_limit=-1"
 
 test-e2e: ## Run E2E tests
-	@$(NPX) playwright test
+	@cd tests/e2e/ ; $(NPX) playwright test
 
 open-test-e2e: ## Open Playwright
 	@$(NPX) playwright open

--- a/tests/Functional/Service/Mailer/SummaryMailServiceTest.php
+++ b/tests/Functional/Service/Mailer/SummaryMailServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Functional\Service\Mailer;
+namespace App\Tests\Functional\Service\Mailer;
 
 use App\Repository\NotificationRepository;
 use App\Repository\UserRepository;

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.44.0",
+        "@playwright/test": "^1.53.0",
         "playwright": "^1.53.0"
       }
     },

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "histologe-e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "histologe-e2e",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.44.0",
+        "playwright": "^1.53.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "histologe-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.44.0",
+    "playwright": "^1.53.0"
+  },
+  "scripts": {
+    "test": "playwright test"
+  },
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@playwright/test": "^1.44.0",
+    "@playwright/test": "^1.53.0",
     "playwright": "^1.53.0"
   },
   "scripts": {

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  expect: { timeout: 5000 },
+  reporter: 'list',
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
+    browserName: 'chromium',
+    headless: true,
+  },
+});

--- a/tests/e2e/tests/basic.spec.ts
+++ b/tests/e2e/tests/basic.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('connexion page loads with correct title', async ({ page }) => {
+    await page.goto(`${process.env.BASE_URL ?? 'http://localhost:8080'}/connexion`);
+    await expect(page).toHaveTitle("Connexion - Signal-Logement");
+});


### PR DESCRIPTION
## Ticket

#3036   

## Description
Test d'utilisation de Playwright à la place de Cypress pour les tests e2e.
https://playwright.dev/docs/codegen#recording-a-test

Objectif : avoir un deuxième job non-bloquant qui fait les tests e2e dans la CI.

## Changements apportés
Ajout des fichiers :
* job GitHub Actions `.github/workflows/playwright.yml`
  * Reprise de toutes les variables d'environnement, et installation complète du système
* configuration de playwright à la racine `tests/e2e/playwright.config.ts`
* description des tests `tests/e2e/tests/basic.spec.ts`
* installation npm indépendante pour ne pas venir court-circuiter les fonctionnalités actuelles standards `tests/e2e/package.json`

## Exécuter les tests en local
- cd `tests/e2e`
- `npx playwright install`
- `npx playwright install-deps`
- `npm i -D @playwright/test`
- `make test-e2e` (=> `npx playwright test`)

## Ouvrir playwright pour construire de nouveaux tests en cliquant
`make open-test-e2e` (=> `npx playwright open`)

## Tests
- [ ] CI fonctionnelle
