### PR TITLE
[QA] Correction filtre fermé pour tous les partenaires

### DIFF
--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -174,7 +174,8 @@ class SearchFilter
                 $subquery = $this->entityManager->getRepository(Affectation::class)->createQueryBuilder('a')
                     ->select('DISTINCT s.id')
                     ->leftJoin('a.signalement', 's')
-                    ->where('a.statut != '.AffectationStatus::CLOSED->value);
+                    ->where('a.statut != :statutFerme')
+                    ->setParameter('statutFerme', AffectationStatus::CLOSED->value);
 
                 // les signalements n'ayant aucune affectation non fermée ou qui sont fermés
                 $qb->andWhere(

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -138,7 +138,8 @@ class SearchFilter
                 $subquery = $this->entityManager->getRepository(Affectation::class)->createQueryBuilder('a')
                     ->select('DISTINCT s.id')
                     ->innerJoin('a.signalement', 's')
-                    ->where('a.statut = '.AffectationStatus::CLOSED->value);
+                    ->where('a.statut = :statut_affectation_closed')
+                    ->setParameter('statut_affectation_closed', AffectationStatus::CLOSED->value);
 
                 // les signalements n'ayant aucune affectation fermée :
                 $qb->andWhere('s.id NOT IN (:subquery)')
@@ -174,8 +175,8 @@ class SearchFilter
                 $subquery = $this->entityManager->getRepository(Affectation::class)->createQueryBuilder('a')
                     ->select('DISTINCT s.id')
                     ->leftJoin('a.signalement', 's')
-                    ->where('a.statut != :statutFerme')
-                    ->setParameter('statutFerme', AffectationStatus::CLOSED->value);
+                    ->where('a.statut != :statut_affectation_closed')
+                    ->setParameter('statut_affectation_closed', AffectationStatus::CLOSED->value);
 
                 // les signalements n'ayant aucune affectation non fermée ou qui sont fermés
                 $qb->andWhere(


### PR DESCRIPTION
## Ticket

#4333   

## Description
Suite à la modification des status d'affectation, deux requêtes avaient été mal modifiées sur la liste des signalements (filtre `Statut de l'affectation`)

## Tests
- [ ] Jouer avec le filtre `Statut de l'affectation`, et vérifier les résultats
