### PR TITLE
[Formulaire usager] Enregistrer ma progression / finir plus tard

### DIFF
--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -57,6 +57,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_les_desordres_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "ecran_intermediaire_les_desordres_previous",
                 "action": "goto:travailleur_social",
@@ -308,6 +315,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_proprete_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_proprete_previous",
                 "action": "resolve:findPreviousScreen",
@@ -380,6 +394,13 @@
                 "slug": "desordres_batiment_eau_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_eau_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -469,6 +490,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_isolation_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_isolation_previous",
                 "action": "resolve:findPreviousScreen",
@@ -536,6 +564,13 @@
                 "slug": "desordres_batiment_maintenance_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_maintenance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -658,6 +693,13 @@
                 "slug": "desordres_batiment_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_nuisibles_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -899,6 +941,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_securite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_securite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -955,6 +1004,13 @@
                 "slug": "desordres_batiment_incendie_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_incendie_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1067,6 +1123,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_accessibilite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_accessibilite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -1123,6 +1186,13 @@
                 "slug": "desordres_batiment_bruit_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_bruit_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1423,6 +1493,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_eau_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_eau_previous",
                 "action": "resolve:findPreviousScreen",
@@ -1542,6 +1619,13 @@
                 "slug": "desordres_logement_aeration_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_aeration_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1718,6 +1802,13 @@
                 "slug": "desordres_logement_chauffage_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_chauffage_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2087,6 +2178,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_humidite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_humidite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -2276,6 +2374,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_securite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_securite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -2400,6 +2505,13 @@
                 "slug": "desordres_logement_electricite_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_electricite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2623,6 +2735,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_nuisibles_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_nuisibles_previous",
                 "action": "resolve:findPreviousScreen",
@@ -2697,6 +2816,13 @@
                 "slug": "desordres_logement_bruit_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_bruit_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2780,6 +2906,13 @@
                 "slug": "desordres_logement_lumiere_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_lumiere_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2872,6 +3005,13 @@
                 "slug": "desordres_precisions_next",
                 "action": "goto.save:desordres_renseignes",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_precisions_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/desordres_profile_occupant.json
+++ b/assets/json/Signalement/desordres_profile_occupant.json
@@ -45,7 +45,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_les_desordres_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -296,7 +296,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_proprete_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -371,7 +371,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_eau_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -457,7 +457,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_isolation_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -527,7 +527,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_maintenance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -649,7 +649,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_nuisibles_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -887,7 +887,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_securite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -946,7 +946,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_incendie_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1055,7 +1055,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_accessibilite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1114,7 +1114,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_bruit_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1411,7 +1411,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_eau_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1533,7 +1533,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_aeration_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1709,7 +1709,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_chauffage_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2075,7 +2075,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_humidite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2264,7 +2264,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_securite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2391,7 +2391,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_electricite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2611,7 +2611,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_nuisibles_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2688,7 +2688,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_bruit_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2771,7 +2771,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_lumiere_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2863,7 +2863,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_precisions_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -45,7 +45,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_les_desordres_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -309,7 +309,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_proprete_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -384,7 +384,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_eau_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -470,7 +470,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_isolation_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -540,7 +540,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_maintenance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -662,7 +662,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_nuisibles_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -900,7 +900,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_securite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -959,7 +959,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_incendie_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1068,7 +1068,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_accessibilite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1127,7 +1127,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_batiment_bruit_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1433,7 +1433,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_eau_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1559,7 +1559,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_aeration_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1735,7 +1735,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_chauffage_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2023,7 +2023,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_humidite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2212,7 +2212,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_securite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2343,7 +2343,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_electricite_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2579,7 +2579,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_nuisibles_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2656,7 +2656,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_bruit_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2739,7 +2739,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_lumiere_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2790,7 +2790,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_logement_proprete_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2900,7 +2900,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "desordres_precisions_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/desordres_profile_tiers.json
+++ b/assets/json/Signalement/desordres_profile_tiers.json
@@ -57,6 +57,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_les_desordres_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "ecran_intermediaire_les_desordres_previous_autre",
                 "action": "goto:travailleur_social",
