### PR TITLE
[BO - Dossier] Ajouter bouton voir les doublons pour tous les agents / admin partenaire

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -435,3 +435,26 @@ document
         console.warn('Something went wrong.', err);
       });
   });
+
+  const submitModalDuplicateAddresses = document.getElementById('btn-submit-modal-duplicate-addresses');
+  if (submitModalDuplicateAddresses) {
+    submitModalDuplicateAddresses.addEventListener('click', function (event) {
+      event.preventDefault();
+      const urlToRedirect = this.dataset.url;
+      const dismissCheckbox = document.getElementById('dismiss-modal-duplicate-addresses');
+      if (dismissCheckbox && dismissCheckbox.checked) {
+        this.setAttribute('disabled', 'disabled');
+        const form = document.getElementById('form-modal-duplicate-addresses');
+        const formData = new FormData(form);
+        fetch(form.action, {
+          method: 'POST',
+          body: formData,
+        })
+        .then((response) => {
+          window.location.href = urlToRedirect;
+        })
+      } else {
+        window.location.href = urlToRedirect;
+      }
+    });
+  }

--- a/migrations/Version20250805124814.php
+++ b/migrations/Version20250805124814.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250805124814 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add duplicate_modal_dismissed_at column to user table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD duplicate_modal_dismissed_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user DROP duplicate_modal_dismissed_at');
+    }
+}

--- a/src/Controller/Back/ProfilController.php
+++ b/src/Controller/Back/ProfilController.php
@@ -369,4 +369,17 @@ class ProfilController extends AbstractController
 
         return $this->json($response, $response['code']);
     }
+
+    #[Route('/dismiss-modal-duplicate-addresses', name: 'dismiss_modal_duplicate_addresses', methods: ['POST'])]
+    public function dismissModalDuplicateAddresses(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        if ($this->isCsrfTokenValid('modal_duplicate_addresses', $request->request->get('_token'))) {
+            /** @var User $user */
+            $user = $this->getUser();
+            $user->setDuplicateModalDismissed();
+            $entityManager->flush();
+        }
+
+        return $this->json(['status' => 'success']);
+    }
 }

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -213,14 +213,11 @@ class SignalementController extends AbstractController
 
         $allPhotosOrdered = PhotoHelper::getSortedPhotos($signalement);
         $suiviSeenMarker->markSeenByUsager($signalement);
-        $signalementsOnSameAddress = [];
-        if ($this->isGranted('ROLE_ADMIN_TERRITORY')) {
-            $signalementsOnSameAddress = $signalementRepository->findOnSameAddress(
-                signalement: $signalement,
-                exclusiveStatus: [],
-                excludedStatus: [SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED, SignalementStatus::ARCHIVED]
-            );
-        }
+        $signalementsOnSameAddress = $signalementRepository->findOnSameAddress(
+            signalement: $signalement,
+            exclusiveStatus: [],
+            excludedStatus: [SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED, SignalementStatus::ARCHIVED]
+        );
         $twigParams = [
             'title' => '#'.$signalement->getReference().' Signalement',
             'situations' => $infoDesordres['criticitesArranged'],

--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -255,7 +255,7 @@ class SignalementController extends AbstractController
             'canTogglePartnerAffectation' => $this->isGranted(AffectationVoter::TOGGLE, $signalement),
             'canSeePartnerAffectation' => $this->isGranted(AffectationVoter::SEE, $signalement),
             'zones' => $zoneRepository->findZonesBySignalement($signalement),
-            'signalementOnSameAddress' => $signalementsOnSameAddress,
+            'signalementsOnSameAddress' => $signalementsOnSameAddress,
         ];
 
         return $this->render('back/signalement/view.html.twig', $twigParams);

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -289,3 +289,11 @@ affectations:
     affected_by: "admin-01@signal-logement.fr"
     motif_cloture: ""
     territory: "Gard"
+  -
+    signalement: 2025-04
+    partner: "partenaire-30-02@signal-logement.fr"
+    statut: "EN_COURS"
+    answered_by: ""
+    affected_by: "admin-01@signal-logement.fr"
+    motif_cloture: ""
+    territory: "Gard"

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -201,6 +201,9 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[ORM\Column]
     private ?bool $hasDoneSubscriptionsChoice = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeImmutable $duplicateModalDismissedAt = null;
