### PR TITLE
[QA] Erreur Doctrine : Donnée trop longue pour la colonne reason webhook brevo

### DIFF
--- a/migrations/Version20250930074948.php
+++ b/migrations/Version20250930074948.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250930074948 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update type column `reason` to longtext';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE email_delivery_issue CHANGE reason reason LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE email_delivery_issue CHANGE reason reason VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/src/Entity/EmailDeliveryIssue.php
+++ b/src/Entity/EmailDeliveryIssue.php
@@ -26,7 +26,7 @@ class EmailDeliveryIssue
     #[ORM\Column(enumType: BrevoEvent::class)]
     private ?BrevoEvent $event = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Column(type: 'text', nullable: true)]
     private ?string $reason;
 
     /** @var array<string, mixed> $payload */


### PR DESCRIPTION
## Ticket

#4683   

## Description
Données reçu trop longue pour le type varchar

## Changements apportés
* Mise à jour du type en longtext

## Pré-requis

## Tests
- [ ] Jouer la migration `make load-migrations` et vérifier le type en base de donnée
