### PR TITLE
[BO - Signalement] Mise à jour requête widget et listing relance auto

### DIFF
--- a/src/Command/Cron/AskFeedbackUsagerCommand.php
+++ b/src/Command/Cron/AskFeedbackUsagerCommand.php
@@ -10,6 +10,7 @@ use App\Repository\SuiviRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
+use Doctrine\DBAL\Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,7 +26,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 class AskFeedbackUsagerCommand extends AbstractCronCommand
 {
     private SymfonyStyle $io;
-    private const FLUSH_COUNT = 1000;
+    private const int FLUSH_COUNT = 1000;
 
     public function __construct(
         private readonly SuiviManager $suiviManager,
@@ -47,6 +48,9 @@ class AskFeedbackUsagerCommand extends AbstractCronCommand
         );
     }
 
+    /**
+     * @throws Exception
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
@@ -98,6 +102,9 @@ class AskFeedbackUsagerCommand extends AbstractCronCommand
         return Command::SUCCESS;
     }
 
+    /**
+     * @throws Exception
+     */
     protected function processSignalementsThirdRelance(
         InputInterface $input,
     ): int {
@@ -109,7 +116,7 @@ class AskFeedbackUsagerCommand extends AbstractCronCommand
         );
         if (!$input->getOption('debug')) {
             $this->io->success(\sprintf(
-                '%s signalement(s) for which the two last suivis are technicals and the last one is older than '
+                '%s signalement(s) for which the two last suivis are feedback requests and the last one is older than '
                 .Suivi::DEFAULT_PERIOD_INACTIVITY.' days',
                 $nbSignalements
             ));
@@ -129,7 +136,7 @@ class AskFeedbackUsagerCommand extends AbstractCronCommand
         );
         if (!$input->getOption('debug')) {
             $this->io->success(\sprintf(
-                '%s signalement(s) for which the last suivi is technical and is older than '
+                '%s signalement(s) for which the last suivi is feedback request and is older than '
                 .Suivi::DEFAULT_PERIOD_INACTIVITY.' days',
                 $nbSignalements
             ));

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -89,9 +89,9 @@ class Suivi implements EntityHistoryInterface
 
     #[ORM\Column(
         type: 'string',
+        nullable: true,
         enumType: SuiviCategory::class,
-        options: ['comment' => 'Value possible enum SuiviCategory'],
-        nullable: true
+        options: ['comment' => 'Value possible enum SuiviCategory']
     )]
     private ?SuiviCategory $category = null;
 

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\Territory;
@@ -308,6 +309,8 @@ class SuiviRepository extends ServiceEntityRepository
 
     /**
      * @return array<int, int|string>
+     *
+     * @throws Exception
      */
     public function findSignalementsForThirdRelance(
         int $period = Suivi::DEFAULT_PERIOD_INACTIVITY,
@@ -316,6 +319,7 @@ class SuiviRepository extends ServiceEntityRepository
 
         $parameters = [
             'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
+            'suivi_category' => SuiviCategory::ASK_FEEDBACK_SENT->value,
             'status_need_validation' => SignalementStatus::NEED_VALIDATION->value,
             'status_closed' => SignalementStatus::CLOSED->value,
             'status_archived' => SignalementStatus::ARCHIVED->value,
@@ -344,6 +348,7 @@ class SuiviRepository extends ServiceEntityRepository
         $connection = $this->getEntityManager()->getConnection();
         $parameters = [
             'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
+            'suivi_category' => SuiviCategory::ASK_FEEDBACK_SENT->value,
             'status_need_validation' => SignalementStatus::NEED_VALIDATION->value,
             'status_archived' => SignalementStatus::ARCHIVED->value,
             'status_closed' => SignalementStatus::CLOSED->value,
@@ -419,7 +424,7 @@ class SuiviRepository extends ServiceEntityRepository
                 INNER JOIN (
                     SELECT su.signalement_id, MIN(su.created_at) AS min_date
                     FROM suivi su
-                    WHERE su.type = :type_suivi_technical
+                    WHERE su.type = :type_suivi_technical AND su.category = :suivi_category
                     GROUP BY su.signalement_id
                     HAVING COUNT(*) >= :nb_suivi_technical
                 ) t1 ON s.id = t1.signalement_id

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -8,6 +8,7 @@ use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\Qualification;
 use App\Entity\Enum\QualificationStatus;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\Enum\SuiviCategory;
 use App\Entity\Enum\VisiteStatus;
 use App\Entity\Intervention;
 use App\Entity\Partner;
@@ -195,6 +196,7 @@ class SearchFilter
                 $parameters = [
                     'day_period' => 0,
                     'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
+                    'suivi_category' => SuiviCategory::ASK_FEEDBACK_SENT->value,
                     'status_need_validation' => SignalementStatus::NEED_VALIDATION->value,
                     'status_archived' => SignalementStatus::ARCHIVED->value,
                     'status_closed' => SignalementStatus::CLOSED->value,

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -12,7 +12,6 @@ use App\Entity\Enum\SuiviCategory;
 use App\Entity\Enum\VisiteStatus;
 use App\Entity\Intervention;
 use App\Entity\Partner;
-use App\Entity\Suivi;
 use App\Entity\User;
 use App\Repository\BailleurRepository;
 use App\Repository\EpciRepository;
@@ -195,8 +194,7 @@ class SearchFilter
                 $connection = $this->entityManager->getConnection();
                 $parameters = [
                     'day_period' => 0,
-                    'type_suivi_technical' => Suivi::TYPE_TECHNICAL,
-                    'suivi_category' => SuiviCategory::ASK_FEEDBACK_SENT->value,
+                    'category_ask_feedback' => SuiviCategory::ASK_FEEDBACK_SENT->value,
                     'status_need_validation' => SignalementStatus::NEED_VALIDATION->value,
                     'status_archived' => SignalementStatus::ARCHIVED->value,
                     'status_closed' => SignalementStatus::CLOSED->value,
@@ -211,7 +209,7 @@ class SearchFilter
                     $parameters['partners'] = $partners;
                     $parameters['status_accepted'] = AffectationStatus::ACCEPTED->value;
                 }
-                $sql = $this->suiviRepository->getSignalementsLastSuivisTechnicalsQuery(
+                $sql = $this->suiviRepository->getSignalementsLastAskFeedbackSuivisQuery(
                     excludeUsagerAbandonProcedure: false,
                     partners: $partners
                 );

--- a/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
+++ b/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
@@ -45,8 +45,8 @@ class AskFeedbackUsagerCommandTest extends KernelTestCase
         $commandTester->assertCommandIsSuccessful();
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('1 signalement(s) for which the two last suivis are technicals ', $output);
-        $this->assertStringContainsString('1 signalement(s) for which the last suivi is technical', $output);
+        $this->assertStringContainsString('1 signalement(s) for which the two last suivis are feedback requests ', $output);
+        $this->assertStringContainsString('1 signalement(s) for which the last suivi is feedback request', $output);
         $this->assertStringContainsString('6 signalement(s) without suivi public', $output);
         $this->assertEmailCount(11);
 

--- a/tests/Functional/Repository/SuiviRepositoryTest.php
+++ b/tests/Functional/Repository/SuiviRepositoryTest.php
@@ -24,7 +24,7 @@ class SuiviRepositoryTest extends KernelTestCase
 
     public function testFindSignalementsForThirdRelance(): void
     {
-        $result = $this->suiviRepository->findSignalementsForThirdRelance();
+        $result = $this->suiviRepository->findSignalementsForThirdAskFeedbackRelance();
         $this->assertCount(1, $result);
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
         $signalement = $signalementRepository->findOneBy(['id' => $result[0]]);


### PR DESCRIPTION
## Ticket

#4319    

## Description
Suivi auto n'est plus égale à relance auto aujourd'hui car elle comprend des suivi de relance de visite du coup ajouter un filtre pour ne garder que les suivi de relance automatique.

## Changements apportés
* Mise à jour requête en ajoutant un filtre utilisé pour widget, liste et commande
* Mise à jour commande 

## Pré-requis
`make load-data`
` make clear-pool pool"=--all"`

## Tests
- [ ] Se connecter en tant qu'utilisateur et vérifier que le widget et la liste sont cohérente. 
- [ ] Vérifier que le signalement `#2025-49` ne remonte plus http://localhost:8080/bo/signalements/?territoire=34&isImported=oui&relancesUsager=NO_SUIVI_AFTER_3_RELANCES&sortBy=lastSuiviAt&direction=DESC  
cette fiche n'a que 2 suivi de relance et 1 suivi de visite 
- [ ] Vérifier que la commande s'exécute toujours
