### PR TITLE
[API - BUG] Partneaire non enregistré sur l'intervention à la création d'un arreté

### DIFF
--- a/src/Factory/InterventionFactory.php
+++ b/src/Factory/InterventionFactory.php
@@ -39,12 +39,12 @@ class InterventionFactory
             ->setDetails($details)
             ->setAdditionalInformation($additionalInformation);
 
-        if ('ARS' === $doneBy) {
-            $intervention->setPartner($affectation->getPartner());
-        } else {
-            $intervention
-                ->setExternalOperator($doneBy)
-                ->setPartner(null);
+        if ($doneBy) {
+            if ('ARS' === $doneBy) {
+                $intervention->setPartner($affectation->getPartner());
+            } else {
+                $intervention->setExternalOperator($doneBy)->setPartner(null);
+            }
         }
 
         if (!empty($concludeProcedures)) {


### PR DESCRIPTION
## Ticket

#4585

## Description
A la création d'un arrêté depuis l'API le partenaire n'était plus enregistré sur l'intervention. Correction

## Tests
- [ ] Créer un arrêté depuis l'API et vérifier que le champ `partner_id` est bien renseigné dans la table intervention
