### PR TITLE
[API - BO] Controle et correction de l'affichage du champ commentBeforeVisite

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -104,7 +104,6 @@ services:
     App\EventListener\EntitySanitizerListener:
         arguments:
             $htmlSanitizer: '@html_sanitizer.sanitizer.app.message_sanitizer'
-            $logger: '@logger'
         tags:
             - { name: doctrine.orm.entity_listener }
 

--- a/src/Entity/Behaviour/EntitySanitizerInterface.php
+++ b/src/Entity/Behaviour/EntitySanitizerInterface.php
@@ -6,7 +6,7 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 
 interface EntitySanitizerInterface
 {
-    public function sanitizeDescription(HtmlSanitizerInterface $htmlSanitizer): void;
+    public function sanitize(HtmlSanitizerInterface $htmlSanitizer): void;
 
     public function getDescription(): ?string;
 }

--- a/src/Entity/Intervention.php
+++ b/src/Entity/Intervention.php
@@ -397,10 +397,13 @@ class Intervention implements EntityHistoryInterface, EntitySanitizerInterface
         return [HistoryEntryEvent::CREATE, HistoryEntryEvent::UPDATE, HistoryEntryEvent::DELETE];
     }
 
-    public function sanitizeDescription(HtmlSanitizerInterface $htmlSanitizer): void
+    public function sanitize(HtmlSanitizerInterface $htmlSanitizer): void
     {
         if (!empty($this->details)) {
             $this->details = $htmlSanitizer->sanitize($this->details);
+        }
+        if (!empty($this->commentBeforeVisite)) {
+            $this->commentBeforeVisite = $htmlSanitizer->sanitize($this->commentBeforeVisite);
         }
     }
 

--- a/templates/back/signalement/view/visites/visite-item.html.twig
+++ b/templates/back/signalement/view/visites/visite-item.html.twig
@@ -69,7 +69,7 @@
         <div class="fr-col-12">
             <strong>Commentaire d'avant visite :</strong>
             <div class="fr-highlight fr-background--white fr-py-3v fr-my-3v fr-ml-0">
-                {% if signalement.interventions is not empty and intervention.commentBeforeVisite is not empty %}
+                {% if intervention.commentBeforeVisite is empty %}
                     <p>Non renseigné</p>
                 {% else %}
                     {{ intervention.commentBeforeVisite|raw }}

--- a/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/VisiteCreateControllerTest.php
@@ -59,6 +59,12 @@ class VisiteCreateControllerTest extends WebTestCase
             $links = $crawler->filter('a.fr-link');
             $this->assertCount(2, $links, 'Il doit y avoir exactement 2 liens dans le contenu HTML.');
         }
+        if ('visite_planned' === $type) {
+            $content = json_decode($this->client->getResponse()->getContent(), true);
+            $this->assertArrayHasKey('commentBeforeVisite', $content);
+            $this->assertEquals('commentaire avant visite ', $content['commentBeforeVisite']);
+        }
+
         $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
@@ -171,6 +177,7 @@ class VisiteCreateControllerTest extends WebTestCase
             [
                 'date' => '2125-01-01',
                 'time' => '12:00',
+                'commentBeforeVisite' => 'commentaire avant visite <script>alert("XSS")</script>',
             ],
             1,
         ];

--- a/tests/Functional/Controller/Back/SignalementVisitesControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementVisitesControllerTest.php
@@ -54,6 +54,7 @@ class SignalementVisitesControllerTest extends WebTestCase
                     'time' => '',
                     'partner' => $partner->getId(),
                     'externalOperator' => '',
+                    'commentBeforeVisite' => 'Commentaire avant visite',
                 ],
                 '_token' => $this->generateCsrfToken(
                     $this->client,
@@ -68,6 +69,12 @@ class SignalementVisitesControllerTest extends WebTestCase
         $this->assertTrue($flashBag->has('success'));
         $successMessages = $flashBag->get('success');
         $this->assertEquals('La date de visite a bien été définie.', $successMessages[0]);
+
+        $this->client->followRedirect();
+        $crawler = $this->client->getCrawler();
+        $highlights = $crawler->filter('.fr-highlight');
+        $this->assertCount(2, $highlights);
+        $this->assertStringContainsString('Commentaire avant visite', $highlights->eq(1)->text());
     }
 
     public function testAddFutureVisiteOnExternalOperator(): void


### PR DESCRIPTION
## Ticket

#4518

## Description
- Ajout de la "sanitizarion" du champ commentBeforeVisite (au persist / update de l'entité)
- Correction de l'affichage du champ sur la page BO signalement
- Ajout de tests

## Tests
- [ ] Ajouter une visite via API contenant du script dans le champ commentBeforeVisite et voir que la balise est supprimé
- [ ] Vérifier que le contenu du champ est bien affiché dans la page BO du signalement sur la visite correspondante
