### PR TITLE
[QA] Mock ProConnect KO - conflit avec RIAL

### DIFF
--- a/tests/Functional/Service/Mailer/SummaryMailServiceTest.php
+++ b/tests/Functional/Service/Mailer/SummaryMailServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Functional\Service\Mailer;
+namespace App\Tests\Functional\Service\Mailer;
 
 use App\Repository\NotificationRepository;
 use App\Repository\UserRepository;

--- a/tests/Unit/Service/Gouv/Rial/Request/RialSearchLocauxParamsTest.php
+++ b/tests/Unit/Service/Gouv/Rial/Request/RialSearchLocauxParamsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Unit\Service\Gouv\Rnb;
+namespace App\Tests\Unit\Service\Gouv\Rial\Request;
 
 use App\Service\Gouv\Rial\Request\RialSearchLocauxParams;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Service/Gouv/Rial/RialServiceTest.php
+++ b/tests/Unit/Service/Gouv/Rial/RialServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Unit\Service\Gouv\Rnb;
+namespace App\Tests\Unit\Service\Gouv\Rial;
 
 use App\Service\Gouv\Rial\RialService;
 use PHPUnit\Framework\TestCase;

--- a/tools/wiremock/postman/proconnect.mock.postman_collection.json
+++ b/tools/wiremock/postman/proconnect.mock.postman_collection.json
@@ -129,13 +129,14 @@
 					}
 				],
 				"url": {
-					"raw": "http://localhost:8082/token",
+					"raw": "http://localhost:8082/proconnect/token",
 					"protocol": "http",
 					"host": [
 						"localhost"
 					],
 					"port": "8082",
 					"path": [
+						"proconnect",
 						"token"
 					]
 				}

--- a/tools/wiremock/src/Mock/ProConnect/ProConnectMock.php
+++ b/tools/wiremock/src/Mock/ProConnect/ProConnectMock.php
@@ -31,7 +31,7 @@ class ProConnectMock
         ));
 
         $wireMock->stubFor(
-            WireMock::post(WireMock::urlMatching('/token'))
+            WireMock::post(WireMock::urlMatching('/proconnect/token'))
                 ->withHeader('Content-Type', WireMock::containing('application/x-www-form-urlencoded'))
                 ->willReturn(
                     WireMock::aResponse()

--- a/tools/wiremock/src/Resources/ProConnect/openid-configuration.json
+++ b/tools/wiremock/src/Resources/ProConnect/openid-configuration.json
@@ -1,6 +1,6 @@
 {
     "authorization_endpoint": "http://localhost:8082/authorize",
-    "token_endpoint": "http://signal_logement_wiremock:8080/token",
+    "token_endpoint": "http://signal_logement_wiremock:8080/proconnect/token",
     "userinfo_endpoint": "http://signal_logement_wiremock:8080/userinfo",
     "end_session_endpoint": "http://localhost:8082/session/end",
     "jwks_uri": "http://signal_logement_wiremock:8080/jwks"


### PR DESCRIPTION
## Ticket

#4222    

## Description
Spécifier une route distincte pour éviter le conflit `/proconnect/token`

## Changements apportés
* Mise à jour de la route
* Correction namespace test 

## Pré-requis
```
make mock-stop && make mock-start
```

## Tests
- [ ] Se connecter via ProConnect Mock
- [ ] Vérifier que la route /token fonctionne toujours via postman