### PR TITLE
[BO - Suivi] Correction de la catégorisation des suivis incitant à la création d'une visite avec une ancienne formulation

### DIFF
--- a/migrations/Version20250721091306.php
+++ b/migrations/Version20250721091306.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250721091306 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return "Change suivi category from INTERVENTION_IS_CREATED to INTERVENTION_IS_REQUIRED if description is 'Aucune information de visite n'a été renseignée pour le logement. Merci de programmer une visite dès que possible !'";
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE suivi SET category = 'INTERVENTION_IS_REQUIRED' WHERE category = 'INTERVENTION_IS_CREATED' AND description LIKE '%renseignée pour le logement. Merci de programmer une visite dès que possible !'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("UPDATE suivi SET category = 'INTERVENTION_IS_CREATED' WHERE category = 'INTERVENTION_IS_REQUIRED' AND description LIKE '%renseignée pour le logement. Merci de programmer une visite dès que possible !'");
+    }
+}


### PR DESCRIPTION
## Ticket

#4351   

## Description
Des suivis réclamant la création d'une visite sur le signalement, dont le texte a depuis été modifié dans ce commit https://github.com/MTES-MCT/histologe/commit/234be845cfe8a8ccfde721f9dc9f976d10775dc5 étaient catégorisés en `INTERVENTION_IS_CREATED` plutôt que `INTERVENTION_IS_REQUIRED`

## Changements apportés
* Création d'une migration pour corriger la catégorisation de ces vieux suivis

## Pré-requis
Se mettre sur la base de prod et vérifier les catégories des suivis `SELECT id, description, category FROM `suivi` WHERE description LIKE '%Aucune information de visite%';`

## Tests
- [ ] `make execute-migration name=Version20250721091306 direction=up`
- [ ] Mettre à jour la requête ci-dessus, et vérifier que les catégories ont été mises à jour
