### PR TITLE
[BO - Signalement] Problème d'affichage de date pour la NDE

### DIFF
--- a/templates/back/signalement/view/nde.html.twig
+++ b/templates/back/signalement/view/nde.html.twig
@@ -68,9 +68,18 @@
         </div>
         <div class="fr-col-12 fr-col-md-6">  
             {% if signalementQualificationNDE %}      
-                <strong>Date dernier DPE :</strong> {{ signalementQualificationNDE.details.date_dernier_dpe  ? ( signalementQualificationNDE.details.date_dernier_dpe|date('Y') < '2023' ? 'Avant 2023' : 'A partir de 2023' ) : ''}}
+                <strong>Date dernier DPE :</strong> {{ signalementQualificationNDE.details.date_dernier_dpe ? ( signalementQualificationNDE.details.date_dernier_dpe|date('Y') < '2023' ? 'Avant 2023' : 'A partir de 2023' ) : ''}}
             {% elseif signalement.typeCompositionLogement %}
-                <strong>Date dernier DPE :</strong> {{ signalement.typeCompositionLogement.desordresLogementChauffageDetailsDpeAnnee  ? ( signalement.typeCompositionLogement.desordresLogementChauffageDetailsDpeAnnee|date('Y') < '2023' ? 'Avant 2023' : 'A partir de 2023' ) : ''}}
+                <strong>Date dernier DPE :</strong>
+                {% if signalement.typeCompositionLogement.desordresLogementChauffageDetailsDpeAnnee %}
+                    {% if signalement.typeCompositionLogement.desordresLogementChauffageDetailsDpeAnnee is same as 'before2023' %}
+                        Avant 2023
+                    {% elseif signalement.typeCompositionLogement.desordresLogementChauffageDetailsDpeAnnee is same as 'post2023' %}
+                        A partir de 2023
+                    {% elseif signalement.typeCompositionLogement.desordresLogementChauffageDetailsDpeAnnee is same as 'nsp' %}
+                        Ne sait pas
+                    {% endif %}
+                {% endif %}
             {% else %}  
                 <strong>Date dernier DPE :</strong> A vérifier            
             {% endif %}            


### PR DESCRIPTION
## Ticket

#4654   

## Description
Si les infos de NDE ne sont pas remplies mais qu'on a quand même saisi des informations dans la partie chauffage du signalement, on peut avoir des soucis d'affichage.

## Tests
- [ ] Reproductible sur base prod avec le signalement 12a46a89-d9d1-46a4-8cb1-cff6507ed533
