### PR TITLE
[BO - Signalement]Suivi /Ajout doc Affichage

### DIFF
--- a/assets/scripts/vanilla/services/component/component_search_checkbox.js
+++ b/assets/scripts/vanilla/services/component/component_search_checkbox.js
@@ -3,6 +3,7 @@ window.addEventListener('refreshSearchCheckboxContainerEvent', () => {
     searchCheckboxCompleteInputValue(element);
     const input = element.querySelector('input[type="text"]');
     const checkboxesContainer = element.querySelector('.search-checkbox');
+    const closeBtn = element.querySelector('.fr-btn--close');
     // init values
     const initialValues = [];
     checkboxesContainer.querySelectorAll('input[type="checkbox"]:checked').forEach((checkbox) => {
@@ -26,6 +27,7 @@ window.addEventListener('refreshSearchCheckboxContainerEvent', () => {
       checkboxesContainer.scrollTop = 0;
       searchCheckboxOrderCheckboxes(element);
       input.value = '';
+      closeBtn.classList.remove('fr-hidden');
     });
     // filter choices on input keyup
     input.addEventListener('keyup', function () {
@@ -49,16 +51,17 @@ window.addEventListener('refreshSearchCheckboxContainerEvent', () => {
         }
       });
     });
-    // hide choices on click outside
+    // hide choices on click outside and on close button
     document.addEventListener('click', function (event) {
       if (!input.contains(event.target) && !checkboxesContainer.contains(event.target)) {
-        checkboxesContainer.style.display = 'none';
-        searchCheckboxCompleteInputValue(element);
-        searchCheckboxTriggerChange(element, initialValues);
+        searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
       }
     });
     element.addEventListener('click', function (event) {
       event.stopPropagation();
+    });
+    closeBtn.addEventListener('click', function (event) {
+       searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
     });
     // reorder on uncheck
     checkboxesContainer.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
@@ -124,4 +127,11 @@ function searchCheckboxTriggerChange(element, initialValues) {
   if (JSON.stringify(currentValues) !== JSON.stringify(initialValues)) {
     element.dispatchEvent(new CustomEvent('searchCheckboxChange'));
   }
+}
+
+function searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues) {
+  checkboxesContainer.style.display = 'none';
+  searchCheckboxCompleteInputValue(element);
+  searchCheckboxTriggerChange(element, initialValues);
+  closeBtn.classList.add('fr-hidden');
 }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -825,7 +825,7 @@ ul + p {
         display: none;
         overflow: auto;
         height: auto;
-        max-height: 190px;
+        max-height: 270px;
         border: 1px solid var(--border-default-grey);
         border-top: 0;
         padding: 0.5rem;
@@ -833,6 +833,13 @@ ul + p {
         position: absolute;
         width: 100%;
         z-index: 10;
+        background: white;
+    }
+    .fr-btn--close {
+        position: absolute;
+        top: 4.5rem;
+        right: 15px;
+        z-index: 11;
         background: white;
     }
 }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -369,6 +369,7 @@ a.fr-btn.fr-btn--icon-left.fr-fi-file-pdf-fill.ignore-blank-style::before {
 }
 
 @media (max-width: 48em) {
+    #suivi-files { order: -1; }
     .signalement-form-only-choice .fr-fieldset__element.item-divided {
         flex-basis: content;
     }

--- a/templates/_partials/signalement/add_suivi.html.twig
+++ b/templates/_partials/signalement/add_suivi.html.twig
@@ -25,10 +25,10 @@
                                 <div class="fr-col-12">
                                     {{ form_row(addSuiviForm.isPublic) }}
                                 </div>
-                                <div class="fr-col-7">
+                                <div class="fr-col-12 fr-col-md-7" id="suivi-description">
                                     {{ form_row(addSuiviForm.description) }}
                                 </div>
-                                <div class="fr-col-5">
+                                <div class="fr-col-12 fr-col-md-5" id="suivi-files">
                                     {{ form_row(addSuiviForm.files) }}
                                 </div>
                             </div>

--- a/templates/_partials/signalement/add_suivi.html.twig
+++ b/templates/_partials/signalement/add_suivi.html.twig
@@ -10,20 +10,30 @@
                         <h1 id="fr-modal-add-suivi-title" class="fr-modal__title">
                             Ajouter un suivi
                         </h1>
-
                         {{ form_start(addSuiviForm, {'attr': {'id': 'signalement-add-suivi-form', 'data-submit-type':'formData'}}) }}
-                        <div class="fr-input-group">
-                            <span class="no-field-errors"></span>
+                        <div class="fr-container">
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-12">
+                                    <div class="fr-input-group">
+                                        <span class="no-field-errors"></span>
+                                    </div>
+                                    {{ form_errors(addSuiviForm) }}
+                                    {% if show_email_alert(signalement.mailDeclarant) and show_email_alert(signalement.mailOccupant) %}
+                                        <p class="fr-badge fr-badge--error">L'adresse e-mail de l'usager n'est pas valide. Vous ne pouvez pas lui envoyer le suivi.</p>
+                                    {% endif %}
+                                </div>
+                                <div class="fr-col-12">
+                                    {{ form_row(addSuiviForm.isPublic) }}
+                                </div>
+                                <div class="fr-col-7">
+                                    {{ form_row(addSuiviForm.description) }}
+                                </div>
+                                <div class="fr-col-5">
+                                    {{ form_row(addSuiviForm.files) }}
+                                </div>
+                            </div>
                         </div>
-                        {{ form_errors(addSuiviForm) }}
-                        {% if show_email_alert(signalement.mailDeclarant) and show_email_alert(signalement.mailOccupant) %}
-                            <p class="fr-badge fr-badge--error">L'adresse e-mail de l'usager n'est pas valide. Vous ne pouvez pas lui envoyer le suivi.</p>
-                        {% endif %}
-                        {{ form_row(addSuiviForm.isPublic) }}
-                        {{ form_row(addSuiviForm.description) }}
-                        {{ form_row(addSuiviForm.files) }}
                         {{ form_end(addSuiviForm) }}
-
                     </div>
                     <div class="fr-modal__footer">
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">

--- a/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
+++ b/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
@@ -65,6 +65,7 @@
         </legend>
         <div class="search-checkbox-container fr-input-group fr-w-100">
             <input id="visite-{{ formType }}[concludeProcedure]_input" type="text" placeholder="Sélectionner une ou plusieurs conclusions" class="fr-input">
+            <button type="button" class="fr-btn--close fr-btn fr-hidden" style="top:2.5rem;">Fermer</button>
             <div class="search-checkbox" class="fr-hidden">
                 {% set listProceduresTypes = enum('\\App\\Entity\\Enum\\ProcedureType') %}
                 {% for type in listProceduresTypes.cases() %}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -167,6 +167,7 @@
             {% endif %}
             <input id="{{ id }}_input" type="text" placeholder="{{ noselectionlabel }}" class="fr-input">
         </div>
+        <button type="button" class="fr-btn--close fr-btn fr-hidden">Fermer</button>
         {{ block('choice_enum_widget_expanded') }}
         {{ block('form_errors') }}
     </div>


### PR DESCRIPTION
## Ticket

#4464

## Description
- Ajout d'un bouton de fermeture sur le composant search checkbox
- Séparation de la modale d'ajout de suivi en deux colonne pour éviter que le composant dépasse sur le bas de la modale

## Pré-requis
`make npm-watch`

## Tests
- [ ] Vérifier que le composant search chekbox s'affiche correctement et que le bouton de fermeture fonctionne