@@ -321,6 +328,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_proprete_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_proprete_previous",
                 "action": "resolve:findPreviousScreen",
@@ -393,6 +407,13 @@
                 "slug": "desordres_batiment_eau_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_eau_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -482,6 +503,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_isolation_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_isolation_previous",
                 "action": "resolve:findPreviousScreen",
@@ -549,6 +577,13 @@
                 "slug": "desordres_batiment_maintenance_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_maintenance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -671,6 +706,13 @@
                 "slug": "desordres_batiment_nuisibles_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_nuisibles_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -912,6 +954,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_securite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_securite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -968,6 +1017,13 @@
                 "slug": "desordres_batiment_incendie_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_incendie_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1080,6 +1136,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_accessibilite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_batiment_accessibilite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -1136,6 +1199,13 @@
                 "slug": "desordres_batiment_bruit_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_batiment_bruit_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1445,6 +1515,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_eau_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_eau_previous",
                 "action": "resolve:findPreviousScreen",
@@ -1568,6 +1645,13 @@
                 "slug": "desordres_logement_aeration_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_aeration_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1744,6 +1828,13 @@
                 "slug": "desordres_logement_chauffage_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_chauffage_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2035,6 +2126,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_humidite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_humidite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -2224,6 +2322,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_securite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_securite_previous",
                 "action": "resolve:findPreviousScreen",
@@ -2352,6 +2457,13 @@
                 "slug": "desordres_logement_electricite_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_electricite_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2591,6 +2703,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_nuisibles_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_nuisibles_previous",
                 "action": "resolve:findPreviousScreen",
@@ -2665,6 +2784,13 @@
                 "slug": "desordres_logement_bruit_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_bruit_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2751,6 +2877,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_lumiere_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "desordres_logement_lumiere_previous",
                 "action": "resolve:findPreviousScreen",
@@ -2799,6 +2932,13 @@
                 "slug": "desordres_logement_proprete_next",
                 "action": "resolve.save:findNextScreen",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_logement_proprete_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2909,6 +3049,13 @@
                 "slug": "desordres_precisions_next",
                 "action": "goto.save:desordres_renseignes",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "desordres_precisions_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -182,6 +182,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "coordonnees_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "coordonnees_occupant_previous",
                 "action": "goto:vos_coordonnees_tiers",
@@ -309,6 +316,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "zone_concernee_zone_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "zone_concernee_zone_previous",
                 "action": "goto:coordonnees_occupant",
@@ -346,6 +360,13 @@
                 "slug": "ecran_intermediaire_type_composition_next",
                 "action": "goto:type_logement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_type_composition_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -506,6 +527,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_previous",
                 "action": "goto:ecran_intermediaire_type_composition",
@@ -606,6 +634,13 @@
                 "label": "Suivant",
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -847,6 +882,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_commodites_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_commodites_previous",
                 "action": "goto:composition_logement",
@@ -929,6 +971,13 @@
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_personnes_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1182,6 +1231,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "bail_dpe_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "bail_dpe_previous",
                 "action": "goto:type_logement_commodites",
@@ -1217,6 +1273,13 @@
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_situation_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1341,6 +1404,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "logement_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "logement_social_previous",
                 "action": "goto:ecran_intermediaire_situation_occupant",
@@ -1448,6 +1518,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "travailleur_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "travailleur_social_previous",
                 "action": "goto:logement_social",
@@ -1484,6 +1561,13 @@
                 "label": "J'y suis presque !",
                 "slug": "ecran_intermediaire_procedure_next",
                 "action": "goto:info_procedure_assurance"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_procedure_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1575,6 +1659,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_assurance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "info_procedure_assurance_previous",
                 "action": "goto:ecran_intermediaire_procedure",
