### PR TITLE
[Fo - Formulaire] Accompagnement TS - Structure

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1480,6 +1480,18 @@
           "validate": {
             "message": "Veuillez indiquer si le foyer bénéficie d'un accompagnement par un ou une travailleuse sociale."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_structure",
+          "label": "Quel est le nom de la structure qui accompagne le foyer ? (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de la structure qui accompagne le foyer."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -1322,6 +1322,18 @@
           "validate": {
             "message": "Veuillez indiquer si un travailleur ou une travailleuse sociale vous accompagne."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_structure",
+          "label": "Quel est le nom de la structure qui vous accompagne ? (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de la structure qui vous accompagne."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -1749,6 +1749,18 @@
           "validate": {
             "message": "Veuillez indiquer si un travailleur ou une travailleuse sociale vous accompagne."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_structure",
+          "label": "Quel est le nom de la structure qui vous accompagne ? (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de la structure qui vous accompagne."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1817,6 +1817,18 @@
           "validate": {
             "message": "Veuillez indiquer si le foyer bénéficie d'un accompagnement par un ou une travailleuse sociale."
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_structure",
+          "label": "Quel est le nom de la structure qui accompagne le foyer ? (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de la structure qui accompagne le foyer."
+          }
         }
       ],
       "footer": [

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1812,6 +1812,18 @@
           "conditional": {
             "show": "formStore.data.travailleur_social_accompagnement === 'oui'"
           }
+        },
+        {
+          "type": "SignalementFormTextfield",
+          "slug": "travailleur_social_accompagnement_nom_structure",
+          "label": "Quel est le nom de la structure qui accompagne le foyer ? (facultatif)",
+          "conditional": {
+            "show": "formStore.data.travailleur_social_accompagnement === 'oui' && formStore.data.travailleur_social_accompagnement_declarant !== 1"
+          },
+          "validate": {
+            "required": false,
+            "message": "Veuillez indiquer le nom de la structure qui accompagne le foyer."
+          }
         }
       ],
       "footer": [

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -770,6 +770,9 @@ function initBoFormSignalementSituation() {
   initRefreshFromRadio('situation', 'signalement_draft_situation_assuranceContactee', [
     '#signalement_draft_situation_reponseAssurance',
   ]);
+  initRefreshFromRadio('situation', 'signalement_draft_situation_accompagnementTravailleurSocial', [
+    '#signalement_draft_situation_accompagnementTravailleurSocialNomStructure',
+  ]);
   window.dispatchEvent(new Event('refreshUploadButtonEvent'));
 
   reloadDeleteFileList();

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -383,6 +383,14 @@ export default defineComponent({
         result += this.addLineIfNeeded('logement_social_numero_allocataire', 'Numéro allocataire : ')
         result += this.addLineIfNeeded('logement_social_montant_allocation', 'Montant allocation : ', ' €')
       }
+      result += this.addLineIfNeeded('travailleur_social_quitte_logement', 'Souhaite quitter le logement ? ')
+      if (this.formStore.data.travailleur_social_quitte_logement === 'oui') {
+        result += this.addLineIfNeeded('travailleur_social_preavis_depart', 'Préavis de départ ? ')
+      }
+      result += this.addLineIfNeeded('travailleur_social_accompagnement', 'Accompagnement par un ou une travailleuse sociale ? ')
+      if (this.formStore.data.travailleur_social_accompagnement === 'oui') {
+        result += this.addLineIfNeeded('travailleur_social_accompagnement_nom_structure', 'Nom de la structure : ')
+      }
       return result
     },
     getFormDataInfosDesordres (): string {

--- a/src/Dto/Api/Response/SignalementResponse.php
+++ b/src/Dto/Api/Response/SignalementResponse.php
@@ -416,6 +416,13 @@ class SignalementResponse
     public bool|string|null $suiviParTravailleurSocial;
 
     #[OA\Property(
+        description: 'Nom de la structure d\'accompagnement.',
+        example: 'Structure Sociale ABC',
+        nullable: true
+    )]
+    public ?string $nomStructureAccompagnement;
+
+    #[OA\Property(
         description: "Indique si le propriétaire a été averti d'une situation concernant le logement.",
         type: 'boolean',
         example: true,

--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -415,6 +415,8 @@ class SignalementDraftRequest
     #[Assert\Length(max: 50)]
     private ?string $travailleurSocialAccompagnementDeclarant = null;
 
+    private ?string $travailleurSocialAccompagnementNomStructure = null;
+
     #[Assert\Choice(
         choices: ['oui', 'non', 'nsp'],
         message: 'Le champ "infoProcedureBailleurPrevenu" est incorrect.',
@@ -1532,6 +1534,18 @@ class SignalementDraftRequest
     public function setTravailleurSocialAccompagnementDeclarant(?string $travailleurSocialAccompagnementDeclarant): self
     {
         $this->travailleurSocialAccompagnementDeclarant = $travailleurSocialAccompagnementDeclarant;
+
+        return $this;
+    }
+
+    public function getTravailleurSocialAccompagnementNomStructure(): ?string
+    {
+        return $this->travailleurSocialAccompagnementNomStructure;
+    }
+
+    public function setTravailleurSocialAccompagnementNomStructure(?string $travailleurSocialAccompagnementNomStructure): self
+    {
+        $this->travailleurSocialAccompagnementNomStructure = $travailleurSocialAccompagnementNomStructure;
 
         return $this;
     }

--- a/src/Dto/Request/Signalement/SituationFoyerRequest.php
+++ b/src/Dto/Request/Signalement/SituationFoyerRequest.php
@@ -76,6 +76,7 @@ readonly class SituationFoyerRequest implements RequestInterface
         private ?string $travailleurSocialAccompagnement = null,
         #[Assert\Length(max: 50)]
         private ?string $travailleurSocialAccompagnementDeclarant = null,
+        private ?string $travailleurSocialAccompagnementNomStructure = null,
         #[Assert\Choice(
             choices: ['oui', 'non'],
             message: 'Le champ "Bénéficiaire du RSA" est incorrect.',
@@ -145,6 +146,11 @@ readonly class SituationFoyerRequest implements RequestInterface
     public function getTravailleurSocialAccompagnementDeclarant(): ?string
     {
         return $this->travailleurSocialAccompagnementDeclarant;
+    }
+
+    public function getTravailleurSocialAccompagnementNomStructure(): ?string
+    {
+        return $this->travailleurSocialAccompagnementNomStructure;
     }
 
     public function getBeneficiaireRsa(): ?string

--- a/src/Entity/Model/SituationFoyer.php
+++ b/src/Entity/Model/SituationFoyer.php
@@ -15,6 +15,7 @@ class SituationFoyer
         private ?string $travailleurSocialPreavisDepart = null,
         private ?string $travailleurSocialAccompagnement = null,
         private ?string $travailleurSocialAccompagnementDeclarant = null,
+        private ?string $travailleurSocialAccompagnementNomStructure = null,
     ) {
     }
 
