### PR TITLE
[FO - Espace suivi usager] corrections

### DIFF
--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -549,8 +549,9 @@ class SignalementController extends AbstractController
             $lastSuiviPublic = $suiviRepository->findLastPublicSuivi($signalement, $user);
             $suiviCategory = null;
             if (!$lastSuiviPublic && SignalementStatus::CLOSED === $signalement->getStatut()) {
-                $suiviCategory = $suiviCategorizerService->getSuiviCategoryFromEnum(SuiviCategory::SIGNALEMENT_IS_CLOSED);
-            } elseif ($lastSuiviPublic) {
+                $lastSuiviPublic = (new Suivi())->setSignalement($signalement)->setCategory(SuiviCategory::SIGNALEMENT_IS_CLOSED);
+            }
+            if ($lastSuiviPublic) {
                 $suiviCategory = $suiviCategorizerService->getSuiviCategoryFromSuivi($lastSuiviPublic);
             }
 

--- a/src/Dto/SuiviCategory.php
+++ b/src/Dto/SuiviCategory.php
@@ -12,6 +12,7 @@ class SuiviCategory
         private readonly string $labelClass,
         private readonly string $title,
         private readonly string $icon,
+        private ?string $description,
     ) {
     }
 
@@ -38,5 +39,10 @@ class SuiviCategory
     public function getIcon(): string
     {
         return $this->icon;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
     }
 }

--- a/src/Service/SuiviCategorizerService.php
+++ b/src/Service/SuiviCategorizerService.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Dto\SuiviCategory as SuiviCategoryDto;
+use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Suivi;
 
@@ -89,22 +90,19 @@ class SuiviCategorizerService
             label: $configuration['label'],
             labelClass: $configuration['labelClass'],
             title: $configuration['title'],
-            icon: $configuration['icon']
+            icon: $configuration['icon'],
+            description: $this->getSuiviCategoryDescription($suivi),
         );
     }
 
