### PR TITLE
[BO - Signalements] Gestion par agent : Modale de choix initial - suivre tous les dossier / dossier avec interaction

### DIFF
--- a/assets/scripts/vanilla/services/bo_modales.js
+++ b/assets/scripts/vanilla/services/bo_modales.js
@@ -68,3 +68,15 @@ if (modalPopNotification) {
     }
   }, 100);
 }
+
+const modalSubscriptionsChoice = document.getElementById('fr-modal-subscriptions-choice');
+if (modalSubscriptionsChoice && !modalPopNotification) {
+  //prevent error dsfr is not defined or null
+  const checkDsfrIntervalModalSubscriptionsChoice = setInterval(() => {
+    if (typeof dsfr !== 'undefined' && dsfr !== null) {
+      clearInterval(checkDsfrIntervalModalSubscriptionsChoice);
+      dsfr(modalSubscriptionsChoice).modal.disclose();
+      
+    }
+  }, 100);
+}

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOnlyChoice.vue
@@ -104,25 +104,3 @@ export default defineComponent({
   emits: ['update:modelValue']
 })
 </script>
-
-<style>
-  .signalement-form-only-choice .fr-fieldset__element {
-    width: 100%;
-    max-width: 500px;
-    padding: 1rem;
-    border: 1px solid var(--border-disabled-grey);
-    background-color: var(--grey-1000-50);
-  }
-  .signalement-form-only-choice .fr-fieldset__element:hover {
-    background-color: var(--grey-1000-50-hover);
-  }
-  .signalement-form-only-choice .fr-fieldset__element.is-checked {
-    border: 1px solid rgb(0, 0, 145);
-  }
-
-  @media (max-width: 48em) {
-    .signalement-form-only-choice .fr-fieldset__element.item-divided {
-      flex-basis: content;
-    }
-  }
-</style>

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -351,6 +351,29 @@ a.fr-btn.fr-btn--icon-left.fr-fi-file-pdf-fill.ignore-blank-style::before {
     resize: vertical;
 }
 
+.signalement-form-only-choice .fr-fieldset__element {
+    width: 100%;
+    max-width: 500px;
+    padding: 1rem;
+    border: 1px solid var(--border-disabled-grey);
+    background-color: var(--grey-1000-50);
+}
+.signalement-form-only-choice.no-max-width .fr-fieldset__element {
+    max-width: none;
+}
+.signalement-form-only-choice .fr-fieldset__element:hover {
+    background-color: var(--grey-1000-50-hover);
+}
+.signalement-form-only-choice .fr-fieldset__element.is-checked {
+    border: 1px solid rgb(0, 0, 145);
+}
+
+@media (max-width: 48em) {
+    .signalement-form-only-choice .fr-fieldset__element.item-divided {
+        flex-basis: content;
+    }
+}
+
 /*PRELOADER*/
 .lds-histologe {
     display: inline-block;

--- a/migrations/Version20250801133849.php
+++ b/migrations/Version20250801133849.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250801133849 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add has_done_subscriptions_choice column to user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD has_done_subscriptions_choice TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP has_done_subscriptions_choice');
+    }
+}

--- a/src/Controller/Back/PartnerController.php
+++ b/src/Controller/Back/PartnerController.php
@@ -34,6 +34,7 @@ use App\Service\Sanitizer;
 use App\Service\Signalement\VisiteNotifier;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -394,6 +395,8 @@ class PartnerController extends AbstractController
         Request $request,
         Partner $partner,
         UserManager $userManager,
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        bool $featureNewDashboard,
     ): JsonResponse|RedirectResponse {
         $this->denyAccessUnlessGranted('USER_CREATE', $partner);
         $user = new User();
@@ -426,6 +429,9 @@ class PartnerController extends AbstractController
                 $userPartner->setUser($userExist);
                 $user = $userExist;
                 $userManager->sendAccountActivationNotification($user);
+            }
+            if (!$userExist && $featureNewDashboard) {
+                $user->setHasDoneSubscriptionsChoice(true);
             }
             $userManager->persist($userPartner);
             $userManager->save($user);

--- a/src/Controller/Back/PopNotificationController.php
+++ b/src/Controller/Back/PopNotificationController.php
@@ -39,7 +39,7 @@ class PopNotificationController extends AbstractController
         $user = $this->getUser();
         $popNotification = $user->getPopNotifications()->count() ? $user->getPopNotifications()->first() : null;
         if ($popNotification) {
-            $popNotificationManager->remove($popNotification);
+            //$popNotificationManager->remove($popNotification);
         }
 
         return new JsonResponse(['success' => true]);

