### PR TITLE
[BO - Signalement] Gestion par agent : Notifications

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ env:
   FEATURE_SUIVI_ACTION: 1
   MAIL_TEST_ENABLE: 0
   MAIL_TEST_EMAIL: 'mailcatcher@signal-logement.fr'
+  FEATURE_NEW_DASHBOARD: 1
 jobs:
   code-quality:
     name: Signal-logement (PHP ${{ matrix.php-versions }})
@@ -155,4 +156,3 @@ jobs:
           MAINTENANCE_ENABLE: 0
           CLAMAV_STRATEGY: 'clamd_network'
           CLAMAV_HOST: 127.0.0.1
-          FEATURE_NEW_DASHBOARD: 1

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -49,6 +49,7 @@ parameters:
     feature_suivi_action: '%env(bool:FEATURE_SUIVI_ACTION)%'
     proconnect_scheme_protocol: '%env(resolve:PROCONNECT_SCHEME_PROTOCOL)%'
     proconnect_domain: '%env(resolve:PROCONNECT_DOMAIN)%'
+    feature_new_dashboard: '%env(bool:FEATURE_NEW_DASHBOARD)%'
 
 services:
     # default configuration for services in *this* file

--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -81,13 +81,17 @@ class NotifyVisitsCommand extends AbstractCronCommand
                 suivi: $suivi
             );
 
-            $this->visiteNotifier->notifyAgents(
-                intervention: $intervention,
-                suivi: $suivi,
-                currentUser: null,
-                notificationMailerType: NotificationMailerType::TYPE_VISITE_FUTURE_REMINDER_TO_PARTNER,
-                notifyAdminTerritory: false,
-            );
+            if ($this->parameterBag->get('feature_new_dashboard')) {
+                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            } else {
+                $this->visiteNotifier->notifyAgents(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: null,
+                    notificationMailerType: NotificationMailerType::TYPE_VISITE_FUTURE_REMINDER_TO_PARTNER,
+                    notifyAdminTerritory: false,
+                );
+            }
 
             $intervention->setReminderBeforeSentAt(new \DateTimeImmutable());
             $this->interventionManager->save($intervention);
@@ -97,18 +101,26 @@ class NotifyVisitsCommand extends AbstractCronCommand
 
         $listPastVisits = $this->interventionRepository->getPastVisits();
         foreach ($listPastVisits as $intervention) {
-            $pastVisiteReminderUsers = $this->getPastVisiteReminderUsers($intervention);
-            foreach ($pastVisiteReminderUsers as $user) {
-                $this->notificationMailerRegistry->send(
-                    new NotificationMail(
-                        type: NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER,
-                        to: $user->getEmail(),
-                        territory: $intervention->getSignalement()->getTerritory(),
-                        signalement: $intervention->getSignalement(),
-                        intervention: $intervention,
-                    )
+            if ($this->parameterBag->get('feature_new_dashboard')) {
+                $this->visiteNotifier->notifyInterventionSubscribers(
+                    notificationMailerType: NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER,
+                    intervention: $intervention,
                 );
+            } else {
+                $pastVisiteReminderUsers = $this->getPastVisiteReminderUsers($intervention);
+                foreach ($pastVisiteReminderUsers as $user) {
+                    $this->notificationMailerRegistry->send(
+                        new NotificationMail(
+                            type: NotificationMailerType::TYPE_VISITE_PAST_REMINDER_TO_PARTNER,
+                            to: $user->getEmail(),
+                            territory: $intervention->getSignalement()->getTerritory(),
+                            signalement: $intervention->getSignalement(),
+                            intervention: $intervention,
+                        )
+                    );
+                }
             }
+
             $intervention->setReminderConclusionSentAt(new \DateTimeImmutable());
             $this->interventionManager->save($intervention);
             ++$countPastVisits;
@@ -129,15 +141,18 @@ class NotifyVisitsCommand extends AbstractCronCommand
                     context: Suivi::CONTEXT_INTERVENTION,
                 );
 
-                $this->visiteNotifier->notifyAgents(
-                    intervention: null,
-                    suivi: $suivi,
-                    currentUser: null,
-                    notificationMailerType: NotificationMailerType::TYPE_VISITE_NEEDED,
-                    notifyAdminTerritory: false,
-                    affectation: $affectation,
-                );
-
+                if ($this->parameterBag->get('feature_new_dashboard')) {
+                    // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                } else {
+                    $this->visiteNotifier->notifyAgents(
+                        intervention: null,
+                        suivi: $suivi,
+                        currentUser: null,
+                        notificationMailerType: NotificationMailerType::TYPE_VISITE_NEEDED,
+                        notifyAdminTerritory: false,
+                        affectation: $affectation,
+                    );
+                }
                 ++$countVisitsToPlan;
             }
         }

--- a/src/Command/Cron/NotifyVisitsCommand.php
+++ b/src/Command/Cron/NotifyVisitsCommand.php
@@ -82,7 +82,11 @@ class NotifyVisitsCommand extends AbstractCronCommand
             );
 
             if ($this->parameterBag->get('feature_new_dashboard')) {
-                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                $this->visiteNotifier->notifySubscribers(
+                    notificationMailerType: NotificationMailerType::TYPE_VISITE_FUTURE_REMINDER_TO_PARTNER,
+                    intervention: $intervention,
+                    suivi: $suivi,
+                );
             } else {
                 $this->visiteNotifier->notifyAgents(
                     intervention: $intervention,
@@ -142,7 +146,11 @@ class NotifyVisitsCommand extends AbstractCronCommand
                 );
 
                 if ($this->parameterBag->get('feature_new_dashboard')) {
-                    // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                    $this->visiteNotifier->notifyAffectationSubscribers(
+                        notificationMailerType: NotificationMailerType::TYPE_VISITE_NEEDED,
+                        affectation: $affectation,
+                        suivi: $suivi
+                    );
                 } else {
                     $this->visiteNotifier->notifyAgents(
                         intervention: null,

--- a/src/Controller/Back/SignalementActionController.php
+++ b/src/Controller/Back/SignalementActionController.php
@@ -45,6 +45,7 @@ class SignalementActionController extends AbstractController
             /** @var User $user */
             $user = $this->getUser();
             $signalement->setStatut(SignalementStatus::ACTIVE);
+            $subscriptionCreated = false;
             $suiviManager->createSuivi(
                 user : $user,
                 signalement: $signalement,
@@ -53,8 +54,12 @@ class SignalementActionController extends AbstractController
                 category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
                 isPublic: true,
                 context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
+                subscriptionCreated: $subscriptionCreated,
             );
             $this->addFlash('success', 'Signalement accepté avec succès !');
+            if ($subscriptionCreated) {
+                $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+            }
         } else {
             $this->addFlash('error', 'Une erreur est survenue...');
         }
@@ -87,7 +92,7 @@ class SignalementActionController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
         $signalement->setStatut(SignalementStatus::REFUSED);
-
+        $subscriptionCreated = false;
         $suiviManager->createSuivi(
             user : $user,
             signalement: $signalement,
@@ -97,9 +102,12 @@ class SignalementActionController extends AbstractController
             isPublic: true,
             context: Suivi::CONTEXT_SIGNALEMENT_REFUSED,
             files: $refusSignalement->getFiles(),
+            subscriptionCreated: $subscriptionCreated,
         );
-
         $this->addFlash('success', 'Signalement refusé avec succès !');
+        if ($subscriptionCreated) {
+            $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+        }
 
         $url = $this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUuid()], UrlGeneratorInterface::ABSOLUTE_URL);
 
@@ -130,6 +138,7 @@ class SignalementActionController extends AbstractController
         try {
             /** @var User $user */
             $user = $this->getUser();
+            $subscriptionCreated = false;
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: $suivi->getDescription(),
@@ -138,6 +147,7 @@ class SignalementActionController extends AbstractController
                 isPublic: $suivi->getIsPublic(),
                 user: $user,
                 files: $form->get('files')->getData(),
+                subscriptionCreated: $subscriptionCreated,
             );
         } catch (\Throwable $exception) {
             $logger->error($exception->getMessage());
@@ -148,6 +158,9 @@ class SignalementActionController extends AbstractController
         }
         $response = ['code' => Response::HTTP_OK];
         $this->addFlash('success', 'Suivi publié avec succès !');
+        if ($subscriptionCreated) {
+            $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+        }
 
         return $this->json($response, $response['code']);
     }
@@ -211,6 +224,7 @@ class SignalementActionController extends AbstractController
                 }
             }
             $signalement->setStatut(SignalementStatus::ACTIVE);
