### PR TITLE
[BO - Dashboard - Messages usagers] Mettre uniquement les affectations en cours pour les usagers dans "messages usagers sans réponse"

### DIFF
--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -664,9 +664,11 @@ class SuiviRepository extends ServiceEntityRepository
                 ->from('App\\Entity\\Affectation', 'af')
                 ->where('af.signalement = signalement')
                 ->andWhere('af.partner IN (:partners)')
+                ->andWhere('af.statut = :affectationStatus')
                 ->getDQL();
             $qb->andWhere($qb->expr()->exists($existsAffectation))
-                ->setParameter('partners', $user->getPartners());
+                ->setParameter('partners', $user->getPartners())
+                ->setParameter('affectationStatus', AffectationStatus::ACCEPTED);
         }
 
         if ($params?->mesDossiersMessagesUsagers && '1' === $params->mesDossiersMessagesUsagers) {


### PR DESCRIPTION
## Ticket

#4630   

## Description
Pour les agents et les admins partenaires, les dossiers apparaissant dans la liste "messages usager sans réponse" doivent être affectés avec affectation active du partenaire de l'utilisateur

## Changements apportés
* Modification de la requête pour filtrer sur le statut de l'affectation du partenaire de l'utilisateur. Rien ne change pour un RT ou un agent

## Pré-requis

## Tests
- [ ] Se mettre sur la base de prod.
- [ ] En SA, repérer un signalement remontant dans cette liste, et ayant un partenaire qui n'a pas encore accepté son affectation. Prendre le contrôle d'un agent de ce partenaire
- [ ] Avec cet agent, aller sur le dashboard, décocher "Afficher uniquement mes dossiers", et vérifier que le signalement n'apparait pas dans les "messages usagers sans réponse"
- [ ] Il doit par contre apparaitre dans l'onglet "nouveaux dossiers".
- [ ] Aller sur le signalement, accepter l'affectation
- [ ] Il doit maintenant apparaitre dans "messages usager sans réponse"
- [ ] Fermer l'affectation, il ne doit plus apparaitre