@@ -146,6 +147,18 @@ class SituationFoyer
         return $this;
     }
 
+    public function getTravailleurSocialAccompagnementNomStructure(): ?string
+    {
+        return $this->travailleurSocialAccompagnementNomStructure;
+    }
+
+    public function setTravailleurSocialAccompagnementNomStructure(?string $travailleurSocialAccompagnementNomStructure): self
+    {
+        $this->travailleurSocialAccompagnementNomStructure = $travailleurSocialAccompagnementNomStructure;
+
+        return $this;
+    }
+
     /** @return array<string, mixed> */
     public function toArray(): array
     {
@@ -160,6 +173,7 @@ class SituationFoyer
             'travailleur_social_preavis_depart' => $this->travailleurSocialPreavisDepart,
             'travailleur_social_accompagnement' => $this->travailleurSocialAccompagnement,
             'travailleur_social_accompagnement_declarant' => $this->travailleurSocialAccompagnementDeclarant,
+            'travailleur_social_accompagnement_nom_structure' => $this->travailleurSocialAccompagnementNomStructure,
         ];
     }
 }

--- a/src/Factory/Api/SignalementResponseFactory.php
+++ b/src/Factory/Api/SignalementResponseFactory.php
@@ -107,6 +107,7 @@ readonly class SignalementResponseFactory
         $signalementResponse->souhaiteQuitterLogement = $this->stringToBool($signalement->getSituationFoyer()?->getTravailleurSocialQuitteLogement());
         $signalementResponse->souhaiteQuitterLogementApresTravaux = $this->stringToBool($signalement->getInformationProcedure()?->getInfoProcedureDepartApresTravaux());
         $signalementResponse->suiviParTravailleurSocial = $this->stringToBool($signalement->getSituationFoyer()?->getTravailleurSocialAccompagnement());