@@ -1643,6 +1734,13 @@
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "utilisation_service_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1836,6 +1934,13 @@
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "informations_complementaires_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -81,7 +81,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "vos_coordonnees_tiers_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -170,7 +170,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -297,7 +297,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "zone_concernee_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -337,7 +337,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_type_composition_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -494,7 +494,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -598,7 +598,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -835,7 +835,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_commodites_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -920,7 +920,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_personnes_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1170,7 +1170,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "bail_dpe_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1208,7 +1208,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_situation_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1329,7 +1329,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "logement_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1436,7 +1436,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "travailleur_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1476,7 +1476,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_procedure_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1563,7 +1563,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_assurance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1634,7 +1634,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "utilisation_service_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1827,7 +1827,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "informations_complementaires_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1867,7 +1867,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "validation_signalement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -101,7 +101,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "vos_coordonnees_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -205,7 +205,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "zone_concernee_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -245,7 +245,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_type_composition_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -402,7 +402,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -506,7 +506,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -744,7 +744,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_commodites_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -825,7 +825,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_personnes_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1002,7 +1002,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "bail_dpe_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1040,7 +1040,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_situation_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1207,7 +1207,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "logement_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1285,7 +1285,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "travailleur_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1325,7 +1325,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_procedure_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1434,7 +1434,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_assurance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1505,7 +1505,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "utilisation_service_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1637,7 +1637,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "informations_complementaires_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1677,7 +1677,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "validation_signalement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -217,6 +217,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "zone_concernee_zone_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "zone_concernee_zone_previous",
                 "action": "goto:vos_coordonnees_occupant",
@@ -254,6 +261,13 @@
                 "slug": "ecran_intermediaire_type_composition_next",
                 "action": "goto:type_logement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_type_composition_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -414,6 +428,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_previous",
                 "action": "goto:ecran_intermediaire_type_composition",
@@ -515,6 +536,13 @@
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -756,6 +784,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_commodites_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_commodites_previous",
                 "action": "goto:composition_logement",
@@ -834,6 +869,13 @@
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_personnes_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1014,6 +1056,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "bail_dpe_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "bail_dpe_previous",
                 "action": "goto:type_logement_composition",
@@ -1049,6 +1098,13 @@
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_situation_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1219,6 +1275,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "logement_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "logement_social_previous",
                 "action": "goto:ecran_intermediaire_situation_occupant",
@@ -1297,6 +1360,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "travailleur_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "travailleur_social_previous",
                 "action": "goto:logement_social",
@@ -1333,6 +1403,13 @@
                 "label": "J'y suis presque !",
                 "slug": "ecran_intermediaire_procedure_next",
                 "action": "goto:info_procedure_assurance"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_procedure_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1446,6 +1523,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure__assurance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "info_procedure__assurance_previous",
                 "action": "goto:ecran_intermediaire_procedure",
@@ -1514,6 +1598,13 @@
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "utilisation_service_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1646,6 +1737,13 @@
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "informations_complementaires_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -225,6 +225,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "signalement_concerne_finish_later",
+                "customCss": "fr-btn--secondary",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "coordonnees_bailleur_previous",
                 "action": "goto:vos_coordonnees_occupant",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -392,6 +392,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_bail_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "info_procedure_bail_previous",
                 "action": "goto:coordonnees_bailleur",
@@ -538,6 +545,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "zone_concernee_zone_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "zone_concernee_zone_previous",
                 "action": "goto:info_procedure_bail",
@@ -575,6 +589,13 @@
                 "slug": "ecran_intermediaire_type_composition_next",
                 "action": "goto:type_logement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_type_composition_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -735,6 +756,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_previous",
                 "action": "goto:ecran_intermediaire_type_composition",
@@ -836,6 +864,13 @@
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1077,6 +1112,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_commodites_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_commodites_previous",
                 "action": "goto:composition_logement",
@@ -1155,6 +1197,13 @@
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_personnes_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1417,6 +1466,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "bail_dpe_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "bail_dpe_previous",
                 "action": "goto:composition_logement_personnes",
