### PR TITLE
[BO - Dashboard] Tableau de bord V2 - Généralisation d'un abortController 

### DIFF
--- a/assets/scripts/vanilla/services/ui/list_filter_helper.js
+++ b/assets/scripts/vanilla/services/ui/list_filter_helper.js
@@ -50,17 +50,17 @@ if (filterForms.length > 0) {
             input.checked = false;
           });
         }
-        if (null != document.getElementById('page')){
+        if (null != document.getElementById('page')) {
           document.getElementById('page').value = 1;
-        }        
+        }
         filterForm.submit();
       });
     });
     filterForm.querySelectorAll('.search-checkbox-container').forEach((select) => {
       select.addEventListener('searchCheckboxChange', function () {
-        if (null != document.getElementById('page')){
+        if (null != document.getElementById('page')) {
           document.getElementById('page').value = 1;
-        }        
+        }
         filterForm.submit();
       });
     });

--- a/tests/Functional/Controller/Back/SubscriptionsChoiceControllerTest.php
+++ b/tests/Functional/Controller/Back/SubscriptionsChoiceControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\Tests\Functional\Controller\Back;
+
 use App\Entity\User;
 use App\Entity\UserSignalementSubscription;
 use App\Repository\SignalementRepository;

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/CountAfermerTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/CountAfermerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Service\DashboardTabPanel\Kpi;
+namespace App\Tests\Unit\Service\DashboardTabPanel\Kpi;
 
 use App\Service\DashboardTabPanel\Kpi\CountAfermer;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/CountDossiersMessagesUsagersTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/CountDossiersMessagesUsagersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Service\DashboardTabPanel\Kpi;
+namespace App\Tests\Unit\Service\DashboardTabPanel\Kpi;
 
 use App\Service\DashboardTabPanel\Kpi\CountDossiersMessagesUsagers;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiBuilderTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/Kpi/TabCountKpiBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Service\DashboardTabPanel\Kpi;
+namespace App\Tests\Unit\Service\DashboardTabPanel\Kpi;
 
 use App\Entity\User;
 use App\Repository\SignalementRepository;


### PR DESCRIPTION
## Ticket

#4512    
<img width="1128" height="835" alt="image" src="https://github.com/user-attachments/assets/98928760-4781-4c30-b7a6-b0c186d226a2" />

## Description
Ne pas surcharger le serveurs inutilement lors de changement d'onglet. Charger uniquement l'onglet en cours en supprimant les requêtes précédemment lancé 

## Changements apportés
* Mise à jour de la fonction initTabsLoader en implémentant AbortController
* Mise à jour namespace de quelques tests 
 
## Pré-requis
```
make npm-watch
```

Ouvrir l'inspecteur du navigateur

## Tests
- [ ] Se balader de panel en panel et vérifier que les requêtes non terminé sont annulé 
