### PR TITLE
[INFRA] Mise à jour Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - .:/home/wiremock
 
   signal_logement_redis:
-    image: redis:7.2.7-alpine
+    image: redis:7.2.9-alpine
     container_name: signal_logement_redis
 
   signal_logement_clamav:


### PR DESCRIPTION
## Ticket

#4336    

## Description
Avant l'upgrade redis sur scalingo, mise à jour de l'env locale dans un premier temps
<img width="913" height="197" alt="Image" src="https://github.com/user-attachments/assets/edb5a7c4-b4a8-4360-b4f9-c17f7a0562db" />

## Changements apportés
* Upgrade de la version de redis `docker-compose`

## Pré-requis
```
make build
```
## Tests
- [ ] Tester la connexion et déconnexion
- [ ] Le dashboard et les filtres de tri carte + liste fonctionne correctement