### PR TITLE
[API] Socle admin de gestion utilisateurs api et permissions

### DIFF
--- a/migrations/Version20250902133331.php
+++ b/migrations/Version20250902133331.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250902133331 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create user_api_permission table and add partner_id on file and suivi tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE user_api_permission (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, territory_id INT DEFAULT NULL, partner_id INT DEFAULT NULL, partner_type VARCHAR(255) DEFAULT NULL COMMENT \'Value possible enum PartnerType\', INDEX IDX_4C6631E2A76ED395 (user_id), INDEX IDX_4C6631E273F74AD4 (territory_id), INDEX IDX_4C6631E29393F8FE (partner_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE user_api_permission ADD CONSTRAINT FK_4C6631E2A76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+        $this->addSql('ALTER TABLE user_api_permission ADD CONSTRAINT FK_4C6631E273F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id)');
+        $this->addSql('ALTER TABLE user_api_permission ADD CONSTRAINT FK_4C6631E29393F8FE FOREIGN KEY (partner_id) REFERENCES partner (id)');
+        $this->addSql('ALTER TABLE file ADD partner_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE file ADD CONSTRAINT FK_8C9F36109393F8FE FOREIGN KEY (partner_id) REFERENCES partner (id)');
+        $this->addSql('CREATE INDEX IDX_8C9F36109393F8FE ON file (partner_id)');
+        $this->addSql('ALTER TABLE suivi ADD partner_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE suivi ADD CONSTRAINT FK_2EBCCA8F9393F8FE FOREIGN KEY (partner_id) REFERENCES partner (id)');
+        $this->addSql('CREATE INDEX IDX_2EBCCA8F9393F8FE ON suivi (partner_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user_api_permission DROP FOREIGN KEY FK_4C6631E2A76ED395');
+        $this->addSql('ALTER TABLE user_api_permission DROP FOREIGN KEY FK_4C6631E273F74AD4');
+        $this->addSql('ALTER TABLE user_api_permission DROP FOREIGN KEY FK_4C6631E29393F8FE');
+        $this->addSql('DROP TABLE user_api_permission');
+        $this->addSql('ALTER TABLE file DROP FOREIGN KEY FK_8C9F36109393F8FE');
+        $this->addSql('DROP INDEX IDX_8C9F36109393F8FE ON file');
+        $this->addSql('ALTER TABLE file DROP partner_id');
+        $this->addSql('ALTER TABLE suivi DROP FOREIGN KEY FK_2EBCCA8F9393F8FE');
+        $this->addSql('DROP INDEX IDX_2EBCCA8F9393F8FE ON suivi');
+        $this->addSql('ALTER TABLE suivi DROP partner_id');
+    }
+}

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -27,6 +27,11 @@ users:
     statut: "ACTIVE"
     is_mailing_active: 0
   -
+    email: api-full-63@signal-logement.fr
+    roles: "[\"ROLE_API_USER\"]"
+    statut: "ACTIVE"
+    is_mailing_active: 0
+  -
     email: admin-01@signal-logement.fr
     roles: "[\"ROLE_ADMIN\"]"
     partner: "Administrateurs Signal-logement"

--- a/src/DataFixtures/Files/User.yml
+++ b/src/DataFixtures/Files/User.yml
@@ -2,13 +2,28 @@ users:
   -
     email: api-01@signal-logement.fr
     roles: "[\"ROLE_API_USER\"]"
-    partner: "Partenaire 13-01"
+    partner: "Partenaire 13-01" #TODO remove partner (managed in UserApiPermission)
     statut: "ACTIVE"
     is_mailing_active: 0
   -
     email: api-02@signal-logement.fr
     roles: "[\"ROLE_API_USER\"]"
-    partner: "Alès Agglomération"
+    partner: "Alès Agglomération" #TODO remove partner (managed in UserApiPermission)
+    statut: "ACTIVE"
+    is_mailing_active: 0
+  -
+    email: api-reunion-epci@signal-logement.fr
+    roles: "[\"ROLE_API_USER\"]"
+    statut: "ACTIVE"
+    is_mailing_active: 0
+  -
+    email: api-oilhi@signal-logement.fr
+    roles: "[\"ROLE_API_USER\"]"
+    statut: "ACTIVE"
+    is_mailing_active: 0
+  -
+    email: api-34-01@signal-logement.fr
+    roles: "[\"ROLE_API_USER\"]"
     statut: "ACTIVE"
     is_mailing_active: 0
   -

