### PR TITLE
[BO - Partenaires] Ajouter filtre interfaçage

### DIFF
--- a/src/Form/SearchPartnerType.php
+++ b/src/Form/SearchPartnerType.php
@@ -88,12 +88,12 @@ class SearchPartnerType extends AbstractType
             'empty_data' => '0',
         ]);
 
-        $builder->add('interconnected', ChoiceType::class, [
+        $builder->add('isOnlyInterconnected', ChoiceType::class, [
             'label' => 'Connexions externes',
             'choices' => [
-                'Tous les partenaires' => 'all',
-                'Avec connexion externe' => 'connected',
-                'Sans connexion externe' => 'not_connected',
+                'Tous les partenaires' => null,
+                'Avec connexion externe' => true,
+                'Sans connexion externe' => false,
             ],
         ]);
 

--- a/src/Form/SearchPartnerType.php
+++ b/src/Form/SearchPartnerType.php
@@ -95,12 +95,6 @@ class SearchPartnerType extends AbstractType
                 'Avec connexion externe' => 'connected',
                 'Sans connexion externe' => 'not_connected',
             ],
-            'row_attr' => [
-                'class' => 'fr-select-group',
-            ],
-            'attr' => [
-                'class' => 'fr-select',
-            ],
         ]);
 
         $builder->add('partnerType', EnumType::class, [

--- a/src/Form/SearchPartnerType.php
+++ b/src/Form/SearchPartnerType.php
@@ -88,23 +88,20 @@ class SearchPartnerType extends AbstractType
             'empty_data' => '0',
         ]);
 
