### PR TITLE
[FO - Suivi usager - Tableau de bord] Ajout tuile demande de poursuite de procédure

### DIFF
--- a/src/Service/SuiviCategoryMapper.php
+++ b/src/Service/SuiviCategoryMapper.php
@@ -70,6 +70,12 @@ class SuiviCategoryMapper
             'title' => 'Votre demande a été enregistrée',
             'icon' => 'success.svg',
         ],
+        SuiviCategory::DEMANDE_POURSUITE_PROCEDURE->name => [
+            'label' => 'Important',
+            'labelClass' => 'fr-badge--warning',
+            'title' => 'Votre demande a été enregistrée',
+            'icon' => 'success.svg',
+        ],
     ];
 
     public function __construct(


### PR DESCRIPTION
## Ticket

#4473    

## Description
Prendre en compte la demande de poursuite de procédure qu'on demande aux usager lors les relances auto

## Changements apportés
* Mise à jour tableau associatif

## Pré-requis

## Tests
- [ ] En tant qu'usager, faire une demande d’arrêt de procédure
- [ ] En tant qu'agent, envoyer des messages public à destination de l'usager, la tuile se met à jour
- [ ] En tant qu'usager accéder à l'url de demande de poursuite de procédure => http://localhost:8080/suivre-mon-signalement/[uuid]/procedure/poursuite et vérifer que le statut se met à jour 
