### PR TITLE
[Tech - Perf] Ajout d'un index sur le champ is_standalone de File

### DIFF
--- a/migrations/Version20250813145232.php
+++ b/migrations/Version20250813145232.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250813145232 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add index on is_standalone column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_is_standalone ON file (is_standalone)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_is_standalone ON file');
+    }
+}

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -13,6 +13,7 @@ use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: FileRepository::class)]
+#[ORM\Index(columns: ['is_standalone'], name: 'idx_is_standalone')]
 class File implements EntityHistoryInterface
 {
     public const STANDALONE_FILES = [


### PR DESCRIPTION
## Ticket

#4482

## Description
Ajout d'un index sur le champ `is_standalone` de `File` pour optimiser la requête récupérant les documents type à joindre aux suivi. 
<img width="874" height="104" alt="sentry_query_standalone" src="https://github.com/user-attachments/assets/b94f3806-50ee-4339-af53-5839e28702a7" />
Avant
<img width="953" height="182" alt="avant_index_standalone" src="https://github.com/user-attachments/assets/fc42115f-a0b3-4144-966c-cda49b1afc10" />
Aprés
<img width="951" height="174" alt="apres_index_standalone" src="https://github.com/user-attachments/assets/3c897e6a-9e03-4d70-bfbb-9aae9bf99600" />

## Pré-requis
`make execute-migration name=Version20250813145232 direction=up`
