### PR TITLE
[BUG - FO] SignalementUserProvider: No occupant user found, trying to find by email.

### DIFF
--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Security;
 
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Manager\UserManager;
 use App\Repository\SignalementRepository;
 use App\Service\Files\ImageVariantProvider;
 use Nelmio\ApiDocBundle\Attribute\Security;
@@ -113,6 +114,7 @@ class SecurityController extends AbstractController
         string $code,
         AuthenticationUtils $authenticationUtils,
         SignalementRepository $signalementRepository,
+        UserManager $userManager,
         Request $request,
     ): Response {
         $signalement = $signalementRepository->findOneByCodeForPublic($code);
@@ -123,6 +125,9 @@ class SecurityController extends AbstractController
         }
         if ($this->getUser()) {
             return $this->redirectToRoute('front_suivi_signalement', ['code' => $code]);
+        }
+        if (!$signalement->getSignalementUsager()?->getOccupant()) {
+            $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
         }
         // get the login error if there is one
         $error = $authenticationUtils->getLastAuthenticationError();

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -17,7 +17,7 @@ signalements:
     adresse_occupant: "3 rue Mars"
     cp_occupant: "13015"
     ville_occupant: "Marseille"
-    mail_occupant: "francis.cabrel@astaffort.com"
+    mail_occupant: ""
     statut: "ACTIVE"
     reference: "2022-1"
     geoloc: "{\"lat\":\"43.3426152\",\"lng\":\"5.3711848\"}"

--- a/tests/Functional/Controller/Back/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementControllerTest.php
@@ -278,7 +278,7 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(SignalementStatus::CLOSED, $signalement->getStatut());
 
         $client->enableProfiler();
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(1);
     }
 
     public function testAdminPartnerSubmitClotureSignalementWithEmailSentToRT(): void

--- a/tests/Functional/Controller/IframeControllerTest.php
+++ b/tests/Functional/Controller/IframeControllerTest.php
@@ -15,7 +15,7 @@ class IframeControllerTest extends WebTestCase
         $client->request('GET', $generatorUrl->generate('iframe_demande_lien_signalement'));
 
         $client->submitForm('demande_lien_signalement_save', [
-            'demande_lien_signalement[email]' => 'francis.cabrel@astaffort.com',
+            'demande_lien_signalement[email]' => 'admin-partenaire-13-01@signal-logement.fr',
             'demande_lien_signalement[adresseHelper]' => '3 rue Mars 13015 Marseille',
             'demande_lien_signalement[adresse]' => '3 rue Mars',
             'demande_lien_signalement[codePostal]' => '13015',

--- a/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionCreatedSubscriberTest.php
@@ -61,7 +61,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
             InterventionCreatedEvent::NAME
         );
 
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(1);
         $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
 
         $nbSuiviInterventionPlanned = self::getContainer()->get(SuiviRepository::class)->count(['category' => SuiviCategory::INTERVENTION_IS_CREATED, 'signalement' => $intervention->getSignalement()]);
@@ -82,7 +82,7 @@ class InterventionCreatedSubscriberTest extends KernelTestCase
         $date = (new \DateTimeImmutable())->modify('+1 day');
         $type = InterventionType::VISITE;
         $this->testNbMailSent($date, $type);
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(1);
     }
 
     public function testInterventionNoVisitInPast(): void

--- a/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/InterventionUpdatedByEsaboraSubscriberTest.php
@@ -51,7 +51,7 @@ class InterventionUpdatedByEsaboraSubscriberTest extends KernelTestCase
             InterventionUpdatedByEsaboraEvent::NAME
         );
 
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(1);
         $this->assertEquals(2, $intervention->getSignalement()->getSuivis()->count());
         $this->assertStringContainsString('a été modifiée', $intervention->getSignalement()->getSuivis()->last()->getDescription());
     }

