### PR TITLE
[BO - Liste signalements] Conditionner l'affichage du bouton RT à l'activation du nouveau dashboard

### DIFF
--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
@@ -10,7 +10,7 @@
         </button>
       </li>
       <!-- TODO: Remove button when FEATURE_NEW_DASHBOARD is removed -->
-      <li v-if="sharedState.user.isResponsableTerritoire">
+      <li v-else-if="sharedState.user.isResponsableTerritoire">
         <button class="fr-tag"
                 ref="myAffectationButton"
                 :aria-pressed="ariaPressed.showMyAffectationOnly.toString()"


### PR DESCRIPTION
## Ticket

#4643   

## Description
Dans la liste des signalements, le bouton RT `Afficher mes affectations uniquement` deviendra inutile une fois le nouveau dashboard (et le système d'abonnements) activé.

## Pré-requis
`npm run watch-bo`

## Tests
- [ ] Vérifier l'affichage des boutons RT, avec ou sans feature flipping
