### PR TITLE
[QA] Correction appel de fonction avec des chaines null

### DIFF
--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -128,7 +128,7 @@ class SecurityController extends AbstractController
         $error = $authenticationUtils->getLastAuthenticationError();
         $targetPath = $this->getTargetPath($request->getSession(), 'code_suivi');
         $title = 'Suivre mon signalement';
-        if (str_contains($targetPath, '/show-export-pdf-usager/')) {
+        if ($targetPath && str_contains($targetPath, '/show-export-pdf-usager/')) {
             $title = 'Accéder à mon export pdf';
         }
 

--- a/src/Messenger/Message/Idoss/DossierMessage.php
+++ b/src/Messenger/Message/Idoss/DossierMessage.php
@@ -90,7 +90,9 @@ final class DossierMessage implements DossierMessageInterface
             'telephoneProprietaire' => $affectation->getSignalement()->getTelProprioDecoded(),
             'mailProprietaire' => $affectation->getSignalement()->getMailProprio(),
         ];
-        $this->descriptionProblemes = mb_strimwidth($affectation->getSignalement()->getDetails(), 0, self::DESCRIPTION_MAX_LENGTH);
+        if ($affectation->getSignalement()->getDetails()) {
+            $this->descriptionProblemes = mb_strimwidth($affectation->getSignalement()->getDetails(), 0, self::DESCRIPTION_MAX_LENGTH);
+        }
         $this->numAllocataire = $affectation->getSignalement()->getNumAllocataire();
         $this->montantAllocation = $affectation->getSignalement()->getMontantAllocation();
         if (true === $affectation->getSignalement()->getIsBailEnCours()) {

--- a/src/Messenger/Message/Idoss/DossierMessage.php
+++ b/src/Messenger/Message/Idoss/DossierMessage.php
@@ -91,7 +91,7 @@ final class DossierMessage implements DossierMessageInterface
             'mailProprietaire' => $affectation->getSignalement()->getMailProprio(),
         ];
         if ($affectation->getSignalement()->getDetails()) {
-            $this->descriptionProblemes = mb_strimwidth($affectation->getSignalement()->getDetails(), 0, self::DESCRIPTION_MAX_LENGTH);
+            $this->descriptionProblemes = $affectation->getSignalement()->getDetails() ? mb_strimwidth($affectation->getSignalement()->getDetails(), 0, self::DESCRIPTION_MAX_LENGTH) : '';
         }
         $this->numAllocataire = $affectation->getSignalement()->getNumAllocataire();
         $this->montantAllocation = $affectation->getSignalement()->getMontantAllocation();

--- a/src/Messenger/Message/Idoss/DossierMessage.php
+++ b/src/Messenger/Message/Idoss/DossierMessage.php
@@ -90,9 +90,7 @@ final class DossierMessage implements DossierMessageInterface
             'telephoneProprietaire' => $affectation->getSignalement()->getTelProprioDecoded(),
             'mailProprietaire' => $affectation->getSignalement()->getMailProprio(),
         ];
-        if ($affectation->getSignalement()->getDetails()) {
-            $this->descriptionProblemes = $affectation->getSignalement()->getDetails() ? mb_strimwidth($affectation->getSignalement()->getDetails(), 0, self::DESCRIPTION_MAX_LENGTH) : '';
-        }
+        $this->descriptionProblemes = !empty($affectation->getSignalement()->getDetails()) ? mb_strimwidth($affectation->getSignalement()->getDetails(), 0, self::DESCRIPTION_MAX_LENGTH) : '';
         $this->numAllocataire = $affectation->getSignalement()->getNumAllocataire();
         $this->montantAllocation = $affectation->getSignalement()->getMontantAllocation();
         if (true === $affectation->getSignalement()->getIsBailEnCours()) {


### PR DESCRIPTION
## Ticket

#4267   

## Description
Correction d'erreurs Sentry pour des appels de fonction avec des chaines null

## Tests
- [ ] S'authentifier dans une page de suivi usager
- [ ] Envoyer à Idoss un dossier qui a une description `null`
