### PR TITLE
[BO - Signalement] Ré-affecter un partenaire / [BO - Affectation] Alerte si non notifiable

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -11,6 +11,13 @@ if (document?.querySelector('.fr-breadcrumb.can-fix')) {
   }
 }
 
+document.querySelectorAll('.open-modal-reinit-affectation').forEach((button) => {
+  button.addEventListener('click', (e) => {
+    document.querySelector('#fr-modal-reinit-affectation .partner-nom').textContent = e.target.dataset.partnerNom
+    document.querySelector('form#fr-modal-reinit-affectation-form').action = e.target.dataset.action
+  })
+})
+
 /* global histoPhotoIds */
 
 document?.querySelector('#btn-display-all-suivis')?.addEventListeners('click touchdown', (e) => {

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -497,9 +497,8 @@ class SignalementCreateController extends AbstractController
                 $partnersList = explode(',', $partnerIds);
                 foreach ($partnersList as $partnerId) {
                     if (isset($partners[$partnerId])) {
-                        $affectation = $affectationManager->createAffectationFrom($signalement, $partners[$partnerId], $user);
+                        $affectation = $affectationManager->createAffectation($signalement, $partners[$partnerId], $user);
                         $signalement->addAffectation($affectation);
-                        $affectationManager->persist($affectation);
                     }
                 }
                 $signalementManager->activateSignalementAndCreateFirstSuivi($signalement, $user);

--- a/src/Service/Signalement/AutoAssigner.php
+++ b/src/Service/Signalement/AutoAssigner.php
@@ -2,7 +2,6 @@
 
 namespace App\Service\Signalement;
 
-use App\Entity\Affectation;
 use App\Entity\AutoAffectationRule;
 use App\Entity\Partner;
 use App\Entity\Signalement;
@@ -10,7 +9,6 @@ use App\Entity\User;
 use App\Manager\AffectationManager;
 use App\Manager\SignalementManager;
 use App\Manager\UserManager;
-use App\Messenger\InterconnectionBus;
 use App\Repository\PartnerRepository;
 use App\Specification\Affectation\AllocataireSpecification;
 use App\Specification\Affectation\CodeInseeSpecification;
@@ -34,7 +32,6 @@ class AutoAssigner
         private AffectationManager $affectationManager,
         private UserManager $userManager,
         private ParameterBagInterface $parameterBag,
-        private InterconnectionBus $interconnectionBus,
         private PartnerRepository $partnerRepository,
         private LoggerInterface $logger,
     ) {
@@ -108,10 +105,6 @@ class AutoAssigner
             $signalement->addAffectation($affectation);
             ++$this->countAffectations;
             $this->affectedPartnersNames[] = $partner->getNom();
-            if ($affectation instanceof Affectation) {
-                $this->affectationManager->persist($affectation);
-                $this->interconnectionBus->dispatch($affectation);
-            }
         }
         $this->affectationManager->flush();
     }

--- a/templates/_partials/_modal_reinit_affectation.html.twig
+++ b/templates/_partials/_modal_reinit_affectation.html.twig
@@ -1,0 +1,32 @@
+<dialog aria-labelledby="fr-modal-reinit-affectation-title" id="fr-modal-reinit-affectation" class="fr-modal" >
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                       <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-reinit-affectation">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 class="fr-modal__title">Réaffecter le partenaire <span class="partner-nom"></span></h1>  
+                        <p>Voulez-vous vraiment réaffecter ce partenaire ?</p>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <form id="fr-modal-reinit-affectation-form" action="" method="POST">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('reinit_affectation_'~signalement.uuid) }}">
+                                    <button class="fr-btn fr-icon-check-line">Valider</button>
+                                </form>
+                            </li>
+                            <li>
+                                <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-reinit-affectation">
+                                    Annuler
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -12,7 +12,7 @@
                     {% for label, messages in app.flashes %}
                         {% for message in messages %}
                             <div role="alert" class="fr-alert fr-alert--{{ label }} fr-alert--sm">
-                                {% if label is same as('error error-raw')  %}
+                                {% if label is same as('error error-raw') or label is same as('success success-raw') %}
                                     <p>{{ message|raw }}</p>
                                 {% else %}
                                     <p>{{ message }}</p>

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -34,9 +34,8 @@
         {% include '_partials/_modal_edit_nde.html.twig' %}
     {% endif %}
     {% if is_granted('SIGN_EDIT', signalement) %}
-        {% include '_partials/_modal_upload_files.html.twig' with {
-            'context': 'form-bo-edit'
-        } %}
+        {% include '_partials/_modal_upload_files.html.twig' with {'context': 'form-bo-edit'} %}
+        {% include '_partials/_modal_reinit_affectation.html.twig' %}
     {% endif %}
     {% if signalement.geoloc.lat is defined and signalement.geoloc.lng is defined %}
         {% include '_partials/_modal_localisation.html.twig' %}

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -66,15 +66,29 @@
                                 {% elseif partnerAffectation.statut is same as constant('App\\Entity\\Affectation::STATUS_CLOSED') %}
                                     <span class="fr-badge fr-badge--sm fr-fi-close-circle-fill">Clôturée</span>
                                 {% endif %}
