### PR TITLE
[B0 - Liste signalement] Mauvaise correspondance sur le statut affectation refusée

### DIFF
--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -155,6 +155,15 @@ affectations:
     signalement: 2023-22
     partner: "partenaire-38-01@signal-logement.fr"
     statut: "REFUSE"
+    answered_by: "admin-territoire-38-01@signal-logement.fr"
+    affected_by: "admin-territoire-38-01@signal-logement.fr"
+    motif_cloture: ""
+    motif_refus: "DOUBLON"
+    territory: "Isère"
+  -
+    signalement: 2023-22
+    partner: "partenaire-38-02@signal-logement.fr"
+    statut: "REFUSE"
     answered_by: "user-38-01@signal-logement.fr"
     affected_by: "user-38-01@signal-logement.fr"
     motif_cloture: ""

--- a/src/Entity/Enum/AffectationStatus.php
+++ b/src/Entity/Enum/AffectationStatus.php
@@ -18,7 +18,8 @@ enum AffectationStatus: string
         return match ($this) {
             self::WAIT => SignalementStatus::NEED_VALIDATION,
             self::ACCEPTED => SignalementStatus::ACTIVE,
-            self::CLOSED, self::REFUSED => SignalementStatus::CLOSED,
+            self::CLOSED => SignalementStatus::CLOSED,
+            self::REFUSED => SignalementStatus::REFUSED,
         };
     }
 

--- a/src/Entity/Enum/SignalementStatus.php
+++ b/src/Entity/Enum/SignalementStatus.php
@@ -21,7 +21,8 @@ enum SignalementStatus: string
         return match ($this) {
             self::DRAFT, self::NEED_VALIDATION => AffectationStatus::WAIT->value,
             self::ACTIVE => AffectationStatus::ACCEPTED->value,
-            self::CLOSED, self::REFUSED, self::ARCHIVED, self::DRAFT_ARCHIVED => AffectationStatus::CLOSED->value,
+            self::REFUSED => AffectationStatus::REFUSED->value,
+            self::CLOSED, self::ARCHIVED, self::DRAFT_ARCHIVED => AffectationStatus::CLOSED->value,
         };
     }
 
@@ -41,6 +42,7 @@ enum SignalementStatus: string
 
     public static function mapFilterStatus(string $label): string
     {
+        dump($label);
         return match ($label) {
             'brouillon' => SignalementStatus::DRAFT->value,
             'nouveau' => SignalementStatus::NEED_VALIDATION->value,

--- a/src/Entity/Enum/SignalementStatus.php
+++ b/src/Entity/Enum/SignalementStatus.php
@@ -42,7 +42,6 @@ enum SignalementStatus: string
 
     public static function mapFilterStatus(string $label): string
     {
-        dump($label);
         return match ($label) {
             'brouillon' => SignalementStatus::DRAFT->value,
             'nouveau' => SignalementStatus::NEED_VALIDATION->value,

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -23,7 +23,7 @@ class SignalementListControllerTest extends WebTestCase
      *
      * @param array<string> $filter
      */
-    public function testFilterSignalements(array $filter, int $results): void
+    public function testFilterSignalements(array $filter, int $results, string $email = 'admin-01@signal-logement.fr'): void
     {
         $client = static::createClient();
         /** @var UrlGeneratorInterface $generatorUrl */
@@ -31,7 +31,7 @@ class SignalementListControllerTest extends WebTestCase
 
         /** @var UserRepository $userRepository */
         $userRepository = static::getContainer()->get(UserRepository::class);
-        $user = $userRepository->findOneBy(['email' => 'admin-01@signal-logement.fr']);
+        $user = $userRepository->findOneBy(['email' => $email]);
         $client->loginUser($user);
         $route = $generatorUrl->generate('back_signalements_list_json');
 
@@ -93,6 +93,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Messages usagers après fermeture' => [['isMessagePostCloture' => 'oui', 'isImported' => 'oui'], 1];
         yield 'Search by Nouveaux messages usagers' => [['isNouveauMessage' => 'oui', 'isImported' => 'oui'], 1];
         yield 'Search by Messages usagers sans réponse' => [['isMessageWithoutResponse' => 'oui', 'isImported' => 'oui'], 0];
+        yield 'Search by Status Refuse for agent 38' => [['status' => 'refuse', 'isImported' => 'oui'], 1, 'user-38-01@signal-logement.fr'];
     }
 
     /**


### PR DESCRIPTION
## Ticket

#4656    

## Description
L'affectation refuse a bien un mapping explicite
En tant qu'agent une recherche sur le statut refusé doit correspondre à une recherche sur l'affectation refusé et non clos

## Changements apportés
* Correction des correspondances dans les enums
* Ajout de fixtures 

## Pré-requis

## Tests
- [ ] Se connecter en tant qu'agent 38 et vérifier que le filtre sur refusé remonte bien 1 signalement
- [ ] Faire un expert et vérifier le signalement remonte bien.