--- a/src/Controller/Back/PopNotificationController.php
+++ b/src/Controller/Back/PopNotificationController.php
@@ -39,7 +39,7 @@ class PopNotificationController extends AbstractController
         $user = $this->getUser();
         $popNotification = $user->getPopNotifications()->count() ? $user->getPopNotifications()->first() : null;
         if ($popNotification) {
-            //$popNotificationManager->remove($popNotification);
+            // $popNotificationManager->remove($popNotification);
         }
 
         return new JsonResponse(['success' => true]);

--- a/src/Controller/Back/SubscriptionsChoiceController.php
+++ b/src/Controller/Back/SubscriptionsChoiceController.php
@@ -26,13 +26,11 @@ class SubscriptionsChoiceController extends AbstractController
         if (!$this->isCsrfTokenValid('subscriptions_choice', $token)) {
             $errorMsg = 'Le token CSRF est invalide, veuillez recharger la page.';
             $response = ['code' => Response::HTTP_BAD_REQUEST, 'errors' => ['custom' => ['errors' => [$errorMsg]]]];
-
-            return $this->json($response, $response['code']);
-        }
-        if (null === $choice) {
+        } elseif (null === $choice) {
             $errorMsg = 'Veuillez faire un choix.';
             $response = ['code' => Response::HTTP_BAD_REQUEST,  'errors' => ['custom' => ['errors' => [$errorMsg]]]];
-
+        }
+        if (isset($response) && isset($errorMsg)) {
             return $this->json($response, $response['code']);
         }
 

--- a/src/Controller/Back/SubscriptionsChoiceController.php
+++ b/src/Controller/Back/SubscriptionsChoiceController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Controller\Back;
+
+use App\Entity\User;
+use App\Repository\UserSignalementSubscriptionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/bo/subscription-choice')]
+class SubscriptionsChoiceController extends AbstractController
+{
+    #[Route('/choice', name: 'subscriptions_choice', methods: ['POST'])]
+    public function choice(
+        Request $request,
+        UserSignalementSubscriptionRepository $userSignalementSubscriptionRepository,
+        EntityManagerInterface $entityManager,
+    ): JsonResponse {
+        $jsonData = $request->toArray();
+        $choice = $jsonData['subscriptions_choice'] ?? null;
+        $token = $jsonData['_token'] ?? null;
+        if (!$this->isCsrfTokenValid('subscriptions_choice', $token)) {
+            $errorMsg = 'Le token CSRF est invalide, veuillez recharger la page.';
+            $response = ['code' => Response::HTTP_BAD_REQUEST, 'errors' => ['custom' => ['errors' => [$errorMsg]]]];
+
+            return $this->json($response, $response['code']);
+        }
+        if (null === $choice) {
+            $errorMsg = 'Veuillez faire un choix.';
+            $response = ['code' => Response::HTTP_BAD_REQUEST,  'errors' => ['custom' => ['errors' => [$errorMsg]]]];
+
+            return $this->json($response, $response['code']);
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+        if ($choice) {
+            $subs = $userSignalementSubscriptionRepository->findLegacyForUserInactiveOnSignalement($user);
+            foreach ($subs as $sub) {
+                $entityManager->remove($sub);
+            }
+        }
+        $user->setHasDoneSubscriptionsChoice(true);
+        $entityManager->flush();
+
+        return $this->json(['code' => Response::HTTP_OK]);
+    }
+}

--- a/src/DataFixtures/Files/Suivi.yml
+++ b/src/DataFixtures/Files/Suivi.yml
@@ -109,3 +109,10 @@ suivis:
   type: 3
   context: signalementClosed
   category: "SIGNALEMENT_IS_CLOSED"
+- 
+  created_by: user-13-05@signal-logement.fr
+  description: "Un message sur le 2023-15 qui m'abonne avec participation"
+  is_public: 0
+  signalement: "2023-13"
+  type: 3
+  category: "MESSAGE_PARTNER"

--- a/src/DataFixtures/Loader/LoadAffectationData.php
+++ b/src/DataFixtures/Loader/LoadAffectationData.php
@@ -14,6 +14,7 @@ use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Repository\TerritoryRepository;
 use App\Repository\UserRepository;
+use App\Repository\UserSignalementSubscriptionRepository;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -32,6 +33,7 @@ class LoadAffectationData extends Fixture implements OrderedFixtureInterface
         private readonly TerritoryRepository $territoryRepository,
         private readonly UserRepository $userRepository,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly UserSignalementSubscriptionRepository $userSignalementSubscriptionRepository,
         #[Autowire(env: 'USER_SYSTEM_EMAIL')]
         private readonly string $userSystemEmail,
     ) {
@@ -90,6 +92,10 @@ class LoadAffectationData extends Fixture implements OrderedFixtureInterface
         if (AffectationStatus::ACCEPTED === $affectation->getStatut()) {
             foreach ($partner->getUsers() as $user) {
                 if (($user->isUserPartner() || $user->isPartnerAdmin()) && UserStatus::ARCHIVE !== $user->getStatut()) {
+                    $subscription = $this->userSignalementSubscriptionRepository->findOneBy(['user' => $user, 'signalement' => $affectation->getSignalement()]);
+                    if ($subscription) {
+                        continue;
+                    }
                     $subscription = new UserSignalementSubscription();
                     $subscription
                         ->setUser($user)

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -198,6 +198,9 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserSignalementSubscription::class, orphanRemoval: true)]
     private Collection $userSignalementSubscriptions;
 
+    #[ORM\Column]
+    private ?bool $hasDoneSubscriptionsChoice = null;
+
     public function __construct()
     {
         $this->suivis = new ArrayCollection();
@@ -212,6 +215,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         $this->popNotifications = new ArrayCollection();
         $this->isMailingSummary = true;
         $this->userSignalementSubscriptions = new ArrayCollection();
+        $this->hasDoneSubscriptionsChoice = false;
     }
 
     public function getId(): ?int
@@ -972,6 +976,18 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
                 $userSignalementSubscription->setUser(null);
             }
         }