+            $subscriptionCreated = false;
             $suiviManager->createSuivi(
                 signalement: $signalement,
                 description: 'Signalement rouvert pour '.$reopenFor,
@@ -218,8 +232,12 @@ class SignalementActionController extends AbstractController
                 category: SuiviCategory::SIGNALEMENT_IS_REOPENED,
                 isPublic: '1' === $request->get('publicSuivi'),
                 user: $user,
+                subscriptionCreated: $subscriptionCreated,
             );
             $this->addFlash('success', 'Signalement rouvert avec succès !');
+            if ($subscriptionCreated) {
+                $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+            }
         } else {
             $this->addFlash('error', 'Erreur lors de la réouverture du signalement !');
         }

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -495,11 +495,17 @@ class SignalementCreateController extends AbstractController
                         $signalement->addAffectation($affectation);
                     }
                 }
-                $signalementManager->activateSignalementAndCreateFirstSuivi($signalement, $user);
+                $subscriptionCreated = $signalementManager->activateSignalementAndCreateFirstSuivi($signalement, $user);
                 $this->addFlash('success', 'Le signalement a bien été créé et validé. Il a été affecté aux partenaires définis.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } elseif ($this->isGranted('ROLE_ADMIN_TERRITORY')) {
-                $signalementManager->activateSignalementAndCreateFirstSuivi($signalement, $user);
+                $subscriptionCreated = $signalementManager->activateSignalementAndCreateFirstSuivi($signalement, $user);
                 $this->addFlash('success', 'Le signalement a bien été créé et validé. Vous n\'avez pas défini de partenaires à affecter, rendez-vous dans le signalement pour en affecter !');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $signalement->setStatut(SignalementStatus::NEED_VALIDATION);
                 $eventDispatcher->dispatch(new SignalementCreatedEvent($signalement), SignalementCreatedEvent::NAME);

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -12,6 +12,7 @@ use App\Dto\Request\Signalement\InformationsLogementRequest;
 use App\Dto\Request\Signalement\ProcedureDemarchesRequest;
 use App\Dto\Request\Signalement\SituationFoyerRequest;
 use App\Entity\Signalement;
+use App\Entity\User;
 use App\Manager\SignalementManager;
 use App\Serializer\SignalementDraftRequestSerializer;
 use App\Service\FormHelper;
@@ -48,9 +49,12 @@ class SignalementEditController extends AbstractController
 
             $errorMessage = FormHelper::getErrorsFromRequest($validator, $adresseOccupantRequest);
             if (empty($errorMessage)) {
-                $signalementManager->updateFromAdresseOccupantRequest($signalement, $adresseOccupantRequest);
+                $subscriptionCreated = $signalementManager->updateFromAdresseOccupantRequest($signalement, $adresseOccupantRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'L\'adresse du logement a bien été modifiée.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -89,9 +93,12 @@ class SignalementEditController extends AbstractController
             $errorMessage = FormHelper::getErrorsFromRequest($validator, $coordonneesTiersRequest);
 
             if (empty($errorMessage)) {
-                $signalementManager->updateFromCoordonneesTiersRequest($signalement, $coordonneesTiersRequest);
+                $subscriptionCreated = $signalementManager->updateFromCoordonneesTiersRequest($signalement, $coordonneesTiersRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'Les coordonnées du tiers déclarant ont bien été modifiées.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -134,9 +141,12 @@ class SignalementEditController extends AbstractController
             $errorMessage = FormHelper::getErrorsFromRequest($validator, $coordonneesFoyerRequest, $validationGroups);
 
             if (empty($errorMessage)) {
-                $signalementManager->updateFromCoordonneesFoyerRequest($signalement, $coordonneesFoyerRequest);
+                $subscriptionCreated = $signalementManager->updateFromCoordonneesFoyerRequest($signalement, $coordonneesFoyerRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'Les coordonnées du foyer ont bien été modifiées.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -182,9 +192,12 @@ class SignalementEditController extends AbstractController
             );
 
             if (empty($errorMessage)) {
-                $signalementManager->updateFromCoordonneesBailleurRequest($signalement, $coordonneesBailleurRequest);
+                $subscriptionCreated = $signalementManager->updateFromCoordonneesBailleurRequest($signalement, $coordonneesBailleurRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'Les coordonnées du bailleur ont bien été modifiées.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -230,9 +243,12 @@ class SignalementEditController extends AbstractController
             );
 
             if (empty($errorMessage)) {
-                $signalementManager->updateFromCoordonneesAgenceRequest($signalement, $coordonneesAgenceRequest);
+                $subscriptionCreated = $signalementManager->updateFromCoordonneesAgenceRequest($signalement, $coordonneesAgenceRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'Les coordonnées de l\'agence ont bien été modifiées.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -277,9 +293,12 @@ class SignalementEditController extends AbstractController
             );
 
             if (empty($errorMessage)) {
-                $signalementManager->updateFromInformationsLogementRequest($signalement, $informationsLogementRequest);
+                $subscriptionCreated = $signalementManager->updateFromInformationsLogementRequest($signalement, $informationsLogementRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'Les informations du logement ont bien été modifiées.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -324,9 +343,12 @@ class SignalementEditController extends AbstractController
                 $validationGroups
             );
             if (empty($errorMessage)) {
-                $signalementManager->updateFromCompositionLogementRequest($signalement, $compositionLogementRequest);
+                $subscriptionCreated = $signalementManager->updateFromCompositionLogementRequest($signalement, $compositionLogementRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'La description du logement a bien été modifiée.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -371,9 +393,12 @@ class SignalementEditController extends AbstractController
             $errorMessage = FormHelper::getErrorsFromRequest($validator, $situationFoyerRequest, $validationGroups);
 
             if (empty($errorMessage)) {
-                $signalementManager->updateFromSituationFoyerRequest($signalement, $situationFoyerRequest);
+                $subscriptionCreated = $signalementManager->updateFromSituationFoyerRequest($signalement, $situationFoyerRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'La situation du foyer a bien été modifiée.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];
@@ -414,9 +439,12 @@ class SignalementEditController extends AbstractController
             $errorMessage = FormHelper::getErrorsFromRequest($validator, $procedureDemarchesRequest, $validationGroups);
 
             if (empty($errorMessage)) {
-                $signalementManager->updateFromProcedureDemarchesRequest($signalement, $procedureDemarchesRequest);
+                $subscriptionCreated = $signalementManager->updateFromProcedureDemarchesRequest($signalement, $procedureDemarchesRequest);
                 $response = ['code' => Response::HTTP_OK];
                 $this->addFlash('success', 'Les procédures et démarches ont bien été modifiées.');
+                if ($subscriptionCreated) {
+                    $this->addFlash('success', User::MSG_SUBSCRIPTION_CREATED);
+                }
             } else {
                 $response = ['code' => Response::HTTP_BAD_REQUEST];
                 $response = [...$response, ...$errorMessage];

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -183,6 +183,13 @@ affectations:
     affected_by: "admin-01@signal-logement.fr"
     territory: "Pas-de-Calais"
   -
+    signalement: 2024-02
+    partner: "partenaire-62-01@signal-logement.fr"
+    statut: "EN_COURS"
+    answered_by: "user-62-01@signal-logement.fr"
+    affected_by: "admin-territoire-62-01@signal-logement.fr"
+    territory: "Pas-de-Calais"
+  -
     signalement: 2023-20
     partner: "partenaire-13-01@signal-logement.fr"
     statut: "EN_COURS"

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -116,7 +116,7 @@ signalements:
     adresse_occupant: "47 Rue du Général Chanzy"
     cp_occupant: "62100"
     ville_occupant: "Calais"
-    statut: "NEED_VALIDATION"
+    statut: "ACTIVE"
     geoloc: "{\"lat\": 50.94877, \"lng\": 1.85867}"
     insee_occupant: "62193"
     nb_pieces_logement: 5

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -394,6 +394,7 @@ users:
     partner: "Partenaire Zone Agde"
     statut: "ACTIVE"
     is_mailing_active: 1
+    is_mailing_summary: 0
   -
     email: admin-territoire-34-02@signal-logement.fr
     roles: "[\"ROLE_ADMIN_TERRITORY\"]"

--- a/src/DataFixtures/Loader/LoadSuiviData.php
+++ b/src/DataFixtures/Loader/LoadSuiviData.php
@@ -29,20 +29,20 @@ class LoadSuiviData extends Fixture implements OrderedFixtureInterface
      */
     public function load(ObjectManager $manager): void
     {
-        $signalements = $this->signalementRepository->findBy(['statut' => [
-            SignalementStatus::ACTIVE->value,
-            SignalementStatus::CLOSED->value,
-        ]]);
+        $signalements = $this->signalementRepository->findBy(['statut' => [SignalementStatus::ACTIVE->value, SignalementStatus::CLOSED->value]]);
+        $admin = $this->userRepository->findOneBy(['email' => $this->parameterBag->get('user_system_email')]);
 
         $second = 1;
         foreach ($signalements as $signalement) {
+            $rt = $this->userRepository->findActiveTerritoryAdmins($signalement->getTerritory()->getId());
+            $user = $rt ? $rt[0] : $admin;
             $suivi = $this->suiviManager->createSuivi(
                 signalement: $signalement,
                 description: Suivi::DESCRIPTION_SIGNALEMENT_VALIDE,
                 type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
                 isPublic: true,
-                user: $this->userRepository->findOneBy(['email' => $this->parameterBag->get('user_system_email')]),
+                user: $user,
                 context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
                 flush: false,
             );

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -54,6 +54,8 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         'API' => 'ROLE_API_USER',
     ];
 
+    public const string MSG_SUBSCRIPTION_CREATED = 'Vous êtes désormais abonné à ce signalement.';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -54,7 +54,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         'API' => 'ROLE_API_USER',
     ];
 
-    public const string MSG_SUBSCRIPTION_CREATED = 'Vous êtes désormais abonné à ce signalement.';
+    public const string MSG_SUBSCRIPTION_CREATED = 'Vous avez rejoint le dossier et recevez désormais les notifications le concernant.';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/EventSubscriber/AffectationClosedSubscriber.php
+++ b/src/EventSubscriber/AffectationClosedSubscriber.php
@@ -44,7 +44,7 @@ readonly class AffectationClosedSubscriber implements EventSubscriberInterface
         );
 
         $signalement->addSuivi($suivi);
-        $this->notificationAndMailSender->sendAffectationClosed($affectation, $user);
+        $this->notificationAndMailSender->sendAffectationClosed($affectation);
         $this->signalementManager->save($signalement);
     }
 }

--- a/src/EventSubscriber/InterventionAbortedSubscriber.php
+++ b/src/EventSubscriber/InterventionAbortedSubscriber.php
@@ -11,6 +11,7 @@ use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\Event;
 
@@ -22,6 +23,8 @@ class InterventionAbortedSubscriber implements EventSubscriberInterface
         private Security $security,
         private VisiteNotifier $visiteNotifier,
         private SuiviManager $suiviManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -58,13 +61,17 @@ class InterventionAbortedSubscriber implements EventSubscriberInterface
                 suivi: $suivi
             );
 
-            $this->visiteNotifier->notifyAgents(
-                intervention: $intervention,
-                suivi: $suivi,
-                currentUser: $currentUser,
-                notificationMailerType: NotificationMailerType::TYPE_VISITE_ABORTED_TO_PARTNER,
-                notifyOtherAffectedPartners: true,
-            );
+            if ($this->featureNewDashboard) {
+                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            } else {
+                $this->visiteNotifier->notifyAgents(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                    notificationMailerType: NotificationMailerType::TYPE_VISITE_ABORTED_TO_PARTNER,
+                    notifyOtherAffectedPartners: true,
+                );
+            }
         }
     }
 }

--- a/src/EventSubscriber/InterventionAbortedSubscriber.php
+++ b/src/EventSubscriber/InterventionAbortedSubscriber.php
@@ -62,7 +62,12 @@ class InterventionAbortedSubscriber implements EventSubscriberInterface
             );
 
             if ($this->featureNewDashboard) {
-                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                $this->visiteNotifier->notifySubscribers(
+                    notificationMailerType: NotificationMailerType::TYPE_VISITE_ABORTED_TO_PARTNER,
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                );
             } else {
                 $this->visiteNotifier->notifyAgents(
                     intervention: $intervention,

--- a/src/EventSubscriber/InterventionCanceledSubscriber.php
+++ b/src/EventSubscriber/InterventionCanceledSubscriber.php
@@ -63,7 +63,7 @@ class InterventionCanceledSubscriber implements EventSubscriberInterface
             );
 
             if ($this->featureNewDashboard) {
-                $this->visiteNotifier->NotifyInAppSubscribers(
+                $this->visiteNotifier->notifyInAppSubscribers(
                     intervention: $intervention,
                     suivi: $suivi,
                     currentUser: $currentUser,

--- a/src/EventSubscriber/InterventionCanceledSubscriber.php
+++ b/src/EventSubscriber/InterventionCanceledSubscriber.php
@@ -63,7 +63,11 @@ class InterventionCanceledSubscriber implements EventSubscriberInterface
             );
 
             if ($this->featureNewDashboard) {
-                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                $this->visiteNotifier->NotifyInAppSubscribers(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                );
             } else {
                 $this->visiteNotifier->notifyAgents(
                     intervention: $intervention,

--- a/src/EventSubscriber/InterventionCanceledSubscriber.php
+++ b/src/EventSubscriber/InterventionCanceledSubscriber.php
@@ -11,6 +11,7 @@ use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\Event;
 
@@ -22,6 +23,8 @@ class InterventionCanceledSubscriber implements EventSubscriberInterface
         private Security $security,
         private VisiteNotifier $visiteNotifier,
         private SuiviManager $suiviManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -59,13 +62,17 @@ class InterventionCanceledSubscriber implements EventSubscriberInterface
                 suivi: $suivi
             );
 
-            $this->visiteNotifier->notifyAgents(
-                intervention: $intervention,
-                suivi: $suivi,
-                currentUser: $currentUser,
-                notificationMailerType: null,
-                notifyOtherAffectedPartners: true,
-            );
+            if ($this->featureNewDashboard) {
+                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            } else {
+                $this->visiteNotifier->notifyAgents(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                    notificationMailerType: null,
+                    notifyOtherAffectedPartners: true,
+                );
+            }
         }
     }
 }

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -11,6 +11,7 @@ use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Workflow\Event\TransitionEvent;
 
@@ -22,6 +23,8 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
         private readonly Security $security,
         private readonly VisiteNotifier $visiteNotifier,
         private readonly SuiviManager $suiviManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -71,13 +74,17 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
                 );
             }
 
-            $this->visiteNotifier->notifyAgents(
-                intervention: $intervention,
-                suivi: $suivi,
-                currentUser: $currentUser,
-                notificationMailerType: NotificationMailerType::TYPE_VISITE_CONFIRMED_TO_PARTNER,
-                notifyOtherAffectedPartners: true,
-            );
+            if ($this->featureNewDashboard) {
+                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            } else {
+                $this->visiteNotifier->notifyAgents(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                    notificationMailerType: NotificationMailerType::TYPE_VISITE_CONFIRMED_TO_PARTNER,
+                    notifyOtherAffectedPartners: true,
+                );
+            }
         }
     }
 }

--- a/src/EventSubscriber/InterventionConfirmedSubscriber.php
+++ b/src/EventSubscriber/InterventionConfirmedSubscriber.php
@@ -75,7 +75,12 @@ class InterventionConfirmedSubscriber implements EventSubscriberInterface
             }
 
             if ($this->featureNewDashboard) {
-                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                $this->visiteNotifier->notifySubscribers(
+                    notificationMailerType: NotificationMailerType::TYPE_VISITE_CONFIRMED_TO_PARTNER,
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                );
             } else {
                 $this->visiteNotifier->notifyAgents(
                     intervention: $intervention,

--- a/src/EventSubscriber/InterventionCreatedSubscriber.php
+++ b/src/EventSubscriber/InterventionCreatedSubscriber.php
@@ -10,6 +10,7 @@ use App\Manager\SuiviManager;
 use App\Service\Intervention\InterventionDescriptionGenerator;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 readonly class InterventionCreatedSubscriber implements EventSubscriberInterface
@@ -17,6 +18,8 @@ readonly class InterventionCreatedSubscriber implements EventSubscriberInterface
     public function __construct(
         private VisiteNotifier $visiteNotifier,
         private SuiviManager $suiviManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -59,12 +62,16 @@ readonly class InterventionCreatedSubscriber implements EventSubscriberInterface
             );
         }
 
-        $this->visiteNotifier->notifyAgents(
-            intervention: $intervention,
-            suivi: $suivi,
-            currentUser: $event->getUser(),
-            notificationMailerType: null,
-            notifyOtherAffectedPartners: true,
-        );
+        if ($this->featureNewDashboard) {
+            // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+        } else {
+            $this->visiteNotifier->notifyAgents(
+                intervention: $intervention,
+                suivi: $suivi,
+                currentUser: $event->getUser(),
+                notificationMailerType: null,
+                notifyOtherAffectedPartners: true,
+            );
+        }
     }
 }

