### PR TITLE
[QA] Gestion clé manquante front_suivi_signalement_documents

### DIFF
--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement.js
@@ -335,16 +335,19 @@ if (modalUploadFiles) {
       uploadedFilesForm.querySelectorAll('input[name="form[file][]"]').forEach((input) => {
         input.remove();
       });
-      modalUploadFiles.querySelectorAll('.select-container select').forEach((select) => {
-        const inputFileId = document.createElement('input');
-        inputFileId.type = 'hidden';
-        inputFileId.name = 'form[file][]';
-        inputFileId.value = select.dataset.fileId;
-        uploadedFilesForm.appendChild(inputFileId);
-      });
-      uploadedFilesForm.submit();
+      const filesToAdd = modalUploadFiles.querySelectorAll('.select-container select');
+      if(filesToAdd.length > 0) {
+        filesToAdd.forEach((select) => {
+          const inputFileId = document.createElement('input');
+          inputFileId.type = 'hidden';
+          inputFileId.name = 'form[file][]';
+          inputFileId.value = select.dataset.fileId;
+          uploadedFilesForm.appendChild(inputFileId);
+        });
+        uploadedFilesForm.submit();
+      }
     }
-
+    
     modalUploadFiles.dataset.validated = true;
   });
 }

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -594,10 +594,12 @@ class SignalementController extends AbstractController
                 if ($form->isValid()) {
                     $docs = $fileRepository->findTempForSignalementAndUserIndexedById($signalement, $signalementUser->getUser());
                     $filesToAttach = [];
-                    foreach ($form->getExtraData()['file'] as $fileId) {
-                        if (isset($docs[$fileId])) {
-                            $docs[$fileId]->setIsTemp(false);
-                            $filesToAttach[] = $docs[$fileId];
+                    if (isset($form->getExtraData()['file'])) {
+                        foreach ($form->getExtraData()['file'] as $fileId) {
+                            if (isset($docs[$fileId])) {
+                                $docs[$fileId]->setIsTemp(false);
+                                $filesToAttach[] = $docs[$fileId];
+                            }
                         }
                     }
                     if ($filesToAttach) {


### PR DESCRIPTION
## Ticket

#4578

## Description
Sur la page "documents" du suivi usager : 
- Lorsque l'on valide la modale d'ajout de document sans en avoir uploadé : on ne soumet plus le formulaire
- Au cas ou une soumission vide passe quand même on vérifie l'existence de la clé coté PHP pour éviter le warning

## Pré-requis
`make npm-build`
## Tests
- [ ] Tester l'ajout de documents depuis la page documents du suivi usager
