### PR TITLE
[QA - BUG] Affectation avec le statut "CLOSED" au lieu de "FERME"

### DIFF
--- a/migrations/Version20250731142328.php
+++ b/migrations/Version20250731142328.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250731142328 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update affectation status from CLOSED to FERME';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE affectation SET statut = 'FERME' WHERE statut = 'CLOSED'");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#4436

## Description
Migration pour corriger les statut d'affectation erronées "CLOSED" au lieu de "FERME". 

Elles sont toutes sur des signalements au statuts archivé mais ca provoque des crash lorsqu'elle sont hydratés (ex parcours de toutes les affectation du partenaire sur le controller `back_signalement_reopen`. Ou plus simplement sur la page SA des signalements archivés.

Je n'ai pas trouvé d’où provenait ce statu en erreur

## Tests
- [ ] `make execute-migration name=Version20250731142328 direction=up`
