### PR TITLE
[BO - Partenaires] Empecher d'activer une interconnexion sans url/token

### DIFF
--- a/migrations/Version20250703165723.php
+++ b/migrations/Version20250703165723.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250703165723 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'set is_esabora_active=0 if is_esabora_active is 1 but esabora_url or esabora_token is NULL.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE partner SET is_esabora_active = 0 WHERE is_esabora_active = 1 AND (esabora_url IS NULL OR esabora_token IS NULL)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Non réversible
+    }
+}

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -96,6 +96,7 @@ class Partner implements EntityHistoryInterface
     private ?bool $isIdossActive = null;
 
     #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Url]
     private ?string $idossUrl = null;
 
     #[ORM\Column(length: 255, nullable: true)]

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -89,9 +89,9 @@ class PartnerRepository extends ServiceEntityRepository
         }
 
         if ($searchPartner->getIsOnlyInterconnected()) {
-            $queryBuilder->andWhere('(p.isEsaboraActive = 1 and p.esaboraUrl is not null) or (p.isIdossActive = 1 and p.idossUrl is not null)');
+            $queryBuilder->andWhere('p.isEsaboraActive = 1 or p.isIdossActive = 1');
         } elseif (false === $searchPartner->getIsOnlyInterconnected()) {
-            $queryBuilder->andWhere('(p.isEsaboraActive = 0 or p.esaboraUrl is null) and (p.isIdossActive = 0 or p.idossUrl is null)');
+            $queryBuilder->andWhere('p.isEsaboraActive = 0  and p.isIdossActive = 0');
         }
 
         if (!empty($searchPartner->getPartnerType())) {

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -99,10 +99,10 @@
                     </div>
                 {% endif %}  
             </div>
-            {% if partner.esaboraUrl or partner.isIdossActive %}
+            {% if partner.isEsaboraActive or partner.isIdossActive %}
                 <h3>Interfaçage</h3>
                 <div class="fr-grid-row fr-grid-row--gutters">
-                    {% if partner.esaboraUrl %}
+                    {% if partner.isEsaboraActive %}
                         <div class="fr-col-6">
                             <div><b>URL ESABORA :</b> {{ partner.esaboraUrl }}</div>
                         </div>
@@ -124,6 +124,9 @@
                         </div>
                     {% endif %}
                     {% if partner.isIdossActive %}
+                        <div class="fr-col-6">
+                            <div><b>URL iDoss :</b> {{ partner.idossUrl }}</div>
+                        </div>
                         <div class="fr-col-6">
                             <div>
                                 <b>Synchronisation iDoss :</b>


### PR DESCRIPTION
## Ticket

#4301   

## Description
Actuellement en prod nous avons 70 partenaires ayant is_esabora_active à true alors que esabora_url et esabora_token sont vides.

Et ce n'est pas étonnant, car on peut éditer/créer un partenaire en activant une interconnexion sans remplir les infos.
C'est la même chose pour iDoss (même si on n'a pas le cas en prod car un seul partenaire iDoss)
C'est aussi la même chose pour SISH

Cela rend la donnée is_esabora_active peu fiable, et donc peu utilisable

## Changements apportés
* Ajout d'une migration pour remettre à false `is_esabora_active` si pas d'url ou de token (on n'a pas fait de migration pour iDoss car un seul partenaire bien paramétré en prod)
* Rajout de contraintes sur PartnerType pour ne rendre les synchro activables que si url/token sont renseignés (esabora et idoss)
* Simplification de  `getPartners` dans` src/Repository/PartnerRepository.php` 

## Pré-requis
Se mettre sur la base de prod
Vérifier les partenaires dans ce cas : 
`SELECT * FROM `partner` WHERE `esabora_url` IS NULL AND `is_esabora_active` = 1 `

## Tests
- [ ] `make execute-migration name=Version20250703165723 direction=up`
- [ ] Relancer la requête ci-dessus et vérifier qu'il n'en reste plus
- [ ] Editer un partenaire SCHS, et vérifier qu'on ne peut pas le définir comme esabora_active sans avoir renseigné d'url ou de token
- [ ] Idem avec iDoss (et vérifier qu'on ne peut mettre qu'une URL et pas un texte lambda)
- [ ] Idem avec Esabora sur un partenaire ARS
- [ ] Vérifier que pour un partenaire lié à iDoss, on a bien son url sur la fiche du partenaire
