### PR TITLE
[BO - Partenaires] Ajout filtre d'interconnection pour Super Admins

### DIFF
--- a/src/Form/SearchPartnerType.php
+++ b/src/Form/SearchPartnerType.php
@@ -88,6 +88,24 @@ class SearchPartnerType extends AbstractType
             'empty_data' => '0',
         ]);
 
+        if ($this->isAdmin) {
+            $builder->add('isOnlyInterconnected', CheckboxType::class, [
+                'row_attr' => [
+                    'class' => 'fr-toggle',
+                ],
+                'label_attr' => [
+                    'class' => 'fr-toggle__label',
+                ],
+                'attr' => [
+                    'class' => 'fr-toggle__input fr-auto-submit',
+                ],
+                'required' => false,
+                'label' => 'N\'afficher que les partenaires inter-connectés',
+                'false_values' => ['0', null],
+                'empty_data' => '0',
+            ]);
+        }
+
         $builder->add('partnerType', EnumType::class, [
             'class' => PartnerType::class,
             'choice_label' => function ($choice) {

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -99,6 +99,10 @@ class PartnerRepository extends ServiceEntityRepository
             $queryBuilder->andHaving('isNotifiable = 0');
         }
 
+        if (isset($searchPartner) && $searchPartner->getIsOnlyInterconnected()) {
+            $queryBuilder->andWhere('p.isEsaboraActive = 1 or p.isIdossActive = 1');
+        }
+
         if (!empty($type)) {
             $queryBuilder
                 ->andWhere('p.type = :type')

--- a/src/Service/ListFilters/SearchPartner.php
+++ b/src/Service/ListFilters/SearchPartner.php
@@ -19,6 +19,7 @@ class SearchPartner
     private ?PartnerType $partnerType = null;
     private ?string $orderType = null;
     private ?bool $isNotNotifiable = null;
+    private ?bool $isOnlyInterconnected = null;
 
     public function __construct(User $user)
     {
@@ -81,6 +82,16 @@ class SearchPartner
     public function setIsNotNotifiable(?bool $isNotNotifiable): void
     {
         $this->isNotNotifiable = $isNotNotifiable;
+    }
+
+    public function getIsOnlyInterconnected(): ?bool
+    {
+        return $this->isOnlyInterconnected;
+    }
+
+    public function setIsOnlyInterconnected(?bool $isOnlyInterconnected): void
+    {
+        $this->isOnlyInterconnected = $isOnlyInterconnected;
     }
 
     /**

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -64,6 +64,11 @@
             <div class="fr-col-12 fr-col-lg-4">
                 {{ form_row(form.isNotNotifiable) }}
             </div>
+            {% if is_granted('ROLE_ADMIN') %}
+                <div class="fr-col-12 fr-col-lg-4">
+                    {{ form_row(form.isOnlyInterconnected) }}
+                </div>
+            {% endif %}
             <div class="fr-col-12 fr-col-lg-4">
                 <a href="{{ path('back_partner_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser les résultats</a>
             </div>

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -164,13 +164,14 @@ class PartnerRepositoryTest extends KernelTestCase
         $this->assertGreaterThan(1, $partnerPaginator->count());
     }
 
-    public function testGetPartnerPaginatorWithSearchPartner(): void
+    public function testGetPartnerPaginatorWithSearchPartnerNotNotifiable(): void
     {
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
         $searchPartner = new SearchPartner($user);
         $searchPartner->setIsNotNotifiable(true);
+        $searchPartner->setIsOnlyInterconnected(false);
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
         $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
         foreach ($partnerPaginator as $partner) {
@@ -178,6 +179,19 @@ class PartnerRepositoryTest extends KernelTestCase
         }
 
         $this->assertEquals(1, $partnerPaginator->count());
+    }
+
+    public function testGetPartnerPaginatorWithSearchPartnerInterconnected(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $searchPartner = new SearchPartner($user);
+        $searchPartner->setIsNotNotifiable(false);
+        $searchPartner->setIsOnlyInterconnected(true);
+        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
+        $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
+        $this->assertEquals(2, $partnerPaginator->count());
     }
 
     public function testGetPartnerQueryBuilder(): void


### PR DESCRIPTION
## Ticket

#4216   

## Description
Ajout filtre d'interconnection pour Super Admins dans la liste des partenaires du BO

## Tests
- [ ] Admin territoire : le filtre n'existe pas
- [ ] Super admin : le filtre fonctionne pour les connexions Esabora et Idoss
