### PR TITLE
[Interconnexion - SISH] Mise à jour message suivi

### DIFF
--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -74,7 +74,7 @@ class EsaboraManager
         if (!empty($description)) {
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
-                description: 'Signalement <b>'.$description.'</b> par '.$affectation->getPartner()->getNom(),
+                description: 'Signalement <b>'.$description.'</b>',
                 type: EsaboraStatus::ESABORA_WAIT->value === $dossierResponse->getSasEtat() ? Suivi::TYPE_TECHNICAL : Suivi::TYPE_AUTO,
                 category: SuiviCategory::SIGNALEMENT_STATUS_IS_SYNCHRO,
                 user: $this->adminUser,
@@ -95,28 +95,29 @@ class EsaboraManager
         ? strtolower($dossierResponse->getEtat())
         : '';
 
+        $namePartner = $affectation->getPartner()->getNom();
         switch ($esaboraStatus) {
             case EsaboraStatus::ESABORA_WAIT->value:
                 if (AffectationStatus::WAIT !== $currentStatus) {
                     $this->affectationManager->updateAffectation($affectation, $user, AffectationStatus::WAIT);
-                    $description = 'remis en attente via '.$dossierResponse->getNameSI();
+                    $description = 'remis en attente par '.$namePartner.' via '.$dossierResponse->getNameSI();
                 }
                 break;
             case EsaboraStatus::ESABORA_ACCEPTED->value:
                 if ($this->shouldBeAcceptedViaEsabora($esaboraDossierStatus, $currentStatus)) {
                     $this->affectationManager->updateAffectation($affectation, $user, AffectationStatus::ACCEPTED);
-                    $description = 'accepté via '.$dossierResponse->getNameSI();
+                    $description = 'accepté par '.$namePartner.' via '.$dossierResponse->getNameSI();
                 }
 
                 if ($this->shouldBeClosedViaEsabora($esaboraDossierStatus, $currentStatus)) {
                     $this->affectationManager->updateAffectation($affectation, $user, AffectationStatus::CLOSED);
-                    $description = 'cloturé via '.$dossierResponse->getNameSI();
+                    $description = 'cloturé par '.$namePartner.' via '.$dossierResponse->getNameSI();
                 }
                 break;
             case EsaboraStatus::ESABORA_REFUSED->value:
                 if (AffectationStatus::REFUSED !== $currentStatus) {
                     $this->affectationManager->updateAffectation($affectation, $user, AffectationStatus::REFUSED);
-                    $description = 'refusé via '.$dossierResponse->getNameSI();
+                    $description = 'refusé par '.$namePartner.' via '.$dossierResponse->getNameSI();
                 }
                 break;
             case EsaboraStatus::ESABORA_REJECTED->value:

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -120,7 +120,7 @@ class EsaboraManagerTest extends KernelTestCase
 
         /** @var Suivi $suivi */
         $suivi = $signalement->getSuivis()->last();
-        $this->assertStringContainsString($suiviDescription, $suivi->getDescription());
+        $this->assertStringContainsString($suiviDescription, $suivi->getDescription(), $suiviDescription);
         $this->assertFalse($suivi->getIsPublic());
         $this->assertEquals($suiviStatus, $suivi->getType());
         $this->assertEmailCount($mailSent ? 1 : 0);
@@ -135,7 +135,7 @@ class EsaboraManagerTest extends KernelTestCase
         yield EsaboraStatus::ESABORA_WAIT->value => [
             '2022-8',
             'etat_a_traiter.json',
-            'remis en attente',
+            'remis en attente par Partenaire 13-02 via Esabora',
             AffectationStatus::WAIT,
             Suivi::TYPE_TECHNICAL,
             false, // suivi mail not sent cause suivi technical
@@ -144,7 +144,7 @@ class EsaboraManagerTest extends KernelTestCase
         yield EsaboraStatus::ESABORA_ACCEPTED->value => [
             '2022-1',
             'etat_importe.json',
-            'accepté via Esabora',
+            'accepté par Partenaire 13-01 via Esabora',
             AffectationStatus::ACCEPTED,
             Suivi::TYPE_AUTO,
             true, // suivi mail sent
@@ -153,7 +153,7 @@ class EsaboraManagerTest extends KernelTestCase
         yield EsaboraStatus::ESABORA_CLOSED->value => [
             '2022-10',
             'etat_termine.json',
-            'cloturé via Esabora',
+            'cloturé par Partenaire 13-02 via Esabora',
             AffectationStatus::CLOSED,
             Suivi::TYPE_AUTO,
             true, // suivi mail sent
@@ -162,7 +162,7 @@ class EsaboraManagerTest extends KernelTestCase
         yield EsaboraStatus::ESABORA_REFUSED->value => [
             '2022-2',
             'etat_non_importe.json',
-            'refusé via Esabora',
+            'refusé par Partenaire 01-01 via Esabora',
             AffectationStatus::REFUSED,
             Suivi::TYPE_AUTO,
             false, // suivi mail not sent cause signalement closed
@@ -180,7 +180,7 @@ class EsaboraManagerTest extends KernelTestCase
         yield EsaboraStatus::ESABORA_ACCEPTED->value.' SISH' => [
             '2022-2',
             '../../sish/ws_etat_dossier_sas/etat_importe.json',
-            'accepté via '.EsaboraSISHService::NAME_SI.' (Dossier 2023/SISH/0010)',
+            'accepté par Partenaire 01-01 via '.EsaboraSISHService::NAME_SI.' (Dossier 2023/SISH/0010)',
             AffectationStatus::ACCEPTED,
             Suivi::TYPE_AUTO,
             false, // suivi mail not sent cause signalement closed
@@ -191,7 +191,7 @@ class EsaboraManagerTest extends KernelTestCase
     ): void {
         $referenceSignalement = '2022-2';
         $filename = '../../sish/ws_etat_dossier_sas/etat_importe.json';
-        $suiviDescription = 'accepté via '.EsaboraSISHService::NAME_SI.' (Dossier 2023/SISH/0010)';
+        $suiviDescription = 'accepté par Partenaire 01-01 via '.EsaboraSISHService::NAME_SI.' (Dossier 2023/SISH/0010)';
         $expectedAffectationStatus = AffectationStatus::ACCEPTED;
         $suiviStatus = Suivi::TYPE_AUTO;
         /** @var Signalement $signalement */

--- a/tests/Unit/Service/Esabora/EsaboraManagerTest.php
+++ b/tests/Unit/Service/Esabora/EsaboraManagerTest.php
@@ -32,8 +32,8 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 class EsaboraManagerTest extends KernelTestCase
 {
     use FixturesHelper;
-    protected const CREATE_ACTION = 'create';
-    protected const UPDATE_ACTION = 'update';
+    protected const string CREATE_ACTION = 'create';
+    protected const string UPDATE_ACTION = 'update';
 
     protected MockObject|AffectationManager $affectationManager;
     protected MockObject|SuiviManager $suiviManager;


### PR DESCRIPTION
## Ticket

#4420    

## Description
Mise à jour des messages de suivi automatique d'Esabora

## Changements apportés
* Mettre la mention par juste après le statut

## Pré-requis
```
make mock-stop && make mock-start
```
## Tests
- [ ] Exécuter la commande make sync-sish et vérifier le message dans le dossier http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000012
<img width="1447" height="120" alt="image" src="https://github.com/user-attachments/assets/1ed9c729-855b-4723-be12-c2e9c0568a4b" />

