### PR TITLE
[QA] CSP Violation: blocked-uri=https://histologe.matomo.cloud/matomo.php

### DIFF
--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -44,6 +44,8 @@ parameters:
       - "https://data.geopf.fr"
       - "https://cdn.matomo.cloud"
       - "https://histologe.matomo.cloud"
+      - "https://histologe.matomo.cloud/*"
+      - "https://histologe.matomo.cloud/matomo.php"
       - "https://koumoul.com"
       - "https://sentry.incubateur.net"
       - "https://rnb-api.beta.gouv.fr"


### PR DESCRIPTION
## Ticket

#4331   

## Description
Il y a environ 200 événements en prod (plus de 5000 en 2 fois sur la staging) de violation de CSP pour la connexion Matomo.
Plusieurs éléments : 
- 200 évenements, principalement sur une fichie signalement ou sur la liste de signalement
- Principalement sur windows, et sur firefox 128 (donc pas sur des navigateurs exotiques)
- Je n'arrive pas à reproduire, même en testant firefox en navigation privée et mode strict

En conclusion, les violations CSP sont rares et probablement dues à des cas particuliers côté utilisateurs (extensions, réseau, proxy...)

J'ai ajouté "`https://histologe.matomo.cloud/*`" et "`https://histologe.matomo.cloud/matomo.php`" dans le `csp.yaml`, mais normalement c'est inutile

## Changements apportés
* Test ajout de 2 liens matomo dans le fichier csp.yaml (sans y croire)

## Pré-requis

## Tests
- [ ] Les différentes étapes des tests à faire