+
+        return $this;
+    }
+
+    public function hasDoneSubscriptionsChoice(): ?bool
+    {
+        return $this->hasDoneSubscriptionsChoice;
+    }
+
+    public function setHasDoneSubscriptionsChoice(bool $hasDoneSubscriptionsChoice): static
+    {
+        $this->hasDoneSubscriptionsChoice = $hasDoneSubscriptionsChoice;
 
         return $this;
     }

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -4,9 +4,16 @@ namespace App\Factory;
 
 use App\Entity\Enum\UserStatus;
 use App\Entity\User;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class UserFactory
 {
+    public function __construct(
+        #[Autowire(env: 'FEATURE_NEW_DASHBOARD')]
+        private bool $featureNewDashboard,
+    ) {
+    }
+
     public function createInstanceFrom(
         string $roleLabel,
         ?string $firstname,
@@ -16,7 +23,7 @@ class UserFactory
         ?bool $isActivateAccountNotificationEnabled = true,
         ?bool $hasPermissionAffectation = false,
     ): User {
-        return (new User())
+        $user = (new User())
             ->setRoles(\in_array($roleLabel, User::ROLES) ? [$roleLabel] : [User::ROLES[$roleLabel]])
             ->setPrenom($firstname)
             ->setNom($lastname)
@@ -25,6 +32,11 @@ class UserFactory
             ->setIsMailingActive($isMailActive)
             ->setIsActivateAccountNotificationEnabled($isActivateAccountNotificationEnabled)
             ->setHasPermissionAffectation($hasPermissionAffectation);
+        if ($this->featureNewDashboard) {
+            $user->setHasDoneSubscriptionsChoice(true);
+        }
+
+        return $user;
     }
 
     /**

--- a/src/Repository/UserSignalementSubscriptionRepository.php
+++ b/src/Repository/UserSignalementSubscriptionRepository.php
@@ -6,6 +6,8 @@ use App\Entity\Affectation;
 use App\Entity\Intervention;
 use App\Entity\Partner;
 use App\Entity\Signalement;
+use App\Entity\Suivi;
+use App\Entity\User;
 use App\Entity\UserSignalementSubscription;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -57,6 +59,21 @@ class UserSignalementSubscriptionRepository extends ServiceEntityRepository
             $queryBuilder->andWhere('JSON_CONTAINS(u.roles, :role_admin_territory) = 0')
             ->setParameter('role_admin_territory', '"ROLE_ADMIN_TERRITORY"');
         }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * @return array<UserSignalementSubscription>
+     */
+    public function findLegacyForUserInactiveOnSignalement(User $user): array
+    {
+        $queryBuilder = $this->createQueryBuilder('s')
+            ->leftJoin(Suivi::class, 'suivi', 'WITH', 'suivi.signalement = s.signalement AND suivi.createdBy = s.user')
+            ->where('s.user = :user')
+            ->andWhere('suivi.id IS NULL')
+            ->andWhere('s.isLegacy = true')
+            ->setParameter('user', $user);
 
         return $queryBuilder->getQuery()->getResult();
     }

--- a/templates/_partials/_modal_subscriptions_choice.twig
+++ b/templates/_partials/_modal_subscriptions_choice.twig
@@ -1,0 +1,79 @@
+<dialog aria-labelledby="fr-modal-subscriptions-choice-title" id="fr-modal-subscriptions-choice" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-situation-foyer">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-subscriptions-choice-title" class="fr-modal__title">
+                            La gestion des dossiers sur Signal Logement évolue !
+                        </h1>
+                        <p>
+                            Signal Logement passe à une gestion des dossiers par Partenaire à une gestion des dossiers par Agent.
+                            <br>
+                            Jusqu'à présent, les dossiers sont gérés par partenaire. Cela signifie que vous recevez des notifications pour tous les dossiers affectés à votre partenaire, même ceux gérés par vos collègues !
+                        </p>
+                        <p>
+                            Avec la gestion des dossiers par agent, voici ce qui change pour les nouveaux dossiers : 
+                        </p>
+                        <ul>
+                            <li>Chaque dossier est rattaché à un ou plusieurs agents au sein de votre partenaire</li>
+                            <li>Vous pouvez désormais choisir de rejoindre ou quitter un dossier</li>
+                            <li>Vous voyez qui de vos collègues intervient sur chaque dossier</li>
+                            <li>Vous ne recevrez plus de notifications ni d'e-mails concernant les dossiers sur lesquels vous n'intervenez pas</li>
+                            <li>Sur votre nouveau tableau de bord, les dossiers mis en avant sont ceux sur lesquels vous intervenez (vous pourrez toujours consulter la liste de tous les dossiers affectés à votre partenaire)</li>
+                        </ul>
+
+                        <p>
+                            <strong>Pour terminer le paramétrage de votre plateforme, veuillez choisir quels dossiers existants nous devons vous attribuer.</strong>
+                            <br>
+                            <span class="fr-hint-text">
+                                <span class="fr-icon-warning-line" aria-hidden="true"></span> 
+                                Ce choix concerne uniquement les dossiers ouverts existants (en cours). Les nouveaux dossiers seront gérés par le nouveau système.
+                            </span>
+                        </p>
+
+                        <form class="signalement-form-only-choice no-max-width" id="subscriptions-choice-form" method="post" action="{{ path('subscriptions_choice') }}">
+                            <div class="fr-input-group">
+                                <span class="no-field-errors"></span>
+                            </div>
+                            <div class="fr-fieldset fr-fieldset__element">
+                                <div class="fr-radio-group">
+                                    <input id="subscriptions_choice_all" type="radio" name="subscriptions_choice" class="fr-input" value="0">
+                                    <label class="fr-label" for="subscriptions_choice_all">
+                                        Tous les dossiers en cours de mon partenaire
+                                        <span class="fr-hint-text">
+                                            Tous les dossiers en cours de votre partenaire vous seront attribués. 
+                                            Cela signifie que vous continuerez à recevoir toutes les notifications concernant ces dossiers, ils apparaîtront tous sur votre tableau de bord.
+                                        </span>
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="fr-fieldset fr-fieldset__element">
+                                <div class="fr-radio-group">
+                                    <input id="subscriptions_choice_picked" type="radio" name="subscriptions_choice" class="fr-input" value="1">
+                                    <label class="fr-label" for="subscriptions_choice_picked">
+                                        Uniquement les dossiers sur lesquels j'ai effectué une action
+                                        <span class="fr-hint-text">
+                                            Seuls les dossiers sur lesquels vous avez déjà effectué une action (accepté le dossier, ajouté un suivi ou un document, modifié des informations, etc.) vous seront attribués. 
+                                            Vous recevrez uniquement les notifications de ces dossiers, ils seront mis en avant sur votre tableau de bord.
+                                        </span>
+                                    </label>
+                                </div>
+                            </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('subscriptions_choice') }}">
+                        </form>
+
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <button class="fr-btn fr-icon-close-line" type="submit" form="subscriptions-choice-form">Valider mon choix</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -101,4 +101,11 @@
         {{ render(controller('App\\Controller\\Back\\PopNotificationController::show')) }}
     {% endif %}
 
