### PR TITLE
[QA] Faire une commande pour pousser des dossiers iDoss en cas de pb

### DIFF
--- a/src/Command/PushIdossDossierCommand.php
+++ b/src/Command/PushIdossDossierCommand.php
@@ -7,7 +7,6 @@ use App\Repository\AffectationRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -27,16 +26,16 @@ class PushIdossDossierCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('uuid', null, InputOption::VALUE_REQUIRED, 'Signalement Uuid');
+            ->addArgument('uuid', null, 'Signalement Uuid');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $uuid = $input->getOption('uuid');
+        $uuid = $input->getArgument('uuid');
 
         if (!$uuid) {
-            $io->error('L\'option --uuid est obligatoire.');
+            $io->error('L\'argument uuid est obligatoire.');
 
             return Command::FAILURE;
         }
@@ -49,8 +48,7 @@ class PushIdossDossierCommand extends Command
             return Command::FAILURE;
         }
 
-        foreach ($affectations as $row) {
-            $affectation = $row['affectation'];
+        foreach ($affectations as $affectation) {
             $this->interconnectionBus->dispatch($affectation);
             $io->success(sprintf(
                 '[%s] Dossier %s poussé vers iDoss',

--- a/src/Command/PushIdossDossierCommand.php
+++ b/src/Command/PushIdossDossierCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Command;
+
+use App\Messenger\InterconnectionBus;
+use App\Repository\AffectationRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:push-idoss-dossier',
+    description: 'Push dossier iDoss pour un signalement donné',
+)]
+class PushIdossDossierCommand extends Command
+{
+    public function __construct(
+        private readonly AffectationRepository $affectationRepository,
+        private readonly InterconnectionBus $interconnectionBus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('uuid', null, InputOption::VALUE_REQUIRED, 'Signalement Uuid');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $uuid = $input->getOption('uuid');
+
+        if (!$uuid) {
+            $io->error('L\'option --uuid est obligatoire.');
+
+            return Command::FAILURE;
+        }
+
+        $affectations = $this->affectationRepository->findAffectationSubscribedToIdoss($uuid);
+
+        if (!$affectations) {
+            $io->warning('Aucun partenaire iDoss affecté à ce signalement.');
+
+            return Command::FAILURE;
+        }
+
+        foreach ($affectations as $row) {
+            $affectation = $row['affectation'];
+            $this->interconnectionBus->dispatch($affectation);
+            $io->success(sprintf(
+                '[%s] Dossier %s poussé vers iDoss',
+                $affectation->getPartner()->getNom(),
+                $affectation->getSignalement()->getUuid()
+            ));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -312,4 +312,25 @@ class AffectationRepository extends ServiceEntityRepository
 
         $qb->getQuery()->execute();
     }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function findAffectationSubscribedToIdoss(
+        string $uuidSignalement,
+    ): array {
+        $qb = $this->createQueryBuilder('a');
+        $qb->select('a AS affectation', 's.uuid AS signalement_uuid');
+        $qb = $qb
+            ->innerJoin('a.partner', 'p')
+            ->innerJoin('a.signalement', 's')
+            ->where('p.isIdossActive = 1')
+            ->andWhere('p.idossUrl IS NOT NULL')
+            ->andWhere('s.statut NOT IN (:signalement_status_list)')
+            ->setParameter('signalement_status_list', [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED])
+            ->andWhere('s.uuid LIKE :uuid_signalement')
+            ->setParameter('uuid_signalement', $uuidSignalement);
+
+        return $qb->getQuery()->getResult();
+    }
 }

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -314,14 +314,13 @@ class AffectationRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<int, Affectation>
      */
     public function findAffectationSubscribedToIdoss(
         string $uuidSignalement,
     ): array {
         $qb = $this->createQueryBuilder('a');
-        $qb->select('a AS affectation', 's.uuid AS signalement_uuid');
-        $qb = $qb
+        $qb->select('a')
             ->innerJoin('a.partner', 'p')
             ->innerJoin('a.signalement', 's')
             ->where('p.isIdossActive = 1')

--- a/tests/Unit/Command/PushIdossDossierCommandTest.php
+++ b/tests/Unit/Command/PushIdossDossierCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\PushIdossDossierCommand;
+use App\Entity\Enum\PartnerType;
+use App\Messenger\InterconnectionBus;
+use App\Repository\AffectationRepository;
+use App\Tests\FixturesHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class PushIdossDossierCommandTest extends TestCase
+{
+    use FixturesHelper;
+
+    private MockObject|AffectationRepository $affectationRepository;
+    private MockObject|InterconnectionBus $interconnectionBus;
+
+    protected function setUp(): void
+    {
+        $this->affectationRepository = $this->createMock(AffectationRepository::class);
+        $this->interconnectionBus = $this->createMock(InterconnectionBus::class);
+        parent::setUp();
+    }
+
+    public function testExecuteWithUuidOptionSuccess(): void
+    {
+        $affectation = $this->getAffectation(PartnerType::COMMUNE_SCHS);
+        $affectation->getPartner()
+            ->setNom('Partenaire 13-05 ESABORA SCHS')
+            ->setIsIdossActive(true)
+            ->setIdossUrl('https://idoss-partenaire-13-05.fr');
+        $affectations = [
+            ['affectation' => $affectation, 'signalement_uuid' => $affectation->getSignalement()->getUuid()],
+        ];
+
+        $this->affectationRepository
+            ->expects($this->once())
+            ->method('findAffectationSubscribedToIdoss')
+            ->with('uuid-test')
+            ->willReturn($affectations);
+
+        $this->interconnectionBus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->equalTo($affectation));
+
+        $command = new PushIdossDossierCommand(
+            $this->affectationRepository,
+            $this->interconnectionBus
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--uuid' => 'uuid-test',
+        ]);
+
+        $this->assertStringContainsString('poussé vers iDoss', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithUuidOptionNoAffectation(): void
+    {
+        $this->affectationRepository
+            ->expects($this->once())
+            ->method('findAffectationSubscribedToIdoss')
+            ->with('uuid-inconnu')
+            ->willReturn([]);
+
+        $this->interconnectionBus
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $command = new PushIdossDossierCommand(
+            $this->affectationRepository,
+            $this->interconnectionBus
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--uuid' => 'uuid-inconnu',
+        ]);
+
+        $this->assertStringContainsString('Aucun partenaire iDoss affecté à ce signalement', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithoutUuidOption(): void
+    {
+        $command = new PushIdossDossierCommand(
+            $this->affectationRepository,
+            $this->interconnectionBus
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertStringContainsString('L\'option --uuid est obligatoire', $commandTester->getDisplay());
+    }
+}

--- a/tests/Unit/Command/PushIdossDossierCommandTest.php
+++ b/tests/Unit/Command/PushIdossDossierCommandTest.php
@@ -33,7 +33,7 @@ class PushIdossDossierCommandTest extends TestCase
             ->setIsIdossActive(true)
             ->setIdossUrl('https://idoss-partenaire-13-05.fr');
         $affectations = [
-            ['affectation' => $affectation, 'signalement_uuid' => $affectation->getSignalement()->getUuid()],
+            $affectation,
         ];
 
         $this->affectationRepository
@@ -54,7 +54,7 @@ class PushIdossDossierCommandTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([
-            '--uuid' => 'uuid-test',
+            'uuid' => 'uuid-test',
         ]);
 
         $this->assertStringContainsString('poussé vers iDoss', $commandTester->getDisplay());
@@ -79,13 +79,13 @@ class PushIdossDossierCommandTest extends TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute([
-            '--uuid' => 'uuid-inconnu',
+            'uuid' => 'uuid-inconnu',
         ]);
 
         $this->assertStringContainsString('Aucun partenaire iDoss affecté à ce signalement', $commandTester->getDisplay());
     }
 
-    public function testExecuteWithoutUuidOption(): void
+    public function testExecuteWithoutUuidArgument(): void
     {
         $command = new PushIdossDossierCommand(
             $this->affectationRepository,
@@ -95,6 +95,6 @@ class PushIdossDossierCommandTest extends TestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
 
-        $this->assertStringContainsString('L\'option --uuid est obligatoire', $commandTester->getDisplay());
+        $this->assertStringContainsString('L\'argument uuid est obligatoire', $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
## Ticket

#4257    

## Description
Ajout d'une commande PushIdossDossierCommand et de son test associé
Commande qui prend en argument l'uuid d'un signalement

## Changements apportés
* Création de la commande, de la requête et du fichier de test

## Pré-requis

## Tests
- [ ] Sur une base de prod récente, jouer la commande avec un des uuid de ce tableau https://histologe-metabase.osc-fr1.scalingo.io/question/1634-signalements-form-pro-affectes-a-idoss
