### PR TITLE
[QA] Controle du str_replace sur la description des suivis

### DIFF
--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -185,7 +185,7 @@ class Suivi implements EntityHistoryInterface
             return self::DESCRIPTION_DELETED.' '.$this->deletedAt->format('d/m/Y');
         }
 
-        if (!$transformHtml) {
+        if (!$transformHtml || empty($this->description)) {
             $description = $this->description;
         } else {
             $description = str_replace('&lt;br /&gt;', '<br />', $this->description);


### PR DESCRIPTION
## Ticket

#4360   

## Description
Controle du str_replace sur la description des suivis (constaté sur staging, n'arriverait sûrement pas en prod)

## Tests
- [ ] Mettre une `description` de `Suivi` à `null` et vérifier l'affichage 
