### PR TITLE
[BO - Dashboard] Dans l'onglet A vérifier, limiter les recherches de communes dans une liste

### DIFF
--- a/assets/scripts/app-back-bo.ts
+++ b/assets/scripts/app-back-bo.ts
@@ -9,6 +9,7 @@ import './vanilla/services/deprecated/data_delete.js'
 import './vanilla/services/bo_modales.js';
 import './vanilla/services/deprecated/table_sortable.js'
 import './vanilla/services/component/component_search_checkbox.js';
+import './vanilla/services/component/component_search_autocomplete.js';
 import './vanilla/services/component/component_phone_number_row.js';
 import './vanilla/services/component/component_search_and_select_badges.js';
 import './vanilla/services/form/ajax_form_handler.js';

--- a/assets/scripts/vanilla/services/component/component_search_autocomplete.js
+++ b/assets/scripts/vanilla/services/component/component_search_autocomplete.js
@@ -12,7 +12,8 @@ function initSearchAutocompleteWidgets() {
 
         if (!input || !datalist) return;
 
-        const choices = JSON.parse(input.getAttribute('data-autocomplete-choices') || '[]');
+        let choices = JSON.parse(input.getAttribute('data-autocomplete-choices') || '[]');
+        choices = choices.map((str) => str.toLowerCase());
 
         function submitForm() {
             if (formName == undefined || formName == '') {
@@ -24,7 +25,7 @@ function initSearchAutocompleteWidgets() {
         }
 
         function isValidChoice(value) {
-            return choices.includes(value);
+            return value === '' || choices.includes(value.toLowerCase());
         }
 
         // Détecter la sélection d'un élément dans la datalist

--- a/assets/scripts/vanilla/services/component/component_search_autocomplete.js
+++ b/assets/scripts/vanilla/services/component/component_search_autocomplete.js
@@ -4,19 +4,20 @@ function initSearchAutocompleteWidgets() {
     const containers = document.querySelectorAll('.search-autocomplete-container');
 
     containers.forEach(container => {
+        const formName = container.getAttribute('data-form-target-name');
+        const form = document.getElementById(formName);
         const input = container.querySelector('input');
         const datalist = container.querySelector('datalist');
+        const errorMessage = container.querySelector('.fr-message--error-value-list');
 
         if (!input || !datalist) return;
 
         const choices = JSON.parse(input.getAttribute('data-autocomplete-choices') || '[]');
 
         function submitForm() {
-            const formName = container.getAttribute('data-form-target-name')
             if (formName == undefined || formName == '') {
               return;
             }
-            const form = document.getElementById(formName);
             if (form) {
                 form.submit();
             }
@@ -43,5 +44,17 @@ function initSearchAutocompleteWidgets() {
                 submitForm();
             }
         });
+
+        // Vérifier la valeur lorsque le formulaire est posté
+        if (form) {
+            form.addEventListener('submit', function(event) {
+                if (!isValidChoice(input.value)) {
+                    event.preventDefault();
+                    errorMessage.classList.remove('fr-hidden');
+                } else {
+                    errorMessage.classList.add('fr-hidden');
+                }
+            });
+        }
     });
 }

--- a/assets/scripts/vanilla/services/component/component_search_autocomplete.js
+++ b/assets/scripts/vanilla/services/component/component_search_autocomplete.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', initSearchAutocompleteWidgets);
+
+function initSearchAutocompleteWidgets() {
+    const containers = document.querySelectorAll('.search-autocomplete-container');
+
+    containers.forEach(container => {
+        const input = container.querySelector('input');
+        const datalist = container.querySelector('datalist');
+
+        if (!input || !datalist) return;
+
+        const choices = JSON.parse(input.getAttribute('data-autocomplete-choices') || '[]');
+
+        function submitForm() {
+            const form = document.getElementById('search-dashboard-averifier-form');
+            if (form) {
+                form.submit();
+            }
+        }
+
+        function isValidChoice(value) {
+            return choices.includes(value);
+        }
+
+        // Détecter la sélection d'un élément dans la datalist
+        input.addEventListener('input', function() {
+            // Vérifier si la valeur correspond exactement à un choix de la liste
+            if (isValidChoice(this.value)) {
+                // Petit délai pour s'assurer que la sélection est complète
+                setTimeout(() => {
+                    submitForm();
+                }, 100);
+            }
+        });
+
+        // Alternative : détecter avec l'événement change
+        input.addEventListener('change', function() {
+            if (isValidChoice(this.value)) {
+                submitForm();
+            }
+        });
+    });
+}

--- a/assets/scripts/vanilla/services/component/component_search_autocomplete.js
+++ b/assets/scripts/vanilla/services/component/component_search_autocomplete.js
@@ -12,7 +12,11 @@ function initSearchAutocompleteWidgets() {
         const choices = JSON.parse(input.getAttribute('data-autocomplete-choices') || '[]');
 
         function submitForm() {
-            const form = document.getElementById('search-dashboard-averifier-form');
+            const formName = container.getAttribute('data-form-target-name')
+            if (formName == undefined || formName == '') {
+              return;
+            }
+            const form = document.getElementById(formName);
             if (form) {
                 form.submit();
             }

--- a/src/Controller/Back/DashboardController.php
+++ b/src/Controller/Back/DashboardController.php
@@ -56,10 +56,12 @@ class DashboardController extends AbstractController
                 $territoireId
             );
 
+            $widgetSettings = $widgetSettingsFactory->createInstanceFrom($user, $territory);
             $searchDashboardAverifier = new SearchDashboardAverifier($user);
             $formSearchAverifier = $this->createForm(SearchDashboardAverifierType::class, $searchDashboardAverifier, [
                 'method' => 'GET',
                 'territory' => $territory,
+                'communesAndCp' => $widgetSettings->getCommunes(),
                 'mesDossiersAverifier' => $mesDossiersAverifier,
             ]);
             $formSearchAverifier->handleRequest($request);
@@ -70,7 +72,7 @@ class DashboardController extends AbstractController
 
             return $this->render('back/dashboard/index.html.twig', [
                 'territoireSelectedId' => $territoireId,
-                'settings' => $widgetSettingsFactory->createInstanceFrom($user, $territory),
+                'settings' => $widgetSettings,
                 'tab_count_kpi' => $tabDataManager->countDataKpi(
                     $territories,
                     $territory?->getId(),

--- a/src/Form/SearchDashboardAverifierType.php
+++ b/src/Form/SearchDashboardAverifierType.php
@@ -4,13 +4,13 @@ namespace App\Form;
 
 use App\Entity\Partner;
 use App\Entity\Territory;
+use App\Form\Type\SearchAutocompleteType;
 use App\Form\Type\SearchCheckboxType;
 use App\Repository\PartnerRepository;
 use App\Service\ListFilters\SearchDashboardAverifier;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Extension\Core\Type\SearchType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -27,10 +27,11 @@ class SearchDashboardAverifierType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('queryCommune', SearchType::class, [
+        $builder->add('queryCommune', SearchAutocompleteType::class, [
             'required' => false,
             'label' => 'Commune ou code postal',
             'attr' => ['placeholder' => 'Taper le nom ou le code postal de la commune'],
+            'autocomplete_choices' => $options['communesAndCp'] ?? [],
         ]);
 
         $builder->add('territoireId', HiddenType::class, [
@@ -92,6 +93,7 @@ class SearchDashboardAverifierType extends AbstractType
             'attr' => ['id' => 'search-dashboard-averifier-form', 'class' => 'bo-filter-form'],
             'territory' => null,
             'mesDossiersAverifier' => null,
+            'communesAndCp' => null,
         ]);
     }
 

--- a/src/Form/Type/SearchAutocompleteType.php
+++ b/src/Form/Type/SearchAutocompleteType.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SearchAutocompleteType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'attr' => ['class' => 'search-autocomplete'],
+            'autocomplete_choices' => [],
+        ]);
+
+        $resolver->setAllowedTypes('autocomplete_choices', 'array');
+    }
+
+    public function getParent(): string
+    {
+        return TextType::class;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['autocomplete_choices'] = $options['autocomplete_choices'];
+
+        // Ajouter les attributs data pour JavaScript
+        $view->vars['attr'] = array_merge($view->vars['attr'], [
+            'data-autocomplete-choices' => json_encode(array_values($options['autocomplete_choices'])),
+            'autocomplete' => 'off',
+        ]);
+    }
+}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -241,7 +241,7 @@
         {% endif %}
         <div class="fr-input-wrap fr-input-wrap--addon">
             {{ form_widget(form, {'attr': (attr|default({}))|merge({'list': id ~ '_datalist'})}) }}
-            <button type="button" class="fr-btn fr-icon-search-line">Rechercher</button>
+            <button type="submit" class="fr-btn fr-icon-search-line">Rechercher</button>
         </div>
         <datalist id="{{ id }}_datalist">
             {% for choice in autocomplete_choices %}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -233,3 +233,21 @@
         {{ block('form_errors') }}
     </div>
 {% endblock %}
+
+{% block search_autocomplete_row %}
+    <div class="search-autocomplete-container fr-input-group {% if errors|length > 0 %}fr-input-group--error{% endif %}" id="{{ id }}">
+        {% if label is not same as(false) %}
+            <label for="{{ id }}" class="fr-label">{{ label }} {{form_help(form)}}</label>
+        {% endif %}
+        <div class="fr-input-wrap fr-input-wrap--addon">
+            {{ form_widget(form, {'attr': (attr|default({}))|merge({'list': id ~ '_datalist'})}) }}
+            <button type="button" class="fr-btn fr-icon-search-line">Rechercher</button>
+        </div>
+        <datalist id="{{ id }}_datalist">
+            {% for choice in autocomplete_choices %}
+                <option value="{{ choice }}">{{ choice }}</option>
+            {% endfor %}
+        </datalist>
+        {{ block('form_errors') }}
+    </div>
+{% endblock %}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -249,5 +249,8 @@
             {% endfor %}
         </datalist>
         {{ block('form_errors') }}
+        <div class="fr-messages-group" aria-live="polite">
+            <p class="fr-message fr-message--error fr-message--error-value-list fr-hidden" id="text-input-error-message-error">Cette valeur ne fait pas partie des propositions.</p>
+        </div>
     </div>
 {% endblock %}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -235,7 +235,7 @@
 {% endblock %}
 
 {% block search_autocomplete_row %}
-    <div class="search-autocomplete-container fr-input-group {% if errors|length > 0 %}fr-input-group--error{% endif %}" id="{{ id }}">
+    <div class="search-autocomplete-container fr-input-group {% if errors|length > 0 %}fr-input-group--error{% endif %}" id="{{ id }}" data-form-target-name="{{ form.parent.vars.attr.id }}">
         {% if label is not same as(false) %}
             <label for="{{ id }}" class="fr-label">{{ label }} {{form_help(form)}}</label>
         {% endif %}


### PR DESCRIPTION
## Ticket

#4631   

## Description
Dans l'onglet `A vérifier` du dashboard, on pouvait choisir des morceaux de communes, ce qui posait problème quand on allait sur la liste complète des signalements (qui elle ne prend que des noms de communes complets).
On limite à présent la recherche aux commune réelles.

## Changements apportés
* Utilisation d'un élément `datalist` associé au champ de saisie

## Pré-requis
- `npm run watch-bo`
- Tests plus simples sur base de production

## Tests
- [ ] Tester le fonctionnement de la recherche et l'affichage de la liste complète
