### PR TITLE
[API] Upload de fichiers — erreur 500 quand un tableau de file n'est pas envoyé

### DIFF
--- a/src/Dto/Api/Request/FilesUploadRequest.php
+++ b/src/Dto/Api/Request/FilesUploadRequest.php
@@ -35,14 +35,15 @@ class FilesUploadRequest implements RequestInterface
     #[Assert\Count(
         min: 1,
         max: 5,
-        minMessage: 'Vous devez téléverser au moins un fichier et vous assurez d\'envoyer un tableau de fichiers (files[]).',
+        minMessage: 'Veuillez téléverser au moins un fichier et l’envoyer sous la forme d’un tableau de fichiers (files[]).',
         maxMessage: 'Vous ne pouvez pas téléverser plus de {{ limit }} fichiers.',
         groups: ['multiple_documents', 'multiple_images']
     )]
     #[Assert\Count(
         min: 1,
         max: 1,
-        minMessage: 'Vous devez téléverser un fichier.',
+        exactMessage: 'Veuillez téléverser un seul fichier et l’envoyer sous la forme d’un tableau de fichiers (files[]).',
+        minMessage: 'Veuillez téléverser un seul fichier.',
         maxMessage: 'Vous ne pouvez téléverser qu\'un seul fichier.',
         groups: ['single']
     )]

--- a/src/Dto/Api/Request/FilesUploadRequest.php
+++ b/src/Dto/Api/Request/FilesUploadRequest.php
@@ -35,7 +35,7 @@ class FilesUploadRequest implements RequestInterface
     #[Assert\Count(
         min: 1,
         max: 5,
-        minMessage: 'Vous devez téléverser au moins un fichier.',
+        minMessage: 'Vous devez téléverser au moins un fichier et vous assurez d\'envoyer un tableau de fichiers (files[]).',
         maxMessage: 'Vous ne pouvez pas téléverser plus de {{ limit }} fichiers.',
         groups: ['multiple_documents', 'multiple_images']
     )]


### PR DESCRIPTION
## Ticket

#4568    

## Description
Constaté lors des derniers tests ou une erreur 500 n'était pas géré lors d'upload de fichiers

## Changements apportés
* Gérer l'erreur de normalisation lorsqu'un tableau n'est pas poussé

## Pré-requis

## Tests
- [ ] Soumettre un fichier au lieu d'un tableau de fichier et vérifier qu'il y'a une erreur 400 au lieu d'une erreur 500
