### PR TITLE
[BO - Interconnexion] Étendre l'interconnexion SCHS aux partenaires EPCI

### DIFF
--- a/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
+++ b/assets/scripts/vanilla/controllers/back_partner_view/form_partner.js
@@ -9,7 +9,9 @@ function histoUpdateFieldsVisibility () {
 
   let showEsabora, showIdoss, showBailleurSocial
   showEsabora = showIdoss = showBailleurSocial = false
-  if (partnerType.value === 'COMMUNE_SCHS') {
+  if ((partnerType.value === 'EPCI')) {
+    showEsabora = true
+  } else if (partnerType.value === 'COMMUNE_SCHS') {
     showEsabora = true
     showIdoss = true
   } else if (partnerType.value === 'ARS') {

--- a/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
+++ b/src/Command/Cron/SynchronizeEsaboraSCHSCommand.php
@@ -3,8 +3,8 @@
 namespace App\Command\Cron;
 
 use App\Entity\Affectation;
-use App\Entity\Enum\PartnerType;
 use App\Entity\Suivi;
+use App\Messenger\Message\Esabora\DossierMessageSCHS;
 use App\Repository\AffectationRepository;
 use App\Repository\SuiviRepository;
 use App\Service\Interconnection\Esabora\EsaboraManager;
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 #[AsCommand(
@@ -56,6 +57,9 @@ class SynchronizeEsaboraSCHSCommand extends AbstractSynchronizeEsaboraCommand
         );
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
@@ -64,8 +68,7 @@ class SynchronizeEsaboraSCHSCommand extends AbstractSynchronizeEsaboraCommand
             $input,
             $output,
             $this->esaboraService,
-            PartnerType::COMMUNE_SCHS,
-            'SAS_Référence'
+            DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA,
         );
 
         $this->synchronizeEvents();
@@ -76,7 +79,7 @@ class SynchronizeEsaboraSCHSCommand extends AbstractSynchronizeEsaboraCommand
     protected function synchronizeEvents(): void
     {
         $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
-            partnerType: PartnerType::COMMUNE_SCHS
+            partnerType: DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA,
         );
         $this->existingEvents = $this->suiviRepository->findExistingEventsForSCHS();
         $count = 0;

--- a/src/Command/Cron/SynchronizeEsaboraSISHCommand.php
+++ b/src/Command/Cron/SynchronizeEsaboraSISHCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 #[AsCommand(
@@ -40,6 +41,9 @@ class SynchronizeEsaboraSISHCommand extends AbstractSynchronizeEsaboraCommand
         );
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->synchronizeStatus(
@@ -47,7 +51,6 @@ class SynchronizeEsaboraSISHCommand extends AbstractSynchronizeEsaboraCommand
             $output,
             $this->esaboraService,
             PartnerType::ARS,
-            'Reference_Dossier'
         );
 
         return Command::SUCCESS;

--- a/src/Command/PushEsaboraDossierCommand.php
+++ b/src/Command/PushEsaboraDossierCommand.php
@@ -4,6 +4,7 @@ namespace App\Command;
 
 use App\Entity\Enum\PartnerType;
 use App\Messenger\InterconnectionBus;
