### PR TITLE
[BO - Historique affectations] Correction de certaines modifications d'affectations restées en chiffres

### DIFF
--- a/migrations/Version20250725142616.php
+++ b/migrations/Version20250725142616.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250725142616 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change affectation status format in history';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $queryOld = $this->getQueryUpdateHistoryUp('old');
+        $this->addSql($queryOld);
+
+        $queryNew = $this->getQueryUpdateHistoryUp('new');
+        $this->addSql($queryNew);
+    }
+
+    private function getQueryUpdateHistoryUp($field): string
+    {
+        return "
+            UPDATE history_entry
+            SET changes = JSON_SET(
+                changes,
+                '$.statut.".$field."',
+                CASE JSON_UNQUOTE(JSON_EXTRACT(changes, '$.statut.".$field."'))
+                    WHEN '0' THEN 'NOUVEAU'
+                    WHEN '1' THEN 'EN_COURS'
+                    WHEN '2' THEN 'REFUSE'
+                    WHEN '3' THEN 'FERME'
+                    ELSE JSON_UNQUOTE(JSON_EXTRACT(changes, '$.statut.".$field."'))
+                END
+            )
+            WHERE entity_name LIKE '%Affectation'
+            AND event = 'UPDATE'
+            AND JSON_EXTRACT(changes, '$.statut.".$field."') IS NOT NULL
+            AND JSON_UNQUOTE(JSON_EXTRACT(changes, '$.statut.".$field."')) IN ('0','1','2','3')
+        ";
+    }
+
+    public function down(Schema $schema): void
+    {
+        $queryOld = $this->getQueryUpdateHistoryDown('old');
+        $this->addSql($queryOld);
+
+        $queryNew = $this->getQueryUpdateHistoryDown('new');
+        $this->addSql($queryNew);
+    }
+
+    private function getQueryUpdateHistoryDown($field): string
+    {
+        return "
+            UPDATE history_entry
+            SET changes = JSON_SET(
+                changes,
+                '$.statut.".$field."',
+                CASE JSON_UNQUOTE(JSON_EXTRACT(changes, '$.statut.".$field."'))
+                    WHEN 'NOUVEAU' THEN '0'
+                    WHEN 'EN_COURS' THEN '1'
+                    WHEN 'REFUSE' THEN '2'
+                    WHEN 'FERME' THEN '3'
+                    ELSE JSON_UNQUOTE(JSON_EXTRACT(changes, '$.statut.".$field."'))
+                END
+            )
+            WHERE entity_name LIKE '%Affectation'
+            AND event = 'UPDATE'
+            AND JSON_EXTRACT(changes, '$.statut.".$field."') IS NOT NULL
+            AND JSON_UNQUOTE(JSON_EXTRACT(changes, '$.statut.".$field."')) IN ('NOUVEAU','EN_COURS','REFUSE','FERME')
+        ";
+    }
+}


### PR DESCRIPTION
## Ticket

#4403   

## Description
Lors de la modification des statuts d'affectations en texte plutôt qu'en chiffre, dans l'historique, la migration était trop restrictive, et n'a pas migré certaines données.

## Pré-requis
Utiliser la base de prod

Vérifier avec cette requête que certaines valeurs n'ont pas été transformées 
```
SELECT *  FROM `history_entry` WHERE event = 'UPDATE' AND entity_name LIKE '%Affectation%'
AND JSON_EXTRACT(changes, '$.statut.old') IS NOT NULL
AND JSON_UNQUOTE(JSON_EXTRACT(changes, '$.statut.old')) IN ('0','1','2','3');
```

## Tests
- [ ] `make execute-migration name=Version20250725142616 direction=up`
- [ ] Vérifier l'exécution avec la requête précédente
