### PR TITLE
[BO - Partenaire] Bloquer les noms vides sans avoir d'erreur 500

### DIFF
--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -97,8 +96,6 @@ class PartnerController extends AbstractController
                 'id' => $partner->getId(),
             ]);
         }
-
-        $this->displayErrors($form);
 
         return $this->render('back/partner/edit.html.twig', [
             'partner' => $partner,
@@ -211,8 +208,6 @@ class PartnerController extends AbstractController
                 'id' => $partner->getId(),
             ]);
         }
-
-        $this->displayErrors($form);
 
         return $this->render('back/partner/edit.html.twig', [
             'partner' => $partner,
@@ -619,14 +614,6 @@ class PartnerController extends AbstractController
         $content = $this->renderView('_partials/_modal_user_create_email.html.twig', ['formCheckMail' => $formCheckMail]);
 
         return $this->json(['content' => $content, 'title' => 'Ajouter un utilisateur']);
-    }
-
-    private function displayErrors(FormInterface $form): void
-    {
-        /** @var FormError $error */
-        foreach ($form->getErrors(true) as $error) {
-            $this->addFlash('error', $error->getMessage());
-        }
     }
 
     private function shouldCancelFutureVisite(Intervention $intervention): bool

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -342,7 +342,7 @@ class Partner implements EntityHistoryInterface
         return $this->type;
     }
 
