### PR TITLE
[QA] Mise à jour du script de synchro de base de données

### DIFF
--- a/scripts/sync-db.sh
+++ b/scripts/sync-db.sh
@@ -28,6 +28,7 @@ scalingo login --api-token "${DUPLICATE_API_TOKEN}"
 echo ">>> Retrieve the addon id"
 addon_id="$( scalingo --app "${DUPLICATE_SOURCE_APP}" addons \
              | grep "${DUPLICATE_ADDON_KIND}" \
+             | sed 's/│/|/g' \
              | cut -d "|" -f 3 \
              | tr -d " " )"
 


### PR DESCRIPTION
## Ticket

#4255
   

## Description
Suite à la derniere maj de la cli de scalingo, l'affichage des addons a changé avec un nouveau séparateur `│` à la place de ` |`

## Changements apportés
* Remplacer le nouveau séparateur par l'ancien |

## Pré-requis
`make scalingo-update-cli`

## Tests
- [ ] Tester juste la ligne qui pose problème en ligne de commande de la ligne 23 à 34 en mettant les valeurs des variable en dur dans la console puis afficher la valeur de addon_id
`echo $addon_id`
```