### PR TITLE
[BO - Form pro] Ajouter case recueil consentement

### DIFF
--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -542,7 +542,6 @@ class SignalementCreateController extends AbstractController
     private function hasConsentError(Request $request): bool
     {
         return !$request->get('consent_signalement_tiers')
-            || !$request->get('consent_donnees_sante')
-            || !$request->get('consent_donnees_cgu');
+            || !$request->get('consent_donnees_sante');
     }
 }

--- a/templates/back/signalement_create/tabs/tab-validation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-validation.html.twig
@@ -22,19 +22,6 @@
                 Je certifie ne pas avoir partagé de données personnelles de santé concernant les personnes occupant le logement.
             </label>
         </div>
-
-        <div class="fr-checkbox-group fr-mb-3v">
-            <input type="checkbox" id="consent-cgu" name="consent_donnees_cgu"
-                   {% if app.request.get('consent_donnees_cgu') %}checked{% endif %}>
-            <label class="fr-label" for="consent-cgu">
-                Je certifie avoir pris connaissance et accepter les&nbsp;
-                <a href="{{ sites_faciles_url }}cgu-agents" target="_blank" rel="noopener">conditions générales d'utilisation</a>&nbsp;
-                et la&nbsp;
-                <a href="{{ sites_faciles_url }}politique-de-confidentialite" target="_blank" rel="noopener">politique de confidentialité</a>&nbsp;
-                du service Signal Logement.
-            </label>
-        </div>
-
         <p id="consentements-error" class="fr-error-text {{ null != hasConsentError and hasConsentError ? '' : 'fr-hidden' }}">
             Veuillez cocher toutes les cases de consentement.
         </p>

--- a/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
@@ -318,7 +318,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->client->request('POST', $route, [
             'consent_signalement_tiers' => 'on',
             'consent_donnees_sante' => 'on',
-            'consent_donnees_cgu' => 'on',
             '_token' => $this->generateCsrfToken($this->client, 'form_signalement_validation'),
         ]);
 
@@ -352,7 +351,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->client->request('POST', $route, [
             'consent_signalement_tiers' => 'on',
             'consent_donnees_sante' => 'on',
-            'consent_donnees_cgu' => 'on',
             '_token' => $this->generateCsrfToken($this->client, 'form_signalement_validation'),
             'partner-ids' => $partner1->getId().','.$partner2->getId(),
         ]);
@@ -385,7 +383,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->client->request('POST', $route, [
             'consent_signalement_tiers' => 'on',
             'consent_donnees_sante' => 'on',
-            'consent_donnees_cgu' => 'on',
             '_token' => $this->generateCsrfToken($this->client, 'form_signalement_validation'),
         ]);
 
@@ -417,7 +414,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->client->request('POST', $route, [
             'consent_signalement_tiers' => 'on',
             'consent_donnees_sante' => 'on',
-            'consent_donnees_cgu' => 'on',
             '_token' => $this->generateCsrfToken($this->client, 'form_signalement_validation'),
         ]);
 
@@ -449,7 +445,6 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->client->request('POST', $route, [
             'consent_signalement_tiers' => 'on',
             'consent_donnees_sante' => 'on',
-            'consent_donnees_cgu' => 'on',
             '_token' => $this->generateCsrfToken($this->client, 'form_signalement_validation'),
         ]);
 


### PR DESCRIPTION
## Ticket

#4368    

<img width="1373" height="300" alt="image" src="https://github.com/user-attachments/assets/3bfb894c-144a-463c-afc7-6cfa4079d925" />

## Description
Ajout des cases à cocher des recueil de consentement 

## Changements apportés
* Ajout des cases à cocher et du contrôle coté contrôleur

## Pré-requis
```
SITES_FACILES_URL=https://signal-logement.beta.gouv.fr/
```

## Tests
- [ ] Aller à la page de validation et soumettre le formulaire sans cocher les cases
- [ ] Vérifier les liens externes
