### PR TITLE
[BO - Dashboard] Tableau de bord V2 - Tracker la navigation par onglet

### DIFF
--- a/assets/scripts/vanilla/controllers/back_dashboard/back_dashboard.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/back_dashboard.js
@@ -18,4 +18,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initFilterTerritoryHandler();
   initTabsLoader();
+
+  window._paq = window._paq || [];
+  window.addEventListener('hashchange', function () {
+    const hash = window.location.hash.substring(1);
+    _paq.push(['setCustomUrl', window.location.pathname + '_' + hash]);
+    _paq.push(['setDocumentTitle', document.title + ' ' + window.location.hash]);
+    _paq.push(['trackPageView']);
+  });
 });


### PR DESCRIPTION
## Ticket

#4311

## Description
Ajout du tracking matomo au changement d'onglet du dashboard via `hashchange`

## Pré-requis
`make npm-build`
`MATOMO_ENABLE=1`

## Tests
- [ ] Jouer avec les onglets du dashboard et voir que les évènements sont bien transmis a matomo
