### PR TITLE
[BO - Signalement] Problème d'accès quand le partenaire lié à une intervention est null

### DIFF
--- a/templates/back/signalement/view/tabs/tab-documents.html.twig
+++ b/templates/back/signalement/view/tabs/tab-documents.html.twig
@@ -7,7 +7,7 @@
 {% for intervention in signalement.interventions | filter(intervention => intervention.type != enum('App\\Entity\\Enum\\InterventionType').ARRETE_PREFECTORAL) %}
     <div class="fr-mt-5v"></div>
     {% include 'back/signalement/view/photos-documents.html.twig' with {
-        'zonetitle': "Photos et documents de la visite du " ~ intervention.scheduledAt|date('d/m/Y') ~ " par " ~ intervention.partner.nom,
+        'zonetitle': "Photos et documents de la visite du " ~ intervention.scheduledAt|date('d/m/Y') ~ " par " ~ (intervention.partner ? intervention.partner.nom : 'Opérateur Externe'),
         'filesFilter': 'visite',
         'interventionId': intervention.id
         } 

--- a/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
@@ -67,7 +67,7 @@
                                                         {{ partner.nom|upper }}
                                                     </option>
                                                 {% endfor %}
-                                                <option value="extern" {% if intervention.partner.id is null %}selected="selected"{% endif %}>Opérateur Externe</option>
+                                                <option value="extern" {% if intervention.partner is null or intervention.partner.id is null %}selected="selected"{% endif %}>Opérateur Externe</option>
                                             </select>
                                             <p id="signalement-reschedule-visite-partner-double-error" class="fr-error-text fr-hidden fr-my-3v">
                                                 Ce partenaire a déjà une visite en cours.


### PR DESCRIPTION
## Ticket

#4514   

## Description
Problème probablement du aux modification sur les visites (https://github.com/MTES-MCT/histologe/pull/4501) mais pas si sûr.
Quand une visite existe avec un partenaire null, la page plante.

## Tests
- [ ] Tester signalement sur base de prod : http://localhost:8080/bo/signalements/63751338bc6f1
