### PR TITLE
[BO - Espace documentaire] Commande pour migrer les grilles de visite de territoire vers les documents type

### DIFF
--- a/src/Command/MigrateTerritoryGridFilesCommand.php
+++ b/src/Command/MigrateTerritoryGridFilesCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Enum\DocumentType;
+use App\Entity\File;
+use App\Factory\FileFactory;
+use App\Repository\TerritoryRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[AsCommand(
+    name: 'app:migrate-territory-grid-files',
+    description: 'Migrate territory grid files',
+)]
+class MigrateTerritoryGridFilesCommand extends Command
+{
+    public function __construct(
+        private readonly TerritoryRepository $territoryRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly FileFactory $fileFactory,
+        private readonly UserRepository $userRepository,
+        private readonly ParameterBagInterface $parameterBag,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $userAdmin = $this->userRepository->findOneBy(['email' => $this->parameterBag->get('admin_email')]);
+
+        $territoriesWithGridFiles = $this->territoryRepository->findAllWithGridFile();
+        foreach ($territoriesWithGridFiles as $territory) {
+            $gridFileName = $territory->getGrilleVisiteFilename();
+
+            $file = new File();
+            $file = $this->fileFactory->createInstanceFrom(
+                filename: $gridFileName,
+                title: 'Grille de visite - '.$territory->getName(),
+                user: $userAdmin,
+                isStandalone: true,
+                documentType: DocumentType::GRILLE_DE_VISITE,
+                territory: $territory,
+            );
+
+            $this->entityManager->persist($file);
+
+            $io->info('File '.$gridFileName.' for territory zip '.$territory->getZip().' has been migrated with success');
+        }
+
+        $this->entityManager->flush();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Factory/FileFactory.php
+++ b/src/Factory/FileFactory.php
@@ -6,6 +6,7 @@ use App\Entity\Enum\DocumentType;
 use App\Entity\File;
 use App\Entity\Intervention;
 use App\Entity\Signalement;
+use App\Entity\Territory;
 use App\Entity\User;
 use App\Service\Signalement\SignalementDocumentTypeMapper;
 
@@ -26,6 +27,7 @@ class FileFactory
         ?bool $isVariantsGenerated = false,
         ?bool $isSuspicious = false,
         ?bool $isStandalone = false,
+        ?Territory $territory = null,
     ): ?File {
         $extension = strtolower(pathinfo($filename, \PATHINFO_EXTENSION));
         $file = (new File())
@@ -75,6 +77,10 @@ class FileFactory
 
         if (null !== $isStandalone) {
             $file->setIsStandalone($isStandalone);
+        }
+
+        if (null !== $territory) {
+            $file->setTerritory($territory);
         }
 
         return $file;

--- a/src/Form/TerritoryType.php
+++ b/src/Form/TerritoryType.php
@@ -44,6 +44,9 @@ class TerritoryType extends AbstractType
             ->add('timezone', null, [
                 'disabled' => true,
             ]);
+
+        // TODO : Supprimer avec le feature flipping FEATURE_NEW_DOCUMENT_SPACE
+        // et faire une migration pour supprimer les champs de la table territory (sans supprimer les fichiers)
         $labelGrilleFile = 'Ajouter la grille de visite spécifique au territoire';
         if ($territory->getGrilleVisiteFilename()) {
             $labelGrilleFile = 'Remplacer la grille de visite spécifique au territoire';

--- a/src/Repository/TerritoryRepository.php
+++ b/src/Repository/TerritoryRepository.php
@@ -105,4 +105,16 @@ class TerritoryRepository extends ServiceEntityRepository
 
         return new Paginator($qb->getQuery());
     }
+
+    /**
+     * @return array<int, Territory>
+     */
+    public function findAllWithGridFile(): array
+    {
+        $qb = $this->createQueryBuilder('t')
+            ->where('t.grilleVisiteFilename IS NOT NULL')
+            ->andWhere('t.isGrilleVisiteDisabled = 0');
+
+        return $qb->getQuery()->getResult();
+    }
 }


### PR DESCRIPTION
## Ticket

#4520   

## Description
Création d'une commande pour migrer les fichiers de grille de visite définies par territoire dans le système de documents types

## Tests
- [ ] Créer plusieurs grilles de visite dans l'interface d'administration des territoires
- [ ] `make console app="migrate-territory-grid-files"`
- [ ] Vérifier que les fichiers apparaissent bien dans l'espace documentaire
