### PR TITLE
[Notification - filtre] Conserver le tri selectionne

### DIFF
--- a/src/Controller/Back/NotificationController.php
+++ b/src/Controller/Back/NotificationController.php
@@ -63,7 +63,7 @@ class NotificationController extends AbstractController
             }
         }
 
-        return $this->redirectToRoute('back_notifications_list');
+        return $this->redirectToRoute('back_notifications_list', $this->addParamFromRequest($request));
     }
 
     #[Route('/notifications/supprimer', name: 'back_notifications_list_delete')]
@@ -88,10 +88,12 @@ class NotificationController extends AbstractController
                 $notificationRepository->deleteUserNotifications($user);
                 $widgetDataManagerCache->invalidateCacheForUser($user->getPartnersTerritories());
                 $this->addFlash('success', 'Toutes les notifications ont été supprimées.');
+
+                return $this->redirectToRoute('back_notifications_list');
             }
         }
 
-        return $this->redirectToRoute('back_notifications_list');
+        return $this->redirectToRoute('back_notifications_list', $this->addParamFromRequest($request));
     }
 
     #[Route('/notifications/{id}/supprimer', name: 'back_notifications_delete_notification')]
@@ -116,6 +118,22 @@ class NotificationController extends AbstractController
             $this->addFlash('error', 'Erreur lors de la suppression de la notification.');
         }
 
-        return $this->redirectToRoute('back_notifications_list');
+        return $this->redirectToRoute('back_notifications_list', $this->addParamFromRequest($request));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function addParamFromRequest(Request $request): array
+    {
+        $params = [];
+        if ($request->get('orderType')) {
+            $params['orderType'] = $request->get('orderType');
+        }
+        if ($request->get('page')) {
+            $params['page'] = $request->get('page');
+        }
+
+        return $params;
     }
 }

--- a/templates/back/notifications/index.html.twig
+++ b/templates/back/notifications/index.html.twig
@@ -17,21 +17,23 @@
         <div class="fr-col-6 fr-text--right">
             <div id="notification-selected-buttons" class="fr-hidden">
                 <span id="notification-selected-buttons-count"></span> sélectionnée(s) :
-                <form method="POST" action="{{ path('back_notifications_list_read') }}">
+                <form method="POST" action="{{ path('back_notifications_list_read', searchNotification.urlParams) }}">
                     <button type="submit" class="fr-btn fr-fi-check-line fr-btn--icon-left">Marquer comme lue(s)</button>
                     <input type="hidden" name="selected_notifications" value="">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token('mark_as_read_'~app.user.id) }}">
                 </form>
-                <form method="POST" action="{{ path('back_notifications_list_delete') }}">
+                <form method="POST" action="{{ path('back_notifications_list_delete', searchNotification.urlParams) }}">
                     <button type="submit" class="fr-btn fr-fi-delete-line fr-btn--danger fr-btn--icon-left">Supprimer</button>
                     <input type="hidden" name="selected_notifications" value="">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token('delete_notifications_'~app.user.id) }}">
                 </form>
             </div>
             <div id="notification-all-buttons">
-                <a href="{{ path('back_notifications_list_read') }}?mark_as_read={{ csrf_token('mark_as_read_'~app.user.id) }}"
+                {% set routeParams = {mark_as_read: csrf_token('mark_as_read_'~app.user.id)}|merge(searchNotification.urlParams) %}
+                <a href="{{ path('back_notifications_list_read', routeParams) }}"
                 class="fr-btn fr-fi-check-line fr-btn--icon-left">Marquer comme lus (tous)</a>
-                <a href="{{ path('back_notifications_list_delete') }}?delete_all_notifications={{ csrf_token('delete_all_notifications_'~app.user.id) }}"
+                {% set routeParams = {delete_all_notifications: csrf_token('delete_all_notifications_'~app.user.id)}|merge(searchNotification.urlParams) %}
+                <a href="{{ path('back_notifications_list_delete', routeParams) }}"
                 class="fr-btn fr-fi-delete-line fr-btn--danger fr-btn--icon-left">Vider</a>
             </div>
         </div>
@@ -80,7 +82,8 @@
                     <td class="fr-text--right fr-ws-nowrap">
                         <a href="{{ path('back_signalement_view',{uuid:notification.suivi.signalement.uuid}) }}#suivis"
                         class="fr-btn fr-btn--sm {{ notification.isSeen ? 'fr-fi-check-line fr-btn--success':'fr-fi-eye-fill' }}"></a>
-                        <a href="{{ path('back_notifications_delete_notification',{id:notification.id}) }}?_token={{ csrf_token('back_delete_notification_'~notification.id) }}"
+                        {% set routeParams = {id: notification.id, _token: csrf_token('back_delete_notification_'~notification.id)}|merge(searchNotification.urlParams) %}
+                        <a href="{{ path('back_notifications_delete_notification', routeParams) }}"
                         class="fr-btn fr-btn--sm fr-btn--danger fr-fi-delete-line"></a>
                     </td>
                 </tr>

--- a/tests/Functional/Controller/NotificationControllerTest.php
+++ b/tests/Functional/Controller/NotificationControllerTest.php
@@ -61,7 +61,7 @@ class NotificationControllerTest extends WebTestCase
     /**
      * @dataProvider provideSelectedNotificationOptions
      */
-    public function testSelectedNotifications(string $route, string $tokenId): void
+    public function testSelectedNotifications(string $route, string $tokenId, string $filter): void
     {
         $client = static::createClient();
         /** @var UrlGeneratorInterface $generatorUrl */
@@ -79,8 +79,8 @@ class NotificationControllerTest extends WebTestCase
             'selected_notifications' => $notificationsId,
         ]);
 
-        $client->request('GET', $route);
-        $this->assertResponseRedirects('/bo/notifications');
+        $client->request('GET', $route.'&'.$filter);
+        $this->assertResponseRedirects('/bo/notifications?'.$filter);
     }
 
     public function provideSelectedNotificationOptions(): \Generator
@@ -91,10 +91,12 @@ class NotificationControllerTest extends WebTestCase
         yield 'Mark as read' => [
             'back_notifications_list_read',
             'mark_as_read_'.$user->getId(),
+            'orderType=s.createdAt-ASC',
         ];
         yield 'Delete' => [
             'back_notifications_list_delete',
             'delete_notifications_'.$user->getId(),
+            'orderType=si.villeOccupant-ASC&page=2',
         ];
     }
 


### PR DESCRIPTION
## Ticket

#4302

## Description
Sur la page de notification, préserver les filtre (ordre de tri, page) après les actions : 
- Marquer comme lu par lot
- Marque tout comme lu
- Suppression unitaire
- Suppression par lot

Les filtres son supprimés après l'action de suppression complète car ca ne fait pas sens de les garder.

## Tests
- [ ] Tester les actions sur la page notification avec et sans filtres
