### PR TITLE
[TECH] Fix SaveStandaloneFilesInFileEntityCommand

### DIFF
--- a/src/Command/SaveStandaloneFilesInFileEntityCommand.php
+++ b/src/Command/SaveStandaloneFilesInFileEntityCommand.php
@@ -2,7 +2,7 @@
 
 namespace App\Command;
 
-use App\DataFixtures\Loader\LoadFileData;
+use App\Entity\File;
 use App\Factory\FileFactory;
 use App\Repository\UserRepository;
 use App\Service\UploadHandlerService;
@@ -35,7 +35,7 @@ class SaveStandaloneFilesInFileEntityCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $userAdmin = $this->userRepository->findOneBy(['email' => $this->parameterBag->get('admin_email')]);
 
-        foreach (LoadFileData::STANDALONE_FILES as $title => $filename) {
+        foreach (File::STANDALONE_FILES as $title => $filename) {
             $this->uploadHandlerService->uploadFromFilename($filename, $this->parameterBag->get('file_dir'));
             $file = $this->fileFactory->createInstanceFrom(
                 filename: $filename,
@@ -47,7 +47,7 @@ class SaveStandaloneFilesInFileEntityCommand extends Command
         }
 
         $this->entityManager->flush();
-        $io->success(count(LoadFileData::STANDALONE_FILES).' standalone files have been saved in File entity');
+        $io->success(count(File::STANDALONE_FILES).' standalone files have been saved in File entity');
 
         return Command::SUCCESS;
     }

--- a/src/DataFixtures/Loader/LoadFileData.php
+++ b/src/DataFixtures/Loader/LoadFileData.php
@@ -3,6 +3,7 @@
 namespace App\DataFixtures\Loader;
 
 use App\Entity\Enum\DocumentType;
+use App\Entity\File;
 use App\Factory\FileFactory;
 use App\Repository\UserRepository;
 use Doctrine\Bundle\FixturesBundle\Fixture;
@@ -12,15 +13,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class LoadFileData extends Fixture implements OrderedFixtureInterface
 {
-    public const STANDALONE_FILES = [
-        '1 - Demande de transmission d\'une copie d\'un DPE' => '1_Demande_de_transmission_d_une_copie_d_un_DPE.docx',
-        '2 - Information au bailleur - Mise en conformité' => '2_Information_au_bailleur_Mise_en_conformite.docx',
-        '3 - Mise en demeure' => '3_Mise_en_demeure.docx',
-        '4 - Invitation à contacter l\'ADIL' => '4_Invitation_a_contacter_l_ADIL.docx',
-        '5 - Engagement du bailleur à réaliser des travaux' => '5_Engagement_du_bailleur_a_realiser_des_travaux.docx',
-        '6 - Saisine de la Commission départementale de conciliation' => '6_Saisine_de_la_Commission_departementale_de_conciliation.docx',
-    ];
-
     public function __construct(
         private readonly ParameterBagInterface $parameterBag,
         private readonly FileFactory $fileFactory,
@@ -39,7 +31,7 @@ class LoadFileData extends Fixture implements OrderedFixtureInterface
         $manager->persist($file);
 
         $userAdmin = $this->userRepository->findOneBy(['email' => $this->parameterBag->get('admin_email')]);
-        foreach (self::STANDALONE_FILES as $title => $filename) {
+        foreach (File::STANDALONE_FILES as $title => $filename) {
             $file = $this->fileFactory->createInstanceFrom(
                 filename: $filename,
                 title: $title,

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -15,6 +15,15 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: FileRepository::class)]
 class File implements EntityHistoryInterface
 {
+    public const STANDALONE_FILES = [
+        '1 - Demande de transmission d\'une copie d\'un DPE' => '1_Demande_de_transmission_d_une_copie_d_un_DPE.docx',
+        '2 - Information au bailleur - Mise en conformité' => '2_Information_au_bailleur_Mise_en_conformite.docx',
+        '3 - Mise en demeure' => '3_Mise_en_demeure.docx',
+        '4 - Invitation à contacter l\'ADIL' => '4_Invitation_a_contacter_l_ADIL.docx',
+        '5 - Engagement du bailleur à réaliser des travaux' => '5_Engagement_du_bailleur_a_realiser_des_travaux.docx',
+        '6 - Saisine de la Commission départementale de conciliation' => '6_Saisine_de_la_Commission_departementale_de_conciliation.docx',
+    ];
+
     /** @var string[] */
     public const array DOCUMENT_MIME_TYPES = [
         'image/jpeg',


### PR DESCRIPTION
## Ticket

#NumIssue   

## Description
Correction de la commande `app:save-standalone-files-in-file-entity` pour qu'elle ne se base plus sur une constantes dépendante du `FixturesBundle` qui n'est pas dispo en environnement de prod

## Changements apportés
- Déplacement  de la constante `STANDALONE_FILES`

## Tests
- [ ] Jouer `make load-fixtures`
- [ ] Jouer `make symfony cmd="app:save-standalone-files-in-file-entity"`