+    {% if feature_new_dashboard and not app.user.hasDoneSubscriptionsChoice %}
+        <button class="fr-hidden" data-fr-opened="false" aria-controls="fr-modal-subscriptions-choice"></button>
+        <div data-ajax-form>
+            {% include '_partials/_modal_subscriptions_choice.twig' %}
+        </div>
+    {% endif %}
+
 {% endblock %}

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -68,7 +68,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
         yield 'Search by Statut de la visite' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 5];
         yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 5];
-        yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18', 'isImported' => 'oui'], 3];
+        yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18', 'isImported' => 'oui'], 2];
         yield 'Search by Statut de l\'affectation' => [['statusAffectation' => 'refuse', 'isImported' => 'oui'], 1];
         yield 'Search by Score criticite' => [['criticiteScoreMin' => 5, 'criticiteScoreMax' => 6, 'isImported' => 'oui'], 9];
         yield 'Search by Declarant' => [['typeDeclarant' => 'locataire', 'isImported' => 'oui'], 51];
@@ -83,8 +83,8 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Signalement Imported' => [['isImported' => 'oui'], 56];
         yield 'Search by Zones' => [['isImported' => 'oui', 'zones' => [1, 2, 3]], 5];
         yield 'Search by Zones on Territory 34' => [['isImported' => 'oui', 'zones' => [1, 2, 3], 'territoire' => '35'], 1];
