### PR TITLE
[BUG - Form BO] informations déclarant enregistrées avec profil locataire

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -612,6 +612,7 @@ function initBoFormSignalementAdresse() {
       '#signalement_draft_coordonnees_mailDeclarant',
       '#signalement_draft_coordonnees_telDeclarant_select',
       '#signalement_draft_coordonnees_telDeclarant_input',
+      '#telDeclarantContainer'
     ],
     ['TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS', 'BAILLEUR'],
     [],

--- a/migrations/Version20250929084507.php
+++ b/migrations/Version20250929084507.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250929084507 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set nom_declarant, prenom_declarant, tel_declarant, tel_declarant_secondaire, mail_declarant to null for profile LOCATAIRE or BAILLEUR_OCCUPANT on signalement V2';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE signalement
+            SET
+                nom_declarant = NULL,
+                prenom_declarant = NULL,
+                tel_declarant = NULL,
+                tel_declarant_secondaire = NULL,
+                mail_declarant = NULL
+            WHERE profile_declarant IN ('LOCATAIRE', 'BAILLEUR_OCCUPANT') AND (created_by_id IS NOT NULL OR created_from_id IS NOT NULL)
+");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -417,6 +417,13 @@ class SignalementCreateController extends AbstractController
 
         $signalementManager->updateDesordresAndScoreWithSuroccupationChanges($signalement, false);
         $signalementQualificationUpdater->updateQualificationFromScore($signalement);
+        if (!$signalement->isTiersDeclarant()) {
+            $signalement->setMailDeclarant(null);
+            $signalement->setNomDeclarant(null);
+            $signalement->setPrenomDeclarant(null);
+            $signalement->setStructureDeclarant(null);
+            $signalement->setTelDeclarant(null);
+        }
         $signalementManager->flush();
 
         $errorMsgs = [];

