### PR TITLE
[BO - Liste signalements] Formatage des dates dans l'export xls/cxv

### DIFF
--- a/src/Messenger/Message/ListExportMessage.php
+++ b/src/Messenger/Message/ListExportMessage.php
@@ -4,6 +4,9 @@ namespace App\Messenger\Message;
 
 class ListExportMessage
 {
+    public const string FORMAT_CSV = 'csv';
+    public const string FORMAT_XLSX = 'xlsx';
+
     private int $userId;
     private string $format;
     /**

--- a/src/Messenger/MessageHandler/ListExportMessageHandler.php
+++ b/src/Messenger/MessageHandler/ListExportMessageHandler.php
@@ -41,10 +41,10 @@ readonly class ListExportMessageHandler
             $selectedColumns = $listExportMessage->getSelectedColumns();
             $format = $listExportMessage->getFormat();
 
-            $spreadsheet = $this->signalementExportLoader->load($user, $filters, $selectedColumns);
-            if ('csv' === $format) {
+            $spreadsheet = $this->signalementExportLoader->load($user, $format, $filters, $selectedColumns);
+            if (ListExportMessage::FORMAT_CSV === $format) {
                 $writer = new Csv($spreadsheet);
-            } elseif ('xlsx' === $format) {
+            } elseif (ListExportMessage::FORMAT_XLSX === $format) {
                 $writer = new Xlsx($spreadsheet);
             }
 


### PR DESCRIPTION
## Ticket
<img width="899" height="374" alt="image" src="https://github.com/user-attachments/assets/8bc7cb61-527a-41b3-9dde-2f8f156ea8fb" />

#4545    

## Description
Tri par date impossible sur les fichiers excel du au format appliqué par défini qui est la chaine de caractère. 
Pas de format applicable sur les fichiers csv

## Changements apportés
* Appliquer le format date sur toutes les colonnes dates du fichiers excel.

## Pré-requis
* Exécution commande `make worker-stop && make worker-consume`
* Ouvrir mailcatcher

## Tests
- [ ] Faire un export xls avec toutes les colonnes et vérifier que le tri par date sur excel fonctionne. 
- [ ] Faire un export csv avec toutes les colonnes et vérifier que tout fonctionne