### PR TITLE
[BO] Stocker les détections de signalement en doublon d'adresse détectés dans le BO

### DIFF
--- a/migrations/Version20250618103218.php
+++ b/migrations/Version20250618103218.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250618103218 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create duplicate_addresse_detection table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE duplicate_addresse_detection (id INT AUTO_INCREMENT NOT NULL, territory_id INT NOT NULL, address VARCHAR(255) NOT NULL, zip VARCHAR(5) NOT NULL, city VARCHAR(100) NOT NULL, nb_duplication INT NOT NULL, INDEX IDX_B1E87E1773F74AD4 (territory_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE duplicate_addresse_detection ADD CONSTRAINT FK_B1E87E1773F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE duplicate_addresse_detection DROP FOREIGN KEY FK_B1E87E1773F74AD4
+        SQL);
+        $this->addSql(<<<'SQL'
+            DROP TABLE duplicate_addresse_detection
+        SQL);
+    }
+}

--- a/src/Controller/Back/DuplicateAddressDetectionController.php
+++ b/src/Controller/Back/DuplicateAddressDetectionController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Repository\DuplicateAddresseDetectionRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/bo/duplication-adresse')]
+class DuplicateAddressDetectionController extends AbstractController
+{
+    #[Route('/', name: 'back_duplicate_address_detection_index')]
+    public function index(
+        DuplicateAddresseDetectionRepository $duplicateAddresseDetectionRepository,
+    ): Response {
+        $duplicateAddresses = $duplicateAddresseDetectionRepository->findBy([], ['id' => 'DESC']);
+
+        return $this->render('back/duplicate_address_detection/index.html.twig', [
+            'duplicateAddresses' => $duplicateAddresses,
+        ]);
+    }
+}

--- a/src/Entity/DuplicateAddresseDetection.php
+++ b/src/Entity/DuplicateAddresseDetection.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\DuplicateAddresseDetectionRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: DuplicateAddresseDetectionRepository::class)]
+class DuplicateAddresseDetection
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $address = null;
+
+    #[ORM\Column(length: 5)]
+    private ?string $zip = null;
+
+    #[ORM\Column(length: 100)]
+    private ?string $city = null;
+
+    #[ORM\Column]
+    private ?int $nbDuplication = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Territory $territory = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getAddress(): ?string
+    {
+        return $this->address;
+    }
+
+    public function setAddress(string $address): static
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    public function getZip(): ?string
+    {
+        return $this->zip;
+    }
+
+    public function setZip(string $zip): static
+    {
+        $this->zip = $zip;
+
+        return $this;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(string $city): static
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function getNbDuplication(): ?int
+    {
+        return $this->nbDuplication;
+    }
+
+    public function setNbDuplication(int $nbDuplication): static
+    {
+        $this->nbDuplication = $nbDuplication;
+
+        return $this;
+    }
+
+    public function getTerritory(): ?Territory
+    {
+        return $this->territory;
+    }
+
+    public function setTerritory(?Territory $territory): static
+    {
+        $this->territory = $territory;
+
+        return $this;
+    }
+}

--- a/src/Repository/DuplicateAddresseDetectionRepository.php
+++ b/src/Repository/DuplicateAddresseDetectionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\DuplicateAddresseDetection;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<DuplicateAddresseDetection>
+ */
+class DuplicateAddresseDetectionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DuplicateAddresseDetection::class);
+    }
+}

--- a/src/Service/Menu/MenuBuilder.php
+++ b/src/Service/Menu/MenuBuilder.php
@@ -55,6 +55,7 @@ readonly class MenuBuilder
             ->addChild(new MenuItem(label: 'Signalement archivés', route: 'back_archived_signalements_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Règles d\'auto-affectation', route: 'back_auto_affectation_rule_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Résumés de suivis', route: 'back_suivi_summaries_index', roleGranted: User::ROLE_ADMIN))
+            ->addChild(new MenuItem(label: 'Doublons d\'adresses', route: 'back_duplicate_address_detection_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Territoires', route: 'back_territory_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Bailleurs', route: 'back_bailleur_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(route: 'back_archived_users_reactiver'))

--- a/templates/back/duplicate_address_detection/index.html.twig
+++ b/templates/back/duplicate_address_detection/index.html.twig
@@ -1,0 +1,56 @@
+{% extends 'back/base_bo.html.twig' %}
+
+{% block title %}Liste des doublons d'adresses{% endblock %}
+
+{% block content %}
+    <section class="fr-p-5v">
+        {% include 'back/breadcrumb_bo.html.twig' with {
+            'level2Title': 'Outils SA',
+            'level2Link': '',
+            'level2Label': '',
+            'level3Title': 'Doublons d\'adresses',
+            'level3Link': '',
+        } %}
+
+        <header>
+            <div class="fr-grid-row">
+                <div class="fr-col-12 fr-text--left">
+                    <h1 class="fr-mb-0">Liste des doublons d'adresses</h1>
+                </div>
+            </div>
+        </header>
+    </section>
+
+    <section class="fr-col-12 fr-py-5v">
+        <h2 class="fr-mb-0" id="desc-table">{{ singular_or_plural(duplicateAddresses|length, 'doublon trouvé', 'doublons trouvés') }}</h2>
+    </section>
+    
+    <section class="fr-col-12 fr-pt-0 fr-px-5v">
+        {% set tableHead %}
+            <th scope="col">Adresse</th>
+            <th scope="col">Nombre de signalement</th>
+            <th scope="col">Territoires</th>
+            <th scope="col">Actions</th>
+        {% endset %}
+        
+        {% set tableBody %}
+            {% for duplicateAddress in duplicateAddresses %}
+                <tr class="signalement-row">
+                    <td>{{ duplicateAddress.address }}</td>
+                    <td>{{ duplicateAddress.nbDuplication }}</td>
+                    <td>{{ duplicateAddress.territory.zip }} {{ duplicateAddress.territory.name }}</td>
+                    <td class="fr-text--right fr-ws-nowrap">
+                        <a href="{{ path('back_signalements_index', { 'isImported': 'oui', 'searchTerms': duplicateAddress.address, 'communes[]': duplicateAddress.city }) }}" class="fr-btn fr-icon-align-justify" title="Voir les signalements">
+                            Voir les signalements
+                        </a>
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endset %}
+
+        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des doublons d\'adresses', 'tableHead': tableHead, 'tableBody': tableBody, 'cancelSortable': true } %}
+
+    </section>
+              
+
+{% endblock %}


### PR DESCRIPTION
## Ticket

#4228

## Description
- Stokage des détection de signalement existant ayant des doublon d'adresse (suite à leur affichage sur la fiche signalement #4153)
- Création d'une page SA affichant la liste des doublon détectés

## Pré-requis
`make execute-migration name=Version20250618103218 direction=up`

## Tests
- [ ] Se rendre sur http://localhost:8080/bo/signalements/00000000-0000-0000-2025-000000000009
- [ ] Se rendre sur http://localhost:8080/bo/duplication-adresse/ et voir l'enregistrement dans la liste