### PR TITLE
[FO - Espace suivi - Messagerie] Marquer les messages comme lus en l'absence de notifications via fallback sur la dernière réponse usager

### DIFF
--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -931,12 +931,12 @@ class SignalementManager extends AbstractManager
         $this->persist($signalement);
         $subscriptionCreated = false;
         $suivi = $this->suiviManager->createSuivi(
-            user: $adminUser,
             signalement: $signalement,
             description: 'Signalement validé',
             type: Suivi::TYPE_AUTO,
             category: SuiviCategory::SIGNALEMENT_IS_ACTIVE,
             isPublic: true,
+            user: $adminUser,
             context: Suivi::CONTEXT_SIGNALEMENT_ACCEPTED,
             flush: false,
             subscriptionCreated: $subscriptionCreated


### PR DESCRIPTION
## Ticket

#4353    

## Description
Marquer les messages comme lus en l'absence de notifications via fallback sur la dernière réponse usager

## Changements apportés
* Ajout d'une fonction pour aller récupérer le dernier suivi usager. 

## Pré-requis

## Tests
- [ ] Créer un suivi public en tant qu'agent
- [ ] Supprimer les notifications générés pour un usager sur un signalement 

- [ ] Commenter le dispatch de l'evenement qui crée les notifs usager
<img width="716" height="241" alt="image" src="https://github.com/user-attachments/assets/fd3eee3c-fa96-42c7-8cda-14098dbc7b4b" />

- [ ] Aller sur la fiche usager les suivis repassent en non lu 
- [ ] Ajouter un commentaire en tant qu'usager en gardant le dispatch commenté, les suivi sont marqué comme lu en regardant le dernier suivi déposé par l'usager à défaut d'avoir  trouver des notifications
