### PR TITLE
[FO - Suivi usager] Dashboard - bailleur prévenu

### DIFF
--- a/templates/front/suivi_signalement_dashboard.html.twig
+++ b/templates/front/suivi_signalement_dashboard.html.twig
@@ -136,7 +136,8 @@
 				(
 				signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR 
 				and signalement.profileDeclarant is not same as enum('App\\Entity\\Enum\\ProfileDeclarant').BAILLEUR_OCCUPANT
-				)  
+				)
+			and not signalement.isProprioAverti
 			%}
 				<div class="fr-callout fr-icon-information-line">
 					<h2 class="fr-callout__title">Prévenez le propriétaire (bailleur)</h2>


### PR DESCRIPTION
## Ticket

#4457    

## Description
Compléter la condition de l'affichage de block avec la vérification du bailleur est prévenu

## Changements apportés
* Ajout d'une condition

## Pré-requis

## Tests
- [ ] Se connecter en tant qu'agent et mettre à jour le dossier en éditant bailleur prevenu à oui
- [ ] Se connecter en tant qu'usager sur la fiche en question et vérifier que le block ne s'affiche plus
