### PR TITLE
[A DISCUTER][QA] Suppression des actions de l'historique au-delà d'1 an

### DIFF
--- a/src/Entity/HistoryEntry.php
+++ b/src/Entity/HistoryEntry.php
@@ -10,6 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['entity_id', 'event', 'entity_name'], name: 'idx_history_entry_entityid_event_entityname')]
 class HistoryEntry
 {
+    public const string EXPIRATION_PERIOD = '- 1 year';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]

--- a/src/Repository/HistoryEntryRepository.php
+++ b/src/Repository/HistoryEntryRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\HistoryEntry;
+use App\Repository\Behaviour\EntityCleanerRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -14,10 +15,23 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method HistoryEntry[]    findAll()
  * @method HistoryEntry[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class HistoryEntryRepository extends ServiceEntityRepository
+class HistoryEntryRepository extends ServiceEntityRepository implements EntityCleanerRepositoryInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, HistoryEntry::class);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function cleanOlderThan(string $period = HistoryEntry::EXPIRATION_PERIOD): int
+    {
+        $queryBuilder = $this->createQueryBuilder('h');
+        $queryBuilder->delete()
+            ->andWhere('DATE(h.createdAt) <= :created_at')
+            ->setParameter('created_at', (new \DateTimeImmutable($period))->format('Y-m-d'));
+
+        return $queryBuilder->getQuery()->execute();
     }
 }

--- a/tests/Functional/Command/Cron/ClearEntitiesCommandTest.php
+++ b/tests/Functional/Command/Cron/ClearEntitiesCommandTest.php
@@ -28,6 +28,7 @@ class ClearEntitiesCommandTest extends KernelTestCase
         $this->assertStringContainsString('Notification(s) deleted', $output);
         $this->assertStringContainsString('SignalementDraft(s) deleted', $output);
         $this->assertStringContainsString('ApiUserToken(s) deleted', $output);
-        $this->assertEmailCount(4);
+        $this->assertStringContainsString('HistoryEntry(s) deleted', $output);
+        $this->assertEmailCount(5);
     }
 }


### PR DESCRIPTION
## Ticket

#4219

## Description
Suppression des action historique antérieure a 1 an

## Tests
- [ ] Sur copie de prod lancer `app:clear-entities`
