### PR TITLE
[Matomo] Eviter le tracking sur la page d'activation avec token

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -59,7 +59,7 @@
         {{ encore_entry_script_tags('app') }}
         {{ encore_entry_link_tags('app') }}
     {% endblock %}
-    {% if matomo is defined and matomo.enable == 1 %}
+    {% if matomo is defined and matomo.enable == 1 and 'activate_account' not in app.request.get('_route') %}
         <!-- Matomo -->
         <script nonce="{{ app.request.attributes.get('csp_script_nonce') }}">
             var _paq = window._paq = window._paq || [];


### PR DESCRIPTION
## Ticket

#4587   

## Description
Afin d'éviter de stocker des token potentiellement sensibles, on évite le tracking sur la page d'activation des comptes

## Tests
- [ ] ajouter un console.log juste après la ligne modifiée pour vérifier qu'on passe bien dans le javascript
- [ ] faire la procédure d'activation de compte (ou récupération de mot de passe), et vérifier qu'on ne passe pas dedans quand il y a un token dans l'url