+        $signalementResponse->nomStructureAccompagnement = $signalement->getSituationFoyer()?->getTravailleurSocialAccompagnementNomStructure();
         $signalementResponse->proprietaireAverti = $signalement->getIsProprioAverti();
         $signalementResponse->moyenInformationProprietaire = $signalement->getInformationProcedure()?->getInfoProcedureBailMoyen();
         $signalementResponse->dateInformationProprietaire = $signalement->getInformationProcedure()?->getInfoProcedureBailDate();

--- a/src/Factory/Signalement/SituationFoyerFactory.php
+++ b/src/Factory/Signalement/SituationFoyerFactory.php
@@ -41,7 +41,8 @@ class SituationFoyerFactory
             travailleurSocialQuitteLogement: $data['travailleur_social_quitte_logement'] ?? null,
             travailleurSocialPreavisDepart: $data['travailleur_social_preavis_depart'] ?? null,
             travailleurSocialAccompagnement: $data['travailleur_social_accompagnement'] ?? null,
-            travailleurSocialAccompagnementDeclarant: $data['travailleur_social_accompagnement_declarant'] ?? null
+            travailleurSocialAccompagnementDeclarant: $data['travailleur_social_accompagnement_declarant'] ?? null,
+            travailleurSocialAccompagnementNomStructure: $data['travailleur_social_accompagnement_nom_structure'] ?? null,
         );
     }
 }

--- a/src/Form/SignalementDraftSituationType.php
+++ b/src/Form/SignalementDraftSituationType.php
@@ -44,6 +44,7 @@ class SignalementDraftSituationType extends AbstractType
         $typeAllocation = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsTypeAllocation() : '';
         $montantAllocation = $signalement->getMontantAllocation();
         $accompagnementTravailleurSocial = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnement() : '';
+        $accompagnementTravailleurSocialNomStructure = $signalement->getSituationFoyer() ? $signalement->getSituationFoyer()->getTravailleurSocialAccompagnementNomStructure() : '';
         $beneficiaireRSA = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireRsa() : '';
         $beneficiaireFSL = $signalement->getInformationComplementaire() ? $signalement->getInformationComplementaire()->getInformationsComplementairesSituationOccupantsBeneficiaireFsl() : '';
         $dateProprietaireAverti = $signalement->getProprioAvertiAt();
@@ -242,6 +243,12 @@ class SignalementDraftSituationType extends AbstractType
                 'placeholder' => false,
                 'mapped' => false,
                 'data' => $accompagnementTravailleurSocial,
