### PR TITLE
[BUG - BO Liste des signalement] Ordre de tri de l'URL non affiché dans  la selectbox

### DIFF
--- a/assets/scripts/vue/components/signalement-view/components/SignalementListHeader.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementListHeader.vue
@@ -55,6 +55,7 @@ export default defineComponent({
     const urlParams = new URLSearchParams(window.location.search)
     const sortBy = urlParams.get('sortBy')
     const direction = urlParams.get('direction')
+    this.sharedState.input.order = 'reference-DESC'
     if (sortBy && direction) {
       const orderValue = `${sortBy}-${direction.toUpperCase()}`
       if (this.orderList.some(item => item.Id === orderValue)) {

--- a/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
+++ b/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
@@ -74,7 +74,6 @@ export function handleSettings (context: any, requestResponse: any): any {
   context.sharedState.user.canSeeMySignalementsButton = requestResponse.isFeatureNewDashboard // TODO: FEATURE_NEW_DASHBOARD feature flipping, remove when not needed
   context.sharedState.user.partnerIds = requestResponse.partnerIds
   context.sharedState.hasSignalementImported = requestResponse.hasSignalementImported
-  context.sharedState.input.order = 'reference-DESC'
   context.sharedState.input.filters.isImported = 'oui'
 
   context.sharedState.territories = []


### PR DESCRIPTION
## Ticket

#4445    

## Description

## Changements apportés
* Suppression de l'initialisation  sur le composant parent

## Pré-requis

## Tests
- [ ] Cliquer sur ce lien http://localhost:8080/bo/signalements/?status=nouveau&isImported=oui&sortBy=villeOccupant&direction=DESC et vérifier que l'option de la liste déroulante de tri est bien sélectionné  