### PR TITLE
[Interconnexion] Absence de logs d'erreur SISH dans la table job_event depuis mai

### DIFF
--- a/src/Service/Interconnection/JobEventHttpClient.php
+++ b/src/Service/Interconnection/JobEventHttpClient.php
@@ -104,7 +104,7 @@ class JobEventHttpClient implements HttpClientInterface
             signalementId: $jobEventMetaData->getSignalementId(),
             partnerId: $jobEventMetaData->getPartnerId(),
             partnerType: $jobEventMetaData->getPartnerType(),
-            flush: 'esabora' === $jobEventMetaData->getService() ? false : true,
+            flush: 'esabora' === $jobEventMetaData->getService() && str_contains($jobEventMetaData->getAction(), 'sync') ? false : true,
         );
 
         return $response;


### PR DESCRIPTION
## Ticket

#4651
```sql
select max(job_event.created_at), action, status, partner_type
from job_event
where service like 'esabora' and action like 'push%'
group by action, status, partner_type;
```
<img width="1001" height="266" alt="image" src="https://github.com/user-attachments/assets/734392c9-0bb8-4897-a853-0b6acc1c08c6" />


## Description
Le push n'est jamais appelé en mode batch donc on peut faire un flush toute de suite, contrairement au synchro
Il existe un effet de bord en cas d'erreur et n'est jamais flusher.

## Changements apportés
* Mise à jour de la condition pour ignorer la synchro pour flusher tous les push tout de suite

## Pré-requis
`make worker-stop && make worker-start`
`make mock-stop && make mock-start`
`
## Tests
- [ ] Faire une affectation et vérifier que le push en succès ou erreur soit bien loggé (eteigner le serveur de mock pour tester l'echec)
- [ ] Exécuter `make sync-sish` et vérifier que les sync continuent d'être loggé