--- a/src/EventSubscriber/InterventionCreatedSubscriber.php
+++ b/src/EventSubscriber/InterventionCreatedSubscriber.php
@@ -63,7 +63,7 @@ readonly class InterventionCreatedSubscriber implements EventSubscriberInterface
         }
 
         if ($this->featureNewDashboard) {
-            $this->visiteNotifier->NotifyInAppSubscribers(
+            $this->visiteNotifier->notifyInAppSubscribers(
                 intervention: $intervention,
                 suivi: $suivi,
                 currentUser: $event->getUser(),

--- a/src/EventSubscriber/InterventionCreatedSubscriber.php
+++ b/src/EventSubscriber/InterventionCreatedSubscriber.php
@@ -63,7 +63,11 @@ readonly class InterventionCreatedSubscriber implements EventSubscriberInterface
         }
 
         if ($this->featureNewDashboard) {
-            // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            $this->visiteNotifier->NotifyInAppSubscribers(
+                intervention: $intervention,
+                suivi: $suivi,
+                currentUser: $event->getUser(),
+            );
         } else {
             $this->visiteNotifier->notifyAgents(
                 intervention: $intervention,

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -59,7 +59,7 @@ readonly class InterventionEditedSubscriber implements EventSubscriberInterface
             }
 
             if ($this->featureNewDashboard) {
-                $this->visiteNotifier->NotifyInAppSubscribers(
+                $this->visiteNotifier->notifyInAppSubscribers(
                     intervention: $intervention,
                     suivi: $suivi,
                     currentUser: $currentUser,

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -9,6 +9,7 @@ use App\Event\InterventionEditedEvent;
 use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 readonly class InterventionEditedSubscriber implements EventSubscriberInterface
@@ -16,6 +17,8 @@ readonly class InterventionEditedSubscriber implements EventSubscriberInterface
     public function __construct(
         private VisiteNotifier $visiteNotifier,
         private SuiviManager $suiviManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -55,12 +58,16 @@ readonly class InterventionEditedSubscriber implements EventSubscriberInterface
                 );
             }
 
-            $this->visiteNotifier->notifyAgents(
-                intervention: $intervention,
-                suivi: $suivi,
-                currentUser: $currentUser,
-                notificationMailerType: null,
-            );
+            if ($this->featureNewDashboard) {
+                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            } else {
+                $this->visiteNotifier->notifyAgents(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                    notificationMailerType: null,
+                );
+            }
         }
     }
 }

--- a/src/EventSubscriber/InterventionEditedSubscriber.php
+++ b/src/EventSubscriber/InterventionEditedSubscriber.php
@@ -59,7 +59,11 @@ readonly class InterventionEditedSubscriber implements EventSubscriberInterface
             }
 
             if ($this->featureNewDashboard) {
-                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                $this->visiteNotifier->NotifyInAppSubscribers(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $currentUser,
+                );
             } else {
                 $this->visiteNotifier->notifyAgents(
                     intervention: $intervention,

--- a/src/EventSubscriber/InterventionRescheduledSubscriber.php
+++ b/src/EventSubscriber/InterventionRescheduledSubscriber.php
@@ -58,7 +58,11 @@ class InterventionRescheduledSubscriber implements EventSubscriberInterface
             );
 
             if ($this->featureNewDashboard) {
-                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+                $this->visiteNotifier->NotifyInAppSubscribers(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $event->getUser(),
+                );
             } else {
                 $this->visiteNotifier->notifyAgents(
                     intervention: $intervention,

--- a/src/EventSubscriber/InterventionRescheduledSubscriber.php
+++ b/src/EventSubscriber/InterventionRescheduledSubscriber.php
@@ -9,6 +9,7 @@ use App\Event\InterventionRescheduledEvent;
 use App\Manager\SuiviManager;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class InterventionRescheduledSubscriber implements EventSubscriberInterface
@@ -16,6 +17,8 @@ class InterventionRescheduledSubscriber implements EventSubscriberInterface
     public function __construct(
         private readonly VisiteNotifier $visiteNotifier,
         private readonly SuiviManager $suiviManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -54,13 +57,17 @@ class InterventionRescheduledSubscriber implements EventSubscriberInterface
                 previousDate: $event->getPreviousDate()
             );
 
-            $this->visiteNotifier->notifyAgents(
-                intervention: $intervention,
-                suivi: $suivi,
-                currentUser: $event->getUser(),
-                notificationMailerType: null,
-                notifyOtherAffectedPartners: true,
-            );
+            if ($this->featureNewDashboard) {
+                // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            } else {
+                $this->visiteNotifier->notifyAgents(
+                    intervention: $intervention,
+                    suivi: $suivi,
+                    currentUser: $event->getUser(),
+                    notificationMailerType: null,
+                    notifyOtherAffectedPartners: true,
+                );
+            }
         }
     }
 }