-    public function getSuiviCategoryFromEnum(SuiviCategory $category): ?SuiviCategoryDto
+    private function getSuiviCategoryDescription(Suivi $suivi): ?string
     {
-        if (isset(self::SUIVI_CATEGORIES_CONFIGURATION[$category->name])) {
-            $configuration = self::SUIVI_CATEGORIES_CONFIGURATION[$category->name];
-
-            return new SuiviCategoryDto(
-                suivi: new Suivi(),
-                label: $configuration['label'],
-                labelClass: $configuration['labelClass'],
-                title: $configuration['title'],
-                icon: $configuration['icon']
-            );
+        if (
+            SuiviCategory::SIGNALEMENT_IS_CLOSED === $suivi->getCategory()
+            && SignalementStatus::CLOSED === $suivi->getSignalement()->getStatut()
+            && $suivi->getSignalement()->getClosedAt()
+        ) {
+            return 'Si nécessaire, vous pouvez envoyer un dernier message avant le '.$suivi->getSignalement()->getClosedAt()->modify('+30 days')->format('d/m/Y').'.';
         }
 
         return null;

--- a/templates/front/_partials/_suivi_signalement_card.html.twig
+++ b/templates/front/_partials/_suivi_signalement_card.html.twig
@@ -8,7 +8,13 @@
 				Déclarant occupant
 			{% endif %}
 			<br>
-			<span class="info">{{ signalement.prenomDeclarant }} {{ signalement.nomDeclarant }}</span>
+			<span class="info">
+				{% if signalement.prenomDeclarant %}
+					{{ signalement.prenomDeclarant }} {{ signalement.nomDeclarant }}
+				{% else %}
+					{{ signalement.prenomOccupant }} {{ signalement.nomOccupant }}
+				{% endif %}
+			</span>
 		</div>
 		<div class="fr-col-12 fr-col-md-6">
 			Référence du dossier

--- a/templates/front/_partials/_suivi_signalement_card.html.twig
+++ b/templates/front/_partials/_suivi_signalement_card.html.twig
@@ -2,7 +2,11 @@
 <div class="signalement-card fr-mb-3w">
 	<div class="fr-grid-row fr-grid-row--gutters">
 		<div class="fr-col-12 fr-col-md-6">
-			Déclarant
+			{% if signalement.isNotOccupant %}
+				Déclarant
+			{% else %}
+				Déclarant occupant
+			{% endif %}
 			<br>
 			<span class="info">{{ signalement.prenomDeclarant }} {{ signalement.nomDeclarant }}</span>
 		</div>
@@ -12,9 +16,11 @@
 			<span class="info">#{{ signalement.reference }}</span>
 		</div>
 		<div class="fr-col-12 fr-col-md-6">
-			Personne occupant le logement
-			<br>
-			<span class="info">{{ signalement.prenomOccupant }} {{ signalement.nomOccupant }}</span>
+			{% if signalement.isNotOccupant %}
+				Personne occupant le logement
+				<br>
+				<span class="info">{{ signalement.prenomOccupant }} {{ signalement.nomOccupant }}</span>
+			{% endif %}
 		</div>
 		<div class="fr-col-12 fr-col-md-6">
 			Statut du dossier

--- a/templates/front/suivi_signalement_dashboard.html.twig
+++ b/templates/front/suivi_signalement_dashboard.html.twig
@@ -28,33 +28,58 @@
 							<p class="fr-tile__detail">Votre signalement a été refusé, vous ne pouvez plus envoyer de messages.</p>            
 							<div class="fr-tile__start">
 								<p class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--error">Signalement refusé</p>           
-							</div>  
+							</div>
+							<h3 class="fr-tile__title">
+								<a href="{{ path('front_suivi_signalement_messages', {'code': signalement.codeSuivi}) }}">
+									<span class="fr-hidden">Signalement refusé</span>
+								</a>
+							</h3>  
 						{% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED and signalement.hasSuiviUsagerPostCloture %}
 							<p class="fr-tile__detail">Votre message suite à la clôture de votre dossier a bien été envoyé. Vous ne pouvez désormais plus envoyer de messages.</p>            
 							<div class="fr-tile__start">
 								<p class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--error">Signalement fermé</p>           
-							</div> 
+							</div>
+							<h3 class="fr-tile__title">
+								<a href="{{ path('front_suivi_signalement_messages', {'code': signalement.codeSuivi}) }}">
+									<span class="fr-hidden">Signalement fermé</span>
+								</a>
+							</h3>  
 						{% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED and date(signalement.closedAt) < date('-30days') %}
 							<p class="fr-tile__detail">Votre dossier a été fermé il y a plus de 30 jours, vous ne pouvez plus envoyer de messages.</p>            
 							<div class="fr-tile__start">
 								<p class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--error">Signalement fermé</p>           
 							</div> 
+							<h3 class="fr-tile__title">
+								<a href="{{ path('front_suivi_signalement_messages', {'code': signalement.codeSuivi}) }}">
+									<span class="fr-hidden">Signalement fermé</span>
+								</a>
+							</h3>  
 						{% elseif signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').ARCHIVED %}
 							<p class="fr-tile__detail">Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.</p>            
 							<div class="fr-tile__start">
-								<p class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--error">Signalement fermé</p>           
+								<p class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--error">Signalement archivé</p>           
 							</div>
+							<h3 class="fr-tile__title">
+								<a href="{{ path('front_suivi_signalement_messages', {'code': signalement.codeSuivi}) }}">
+									<span class="fr-hidden">Signalement archivé</span>
+								</a>
+							</h3>
 						{% else %}
 							{% if suiviCategory %}
 								<h3 class="fr-tile__title">
 									<a href="{{ path('front_suivi_signalement_messages', {'code': signalement.codeSuivi}) }}{% if suiviCategory.suivi.id %}#suivi_{{suiviCategory.suivi.id}}{% endif %}">
 										{{suiviCategory.title}}
 									</a>
-								</h3>            
+								</h3>
 								<p class="fr-tile__detail">{{suiviCategory.suivi.createdAt|date('d/m/Y')}}</p>
 								<div class="fr-tile__start">
 									<p class="fr-badge fr-badge--sm fr-badge--no-icon {{suiviCategory.labelClass}}">{{suiviCategory.label}}</p>           
 								</div>
+								{% if suiviCategory.description %}
+									<div class="fr-card__start">
+        								<p class="fr-card__detail">{{suiviCategory.description}}</p>
+									</div>    
+								{% endif %}   
 							{% else %}
 							  	<p class="fr-tile__detail">Votre signalement est en cours de validation.</p>            
 								<div class="fr-tile__start">

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -93,7 +93,7 @@
 		</div>
 
 		<div class="fr-col-12 fr-col-md-6">
-			<h2 class="title-blue-france fr-mb-1w">Suivre les échanges</h2>
+			<h2 class="title-blue-france fr-mb-1w">Suivre vos échanges</h2>
 			<div>Votre dossier a bien été enregistré le {{ signalement.createdAt|date('d/m/Y') }}.</div>
 			{% for suivi in signalement.suivis|reverse %}
 				{% set isUnreadMessage = false %}

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -93,6 +93,7 @@ class SignalementControllerTest extends WebTestCase
         $crawler = $client->request('GET', $urlSuiviSignalementUser);
 
         if (SignalementStatus::ARCHIVED->value === $status) {
+            $this->assertResponseStatusCodeSame(200);
             $this->assertEquals(
                 'Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.',
                 $crawler->filter('.fr-tile__detail')->text()


### PR DESCRIPTION
## Ticket

#4380
#4381
#4382
#4383

## Description
- Ajout d'une description "Si nécessaire, vous pouvez envoyer un dernier message avant le dd/mm/yyyy." sur la carte indiquant la fermeture du signalement
- Remplacement du titre "Suivre les échanges" par "Suivre vos échanges"
- En cas de déclarant occupant masquer le champ "Personne occupant le logement"
- Même quand le signalement est fermé/refusé/archivé la carte de l'accueil mène vers la page messagerie

## Tests
- [ ] Vérifier les 4 modifications
