### PR TITLE
[QA] Eviter les erreurs 500 lors de mauvais paramètre page

### DIFF
--- a/src/Service/Behaviour/SearchQueryTrait.php
+++ b/src/Service/Behaviour/SearchQueryTrait.php
@@ -12,7 +12,7 @@ trait SearchQueryTrait
 
     public function getPage(): int
     {
-        if ($this->page < 1) {
+        if ($this->page < 1 || empty($this->page)) {
             return 1;
         }
 
@@ -21,6 +21,11 @@ trait SearchQueryTrait
 
     public function setPage(?string $page): void
     {
+        if (empty($page) || !is_numeric($page) || (int) $page < 1) {
+            $this->page = 1;
+
+            return;
+        }
         $this->page = (int) $page;
     }
 


### PR DESCRIPTION
## Ticket

#4310   

## Description
Eviter les erreurs 500 lors de mauvais paramètre page

## Tests
- [ ] Tester les pages de filtres du BO et vérifier que même avec un paramètre absurde, on se retrouve en page 1 (plutôt qu'en erreur 500)
