### PR TITLE
[FO - Suivi usager] Petites corrections 

### DIFF
--- a/templates/_partials/_modal_file_delete.html.twig
+++ b/templates/_partials/_modal_file_delete.html.twig
@@ -20,7 +20,7 @@
                             <div class="fr-select-group">
                                 Vous êtes sur le point de supprimer le document <b><span class="fr-modal-file-delete-filename"></span></b>. <br>
                                 Une fois supprimé, le fichier ne sera plus visible dans le signalement. <br>
-                                {% if app.request.get('_route') != 'front_suivi_signalement' %}
+                                {% if app.request.get('_route') not in ['front_suivi_signalement', 'front_suivi_signalement_messages', 'front_suivi_signalement_documents'] %}
                                     Si vous avez partagé le document à l'usager, il n'y aura plus accès.
                                 {% endif %}
                             </div>

--- a/templates/_partials/_modal_file_delete.html.twig
+++ b/templates/_partials/_modal_file_delete.html.twig
@@ -14,13 +14,13 @@
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal-delete-file" class="fr-modal__title">
-                                Supprimer le document</span>
+                                Supprimer le document
                             </h1>
 
                             <div class="fr-select-group">
                                 Vous êtes sur le point de supprimer le document <b><span class="fr-modal-file-delete-filename"></span></b>. <br>
-                                Une fois supprimé, le fichier ne sera plus visible dans le signalement. <br>
-                                {% if app.request.get('_route') not in ['front_suivi_signalement', 'front_suivi_signalement_messages', 'front_suivi_signalement_documents'] %}
+                                Une fois supprimé, le fichier ne sera plus visible dans le {{ is_granted('ROLE_USER_PARTNER') ? 'signalement' : 'dossier' }}. <br>
+                                {% if is_granted('ROLE_USER_PARTNER') %}
                                     Si vous avez partagé le document à l'usager, il n'y aura plus accès.
                                 {% endif %}
                             </div>

--- a/templates/front/_partials/_suivi_signalement_card.html.twig
+++ b/templates/front/_partials/_suivi_signalement_card.html.twig
@@ -37,7 +37,7 @@
 		</div>
 		{% if link is not defined or link is same as true %}
 			<div class="fr-col-12 fr-text--right">
-				<a class="fr-link fr-icon-arrow-right-line fr-link--icon-right" href="{{ path('front_suivi_signalement_dossier',{code:signalement.codeSuivi}) }}">Accéder au dossier</a>
+				<a class="fr-link fr-icon-arrow-right-line fr-link--icon-right" href="{{ path('front_suivi_signalement',{code:signalement.codeSuivi}) }}">Retour à l'accueil du dossier</a>
 			</div>
 		{% endif %}
 	</div>	

--- a/templates/front/suivi_signalement_dashboard.html.twig
+++ b/templates/front/suivi_signalement_dashboard.html.twig
@@ -81,7 +81,11 @@
 									</div>    
 								{% endif %}   
 							{% else %}
-							  	<p class="fr-tile__detail">Votre signalement est en cours de validation.</p>            
+							  	<p class="fr-tile__detail">
+									<a href="{{ path('front_suivi_signalement_messages', {'code': signalement.codeSuivi}) }}">
+										Votre signalement est en cours de validation.
+									</a>
+								</p>            
 								<div class="fr-tile__start">
 									<p class="fr-badge fr-badge--sm fr-badge--no-icon fr-badge--info">Validation en cours</p>           
 								</div>

--- a/templates/front/suivi_signalement_documents.html.twig
+++ b/templates/front/suivi_signalement_documents.html.twig
@@ -55,6 +55,8 @@
 			{% endif %}
 			{% if photos is not empty %}
 				<p>
+					Vous pouvez uniquement supprimer les documents et photos que vous avez vous-même ajoutés.
+					<br>
 					Cliquez sur une photo pour l'afficher dans un nouvel onglet.
 				</p>
 				<div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3v">

--- a/templates/front/suivi_signalement_dossier.html.twig
+++ b/templates/front/suivi_signalement_dossier.html.twig
@@ -18,7 +18,7 @@
 
 		<div class="fr-col-12 fr-col-md-6">
 			<h1 class="title-blue-france">Détails du dossier</h1>
-			{% include 'front/_partials/_suivi_signalement_card.html.twig' with {link: false} %}
+			{% include 'front/_partials/_suivi_signalement_card.html.twig' %}
 
 			<h2 class="title-blue-france fr-mb-1w">Que voulez-vous faire</h2>
 			<ul class="fr-btns-group fr-btns-group--center fr-btns-group--icon-left">


### PR DESCRIPTION
## Ticket

#4383
#4454
#4455 
#4458

## Description
#4383 la tuile "Validation en cours" du dashboard usager devient un lien vers les détail du dossier (comme toutes les autres tuiles)
#4454 Ajout d'une précision concernant la suppression des photos
#4455 Dans la modale de suppression des doc (commune au BO et FO) prise en charge des nouvelle page FO pour retirerr la mention concernant le partage à l'usager
#4458 Modification du lien "Accéder au dossier" en "Retour à l'accueil du dossier"