--- a/src/EventSubscriber/InterventionRescheduledSubscriber.php
+++ b/src/EventSubscriber/InterventionRescheduledSubscriber.php
@@ -58,7 +58,7 @@ class InterventionRescheduledSubscriber implements EventSubscriberInterface
             );
 
             if ($this->featureNewDashboard) {
-                $this->visiteNotifier->NotifyInAppSubscribers(
+                $this->visiteNotifier->notifyInAppSubscribers(
                     intervention: $intervention,
                     suivi: $suivi,
                     currentUser: $event->getUser(),

--- a/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
+++ b/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
@@ -10,6 +10,7 @@ use App\Manager\SuiviManager;
 use App\Service\Intervention\InterventionDescriptionGenerator;
 use App\Service\Mailer\NotificationMailerType;
 use App\Service\Signalement\VisiteNotifier;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 readonly class InterventionUpdatedByEsaboraSubscriber implements EventSubscriberInterface
@@ -17,6 +18,8 @@ readonly class InterventionUpdatedByEsaboraSubscriber implements EventSubscriber
     public function __construct(
         private VisiteNotifier $visiteNotifier,
         private SuiviManager $suiviManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -60,12 +63,16 @@ readonly class InterventionUpdatedByEsaboraSubscriber implements EventSubscriber
             );
         }
 
-        $this->visiteNotifier->notifyAgents(
-            intervention: $intervention,
-            suivi: $suivi,
-            currentUser: $event->getUser(),
-            notificationMailerType: null,
-            notifyOtherAffectedPartners: true,
-        );
+        if ($this->featureNewDashboard) {
+            // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+        } else {
+            $this->visiteNotifier->notifyAgents(
+                intervention: $intervention,
+                suivi: $suivi,
+                currentUser: $event->getUser(),
+                notificationMailerType: null,
+                notifyOtherAffectedPartners: true,
+            );
+        }
     }
 }

