### PR TITLE
[BO - Espace documentaire] Modale de détails de document

### DIFF
--- a/assets/scripts/vanilla/controllers/back_territory_management_document/back_territory_management_document_index.js
+++ b/assets/scripts/vanilla/controllers/back_territory_management_document/back_territory_management_document_index.js
@@ -11,7 +11,7 @@ if (searchFilesForm) {
       document.getElementById('fr-modal-document-view-document-created-at').textContent = e.target.dataset.createdat;
       document.getElementById('fr-modal-document-view-document-created-by').textContent = e.target.dataset.createdby;
       document.getElementById('fr-modal-document-view-document-title').textContent = e.target.dataset.title;
-      document.getElementById('fr-modal-document-view-document-description').innerHTML = e.target.dataset.description;
+      document.getElementById('fr-modal-document-view-document-description').innerText = e.target.dataset.description;
       document.getElementById('fr-modal-document-edit-btn-submit').href = e.target.dataset.url;
     });
   });

--- a/assets/scripts/vanilla/controllers/back_territory_management_document/back_territory_management_document_index.js
+++ b/assets/scripts/vanilla/controllers/back_territory_management_document/back_territory_management_document_index.js
@@ -6,6 +6,15 @@ import {
 const searchFilesForm = document.getElementById('search-territory-files-type-form');
 
 if (searchFilesForm) {
+  document.querySelectorAll('.open-modal-document-view').forEach((button) => {
+    button.addEventListener('click', (e) => {
+      document.getElementById('fr-modal-document-view-document-created-at').textContent = e.target.dataset.createdat;
+      document.getElementById('fr-modal-document-view-document-created-by').textContent = e.target.dataset.createdby;
+      document.getElementById('fr-modal-document-view-document-title').textContent = e.target.dataset.title;
+      document.getElementById('fr-modal-document-view-document-description').innerHTML = e.target.dataset.description;
+      document.getElementById('fr-modal-document-edit-btn-submit').href = e.target.dataset.url;
+    });
+  });
   document.querySelectorAll('.open-modal-document-delete').forEach((button) => {
     button.addEventListener('click', (e) => {
       document.getElementById('fr-modal-document-delete-document-title').textContent = e.target.dataset.title;

--- a/src/Controller/Back/AdminTerritoryFilesController.php
+++ b/src/Controller/Back/AdminTerritoryFilesController.php
@@ -21,7 +21,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -100,7 +99,6 @@ class AdminTerritoryFilesController extends AbstractController
         FileScanner $fileScanner,
         LoggerInterface $logger,
         ImageManipulationHandler $imageManipulationHandler,
-        HtmlSanitizerInterface $htmlSanitizer,
     ): JsonResponse {
         $file = new File();
         /** @var User $user */
@@ -157,7 +155,7 @@ class AdminTerritoryFilesController extends AbstractController
                         $file->setScannedAt(new \DateTimeImmutable());
                         $file->setIsStandalone(true);
                         $file->setUploadedBy($user);
-                        $file->setDescription($htmlSanitizer->sanitize($file->getDescription()));
+                        $file->setDescription($file->getDescription());
                         $em->persist($file);
                         $em->flush();
 

--- a/templates/back/admin-territory-files/index.html.twig
+++ b/templates/back/admin-territory-files/index.html.twig
@@ -103,7 +103,7 @@
                             data-createdat="{{ file.createdAt|date('d/m/Y') }}"
                             data-createdby="{{ file.uploadedBy ? file.uploadedBy.fullName : 'Admin' }}"
                             data-title="{{ file.title }}"
-                            data-description="{{ file.description and file.description is not same as '' ? file.description|nl2br : '/' }}"
+                            data-description="{{ file.description ?? '/' }}"
                             >Voir les détails du document {{ file.title }}</button>
                         <a href="" class="fr-btn fr-icon-edit-line" title="Editer le document {{ file.title }}"
                             >Editer le document {{ file.title }}</a>

--- a/templates/back/admin-territory-files/index.html.twig
+++ b/templates/back/admin-territory-files/index.html.twig
@@ -94,24 +94,33 @@
                     </td>
                     {% endif %}
                     <td class="fr-text--right fr-ws-nowrap">
-                        <a href="" class="fr-btn fr-icon-eye-line" title="Voir les détails du document {{file.title}}"
-                            >Voir les détails du document {{ file.title }}</a>
-                        <a href="" class="fr-btn fr-icon-edit-line" title="Editer le document {{file.title}}"
-                            >Editer le document {{file.title}}</a>
+                        <button
+                            class="fr-btn fr-icon-eye-line open-modal-document-view"
+                            title="Voir les détails du document {{ file.title }}"
+                            data-fr-opened="false" 
+                            aria-controls="fr-modal-document-view"
+                            data-url="{{ path('back_territory_management_document_edit', { file: file.id }) }}"
+                            data-createdat="{{ file.createdAt|date('d/m/Y') }}"
+                            data-createdby="{{ file.uploadedBy ? file.uploadedBy.fullName : 'Admin' }}"
+                            data-title="{{ file.title }}"
+                            data-description="{{ file.description and file.description is not same as '' ? file.description|nl2br : '/' }}"
+                            >Voir les détails du document {{ file.title }}</button>
+                        <a href="" class="fr-btn fr-icon-edit-line" title="Editer le document {{ file.title }}"
+                            >Editer le document {{ file.title }}</a>
                         <a href="{{ sign_url(path('show_file', {uuid: file.uuid})) }}"
                                 class="fr-btn fr-icon-download-line"
-                                title="Ouvrir le document {{file.title}} - Ouvre une nouvelle fenêtre"
+                                title="Ouvrir le document {{ file.title }} - Ouvre une nouvelle fenêtre"
                                 target="_blank"
                                 rel="noopener"
-                            >Ouvrir le document {{file.title}}</a>
-                        <button 
-                            class="fr-btn fr-btn--secondary fr-icon-delete-line open-modal-document-delete" 
-                            title="Supprimer le document {{file.title}}" 
-                            data-fr-opened="false" 
+                            >Ouvrir le document {{ file.title }}</a>
+                        <button
+                            class="fr-btn fr-btn--secondary fr-icon-delete-line open-modal-document-delete"
+                            title="Supprimer le document {{ file.title }}"
+                            data-fr-opened="false"
                             aria-controls="fr-modal-document-delete"
-                            data-url="{{ path('back_territory_management_document_delete_ajax', {file: file.id}) }}?_token={{ csrf_token('document_delete') }}"
-                            data-title="{{file.title}}"
-                            >Supprimer le document {{file.title}}</button>
+                            data-url="{{ path('back_territory_management_document_delete_ajax', { file: file.id }) }}?_token={{ csrf_token('document_delete') }}"
+                            data-title="{{ file.title }}"
+                            >Supprimer le document {{ file.title }}</button>
                     </td>
                 </tr>
             {% endfor %}
@@ -124,6 +133,39 @@
             {{ macros.customPagination(pages, searchTerritoryFiles.page, 'back_territory_management_document', searchTerritoryFiles.urlParams) }}
         </div>
     </section>
+
+    {# Modale de visualisation #}
+    <dialog aria-labelledby="fr-modal-title-document-view" id="fr-modal-document-view" class="fr-modal">
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-document-view">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h1 id="fr-modal-title-document-view" class="fr-modal__title">
+                                Détails du document
+                            </h1>
+                            <p class="fr-pb-5v"><i>Ajouté le <span id="fr-modal-document-view-document-created-at"></span> par <span id="fr-modal-document-view-document-created-by"></span></i></p>
+                            <p><strong>Titre :</strong> <span id="fr-modal-document-view-document-title"></span></p>
+                            <p>
+                                <strong>Description :</strong>
+                                <br><br>
+                                <span id="fr-modal-document-view-document-description"></span>
+                            </p>
+                        </div>
+                        <div class="fr-modal__footer">
+                            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <a href="#" class="fr-btn fr-btn--secondary fr-icon-edit-line" id="fr-modal-document-edit-btn-submit">Editer le document</a>
+                                <button class="fr-btn fr-icon-close-line" type="button" aria-controls="fr-modal-document-delete">Fermer</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </dialog>
 
     {# Modale de suppression #}
     <dialog aria-labelledby="fr-modal-title-document-delete" id="fr-modal-document-delete" class="fr-modal">


### PR DESCRIPTION
## Ticket

#4491   

## Description
Ajout de la modale qui s'affiche pour voir les détails d'un document (et sécurisation de la description pour pouvoir sauter des lignes)

## Tests
- [ ] Ajouter des documents avec scripts et vérifier l'enregistrement
- [ ] Vérifier l'affichage des détails de documents dans la modale