@@ -1452,6 +1508,13 @@
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_situation_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1622,6 +1685,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "logement_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "logement_social_previous",
                 "action": "goto:ecran_intermediaire_situation_occupant",
@@ -1717,6 +1787,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "travailleur_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "travailleur_social_previous",
                 "action": "goto:logement_social",
@@ -1756,6 +1833,13 @@
                 "accessibility": {
                   "focus": true
                 }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_procedure_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1865,6 +1949,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_assurance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "info_procedure_assurance_previous",
                 "action": "goto:ecran_intermediaire_procedure",
@@ -1941,6 +2032,13 @@
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "utilisation_service_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2087,6 +2185,13 @@
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "informations_complementaires_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -226,8 +226,8 @@
               {
                 "type": "SignalementFormButton",
                 "label": "Finir plus tard",
-                "slug": "signalement_concerne_finish_later",
-                "customCss": "fr-btn--secondary",
+                "slug": "coordonnees_bailleur_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
                 "action": "finish.save:/"
               },
               {

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -85,7 +85,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "vos_coordonnees_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -213,7 +213,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_bailleur_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -367,7 +367,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_bail_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -526,7 +526,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "zone_concernee_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -566,7 +566,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_type_composition_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -723,7 +723,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -827,7 +827,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1065,7 +1065,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_commodites_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1146,7 +1146,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_personnes_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1405,7 +1405,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "bail_dpe_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1443,7 +1443,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_situation_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1610,7 +1610,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "logement_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1705,7 +1705,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "travailleur_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1745,7 +1745,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_procedure_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1853,7 +1853,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_assurance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1932,7 +1932,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "utilisation_service_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2078,7 +2078,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "informations_complementaires_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2118,7 +2118,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "validation_signalement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -183,6 +183,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "coordonnees_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "coordonnees_occupant_previous",
                 "action": "goto:vos_coordonnees_tiers",
@@ -300,6 +307,13 @@
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:info_procedure_bail",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "coordonnees_bailleur_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -460,6 +474,13 @@
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_logement_social_service_secours === 'oui' && (formStore.data.info_procedure_bailleur_prevenu === 'non' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() < 2))"
                 }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_bail_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -632,6 +653,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "zone_concernee_zone_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "zone_concernee_zone_previous",
                 "action": "goto:info_procedure_bail",
@@ -669,6 +697,13 @@
                 "slug": "ecran_intermediaire_type_composition_next",
                 "action": "goto:type_logement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_type_composition_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -829,6 +864,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_previous",
                 "action": "goto:ecran_intermediaire_type_composition",
@@ -930,6 +972,13 @@
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1171,6 +1220,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_commodites_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_commodites_previous",
                 "action": "goto:composition_logement",
@@ -1228,6 +1284,13 @@
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_personnes_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1471,6 +1534,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "bail_dpe_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "bail_dpe_previous",
                 "action": "goto:composition_logement_personnes",
@@ -1507,6 +1577,13 @@
                 "label": "J'y suis presque !",
                 "slug": "ecran_intermediaire_procedure_next",
                 "action": "goto:info_procedure_assurance"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_procedure_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1604,6 +1681,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_assurance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "info_procedure_assurance_previous",
                 "action": "goto:ecran_intermediaire_procedure",