--- a/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
+++ b/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
@@ -64,7 +64,7 @@ readonly class InterventionUpdatedByEsaboraSubscriber implements EventSubscriber
         }
 
         if ($this->featureNewDashboard) {
-            $this->visiteNotifier->NotifyInAppSubscribers(
+            $this->visiteNotifier->notifyInAppSubscribers(
                 intervention: $intervention,
                 suivi: $suivi,
                 currentUser: $event->getUser(),

--- a/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
+++ b/src/EventSubscriber/InterventionUpdatedByEsaboraSubscriber.php
@@ -64,7 +64,11 @@ readonly class InterventionUpdatedByEsaboraSubscriber implements EventSubscriber
         }
 
         if ($this->featureNewDashboard) {
-            // Rentre à présent dans le système classique de notification à la création de suivi (voir SuiviCreatedSubscriber->onSuiviCreated)
+            $this->visiteNotifier->NotifyInAppSubscribers(
+                intervention: $intervention,
+                suivi: $suivi,
+                currentUser: $event->getUser(),
+            );
         } else {
             $this->visiteNotifier->notifyAgents(
                 intervention: $intervention,

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -7,7 +7,6 @@ use App\Entity\Enum\SuiviCategory;
 use App\Entity\Suivi;
 use App\Event\SuiviCreatedEvent;
 use App\Service\NotificationAndMailSender;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class SuiviCreatedSubscriber implements EventSubscriberInterface
@@ -16,8 +15,6 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private readonly NotificationAndMailSender $notificationAndMailSender,
-        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
-        private readonly bool $featureNewDashboard,
     ) {
     }
 
@@ -35,7 +32,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
         if (Suivi::TYPE_TECHNICAL === $suivi->getType()) {
             return;
         }
-        if (Suivi::CONTEXT_INTERVENTION === $suivi->getContext() && !$this->featureNewDashboard) {
+        if (Suivi::CONTEXT_INTERVENTION === $suivi->getContext()) {
             return;
         }
 
@@ -46,9 +43,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
         }
 
         $this->sendToAdminAndPartners($suivi);
-        if (Suivi::CONTEXT_INTERVENTION !== $suivi->getContext()) {
-            $this->sendToUsagers($suivi);
-        }
+        $this->sendToUsagers($suivi);
     }
 
     private function sendToAdminAndPartners(Suivi $suivi): void

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -46,7 +46,9 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
         }
 
         $this->sendToAdminAndPartners($suivi);
-        $this->sendToUsagers($suivi);
+        if (Suivi::CONTEXT_INTERVENTION !== $suivi->getContext()) {
+            $this->sendToUsagers($suivi);
+        }
     }
 
     private function sendToAdminAndPartners(Suivi $suivi): void

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -176,7 +176,7 @@ class AffectationManager extends Manager
     private function removeAffectationAndSubscriptions(Affectation $affectation): void
     {
         if ($this->featureNewDashboard) {
-            $subscriptions = $this->userSignalementSubscriptionRepository->findForAffectation($affectation);
+            $subscriptions = $this->userSignalementSubscriptionRepository->findForAffectation(affectation: $affectation, excludeRT: true);
             foreach ($subscriptions as $subscription) {
                 $this->remove($subscription);
             }

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -339,7 +339,7 @@ class SignalementManager extends AbstractManager
     public function updateFromAdresseOccupantRequest(
         Signalement $signalement,
         AdresseOccupantRequest $adresseOccupantRequest,
-    ): void {
+    ): bool {
         $signalement->setAdresseOccupant($adresseOccupantRequest->getAdresse())
             ->setCpOccupant($adresseOccupantRequest->getCodePostal())
             ->setVilleOccupant($adresseOccupantRequest->getVille())
@@ -355,7 +355,7 @@ class SignalementManager extends AbstractManager
 
         $this->save($signalement);
 
-        $this->suiviManager->addSuiviIfNeeded(
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'L\'adresse du logement a été modifiée par '
         );
@@ -364,7 +364,7 @@ class SignalementManager extends AbstractManager
     public function updateFromCoordonneesTiersRequest(
         Signalement $signalement,
         CoordonneesTiersRequest $coordonneesTiersRequest,
-    ): void {
+    ): bool {
         if (ProfileDeclarant::BAILLEUR == $signalement->getProfileDeclarant()) {
             $signalement
                 ->setTypeProprio(
@@ -392,7 +392,8 @@ class SignalementManager extends AbstractManager
         }
 
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'Les coordonnées du tiers déclarant ont été modifiées par ',
         );
@@ -401,7 +402,7 @@ class SignalementManager extends AbstractManager
     public function updateFromCoordonneesFoyerRequest(
         Signalement $signalement,
         CoordonneesFoyerRequest $coordonneesFoyerRequest,
-    ): void {
+    ): bool {
         if (ProfileDeclarant::BAILLEUR_OCCUPANT == $signalement->getProfileDeclarant()) {
             $signalement
                 ->setTypeProprio(
@@ -421,7 +422,8 @@ class SignalementManager extends AbstractManager
             ->setTelOccupantBis($coordonneesFoyerRequest->getTelephoneBis());
 
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'Les coordonnées du foyer ont été modifiées par ',
         );
@@ -430,7 +432,7 @@ class SignalementManager extends AbstractManager
     public function updateFromCoordonneesBailleurRequest(
         Signalement $signalement,
         CoordonneesBailleurRequest $coordonneesBailleurRequest,
-    ): void {
+    ): bool {
         $bailleur = null;
         if ($signalement->getIsLogementSocial() && $coordonneesBailleurRequest->getDenomination()) {
             $bailleur = $this->bailleurRepository->findOneBailleurBy(
@@ -477,7 +479,8 @@ class SignalementManager extends AbstractManager
         $signalement->setInformationComplementaire($informationComplementaire);
 
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'Les coordonnées du bailleur ont été modifiées par ',
         );
@@ -486,7 +489,7 @@ class SignalementManager extends AbstractManager
     public function updateFromCoordonneesAgenceRequest(
         Signalement $signalement,
         CoordonneesAgenceRequest $coordonneesAgenceRequest,
-    ): void {
+    ): bool {
         $signalement
             ->setDenominationAgence($coordonneesAgenceRequest->getDenomination())
             ->setNomAgence($coordonneesAgenceRequest->getNom())
@@ -499,7 +502,8 @@ class SignalementManager extends AbstractManager
             ->setVilleAgence($coordonneesAgenceRequest->getVille());
 
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'Les coordonnées de l\'agence ont été modifiées par ',
         );
@@ -508,7 +512,7 @@ class SignalementManager extends AbstractManager
     public function updateFromInformationsLogementRequest(
         Signalement $signalement,
         InformationsLogementRequest $informationsLogementRequest,
-    ): void {
+    ): bool {
         if (is_numeric($informationsLogementRequest->getNombrePersonnes())) {
             $signalement->setNbOccupantsLogement((int) $informationsLogementRequest->getNombrePersonnes());
         }
@@ -596,7 +600,8 @@ class SignalementManager extends AbstractManager
         $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
 
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'Les informations sur le logement ont été modifiées par ',
         );
@@ -652,7 +657,7 @@ class SignalementManager extends AbstractManager
     public function updateFromCompositionLogementRequest(
         Signalement $signalement,
         CompositionLogementRequest $compositionLogementRequest,
-    ): void {
+    ): bool {
         $signalement->setNatureLogement($compositionLogementRequest->getType());
         $signalement->setSuperficie((float) $compositionLogementRequest->getSuperficie());
 
@@ -709,7 +714,8 @@ class SignalementManager extends AbstractManager
         $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
 
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'La description du logement a été modifiée par ',
         );
@@ -721,7 +727,7 @@ class SignalementManager extends AbstractManager
     public function updateFromSituationFoyerRequest(
         Signalement $signalement,
         SituationFoyerRequest $situationFoyerRequest,
-    ): void {
+    ): bool {
         $signalement
             ->setIsLogementSocial(
                 SignalementInputValueMapper::map(
@@ -807,7 +813,8 @@ class SignalementManager extends AbstractManager
         $this->updateDesordresAndScoreWithSuroccupationChanges($signalement);
         $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'La situation du foyer a été modifiée par ',
         );
@@ -816,7 +823,7 @@ class SignalementManager extends AbstractManager
     public function updateFromProcedureDemarchesRequest(
         Signalement $signalement,
         ProcedureDemarchesRequest $procedureDemarchesRequest,
-    ): void {
+    ): bool {
         $signalement->setIsProprioAverti('' === $procedureDemarchesRequest->getIsProprioAverti() ? null : (bool) ($procedureDemarchesRequest->getIsProprioAverti()));
 
         $informationProcedure = new InformationProcedure();
@@ -852,7 +859,8 @@ class SignalementManager extends AbstractManager
         }
 
         $this->save($signalement);
-        $this->suiviManager->addSuiviIfNeeded(
+
+        return $this->suiviManager->addSuiviIfNeeded(
             signalement: $signalement,
             description: 'Les procédures et démarches ont été modifiées par ',
         );
@@ -917,12 +925,12 @@ class SignalementManager extends AbstractManager
         }
     }
 
-    public function activateSignalementAndCreateFirstSuivi(Signalement $signalement, ?User $adminUser): void
+    public function activateSignalementAndCreateFirstSuivi(Signalement $signalement, ?User $adminUser): bool
     {
         $signalement->setStatut(SignalementStatus::ACTIVE);
         $signalement->setValidatedAt(new \DateTimeImmutable());
         $this->persist($signalement);
-
+        $subscriptionCreated = false;
         $suivi = $this->suiviManager->createSuivi(
             user: $adminUser,
             signalement: $signalement,
@@ -931,8 +939,11 @@ class SignalementManager extends AbstractManager
             category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
             isPublic: true,
             context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
-            flush: false
+            flush: false,
+            subscriptionCreated: $subscriptionCreated
         );
         $this->persist($suivi);
+
+        return $subscriptionCreated;
     }
 }

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -400,6 +400,9 @@ class PartnerRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * @deprecated this method will be removed once the FEATURE_NEW_DASHBOARD feature flag is removed
+     */
     public function getWithUserPartners(Partner $partner): Partner
     {
         return $this->createQueryBuilder('p')

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -69,9 +69,9 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $queryBuilder = $this->createQueryBuilder('u');
 
         return $queryBuilder
-            ->andWhere('u.roles LIKE :role')
-            ->setParameter('role', '%"ROLE_ADMIN"%')
-            ->andWhere('u.statut LIKE :active')
+            ->andWhere('JSON_CONTAINS(u.roles, :role_admin) = 1')
+            ->setParameter('role_admin', '"ROLE_ADMIN"')
+            ->andWhere('u.statut = :active')
             ->setParameter('active', UserStatus::ACTIVE)
             ->getQuery()
             ->getResult();
@@ -540,6 +540,8 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     }
 
     /**
+     * @deprecated this method will be removed once the FEATURE_NEW_DASHBOARD feature flag is removed
+     *
      * @return array<int, User>
      */
     public function findUsersAffectedToSignalement(Signalement $signalement, ?Partner $partnerToExclude = null): array
@@ -557,6 +559,25 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             $queryBuilder
                 ->andWhere('a.partner != :partner')
                 ->setParameter('partner', $partnerToExclude);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * @return array<int, User>
+     */
+    public function findUsersSubscribedToSignalement(Signalement $signalement, ?bool $onlyRT = false): array
+    {
+        $queryBuilder = $this->createQueryBuilder('u')
+            ->innerJoin('u.userSignalementSubscriptions', 'uss')
+            ->where('uss.signalement = :signalement')
+            ->setParameter('signalement', $signalement)
+            ->andWhere('u.statut = :userStatus')
+            ->setParameter('userStatus', UserStatus::ACTIVE);
+        if ($onlyRT) {
+            $queryBuilder->andWhere('JSON_CONTAINS(u.roles, :roleRT) = 1')
+                ->setParameter('roleRT', '"ROLE_ADMIN_TERRITORY"');
         }
 
         return $queryBuilder->getQuery()->getResult();

--- a/src/Repository/UserSignalementSubscriptionRepository.php
+++ b/src/Repository/UserSignalementSubscriptionRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Affectation;
 use App\Entity\UserSignalementSubscription;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -14,5 +15,26 @@ class UserSignalementSubscriptionRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, UserSignalementSubscription::class);
+    }
+
+    /**
+     * @return array<UserSignalementSubscription>
+     */
+    public function findForAffectation(Affectation $affectation): array
+    {
+        $signalement = $affectation->getSignalement();
+        $partner = $affectation->getPartner();
+
+        $queryBuilder = $this->createQueryBuilder('s')
+            ->innerJoin('s.user', 'u')
+            ->innerJoin('u.userPartners', 'up')
+            ->where('s.signalement = :signalement')->setParameter('signalement', $signalement)
+            ->andWhere('up.partner = :partner')->setParameter('partner', $partner)
+            ->andWhere('JSON_CONTAINS(u.roles, :role_admin_partner) = 1 OR JSON_CONTAINS(u.roles, :role_user_partner) = 1')
+            ->setParameter('role_admin_partner', '"ROLE_ADMIN_PARTNER"')
+            ->setParameter('role_user_partner', '"ROLE_USER_PARTNER"')
+        ;
+
+        return $queryBuilder->getQuery()->getResult();
     }
 }

--- a/src/Repository/UserSignalementSubscriptionRepository.php
+++ b/src/Repository/UserSignalementSubscriptionRepository.php
@@ -55,7 +55,7 @@ class UserSignalementSubscriptionRepository extends ServiceEntityRepository
             ->andWhere('up.partner = :partner')->setParameter('partner', $partner);
         if ($excludeRT) {
             $queryBuilder->andWhere('JSON_CONTAINS(u.roles, :role_admin_territory) = 0')
-            ->setParameter('role_admin_territory', 'ROLE_ADMIN_TERRITORY');
+            ->setParameter('role_admin_territory', '"ROLE_ADMIN_TERRITORY"');
         }
 
         return $queryBuilder->getQuery()->getResult();

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -109,6 +109,20 @@ class VisiteNotifier
         }
     }
 
+    public function NotifyInAppSubscribers(
+        Intervention $intervention,
+        Suivi $suivi,
+        ?User $currentUser = null,
+    ): void {
+        $listUsersToNotify = $this->userRepository->findUsersSubscribedToSignalement($intervention->getSignalement());
+        foreach ($listUsersToNotify as $user) {
+            if ($user === $currentUser) {
+                continue;
+            }
+            $this->notifyAgent(user: $user, suivi: $suivi, intervention: $intervention);
+        }
+    }
+
     public function notifyInterventionSubscribers(
         NotificationMailerType $notificationMailerType,
         Intervention $intervention,

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -150,10 +150,11 @@ class VisiteNotifier
                 );
             }
         }
-
-        $notification = $this->notificationFactory->createInstanceFrom(user: $user, type: NotificationType::NOUVEAU_SUIVI, suivi: $suivi);
-        $this->entityManager->persist($notification);
-        $this->entityManager->flush();
+        if ($suivi) {
+            $notification = $this->notificationFactory->createInstanceFrom(user: $user, type: NotificationType::NOUVEAU_SUIVI, suivi: $suivi);
+            $this->entityManager->persist($notification);
+            $this->entityManager->flush();
+        }
     }
 
     public function notifyVisiteToConclude(Intervention $intervention): int

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -109,7 +109,7 @@ class VisiteNotifier
         }
     }
 
