### PR TITLE
[BUG - Export PDF] Masquer les information agent présente sur le suivi lors de l'export usager

### DIFF
--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -610,9 +610,11 @@
                             <tr>
                                 <td style="padding:.5rem;width: 15%">
                                     {% if suivi.createdBy is defined and suivi.createdBy is not null %}
-                                        <b> {{ suivi.createdBy.nomComplet(true) }}</b>
-                                        {% if suivi.createdBy.fonction %}({{ suivi.createdBy.fonction }}){% endif %}
-                                        <br>
+                                        ️{% if not isForUsager %}
+                                            <b> {{ suivi.createdBy.nomComplet(true) }}</b>
+                                            {% if suivi.createdBy.fonction %}({{ suivi.createdBy.fonction }}){% endif %}
+                                            <br>
+                                        {% endif %}
                                         <small>
                                         {% if suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER
                                                         or suivi.category is same as enum('App\\Entity\\Enum\\SuiviCategory').MESSAGE_USAGER_POST_CLOTURE
@@ -655,8 +657,10 @@
                     <h2>Photo : {{ photo.title }}</h2>
                     {% if photo.documentType.name == 'PHOTO_VISITE' %}
                        <h3>Photo de la visite du {{ photo.intervention is defined and photo.intervention.scheduledAt is defined ? photo.intervention.scheduledAt|date('d/m/Y') : 'N/R'}}</h3>  
-                    {% endif %}                    
-                    <small>Ajoutée par {{ photo.uploadedBy.nomComplet ?? 'N/R' }}</small><br>
+                    {% endif %}
+                    {% if not isForUsager %}                    
+                        <small>Ajoutée par {{ photo.uploadedBy.nomComplet ?? 'N/R' }}</small><br>
+                    {% endif %}
                     <small>le {{ photo.createdAt is defined ? photo.createdAt|date('d/m/Y') : 'N/R' }}</small><br>                    
                     {% set encodedImage = photo.filename(constant('App\\Service\\ImageManipulationHandler::SUFFIX_RESIZE')) | image64 %}
                     {% if encodedImage is not null %}                    


### PR DESCRIPTION
## Ticket

#4589

## Description
Lorsque l'export PDF est fait par un usager on masque : 
- Le nom, prénom et fonction de l'agent ayant déposé le suivi.
- Le nom et prénom de l'agent ayant ajouté les photos

## Tests
- [ ] Ajouter un suivi public sur un signalement et des photo de la situation depuis le BO. Exporter le PDF coté usager et s'assurer que les donnée personnelles d'agent n’apparaissent pas
