### PR TITLE
[Suivis - Accusés de lecture] BO - déplacer le badge

### DIFF
--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -63,11 +63,6 @@
                     {{ signalement.isNotOccupant ? 'DECLARANT':'OCCUPANT'}}
                 {% endif %}
             {% endif %}
-            {% if feature_accuse_lecture %}
-                {% if suivi.isPublic and suivi.type is not same as (2) %}
-                    <span class="fr-badge fr-badge--{{ suivi.isSeenByUsager ? 'success fr-background--notif-info' : 'error fr-background--notif-error' }}">{{ suivi.isSeenByUsager ? 'Lu' : 'Non lu' }}</span>
-                {% endif %}
-            {% endif  %}
         </div>
 
         {% if is_granted('ROLE_ADMIN') %}
@@ -83,6 +78,12 @@
             {% else %}
                 <span class="fr-badge fr-badge--no-icon" title="Suivi interne">Suivi interne</span>
             {% endif %}
+            {% if feature_accuse_lecture %}
+                <br>
+                {% if suivi.isPublic and suivi.type is not same as (2) %}
+                    <span class="fr-badge fr-badge--{{ suivi.isSeenByUsager ? 'success fr-background--notif-info' : 'error fr-background--notif-error' }}">{{ suivi.isSeenByUsager ? 'Lu' : 'Non lu' }}</span>
+                {% endif %}
+            {% endif  %}
         </div>
         {% if is_granted('ROLE_ADMIN') %}
             <div class="fr-col-1 fr-text--right">


### PR DESCRIPTION
## Ticket

#4288   

## Description
> sur la page du signalement, je propose de mettre l'accusé de lecture non pas sous le nom du redacteur du suivi mais sous le Tag Visible par l usager, à droite

## Changements apportés
* Changement du twig

## Pré-requis

## Tests
- [ ] Vérifier la page de signalement dans le BO