-    public function NotifyInAppSubscribers(
+    public function notifyInAppSubscribers(
         Intervention $intervention,
         Suivi $suivi,
         ?User $currentUser = null,

--- a/src/Service/Signalement/VisiteNotifier.php
+++ b/src/Service/Signalement/VisiteNotifier.php
@@ -5,13 +5,13 @@ namespace App\Service\Signalement;
 use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\NotificationType;
-use App\Entity\Enum\Qualification;
 use App\Entity\Intervention;
 use App\Entity\Suivi;
 use App\Entity\User;
 use App\Factory\NotificationFactory;
 use App\Manager\SignalementManager;
 use App\Repository\UserRepository;
+use App\Repository\UserSignalementSubscriptionRepository;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
@@ -27,6 +27,7 @@ class VisiteNotifier
         private readonly NotificationMailerRegistry $notificationMailerRegistry,
         private readonly UserRepository $userRepository,
         private readonly NotificationAndMailSender $notificationAndMailSender,
+        private readonly UserSignalementSubscriptionRepository $userSignalementSubscriptionRepository,
     ) {
     }
 
@@ -52,6 +53,9 @@ class VisiteNotifier
         }
     }
 
+    /**
+     * @deprecated this method will be removed once the FEATURE_NEW_DASHBOARD feature flag is removed
+     */
     public function notifyAgents(
         ?Intervention $intervention,
         Suivi $suivi,
@@ -85,16 +89,52 @@ class VisiteNotifier
         }
         foreach ($listUsersToNotify as $user) {
             if ($user != $currentUser) {
-                $this->notifyAgent($user, $intervention, $suivi, $notificationMailerType, $affectation);
+                $this->notifyAgent(user: $user, suivi: $suivi, intervention: $intervention, notificationMailerType: $notificationMailerType, affectation: $affectation);
             }
+        }
+    }
+
+    public function notifySubscribers(
+        NotificationMailerType $notificationMailerType,
+        Intervention $intervention,
+        Suivi $suivi,
+        ?User $currentUser = null,
+    ): void {
+        $listUsersToNotify = $this->userRepository->findUsersSubscribedToSignalement($intervention->getSignalement());
+        foreach ($listUsersToNotify as $user) {
+            if ($user === $currentUser) {
+                continue;
+            }
+            $this->notifyAgent(user: $user, suivi: $suivi, notificationMailerType: $notificationMailerType, intervention: $intervention);
+        }
+    }
+
+    public function notifyInterventionSubscribers(
+        NotificationMailerType $notificationMailerType,
+        Intervention $intervention,
+    ): void {
+        $subs = $this->userSignalementSubscriptionRepository->findForIntervention($intervention);
+        foreach ($subs as $subscription) {
+            $this->notifyAgent(user: $subscription->getUser(), notificationMailerType: $notificationMailerType, intervention: $intervention);
+        }
+    }
+
+    public function notifyAffectationSubscribers(
+        NotificationMailerType $notificationMailerType,
+        Affectation $affectation,
+        Suivi $suivi,
+    ): void {
+        $subs = $this->userSignalementSubscriptionRepository->findForAffectation($affectation);
+        foreach ($subs as $subscription) {
+            $this->notifyAgent(user: $subscription->getUser(), suivi: $suivi, notificationMailerType: $notificationMailerType, affectation: $affectation);
         }
     }
 
     private function notifyAgent(
         User $user,
-        ?Intervention $intervention,
-        Suivi $suivi,
-        ?NotificationMailerType $notificationMailerType,
+        ?Suivi $suivi = null,
+        ?Intervention $intervention = null,
+        ?NotificationMailerType $notificationMailerType = null,
         ?Affectation $affectation = null,
     ): void {
         if ($notificationMailerType) {
@@ -120,13 +160,6 @@ class VisiteNotifier
     {
         $signalement = $intervention->getSignalement();
         $listUsersToNotify = $this->userRepository->findActiveTerritoryAdmins($signalement->getTerritory()->getId(), $signalement->getInseeOccupant());
-        $affectations = $signalement->getAffectations();
-        foreach ($affectations as $affectation) {
-            if ($affectation->getPartner()->hasCompetence(Qualification::VISITES)) {
-                $listUsersPartner = $affectation->getPartner()->getUsers();
-                $listUsersToNotify = array_unique(array_merge($listUsersToNotify, $listUsersPartner->toArray()), \SORT_REGULAR);
-            }
-        }
 
         foreach ($listUsersToNotify as $user) {
             if ($user->getIsMailingActive()) {

--- a/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
+++ b/tests/Functional/Command/Cron/AskFeedbackUsagerCommandTest.php
@@ -26,7 +26,7 @@ class AskFeedbackUsagerCommandTest extends KernelTestCase
         $commandTester->assertCommandIsSuccessful();
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('8 signalement(s) for which a request for feedback will be sent', $output);
+        $this->assertStringContainsString('9 signalement(s) for which a request for feedback will be sent', $output);
         $this->assertEmailCount(0);
     }
 
@@ -47,10 +47,10 @@ class AskFeedbackUsagerCommandTest extends KernelTestCase
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('1 signalement(s) for which the two last suivis are feedback requests ', $output);
         $this->assertStringContainsString('1 signalement(s) for which the last suivi is feedback request', $output);
-        $this->assertStringContainsString('6 signalement(s) without suivi public', $output);
-        $this->assertEmailCount(11);
+        $this->assertStringContainsString('7 signalement(s) without suivi public', $output);
+        $this->assertEmailCount(12);
 
         $nbSuiviFeedback = self::getContainer()->get(SuiviRepository::class)->count(['category' => SuiviCategory::ASK_FEEDBACK_SENT]);
-        $this->assertEquals(11, $nbSuiviFeedback);
+        $this->assertEquals(12, $nbSuiviFeedback);
     }
 }

--- a/tests/Functional/Controller/Api/AffectationUpdateControllerTest.php
+++ b/tests/Functional/Controller/Api/AffectationUpdateControllerTest.php
@@ -123,7 +123,7 @@ class AffectationUpdateControllerTest extends WebTestCase
                 'message' => 'lorem ipsum dolor sit amet',
             ],
             'FERME',
-            1,
+            2,
         ];
 
         yield 'FERME ==> NOUVEAU' => [

--- a/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
@@ -52,7 +52,7 @@ class ArreteCreateControllerTest extends WebTestCase
             }
             $this->assertStringContainsString($value, $lastDescription);
         }
