### PR TITLE
[Suivis] Correction de l'affichage de l'expéditeur quand usager avec compte pro

### DIFF
--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -40,8 +40,8 @@
                 </div>
                 <div class="part-infos-hover" data-template="tippy_suivi_{{ suivi.id }}" >
                 {{
-                    'ROLE_USAGER' in suivi.createdBy.roles or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER
-                        ? (suivi.createdBy.email is same as signalement.mailOccupant
+                    suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').DOCUMENT_DELETED_BY_USAGER
+                        ? (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant
                             ? 'OCCUPANT'~ '\n' ~ suivi.createdBy.nomComplet(true)
                             : 'DECLARANT'~ '\n' ~ suivi.createdBy.nomComplet(true)
                         )|nl2br

--- a/templates/back/signalement/view/suivis.html.twig
+++ b/templates/back/signalement/view/suivis.html.twig
@@ -40,15 +40,15 @@
                 </div>
                 <div class="part-infos-hover" data-template="tippy_suivi_{{ suivi.id }}" >
                 {{
-                    'ROLE_USAGER' in suivi.createdBy.roles
+                    'ROLE_USAGER' in suivi.createdBy.roles or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER
                         ? (suivi.createdBy.email is same as signalement.mailOccupant
-                            ? 'OCCUPANT'~ '\n' ~ suivi.createdBy.nomComplet|capitalize
-                            : 'DECLARANT'~ '\n' ~ suivi.createdBy.nomComplet|capitalize
+                            ? 'OCCUPANT'~ '\n' ~ suivi.createdBy.nomComplet(true)
+                            : 'DECLARANT'~ '\n' ~ suivi.createdBy.nomComplet(true)
                         )|nl2br
                         : (suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory)
                             ? (suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).isArchive
                                 ? 'Partenaire supprimé'
-                                : suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom ~ '\n' ~ suivi.createdBy.prenom ~ ' ' ~ suivi.createdBy.nom
+                                : suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom ~ '\n' ~ suivi.createdBy.nomComplet(true)
                             )
                             : 'Aucun')|nl2br
                 }}

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -70,11 +70,7 @@
 						Suivi automatique
 					{% elseif suivi.createdBy is not null %}
 						{% if suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').DOCUMENT_DELETED_BY_USAGER %}
-							{{
-								(suivi.createdBy.email
-								? (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT')
-								: 'Occupant ou déclarant')
-							}}
+							{{ suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT' }}
 						{% else %}
 							{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
 						{% endif %}					

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -69,7 +69,7 @@
 					{% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
 						Suivi automatique
 					{% elseif suivi.createdBy is not null %}
-						{% if suivi.createdBy.partners|length %}
+						{% if suivi.createdBy.partners|length and suivi.category is not same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER %}
 							{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
 						{% else %}
 							{{(suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')}}

--- a/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
+++ b/templates/front/_partials/_suivi_signalement_tab_suivi.html.twig
@@ -69,10 +69,14 @@
 					{% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
 						Suivi automatique
 					{% elseif suivi.createdBy is not null %}
-						{% if suivi.createdBy.partners|length and suivi.category is not same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER %}
-							{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
+						{% if suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').DOCUMENT_DELETED_BY_USAGER %}
+							{{
+								(suivi.createdBy.email
+								? (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT')
+								: 'Occupant ou déclarant')
+							}}
 						{% else %}
-							{{(suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')}}
+							{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
 						{% endif %}					
             		{% else %}
 						{{(suivi.createdAt|date('Y') >= 2024) ? 'Occupant ou déclarant' : 'Vous' }}					

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -113,10 +113,14 @@
 							{% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
 								Suivi automatique
 							{% elseif suivi.createdBy is not null %}
-								{% if suivi.createdBy.partners|length and suivi.category is not same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER %}
-									{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
+								{% if suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').DOCUMENT_DELETED_BY_USAGER %}
+									{{
+										(suivi.createdBy.email
+										? (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT')
+										: 'Occupant ou déclarant')
+									}}
 								{% else %}
-									{{(suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Occupant ou déclarant')}}
+									{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
 								{% endif %}
 							{% else %}
 								{{(suivi.createdAt|date('Y') >= 2024) ? 'Occupant ou déclarant' : 'Vous' }}

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -113,13 +113,13 @@
 							{% if suivi.type is same as constant('App\\Entity\\Suivi::TYPE_TECHNICAL') %}
 								Suivi automatique
 							{% elseif suivi.createdBy is not null %}
-								{% if suivi.createdBy.partners|length %}
+								{% if suivi.createdBy.partners|length and suivi.category is not same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER %}
 									{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
 								{% else %}
-									{{(suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')}}
-								{% endif %}					
+									{{(suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Occupant ou déclarant')}}
+								{% endif %}
 							{% else %}
-								{{(suivi.createdAt|date('Y') >= 2024) ? 'Occupant ou déclarant' : 'Vous' }}					
+								{{(suivi.createdAt|date('Y') >= 2024) ? 'Occupant ou déclarant' : 'Vous' }}
 							{% endif %}
 							-
 							{{ suivi.createdAt|date('d/m/Y') }}

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -114,11 +114,7 @@
 								Suivi automatique
 							{% elseif suivi.createdBy is not null %}
 								{% if suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').DOCUMENT_DELETED_BY_USAGER %}
-									{{
-										(suivi.createdBy.email
-										? (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT')
-										: 'Occupant ou déclarant')
-									}}
+									{{ suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT' }}
 								{% else %}
 									{{suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A'}}
 								{% endif %}

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -614,10 +614,15 @@
                                         {% if suivi.createdBy.fonction %}({{ suivi.createdBy.fonction }}){% endif %}
                                         <br>
                                         <small>
-                                        {% if suivi.createdBy.partners|length and suivi.category is not same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER %}
-                                            [{{ suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'Aucun' }}]
+                                        {% if suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').DOCUMENT_DELETED_BY_USAGER %}
+							                {{
+                                                (suivi.createdBy.email
+                                                ? (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT')
+                                                : 'Occupant ou déclarant')
+                                                ~ '\n' ~ suivi.createdBy.nomComplet(true)
+                                            }}
                                         {% else %}
-							                {{(suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')}}
+								            [{{ suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'Aucun' }}]
                                         {% endif %}
                                         </small>
                                         <br>

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -610,18 +610,23 @@
                             <tr>
                                 <td style="padding:.5rem;width: 15%">
                                     {% if suivi.createdBy is defined and suivi.createdBy is not null %}
-                                        <b> {{ suivi.createdBy.nom|upper~'. '~ suivi.createdBy.prenom|capitalize }}</b>
+                                        <b> {{ suivi.createdBy.nomComplet(true) }}</b>
                                         {% if suivi.createdBy.fonction %}({{ suivi.createdBy.fonction }}){% endif %}
                                         <br>
-                                        <small>[{{ suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'Aucun' }}
-                                            ]</small>
+                                        <small>
+                                        {% if suivi.createdBy.partners|length and suivi.category is not same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER %}
+                                            [{{ suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory) ? suivi.createdBy.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'Aucun' }}]
+                                        {% else %}
+							                {{(suivi.createdBy.email ? (suivi.createdBy.email is same as signalement.mailOccupant ? 'OCCUPANT' : 'DECLARANT') : 'Aucun')}}
+                                        {% endif %}
+                                        </small>
                                         <br>
                                     {% else %}
                                         <b> Aucun</b>
                                     {% endif %}
                                     <small>{{ suivi.createdAt|date('d/m/Y') }}</small>
                                 </td>
-                                <td style="padding:.5rem;width:85%">  {{ suivi.description|raw }}</td>
+                                <td style="padding:.5rem;width:85%">{{ suivi.description|raw }}</td>
                             </tr>
                         {% endif %}
                     {% endfor %}

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -616,9 +616,7 @@
                                         <small>
                                         {% if suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').DOCUMENT_DELETED_BY_USAGER %}
 							                {{
-                                                (suivi.createdBy.email
-                                                ? (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT')
-                                                : 'Occupant ou déclarant')
+                                                (suivi.createdBy is same as signalement.getSignalementUsager.getOccupant ? 'OCCUPANT' : 'DECLARANT')
                                                 ~ '\n' ~ suivi.createdBy.nomComplet(true)
                                             }}
                                         {% else %}


### PR DESCRIPTION
## Ticket

#4354
#4355

## Description
Correction de l'affichage de l'expéditeur quand usager avec compte pro

## Changements apportés
* Dans fiche signalement
* Dans page de suivi de signalement actuelle et à venir
* Dans pdf

## Pré-requis
`make worker-stop && make worker-start` (pour l'export pdf)

## Tests
- [ ] Créer un signalement via le formulaire pro en utilisant les coordonnées de l'agent connecté (ajouter un occupant, sans saisir d'adresse e-mail)
- [ ] Se connecter à la page de suivi en tant que déclarant, poster un message : vérifier qu'on apparait partout en `Déclarant` (plutôt qu'en agent)
- [ ] Se connecter à la page de suivi en tant qu'occupant, poster un message : vérifier qu'on apparait en `Déclarant ou occupant` (plutôt que `Aucun`)
