### PR TITLE
[QA] Investigation adresse Lyon qui renvoie le code insee commune au lieu du code insee arrondissements

### DIFF
--- a/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
+++ b/assets/scripts/vue/components/signalement-form/TheSignalementAppForm.vue
@@ -291,6 +291,15 @@ export default defineComponent({
         this.territoryModalLabel = requestResponse.label
         this.territoryModalDescription = requestResponse.message
         this.isTerritoryModalOpen = true
+
+        Sentry.captureMessage(this.territoryModalDescription, {
+          level: "error",
+          extra: {
+            adresse: formStore.data.adresse_logement_adresse,
+            code_postal: formStore.data.adresse_logement_adresse_detail_code_postal,
+            insee: formStore.data.adresse_logement_adresse_detail_insee,
+          },
+        });
       }
     },
     changeScreenBySlug (requestResponse: any) {


### PR DESCRIPTION
## Ticket

#4646    

## Description
Ajout de l'adresse dans les erreurs d’incohérence entre le code postal et le code insee.
L'objectif est d'anticiper les mises à jour et comprendre pourquoi des adresse de Lyon et Marseille 

## Changements apportés
* Ajout de log

## Pré-requis
https://histologe-staging-pr4647.osc-fr1.scalingo.io/signalement

## Tests
- [ ] Test avec cette adresse qui est une vrai adresse de Lille (43 Rue de Cronstadt, 59000 Lille) 

<img width="588" height="223" alt="image" src="https://github.com/user-attachments/assets/cc516f05-601d-4a36-adb1-2f1c7d73f9ab" />

L'erreur JS est lié avec l'erreur PHP (je laisse l'erreur PHP car c'est le board qu'on regarde le plus)
https://sentry.incubateur.net/organizations/betagouv/issues/203137/?project=142&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=2