-        if ($this->isAdmin) {
-            $builder->add('isOnlyInterconnected', CheckboxType::class, [
-                'row_attr' => [
-                    'class' => 'fr-toggle',
-                ],
-                'label_attr' => [
-                    'class' => 'fr-toggle__label',
-                ],
-                'attr' => [
-                    'class' => 'fr-toggle__input fr-auto-submit',
-                ],
-                'required' => false,
-                'label' => 'N\'afficher que les partenaires inter-connectés',
-                'false_values' => ['0', null],
-                'empty_data' => '0',
-            ]);
-        }
+        $builder->add('interconnected', ChoiceType::class, [
+            'label' => 'Connexions externes',
+            'choices' => [
+                'Tous les partenaires' => 'all',
+                'Avec connexion externe' => 'connected',
+                'Sans connexion externe' => 'not_connected',
+            ],
+            'row_attr' => [
+                'class' => 'fr-select-group',
+            ],
+            'attr' => [
+                'class' => 'fr-select',
+            ],
+        ]);
 
         $builder->add('partnerType', EnumType::class, [
             'class' => PartnerType::class,

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -91,7 +91,7 @@ class PartnerRepository extends ServiceEntityRepository
         if ($searchPartner->getIsOnlyInterconnected()) {
             $queryBuilder->andWhere('(p.isEsaboraActive = 1 and p.esaboraUrl is not null) or (p.isIdossActive = 1 and p.idossUrl is not null)');
         } elseif (false === $searchPartner->getIsOnlyInterconnected()) {
-            $queryBuilder->andWhere('(p.isEsaboraActive = 0 or p.esaboraUrl is null) or (p.isIdossActive = 0 or p.idossUrl is null)');
+            $queryBuilder->andWhere('(p.isEsaboraActive = 0 or p.esaboraUrl is null) and (p.isIdossActive = 0 or p.idossUrl is null)');
         }
 
         if (!empty($searchPartner->getPartnerType())) {

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -99,8 +99,10 @@ class PartnerRepository extends ServiceEntityRepository
             $queryBuilder->andHaving('isNotifiable = 0');
         }
 
-        if (isset($searchPartner) && $searchPartner->getIsOnlyInterconnected()) {
+        if (isset($searchPartner) && 'connected' === $searchPartner->getInterconnected()) {
             $queryBuilder->andWhere('p.isEsaboraActive = 1 or p.isIdossActive = 1');
+        } elseif (isset($searchPartner) && 'not_connected' === $searchPartner->getInterconnected()) {
+            $queryBuilder->andWhere('p.isEsaboraActive = 0 and p.isIdossActive = 0');
         }
 
         if (!empty($type)) {

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -89,9 +89,9 @@ class PartnerRepository extends ServiceEntityRepository
         }
 
         if ($searchPartner->getIsOnlyInterconnected()) {
-            $queryBuilder->andWhere('p.isEsaboraActive = 1 or p.isIdossActive = 1');
+            $queryBuilder->andWhere('(p.isEsaboraActive = 1 and p.esaboraUrl is not null) or (p.isIdossActive = 1 and p.idossUrl is not null)');
         } elseif (false === $searchPartner->getIsOnlyInterconnected()) {
-            $queryBuilder->andWhere('p.isEsaboraActive = 0 and p.isIdossActive = 0');
+            $queryBuilder->andWhere('(p.isEsaboraActive = 0 or p.esaboraUrl is null) or (p.isIdossActive = 0 or p.idossUrl is null)');
         }
 
         if (!empty($searchPartner->getPartnerType())) {

--- a/src/Service/ListFilters/SearchPartner.php
+++ b/src/Service/ListFilters/SearchPartner.php
@@ -19,7 +19,7 @@ class SearchPartner
     private ?PartnerType $partnerType = null;
     private ?string $orderType = null;
     private ?bool $isNotNotifiable = null;
-    private ?string $interconnected = null;
+    private ?bool $isOnlyInterconnected = null;
 
     public function __construct(User $user)
     {
@@ -84,14 +84,14 @@ class SearchPartner
         $this->isNotNotifiable = $isNotNotifiable;
     }
 
-    public function getInterconnected(): ?string
+    public function getIsOnlyInterconnected(): ?bool
     {
-        return $this->interconnected;
+        return $this->isOnlyInterconnected;
     }
 
-    public function setInterconnected(?string $interconnected): void
+    public function setIsOnlyInterconnected(?bool $isOnlyInterconnected): void
     {
-        $this->interconnected = $interconnected;
+        $this->isOnlyInterconnected = $isOnlyInterconnected;
     }
 
     /**

--- a/src/Service/ListFilters/SearchPartner.php
+++ b/src/Service/ListFilters/SearchPartner.php
@@ -19,7 +19,7 @@ class SearchPartner
     private ?PartnerType $partnerType = null;
     private ?string $orderType = null;
     private ?bool $isNotNotifiable = null;
-    private ?bool $isOnlyInterconnected = null;
+    private ?string $interconnected = null;
 
     public function __construct(User $user)
     {
@@ -84,14 +84,14 @@ class SearchPartner
         $this->isNotNotifiable = $isNotNotifiable;
     }
 
-    public function getIsOnlyInterconnected(): ?bool
+    public function getInterconnected(): ?string
     {
-        return $this->isOnlyInterconnected;
+        return $this->interconnected;
     }
 
-    public function setIsOnlyInterconnected(?bool $isOnlyInterconnected): void
+    public function setInterconnected(?string $interconnected): void
     {
-        $this->isOnlyInterconnected = $isOnlyInterconnected;
+        $this->interconnected = $interconnected;
     }
 
     /**

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -59,16 +59,14 @@
             <div class="fr-col-12 fr-col-lg-4">
                 {{ form_row(form.partnerType) }}
             </div>
+            <div class="fr-col-12 fr-col-lg-4">
+                {{ form_row(form.interconnected) }}
+            </div>
         </div>
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12 fr-col-lg-4">
                 {{ form_row(form.isNotNotifiable) }}
             </div>
-            {% if is_granted('ROLE_ADMIN') %}
-                <div class="fr-col-12 fr-col-lg-4">
-                    {{ form_row(form.isOnlyInterconnected) }}
-                </div>
-            {% endif %}
             <div class="fr-col-12 fr-col-lg-4">
                 <a href="{{ path('back_partner_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser les résultats</a>
             </div>

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -49,34 +49,26 @@
         {{ form_errors(form) }}
         <div class="fr-grid-row fr-grid-row--bottom fr-grid-row--gutters">
         
-            {% if is_granted('ROLE_ADMIN') %}
-                {% set cssClass = 'fr-col-lg-3' %}
-            {% else %}
-                {% set cssClass = 'fr-col-lg-4' %}
-            {% endif %}
-            <div class="fr-col-12 {{ cssClass }}">
+            <div class="fr-col-12 fr-col-lg-4">
                 {{ form_row(form.queryPartner) }}
             </div>
             {% if is_granted('ROLE_ADMIN') %}
-                <div class="fr-col-12 fr-col-lg-3">
+                <div class="fr-col-12 fr-col-lg-4">
                     {{ form_row(form.territoire) }}
                 </div>
             {% endif %}
-            <div class="fr-col-12 {{ cssClass }}">
+            <div class="fr-col-12 fr-col-lg-4">
                 {{ form_row(form.partnerType) }}
             </div>
-            <div class="fr-col-12 {{ cssClass }}">
+            <div class="fr-col-12 fr-col-lg-4">
                 {{ form_row(form.isOnlyInterconnected) }}
             </div>
-        </div>
-        <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12 fr-col-lg-4">
                 {{ form_row(form.isNotNotifiable) }}
             </div>
             <div class="fr-col-12 fr-col-lg-4">
                 <a href="{{ path('back_partner_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser les résultats</a>
             </div>
-        </div>
     </section>
 
     <section class="fr-col-12 fr-py-5v">

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -48,19 +48,25 @@
     <section class="fr-col-12">
         {{ form_errors(form) }}
         <div class="fr-grid-row fr-grid-row--bottom fr-grid-row--gutters">
-            <div class="fr-col-12 fr-col-lg-4">
+        
+            {% if is_granted('ROLE_ADMIN') %}
+                {% set cssClass = 'fr-col-lg-3' %}
+            {% else %}
+                {% set cssClass = 'fr-col-lg-4' %}
+            {% endif %}
+            <div class="fr-col-12 {{ cssClass }}">
                 {{ form_row(form.queryPartner) }}
             </div>
             {% if is_granted('ROLE_ADMIN') %}
-                <div class="fr-col-12 fr-col-lg-4">
+                <div class="fr-col-12 fr-col-lg-3">
                     {{ form_row(form.territoire) }}
                 </div>
             {% endif %}
-            <div class="fr-col-12 fr-col-lg-4">
+            <div class="fr-col-12 {{ cssClass }}">
                 {{ form_row(form.partnerType) }}
             </div>
-            <div class="fr-col-12 fr-col-lg-4">
-                {{ form_row(form.interconnected) }}
+            <div class="fr-col-12 {{ cssClass }}">
+                {{ form_row(form.isOnlyInterconnected) }}
             </div>
         </div>
         <div class="fr-grid-row fr-grid-row--gutters">

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -11,7 +11,7 @@
         {% set row_attr = row_attr|merge({'class': (row_attr.class|default('') ~ ' fr-select-group')|trim}) %}
     {% elseif 'checkbox' in block_prefixes %}
         {% if row_attr.class is defined and row_attr.class starts with 'fr-toggle' %}
-            {% set row_attr = row_attr|merge({'class': row_attr.class ~ ' fr-mb-6v'}) %}
+            {% set row_attr = row_attr|merge({'class': row_attr.class}) %}
         {% else %}
             {% set row_attr = row_attr|merge({'class': (row_attr.class|default('') ~ ' fr-checkbox-group fr-mb-6v')|trim}) %}
         {% endif %}

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -159,7 +159,9 @@ class PartnerRepositoryTest extends KernelTestCase
     {
         $user = new User();
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '69']);
-        $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null);
+        $searchPartner = new SearchPartner($user);
+        $searchPartner->setTerritoire($territory);
+        $partnerPaginator = $this->partnerRepository->getPartners(1, $searchPartner);
 
         $this->assertGreaterThan(1, $partnerPaginator->count());
     }
@@ -171,9 +173,10 @@ class PartnerRepositoryTest extends KernelTestCase
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
         $searchPartner = new SearchPartner($user);
         $searchPartner->setIsNotNotifiable(true);
-        $searchPartner->setInterconnected('all');
+        $searchPartner->setIsOnlyInterconnected(null);
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
-        $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
+        $searchPartner->setTerritoire($territory);
+        $partnerPaginator = $this->partnerRepository->getPartners(50, $searchPartner);
         foreach ($partnerPaginator as $partner) {
             $this->assertFalse($partner[0]->receiveEmailNotifications());
         }
@@ -188,9 +191,10 @@ class PartnerRepositoryTest extends KernelTestCase
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
         $searchPartner = new SearchPartner($user);
         $searchPartner->setIsNotNotifiable(false);
-        $searchPartner->setInterconnected('connected');
+        $searchPartner->setIsOnlyInterconnected(true);
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
-        $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
+        $searchPartner->setTerritoire($territory);
+        $partnerPaginator = $this->partnerRepository->getPartners(50, $searchPartner);
         $this->assertEquals(2, $partnerPaginator->count());
     }
 
@@ -201,9 +205,10 @@ class PartnerRepositoryTest extends KernelTestCase
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
         $searchPartner = new SearchPartner($user);
         $searchPartner->setIsNotNotifiable(false);
-        $searchPartner->setInterconnected('not_connected');
+        $searchPartner->setIsOnlyInterconnected(false);
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
-        $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
+        $searchPartner->setTerritoire($territory);
+        $partnerPaginator = $this->partnerRepository->getPartners(50, $searchPartner);
         $this->assertEquals(6, $partnerPaginator->count());
     }
 

--- a/tests/Functional/Repository/PartnerRepositoryTest.php
+++ b/tests/Functional/Repository/PartnerRepositoryTest.php
@@ -171,7 +171,7 @@ class PartnerRepositoryTest extends KernelTestCase
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
         $searchPartner = new SearchPartner($user);
         $searchPartner->setIsNotNotifiable(true);
-        $searchPartner->setIsOnlyInterconnected(false);
+        $searchPartner->setInterconnected('all');
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
         $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
         foreach ($partnerPaginator as $partner) {
@@ -188,10 +188,23 @@ class PartnerRepositoryTest extends KernelTestCase
         $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
         $searchPartner = new SearchPartner($user);
         $searchPartner->setIsNotNotifiable(false);
-        $searchPartner->setIsOnlyInterconnected(true);
+        $searchPartner->setInterconnected('connected');
         $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
         $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
         $this->assertEquals(2, $partnerPaginator->count());
+    }
+
+    public function testGetPartnerPaginatorWithSearchPartnerNotInterconnected(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => self::USER_ADMIN_TERRITORY_13]);
+        $searchPartner = new SearchPartner($user);
+        $searchPartner->setIsNotNotifiable(false);
+        $searchPartner->setInterconnected('not_connected');
+        $territory = $this->entityManager->getRepository(Territory::class)->findOneBy(['zip' => '13']);
+        $partnerPaginator = $this->partnerRepository->getPartners(1, 50, $user, $territory, null, null, $searchPartner);
+        $this->assertEquals(6, $partnerPaginator->count());
     }
 
     public function testGetPartnerQueryBuilder(): void


### PR DESCRIPTION
## Ticket

#4284    

## Description
Ajouter un filtre "Connexions externes" : liste déroulante avec choix unique avec les valeurs :

- Tous les partenaires (par défaut)
- Avec connexion externe
- Sans connexion externe
Filtre sur les partenaires avec un interfaçage actif

## Changements apportés
* FormType
* ParnerRepository
* twig
* tests

## Pré-requis

## Tests
- [ ] Tester que le filtre est disponible pour les SA et les RT, sous la forme d'une selectbox