+use App\Messenger\Message\Esabora\DossierMessageSCHS;
 use App\Repository\AffectationRepository;
 use App\Repository\TerritoryRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -58,7 +59,7 @@ class PushEsaboraDossierCommand extends Command
         $affectations = null;
         if ($uuid) {
             $affectations = $this->affectationRepository->findAffectationSubscribedToEsabora(
-                partnerType: 'sish' === $serviceType ? PartnerType::ARS : PartnerType::COMMUNE_SCHS,
+                partnerType: 'sish' === $serviceType ? PartnerType::ARS : DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA,
                 isSynchronized: false,
                 uuidSignalement: $uuid
             );

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -164,7 +164,7 @@ class PartnerController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            if (!\in_array($partner->getType(), [EnumPartnerType::ARS, EnumPartnerType::COMMUNE_SCHS])) {
+            if (!\in_array($partner->getType(), [EnumPartnerType::ARS, EnumPartnerType::COMMUNE_SCHS, EnumPartnerType::EPCI])) {
                 $partner->setIsEsaboraActive(false);
             }
             if (!\in_array($partner->getType(), [EnumPartnerType::COMMUNE_SCHS])) {

--- a/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
+++ b/src/Factory/Interconnection/Esabora/DossierMessageSCHSFactory.php
@@ -3,7 +3,6 @@
 namespace App\Factory\Interconnection\Esabora;
 
 use App\Entity\Affectation;
-use App\Entity\Enum\PartnerType;
 use App\Entity\Signalement;
 use App\Messenger\Message\Esabora\DossierMessageSCHS;
 use App\Service\Interconnection\Esabora\AbstractEsaboraService;
@@ -22,7 +21,7 @@ class DossierMessageSCHSFactory extends AbstractDossierMessageFactory
     public function supports(Affectation $affectation): bool
     {
         return $this->isEsaboraPartnerActive($affectation)
-            && PartnerType::COMMUNE_SCHS === $affectation->getPartner()->getType();
+            && in_array($affectation->getPartner()->getType(), DossierMessageSCHS::CAN_SYNC_SCHS_ESABORA);
     }
 
     public function createInstance(Affectation $affectation): DossierMessageSCHS

--- a/src/Messenger/Message/Esabora/DossierMessageSCHS.php
+++ b/src/Messenger/Message/Esabora/DossierMessageSCHS.php
@@ -7,6 +7,12 @@ use App\Messenger\Message\DossierMessageInterface;
 
 final class DossierMessageSCHS implements DossierMessageInterface
 {
+    /** @var PartnerType[] */
+    public const array CAN_SYNC_SCHS_ESABORA = [
+        PartnerType::COMMUNE_SCHS,
+        PartnerType::EPCI,
+    ];
+
     private ?string $url = null;
 
     private ?string $token = null;

--- a/tests/Unit/Command/Cron/SynchronizeEsaboraSCHSCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeEsaboraSCHSCommandTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class SynchronizeEsaboraSCHSCommandTest extends KernelTestCase
 {
-    public const PATH_MOCK = '/../../../../tools/wiremock/src/Resources/Esabora/schs/';
+    public const string PATH_MOCK = '/../../../../tools/wiremock/src/Resources/Esabora/schs/';
 
     public function testSyncDossierEsaboraSCHS(): void
     {

--- a/tests/Unit/Command/Cron/SynchronizeEsaboraSISHCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeEsaboraSISHCommandTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 class SynchronizeEsaboraSISHCommandTest extends KernelTestCase
 {
     use FixturesHelper;
-    public const PATH_MOCK = '/../../../../tools/wiremock/src/Resources/Esabora/sish/';
+    public const string PATH_MOCK = '/../../../../tools/wiremock/src/Resources/Esabora/sish/';
 
     public function testSyncDossierEsaboraSISH(): void
     {


### PR DESCRIPTION
## Ticket

#4292   

## Description
Ajouter le type de partenaire EPCI aux contrainte de l’interconnexion SCHS

## Changements apportés
* Mise à jour commandes
* Mise à jour contrôle JS
* Mise à jour des contraintes pour étendre aux EPCI

## Pré-requis
```
make npm-watch
make mock-stop && make mock-start
make worker-start && make worker-start
```
- Transformer ce partenaire SCHS en EPCI
- Préparer un partenaire EPCI avec les identifiants wiremock pour tester la synchro

## Tests
- [ ] Mettre à jour un type partenaire SCHS en EPCI (ex: http://localhost:8080/bo/partenaires/6/voir) et vérifier que la zone d'édition esabora s'affiche
- [ ]  Affecter le partenaire et vérifier que dans la table job_event, l'action push s'est effectué avec succès
- [ ] Exécuter une synchronisation SCHS `make console app="sync-esabora-schs"`  et vérifier que les événements de la  table job_event sont présent avec le partenaire EPCI
- [ ] Editer la colonne `is_synchronized`  de la table Affectation puis exécuter une synchronisation unitaire et vérifier que l'état de cet événement dans  `job_event`
- [ ] Couper le worker, affecter un partenaire EPCI (vérifier les identifiants) puis faire un push manuel via la commande `make console app="push-esabora-dossier"` et vérifier la table job_event

### TNR
- Affectation, exécution des commandes avec des partenaire SCHS
- Affectation, exécution des commandes avec des partenaires ARS