### PR TITLE
[BO - Dashboard RT] Erreur accès à la liste des partenaires avec connexions externes depuis le dashboard

### DIFF
--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -58,20 +58,27 @@
                         link: path('back_user_inactive_accounts')
                     } %}
 
+                    {% set linkPartenairesParams = { isNotNotifiable: 1 } %}
+                    {% if is_granted('ROLE_ADMIN') %}
+                        {% set linkPartenairesParams = linkPartenairesParams|merge({ territoire: items.territory_id }) %}
+                    {% endif %}
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
                         icon_path: 'img/picto-dsfr/notification.svg',
                         title: 'Partenaires non notifiables',
                         badge_class: 'fr-badge--info',
                         badge_label: singular_or_plural(items.data_kpi.partenaires_non_notifiables, ' Partenaire', 'Partenaires'),
-                        link: path('back_partner_index', { isNotNotifiable: 1, territoire: items.territory_id })
+                        link: path('back_partner_index', linkPartenairesParams)
                     } %}
-
+                    {% set linkSIParams = { isOnlyInterconnected: 1 } %}
+                    {% if is_granted('ROLE_ADMIN') %}
+                        {% set linkSIParams = linkSIParams|merge({ territoire: items.territory_id }) %}
+                    {% endif %}
                     {% include 'back/dashboard/components/_tuile.html.twig' with {
                         icon_path: 'img/picto-dsfr/system.svg',
                         title: 'Interfaçages SI externes',
                         badge_class: 'fr-badge--info',
                         badge_label: singular_or_plural(items.data_kpi.partenaires_interfaces, ' Partenaire', 'Partenaires'),
-                        link: path('back_partner_index', { isOnlyInterconnected: 1, territoire: items.territory_id })
+                        link: path('back_partner_index', linkSIParams)
                     } %}
                 </div>
                 {% if is_granted('ROLE_ADMIN') %}

--- a/templates/back/dashboard/tabs/dossiers_nouveaux/_body_dossier_non_affectation.html.twig
+++ b/templates/back/dashboard/tabs/dossiers_nouveaux/_body_dossier_non_affectation.html.twig
@@ -7,7 +7,7 @@
 <section class="fr-mb-5v">
     <header class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-12 fr-col-md-9">
-            <h3 class="fr-text-label--blue-france tab-panel-title-with-document-search-icon">Dossiers non affecté aux partenaires ({{ count }})</h3>
+            <h3 class="fr-text-label--blue-france tab-panel-title-with-document-search-icon">Dossiers non affectés aux partenaires ({{ count }})</h3>
         </div>
         {% include 'back/dashboard/components/_select_sort_dossiers_nouveaux.html.twig' with {
             data_sort_body: 'dossiers-non-affectation'


### PR DESCRIPTION
## Ticket

#4628   

## Description
Je suis RT du 13
Je vais sur mon dashboard
Je clique sur la carte Interfaçage SI externe (qui indique 3 partenaires)
Quand j'accède à la liste des partenaires, la liste n'est pas filtrée et j'ai l'erreur Ce formulaire ne doit pas contenir de champs supplémentaires.

Même souci pour les partenaires non notifiables

:warning: pour les SA, le lien de la première carte `Comptes bientôt archivés` mène toujours vers la liste non-filtrée, ce n'est pas grave pour l'instant, on ajustera si le besoin s'en fait sentir. https://mattermost.incubateur.net/betagouv/pl/wp5zt8n3jtfdjnxpqji7xfbcuc

## Changements apportés
* Fix typo sur `Dossiers non affectés aux partenaires`
* Pour les deux cartes, on ne met l'id du territoire dans le lien que si on est SA

## Pré-requis

## Tests
- [ ] Tester les liens des tuiles du dashboard en RT, puis en SA en filtrant sur un territoire et sans filtrer
