### PR TITLE
[BO - Dashboard] Remplacer le label par une pastille + texte

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -722,6 +722,14 @@ ul + p {
     background-color: var(--text-default-success);
 }
 
+.confetti.closed{
+    background-color: var(--blue-france-850-200);
+}
+
+.confetti.refused{
+    background-color: var(--text-default-grey);
+}
+
 .fr-tile.tile-last-suivi {
     height:auto;
     .fr-tile__pictogram{

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -12,10 +12,13 @@
             <hr class="hr--blue-france">
             <div class="fr-container--fluid">
                 {% for item in items.data %}
-                    {% set statutClass = item.statut == 'en cours'
-                        ? 'fr-badge--success'
-                        : (item.statut == 'refusé' ? 'fr-badge--error' : 'fr-badge--grey')
-                    %}
+                    {% set classes = {
+                        'en cours': 'active',
+                        'fermé': 'closed',
+                        'refusé': 'refused'
+                    } %}
+
+                    {% set confettiClass = classes[item.statut]|default('') %}
                     {% set actionClass = item.actionDepuis == 'OUI'
                         ? 'fr-badge--success'
                         : 'fr-badge--grey'
@@ -28,7 +31,7 @@
                                 <div><strong class="fr-text--lg">' ~ declarantInfo ~ '</strong></div>
                                 <div>' ~ item.adresse ~ '</div>
                                 <div class="fr-mt-1v">
-                                    <span class="fr-badge ' ~ statutClass ~ ' fr-badge--no-icon">' ~ item.statut ~ '</span>
+                                    <span class="confetti ' ~ confettiClass ~ '"></span> ' ~ item.statut|capitalize ~ '
                                 </div>
                             </div>',
                             '<div><strong class="fr-text--lg">' ~ item.derniereAction ~ '</strong></div><div>' ~ item.derniereActionAt|date('d/m/Y à H:i') ~ '</div>',


### PR DESCRIPTION
## Ticket

#4617   

## Description
Dans le BO, sur le dashboard / onglet Accueil : le statut des dossier est affiché sous forme de label
Dans la maquette, il était prévu sous une forme pastille + texte (pour moins attirer l'oeil), comme c'est le cas sur l'espace suivi FO

## Changements apportés
* Changement twig et css

## Pré-requis
npm run watch

## Tests
- [ ] Vérifier l'affichage du dashboard
