### PR TITLE
[BO - Export PDF] Problème formatage Suivi tronquée

### DIFF
--- a/templates/pdf/base_pdf.html.twig
+++ b/templates/pdf/base_pdf.html.twig
@@ -10,8 +10,15 @@
             font-size: 12px;
         }
 
+        table {
+            width: 100%;
+            table-layout: fixed;
+        }
         table.border, table.border > tr, table.border td {
             border: 1px solid rgba(0, 0, 0, .5);
+        }
+        table tr td{
+            vertical-align: top;
         }
 
         .page:not(:last-child) {

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -36,7 +36,7 @@
                 {% endfor %}
             {% endif %}
 
-            <table style="width: 100%">
+            <table>
                 <tr>
                     <td style="width: 50%">
                         <h3 style="margin-bottom: 0">Informations de l'occupant</h3>
@@ -263,7 +263,7 @@
             <text>{{ signalement.details|nl2br }}</text>
         </section>
         <section>
-            <table style="width: 100%">
+            <table>
                 <tr>
                     <td style="width: 50%">
                         <h3>Informations propriétaire</h3>
@@ -482,7 +482,7 @@
         {% if isForUsager is same as false %}
             <section>
                 <h2>Prise en charge partenaire</h2>
-                <table style="width: 100%;text-align: center;" class="border">
+                <table style="text-align: center;" class="border">
                     <tr>
                         <td style="width: 33%"><b>En attente</b></td>
                         <td style="width: 34%"><b>Accepté</b></td>
@@ -608,7 +608,7 @@
         <div class="page" style="padding-top: 25px!important;">
             <section>
                 <h2>Suivi(s)</h2>
-                <table class="fr-stripped" style="width: 100%">
+                <table class="fr-stripped">
                     {% for suivi in signalement.suivis|reverse %}
                         {% if (isForUsager and suivi.isPublic) or isForUsager is same as false  %}                            
                             <tr>


### PR DESCRIPTION
## Ticket

#4391

## Description
Modification du template de l'export PDF pour : 
- Que les tableaux ne dépasse jamais 100% de la largeur (même dans le cas de très long lien par exemple)
- Que le contenu des cellules soient alignés en haut (pour voir qui à déposé le suivi dés le départ en cas de long suivi)

## Tests
- [ ] Tester un export