-        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 7];
-        yield 'Search by dates depot and dates of last suivi' => [['isImported' => 'oui', 'dateDepotDebut' => '2023-01-01', 'dateDepotFin' => '2023-03-31', 'dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-12-31'], 3];
+        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 6];
+        yield 'Search by dates depot and dates of last suivi' => [['isImported' => 'oui', 'dateDepotDebut' => '2023-01-01', 'dateDepotFin' => '2023-03-31', 'dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-12-31'], 2];
         yield 'Search by Demande fermeture usager territoire 13' => [['territoire' => '13', 'usagerAbandonProcedure' => '1'], 1];
         yield 'Search by Demande fermeture usager all' => [['usagerAbandonProcedure' => '1'], 2];
         yield 'Search by Mes dossiers' => [['showMySignalementsOnly' => 'oui', 'isImported' => 'oui'], 1];
@@ -251,7 +251,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Status Fermé' => [['isImported' => 'oui', 'status' => 'ferme'], 3];
         yield 'Search by Status Fermé on Territory 1' => [['territoire' => '1', 'isImported' => 'oui', 'status' => 'ferme'], 1];
         yield 'Search by Status Fermé on Territory 13' => [['territoire' => '13', 'isImported' => 'oui', 'status' => 'ferme'], 2];
-        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 2];
+        yield 'Search by Sans suivi in territory 13' => [['isImported' => 'oui', 'sansSuiviPeriode' => 30, 'territoire' => '13'], 1];
     }
 
     /**

--- a/tests/Functional/Controller/Back/SubscriptionsChoiceControllerTest.php
+++ b/tests/Functional/Controller/Back/SubscriptionsChoiceControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Entity\User;
+use App\Entity\UserSignalementSubscription;
+use App\Repository\SignalementRepository;
+use App\Repository\UserRepository;
+use App\Repository\UserSignalementSubscriptionRepository;
+use App\Tests\SessionHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class SubscriptionsChoiceControllerTest extends WebTestCase
+{
+    use SessionHelper;
+
+    private ?KernelBrowser $client = null;
+    private ?EntityManagerInterface $entityManager = null;
+    private ?UserRepository $userRepository = null;
+    private ?User $user = null;
+    private ?SignalementRepository $signalementRepository = null;
+    private ?UserSignalementSubscriptionRepository $userSignalementSubscriptionRepository = null;
+    private ?RouterInterface $router = null;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        /* @var RouterInterface $router */
+        $this->router = static::getContainer()->get(RouterInterface::class);
+        $this->userRepository = static::getContainer()->get(UserRepository::class);
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $this->signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $this->userSignalementSubscriptionRepository = static::getContainer()->get(UserSignalementSubscriptionRepository::class);
+        $this->user = $this->userRepository->findOneBy(['email' => 'user-13-05@signal-logement.fr']);
+        $this->client->loginUser($this->user);
+    }
+
+    public function testSubscriptionChoiceAll(): void
+    {
+        $payload = json_encode([
+            'subscriptions_choice' => '0',
+            '_token' => $this->generateCsrfToken($this->client, 'subscriptions_choice'),
+        ]);
+        $route = $this->router->generate('subscriptions_choice');
+        $this->client->request('POST', $route, [], [], [], $payload);
+
+        $subs = $this->userSignalementSubscriptionRepository->findBy(['user' => $this->user]);
+        $this->assertCount(4, $subs);
+        $this->assertEquals($this->user->hasDoneSubscriptionsChoice(), true);
+    }
+
+    public function testSubscriptionChoiceNone(): void
+    {
+        $otherSignalement = $this->signalementRepository->findOneBy(['reference' => '2023-12']);
+        $subscription = new UserSignalementSubscription();
+        $subscription->setSignalement($otherSignalement);
+        $subscription->setUser($this->user);
+        $subscription->setCreatedBy($this->user);
+        $this->entityManager->persist($subscription);
+        $this->entityManager->flush();
+
+        $payload = json_encode([
+            'subscriptions_choice' => '1',
+            '_token' => $this->generateCsrfToken($this->client, 'subscriptions_choice'),
+        ]);
+        $route = $this->router->generate('subscriptions_choice');
+        $this->client->request('POST', $route, [], [], [], $payload);
+
+        $subs = $this->userSignalementSubscriptionRepository->findBy(['user' => $this->user]);
+        $this->assertCount(2, $subs);
+        $this->assertEquals($this->user->hasDoneSubscriptionsChoice(), true);
+    }
+}

