### PR TITLE
[BO - Formulaire Pro] Ajout des précisions de hauteur lorsque le plafond est trop bas

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -405,11 +405,21 @@ function initBoFormSignalementDesordres() {
     }
   }
 
+  function clearInputError(event) {
+    const inputTextElement = event.target;
+    inputTextElement.parentElement.classList.remove('fr-input-group--error');
+    const errorElement = inputTextElement.parentElement.querySelector('.fr-error-text');
+    if (errorElement) {
+      errorElement.classList.add('fr-hidden');
+    }
+  }
+
   function updateSelectedPrecisions(modal) {
     const critereId = modal.dataset.critereid;
     const precisionContainer = document.querySelector(`#item-critere-${critereId}`);
 
     let hasPrecisionsChosen = false;
+    let displayPrecisionError = false;
     const ulElement = precisionContainer ? precisionContainer.querySelector('ul') : null;
     if (ulElement) {
       ulElement.innerHTML = '';
@@ -419,8 +429,13 @@ function initBoFormSignalementDesordres() {
           let precision = '';
           if ('desordres_logement_lumiere_plafond_trop_bas' == modal.dataset.critereslug) {
             const inputTextElement = checkbox.parentElement.querySelector("input[type='text']");
+            inputTextElement.removeEventListener('input', clearInputError); // avoids double listener
+            inputTextElement.addEventListener('input', clearInputError);
             if ('' != inputTextElement.value) {
               precision = ' (hauteur : ' + inputTextElement.value + ' cm)';
+            }
+            if (inputTextElement.parentElement.classList.contains('fr-input-group--error')) {
+              displayPrecisionError = true;
             }
           }
 
@@ -458,14 +473,18 @@ function initBoFormSignalementDesordres() {
     }
 
     const errorElement = precisionContainer ? precisionContainer.querySelector('p') : null;
-    if (hasPrecisionsChosen) {
+    if (hasPrecisionsChosen && !displayPrecisionError) {
       precisionContainer.classList.add('fr-border--grey');
       precisionContainer.classList.remove('fr-border--red');
       errorElement.classList.add('fr-hidden');
     } else {
       precisionContainer.classList.remove('fr-border--grey');
       precisionContainer.classList.add('fr-border--red');
-      errorElement.innerHTML = 'Veuillez renseigner les détails du désordre';
+      if (displayPrecisionError) {
+        errorElement.innerHTML = 'Merci de corriger les détails du désordre';
+      } else {
+        errorElement.innerHTML = 'Veuillez renseigner les détails du désordre';
+      }
       errorElement.classList.remove('fr-hidden');
     }
   }

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -416,7 +416,15 @@ function initBoFormSignalementDesordres() {
       const checkboxes = modal.querySelectorAll("input[type='checkbox']");
       checkboxes.forEach((checkbox) => {
         if (checkbox.checked) {
-          const precisionLabel = checkbox.labels[0].innerHTML;
+          let precision = '';
+          if ('desordres_logement_lumiere_plafond_trop_bas' == modal.dataset.critereslug) {
+            const inputTextElement = checkbox.parentElement.querySelector("input[type='text']");
+            if ('' != inputTextElement.value) {
+              precision = ' (hauteur : ' + inputTextElement.value + ' cm)';
+            }
+          }
+
+          const precisionLabel = checkbox.labels[0].innerHTML + precision;
           const precisionItem = document.createElement('li');
           precisionItem.innerHTML = precisionLabel;
           ulElement.appendChild(precisionItem);

--- a/src/Form/SignalementDraftDesordresType.php
+++ b/src/Form/SignalementDraftDesordresType.php
@@ -101,6 +101,8 @@ class SignalementDraftDesordresType extends AbstractType
                     $key = 'desordres_logement_lumiere_plafond_trop_bas'.$suffix;
                     $value = isset($jsonContent[$key]) ? $jsonContent[$key] : null;
                     $builder->add('precisions_'.$critere->getId().'_'.$key, NumberType::class, [
+                        'label' => 'Précisez la hauteur du plafond (en cm)',
+                        'help' => 'Format attendu : saisir un nombre entier',
                         'required' => false,
                         'mapped' => false,
                         'data' => $value,

--- a/src/Form/SignalementDraftDesordresType.php
+++ b/src/Form/SignalementDraftDesordresType.php
@@ -87,7 +87,6 @@ class SignalementDraftDesordresType extends AbstractType
                         'data-slug-critere' => $critere->getSlugCritere(),
                     ],
                 ]);
-
             } elseif ('desordres_logement_lumiere_plafond_trop_bas' === $critereSlug) {
                 $jsonContent = $signalement ? $signalement->getJsonContent() : [];
                 $suffixes = [
@@ -98,7 +97,7 @@ class SignalementDraftDesordresType extends AbstractType
                 ];
 
                 foreach ($suffixes as $suffix) {
-                    $key = $critereSlug.$suffix;
+                    $key = 'desordres_logement_lumiere_plafond_trop_bas'.$suffix;
                     $value = isset($jsonContent[$key]) ? $jsonContent[$key] : '';
                     $builder->add('precisions_'.$critere->getId().'_'.$key, TextType::class, [
                         'label' => 'Hauteur (en cm)',

--- a/src/Form/SignalementDraftDesordresType.php
+++ b/src/Form/SignalementDraftDesordresType.php
@@ -11,6 +11,7 @@ use App\Utils\TrimHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -98,9 +99,8 @@ class SignalementDraftDesordresType extends AbstractType
 
                 foreach ($suffixes as $suffix) {
                     $key = 'desordres_logement_lumiere_plafond_trop_bas'.$suffix;
-                    $value = isset($jsonContent[$key]) ? $jsonContent[$key] : '';
-                    $builder->add('precisions_'.$critere->getId().'_'.$key, TextType::class, [
-                        'label' => 'Hauteur (en cm)',
+                    $value = isset($jsonContent[$key]) ? $jsonContent[$key] : null;
+                    $builder->add('precisions_'.$critere->getId().'_'.$key, NumberType::class, [
                         'required' => false,
                         'mapped' => false,
                         'data' => $value,

--- a/src/Form/SignalementDraftDesordresType.php
+++ b/src/Form/SignalementDraftDesordresType.php
@@ -87,6 +87,30 @@ class SignalementDraftDesordresType extends AbstractType
                         'data-slug-critere' => $critere->getSlugCritere(),
                     ],
                 ]);
+
+            } elseif ('desordres_logement_lumiere_plafond_trop_bas' === $critereSlug) {
+                $jsonContent = $signalement ? $signalement->getJsonContent() : [];
+                $suffixes = [
+                    '_piece_a_vivre',
+                    '_cuisine',
+                    '_salle_de_bain',
+                    '_toutes_pieces',
+                ];
+
+                foreach ($suffixes as $suffix) {
+                    $key = $critereSlug.$suffix;
+                    $value = isset($jsonContent[$key]) ? $jsonContent[$key] : '';
+                    $builder->add('precisions_'.$critere->getId().'_'.$key, TextType::class, [
+                        'label' => 'Hauteur (en cm)',
+                        'required' => false,
+                        'mapped' => false,
+                        'data' => $value,
+                        'attr' => [
+                            'data-slug-critere' => $critere->getSlugCritere(),
+                            'placeholder' => 'Ex : 200',
+                        ],
+                    ]);
+                }
             }
         }
 

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -275,7 +275,7 @@ class SignalementBoManager
                 }
             }
             if (str_starts_with($fieldName, 'precisions_')) {
-                if (str_ends_with($fieldName, 'details_type_nuisibles')) {
+                if (str_ends_with($fieldName, 'details_type_nuisibles') || str_contains($fieldName, '_plafond_trop_bas')) {
                     $idJsonData = $this->extractCritere($fieldName);
                     $jsonContent[$idJsonData] = $fieldData;
                 } else {
@@ -296,6 +296,11 @@ class SignalementBoManager
     {
         // Expression régulière pour capturer la partie "desordres_*_nuisibles_autres"
         if (preg_match('/precisions_\d+_(desordres_[a-z_]+_nuisibles_autres)_details_type_nuisibles/', $fieldName, $matches)) {
+            return $matches[1];
+        }
+
+        // Expression régulière pour capturer la partie "desordres_*_nuisibles_autres" "desordres_*_lumiere_plafond_trop_bas_piece_a_vivre"
+        if (preg_match('/precisions_\d+_(desordres_logement_lumiere_plafond_trop_bas[a-z_]+)/', $fieldName, $matches)) {
             return $matches[1];
         }
 

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -104,8 +104,8 @@
                                                 </label>
                                                 {% if formDesordres and attribute(formDesordres, detailsFieldName) is defined %}
                                                     {{ form_widget(attribute(formDesordres, detailsFieldName)) }}
-                                                    {% else %}
-                                                {{ form_widget(field) }}
+                                                {% else %}
+                                                    {{ form_widget(field) }}
                                                 {% endif %}
                                             </div>
                                         </div>
@@ -118,6 +118,11 @@
                                             <div class="fr-checkbox-group">
                                                 {{ form_widget(child) }}
                                                 <label class="fr-label" for="{{ child.vars.id }}"><span>{{ child.vars.label|raw }}</span></label>
+                                                {# Vérification si le champ texte existe pour le critère plafond trop bas }
+                                                {% if field.vars.attr['data-slug-critere'] is same as 'desordres_logement_lumiere_plafond_trop_bas' %}
+                                                    <label for="{{ child.vars.id }}_taille">Précisez la hauteur du plafond (en cm)</label>
+                                                    <input type="text" class="fr-input" id="{{ child.vars.id }}_taille" name="{{ child.vars.full_name }}_taille" placeholder="Ex : 200" />
+                                                {% endif %#}
                                             </div>
                                         </div>
                                     </fieldset>

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -69,6 +69,7 @@
     {% endif %}
     {% set nuisibles_autres_critere = '_details_type_nuisibles' %}
     {% set nuisibles_logement_autres_critere = '_desordres_logement_nuisibles_autres' %}
+    {% set precisionHauteur = 'desordres_logement_lumiere_plafond_trop_bas' %}
 
     {% if field.vars.name starts with 'precisions_' and not field.rendered %}
         {% set critereId = field.vars.id|replace({'signalement_draft_desordres_precisions_': ''}) %}
@@ -118,11 +119,24 @@
                                             <div class="fr-checkbox-group">
                                                 {{ form_widget(child) }}
                                                 <label class="fr-label" for="{{ child.vars.id }}"><span>{{ child.vars.label|raw }}</span></label>
-                                                {# Vérification si le champ texte existe pour le critère plafond trop bas }
-                                                {% if field.vars.attr['data-slug-critere'] is same as 'desordres_logement_lumiere_plafond_trop_bas' %}
-                                                    <label for="{{ child.vars.id }}_taille">Précisez la hauteur du plafond (en cm)</label>
-                                                    <input type="text" class="fr-input" id="{{ child.vars.id }}_taille" name="{{ child.vars.full_name }}_taille" placeholder="Ex : 200" />
-                                                {% endif %#}
+                                                {# Vérification si le champ texte existe pour le critère plafond trop bas #}
+                                                {% if field.vars.attr['data-slug-critere'] is same as precisionHauteur %}
+                                                    <div class="fr-mt-2v">
+                                                        {% set piece = '_toutes_pieces' %}
+                                                        {% if 'cuisine' in child.vars.label|raw %}
+                                                            {% set piece = '_cuisine' %}
+                                                        {% elseif 'salle de bain' in child.vars.label|raw %}
+                                                            {% set piece = '_salle_de_bain' %}
+                                                        {% elseif 'salon' in child.vars.label|raw %}
+                                                            {% set piece = '_piece_a_vivre' %}
+                                                        {% endif %}
+                                                        {% set detailsFieldName = field.vars.name ~ '_' ~ precisionHauteur ~ piece %}
+                                                        <label for="{{ detailsFieldName }}">Précisez la hauteur du plafond (en cm)</label>
+                                                        {% if formDesordres and attribute(formDesordres, detailsFieldName) is defined %}
+                                                            {{ form_widget(attribute(formDesordres, detailsFieldName)) }}
+                                                        {% endif %}
+                                                    </div>
+                                                {% endif %}
                                             </div>
                                         </div>
                                     </fieldset>

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -131,8 +131,9 @@
                                                             {% set piece = '_piece_a_vivre' %}
                                                         {% endif %}
                                                         {% set detailsFieldName = field.vars.name ~ '_' ~ precisionHauteur ~ piece %}
-                                                        <label for="{{ detailsFieldName }}">Précisez la hauteur du plafond (en cm)</label>
                                                         {% if formDesordres and attribute(formDesordres, detailsFieldName) is defined %}
+                                                            <label for="{{ detailsFieldName }}">Précisez la hauteur du plafond (en cm)</label>
+                                                            <span class="fr-hint-text">Format attendu : saisir un nombre entier</span>
                                                             {{ form_widget(attribute(formDesordres, detailsFieldName)) }}
                                                         {% endif %}
                                                     </div>

--- a/templates/back/signalement_create/tabs/tab-desordres.html.twig
+++ b/templates/back/signalement_create/tabs/tab-desordres.html.twig
@@ -132,9 +132,7 @@
                                                         {% endif %}
                                                         {% set detailsFieldName = field.vars.name ~ '_' ~ precisionHauteur ~ piece %}
                                                         {% if formDesordres and attribute(formDesordres, detailsFieldName) is defined %}
-                                                            <label for="{{ detailsFieldName }}">Précisez la hauteur du plafond (en cm)</label>
-                                                            <span class="fr-hint-text">Format attendu : saisir un nombre entier</span>
-                                                            {{ form_widget(attribute(formDesordres, detailsFieldName)) }}
+                                                            {{ form_row(attribute(formDesordres, detailsFieldName)) }}
                                                         {% endif %}
                                                     </div>
                                                 {% endif %}


### PR DESCRIPTION
## Ticket

#4344   

## Description
Dans le formulaire pro, ajout des précisions de hauteur lorsque le plafond est trop bas

## Pré-requis
`npm run watch`

## Tests
- [ ] Créer un signalement via formulaire pro avec désordre `plafond trop bas`
- [ ] Tester les valeurs dans les différents champs, et l'affichage
- [ ] Tester la validation et l'affichage des désordres
