### PR TITLE
[BO - Zones / carto] Rendre les zones visibles

### DIFF
--- a/assets/scripts/vue/components/signalement-view/TheSignalementAppList.vue
+++ b/assets/scripts/vue/components/signalement-view/TheSignalementAppList.vue
@@ -15,6 +15,7 @@
                 @changeTerritory="handleTerritoryChange"
                 @clickReset="handleClickReset"
                 :layout="'horizontal'"
+                :viewType="'list'"
             />
           </div>
         </div>

--- a/assets/scripts/vue/components/signalement-view/TheSignalementCartoApp.vue
+++ b/assets/scripts/vue/components/signalement-view/TheSignalementCartoApp.vue
@@ -9,6 +9,7 @@
             @changeTerritory="handleTerritoryChange"
             @clickReset="handleClickReset"
             :layout="'vertical'"
+            :viewType="'carto'"
         />
       </div>
       <div class="fr-col-9 fr-col-md-10">

--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
@@ -29,7 +29,7 @@
       </li>
       <li>
         <button
-            v-if="sharedState.zones.length > 0"
+            v-if="sharedState.zones.length > 0 && viewType === 'carto'"
             ref="isZonesDisplayedButton"
             class="fr-tag"
             :aria-pressed="ariaPressed.isZonesDisplayed.toString()"
@@ -397,6 +397,11 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'horizontal'
+    },
+    viewType: {
+      type: String,
+      required: false,
+      default: 'list'
     },
     onChange: { type: Function }
   },

--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
@@ -27,6 +27,16 @@
         >Afficher les signalements importés
         </button>
       </li>
+      <li>
+        <button
+            v-if="sharedState.zones.length > 0"
+            ref="isZonesDisplayedButton"
+            class="fr-tag"
+            :aria-pressed="ariaPressed.isZonesDisplayed.toString()"
+            @click="toggleIsZonesDisplayed"
+        >Afficher les zones du territoire
+        </button>
+      </li>
     </ul>
   </div>
   <div :class="defineCssBloc1()">