-        $this->assertEmailCount(1);
+        $this->assertEmailCount(2);
         $this->assertEquals(201, $this->client->getResponse()->getStatusCode());
         $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }

--- a/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
@@ -2,7 +2,9 @@
 
 namespace App\Tests\Functional\Controller\Api;
 
+use App\Entity\Enum\NotificationType;
 use App\Entity\User;
+use App\Repository\NotificationRepository;
 use App\Repository\SignalementRepository;
 use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -52,7 +54,9 @@ class ArreteCreateControllerTest extends WebTestCase
             }
             $this->assertStringContainsString($value, $lastDescription);
         }
-        $this->assertEmailCount(2);
+        $notifs = self::getContainer()->get(NotificationRepository::class)->findBy(['signalement' => $signalement, 'type' => NotificationType::NOUVEAU_SUIVI]);
+        $this->assertCount(3, $notifs);
+        $this->assertEmailCount(1);
         $this->assertEquals(201, $this->client->getResponse()->getStatusCode());
         $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }

--- a/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
@@ -146,7 +146,7 @@ class VisiteCreateControllerTest extends WebTestCase
                 ],
                 'details' => 'lorem ipsum dolor sit <em>amet</em>',
             ],
-            2,
+            4,
         ];
         yield 'test create visite confirmed with no usager notification' => [
             'visite_confirmed',
@@ -163,7 +163,7 @@ class VisiteCreateControllerTest extends WebTestCase
                 ],
                 'details' => 'lorem ipsum dolor sit <em>amet</em>',
             ],
-            1,
+            3,
         ];
 
         yield 'test create visite planned' => [
@@ -172,7 +172,7 @@ class VisiteCreateControllerTest extends WebTestCase
                 'date' => '2125-01-01',
                 'time' => '12:00',
             ],
-            2,
+            1,
         ];
     }
 

--- a/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
@@ -146,7 +146,7 @@ class VisiteCreateControllerTest extends WebTestCase
                 ],
                 'details' => 'lorem ipsum dolor sit <em>amet</em>',
             ],
-            3,
+            2,
         ];
         yield 'test create visite confirmed with no usager notification' => [
             'visite_confirmed',
@@ -163,7 +163,7 @@ class VisiteCreateControllerTest extends WebTestCase
                 ],
                 'details' => 'lorem ipsum dolor sit <em>amet</em>',
             ],
-            2,
+            1,
         ];
 
         yield 'test create visite planned' => [
@@ -172,7 +172,7 @@ class VisiteCreateControllerTest extends WebTestCase
                 'date' => '2125-01-01',
                 'time' => '12:00',
             ],
-            1,
+            2,
         ];
     }
 

--- a/tests/Functional/Controller/Back/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementControllerTest.php
@@ -317,7 +317,7 @@ class SignalementControllerTest extends WebTestCase
         $this->assertStringContainsString('/bo/signalements/', $response['url']);
 
         $client->enableProfiler();
-        $this->assertEmailCount(1);
+        $this->assertEmailCount(2);
     }
 
     public function testUserPartnerSubmitClotureSignalementWithEmailSentToPartnersAndRT(): void

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -67,7 +67,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Procédure estimée' => [['procedure' => 'rsd', 'isImported' => 'oui'], 7];
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
         yield 'Search by Statut de la visite' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 5];
-        yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 35];
+        yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 5];
         yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18', 'isImported' => 'oui'], 3];
         yield 'Search by Statut de l\'affectation' => [['statusAffectation' => 'refuse', 'isImported' => 'oui'], 1];
         yield 'Search by Score criticite' => [['criticiteScoreMin' => 5, 'criticiteScoreMax' => 6, 'isImported' => 'oui'], 9];

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -87,7 +87,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by dates depot and dates of last suivi' => [['isImported' => 'oui', 'dateDepotDebut' => '2023-01-01', 'dateDepotFin' => '2023-03-31', 'dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-12-31'], 3];
         yield 'Search by Demande fermeture usager territoire 13' => [['territoire' => '13', 'usagerAbandonProcedure' => '1'], 1];
         yield 'Search by Demande fermeture usager all' => [['usagerAbandonProcedure' => '1'], 2];
-        yield 'Search by Mes dossiers' => [['showMySignalementsOnly' => 'oui', 'isImported' => 'oui'], 0];
+        yield 'Search by Mes dossiers' => [['showMySignalementsOnly' => 'oui', 'isImported' => 'oui'], 1];
     }
 
     /**
@@ -330,6 +330,6 @@ class SignalementListControllerTest extends WebTestCase
         $client->request('GET', $route, ['showMySignalementsOnly' => 'oui', 'isImported' => 'oui'], [], ['HTTP_Accept' => 'application/json']);
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertEquals(1, $result['pagination']['total_items']);
+        $this->assertEquals(2, $result['pagination']['total_items']);
     }
 }

--- a/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
@@ -61,7 +61,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
             InterventionCreatedEvent::NAME
         );
 
-        $this->assertEmailCount(3);
+        $this->assertEmailCount(2);
         $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
 
         $nbSuiviInterventionPlanned = self::getContainer()->get(SuiviRepository::class)->count(['category' => SuiviCategory::INTERVENTION_IS_CREATED, 'signalement' => $intervention->getSignalement()]);
@@ -74,7 +74,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $date = (new \DateTimeImmutable())->modify('-1 day');
         $type = InterventionType::VISITE;
         $this->testNbMailSent($date, $type);
-        $this->assertEmailCount(1);
+        $this->assertEmailCount(0);
     }
 
     public function testInterventionVisitInFuture(): void
@@ -82,7 +82,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $date = (new \DateTimeImmutable())->modify('+1 day');
         $type = InterventionType::VISITE;
         $this->testNbMailSent($date, $type);
-        $this->assertEmailCount(3);
+        $this->assertEmailCount(2);
     }
 
     public function testInterventionNoVisitInPast(): void
@@ -90,7 +90,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $date = (new \DateTimeImmutable())->modify('-1 day');
         $type = InterventionType::ARRETE_PREFECTORAL;
         $this->testNbMailSent($date, $type, Intervention::STATUS_DONE);
-        $this->assertEmailCount(3);
+        $this->assertEmailCount(2);
     }
 
     private function testNbMailSent(\DateTimeImmutable $date, InterventionType $type, string $status = Intervention::STATUS_PLANNED): void

--- a/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
@@ -51,7 +51,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@signal-logement.fr']);
-        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager);
+        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager, true);
         $eventDispatcher->addSubscriber($interventionCreatedSubscriber);
 
         $intervention = $interventions[0];
@@ -109,7 +109,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@signal-logement.fr']);
-        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager);
+        $interventionCreatedSubscriber = new InterventionCreatedSubscriber($visiteNotifier, $suiviManager, true);
         $eventDispatcher->addSubscriber($interventionCreatedSubscriber);
 
         $intervention->setScheduledAt($date);

--- a/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
@@ -61,7 +61,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
             InterventionCreatedEvent::NAME
         );
 
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(3);
         $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
 
         $nbSuiviInterventionPlanned = self::getContainer()->get(SuiviRepository::class)->count(['category' => SuiviCategory::INTERVENTION_IS_CREATED, 'signalement' => $intervention->getSignalement()]);
@@ -74,7 +74,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $date = (new \DateTimeImmutable())->modify('-1 day');
         $type = InterventionType::VISITE;
         $this->testNbMailSent($date, $type);
-        $this->assertEmailCount(0);
+        $this->assertEmailCount(1);
     }
 
     public function testInterventionVisitInFuture(): void
@@ -82,7 +82,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $date = (new \DateTimeImmutable())->modify('+1 day');
         $type = InterventionType::VISITE;
         $this->testNbMailSent($date, $type);
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(3);
     }
 
     public function testInterventionNoVisitInPast(): void
@@ -90,7 +90,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $date = (new \DateTimeImmutable())->modify('-1 day');
         $type = InterventionType::ARRETE_PREFECTORAL;
         $this->testNbMailSent($date, $type, Intervention::STATUS_DONE);
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(3);
     }
 
     private function testNbMailSent(\DateTimeImmutable $date, InterventionType $type, string $status = Intervention::STATUS_PLANNED): void

--- a/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
@@ -51,7 +51,7 @@ class InterventionUpdatedByEsaboraSubscriberTest extends KernelTestCase
             InterventionUpdatedByEsaboraEvent::NAME
         );
 
-        $this->assertEmailCount(3);
+        $this->assertEmailCount(2);
         $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
         $this->assertStringContainsString('a été modifiée', $intervention->getSignalement()->getSuivis()->last()->getDescription());
     }

--- a/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
@@ -41,7 +41,7 @@ class InterventionUpdatedByEsaboraSubscriberTest extends KernelTestCase
         /** @var UserRepository $userRepository */
         $userRepository = $this->entityManager->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => 'admin-territoire-13-01@signal-logement.fr']);