--- a/tests/Functional/Manager/UserManagerTest.php
+++ b/tests/Functional/Manager/UserManagerTest.php
@@ -93,30 +93,16 @@ class UserManagerTest extends KernelTestCase
         return $userRepository->findOneBy(['email' => $userEmail]);
     }
 
-    public function testGetUserAndTypeForSignalementAndEmail(): void
+    public function testCreateUsagerOccupantFromSignalementWithoutMailOccupant(): void
     {
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
-        $signalement = $signalementRepository->findOneBy(['reference' => '2023-120']);
+        $signalement = $signalementRepository->findOneBy(['reference' => '2022-1']);
 
-        $user = $this->userManager->getOrCreateUserForSignalementAndEmail($signalement, $signalement->getMailOccupant());
-        $this->assertEquals($signalement->getMailOccupant(), $user->getEmail());
-        $type = $this->userManager->getUserTypeForSignalementAndUser($signalement, $user);
-        $this->assertEquals(UserManager::OCCUPANT, $type);
+        $user = $this->userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
 
-        $user = $this->userManager->getOrCreateUserForSignalementAndEmail($signalement, $signalement->getMailDeclarant());
-        $this->assertEquals($signalement->getMailDeclarant(), $user->getEmail());
-        $type = $this->userManager->getUserTypeForSignalementAndUser($signalement, $user);
-        $this->assertEquals(UserManager::DECLARANT, $type);
-
-        $user = $this->userManager->getOrCreateUserForSignalementAndEmail($signalement, 'lalala@nanani.fr');
-        $this->assertNull($user);
-        $type = $this->userManager->getUserTypeForSignalementAndUser($signalement, $user);
-        $this->assertNull($type);
-
-        $signalement->setMailDeclarant($signalement->getMailOccupant());
-        $user = $this->userManager->getOrCreateUserForSignalementAndEmail($signalement, $signalement->getMailDeclarant());
-        $type = $this->userManager->getUserTypeForSignalementAndUser($signalement, $user);
-        $this->assertEquals(UserManager::OCCUPANT, $type);
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertEquals('sl__', substr($user->getEmail(), 0, 4));
+        $this->assertEquals($user, $signalement->getSignalementUsager()->getOccupant());
     }
 }

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -190,11 +190,10 @@ class SignalementRepositoryTest extends KernelTestCase
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
         $emailExistingSignalements = $signalementRepository->findAllForEmailAndAddress(
-            'francis.cabrel@astaffort.com',
+            'admin-partenaire-13-01@signal-logement.fr',
             '3 rue Mars',
             '13015',
             'Marseille',
-            false
         );
         $this->assertEquals(1, \count($emailExistingSignalements));
     }

--- a/tests/Functional/Service/NotificationAndMailSenderTest.php
+++ b/tests/Functional/Service/NotificationAndMailSenderTest.php
@@ -312,6 +312,7 @@ class NotificationAndMailSenderTest extends KernelTestCase
 
         $this->entityManager->persist($suivi);
 
+        $signalement->setMailOccupant('temp_for_test@signal-logement.fr');
         $expectedAdress = [$signalement->getMailOccupant()];
 
         $notificationAndMailSender = new NotificationAndMailSender(


### PR DESCRIPTION
## Ticket

#4442

## Description
Afin de ne plus retomber sur le message de log du ticket et ses inconvénients (accusé de lecture non fonctionnel principalement) : 
- On crée toujours un utilisateur occupant pour le signalement, si l'e-mail n'est pas renseigné on en génère un (cet e-mail n'est jamais utilisé, ni affiché)
- Pour corriger l'existant on ajoute le contrôle/création des user inexistants dans `loginFO`

## Changements apportés
* Modifications d'une fixture pour avoir une signalement tiers pro sans email occupant
* Corrections des test en lien avec cette fixtures
* Ajout de tests sur le login et la création d'user sans email occupant
* Suppression de tests et fonctions plus utilisés

## Pré-requis
`make load-fixtures`

## Tests
- [ ] Tester la connexion usager sur le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2022-000000000001
