### PR TITLE
[QA] Correction création de suivi quand on ajoute une photo de visite non liée à une visite

### DIFF
--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -161,7 +161,7 @@ class SuiviManager extends Manager
             }
         }
 
-        if (DocumentType::PHOTO_VISITE === $documentType) {
+        if (DocumentType::PHOTO_VISITE === $documentType && null !== $intervention) {
             $isVisibleUsager = true;
             $partner = $user->getPartnerInTerritoryOrFirstOne($signalement->getTerritory());
             if ($nbPhotos > 0) {

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -50,7 +50,10 @@
                                     and photo.desordreSlug is not same as null %}
                                 {{ signalement.getDesordreLabel(photo.desordreSlug) }}
                             {% elseif photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_VISITE %}
-                                {{ photo.documentType.label() }} du {{ photo.intervention.scheduledAt|date('d/m/Y') }} par {{ photo.intervention.partner.nom}}
+                                {{ photo.documentType.label() }}
+                                {% if photo.intervention %}
+                                    du {{ photo.intervention.scheduledAt|date('d/m/Y') }} par {{ photo.intervention.partner.nom}}
+                                {% endif %}
                             {% else %}
                                 {{ photo.documentType.label() }}
                             {% endif %}

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -49,11 +49,8 @@
                             {% if photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_SITUATION
                                     and photo.desordreSlug is not same as null %}
                                 {{ signalement.getDesordreLabel(photo.desordreSlug) }}
-                            {% elseif photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_VISITE %}
-                                {{ photo.documentType.label() }}
-                                {% if photo.intervention %}
-                                    du {{ photo.intervention.scheduledAt|date('d/m/Y') }} par {{ photo.intervention.partner.nom}}
-                                {% endif %}
+                            {% elseif photo.documentType is same as enum('App\\Entity\\Enum\\DocumentType').PHOTO_VISITE and photo.intervention %}
+                                {{ photo.documentType.label() }} du {{ photo.intervention.scheduledAt|date('d/m/Y') }} par {{ photo.intervention.partner.nom}}
                             {% else %}
                                 {{ photo.documentType.label() }}
                             {% endif %}


### PR DESCRIPTION
## Ticket

#4242   

## Description
Correction création de suivi quand on ajoute une photo de visite non liée à une visite

## Tests
- [ ] BO : Ajouter un document de type "Photo de visite" non lié à une visite existante et vérifier que ça fonctionne
