### PR TITLE
[TECH] Ajout contrainte unicité affectation (signalement, partenaire)

### DIFF
--- a/migrations/Version20250729071740.php
+++ b/migrations/Version20250729071740.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250729071740 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique constraint to affectation table for signalement and partner';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->skipIf(!in_array($_ENV['APP_ENV'], ['test', 'dev']), 'This migration should only run in test or dev environments');
+        $this->addSql('CREATE UNIQUE INDEX unique_affectation_signalement_partner ON affectation (signalement_id, partner_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX unique_affectation_signalement_partner ON affectation');
+    }
+}

--- a/src/Command/RemoveDuplicateAffectationCommand.php
+++ b/src/Command/RemoveDuplicateAffectationCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\AffectationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:remove-duplicate-affectation',
+    description: 'Remove duplicate affectations',
+)]
+class RemoveDuplicateAffectationCommand
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly AffectationRepository $affectationRepository,
+    ) {
+    }
+
+    public function __invoke(SymfonyStyle $io): int
+    {
+        $sql = "SELECT GROUP_CONCAT(CONCAT(id, '-', statut)) as duplicates FROM affectation GROUP BY signalement_id, partner_id HAVING COUNT(*) > 1;";
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $res = $stmt->executeQuery();
+        $list = $res->fetchAllAssociative();
+
+        foreach ($list as $item) {
+            $duplicates = explode(',', $item['duplicates']);
+            $i = 0;
+            $msg = '';
+            foreach ($duplicates as $duplicate) {
+                $parts = explode('-', $duplicate);
+                // dans tous les cas on garde uniquement la première affectation (qui est toujours celle en cours quand des statuts différents existent)
+                if ($i > 0) {
+                    $affectation = $this->affectationRepository->find($parts[0]);
+                    $this->entityManager->remove($affectation);
+                    $this->entityManager->flush();
+                    if ($i > 1) {
+                        $msg .= ' / ';
+                    }
+                    $msg .= 'Affectation '.$duplicate.' supprimée';
+                } else {
+                    $msg .= 'Affectation '.$duplicate.' conservée. [';
+                }
+                ++$i;
+            }
+            $io->info($msg.']');
+        }
+        // ajout de la contrainte d'unicité
+        $this->entityManager->getConnection()->executeStatement(
+            'CREATE UNIQUE INDEX unique_affectation_signalement_partner ON affectation (signalement_id, partner_id)'
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: AffectationRepository::class)]
+#[ORM\UniqueConstraint(name: 'unique_affectation_signalement_partner', columns: ['signalement_id', 'partner_id'])]
 class Affectation implements EntityHistoryInterface
 {
     #[ORM\Id]

--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -342,7 +342,7 @@ class PartnerRepository extends ServiceEntityRepository
         }
 
         $sql = '
-                SELECT p.id, p.nom as name
+                SELECT DISTINCT p.id, p.nom as name
                 FROM partner p
                 LEFT JOIN partner_zone pz ON p.id = pz.partner_id
                 LEFT JOIN zone z ON pz.zone_id = z.id


### PR DESCRIPTION
## Ticket

#4396

## Description
- Correction de la requête provoquant le bug (les partenaire était proposé en double ou plus dans la modale d'affectation dans certains cas)
- Création de la commande de suppression des affectations dédoublonnées et d'ajout de la contrainte d'unicité

## Tests
- [ ] Sur copie de base de prod lancer la commande `app:remove-duplicate-affectation`, vérifier que les suppression sont stoquer dans l'historique et que la contrainte d'unicité est bien présente sur la table affectation
