### PR TITLE
[BO - Dashboard] Pas de remise à 0 malgré suppression des notifications

### DIFF
--- a/src/Controller/Back/NotificationController.php
+++ b/src/Controller/Back/NotificationController.php
@@ -52,13 +52,13 @@ class NotificationController extends AbstractController
         if ($request->get('selected_notifications')) {
             if ($this->isCsrfTokenValid('mark_as_read_'.$user->getId(), $request->get('csrf_token'))) {
                 $notificationRepository->markUserNotificationsAsSeen($user, explode(',', $request->get('selected_notifications')));
-                $widgetDataManagerCache->invalidateCacheForUser();
+                $widgetDataManagerCache->invalidateCacheForUser($user->getPartnersTerritories());
                 $this->addFlash('success', 'Les notifications sélectionnées ont été marquées comme lues.');
             }
         } else {
             if ($this->isCsrfTokenValid('mark_as_read_'.$user->getId(), $request->get('mark_as_read'))) {
                 $notificationRepository->markUserNotificationsAsSeen($user);
-                $widgetDataManagerCache->invalidateCacheForUser();
+                $widgetDataManagerCache->invalidateCacheForUser($user->getPartnersTerritories());
                 $this->addFlash('success', 'Toutes les notifications ont été marquées comme lues.');
             }
         }
@@ -77,7 +77,7 @@ class NotificationController extends AbstractController
         if ($request->get('selected_notifications')) {
             if ($this->isCsrfTokenValid('delete_notifications_'.$user->getId(), $request->get('csrf_token'))) {
                 $notificationRepository->deleteUserNotifications($user, explode(',', $request->get('selected_notifications')));
-                $widgetDataManagerCache->invalidateCacheForUser();
+                $widgetDataManagerCache->invalidateCacheForUser($user->getPartnersTerritories());
                 $this->addFlash('success', 'Les notifications sélectionnées ont été supprimées.');
             }
         } else {
@@ -86,7 +86,7 @@ class NotificationController extends AbstractController
                 $request->get('delete_all_notifications')
             )) {
                 $notificationRepository->deleteUserNotifications($user);
-                $widgetDataManagerCache->invalidateCacheForUser();
+                $widgetDataManagerCache->invalidateCacheForUser($user->getPartnersTerritories());
                 $this->addFlash('success', 'Toutes les notifications ont été supprimées.');
             }
         }
@@ -110,7 +110,7 @@ class NotificationController extends AbstractController
         if ($notification->getUser()->getId() === $user->getId() && $this->isCsrfTokenValid('back_delete_notification_'.$notification->getId(), $request->get('_token'))) {
             $em->remove($notification);
             $em->flush();
-            $widgetDataManagerCache->invalidateCacheForUser();
+            $widgetDataManagerCache->invalidateCacheForUser($user->getPartnersTerritories());
             $this->addFlash('success', 'Notification supprimée avec succès');
         } else {
             $this->addFlash('error', 'Erreur lors de la suppression de la notification.');

--- a/src/Service/DashboardWidget/WidgetDataManagerCache.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerCache.php
@@ -144,6 +144,16 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
 
         try {
             $this->dashboardCache->delete($key);
+
+            // Si plusieurs territoires, supprimer aussi le cache pour chaque territoire individuellement
+            if (count($territories) > 1) {
+                foreach (array_keys($territories) as $territoryKey) {
+                    $singleKey = 'countDataKpi'
+                        .'-'.$this->commonKey.$territoryKey
+                        .'-id-'.$user->getId();
+                    $this->dashboardCache->delete($singleKey);
+                }
+            }
         } catch (InvalidArgumentException $exception) {
             $this->logger->error(\sprintf('Invalidate cache failed %s', $exception->getMessage()));
         }

--- a/src/Service/DashboardWidget/WidgetDataManagerCache.php
+++ b/src/Service/DashboardWidget/WidgetDataManagerCache.php
@@ -129,14 +129,17 @@ class WidgetDataManagerCache implements WidgetDataManagerInterface
     }
 
     /**
+     * @param array<int, mixed> $territories
+     *
      * @throws InvalidArgumentException
      */
-    public function invalidateCacheForUser(): void
+    public function invalidateCacheForUser(array $territories): void
     {
         /** @var User $user */
         $user = $this->security->getUser();
+        $territoriesKey = implode('-', array_keys($territories));
         $key = 'countDataKpi'
-            .'-'.$this->commonKey
+            .'-'.$this->commonKey.$territoriesKey
             .'-id-'.$user->getId();
 
         try {


### PR DESCRIPTION
## Ticket

#4239   

## Description
Malgré une suppression des notifications, le widget Nouveau suivi n'était pas remis à 0 sur le dashboard.
--> en cause, une clé comprenant le zip concerné dans la création du cache, mais une clé sans zip dans la suppression du cache

## Changements apportés
* Ajout du tableau de territoires dans la clé de suppression du cache
* Modification de la fonction `invalidateCacheForUser` pour prendre en compte ces zip de territoire. (à noter que s'il y a plusieurs territoires, il faut supprimer le cache de tous les territoires ensemble + le cache de chacun des territoires, car on peut choisir le territoire côté dashboard, mais pas côté Notifications)

## Pré-requis

## Tests
- [ ] Avec différents utilisateurs, multi-territoires ou non, aller sur le dashboard, mémoriser le nombre de suivi, vider les notifications, puis revérifier le dashboard
- [ ] il est aussi possible de seulement regarder les appels au cache et au vidage de cache pour vérifier les clés
