### PR TITLE
[SISH] Envoi de la dénomination du propriétaire si le nom de famille n'est pas renseigné

### DIFF
--- a/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSISHFactory.php
@@ -172,7 +172,9 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
                 ->setTelephone($tel);
         }
 
-        if (PersonneType::PROPRIETAIRE === $personneType && !empty($signalement->getNomProprio())) {
+        if (PersonneType::PROPRIETAIRE === $personneType
+            && (!empty($signalement->getNomProprio()) || !empty($signalement->getDenominationProprio()))
+        ) {
             $tel = $signalement->getTelProprioDecoded(true)
                 ? substr($signalement->getTelProprioDecoded(true), 0, 20)
                 : null;
@@ -180,11 +182,17 @@ class DossierMessageSISHFactory extends AbstractDossierMessageFactory
             $prenom = $signalement->getPrenomProprio()
                 ? substr($signalement->getPrenomProprio(), 0, 30)
                 : null;
+            $nom = $signalement->getNomProprio()
+                ? substr($signalement->getNomProprio(), 0, 60)
+                : null;
+            if (empty($nom) && !empty($signalement->getDenominationProprio())) {
+                $nom = substr($signalement->getDenominationProprio(), 0, 60);
+            }
 
             $dossierMessageSISHPersonne = new DossierMessageSISHPersonne();
             $dossierMessageSISHPersonne
                 ->setType(PersonneType::PROPRIETAIRE->value)
-                ->setNom(substr($signalement->getNomProprio(), 0, 60))
+                ->setNom($nom)
                 ->setAdresse($signalement->getAdresseProprio())
                 ->setEmail($signalement->getMailProprio())
                 ->setTelephone($tel);

--- a/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
+++ b/tests/Unit/Factory/Esabora/DossierMessageSISHFactoryTest.php
@@ -63,6 +63,7 @@ class DossierMessageSISHFactoryTest extends TestCase
         $signalement->setInseeOccupant(null);
 
         $dossierMessage = $dossierMessageFactory->createInstance($affectation);
+        $this->assertEquals($signalement->getNomProprio(), $dossierMessage->getPersonnes()[1]->getNom());
         $this->assertEquals(1.5, $dossierMessage->getSignalementScore());
         $this->assertCount(2, $dossierMessage->getPiecesJointesDocuments());
         $this->assertEquals(PartnerType::ARS, $dossierMessage->getPartnerType());


### PR DESCRIPTION
## Ticket

#4220   

## Description
Lorsque la dénomination du propriétaire est renseignée sans nom de famille, les infos de propriétaires ne sont plus envoyées à SISH.

## Changements apportés
* Modification des tests pour envoi d'infos

## Tests
- [ ] Affecter SISH sur un signalement sans dénomination du proprio mais avec nom de famille
- [ ] Affecter SISH sans nom de famille, avec dénomination
- [ ] Affecter SISH sans l'un, ni l'autre
