### PR TITLE
[Suivi usager] Authentifier en priorité les usagers avec getSignalementUsager

### DIFF
--- a/src/Security/Provider/SignalementUserProvider.php
+++ b/src/Security/Provider/SignalementUserProvider.php
@@ -72,7 +72,7 @@ class SignalementUserProvider implements UserProviderInterface
         if (UserManager::DECLARANT === $type) {
             $user = $signalement->getSignalementUsager()?->getDeclarant();
             if (empty($user)) {
-                $this->logger->info('SignalementUserProvider: No declarant user found, trying to find by email.');
+                $this->logger->error('SignalementUserProvider: No declarant user found, trying to find by email.');
                 $user = $this->userRepository->findOneBy(['email' => $signalement->getMailDeclarant()]);
             }
 
@@ -85,7 +85,7 @@ class SignalementUserProvider implements UserProviderInterface
 
         $user = $signalement->getSignalementUsager()?->getOccupant();
         if (empty($user)) {
-            $this->logger->info('SignalementUserProvider: No occupant user found, trying to find by email.');
+            $this->logger->error('SignalementUserProvider: No occupant user found, trying to find by email.');
             $user = $this->userRepository->findOneBy(['email' => $signalement->getMailOccupant()]);
         }
 

--- a/src/Security/Provider/SignalementUserProvider.php
+++ b/src/Security/Provider/SignalementUserProvider.php
@@ -68,7 +68,10 @@ class SignalementUserProvider implements UserProviderInterface
     public function getUsagerData(Signalement $signalement, string $type, string $codeSuivi): array
     {
         if (UserManager::DECLARANT === $type) {
-            $user = $this->userRepository->findOneBy(['email' => $signalement->getMailDeclarant()]);
+            $user = $signalement->getSignalementUsager()?->getDeclarant();
+            if (empty($user)) {
+                $user = $this->userRepository->findOneBy(['email' => $signalement->getMailDeclarant()]);
+            }
 
             return [
                 'identifier' => $codeSuivi.':'.UserManager::DECLARANT,
@@ -76,7 +79,11 @@ class SignalementUserProvider implements UserProviderInterface
                 'user' => $user,
             ];
         }
-        $user = $this->userRepository->findOneBy(['email' => $signalement->getMailOccupant()]);
+
+        $user = $signalement->getSignalementUsager()?->getOccupant();
+        if (empty($user)) {
+            $user = $this->userRepository->findOneBy(['email' => $signalement->getMailOccupant()]);
+        }
 
         return [
             'identifier' => $codeSuivi.':'.UserManager::OCCUPANT,

--- a/src/Security/Provider/SignalementUserProvider.php
+++ b/src/Security/Provider/SignalementUserProvider.php
@@ -9,6 +9,7 @@ use App\Repository\SignalementRepository;
 use App\Repository\UserRepository;
 use App\Security\User\SignalementUser;
 use Doctrine\ORM\NonUniqueResultException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -18,6 +19,7 @@ class SignalementUserProvider implements UserProviderInterface
     public function __construct(
         private readonly SignalementRepository $signalementRepository,
         private readonly UserRepository $userRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -70,6 +72,7 @@ class SignalementUserProvider implements UserProviderInterface
         if (UserManager::DECLARANT === $type) {
             $user = $signalement->getSignalementUsager()?->getDeclarant();
             if (empty($user)) {
+                $this->logger->info('SignalementUserProvider: No declarant user found, trying to find by email.');
                 $user = $this->userRepository->findOneBy(['email' => $signalement->getMailDeclarant()]);
             }
 
@@ -82,6 +85,7 @@ class SignalementUserProvider implements UserProviderInterface
 
         $user = $signalement->getSignalementUsager()?->getOccupant();
         if (empty($user)) {
+            $this->logger->info('SignalementUserProvider: No occupant user found, trying to find by email.');
             $user = $this->userRepository->findOneBy(['email' => $signalement->getMailOccupant()]);
         }
 


### PR DESCRIPTION
## Ticket

#4353

## Description
Lors de l'authentification sur la page de suivi usager, on allait chercher le `User` avec l'adressse e-mail, mais elle peut être modifiée après la création, et le `User` récupéré n'est donc pas fiable.
Pour plus de fiabilité, on récupère en priorité via la liaison `getSignalementUsager`.
Cela permet notamment de mieux gérer les suivis qui ont été vus, car les notifications sont liées via `getSignalementUsager`.

## Tests
- [ ] Dans un signalement, modifier l'adresse e-mail du déclarant ou de l'occupant
- [ ] Puis créer un suivi visible de l'usager
- [ ] Ensuite aller sur la page de suivi avec le déclarant ou l'occupant (selon ce qui a été modifié) et vérifier que la notification du suivi est bien "Vue"