+                                {% if not partnerAffectation.partner.receiveEmailNotifications %}
+                                    <span class="fr-badge fr-badge--warning fr-badge--sm">Notif. e-mail désactivées</span>
+                                {% endif %}
                             </div>
-                            {% if signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}
-                                <div class="fr-col-2 fr-text--right">
+                            <div class="fr-col-2 fr-text--right">
+                                {% if is_granted('AFFECTATION_REINIT', partnerAffectation) %}
+                                    <button 
+                                        title="Réaffecter le partenaire" 
+                                        class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-refresh-line open-modal-reinit-affectation"
+                                        data-fr-opened="false" 
+                                        aria-controls="fr-modal-reinit-affectation"
+                                        data-partner-nom="{{ partnerAffectation.partner.nom }}"
+                                        data-action="{{ path('back_signalement_affectation_reinit', {affectation: partnerAffectation.id}) }}"
+                                        >
+                                    </button>
+                                {% endif %}
+                                {% if signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}
                                     <button title="Désaffecter le partenaire"
                                             data-delete="{{ path('back_signalement_remove_partner',{uuid:signalement.uuid,affectation:partnerAffectation.id}) }}"
                                             data-token="{{ csrf_token('signalement_remove_partner_'~signalement.id) }}"
                                             class="fr-btn fr-btn--sm fr-btn--secondary fr-fi-delete-line partner-row-delete"></button>
-                                </div>
-                            {% endif %}
+                                {% endif %}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/tests/Functional/Manager/AffectationManagerTest.php
+++ b/tests/Functional/Manager/AffectationManagerTest.php
@@ -9,6 +9,7 @@ use App\Entity\User;
 use App\Manager\AffectationManager;
 use App\Manager\HistoryEntryManager;
 use App\Manager\SuiviManager;
+use App\Messenger\InterconnectionBus;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -23,6 +24,7 @@ class AffectationManagerTest extends KernelTestCase
     private HistoryEntryManager $historyEntryManager;
     private AffectationManager $affectationManager;
     private EventDispatcherInterface $eventDispatcher;
+    private InterconnectionBus $interconnectionBus;
 
     protected function setUp(): void
     {
@@ -32,12 +34,14 @@ class AffectationManagerTest extends KernelTestCase
         $this->logger = self::getContainer()->get(LoggerInterface::class);
         $this->historyEntryManager = self::getContainer()->get(HistoryEntryManager::class);
         $this->eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+        $this->interconnectionBus = self::getContainer()->get(InterconnectionBus::class);
         $this->affectationManager = new AffectationManager(
             $this->managerRegistry,
             $this->suiviManager,
             $this->logger,
             $this->historyEntryManager,
             $this->eventDispatcher,
+            $this->interconnectionBus,
             Affectation::class,
         );
     }

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -194,6 +194,18 @@ class PartnerRepositoryTest extends KernelTestCase
         $this->assertGreaterThan(1, $partnersQueryBuilder->getQuery()->getResult());
     }
 
+    public function testCountPartnerNonNotifiables(): void
+    {
+        $count = $this->partnerRepository->countPartnerNonNotifiables([]);
+        $this->assertEquals(1, $count->getNonNotifiables());
+
+        $count = $this->partnerRepository->countPartnerNonNotifiables([13]);
+        $this->assertEquals(1, $count->getNonNotifiables());
+
+        $count = $this->partnerRepository->countPartnerNonNotifiables([1]);
+        $this->assertEquals(0, $count->getNonNotifiables());
+    }
+
     protected function tearDown(): void
     {
         $this->entityManager->close();

--- a/tests/Unit/Service/AutoAssignerTest.php
+++ b/tests/Unit/Service/AutoAssignerTest.php
@@ -11,7 +11,6 @@ use App\Entity\SignalementQualification;
 use App\Manager\AffectationManager;
 use App\Manager\SignalementManager;
 use App\Manager\UserManager;
-use App\Messenger\InterconnectionBus;
 use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Service\Signalement\AutoAssigner;
@@ -209,8 +208,6 @@ class AutoAssignerTest extends KernelTestCase
         $userManager = $this->createMock(UserManager::class);
         /** @var ParameterBagInterface|MockObject $parameterBag */
         $parameterBag = $this->createMock(ParameterBagInterface::class);
-        /** @var InterconnectionBus|MockObject $esaboraBus */
-        $esaboraBus = $this->createMock(InterconnectionBus::class);
         /** @var LoggerInterface $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $autoAssigner = new AutoAssigner(
@@ -218,7 +215,6 @@ class AutoAssignerTest extends KernelTestCase
             $this->affectationManager,
             $userManager,
             $parameterBag,
-            $esaboraBus,
             $this->partnerRepository,
             $logger,
         );


### PR DESCRIPTION
## Ticket

#3541
#3999

## Description
- Correction de la requête du widget "Partenaires non notifiables"
- Ajout d'un warning sur la liste des partenaire affectés a un signalement quand il ne sont pas notifiable
- Ajout d'une information dans le message de sucés suite à une affectation si le partenaire est non notifiable
- Ajout d'une option "Réaffecter le partenaire" quand l'affectation est cloturé ou refusé sur un signalement actif
- Refacto de la création d'affectation pour la gestion du `interconnectionBus->dispatch` (qui n'était pas faite sur le form PRO)

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis

## Tests
- [ ] Les différentes étapes des tests à faire
