### PR TITLE
[BO - Notifications] Pouvoir trier par lu / non lu

### DIFF
--- a/src/Form/SearchNotificationType.php
+++ b/src/Form/SearchNotificationType.php
@@ -20,6 +20,8 @@ class SearchNotificationType extends AbstractType
             'choices' => [
                 'Date (la plus récente)' => 'n.createdAt-DESC',
                 'Date (la plus ancienne)' => 'n.createdAt-ASC',
+                'Non lues en premier' => 'n.isSeen-ASC',
+                'Non lues en dernier' => 'n.isSeen-DESC',
                 'Référence (ordre croissant)' => 'si.reference-ASC',
                 'Référence (ordre décroissant)' => 'si.reference-DESC',
                 'Nom de l\'auteur (A -> Z)' => 'cb.nom-ASC',


### PR DESCRIPTION
## Ticket

#4582   

## Description
Dans la liste des notifications, pouvoir trier par le fait qu'elles sont lues ou non lues

## Tests
- [ ] Vérifier le nouveau tri