+            ])
+            ->add('accompagnementTravailleurSocialNomStructure', TextType::class, [
+                'label' => 'Nom de la structure d\'accompagnement',
+                'required' => false,
+                'mapped' => false,
+                'data' => $accompagnementTravailleurSocialNomStructure,
             ])
             ->add('beneficiaireRSA', ChoiceType::class, [
                 'label' => 'Bénéficiaire RSA',

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -759,6 +759,9 @@ class SignalementManager extends AbstractManager
             ->setTravailleurSocialAccompagnement(
                 $situationFoyerRequest->getTravailleurSocialAccompagnement()
             )
+            ->setTravailleurSocialAccompagnementNomStructure(
+                $situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure()
+            )
             ->setLogementSocialAllocationCaisse($situationFoyerRequest->getIsAllocataire());
 
         if ('non' === $situationFoyerRequest->getTravailleurSocialPreavisDepart()) {

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -214,6 +214,7 @@ class SignalementBoManager
         $informationComplementaire->setInformationsComplementairesSituationOccupantsTypeAllocation($form->get('typeAllocation')->getData());
         $signalement->setMontantAllocation((int) $form->get('montantAllocation')->getData());
         $situationFoyer->setTravailleurSocialAccompagnement($form->get('accompagnementTravailleurSocial')->getData());
+        $situationFoyer->setTravailleurSocialAccompagnementNomStructure($form->get('accompagnementTravailleurSocialNomStructure')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireRsa($form->get('beneficiaireRSA')->getData());
         $informationComplementaire->setInformationsComplementairesSituationOccupantsBeneficiaireFsl($form->get('beneficiaireFSL')->getData());
         if (!empty($form->get('dateProprietaireAverti')->getData())) {

--- a/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
+++ b/templates/back/signalement/view/edit-modals/edit-situation-foyer.html.twig
@@ -132,6 +132,12 @@
                                 </select>
                             </div>
 
+                            <div class="fr-input-group">
+                                {% set travailleurSocialAccompagnementNomStructure = signalement.situationFoyer ? signalement.situationFoyer.travailleurSocialAccompagnementNomStructure : null %}
+                                <label class="fr-label" for="situationFoyerTravailleurSocialAccompagnementNomStructure">Nom de la structure d'accompagnement</label>
+                                <input class="fr-input" type="text" id="situationFoyerTravailleurSocialAccompagnementNomStructure" name="travailleurSocialAccompagnementNomStructure" value="{{ travailleurSocialAccompagnementNomStructure }}">
+                            </div>
+
                             <div class="fr-select-group">
                                 {% set beneficiaireRsa = signalement.informationComplementaire ? signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa : null %}
                                 <label class="fr-label" for="situationFoyerBeneficiaireRsa">Bénéficiaire RSA (facultatif)</label>

--- a/templates/back/signalement/view/information/information-situation-foyer.html.twig
+++ b/templates/back/signalement/view/information/information-situation-foyer.html.twig
@@ -90,7 +90,8 @@
             Ne sait pas
         {% endif %}
     </div>
-    <div class="fr-col-12 fr-col-md-6">
+    {% set structureAccompagnement = signalement.situationFoyer and signalement.situationFoyer.travailleurSocialAccompagnement is same as 'oui' %}
+    <div class="fr-col-12 {% if structureAccompagnement %}fr-col-md-6{% endif %}">
         <strong>Accompagnement par un ou une travailleuse sociale :</strong>
         {% if signalement.situationFoyer %}
             {% if signalement.situationFoyer.travailleurSocialAccompagnement is same as 'oui' %}
@@ -102,7 +103,7 @@
             {% endif %}
         {% endif %}
     </div>
-    {% if signalement.situationFoyer and signalement.situationFoyer.travailleurSocialAccompagnement is same as 'oui'%}
+    {% if structureAccompagnement %}
         <div class="fr-col-12 fr-col-md-6">
             <strong>Nom de la structure d'accompagnement :</strong>
             {{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}

--- a/templates/back/signalement/view/information/information-situation-foyer.html.twig
+++ b/templates/back/signalement/view/information/information-situation-foyer.html.twig
@@ -90,7 +90,7 @@
             Ne sait pas
         {% endif %}
     </div>
-    <div class="fr-col-12">
+    <div class="fr-col-12 fr-col-md-6">
         <strong>Accompagnement par un ou une travailleuse sociale :</strong>
         {% if signalement.situationFoyer %}
             {% if signalement.situationFoyer.travailleurSocialAccompagnement is same as 'oui' %}
@@ -102,6 +102,12 @@
             {% endif %}
         {% endif %}
     </div>
+    {% if signalement.situationFoyer and signalement.situationFoyer.travailleurSocialAccompagnement is same as 'oui'%}
+        <div class="fr-col-12 fr-col-md-6">
+            <strong>Nom de la structure d'accompagnement :</strong>
+            {{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}
+        </div>
+    {% endif %}
     <div class="fr-col-12 fr-col-md-6">
         <strong>Bénéficiaire RSA :</strong>
         {% if signalement.informationComplementaire %}

--- a/templates/back/signalement_create/tabs/tab-situation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-situation.html.twig
@@ -62,6 +62,9 @@
                 {{ form_row(formSituation.accompagnementTravailleurSocial) }}
             </div>
             <div class="fr-fieldset__element">
+                {{ form_row(formSituation.accompagnementTravailleurSocialNomStructure) }}
+            </div>
+            <div class="fr-fieldset__element">
                 {{ form_row(formSituation.beneficiaireRSA) }}
             </div>
             <div class="fr-fieldset__element">

--- a/templates/front/suivi_signalement_dossier.html.twig
+++ b/templates/front/suivi_signalement_dossier.html.twig
@@ -428,7 +428,7 @@
 							{{signalement.situationFoyer.travailleurSocialAccompagnement(false)|capitalize}}
 						</li>
 					{% endif %}
-					{% if signalement.situationFoyer.travailleurSocialAccompagnementNomStructure %}
+					{% if signalement.situationFoyer.travailleurSocialAccompagnement(false) and signalement.situationFoyer.travailleurSocialAccompagnementNomStructure %}
 						<li>Nom de la structure d'accompagnement :
 							{{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}
 						</li>

--- a/templates/front/suivi_signalement_dossier.html.twig
+++ b/templates/front/suivi_signalement_dossier.html.twig
@@ -428,6 +428,11 @@
 							{{signalement.situationFoyer.travailleurSocialAccompagnement(false)|capitalize}}
 						</li>
 					{% endif %}
+					{% if signalement.situationFoyer.travailleurSocialAccompagnementNomStructure %}
+						<li>Nom de la structure d'accompagnement :
+							{{ signalement.situationFoyer.travailleurSocialAccompagnementNomStructure }}
+						</li>
+					{% endif %}
 				{% endif %}
 				{% if signalement.informationComplementaire %}
 					{% if signalement.informationComplementaire.informationsComplementairesSituationOccupantsBeneficiaireRsa %}

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -219,7 +219,6 @@ class SignalementEditControllerTest extends WebTestCase
      */
     private function getPayloadSituationFoyer(): array
     {
-        // TODO : ajouter le nom de la structure si travailleur social ?
         return [
             'isLogementSocial' => 'non',
             'isRelogement' => 'non',

--- a/tests/Functional/Controller/Back/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementEditControllerTest.php
@@ -219,6 +219,7 @@ class SignalementEditControllerTest extends WebTestCase
      */
     private function getPayloadSituationFoyer(): array
     {
+        // TODO : ajouter le nom de la structure si travailleur social ?
         return [
             'isLogementSocial' => 'non',
             'isRelogement' => 'non',

--- a/tests/Unit/Dto/Request/Signalement/SignalementDraftRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SignalementDraftRequestTest.php
@@ -46,6 +46,7 @@ class SignalementDraftRequestTest extends WebTestCase
         $this->assertSame('D', $signalementDraftRequest->getBailDpeClasseEnergetique());
         $this->assertSame('oui', $signalementDraftRequest->getTravailleurSocialAccompagnement());
         $this->assertSame('1', $signalementDraftRequest->getTravailleurSocialAccompagnementDeclarant());
+        $this->assertSame('Organisme Exemple', $signalementDraftRequest->getTravailleurSocialAccompagnementNomStructure());
         $this->assertSame('oui', $signalementDraftRequest->getInfoProcedureAssuranceContactee());
         $this->assertSame(
             'Réponse de l\'assurance',
@@ -289,6 +290,7 @@ class SignalementDraftRequestTest extends WebTestCase
             ->setTravailleurSocialPreavisDepart('oui')
             ->setTravailleurSocialAccompagnement('oui')
             ->setTravailleurSocialAccompagnementDeclarant('1')
+            ->setTravailleurSocialAccompagnementNomStructure('Organisme Exemple')
             ->setInfoProcedureBailleurPrevenu('oui')
             ->setInfoProcedureBailMoyen('sms')
             ->setInfoProcedureBailDate('11/2024')

--- a/tests/Unit/Dto/Request/Signalement/SituationFoyerRequestTest.php
+++ b/tests/Unit/Dto/Request/Signalement/SituationFoyerRequestTest.php
@@ -29,6 +29,7 @@ class SituationFoyerRequestTest extends KernelTestCase
             travailleurSocialPreavisDepart: 'oui',
             travailleurSocialAccompagnement: 'oui',
             travailleurSocialAccompagnementDeclarant: '1',
+            travailleurSocialAccompagnementNomStructure: 'Organisme Exemple',
             beneficiaireRsa: 'oui',
             beneficiaireFsl: 'non',
             revenuFiscal: '20000'
@@ -44,6 +45,7 @@ class SituationFoyerRequestTest extends KernelTestCase
         $this->assertSame('oui', $situationFoyerRequest->getTravailleurSocialPreavisDepart());
         $this->assertSame('oui', $situationFoyerRequest->getTravailleurSocialAccompagnement());
         $this->assertSame('1', $situationFoyerRequest->getTravailleurSocialAccompagnementDeclarant());
+        $this->assertSame('Organisme Exemple', $situationFoyerRequest->getTravailleurSocialAccompagnementNomStructure());
         $this->assertSame('oui', $situationFoyerRequest->getBeneficiaireRsa());
         $this->assertSame('non', $situationFoyerRequest->getBeneficiaireFsl());
         $this->assertSame('20000', $situationFoyerRequest->getRevenuFiscal());


### PR DESCRIPTION
## Ticket

#4528

## Description
Pour les occupants et tiers (hors secours)
Sur l'écran `travailleur_social`
Quand la réponse à la question `travailleur_social_accompagnement` est oui
Alors, on ajoute une question facultative, champ texte :
- Quel est le nom de la structure qui vous accompagne ? (occupants)
- Quel est le nom de la structure qui accompagne le foyer ? (tiers hors secours)


## Changements apportés
* Ajout de la nouvelle question dans les 5 json des 5 profils concernés pour le formulaire usager
* Ajout de cette information (ainqi des autres infos de travailleur social) dans le récap à la fin du formulaire (`SignalementFormOverview`)
* Ajout de cette information dans les différents Dto (api, édition bo, création bo)
* Ajout de cette information dans les factory, le form pour la création bo, et les manager
* Ajout de cette info dans les twig
* Mise à jour des tests

:warning: Je n'ai pas ajouté dans l'export pdf car il n'y a rien sur le travailleur social dans l'export pdf... peut-être à ajouter

## Pré-requis
`npm run watch`

## Tests
- [ ] Avec différents profils, déposer un signalement sur le form usager, et vérifier la présence de la nouvelle question conditionnée.
- [ ] Vérifier qu'elle est reprise dans le récapitulatif à la fin
- [ ] Vérifier sur le BO qu'elle est bien enregistrée, et qu'on peut la modifier
- [ ] Vérifier sur la page de suivi usager qu'elle est présente
- [ ] Déposer un signalement depuis le form pro, et vérifier qu'on peut également renseigner cette information et qu'elle est enregistrée
- [ ] Avec l'API, consulter un de ces signalements, et vérifier qu'on a aussi le nom de la structure
