### PR TITLE
[BO - Filtre Visite] Bug filtre Conclusion a renseigner

### DIFF
--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -314,11 +314,13 @@ class SearchFilter
                         break;
                     case VisiteStatus::PLANIFIEE->value:
                         $todayDatetime = new \DateTime();
-                        $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_PLANNED.'\' AND intervSearch.scheduledAt > '.$todayDatetime->format('Y-m-d').')';
+                        $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_PLANNED.'\' AND intervSearch.scheduledAt > :interventionScheduledAt)';
+                        $qb->setParameter('interventionScheduledAt', $todayDatetime->format('Y-m-d'));
                         break;
                     case VisiteStatus::CONCLUSION_A_RENSEIGNER->value:
                         $todayDatetime = new \DateTime();
-                        $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_PLANNED.'\' AND intervSearch.scheduledAt <= '.$todayDatetime->format('Y-m-d').')';
+                        $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_PLANNED.'\' AND intervSearch.scheduledAt <= :interventionScheduledAt)';
+                        $qb->setParameter('interventionScheduledAt', $todayDatetime->format('Y-m-d'));
                         break;
                     case VisiteStatus::TERMINEE->value:
                         $queryVisites .= '(intervSearch.status = \''.Intervention::STATUS_DONE.'\')';

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -64,7 +64,9 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Date de depot' => [['dateDepotDebut' => '2023-03-08', 'dateDepotFin' => '2023-03-16', 'isImported' => 'oui'], 2];
         yield 'Search by Procédure estimée' => [['procedure' => 'rsd', 'isImported' => 'oui'], 7];
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
-        yield 'Search by Statut de la visite' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 5];
+        yield 'Search by Statut de la visite "Planifié"' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 4];
+        yield 'Search by Statut de la visite "Conclusion à renseigner"' => [['visiteStatus' => 'Conclusion à renseigner', 'isImported' => 'oui'], 1];
+        yield 'Search by Statut de la visite "Terminé"' => [['visiteStatus' => 'Terminée', 'isImported' => 'oui'], 6];
         yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 5];
         yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18', 'isImported' => 'oui'], 2];
         yield 'Search by Statut de l\'affectation' => [['statusAffectation' => 'refuse', 'isImported' => 'oui'], 1];


### PR DESCRIPTION
## Ticket

#4552

## Description
Les filtres "Visite planifiée" et "Conclusion de visite à renseigner" ne fonctionnait pas correctement à cause d'un format sur les date mal échappé dans la requête les concernant
- Correction de la requête
- Ajout de tests

## Tests
- [ ] Vérifier que les filtres "Conclusion de visite à renseigner" et "Visite planifiée" retourne des résultats cohérent et génère une requête correcte sur la partie date