--- a/src/DataFixtures/Files/UserApiPermission.yml
+++ b/src/DataFixtures/Files/UserApiPermission.yml
@@ -1,0 +1,28 @@
+user_api_permissions:
+  -
+    user: "api-reunion-epci@signal-logement.fr"
+    territory: "La Réunion"
+    partner_type: "EPCI"
+  -
+    user: "api-oilhi@signal-logement.fr"
+    partner_type: "COMMUNE_SCHS"
+  -
+    user: "api-34-01@signal-logement.fr"
+    territory: "Hérault"
+    partner_type: "EPCI"
+  -
+    user: "api-34-01@signal-logement.fr"
+    territory: "Hérault"
+    partner_type: "CAF_MSA"
+  -
+    user: "api-34-01@signal-logement.fr"
+    partner: "Ville de Montpellier"
+  -
+    user: "api-34-01@signal-logement.fr"
+    partner: "CD 34"
+  -
+    user: "api-01@signal-logement.fr"
+    partner: "Partenaire 13-01"
+  -
+    user: "api-02@signal-logement.fr"
+    partner: "Alès Agglomération"

--- a/src/DataFixtures/Files/UserApiPermission.yml
+++ b/src/DataFixtures/Files/UserApiPermission.yml
@@ -7,6 +7,9 @@ user_api_permissions:
     user: "api-oilhi@signal-logement.fr"
     partner_type: "COMMUNE_SCHS"
   -
+    user: "api-full-63@signal-logement.fr"
+    territory: "Puy-de-Dôme"
+  -
     user: "api-34-01@signal-logement.fr"
     territory: "Hérault"
     partner_type: "EPCI"

--- a/src/DataFixtures/Loader/LoadUserApiPermission.php
+++ b/src/DataFixtures/Loader/LoadUserApiPermission.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\DataFixtures\Loader;
+
+use App\Entity\Enum\PartnerType;
+use App\Entity\UserApiPermission;
+use App\Repository\PartnerRepository;
+use App\Repository\TerritoryRepository;
+use App\Repository\UserRepository;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\Yaml\Yaml;
+
+class LoadUserApiPermission extends Fixture implements OrderedFixtureInterface
+{
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly TerritoryRepository $territoryRepository,
+        private readonly PartnerRepository $partnerRepository,
+    ) {
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $UAPRows = Yaml::parseFile(__DIR__.'/../Files/UserApiPermission.yml');
+        foreach ($UAPRows['user_api_permissions'] as $row) {
+            $this->loadUserApiPermission($manager, $row);
+        }
+        $manager->flush();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function loadUserApiPermission(ObjectManager $manager, array $row): void
+    {
+        $user = $this->userRepository->findOneBy(['email' => $row['user']]);
+        $userApiPermission = new UserApiPermission();
+        $userApiPermission->setUser($user);
+        if (isset($row['partner'])) {
+            $partner = $this->partnerRepository->findOneBy(['nom' => $row['partner']]);
+            $userApiPermission->setPartner($partner);
+        } else {
+            if (isset($row['territory'])) {
+                $territory = $this->territoryRepository->findOneBy(['name' => $row['territory']]);
+                $userApiPermission->setTerritory($territory);
+            }
+            if (isset($row['partner_type'])) {
+                $partnerType = PartnerType::from($row['partner_type']);
+                $userApiPermission->setPartnerType($partnerType);
+            }
+        }
+        $manager->persist($userApiPermission);
+    }
+
+    public function getOrder(): int
+    {
+        return 24;
+    }
+}

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -159,6 +159,9 @@ class File implements EntityHistoryInterface
     #[ORM\JoinColumn(nullable: true)]
     private ?Territory $territory = null;
 
+    #[ORM\ManyToOne]
+    private ?Partner $partner = null;
+
     public function __construct()
     {
         $this->uuid = Uuid::v4();
@@ -490,5 +493,17 @@ class File implements EntityHistoryInterface
     public function getHistoryRegisteredEvent(): array
     {
         return [HistoryEntryEvent::CREATE, HistoryEntryEvent::UPDATE, HistoryEntryEvent::DELETE];
+    }
+
+    public function getPartner(): ?Partner
+    {
+        return $this->partner;
+    }
+
+    public function setPartner(?Partner $partner): static
+    {
+        $this->partner = $partner;
+
+        return $this;
     }
 }

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -111,6 +111,9 @@ class Suivi implements EntityHistoryInterface
     #[ORM\OneToMany(mappedBy: 'suivi', targetEntity: SuiviFile::class, orphanRemoval: true)]
     private Collection $suiviFiles;
 
