### PR TITLE
[TECH] Validation manquante des combinaisons d'options dans la commande de création d'utilisateur API

### DIFF
--- a/src/Command/CreateApiPartnerUsersCommand.php
+++ b/src/Command/CreateApiPartnerUsersCommand.php
@@ -55,6 +55,18 @@ class CreateApiPartnerUsersCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
+        if ($input->getOption('partner_id')
+            && (
+                $input->getOption('zip')
+                || $input->getOption('partner_name')
+                || $input->getOption('bo_email')
+            )
+        ) {
+            $io->error('Too many options, you cannot use the --partner_id option with the --zip, --partner_name or --bo_email options.');
+
+            return Command::FAILURE;
+        }
+
         $apiEmail = $input->getOption('api_email');
 
         if (empty($apiEmail) || !EmailFormatValidator::validate($apiEmail)) {
@@ -176,7 +188,13 @@ class CreateApiPartnerUsersCommand extends Command
         $this->userManager->persist($userPartner);
         $this->userManager->save($user);
 
-        $io->success('API account was created for '.$apiEmail.' with password '.$password);
+        $io->success(sprintf(
+            'API account was created for %s with password %s.'.\PHP_EOL.
+            'Please send the password securely via https://vaultwarden.incubateur.net/#/login'.\PHP_EOL.
+            'Documentation: https://github.com/MTES-MCT/histologe/wiki/API-Signal-Logement',
+            $apiEmail,
+            $password,
+        ));
 
         return Command::SUCCESS;
     }

--- a/tests/Functional/Command/CreateApiPartnerUsersCommandTest.php
+++ b/tests/Functional/Command/CreateApiPartnerUsersCommandTest.php
@@ -80,4 +80,24 @@ class CreateApiPartnerUsersCommandTest extends KernelTestCase
         $output = $commandTester->getDisplay();
         $this->assertStringContainsString('User already exists with BO e-mail', $output, $output);
     }
+
+    public function testTooManyOptions(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('app:create-api-partner-users');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            '--api_email' => 'api-too-many-options@signal-logement.fr',
+            '--partner_id' => 1,
+            '--zip' => 13,
+            '--partner_name' => 'Nouveau partenaire',
+            '--bo_email' => 'user-13-02-signal-logement.fr',
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Too many options', $output, $output);
+    }
 }


### PR DESCRIPTION
## Ticket

#4427   

## Description
Ajout de la validation manquante et ajout de la procédure dans le message de confirmation en cas de succès

## Changements apportés
* Modification de la commande

## Pré-requis

## Tests
- [ ] Exécuter la commande suivante `make console app="create-api-partner-users --api_email=user@api.fr --partner_id=1 --partner_name=my_partner --zip=13 --bo_email=bo@mail.fr" ` et vérifier que le message d'erreur `Too many opttions`  s'affiche
- [ ] Exécuter la commande avec le bon usage et vérifier qu'elle fonctionne normalement
