### PR TITLE
[BO - Signalement] Correction de l'affichage quand aucune adresse trouvée

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/pick-localisation.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/pick-localisation.js
@@ -36,6 +36,15 @@ if (modalLocalisation) {
       fetch(apiAdresse + address + '&postcode=' + postCode)
         .then((response) => response.json())
         .then((json) => {
+          // If no result, display error message
+          if (!json.features || json.features.length === 0) {
+            modalPickLocalisationMessage.innerText =
+              "Adresse introuvable, merci de préciser l'adresse grâce au formulaire.";
+            modalPickLocalisationMessage.classList.remove('fr-hidden');
+            const modalPickLocalisationMap = document.getElementById('fr-modal-pick-localisation-map');
+            modalPickLocalisationMap.classList.add('fr-hidden');
+            return;
+          }
           map.setView(
             [json.features[0].geometry.coordinates[1], json.features[0].geometry.coordinates[0]],
             18


### PR DESCRIPTION
## Ticket

#4602   

## Description
Dans la modale "Sélectionner le batiment sur la carte", on utilise un service de geocodage pour spécifier un batiment lié à l'adresse.
Lorsque le service de geocodage ne trouve pas une adresse, il ne retourne pas de `features`. Et notre affichage plante donc. On ajoute une gestion d'erreur.

## Pré-requis
`npm run watch-bo`

## Tests
- [ ] Réutiliser l'adresse du signalement `9adf2e45-c8b0-4a35-8ab7-1445afde4b2a` par exemple et vérifier qu'un retour textuel est affiché.
