### PR TITLE
[FO - Suivi usager - Tableau de bord] Ajout tuile demande d'arrêt de procédure

### DIFF
--- a/src/Controller/SignalementFileController.php
+++ b/src/Controller/SignalementFileController.php
@@ -147,11 +147,11 @@ class SignalementFileController extends AbstractController
                 $description .= 'par l\'usager :';
                 $description .= '<ul><li>'.$filename.'</li></ul>';
                 $suiviManager->createSuivi(
-                    user: $signalementUser->getUser(),
                     signalement: $signalement,
                     description: $description,
                     type: Suivi::TYPE_AUTO,
                     category: SuiviCategory::DOCUMENT_DELETED_BY_USAGER,
+                    user: $signalementUser->getUser(),
                 );
                 $message = $file->isTypeDocument() ? 'Le document a bien été supprimé.' : 'La photo a bien été supprimée.';
                 $this->addFlash('success', $message);

--- a/src/Service/SuiviCategoryMapper.php
+++ b/src/Service/SuiviCategoryMapper.php
@@ -7,9 +7,9 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Suivi;
 
-class SuiviCategorizerService
+class SuiviCategoryMapper
 {
-    private const SUIVI_CATEGORIES_CONFIGURATION = [
+    private const array SUIVI_CATEGORIES_CONFIGURATION = [
         SuiviCategory::ASK_DOCUMENT->name => [
             'label' => 'A faire',
             'labelClass' => 'fr-badge--info',
@@ -64,13 +64,19 @@ class SuiviCategorizerService
             'title' => 'Fermeture de votre dossier',
             'icon' => 'conclusion.svg',
         ],
+        SuiviCategory::DEMANDE_ABANDON_PROCEDURE->name => [
+            'label' => 'Important',
+            'labelClass' => 'fr-badge--warning',
+            'title' => 'Votre demande a été enregistrée',
+            'icon' => 'success.svg',
+        ],
     ];
 
     public function __construct(
     ) {
     }
 
-    public function getSuiviCategoryFromSuivi(Suivi $suivi): SuiviCategoryDto
+    public function mapFromSuivi(Suivi $suivi): SuiviCategoryDto
     {
         if ($suivi->getCategory() && isset(self::SUIVI_CATEGORIES_CONFIGURATION[$suivi->getCategory()->name])) {
             $configuration = self::SUIVI_CATEGORIES_CONFIGURATION[$suivi->getCategory()->name];


### PR DESCRIPTION
## Ticket

#4459   

## Description
Prendre en compte l’arrêt de la procédure 

## Changements apportés
* Renommer service 
* Exclure les catégories de suivi usager générique à la place d'exclure l'usager

## Pré-requis

## Tests
- [ ] Faire une demande d’arrêt de procédure et vérifie que la tuile se met à jour 
- [ ] Ajouter un document et vérifier que le tuile ne se met pas à jour
- [ ] Ajouter un message et vérifier que la tuile ne se met pas à jour
- [ ] Supprimer un document et vérifier que la tuile ne se met pas à jour 