-        $interventionUpdatedByEsaboraSubscriber = new InterventionUpdatedByEsaboraSubscriber($visiteNotifier, $suiviManager);
+        $interventionUpdatedByEsaboraSubscriber = new InterventionUpdatedByEsaboraSubscriber($visiteNotifier, $suiviManager, true);
         $eventDispatcher->addSubscriber($interventionUpdatedByEsaboraSubscriber);
 
         $intervention = $interventions[0];

--- a/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
@@ -51,7 +51,7 @@ class InterventionUpdatedByEsaboraSubscriberTest extends KernelTestCase
             InterventionUpdatedByEsaboraEvent::NAME
         );
 
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(3);
         $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
         $this->assertStringContainsString('a été modifiée', $intervention->getSignalement()->getSuivis()->last()->getDescription());
     }

--- a/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/SignalementClosedSubscriberTest.php
@@ -80,9 +80,9 @@ class SignalementClosedSubscriberTest extends KernelTestCase
         $this->assertEmailAddressContains($clotureMail, 'to', 'ne-pas-repondre@signal-logement.beta.gouv.fr');
         $this->assertCount(2, $clotureMail->getBcc());
         $this->assertEmailAddressContains($clotureMail, 'bcc', 'partenaire-34-04@signal-logement.fr');
-        $this->assertEmailAddressContains($clotureMail, 'bcc', 'user-partenaire-34-02@signal-logement.fr');
+        $this->assertEmailAddressContains($clotureMail, 'bcc', 'admin-territoire-34-01@signal-logement.fr');
 
         $notifications = $this->notificationRepository->findBy(['signalement' => $signalementClosed, 'type' => NotificationType::CLOTURE_SIGNALEMENT]);
-        $this->assertCount(5, $notifications);
+        $this->assertCount(4, $notifications);
     }
 }

--- a/tests/Functional/Manager/InterventionManagerTest.php
+++ b/tests/Functional/Manager/InterventionManagerTest.php
@@ -110,7 +110,7 @@ class InterventionManagerTest extends KernelTestCase
             )
         );
 
-        $this->assertEmailCount(3);
+        $this->assertEmailCount(2);
     }
 
     /**

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -47,6 +47,7 @@ class SuiviManagerTest extends KernelTestCase
             $this->security,
             $this->htmlSanitizerInterface,
             $this->userSignalementSubscriptionRepository,
+            true,
             Suivi::class,
         );
     }

--- a/tests/Functional/Service/Signalement/VisiteNotifierTest.php
+++ b/tests/Functional/Service/Signalement/VisiteNotifierTest.php
@@ -50,7 +50,7 @@ class VisiteNotifierTest extends KernelTestCase
         $intervention = $signalement->getInterventions()[0];
 
         $nbNotified = $this->visiteNotifier->notifyVisiteToConclude($intervention);
-        $this->assertEquals($nbNotified, 6);
+        $this->assertEquals($nbNotified, 3);
     }
 
     public function testNotifyVisiteToConclude69(): void
@@ -60,6 +60,6 @@ class VisiteNotifierTest extends KernelTestCase
         $intervention = $signalement->getInterventions()[0];
 
         $nbNotified = $this->visiteNotifier->notifyVisiteToConclude($intervention);
-        $this->assertEquals($nbNotified, 2);
+        $this->assertEquals($nbNotified, 1);
     }
 }

--- a/tests/Functional/Service/Signalement/VisiteNotifierTest.php
+++ b/tests/Functional/Service/Signalement/VisiteNotifierTest.php
@@ -8,6 +8,7 @@ use App\Factory\NotificationFactory;
 use App\Manager\SignalementManager;
 use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
+use App\Repository\UserSignalementSubscriptionRepository;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\NotificationAndMailSender;
 use App\Service\Signalement\VisiteNotifier;
@@ -27,6 +28,7 @@ class VisiteNotifierTest extends KernelTestCase
         $notificationMailerRegistry = static::getContainer()->get(NotificationMailerRegistry::class);
         $userRepository = static::getContainer()->get(UserRepository::class);
         $notificationAndMailerSender = static::getContainer()->get(NotificationAndMailSender::class);
+        $userSignalementSubscriptionRepository = static::getContainer()->get(UserSignalementSubscriptionRepository::class);
 
         $this->visiteNotifier = new VisiteNotifier(
             $entityManager,
@@ -35,6 +37,7 @@ class VisiteNotifierTest extends KernelTestCase
             $notificationMailerRegistry,
             $userRepository,
             $notificationAndMailerSender,
+            $userSignalementSubscriptionRepository,
         );
 
         $this->signalementRepository = $entityManager->getRepository(Signalement::class);


### PR DESCRIPTION
## Ticket

#4350

## Description
Gestions des notifications basé sur le système d'abonnements aux signalements
- Notification email 
- Notification in app

Plus précisément : 
- TYPE_SIGNALEMENT_CLOSED_TO_PARTNERS 
- TYPE_SIGNALEMENT_CLOSED_TO_PARTNER
- TYPE_NEW_COMMENT_BACK
- TYPE_DEMANDE_ABANDON_PROCEDURE_TO_ADMIN
----------
- TYPE_VISITE_NEEDED
- TYPE_VISITE_CONFIRMED_TO_PARTNER
- TYPE_VISITE_ABORTED_TO_PARTNER
- TYPE_VISITE_FUTURE_REMINDER_TO_PARTNER
- TYPE_VISITE_PAST_REMINDER_TO_PARTNER
- TYPE_VISITE_CANCELED_TO_USAGER
- TYPE_ARRETE_CREATED_TO_USAGER
- TYPE_VISITE_EDITED_TO_USAGER
- TYPE_VISITE_RESCHEDULED_TO_USAGER
- TYPE_ARRETE_CREATED_TO_USAGER

Gestion des abonnements
- Abonnement automatique a un signalement lors d'une action sur le dossier
- Suppression des abonnement d'agent lors d'une suppression d'affectation

## Changements apportés
* Fixtures : Création de l'abonnement de l'acceptant à la création des affectations
* Fixtures : Récupération du premier RT du territoire à la création des suivi de validation pour avoir les abonnement du RT

## Pré-requis
`make load-fixtures`

## Tests
- [ ] Idéalement il faudrait tester les notification email et in app de chaque type de notification listé dans la description, en gardant à l'esprit l'existence des email de récap pour certaines d'entre elles