@@ -394,7 +404,7 @@ export default defineComponent({
   computed: {
     filtersSanitized () {
       const filters = Object.entries(this.sharedState.input.filters).filter(([key, value]) => {
-        if (key === 'isImported' || key === 'showMyAffectationOnly' || key === 'showWithoutAffectationOnly') {
+        if (key === 'isImported' || key === 'isZonesDisplayed' || key === 'showMyAffectationOnly' || key === 'showWithoutAffectationOnly') {
           return false
         }
         if (value !== null) {
@@ -445,6 +455,14 @@ export default defineComponent({
     },  
     toggleIsImported () {
       this.sharedState.input.filters.isImported = this.sharedState.input.filters.isImported !== 'oui'
+        ? 'oui'
+        : null
+      if (typeof this.onChange === 'function') {
+        this.onChange(false)
+      }
+    },
+    toggleIsZonesDisplayed () {
+      this.sharedState.input.filters.isZonesDisplayed = this.sharedState.input.filters.isZonesDisplayed !== 'oui'
         ? 'oui'
         : null
       if (typeof this.onChange === 'function') {
@@ -551,6 +569,7 @@ export default defineComponent({
         dateDepot: null,
         dateDernierSuivi: null,
         isImported: null,
+        isZonesDisplayed: null,
         showMyAffectationOnly: null,
         showWithoutAffectationOnly: null,
         statusAffectation: null,
@@ -570,6 +589,10 @@ export default defineComponent({
 
       if (this.$refs.isImportedButton) {
         (this.$refs.isImportedButton as HTMLElement).setAttribute('aria-pressed', 'false')
+      }
+
+      if (this.$refs.isZonesDisplayedButton) {
+        (this.$refs.isZonesDisplayedButton as HTMLElement).setAttribute('aria-pressed', 'false')
       }
 
       this.reset = !this.reset
@@ -593,6 +616,7 @@ export default defineComponent({
       sharedProps: store.props,
       ariaPressed: {
         isImported: store.state.input.filters.isImported === 'oui',
+        isZonesDisplayed: store.state.input.filters.isZonesDisplayed === 'oui',
         showMyAffectationOnly: store.state.input.filters.showMyAffectationOnly === 'oui',
         showWithoutAffectationOnly: store.state.input.filters.showWithoutAffectationOnly === 'oui'
       },

--- a/assets/scripts/vue/components/signalement-view/interfaces/filters.ts
+++ b/assets/scripts/vue/components/signalement-view/interfaces/filters.ts
@@ -29,6 +29,7 @@ export const SEARCH_FILTERS = [
   { type: 'text', name: 'showMyAffectationOnly', showOptions: true, defaultValue: null },
   { type: 'text', name: 'showWithoutAffectationOnly', showOptions: true, defaultValue: null },
   { type: 'text', name: 'isImported', showOptions: false, defaultValue: null },
+  { type: 'text', name: 'isZonesDisplayed', showOptions: false, defaultValue: null },
   { type: 'collection', name: 'communes', showOptions: false, defaultValue: null },
   { type: 'collection', name: 'epcis', showOptions: false, defaultValue: null },
   { type: 'collection', name: 'etiquettes', showOptions: true, defaultValue: null },

--- a/assets/scripts/vue/components/signalement-view/store.ts
+++ b/assets/scripts/vue/components/signalement-view/store.ts
@@ -34,6 +34,7 @@ export const store = {
         dateDepot: null,
         dateDernierSuivi: null,
         isImported: 'oui' as 'oui' | null,
+        isZonesDisplayed: null as 'oui' | null,
         showMyAffectationOnly: null as 'oui' | null,
         showWithoutAffectationOnly: null as 'oui' | null,
         statusAffectation: null,

--- a/src/Controller/Back/CartographieController.php
+++ b/src/Controller/Back/CartographieController.php
@@ -57,6 +57,17 @@ class CartographieController extends AbstractController
             foreach ($zones as $zone) {
                 $zoneAreas[] = $zone->getArea();
             }
+        } elseif (!empty($filters['isZonesDisplayed'])) {
+            $criteria = [];
+            if (!empty($filters['territories'])) {
+                $criteria['territory'] = $filters['territories'];
+            } elseif (!$this->isGranted('ROLE_ADMIN')) {
+                $criteria['territory'] = $user->getPartnersTerritories();
+            }
+            $zones = $zoneRepository->findBy($criteria);
+            foreach ($zones as $zone) {
+                $zoneAreas[] = $zone->getArea();
+            }
         }
 
         return $this->json(

--- a/src/Dto/Request/Signalement/SignalementSearchQuery.php
+++ b/src/Dto/Request/Signalement/SignalementSearchQuery.php
@@ -85,6 +85,8 @@ class SignalementSearchQuery
         private readonly ?int $page = 1,
         #[Assert\Choice(['oui'])]
         private readonly ?string $isImported = null,
+        #[Assert\Choice(['oui'])]
+        private readonly ?string $isZonesDisplayed = null,
         #[Assert\Choice(['NO_SUIVI_AFTER_3_RELANCES'])]
         private readonly ?string $relancesUsager = null,
         private readonly ?bool $usagerAbandonProcedure = false,
@@ -251,6 +253,11 @@ class SignalementSearchQuery
         return $this->isImported;
     }
 
+    public function getIsZonesDisplayed(): ?string
+    {
+        return $this->isZonesDisplayed;
+    }
+
     public function getRelancesUsager(): ?string
     {
         return $this->relancesUsager;
@@ -363,6 +370,11 @@ class SignalementSearchQuery
         };
 
         $filters['isImported'] = match ($this->getIsImported()) {
+            'oui' => true,
+            default => null,
+        };
+
+        $filters['isZonesDisplayed'] = match ($this->getIsZonesDisplayed()) {
             'oui' => true,
             default => null,
         };

--- a/tests/Functional/Controller/CartographieControllerTest.php
+++ b/tests/Functional/Controller/CartographieControllerTest.php
@@ -142,5 +142,8 @@ class CartographieControllerTest extends WebTestCase
         yield 'Partenaire by visites' => [self::PARTNER, 'bo-filters-visites', ['0']];
         yield 'Admin partner multi territory by territory' => [self::ADMIN_PARTNER_MULTI_TERRITORIES, 'bo-filters-territories', ['1']];
         yield 'User partner multi territory by territory' => [self::USER_PARTNER_MULTI_TERRITORIES, 'bo-filters-territories', ['31']];
+        yield 'Super Admin by isZonesDisplayed' => [self::SUPER_ADMIN, 'bo-filters-isZonesDisplayed', ['oui']];
+        yield 'Resp territoire by isZonesDisplayed' => [self::ADMIN_TERRITOIRE, 'bo-filters-isZonesDisplayed', ['oui']];
+        yield 'Partenaire by isZonesDisplayed' => [self::PARTNER, 'bo-filters-isZonesDisplayed', ['oui']];
     }
 }

--- a/tests/Unit/Dto/Request/Signalement/SignalementSearchQueryTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SignalementSearchQueryTest.php
@@ -41,6 +41,7 @@ class SignalementSearchQueryTest extends KernelTestCase
             procedureConstatee: 'non_decence',
             page: 1,
             isImported: 'oui',
+            isZonesDisplayed: 'oui',
             relancesUsager: 'NO_SUIVI_AFTER_3_RELANCES',
             usagerAbandonProcedure: true,
             nouveauSuivi: 'oui',
@@ -80,6 +81,7 @@ class SignalementSearchQueryTest extends KernelTestCase
             ],
             'statusAffectation' => 'accepte',
             'isImported' => true,
+            'isZonesDisplayed' => true,
             'relances_usager' => [
                 'NO_SUIVI_AFTER_3_RELANCES',
             ],


### PR DESCRIPTION
## Ticket

#4283   

## Description
Je propose que le label cliquable permette d'ajouter le tracé de toutes les zones du territoire, indépendamment de s'il y a des signalements dans ces zones ou non
On peut leur mettre un label cliquable "Afficher les zones du territoire" au même titre qu'on "Afficher les signalements importés" / "mes affectations" pour les RT

## Changements apportés
* Ajout d'un bouton toggle dans la carto
* Adaptation de CartographieController pour prendre en compte ce bouton si des zones n'ont pas déjà été choisies
* Mise à jour des tests

## Pré-requis

## Tests
- [ ] Faire des tests sur la carto avec différents rôles
- [ ] Vérifier que le filtre zones prend le pas
- [ ] Vérifier qu'il n'y a pas d'impact sur la liste des signalements
