### PR TITLE
[BO - Partenaires] Ajouter les partenaires avec mails non délivrables

### DIFF
--- a/src/Form/SearchUserType.php
+++ b/src/Form/SearchUserType.php
@@ -30,6 +30,11 @@ class SearchUserType extends AbstractType
         'Oui' => 'Oui',
         'Non' => 'Non',
     ];
+    /** @var array<string, string> */
+    private const array EMAIL_DELIVERY_ISSUE = [
+        'Adresse e-mail fonctionnelle' => 'Non',
+        'Problème d\'adresse e-mail' => 'Oui',
+    ];
 
     private bool $isAdmin = false;
     /**
@@ -113,6 +118,12 @@ class SearchUserType extends AbstractType
             'required' => false,
             'placeholder' => 'Tous les droits d\'affectation',
             'label' => 'Droits d\'affectation',
+        ]);
+        $builder->add('emailDeliveryIssue', ChoiceType::class, [
+            'choices' => self::EMAIL_DELIVERY_ISSUE,
+            'required' => false,
+            'placeholder' => 'Tous',
+            'label' => 'Problème d\'adresse e-mail',
         ]);
 
         $builder->add('orderType', ChoiceType::class, [

--- a/src/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoader.php
+++ b/src/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoader.php
@@ -28,6 +28,7 @@ class DossiersDernierActionTabBodyLoader extends AbstractTabBodyLoader
         if ($user->isTerritoryAdmin() || $user->isSuperAdmin()) {
             $data['data_kpi'] = [
                 'comptes_en_attente' => $this->tabDataManager->countUsersPendingToArchive($this->tabQueryParameters),
+                'comptes_pb_email' => $this->tabDataManager->countUsersPbEmail($this->tabQueryParameters),
                 'partenaires_non_notifiables' => $this->tabDataManager->countPartenairesNonNotifiables($this->tabQueryParameters),
                 'partenaires_interfaces' => $this->tabDataManager->countPartenairesInterfaces($this->tabQueryParameters),
             ];

--- a/src/Service/DashboardTabPanel/TabDataManager.php
+++ b/src/Service/DashboardTabPanel/TabDataManager.php
@@ -111,6 +111,18 @@ class TabDataManager
         return \count($users);
     }
 
+    public function countUsersPbEmail(?TabQueryParameters $tabQueryParameters = null): int
+    {
+        /** @var User $user */
+        $user = $this->security->getUser();
+        $territories = [];
+        if ($tabQueryParameters && $tabQueryParameters->territoireId) {
+            $territories[] = $this->territoryRepository->find($tabQueryParameters->territoireId);
+        }
+
+        return $this->userRepository->countAgentsPbEmail($user, $territories);
+    }
+
     public function countPartenairesNonNotifiables(?TabQueryParameters $tabQueryParameters = null): int
     {
         $territories = [];

--- a/src/Service/ListFilters/SearchUser.php
+++ b/src/Service/ListFilters/SearchUser.php
@@ -26,6 +26,7 @@ class SearchUser
     private ?string $statut = null;
     private ?string $role = null;
     private ?string $permissionAffectation = null;
+    private ?string $emailDeliveryIssue = null;
     private ?string $orderType = null;
 
     public function __construct(User $user)
@@ -118,6 +119,16 @@ class SearchUser
         $this->permissionAffectation = $permissionAffectation;
     }
 
+    public function getEmailDeliveryIssue(): ?string
+    {
+        return $this->emailDeliveryIssue;
+    }
+
+    public function setEmailDeliveryIssue(?string $emailDeliveryIssue): void
+    {
+        $this->emailDeliveryIssue = $emailDeliveryIssue;
+    }
+
     public function getOrderType(): ?string
     {
         return $this->orderType;
@@ -172,6 +183,9 @@ class SearchUser
         }
         if ($this->permissionAffectation) {
             $filters['Droits d\'affectation'] = $this->permissionAffectation;
+        }
+        if ($this->emailDeliveryIssue) {
+            $filters['Problème d\'adresse e-mail'] = $this->emailDeliveryIssue;
         }
 
         return $filters;

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -57,6 +57,17 @@
                         badge_label: singular_or_plural(items.data_kpi.comptes_en_attente, ' compte', 'comptes'),
                         link: path('back_user_inactive_accounts')
                     } %}