--- a/tests/Functional/Service/Notification/NotificationCounterTest.php
+++ b/tests/Functional/Service/Notification/NotificationCounterTest.php
@@ -27,6 +27,6 @@ class NotificationCounterTest extends KernelTestCase
 
         $user = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
         $notificationCount = (new NotificationCounter($notificationRepository))->countUnseenNotification($user);
-        $this->assertEquals(11, $notificationCount);
+        $this->assertEquals(12, $notificationCount);
     }
 }

--- a/tests/Unit/Factory/UserFactoryTest.php
+++ b/tests/Unit/Factory/UserFactoryTest.php
@@ -30,7 +30,7 @@ class UserFactoryTest extends KernelTestCase
     {
         $partner = new Partner();
 
-        $user = (new UserFactory())->createInstanceFrom(
+        $user = (new UserFactory(true))->createInstanceFrom(
             roleLabel: 'Agent',
             firstname: 'John',
             lastname: 'Doe',
@@ -49,7 +49,7 @@ class UserFactoryTest extends KernelTestCase
 
     public function testCreateUserAdminInstanceWithoutPartnerAndTerritory(): void
     {
-        $user = (new UserFactory())->createInstanceFrom(
+        $user = (new UserFactory(true))->createInstanceFrom(
             roleLabel: 'Super Admin',
             firstname: 'John',
             lastname: 'Doe',
@@ -80,7 +80,7 @@ class UserFactoryTest extends KernelTestCase
             'isMailingActive' => true,
         ];
 
-        $user = (new UserFactory())->createInstanceFromArray($data);
+        $user = (new UserFactory(true))->createInstanceFromArray($data);
         $userPartner = (new UserPartner())->setPartner($partner)->setUser($user);
         $user->addUserPartner($userPartner);
 


### PR DESCRIPTION
## Ticket

#4341

## Description
Création de la modale de choix initial pour les abonnements aux signalements
- Choix : Tous les dossier -> Ne change rien.
- Choix : Dossier avec action -> Supprime les abonnement "legacy" pour les signalement sans suivi de l'user. 

Dans les deux cas : enregistre le choix comme effectué pour ne plus affiché la modale

## Pré-requis
`make npm-build`
`make execute-migration name=Version20250801133849 direction=up`

## Tests
- [ ] Tester les deux choix