+
     public function __construct()
     {
         $this->suivis = new ArrayCollection();
@@ -988,6 +991,18 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     public function setHasDoneSubscriptionsChoice(bool $hasDoneSubscriptionsChoice): static
     {
         $this->hasDoneSubscriptionsChoice = $hasDoneSubscriptionsChoice;
+
+        return $this;
+    }
+
+    public function isDuplicateModalDismissed(): bool
+    {
+        return null !== $this->duplicateModalDismissedAt;
+    }
+
+    public function setDuplicateModalDismissed(): static
+    {
+        $this->duplicateModalDismissedAt = new \DateTimeImmutable();
 
         return $this;
     }

--- a/templates/_partials/_modal-duplicate-addresses.html.twig
+++ b/templates/_partials/_modal-duplicate-addresses.html.twig
@@ -1,0 +1,43 @@
+<dialog aria-labelledby="fr-modal-duplicate-addresses-title" id="fr-modal-duplicate-addresses" class="fr-modal" >
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                       <button type="button" class="fr-btn--close fr-btn" aria-controls="fr-modal-duplicate-addresses">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 class="fr-modal__title">Dossiers à la même adresse</h1>
+                        <p>
+                            Vous allez être redirigé vers la liste des dossiers à la même adresse.
+                        </p>
+                        <p>
+                            Attention, vous verrez uniquement les dossiers auxquels votre partenaire {{app.user.getPartnerInTerritory(signalement.territory).nom}} a été affecté.
+                        </p>
+                        <form action="{{ path('dismiss_modal_duplicate_addresses') }}" method="POST" id="form-modal-duplicate-addresses">
+                            <div class="fr-checkbox-group">
+                                <input name="dismiss" type="checkbox" id="dismiss-modal-duplicate-addresses" class="fr-checkbox" value="1" >
+                                <label class="fr-label" for="dismiss-modal-duplicate-addresses">Ne plus afficher ce message</label>
+                            </div>
+                            <input type="hidden" name="_token" value="{{ csrf_token('modal_duplicate_addresses') }}">
+                        </form>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button type="button" class="fr-btn fr-icon-check-line" id="btn-submit-modal-duplicate-addresses" data-url="{{ routeForListOfSignalementOnAddress }}">
+                                    Voir la liste
+                                </button>
+                            </li>
+                            <li>
+                                <button type="button" class="fr-btn fr-btn--secondary fr-icon-close-line" aria-controls="fr-modal-duplicate-addresses">
+                                    Annuler
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -107,7 +107,7 @@
                     </div>
                 {% endif %}
 
-                {% if signalementOnSameAddress|length > 0 %}
+                {% if signalementsOnSameAddress|length > 0 %}
                     {% set routeForListOfSignalementOnAddress = path('back_signalements_index', { 'isImported': 'oui', 'searchTerms': signalement.adresseOccupant, 'communes[]': signalement.cpOccupant }) %}
                     {% if is_granted('ROLE_ADMIN_TERRITORY') or app.user.isDuplicateModalDismissed %}
                     {% else %}
@@ -138,15 +138,15 @@
                                 </button>
                             </li>
                         {% endif %}
-                        {% if signalementOnSameAddress|length > 0 %}
+                        {% if signalementsOnSameAddress|length > 0 %}
                             <li>
                                 {% if is_granted('ROLE_ADMIN_TERRITORY') or app.user.isDuplicateModalDismissed %}
                                     <a href="{{ routeForListOfSignalementOnAddress }}" class="fr-btn fr-icon-alarm-warning-line">
-                                        {{ signalementOnSameAddress|length > 1 ? signalementOnSameAddress|length ~ ' signalements à la même adresse' : signalementOnSameAddress|length ~  ' signalement à la même adresse' }}
+                                        {{ signalementsOnSameAddress|length > 1 ? signalementsOnSameAddress|length ~ ' signalements à la même adresse' : signalementsOnSameAddress|length ~  ' signalement à la même adresse' }}
                                     </a>
                                 {% else %}
                                     <button class="fr-btn fr-icon-alarm-warning-line" aria-controls="fr-modal-duplicate-addresses" data-fr-opened="false"  type="button">
-                                        {{ signalementOnSameAddress|length > 1 ? signalementOnSameAddress|length ~ ' signalements à la même adresse' : signalementOnSameAddress|length ~  ' signalement à la même adresse' }}
+                                        {{ signalementsOnSameAddress|length > 1 ? signalementsOnSameAddress|length ~ ' signalements à la même adresse' : signalementsOnSameAddress|length ~  ' signalement à la même adresse' }}
                                     </button>
                                 {% endif %}
                             </li>

--- a/templates/back/signalement/view/header.html.twig
+++ b/templates/back/signalement/view/header.html.twig
@@ -107,6 +107,14 @@
                     </div>
                 {% endif %}
 
+                {% if signalementOnSameAddress|length > 0 %}
+                    {% set routeForListOfSignalementOnAddress = path('back_signalements_index', { 'isImported': 'oui', 'searchTerms': signalement.adresseOccupant, 'communes[]': signalement.cpOccupant }) %}
+                    {% if is_granted('ROLE_ADMIN_TERRITORY') or app.user.isDuplicateModalDismissed %}
+                    {% else %}
+                        {% include '_partials/_modal-duplicate-addresses.html.twig' %}
+                    {% endif %}
+                {% endif %}
+
                 <div class="fr-mt-3v">
                     <ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left fr-btns-group--sm">
                         {% if signalement.geoloc.lat is defined and signalement.geoloc.lng is defined %}
@@ -130,13 +138,19 @@
                                 </button>
                             </li>
                         {% endif %}
-                        {% if is_granted('ROLE_ADMIN_TERRITORY') and signalementOnSameAddress|length > 0 %}
+                        {% if signalementOnSameAddress|length > 0 %}
                             <li>
-                                <a href="{{ path('back_signalements_index', { 'isImported': 'oui', 'searchTerms': signalement.adresseOccupant, 'communes[]': signalement.cpOccupant }) }}" class="fr-btn fr-icon-alarm-warning-line">
-                                    {{ signalementOnSameAddress|length > 1 ? signalementOnSameAddress|length ~ ' signalements à la même adresse' : signalementOnSameAddress|length ~  ' signalement à la même adresse' }}
-                                </a>
+                                {% if is_granted('ROLE_ADMIN_TERRITORY') or app.user.isDuplicateModalDismissed %}
+                                    <a href="{{ routeForListOfSignalementOnAddress }}" class="fr-btn fr-icon-alarm-warning-line">
+                                        {{ signalementOnSameAddress|length > 1 ? signalementOnSameAddress|length ~ ' signalements à la même adresse' : signalementOnSameAddress|length ~  ' signalement à la même adresse' }}
+                                    </a>
+                                {% else %}
+                                    <button class="fr-btn fr-icon-alarm-warning-line" aria-controls="fr-modal-duplicate-addresses" data-fr-opened="false"  type="button">
+                                        {{ signalementOnSameAddress|length > 1 ? signalementOnSameAddress|length ~ ' signalements à la même adresse' : signalementOnSameAddress|length ~  ' signalement à la même adresse' }}
+                                    </button>
+                                {% endif %}
                             </li>
-                        {% endif %}
+                        {% endif %}    
                     </ul>
                 </div>
             </div>

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -84,7 +84,7 @@ class BackStatistiquesControllerTest extends WebTestCase
             ['result' => 0, 'label' => 'count_signalement_archives'],
         ]];
         yield 'User partenaire multi territories' => ['back_statistiques_filter', [], self::USER_USER_PARTNER_MULTI_TERRITORIES, [
-            ['result' => 3, 'label' => 'count_signalement'],
+            ['result' => 4, 'label' => 'count_signalement'],
             ['result' => 0, 'label' => 'count_signalement_refuses'],
             ['result' => 0, 'label' => 'count_signalement_archives'],
         ]];


### PR DESCRIPTION
## Ticket

#4324

## Description
Le bouton [X Signalement à la mème adresse] et à présent visible pour tous (auparavant limité au RT)
- Au clic pour les non RT une modale s'affiche pour indiquer les problèmes de visibilité potentiels. Si je coche la case "Ne plus afficher ce message" et que je valide la modale (bouton "Voir la liste"), cette modale ne s'affichera plu pour l'user.
- Pas de changement pour ls RT/SA

## Changements apportés
* Ajout d'une colonne dans la table user pour savoir si la case "Ne plus afficher ce message" à été coché. (j'ai enregistré une date plutôt qu'un bool en envisageant une possible évolution : réaficher la modale une fois un certains délais passé)

## Pré-requis
`make ntm-build`
`make load-fixtures`
`make execute-migration name=Version20250805124814 direction=up`

## Tests
- [ ] Se connecter en RT/SA sur le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2025-000000000004 et voir que rien a changé
- [ ] Se connecter avec user-partenaire-30@signal-logement.fr sur le même signalement et tester la modale
