### PR TITLE
[Tech] La date de dernière connexion reste à null pour une connexion usager

### DIFF
--- a/src/Security/Authenticator/CodeSuiviLoginAuthenticator.php
+++ b/src/Security/Authenticator/CodeSuiviLoginAuthenticator.php
@@ -8,6 +8,7 @@ use App\Manager\UserManager;
 use App\Repository\SignalementRepository;
 use App\Security\Provider\SignalementUserProvider;
 use App\Security\User\SignalementUser;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,6 +33,7 @@ class CodeSuiviLoginAuthenticator extends AbstractLoginFormAuthenticator
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly SignalementRepository $signalementRepository,
         private readonly SignalementUserProvider $signalementUserProvider,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -127,6 +129,13 @@ class CodeSuiviLoginAuthenticator extends AbstractLoginFormAuthenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
+        /** @var SignalementUser $signalementUser */
+        $signalementUser = $token->getUser();
+        $user = $signalementUser->getUser();
+        if ($user) {
+            $user->setLastLoginAt(new \DateTimeImmutable());
+            $this->entityManager->flush();
+        }
         if ($targetPath = $this->getTargetPath($request->getSession(), $firewallName)) {
             return new RedirectResponse($targetPath);
         }

--- a/tests/Unit/Security/Authenticator/CodeSuiviLoginAuthenticatorTest.php
+++ b/tests/Unit/Security/Authenticator/CodeSuiviLoginAuthenticatorTest.php
@@ -9,6 +9,7 @@ use App\Security\Authenticator\CodeSuiviLoginAuthenticator;
 use App\Security\Provider\SignalementUserProvider;
 use App\Security\User\SignalementUser;
 use App\Tests\FixturesHelper;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,11 +23,13 @@ class CodeSuiviLoginAuthenticatorTest extends TestCase
     private MockObject|SignalementRepository $signalementRepository;
     private MockObject|SignalementUserProvider $signalementUserProvider;
     private MockObject|UrlGeneratorInterface $urlGenerator;
+    private MockObject|EntityManagerInterface $entityManager;
 
     protected function setUp(): void
     {
         $this->signalementRepository = $this->createMock(SignalementRepository::class);
         $this->signalementUserProvider = $this->createMock(SignalementUserProvider::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
     }
 
@@ -46,7 +49,8 @@ class CodeSuiviLoginAuthenticatorTest extends TestCase
         $authenticator = new CodeSuiviLoginAuthenticator(
             $this->urlGenerator,
             $this->signalementRepository,
-            $this->signalementUserProvider
+            $this->signalementUserProvider,
+            $this->entityManager,
         );
 
         $passport = $authenticator->authenticate($request);
@@ -181,7 +185,12 @@ class CodeSuiviLoginAuthenticatorTest extends TestCase
 
         $request = new Request([], ['code' => 'wrongcode']);
         $this->signalementRepository->method('findOneByCodeForPublic')->willReturn(null);
-        $authenticator = new CodeSuiviLoginAuthenticator($this->urlGenerator, $this->signalementRepository, $this->signalementUserProvider);
+        $authenticator = new CodeSuiviLoginAuthenticator(
+            $this->urlGenerator,
+            $this->signalementRepository,
+            $this->signalementUserProvider,
+            $this->entityManager
+        );
         $authenticator->authenticate($request);
     }
 
@@ -205,7 +214,8 @@ class CodeSuiviLoginAuthenticatorTest extends TestCase
         $authenticator = new CodeSuiviLoginAuthenticator(
             $this->urlGenerator,
             $this->signalementRepository,
-            $this->signalementUserProvider
+            $this->signalementUserProvider,
+            $this->entityManager,
         );
         $authenticator->authenticate($request);
     }
@@ -226,7 +236,12 @@ class CodeSuiviLoginAuthenticatorTest extends TestCase
 
         $this->signalementRepository->method('findOneByCodeForPublic')->willReturn($signalement);
 
-        $authenticator = new CodeSuiviLoginAuthenticator($this->urlGenerator, $this->signalementRepository, $this->signalementUserProvider);
+        $authenticator = new CodeSuiviLoginAuthenticator(
+            $this->urlGenerator,
+            $this->signalementRepository,
+            $this->signalementUserProvider,
+            $this->entityManager
+        );
         $authenticator->authenticate($request);
     }
 


### PR DESCRIPTION
## Ticket

#4226    

## Description
Manque la date de connexion pour l'usager

## Changements apportés
* Mise à jour `CodeSuiviLoginAuthenticator`

## Pré-requis

## Tests
- [ ] Se connecter avec un usager et vérifier que la date de dernière connexion n'est pas à null et bien à jour 