--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -78,6 +78,9 @@ class SignalementEditController extends AbstractController
         ValidatorInterface $validator,
     ): JsonResponse {
         $this->denyAccessUnlessGranted('SIGN_EDIT', $signalement);
+        if ($signalement->isV2() && !$signalement->getIsNotOccupant()) {
+            throw $this->createAccessDeniedException();
+        }
         $payload = $request->getPayload()->all();
         if ($this->isCsrfTokenValid(
             'signalement_edit_coordonnees_tiers_'.$signalement->getId(),

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -85,6 +85,7 @@ class SignalementBoManager
             $signalement->setNomDeclarant(null);
             $signalement->setPrenomDeclarant(null);
             $signalement->setStructureDeclarant(null);
+            $signalement->setTelDeclarant(null);
         }
 
         $signalement->setStatut(SignalementStatus::DRAFT);

--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -381,12 +381,7 @@ class SignalementBuilder
                 ->setNomOccupant($this->signalementDraftRequest->getVosCoordonneesOccupantNom())
                 ->setPrenomOccupant($this->signalementDraftRequest->getVosCoordonneesOccupantPrenom())
                 ->setTelOccupant($this->signalementDraftRequest->getVosCoordonneesOccupantTel())
-                ->setTelOccupantBis($this->signalementDraftRequest->getVosCoordonneesOccupantTelSecondaire())
-                ->setNomDeclarant($this->signalementDraftRequest->getVosCoordonneesOccupantNom())
-                ->setPrenomDeclarant($this->signalementDraftRequest->getVosCoordonneesOccupantPrenom())
-                ->setTelDeclarant($this->signalementDraftRequest->getVosCoordonneesOccupantTel())
-                ->setTelDeclarantSecondaire($this->signalementDraftRequest->getVosCoordonneesOccupantTelSecondaire())
-                ->setMailDeclarant($this->signalementDraftRequest->getVosCoordonneesOccupantEmail());
+                ->setTelOccupantBis($this->signalementDraftRequest->getVosCoordonneesOccupantTelSecondaire());
         } else {
             $this->signalement
                 ->setIsNotOccupant(true)

--- a/templates/back/signalement/view/tabs/tab-foyer.html.twig
+++ b/templates/back/signalement/view/tabs/tab-foyer.html.twig
@@ -1,7 +1,7 @@
 <h2 class="fr-h4">Informations du foyer</h2>
 
 <div data-ajax-form>
-{% if signalement.isNotOccupant %}
+{% if signalement.isNotOccupant or (not signalement.isV2 and signalement.mailDeclarant) %}
 {% include 'back/signalement/view/information/information-tiers.html.twig' %}
 
 <hr class="fr-mt-3w fr-hr">

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -105,7 +105,9 @@
                 {{ form_row(formCoordonnees.mailDeclarant) }}
             </div>
             <div class="fr-fieldset__element">
-                {{ form_row(formCoordonnees.telDeclarant) }}
+                <div id="telDeclarantContainer">
+                    {{ form_row(formCoordonnees.telDeclarant) }}
+                </div>
             </div>
         </fieldset>
 

--- a/tests/Functional/Service/Signalement/SignalementBuilderTest.php
+++ b/tests/Functional/Service/Signalement/SignalementBuilderTest.php
@@ -116,14 +116,9 @@ class SignalementBuilderTest extends KernelTestCase
             '+2693621161',
             $signalement->getTelOccupantBis()
         );
-        $this->assertEquals(
-            '+'.self::FR_PHONE_COUNTRY_CODE.'0644784515',
-            $signalement->getTelDeclarant()
-        );
-        $this->assertEquals(
-            '+2693621161',
-            $signalement->getTelDeclarantSecondaire()
-        );
+        $this->assertNull($signalement->getTelDeclarant());
+        $this->assertNull($signalement->getMailDeclarant());
+        $this->assertNull($signalement->getTelDeclarantSecondaire());
         $this->assertEquals(
             '+'.self::FR_PHONE_COUNTRY_CODE.'0644784516',
             $signalement->getTelProprio()


### PR DESCRIPTION
## Ticket

#4642

## Description
Suite à l'alerte concernant le signalement `2025-185` du `04` sur lequel un déclarant recevait des notification alors qu'il s’agissait d'un signalement LOCATAIRE, j'ai détecté et corrigé plusieurs problèmes.

Form BO : 
- On vide les champs concernant le déclarant avant validation du signalement pour les profils LOCATAIRE et BAILLEUR_OCCUPANT (afin d'éviter qu'un déclarant invisible puisse être notifié)
- On grise le label du téléphone déclarant sur l'onglet coordonnées

Form FO : 
- On ne copie plus les champs de l'occupant dans ceux du déclarant pour les profils LOCATAIRE et BAILLEUR_OCCUPANT (afin d'éviter en cas de modification du mail déclarant de continuer a notifier l'ancien

Fiche signalement BO : 
- Pour les anciens signalement (avant le nouveau form FO) si un déclarant différent de l'occupant est enregistré on l'affiche peu importe le type de profil déclarant, car il semble que pour des import ou des ancienne version la données soit valide est utile

Migration
- Pour tous les signalement V2 (nouveau form FO et BO) on supprime les ifnormations déclarant pour les profil LOCATAIRE et BAILLEUR_OCCUPANT

## Pré-requis
`make npm-watch`
`make execute-migration name=Version20250929084507 direction=up`

## Tests
- [ ] Déposer un signalement FO en LOCATAIRE OU BAILLEUR_OCCUPANT et s'assurer qu'aucune information déclarant est enregistré.
- [ ] Déposer un signalement BO en LOCATAIRE OU BAILLEUR_OCCUPANT et s'assurer qu'aucune information déclarant est enregistré.
- [ ] Vérifier qu'aucun signalement v2 de profil LOCATAIRE OU BAILLEUR_OCCUPANT ne contient des information déclarant.