+                    {% set linkAdresseEmail = { emailDeliveryIssue: 'Oui' } %}
+                    {% if is_granted('ROLE_ADMIN') %}
+                        {% set linkAdresseEmail = linkAdresseEmail|merge({ territory: items.territory_id }) %}
+                    {% endif %}
+                    {% include 'back/dashboard/components/_tuile.html.twig' with {
+                        icon_path: 'img/picto-dsfr/connection-lost.svg',
+                        title: 'Agents avec un problème d\'e-mail',
+                        badge_class: 'fr-badge--error',
+                        badge_label: singular_or_plural(items.data_kpi.comptes_pb_email, ' agent', 'agents'),
+                        link: path('back_user_index', linkAdresseEmail)
+                    } %}
 
                     {% set linkPartenairesParams = { isNotNotifiable: 1 } %}
                     {% if is_granted('ROLE_ADMIN') %}

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -223,7 +223,6 @@
             </div>
 
             {% set tableHead %}
-                {# <th scope="col">Dernière connexion</th> #}
                 <th scope="col">Nom</th>
                 <th scope="col">Prénom</th>
                 <th scope="col">Fonction</th>
@@ -242,15 +241,11 @@
                 {% for user in partner.users|filter(user => user.id is not null) %}
                     {% if is_granted('ROLE_ADMIN') or 'ROLE_API_USER' not in user.roles %}
                         <tr class="user-row">
-                            {# <td>{{ user.getLastLoginAtStr('d/m/Y') }}</td> #}
                             <td>{{ user.nom }}</td>
                             <td>{{ user.prenom }}</td>
                             <td>{{ user.fonction }}</td>
                             <td>{{ user.email }}<br>
                                 Dernière connexion : {{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}
-                                {# {% if user.emailDeliveryIssue.event.value|default(false) %}
-                                    <span class="fr-badge fr-badge--warning fr-badge--sm"> </span>
-                                {% endif %} #}
                             </td>
                             <td>
                                 <span class="fr-badge fr-badge--blue-ecume fr-mb-1v">

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -69,7 +69,12 @@
                     <div><b>Territoire :</b> {{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : ''}}</div>
                 </div>
                 <div class="fr-col-6">
-                    <div><b>E-mail de contact :</b> {{ partner.email }}</div>
+                    <div>
+                        <b>E-mail de contact :</b> {{ partner.email }}
+                        {% if partner.emailDeliveryIssue.event.value|default(false) %}
+                            <span class="fr-badge fr-badge--warning fr-badge--sm">Problème d'e-mail non remis</span>
+                        {% endif %}
+                    </div>
                 </div>
                 <div class="fr-col-6">
                     <div><b>Type :</b> {{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'N/A') }}</div>
@@ -218,7 +223,7 @@
             </div>
 
             {% set tableHead %}
-                <th scope="col">Dernière connexion</th>
+                {# <th scope="col">Dernière connexion</th> #}
                 <th scope="col">Nom</th>
                 <th scope="col">Prénom</th>
                 <th scope="col">Fonction</th>
@@ -229,6 +234,7 @@
                 {% if is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
                 <th scope="col">Droits d'affectation</th>
                 {% endif %}
+                <th scope="col">Problème d'adresse e-mail</th>
                 <th scope="col" class="fr-text--right">Actions</th>
             {% endset %}
 
@@ -236,11 +242,16 @@
                 {% for user in partner.users|filter(user => user.id is not null) %}
                     {% if is_granted('ROLE_ADMIN') or 'ROLE_API_USER' not in user.roles %}
                         <tr class="user-row">
-                            <td>{{ user.getLastLoginAtStr('d/m/Y') }}</td>
+                            {# <td>{{ user.getLastLoginAtStr('d/m/Y') }}</td> #}
                             <td>{{ user.nom }}</td>
                             <td>{{ user.prenom }}</td>
                             <td>{{ user.fonction }}</td>
-                            <td>{{ user.email }}</td>
+                            <td>{{ user.email }}<br>
+                                Dernière connexion : {{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}
+                                {# {% if user.emailDeliveryIssue.event.value|default(false) %}
+                                    <span class="fr-badge fr-badge--warning fr-badge--sm"> </span>
+                                {% endif %} #}
+                            </td>
                             <td>
                                 <span class="fr-badge fr-badge--blue-ecume fr-mb-1v">
                                     {% if user.isMailingActive %}
@@ -267,6 +278,13 @@
                             {% if is_granted('ASSIGN_PERMISSION_AFFECTATION', partner) %}
                             <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
                             {% endif %}
+                            <td>
+                                {% if user.emailDeliveryIssue.event.value|default(false) %}
+                                    <span class="fr-badge fr-badge--warning fr-badge--sm">OUI</span>
+                                {% else %}
+                                    Non
+                                {% endif %}
+                            </td>
                             <td class="fr-text--right">
                                 {% if is_granted('USER_EDIT', user) %}
                                     <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"

--- a/templates/back/signalement/view/affectation/_item-with-action.html.twig
+++ b/templates/back/signalement/view/affectation/_item-with-action.html.twig
@@ -44,7 +44,7 @@
                     <span class="fr-badge fr-badge--warning fr-badge--sm">Notif. e-mail désactivées</span>
                 {% endif %}
                 {% if partnerAffectation.partner.emailDeliveryIssue.event.value|default(false) %}
-                    <span class="fr-badge fr-badge--warning fr-badge--sm">Problème de courriel non remis</span>
+                    <span class="fr-badge fr-badge--warning fr-badge--sm">Problème d'e-mail non remis</span>
                 {% endif %}
             </div>
             <div class="fr-col-2 fr-text--right">

--- a/templates/back/signalement/view/information/information-foyer.html.twig
+++ b/templates/back/signalement/view/information/information-foyer.html.twig
@@ -43,7 +43,7 @@
                 <p class="fr-badge fr-badge--error">Format non valide</p>
             {% endif %}
             {% if signalement.signalementUsager.occupant.emailDeliveryIssue.event.value|default(false) %}
-                <p class="fr-badge fr-badge--warning">Problème de courriel non remis</p>
+                <p class="fr-badge fr-badge--warning">Problème d'e-mail non remis</p>
             {% endif %}
         {% endif %}
     </div>

--- a/templates/back/signalement/view/information/information-tiers.html.twig
+++ b/templates/back/signalement/view/information/information-tiers.html.twig
@@ -49,7 +49,7 @@
                 <p class="fr-badge fr-badge--error">Format non valide</p>
             {% endif %}
             {% if signalement.signalementUsager.declarant.emailDeliveryIssue.event.value|default(false) %}
-                <p class="fr-badge fr-badge--warning">Problème de courriel non remis</p>
+                <p class="fr-badge fr-badge--warning">Problème d'e-mail non remis</p>
             {% endif %}
         {% endif %}
     </div>

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -54,6 +54,9 @@
                 {{ form_row(form.permissionAffectation) }}
             </div>
             <div class="fr-col-12 fr-col-lg-3">
+                {{ form_row(form.emailDeliveryIssue) }}
+            </div>
+            <div class="fr-col-12 fr-col-lg-3">
                 <a href="{{ path('back_user_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser les résultats</a>
             </div>
         </div>
@@ -87,9 +90,10 @@
             <th scope="col">Partenaire</th>
             <th scope="col">Type de partenaire</th>
             <th scope="col">Statut du compte</th>
-            <th scope="col">Dernière connexion</th>
+            {# <th scope="col">Dernière connexion</th> #}
             <th scope="col">Rôle</th>
             <th scope="col">Droits d'affectation</th>
+            <th scope="col">Problème d'adresse e-mail</th>
             <th scope="col" class="fr-text--right">Actions</th>
         {% endset %}
 
@@ -112,7 +116,9 @@
                         {{ user.prenom }} {{ user.nom }}
                         {% if user.fonction %}({{ user.fonction }}){% endif %}
                     </td>
-                    <td>{{ user.email }}</td>
+                    <td>{{ user.email }}<br>
+                        Dernière connexion : {{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}
+                    </td>
                     <td>
                         {% for partner in user.partners %}
                             {{ partner.nom }}
@@ -138,9 +144,17 @@
                             {{ user.statut.label }}
                         {% endif %}
                     </td>
-                    <td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}</td>
+                    {# <td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}</td>
+                     #}
                     <td>{{ user.roleLabel() }}</td>
                     <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
+                    <td>
+                        {% if user.emailDeliveryIssue.event.value|default(false) %}
+                            <span class="fr-badge fr-badge--warning fr-badge--sm">OUI</span>
+                        {% else %}
+                            Non
+                        {% endif %}
+                    </td>
                     <td class="fr-text--right">
                         {% if user.getPartners|length %}
                             <a href="#" class="fr-btn fr-fi-edit-line fr-mt-3v btn-edit-partner-user"

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -90,7 +90,6 @@
             <th scope="col">Partenaire</th>
             <th scope="col">Type de partenaire</th>
             <th scope="col">Statut du compte</th>
-            {# <th scope="col">Dernière connexion</th> #}
             <th scope="col">Rôle</th>
             <th scope="col">Droits d'affectation</th>
             <th scope="col">Problème d'adresse e-mail</th>
@@ -144,8 +143,6 @@
                             {{ user.statut.label }}
                         {% endif %}
                     </td>
-                    {# <td>{{ user.lastLoginAt ? user.lastLoginAt|date('d/m/Y') : '-'}}</td>
-                     #}
                     <td>{{ user.roleLabel() }}</td>
                     <td>{{ user.isSuperAdmin() or user.isTerritoryAdmin() or user.hasPermissionAffectation() ? 'Oui' : 'Non' }}</td>
                     <td>

--- a/tests/Unit/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoaderTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoaderTest.php
@@ -33,6 +33,7 @@ class DossiersDernierActionTabBodyLoaderTest extends TestCase
         $expectedData = ['foo' => 'bar'];
         $expectedKpi = [
             'comptes_en_attente' => 3,
+            'comptes_pb_email' => 0,
             'partenaires_non_notifiables' => 2,
             'partenaires_interfaces' => 1,
         ];


### PR DESCRIPTION
## Ticket

#4648    

## Description
Dans la liste des utilisateurs, et dans la liste des agents d'un partenaire, on montre qu'un agent a une adresse e-mail non délivrable
Dans la fiche du partenaire, on accole un ⚠️ à l'adresse e-mail du partenaire si elle est non délivrable
Dans la liste des utilisateurs on fait un filtre sur les adresses e-mail non délivrables
On ajoute un widget sur le dashboard qui mène vers la liste des utilisateurs filtrée

## Changements apportés
* Ajout du nouveau filtre dans SearchUserType et SearchUser
* Création du nouveau widget du dashboard
* Changement des listes d'utilisateurs en twig

## Pré-requis

Avant de commencer les tests (sur les fixtures), utiliser postman pour créer des EmailDeliveryIssue

## Tests
- [ ] En SA, vérifier sur le tableau de bord le nouveau widget (avec ou sans le filtre territoire, et vérifier le lien)
- [ ] Idem en RT
- [ ] Sur la liste utilisateur vérifier l'affichage, et le fonctionnement du nouveau filtre
- [ ] Sur une fiche partenaire dont l'e-mail n'est pas notifiable, vérifier l'affichage
- [ ] Vérifier aussi l'affichage de la liste des agents d'un partenaire