@@ -1684,6 +1768,13 @@
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "utilisation_service_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -81,7 +81,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "vos_coordonnees_tiers_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -171,7 +171,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -291,7 +291,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_bailleur_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -438,7 +438,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_bail_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -620,7 +620,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "zone_concernee_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -660,7 +660,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_type_composition_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -817,7 +817,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -921,7 +921,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1159,7 +1159,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_commodites_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1219,7 +1219,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_personnes_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1459,7 +1459,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "bail_dpe_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1499,7 +1499,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_procedure_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1592,7 +1592,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_assurance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1675,7 +1675,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "utilisation_service_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1715,7 +1715,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "validation_signalement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -89,7 +89,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "vos_coordonnees_tiers_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -178,7 +178,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -300,7 +300,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_bailleur_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -447,7 +447,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_bail_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -629,7 +629,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "zone_concernee_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -669,7 +669,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_type_composition_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -826,7 +826,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -930,7 +930,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1168,7 +1168,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_commodites_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1253,7 +1253,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_personnes_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1493,7 +1493,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "bail_dpe_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1531,7 +1531,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_situation_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1652,7 +1652,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "logement_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1759,7 +1759,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "travailleur_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1799,7 +1799,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_procedure_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1892,7 +1892,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_assurance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1971,7 +1971,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "utilisation_service_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2130,7 +2130,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "informations_complementaires_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2170,7 +2170,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "validation_signalement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -190,6 +190,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "coordonnees_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "coordonnees_occupant_previous",
                 "action": "goto:vos_coordonnees_tiers",
@@ -309,6 +316,13 @@
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:info_procedure_bail",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "coordonnees_bailleur_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -469,6 +483,13 @@
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui' && (formStore.data.info_procedure_bailleur_prevenu === 'non' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() < 2))"
                 }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_bail_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -641,6 +662,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "zone_concernee_zone_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "zone_concernee_zone_previous",
                 "action": "goto:info_procedure_bail",
@@ -678,6 +706,13 @@
                 "slug": "ecran_intermediaire_type_composition_next",
                 "action": "goto:type_logement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_type_composition_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -838,6 +873,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_previous",
                 "action": "goto:ecran_intermediaire_type_composition",
@@ -939,6 +981,13 @@
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1180,6 +1229,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_commodites_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_commodites_previous",
                 "action": "goto:composition_logement",
@@ -1262,6 +1318,13 @@
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_personnes_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1505,6 +1568,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "bail_dpe_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "bail_dpe_previous",
                 "action": "goto:composition_logement_personnes",
@@ -1540,6 +1610,13 @@
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_situation_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1664,6 +1741,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "logement_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "logement_social_previous",
                 "action": "goto:ecran_intermediaire_situation_occupant",
@@ -1771,6 +1855,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "travailleur_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "travailleur_social_previous",
                 "action": "goto:logement_social",
@@ -1807,6 +1898,13 @@
                 "label": "J'y suis presque !",
                 "slug": "ecran_intermediaire_procedure_next",
                 "action": "goto:info_procedure_assurance"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_procedure_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1904,6 +2002,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_assurance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "info_procedure_assurance_previous",
                 "action": "goto:ecran_intermediaire_procedure",
