### PR TITLE
[BO - Modale gestion dossiers] Typo et modif de texte

### DIFF
--- a/templates/_partials/_modal_subscriptions_choice.twig
+++ b/templates/_partials/_modal_subscriptions_choice.twig
@@ -11,19 +11,20 @@
                             La gestion des dossiers sur Signal Logement évolue !
                         </h1>
                         <p>
-                            Signal Logement passe d'une gestion des dossiers par Partenaire à une gestion des dossiers par Agent.
+                            Signal Logement passe d'une gestion des dossiers <strong>par Partenaire</strong> à une gestion des dossiers <strong>par Agent</strong>.
                             <br>
                             Jusqu'à présent, les dossiers étaient gérés par partenaire. Cela signifie que vous receviez des notifications pour tous les dossiers affectés à votre partenaire, même ceux gérés par vos collègues !
                         </p>
                         <p>
-                            Avec la gestion des dossiers par agent, voici ce qui change pour les nouveaux dossiers : 
+                            Avec <strong>la gestion des dossiers par agent</strong>, voici ce qui change pour les nouveaux dossiers : 
                         </p>
                         <ul>
                             <li>Chaque dossier est rattaché à un ou plusieurs agents au sein de votre partenaire</li>
                             <li>Vous pouvez désormais choisir de rejoindre ou quitter un dossier</li>
-                            <li>Vous pouvez voir lequel vos collègues intervient sur chaque dossier</li>
+                            <li>Vous pouvez voir lesquels de vos collègues interviennent sur chaque dossier</li>
                             <li>Vous ne recevrez plus de notifications ni d'e-mails concernant les dossiers sur lesquels vous n'intervenez pas</li>
-                            <li>Sur votre nouveau tableau de bord, les dossiers mis en avant sont ceux sur lesquels vous intervenez (vous pourrez toujours consulter la liste de tous les dossiers affectés à votre partenaire)</li>
+                            <li>Sur votre nouveau tableau de bord, les dossiers mis en avant sont ceux sur lesquels vous intervenez</li>
+                            <li>Vous pourrez toujours consulter la liste de tous les dossiers affectés à votre partenaire</li>
                         </ul>
 
                         <p>


### PR DESCRIPTION
## Ticket

#4616   

## Description
Dans la modale pour choisir la gestion des dossiers existants : 
- il y a une typo dans la phrase `Vous pouvez voir lequel vos collègues intervient sur chaque dossier` à remplacer par `Vous pouvez voir lesquels de vos collègues interviennent sur chaque dossier` 
- la parenthèse qui a été ajoutée `vous pourrez toujours consulter la liste de tous les dossiers affectés à votre partenaire` -> il faudrait la mettre comme un nouveau point dans la liste, sans les parenthèses 
- il faudrait mettre en gras les mots surlignés en bleu dans la modale : 
    - `par Partenaire` et `par Agent` dans la première phrase.
    - `la gestion des dossiers par agent` dans la phrase avant la liste

<img src="https://github.com/user-attachments/assets/aedef57a-3f9b-4202-b968-519261afb782" />

## Changements apportés
* Changement du twug

## Pré-requis

## Tests
- [ ] Vérifier la modale