+    #[ORM\ManyToOne]
+    private ?Partner $partner = null;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
@@ -380,6 +383,18 @@ class Suivi implements EntityHistoryInterface
                 $suiviFile->setSuivi(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getPartner(): ?Partner
+    {
+        return $this->partner;
+    }
+
+    public function setPartner(?Partner $partner): static
+    {
+        $this->partner = $partner;
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -204,6 +204,12 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $duplicateModalDismissedAt = null;
 
+    /**
+     * @var Collection<int, UserApiPermission>
+     */
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserApiPermission::class, orphanRemoval: true)]
+    private Collection $userApiPermissions;
+
     public function __construct()
     {
         $this->suivis = new ArrayCollection();
@@ -219,6 +225,7 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         $this->isMailingSummary = true;
         $this->userSignalementSubscriptions = new ArrayCollection();
         $this->hasDoneSubscriptionsChoice = false;
+        $this->userApiPermissions = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -1003,6 +1010,36 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
     public function setDuplicateModalDismissed(): static
     {
         $this->duplicateModalDismissedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, UserApiPermission>
+     */
+    public function getUserApiPermissions(): Collection
+    {
+        return $this->userApiPermissions;
+    }
+
+    public function addUserApiPermission(UserApiPermission $userApiPermission): static
+    {
+        if (!$this->userApiPermissions->contains($userApiPermission)) {
+            $this->userApiPermissions->add($userApiPermission);
+            $userApiPermission->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removeUserApiPermission(UserApiPermission $userApiPermission): static
+    {
+        if ($this->userApiPermissions->removeElement($userApiPermission)) {
+            // set the owning side to null (unless already changed)
+            if ($userApiPermission->getUser() === $this) {
+                $userApiPermission->setUser(null);
+            }
+        }
 
         return $this;
     }

--- a/src/Entity/UserApiPermission.php
+++ b/src/Entity/UserApiPermission.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Entity;
+
+use App\Entity\Enum\PartnerType;
+use App\Repository\UserApiPermissionRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: UserApiPermissionRepository::class)]
+class UserApiPermission
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'userApiPermissions')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne]
+    private ?Territory $territory = null;
+
+    #[ORM\ManyToOne]
+    private ?Partner $partner = null;
+
+    #[ORM\Column(
+        type: 'string',
+        nullable: true,
+        enumType: PartnerType::class,
+        options: ['comment' => 'Value possible enum PartnerType']
+    )]
+    private ?PartnerType $partnerType = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getTerritory(): ?Territory
+    {
+        return $this->territory;
+    }
+
+    public function setTerritory(?Territory $territory): static
+    {
+        $this->territory = $territory;
+
+        return $this;
+    }
+
+    public function getPartner(): ?Partner
+    {
+        return $this->partner;
+    }
+
+    public function setPartner(?Partner $partner): static
+    {
+        $this->partner = $partner;
+
+        return $this;
+    }
+
+    public function getPartnerType(): ?PartnerType
+    {
+        return $this->partnerType;
+    }
+
+    public function setPartnerType(?PartnerType $partnerType): static
+    {
+        $this->partnerType = $partnerType;
+
+        return $this;
+    }
+}

--- a/src/Repository/UserApiPermissionRepository.php
+++ b/src/Repository/UserApiPermissionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\UserApiPermission;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<UserApiPermission>
+ */
+class UserApiPermissionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UserApiPermission::class);
+    }
+}

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -36,7 +36,7 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserList(): \Generator
     {
-        yield 'Search without params' => [[], 68];
+        yield 'Search without params' => [[], 71];
         yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 22];
         yield 'Search with territory 13' => [['territory' => 13], 17];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];
@@ -99,7 +99,7 @@ class BackUserControllerTest extends WebTestCase
 
         $client->request('GET', $route, ['role' => 'ROLE_API_USER']);
 
-        $this->assertSelectorTextContains('h1', 'Exporter la liste des 2 utilisateurs');
+        $this->assertSelectorTextContains('h1', 'Exporter la liste des 5 utilisateurs');
     }
 
     public function testInactiveAccounts(): void

--- a/tests/Functional/Controller/Back/BackUserControllerTest.php
+++ b/tests/Functional/Controller/Back/BackUserControllerTest.php
@@ -36,7 +36,7 @@ class BackUserControllerTest extends WebTestCase
 
     public function provideParamsUserList(): \Generator
     {
-        yield 'Search without params' => [[], 71];
+        yield 'Search without params' => [[], 72];
         yield 'Search with queryUser admin' => [['queryUser' => 'admin'], 22];
         yield 'Search with territory 13' => [['territory' => 13], 17];
         yield 'Search with territory 13 and partner 6 and 7' => [['territory' => 13, 'partners' => [6, 7]], 2];
@@ -99,7 +99,7 @@ class BackUserControllerTest extends WebTestCase
 
         $client->request('GET', $route, ['role' => 'ROLE_API_USER']);
 
-        $this->assertSelectorTextContains('h1', 'Exporter la liste des 5 utilisateurs');
+        $this->assertSelectorTextContains('h1', 'Exporter la liste des 6 utilisateurs');
     }
 
     public function testInactiveAccounts(): void


### PR DESCRIPTION
## Ticket

#4537

## Description
- Création de la table `user_api_permission` et ajout de fixtures pour cette table
- Création d'un champ `partner_id` nullable dans les tables `Suivi `et `File`

## Tests
- [ ] `make load-fixtures`