@@ -1980,6 +2085,13 @@
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "utilisation_service_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2139,6 +2251,13 @@
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "informations_complementaires_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -77,7 +77,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "vos_coordonnees_tiers_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -166,7 +166,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -285,7 +285,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "coordonnees_bailleur_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -432,7 +432,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_bail_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -614,7 +614,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "zone_concernee_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -654,7 +654,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_type_composition_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -811,7 +811,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -915,7 +915,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1153,7 +1153,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "type_logement_commodites_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1237,7 +1237,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "composition_logement_personnes_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1477,7 +1477,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "bail_dpe_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1515,7 +1515,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_situation_occupant_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1636,7 +1636,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "logement_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1754,7 +1754,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "travailleur_social_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1794,7 +1794,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "ecran_intermediaire_procedure_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1887,7 +1887,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "info_procedure_assurance_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -1966,7 +1966,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "utilisation_service_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2125,7 +2125,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "informations_complementaires_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {
@@ -2165,7 +2165,7 @@
         {
           "type": "SignalementFormSubscreen",
           "slug": "validation_signalement_footer",
-          "customCss": "button-group-responsive-inverted",
+          "customCss": "button-group-footer",
           "components": {
             "body": [
               {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -178,6 +178,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "coordonnees_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "coordonnees_occupant_previous",
                 "action": "goto:vos_coordonnees_tiers",
@@ -294,6 +301,13 @@
                 "slug": "coordonnees_bailleur_next",
                 "action": "goto.save:info_procedure_bail",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "coordonnees_bailleur_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -454,6 +468,13 @@
                 "conditional": {
                   "show": "formStore.data.signalement_concerne_logement_social_autre_tiers === 'oui' && (formStore.data.info_procedure_bailleur_prevenu === 'non' || (formStore.data.info_procedure_bailleur_prevenu === 'oui' && formStore.countMonthsSinceBailleurPrevenu() !== undefined && formStore.countMonthsSinceBailleurPrevenu() < 2))"
                 }
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_bail_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -626,6 +647,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "zone_concernee_zone_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "zone_concernee_zone_previous",
                 "action": "goto:info_procedure_bail",
@@ -663,6 +691,13 @@
                 "slug": "ecran_intermediaire_type_composition_next",
                 "action": "goto:type_logement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_type_composition_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -823,6 +858,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_previous",
                 "action": "goto:ecran_intermediaire_type_composition",
@@ -924,6 +966,13 @@
                 "slug": "composition_logement_next",
                 "action": "goto.save:type_logement_commodites",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1165,6 +1214,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "type_logement_commodites_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "type_logement_commodites_previous",
                 "action": "goto:composition_logement",
@@ -1246,6 +1302,13 @@
                 "slug": "composition_logement_personnes_next",
                 "action": "goto.save:bail_dpe",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "composition_logement_personnes_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1489,6 +1552,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "bail_dpe_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "bail_dpe_previous",
                 "action": "goto:composition_logement_personnes",
@@ -1524,6 +1594,13 @@
                 "slug": "ecran_intermediaire_situation_occupant_next",
                 "action": "goto.save:logement_social",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_situation_occupant_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1648,6 +1725,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "logement_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "logement_social_previous",
                 "action": "goto:ecran_intermediaire_situation_occupant",
@@ -1766,6 +1850,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "travailleur_social_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "travailleur_social_previous",
                 "action": "goto:logement_social",
@@ -1802,6 +1893,13 @@
                 "label": "J'y suis presque !",
                 "slug": "ecran_intermediaire_procedure_next",
                 "action": "goto:info_procedure_assurance"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "ecran_intermediaire_procedure_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -1899,6 +1997,13 @@
               },
               {
                 "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "info_procedure_assurance_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
+              },
+              {
+                "type": "SignalementFormButton",
                 "label": "Précédent",
                 "slug": "info_procedure_assurance_previous",
                 "action": "goto:ecran_intermediaire_procedure",
@@ -1975,6 +2080,13 @@
                 "slug": "utilisation_service_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "utilisation_service_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",
@@ -2134,6 +2246,13 @@
                 "slug": "informations_complementaires_next",
                 "action": "goto.save:validation_signalement",
                 "customCss": "fr-btn--icon-left fr-icon-check-line"
+              },
+              {
+                "type": "SignalementFormButton",
+                "label": "Finir plus tard",
+                "slug": "informations_complementaires_finish_later",
+                "customCss": "fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline",
+                "action": "finish.save:/"
               },
               {
                 "type": "SignalementFormButton",

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormButton.vue
@@ -109,6 +109,12 @@ export default defineComponent({
   color: var(--text-action-high-blue-france);
   box-shadow: inset 0 0 0 1px var(--border-action-high-blue-france);
 }
+.fr-btn.fr-btn--tertiary-no-outline.fr-btn--loading:disabled {
+  background-color: transparent;
+  --hover: inherit;
+  --active: inherit;
+  color: var(--text-action-high-blue-france);
+}
 .fr-btn.btn-link {
   background-color: white;
   color: var(--blue-france-sun-113-625);

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -278,7 +278,7 @@ export default defineComponent({
 <style>
   @media (max-width: 48em) {
     .form-screen-body {
-      margin-bottom: 8.5rem !important;
+      margin-bottom: 11rem !important;
     }
 
     .form-screen-body-margin {

--- a/assets/scripts/vue/components/signalement-form/store.ts
+++ b/assets/scripts/vue/components/signalement-form/store.ts
@@ -72,7 +72,8 @@ const formStore: FormStore = reactive({
   data: {
     uuidSignalementDraft: '',
     signalementReference: '',
-    lienSuivi: ''
+    lienSuivi: '',
+    errorMessage: ''
   },
   props: {
     ajaxurl: '',

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -95,20 +95,53 @@ pre {
             }
         }
     }
+    .button-group-responsive-inverted > div {
+        display: flex;
+        flex-direction: column;
+    }
+    .button-group-responsive-inverted .signalement-form-button[id*="next"],
+    .button-group-responsive-inverted .signalement-form-link[id*="next"] {
+        order: 1;
+    }
+    .button-group-responsive-inverted .signalement-form-button[id*="previous"],
+    .button-group-responsive-inverted .signalement-form-link[id*="previous"] {
+        order: 2;
+    }
+    .button-group-responsive-inverted .signalement-form-button[id*="finish_later"],
+    .button-group-responsive-inverted .signalement-form-link[id*="finish_later"] {
+        order: 3;
+    }
 }
 
 @media (min-width: 48em) {
     .button-group-responsive-inverted {
-        > div {
-            display: flex;
-            justify-content: right;
-            flex-direction: row-reverse;
+        width: 100%;
+    }
+    .button-group-responsive-inverted > div {
+        display: flex;
+        flex-wrap: nowrap;
+        flex-direction: row-reverse;
+        justify-content: flex-end; /* par défaut : tous à droite */
+        gap: 0.5rem;
+        width: 100%;
+    }
 
-            .signalement-form-button, .signalement-form-link {
-                display: inline-flex;
-                margin-left: 0.25rem;
-            }
-        }
+    /* Tous les boutons */
+    .button-group-responsive-inverted .signalement-form-button,
+    .button-group-responsive-inverted .signalement-form-link {
+        display: inline-flex;
+    }
+
+    /* Bouton Précédent à gauche */
+    .button-group-responsive-inverted .signalement-form-button[id*="previous"],
+    .button-group-responsive-inverted .signalement-form-link[id*="previous"] {
+        margin-right: auto;
+    }
+
+    /* Les autres ont une petite marge entre eux */
+    .button-group-responsive-inverted .signalement-form-button:not([id*="previous"]),
+    .button-group-responsive-inverted .signalement-form-link:not([id*="previous"]) {
+        margin-left: 0.25rem;
     }
 }
 

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -96,6 +96,7 @@ pre {
     }
     
     .button-group-footer {
+        width: 100%;
         > div {
             display: flex;
             flex-direction: column;

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -83,65 +83,68 @@ pre {
         width: 100%;
     }
 
-    .button-group-responsive-inverted {
-        .signalement-form-button, .signalement-form-link {
-            display: flex;
+    .button-group-responsive-inverted .signalement-form-button,
+    .button-group-responsive-inverted .signalement-form-link,
+    .button-group-footer .signalement-form-button {
+        display: flex;
+        width: 100%;
+        margin-bottom: 0.75rem;
+        button, a {
             width: 100%;
-            margin-bottom: 0.75rem;
-
-            button, a {
-                width: 100%;
-                justify-content: center;
-            }
+            justify-content: center;
         }
     }
-    .button-group-responsive-inverted > div {
-        display: flex;
-        flex-direction: column;
-    }
-    .button-group-responsive-inverted .signalement-form-button[id*="next"],
-    .button-group-responsive-inverted .signalement-form-link[id*="next"] {
-        order: 1;
-    }
-    .button-group-responsive-inverted .signalement-form-button[id*="previous"],
-    .button-group-responsive-inverted .signalement-form-link[id*="previous"] {
-        order: 2;
-    }
-    .button-group-responsive-inverted .signalement-form-button[id*="finish_later"],
-    .button-group-responsive-inverted .signalement-form-link[id*="finish_later"] {
-        order: 3;
+    
+    .button-group-footer {
+        > div {
+            display: flex;
+            flex-direction: column;
+        }
+        .signalement-form-button[id*="next"] {
+            order: 1;
+        }
+        .signalement-form-button[id*="previous"] {
+            order: 2;
+        }
+        .signalement-form-button[id*="finish_later"] {
+            order: 3;
+        }
     }
 }
 
 @media (min-width: 48em) {
+    
     .button-group-responsive-inverted {
+        > div {
+            display: flex;
+            justify-content: right;
+            flex-direction: row-reverse;
+
+            .signalement-form-button, .signalement-form-link {
+                display: inline-flex;
+                margin-left: 0.25rem;
+            }
+        }
+    }
+    .button-group-footer {
         width: 100%;
-    }
-    .button-group-responsive-inverted > div {
-        display: flex;
-        flex-wrap: nowrap;
-        flex-direction: row-reverse;
-        justify-content: flex-end; /* par défaut : tous à droite */
-        gap: 0.5rem;
-        width: 100%;
-    }
-
-    /* Tous les boutons */
-    .button-group-responsive-inverted .signalement-form-button,
-    .button-group-responsive-inverted .signalement-form-link {
-        display: inline-flex;
-    }
-
-    /* Bouton Précédent à gauche */
-    .button-group-responsive-inverted .signalement-form-button[id*="previous"],
-    .button-group-responsive-inverted .signalement-form-link[id*="previous"] {
-        margin-right: auto;
-    }
-
-    /* Les autres ont une petite marge entre eux */
-    .button-group-responsive-inverted .signalement-form-button:not([id*="previous"]),
-    .button-group-responsive-inverted .signalement-form-link:not([id*="previous"]) {
-        margin-left: 0.25rem;
+        > div {
+            display: flex;
+            flex-wrap: nowrap;
+            flex-direction: row-reverse;
+            justify-content: flex-end; /* par défaut : tous à droite */
+            gap: 0.5rem;
+            width: 100%;
+        }
+        .signalement-form-button {
+            display: inline-flex;
+        }
+        .signalement-form-button[id*="previous"] {
+            margin-right: auto;
+        }
+        .signalement-form-button:not([id*="previous"]) {
+            margin-left: 0.25rem;
+        }
     }
 }
 

--- a/config/packages/dev/web_profiler.yaml
+++ b/config/packages/dev/web_profiler.yaml
@@ -1,5 +1,5 @@
 web_profiler:
-    toolbar: true
+    toolbar: false
     intercept_redirects: false
 
 framework:

--- a/config/packages/dev/web_profiler.yaml
+++ b/config/packages/dev/web_profiler.yaml
@@ -1,5 +1,5 @@
 web_profiler:
-    toolbar: false
+    toolbar: true
     intercept_redirects: false
 
 framework:


### PR DESCRIPTION
## Ticket

#1674   

## Description
Ajouter un bouton `Finir plus tard` en bas de chaque page, à partir de la création du brouillon, (soit la page suivant la page coordonnées du déclarant, pour s'assurer que le check des doublons a déjà été fait)

Au clic sur le bouton par l usager, on envoie à l'usager un mail, le même que lorsque un doublon de brouillon même adresse+même déclarant est identifié. Puis l'usager est envoyé sur la page "un mail vous a été envoyé"

Petit changement css pour qu'en mobile les boutons suivant/précédent soit en pleine largeur

## Changements apportés
* Ajout d'un composant bouton "Finir plus tard" sur tous les écrans concernés pour tous les profils
* Modifications css pour la disposition des boutons du footer
* Modification du SignalementFormScreen pour créer une nouvelle action `finishLater`

## Pré-requis

## Tests
- [ ] Créer des signalements avec les différents profils
- [ ] Vérifier que le bouton Finir plus tard apparait bien sur tous les écrans concernés
- [ ] Tester ce bouton, vérifier qu'on est bien redirigé sur l'écran, qu'on reçoit un mail et que ce mail nous redirige bien vers notre brouillon de signalement
