### PR TITLE
[BO - Formulaire pro] Filtre des adresses par territoires de l'utilisateur

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -1,4 +1,3 @@
-import { attacheAutocompleteAddressEvent } from '../../services/component/component_search_address'
 import { initSearchAndSelectBadges } from '../../services/component/component_search_and_select_badges'
 
 let boFormSignalementCurrentTabIsDirty = false
@@ -442,8 +441,6 @@ function initBoFormSignalementDesordres() {
 
 function initComponentAdress(id) {
   const addressInput = document.querySelector(id)
-  attacheAutocompleteAddressEvent(addressInput)
-
   const addressInputParent = addressInput.parentElement.parentElement.parentElement
   const manualAddressSwitcher = addressInputParent?.querySelector('.bo-signalement-manual-address-switcher')
   const manualAddressContainer = addressInputParent?.querySelector('.bo-form-signalement-manual-address-container')

--- a/assets/scripts/vanilla/services/component/component_search_address.js
+++ b/assets/scripts/vanilla/services/component/component_search_address.js
@@ -32,7 +32,6 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
   }
   const addressGroup = document?.querySelector(inputAdresse.dataset.autocompleteQuerySelector)
   const fieldFilterAddress = document?.querySelector('#signalement_draft_address_filterSearchAddressTerritory')
-  const zipFilterAddress = fieldFilterAddress ? fieldFilterAddress.value : ''
 
   const apiAdresse = 'https://data.geopf.fr/geocodage/search/?q='
   let addressAbortController;
@@ -45,8 +44,14 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
 
     if (adresse.length > 8) {
       addressAbortController = new AbortController();
-      let query = apiAdresse + adresse + ' ' + zipFilterAddress
-      const limit = inputAdresse.getAttribute('data-form-limit')
+      const zipFilterAddress = fieldFilterAddress ? fieldFilterAddress.value : ''
+      let query = apiAdresse + adresse
+      let limit = inputAdresse.getAttribute('data-form-limit')
+      if (zipFilterAddress !== '') {
+        const splitFilter = zipFilterAddress.split('|')
+        query += ' ' + splitFilter[1]
+        limit = splitFilter[0]
+      }
       if (inputAdresse.getAttribute('data-form-lat')) {
         query += '&lat=' + inputAdresse.getAttribute('data-form-lat')
       }

--- a/assets/scripts/vanilla/services/component/component_search_address.js
+++ b/assets/scripts/vanilla/services/component/component_search_address.js
@@ -31,6 +31,9 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
     suffix = '-' + inputAdresse.dataset.suffix
   }
   const addressGroup = document?.querySelector(inputAdresse.dataset.autocompleteQuerySelector)
+  const fieldFilterAddress = document?.querySelector('#signalement_draft_address_filterSearchAddressTerritory')
+  const zipFilterAddress = fieldFilterAddress ? fieldFilterAddress.value : ''
+
   const apiAdresse = 'https://data.geopf.fr/geocodage/search/?q='
   let addressAbortController;
   inputAdresse.addEventListener('input', (e) => {
@@ -42,7 +45,7 @@ export function attacheAutocompleteAddressEvent (inputAdresse) {
 
     if (adresse.length > 8) {
       addressAbortController = new AbortController();
-      let query = apiAdresse + adresse
+      let query = apiAdresse + adresse + ' ' + zipFilterAddress
       const limit = inputAdresse.getAttribute('data-form-limit')
       if (inputAdresse.getAttribute('data-form-lat')) {
         query += '&lat=' + inputAdresse.getAttribute('data-form-lat')

--- a/src/Form/SignalementDraftAddressType.php
+++ b/src/Form/SignalementDraftAddressType.php
@@ -52,15 +52,18 @@ class SignalementDraftAddressType extends AbstractType
                 'data' => $territory->getZip().'|'.$territory->getName(),
             ]);
         } else {
+            if (!empty($signalement)) {
+                $territory = $signalement->getTerritory();
+            }
             $choicesTerritories = [];
-            foreach ($territories as $territory) {
-                $choicesTerritories[$territory->getZip().' - '.$territory->getName()] = $territory->getZip().'|'.$territory->getName();
+            foreach ($territories as $territoryItem) {
+                $choicesTerritories[$territoryItem->getZip().' - '.$territoryItem->getName()] = $territoryItem->getZip().'|'.$territoryItem->getName();
             }
             $builder->add('filterSearchAddressTerritory', ChoiceType::class, [
                 'mapped' => false,
                 'choices' => $choicesTerritories,
                 'label' => 'Territoire',
-                'data' => $user->isSuperAdmin() ? '' : $territory->getZip().'|'.$territory->getName(),
+                'data' => $territory ? $territory->getZip().'|'.$territory->getName() : '',
             ]);
         }
 

--- a/templates/back/signalement_create/tabs/tab-adresse.html.twig
+++ b/templates/back/signalement_create/tabs/tab-adresse.html.twig
@@ -9,6 +9,7 @@
                 <h2 class="fr-h4">Adresse du logement <span class="text-required">*</span></h2>
             </legend>
             <div class="fr-fieldset__element">
+                {{ form_row(form.filterSearchAddressTerritory) }}
                 {{ form_row(form.adresseCompleteOccupant) }}
                 <div class="fr-address-group-container">
                     <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">


### PR DESCRIPTION
## Ticket

#4120   

## Description
Dans le formulaire pro, permettre de filtrer sur les territoires de l'utliisateur en cours

## Changements apportés
* Si l'utilisateur n'a qu'un territoire : champ caché avec le territoire de l'utilisateur
* Si multiterritoire : liste déroulante avec les territoires de l'utilisateur
* Si super admin : liste déroulante avec tous les territoires

Finalement, j'ai mis un double filtre :
- d'une part, au moment de la requête : utiliser le nom du département plutôt que le numéro, parce que pour certains départements (le 01), ça ne filtrait pas bien
- d'autre part, au moment de l'affichage : utiliser le numéro du département pour filtrer les résultats parce que parfois, il restait des résultats non voulus 

## Pré-requis
`npm run watch-bo`

## Tests
- [ ] TNR sur les autres pages où est utilisé le composant
- [ ] Test avec Super Admin admin-01@signal-logement.fr
- [ ] Avec multi-territoire admin-partenaire-multi-ter-13-01@signal-logement.fr (vérifier en enregistrant le signalement)
- [ ] Avec user-13-01@signal-logement.fr
- [ ] Avec user-01-01@signal-logement.fr
- [ ] Avec user-63-01@signal-logement.fr
