### PR TITLE
[BUG - Export BO] Export incohérent aprés liesn vers liste de signalement depuis le bouton doublon d'adresse

### DIFF
--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -30,7 +30,6 @@ class SignalementListController extends AbstractController
         #[MapQueryString] ?SignalementSearchQuery $signalementSearchQuery = null,
     ): JsonResponse {
         $session->set('signalementSearchQuery', $signalementSearchQuery);
-        $session->save();
         /** @var User $user */
         $user = $this->getUser();
         $filters = null !== $signalementSearchQuery
@@ -43,11 +42,15 @@ class SignalementListController extends AbstractController
             ];
         $signalements = $signalementManager->findSignalementAffectationList($user, $filters);
 
-        return $this->json(
+        $response = $this->json(
             $signalements,
             Response::HTTP_OK,
             ['content-type' => 'application/json'],
             ['groups' => ['signalements:read']]
         );
+
+        $session->save();
+
+        return $response;
     }
 }


### PR DESCRIPTION
## Ticket

#4477

## Description
Les filtre de recherche de signalement ne sont pas toujours écrits en session, ce qui fait que quand on clique sur export on se retrouve avec les filtré précédent ou par défaut.

## Changements apportés
Il semble que forcer le session save après la génération de la répons fonctionne mieux (je n'ai pas vraiement compris pourquoi)

## Tests
- [ ] Le problème initial est facilement reproductible sur une copie de base de prod depuis le signalement 2023-384 du 34. Vérifier qu'il ne se reproduit plus.
