### PR TITLE
[BUG] reprise de données prénom,nom pour appliquer un trim 

### DIFF
--- a/src/Command/TrimSignalementFieldsCommand.php
+++ b/src/Command/TrimSignalementFieldsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\SignalementRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:trim-signalement-fields',
+    description: 'Trim signalement fields'
+)]
+class TrimSignalementFieldsCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private SignalementRepository $signalementRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        // See https://symfony.com/doc/current/console/style.html
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->signalementRepository->trimFields();
+
+        $this->io->success('Signalement fields were successfully fixed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2370,4 +2370,22 @@ class SignalementRepository extends ServiceEntityRepository
 
         return $conn->executeQuery($sql, $paramsToBind, $types)->fetchAllAssociative();
     }
+
+    public function trimFields(): void
+    {
+        $connection = $this->getEntityManager()->getConnection();
+        // Replace unbreakable spaces, and then trim
+        $sql = 'UPDATE signalement SET
+            mail_occupant = TRIM(REPLACE(mail_occupant, UNHEX("C2A0"), " ")),
+            prenom_occupant = TRIM(REPLACE(prenom_occupant, UNHEX("C2A0"), " ")),
+            nom_occupant = TRIM(REPLACE(nom_occupant, UNHEX("C2A0"), " ")),
+            mail_declarant = TRIM(REPLACE(mail_declarant, UNHEX("C2A0"), " ")),
+            prenom_declarant = TRIM(REPLACE(prenom_declarant, UNHEX("C2A0"), " ")),
+            nom_declarant = TRIM(REPLACE(nom_declarant, UNHEX("C2A0"), " ")),
+            mail_proprio = TRIM(REPLACE(mail_proprio, UNHEX("C2A0"), " ")),
+            prenom_proprio = TRIM(REPLACE(prenom_proprio, UNHEX("C2A0"), " ")),
+            nom_proprio = TRIM(REPLACE(nom_proprio, UNHEX("C2A0"), " "))';
+
+        $connection->prepare($sql)->executeStatement();
+    }
 }


### PR DESCRIPTION
## Ticket

#4567

## Description
- Copie de l'ancienne commande existante pour pouvoir la relancer https://github.com/MTES-MCT/histologe/pull/4035/files

## Tests
- [ ] Insérer une prenom/nom de déclarant ou occupant avec un espace initial sur un signalement. Lancer la commande `app:trim-signalement-fields` et vérifier que l'espace a bien été supprimé
