### PR TITLE
[BO - Dashboard] Suppression du cache lorsque choix de ses dossiers seulement sur la modale d'abonnement

### DIFF
--- a/src/Controller/Back/SubscriptionsChoiceController.php
+++ b/src/Controller/Back/SubscriptionsChoiceController.php
@@ -4,11 +4,14 @@ namespace App\Controller\Back;
 
 use App\Entity\User;
 use App\Repository\UserSignalementSubscriptionRepository;
+use App\Service\DashboardTabPanel\Kpi\TabCountKpiCacheHelper;
+use App\Service\DashboardTabPanel\TabQueryParameters;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapQueryString;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/bo/subscription-choice')]
@@ -18,6 +21,8 @@ class SubscriptionsChoiceController extends AbstractController
     public function choice(
         Request $request,
         UserSignalementSubscriptionRepository $userSignalementSubscriptionRepository,
+        TabCountKpiCacheHelper $tabCountKpiCacheHelper,
+        #[MapQueryString] TabQueryParameters $tabQueryParameter,
         EntityManagerInterface $entityManager,
     ): JsonResponse {
         $jsonData = $request->toArray();
@@ -41,6 +46,20 @@ class SubscriptionsChoiceController extends AbstractController
             foreach ($subs as $sub) {
                 $entityManager->remove($sub);
             }
+            if (!$this->isGranted('ROLE_ADMIN_TERRITORY')) {
+                $tabQueryParameter->mesDossiersMessagesUsagers = '1';
+                $tabQueryParameter->mesDossiersAverifier = '1';
+            }
+            $isDeletedCacheOngletMessagesUsagers = $tabCountKpiCacheHelper->delete(
+                TabCountKpiCacheHelper::DOSSIERS_MESSAGES_USAGERS,
+                $user,
+                $tabQueryParameter
+            );
+            $isDeletedCacheOngletAverifier = $tabCountKpiCacheHelper->delete(
+                TabCountKpiCacheHelper::DOSSIERS_A_VERIFIER,
+                $user,
+                $tabQueryParameter
+            );
         }
         $user->setHasDoneSubscriptionsChoice(true);
         $entityManager->flush();

--- a/src/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelper.php
+++ b/src/Service/DashboardTabPanel/Kpi/TabCountKpiCacheHelper.php
@@ -32,6 +32,13 @@ class TabCountKpiCacheHelper
         });
     }
 
+    public function delete(string $kpiName, User $user, ?TabQueryParameters $params): bool
+    {
+        $key = $this->generateKey($kpiName, $user, $params);
+
+        return $this->cache->delete($key);
+    }
+
     private function generateKey(string $kpiName, User $user, ?TabQueryParameters $params): string
     {
         $roleKey = implode('-', array_filter($user->getRoles(), fn ($role) => 'ROLE_USER' !== $role));


### PR DESCRIPTION
## Ticket

#4619   

## Description
Les abonnements sont tous créés en une fois avec la commande `init-user-signalement-subscriptions` (c'est-à-dire que tous les utilisateurs sont automatiquement abonnés à tous les signalements auxquels son partenaire est affecté)
Lorsqu'un utilisateur se connecte pour la première fois, il arrive sur le dashboard, les compteurs se calculent en fonction de ces abonnements créés avec la commande.
Il a une modale pour lui permettre de choisir ses abonnements : 
--> S'il choisit d'être abonné à tous les signalements sur lequel son partenaire est affecté, il ne se passe rien.
--> S'il choisit d'être abonné aux signalements sur lesquels il a fait des actions, alors on supprime les abonnements créés en trop. Et du coup les compteurs des 2 derniers onglets ne sont plus bons, car ce sont ceux du cache calculés précédemment (donc avec des abonnements créés pour tous les signalements sur lesquels son partenaire est affecté)

## Changements apportés
* Création d'une fonction de suppression des caches dans TabCountKpiCacheHelper
* En cas de choix 2, on supprime les caches des 2 derniers onglets. (si agent ou admin partenaire, on définit `mesDossiersMessagesUsagers` et `mesDossiersAverifier` à 1)

## Pré-requis
`make console app="init-user-signalement-subscriptions"`
## Tests
- [ ] Se connecter avec un agent dont le partenaire est affecté à plusieurs signalements (plus simple avec base de prod)
- [ ] Avant l'apparition de la modale (ou dans l'inspecteur), vérifier les compteurs des derniers onglets
- [ ] Sélectionner le choix 2 dans la modale, et vérifier que la page se recharge avec des compteurs différents. Aller dans les onglets pour vérifier qu'ils sont ok avec les listes
- [ ] Idem en sélectionnant le choix 1
- [ ] Idem avec un RT
