### PR TITLE
[BO - Dashboard] Modifier l'icône dans le bouton de la modale pour gérer les notifs

### DIFF
--- a/templates/_partials/_modal_subscriptions_choice.twig
+++ b/templates/_partials/_modal_subscriptions_choice.twig
@@ -69,7 +69,7 @@
                     </div>
                     <div class="fr-modal__footer">
                         <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button class="fr-btn fr-icon-close-line" type="submit" form="subscriptions-choice-form">Valider mon choix</button>
+                            <button class="fr-btn fr-icon-check-line" type="submit" form="subscriptions-choice-form">Valider mon choix</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Ticket

#4573   

## Description
Dans la modale où on propose de choisir comment être notifié, il faudrait changer l'icône pour mettre un check ✔️ , plutôt qu'une croix

## Changements apportés
* Changement de la classe dans le twig

## Pré-requis

## Tests
- [ ] Vérifier
