### PR TITLE
[QA] Faire du reporting d'erreurs CSP

### DIFF
--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -70,3 +70,5 @@ parameters:
     worker-src:
       - "'self'"
       - "blob:"
+    report-uri:
+      - "/csp-report"

--- a/src/Controller/Security/CspReportController.php
+++ b/src/Controller/Security/CspReportController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller\Security;
 
 use Psr\Log\LoggerInterface;
@@ -9,8 +10,9 @@ use Symfony\Component\Routing\Attribute\Route;
 class CspReportController
 {
     public function __construct(
-        private readonly LoggerInterface $logger
-    ) {}
+        private readonly LoggerInterface $logger,
+    ) {
+    }
 
     #[Route('/csp-report', name: 'csp_report', methods: ['POST'])]
     public function report(Request $request): Response
@@ -26,9 +28,8 @@ class CspReportController
                 $report['violated-directive'] ?? 'N/A',
                 $report['document-uri'] ?? 'N/A',
             );
-            $this->logger->warning($logMessage); 
+            $this->logger->warning($logMessage);
             \Sentry\captureMessage($logMessage);
-
         }
 
         return new Response('', Response::HTTP_NO_CONTENT);

--- a/src/Controller/Security/CspReportController.php
+++ b/src/Controller/Security/CspReportController.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Controller\Security;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class CspReportController
+{
+    public function __construct(
+        private readonly LoggerInterface $logger
+    ) {}
+
+    #[Route('/csp-report', name: 'csp_report', methods: ['POST'])]
+    public function report(Request $request): Response
+    {
+        $content = json_decode($request->getContent(), true);
+
+        if (isset($content['csp-report'])) {
+            $report = $content['csp-report'];
+
+            $logMessage = sprintf(
+                'CSP Violation: blocked-uri=%s, violated-directive=%s, document-uri=%s',
+                $report['blocked-uri'] ?? 'N/A',
+                $report['violated-directive'] ?? 'N/A',
+                $report['document-uri'] ?? 'N/A',
+            );
+            $this->logger->warning($logMessage); 
+            \Sentry\captureMessage($logMessage);
+
+        }
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Controller/Security/CspReportController.php
+++ b/src/Controller/Security/CspReportController.php
@@ -17,10 +17,10 @@ class CspReportController
     #[Route('/csp-report', name: 'csp_report', methods: ['POST'])]
     public function report(Request $request): Response
     {
-        $content = json_decode($request->getContent(), true);
+        $payload = json_decode($request->getContent(), true);
 
-        if (isset($content['csp-report'])) {
-            $report = $content['csp-report'];
+        if (isset($payload['csp-report'])) {
+            $report = $payload['csp-report'];
 
             $logMessage = sprintf(
                 'CSP Violation: blocked-uri=%s, violated-directive=%s, document-uri=%s',

--- a/src/EventListener/ContentSecurityPolicyListener.php
+++ b/src/EventListener/ContentSecurityPolicyListener.php
@@ -62,6 +62,7 @@ readonly class ContentSecurityPolicyListener
             'form-action' => $this->formatCspDirective($cspParameters['form-action'] ?? []),
             'frame-ancestors' => $this->formatCspDirective($cspParameters['frame-ancestors'] ?? []),
             'media-src' => $this->formatCspDirective($cspParameters['media-src'] ?? []),
+            'report-uri' => $this->formatCspDirective($cspParameters['report-uri'] ?? []),
         ];
 
         $csp = $this->buildCspHeader($cspDirectives);

--- a/templates/back/dashboard/index.html.twig
+++ b/templates/back/dashboard/index.html.twig
@@ -3,7 +3,6 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-    <script>alert("violation CSP !");</script>
     <div
         id="app-dashboard"
         data-ajaxurl-settings="{{ path('back_widget_settings') }}"

--- a/templates/back/dashboard/index.html.twig
+++ b/templates/back/dashboard/index.html.twig
@@ -3,6 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
+    <script>alert("violation CSP !");</script>
     <div
         id="app-dashboard"
         data-ajaxurl-settings="{{ path('back_widget_settings') }}"

--- a/tests/Functional/Controller/Security/CspReportControllerTest.php
+++ b/tests/Functional/Controller/Security/CspReportControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Tests\Functional\Controller\Security;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class CspReportControllerTest extends WebTestCase
+{
+    public function testCspReportWithValidPayload(): void
+    {
+        $client = static::createClient();
+
+        $payload = [
+            'csp-report' => [
+                'blocked-uri' => 'https://malicious-site.com',
+                'violated-directive' => 'script-src',
+                'document-uri' => 'https://histologe.fr',
+                'original-policy' => "default-src 'self'; script-src 'self'",
+                'source-file' => 'https://histologe.fr/js/app.js',
+                'line-number' => 42,
+                'column-number' => 10,
+            ],
+        ];
+
+        $client->request(
+            'POST',
+            '/csp-report',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($payload)
+        );
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        $this->assertEmpty($client->getResponse()->getContent());
+    }
+
+    public function testCspReportWithGetMethod(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/csp-report');
+
+        // La route n'accepte que POST, donc GET devrait retourner 405 Method Not Allowed
+        $this->assertEquals(Response::HTTP_METHOD_NOT_ALLOWED, $client->getResponse()->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Ticket

#2692   

## Description
Mettre en place une route qui capte les violations de CSP et les envoie à Sentry

## Changements apportés
* Changement de `ContentSecurityPolicyListener` pour inclure une `report-uri` définie dans le `csp.yaml`
* Création du controller

## Pré-requis
Désactiver uBlock, ou vérifier qu'il n'y a pas le paramètre `no-csp-reports: * true`

## Tests
- [ ] Créer consciemment une violation CSP (par exemple en mettant un script inline dans un template 
`<script>alert("violation CSP !");</script>`)
- [ ] Aller sur la page concernée, et vérifier que la route csp-report est bien appelée
- [ ] Vérifier dans les logs qu'on a bien une `CSP Violation`
- [ ] Pour tester la capture dans Sentry, tester depuis la reviewApp https://histologe-staging-pr4241.osc-fr1.scalingo.io/connexion (en désactivant uBlock aussi)
- [ ] Dès l'affichage de la page, on a une violation CSP (à corriger plus tard du coup), mais ça permet d'aller vérifier que l'erreur remonte bien dans Sentry