-    public function setType(PartnerType $type): static
+    public function setType(?PartnerType $type): static
     {
         $this->type = $type;
 

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -79,6 +79,7 @@ class Partner implements EntityHistoryInterface
     private ?Territory $territory = null;
 
     #[ORM\Column(type: 'string', nullable: true, enumType: PartnerType::class)]
+    #[Assert\NotBlank(message: 'Merci de choisir le type de partenaire.')]
     private ?PartnerType $type = null;
 
     /** @var array<Qualification> $competence */

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -43,7 +43,7 @@ class Partner implements EntityHistoryInterface
     private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    #[Assert\NotBlank]
+    #[Assert\NotBlank(message: 'Merci de saisir un nom.')]
     #[Assert\Length(max: 255)]
     #[Groups(['widget-settings:read'])]
     private ?string $nom = null;

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -59,7 +59,11 @@ class PartnerType extends AbstractType
         $territory = $options['data']->getTerritory();
 
         $builder
-            ->add('nom', TextType::class, [
+            ->add('nom', null, [
+                'label' => 'Nom du partenaire',
+                'help' => 'Le nom du partenaire sera visible dans les signalements pour les autres partenaires',
+                'required' => false,
+                'empty_data' => '',
                 'attr' => [
                     'class' => 'fr-input',
                 ],

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -64,18 +64,12 @@ class PartnerType extends AbstractType
                 'help' => 'Le nom du partenaire sera visible dans les signalements pour les autres partenaires',
                 'required' => false,
                 'empty_data' => '',
-                'attr' => [
-                    'class' => 'fr-input',
-                ],
             ])
             ->add('email', EmailType::class, [
                 'label' => 'E-mail de contact (facultatif)',
                 'help' => 'S\'il y a des responsables de territoire au sein du partenaire, cette adresse e-mail sera visible par les agents du territoire.',
                 'required' => false,
                 'empty_data' => '',
-                'attr' => [
-                    'class' => 'fr-input',
-                ],
             ])
             ->add('emailNotifiable', ChoiceType::class, [
                 'choices' => [
@@ -89,15 +83,13 @@ class PartnerType extends AbstractType
             ->add('type', EnumType::class, [
                 'label' => 'Type de partenaire',
                 'help' => 'Sélectionnez un type pour afficher les champs à remplir. Si vous ne trouvez pas de type de partenaire adapté, sélectionnez "Autre".',
-                'help_attr' => [
-                    'class' => 'fr-hint-text',
-                ],
                 'class' => EnumPartnerType::class,
                 'choice_label' => function ($choice) {
                     return $choice->label();
                 },
                 'placeholder' => 'Sélectionner un type',
                 'disabled' => !$this->isAdminTerritory,
+                'required' => false,
             ])
             ->add('competence', SearchCheckboxEnumType::class, [
                 'class' => Qualification::class,
@@ -115,9 +107,6 @@ class PartnerType extends AbstractType
                 'noselectionlabel' => 'Sélectionner une ou plusieurs compétences',
                 'nochoiceslabel' => 'Aucune compétence disponible',
                 'help' => 'Choisissez une ou plusieurs compétences parmi la liste ci-dessous.',
-                'help_attr' => [
-                    'class' => 'fr-hint-text',
-                ],
                 'required' => false,
             ])
             ->add('isEsaboraActive', CheckboxType::class, [
@@ -128,17 +117,11 @@ class PartnerType extends AbstractType
                 'disabled' => !$this->isAdminTerritory,
             ])
             ->add('esaboraUrl', UrlType::class, [
-                'attr' => [
-                    'class' => 'fr-input',
-                ],
                 'required' => false,
                 'disabled' => !$this->isAdmin,
                 'default_protocol' => null,
             ])
             ->add('esaboraToken', TextType::class, [
-                'attr' => [
-                    'class' => 'fr-input',
-                ],
                 'required' => false,
                 'disabled' => !$this->isAdmin,
             ]);
@@ -150,9 +133,6 @@ class PartnerType extends AbstractType
                 'required' => false,
             ])
             ->add('idossUrl', UrlType::class, [
-                'attr' => [
-                    'class' => 'fr-input',
-                ],
                 'required' => false,
                 'default_protocol' => null,
             ]);
@@ -167,11 +147,8 @@ class PartnerType extends AbstractType
             'choice_label' => function (Territory $territory) {
                 return $territory->getZip().' - '.$territory->getName();
             },
-            'attr' => [
-                'class' => 'fr-select',
-            ],
             'row_attr' => [
-                'class' => !$this->isAdmin ? 'fr-input-group fr-hidden' : 'fr-input-group',
+                'class' => !$this->isAdmin ? 'fr-hidden' : '',
             ],
             'label' => 'Territoire',
             'required' => true,

--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -69,10 +69,13 @@ class PartnerType extends AbstractType
                 ],
             ])
             ->add('email', EmailType::class, [
+                'label' => 'E-mail de contact (facultatif)',
+                'help' => 'S\'il y a des responsables de territoire au sein du partenaire, cette adresse e-mail sera visible par les agents du territoire.',
+                'required' => false,
+                'empty_data' => '',
                 'attr' => [
                     'class' => 'fr-input',
                 ],
-                'required' => false,
             ])
             ->add('emailNotifiable', ChoiceType::class, [
                 'choices' => [
@@ -84,21 +87,16 @@ class PartnerType extends AbstractType
                 'help' => 'Est-ce que les e-mails concernant les signalements du partenaire doivent être envoyés à cette adresse ?',
             ])
             ->add('type', EnumType::class, [
+                'label' => 'Type de partenaire',
+                'help' => 'Sélectionnez un type pour afficher les champs à remplir. Si vous ne trouvez pas de type de partenaire adapté, sélectionnez "Autre".',
+                'help_attr' => [
+                    'class' => 'fr-hint-text',
+                ],
                 'class' => EnumPartnerType::class,
                 'choice_label' => function ($choice) {
                     return $choice->label();
                 },
-                'row_attr' => [
-                    'class' => 'fr-select-group',
-                ],
                 'placeholder' => 'Sélectionner un type',
-                'attr' => [
-                    'class' => 'fr-select',
-                ],
-                'help' => 'Choisissez un type de partenaire parmi la liste ci-dessous.',
-                'help_attr' => [
-                    'class' => 'fr-hint-text',
-                ],
                 'disabled' => !$this->isAdminTerritory,
             ])
             ->add('competence', SearchCheckboxEnumType::class, [

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -9,16 +9,7 @@
 		<fieldset class="fr-fieldset" role="group" aria-labelledby="info-generale-fieldset-legend">
 			<legend class="fr-fieldset__legend fr-h3 fr-mb-0" id="info-generale-fieldset-legend">Informations générales</legend>
 			<div class="fr-fieldset__element">
-				<div class="fr-input-group">
-					<label for="{{ form.nom.vars.id }}" class="fr-label">
-						Nom du partenaire<sup class="fr-text-label--red-marianne">*</sup>
-						<span class="fr-hint-text">Le nom du partenaire sera visible dans les signalements pour les autres partenaires</span>
-					</label>
-					{{ form_widget(form.nom) }}
-					<p class="fr-error-text fr-hidden">
-						Vous devez renseigner le nom du partenaire.
-					</p>
-				</div>
+                {{ form_row(form.nom) }}
 			</div>
 			<div class="fr-fieldset__element">
 				<div class="fr-input-group">

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -12,28 +12,13 @@
                 {{ form_row(form.nom) }}
 			</div>
 			<div class="fr-fieldset__element">
-				<div class="fr-input-group">
-					<label for="{{ form.email.vars.id }}" class="fr-label">
-						E-mail de contact (facultatif)
-						<span class="fr-hint-text">S'il y a des responsables de territoire au sein du partenaire, cette adresse e-mail sera visible par les agents du territoire.</span>
-					</label>
-					{{ form_widget(form.email) }}
-				</div>
+                {{ form_row(form.email) }}
 			</div>
 			<div class="fr-fieldset__element fr-mb-n1v">
 				{{ form_row(form.emailNotifiable) }}
 			</div>
 			<div class="fr-fieldset__element">
-				<div class="fr-select-group">
-					<label for="{{ form.type.vars.id }}" class="fr-label">
-						Type de partenaire<sup class="fr-text-label--red-marianne">*</sup>
-						<span class="fr-hint-text">Sélectionnez un type pour afficher les champs à remplir. Si vous ne trouvez pas de type de partenaire adapté, sélectionnez "Autre".</span>
-					</label>
-					{{ form_widget(form.type) }}
-					<p class="fr-error-text fr-hidden">
-						Vous devez renseigner le type de partenaire.
-					</p>
-				</div>
+                {{ form_row(form.type) }}
 			</div>
 			<div class="fr-fieldset__element">
 				{% if form.competence is defined %}

--- a/templates/back/partner/_form.html.twig
+++ b/templates/back/partner/_form.html.twig
@@ -1,5 +1,5 @@
 {% form_theme form 'form/dsfr_theme.html.twig' %}
-{{ form_start(form,{attr:{'class':'needs-validation','novalidate':true}}) }}
+{{ form_start(form) }}
 
 <div class="fr-grid-row fr-grid-row--gutters">
 	<div class="fr-col-12">


### PR DESCRIPTION
## Ticket

#4332    

## Description
Lorsqu'on éditait un partenaire et mettait un nom vide, on avait une erreur 500.

## Changements apportés
* Utilisation du formtype pour éviter l'erreur 500 et avoir un affichage propre

## Tests
- [ ] Faire différents tests d'édition de partenaire
