### PR TITLE
[API] Mettre en avant dans la doc et les erreurs la contrainte affectation EN_COURS pour toute nouvelle ressource (suivi, visite, arrete)

### DIFF
--- a/src/Controller/Api/ArreteCreateController.php
+++ b/src/Controller/Api/ArreteCreateController.php
@@ -9,7 +9,6 @@ use App\Entity\Enum\Qualification;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Event\InterventionCreatedEvent;
-use App\EventListener\SecurityApiExceptionListener;
 use App\Manager\InterventionManager;
 use App\Security\Voter\Api\ApiSignalementPartnerVoter;
 use App\Service\Security\PartnerAuthorizedResolver;
@@ -42,7 +41,7 @@ class ArreteCreateController extends AbstractController
      */
     #[OA\Post(
         path: '/api/signalements/{uuid}/arretes',
-        description: 'Création d\'un arrêté préfectoral',
+        description: 'Création d\'un arrêté préfectoral<br>⚠️ <a href="#tag/Affectations/operation/patch_api_affectations_update">Condition : l\'affectation du partenaire doit être au statut `EN_COURS`</a>',
         summary: 'Création d\'un arrêté préfectoral',
         security: [['Bearer' => []]],
         requestBody: new OA\RequestBody(
@@ -179,8 +178,7 @@ class ArreteCreateController extends AbstractController
         $partner = $this->partnerAuthorizedResolver->resolvePartner($user, $arreteRequest->partenaireUuid);
         $this->denyAccessUnlessGranted(
             ApiSignalementPartnerVoter::API_ADD_INTERVENTION,
-            ['signalement' => $signalement, 'partner' => $partner],
-            SecurityApiExceptionListener::ACCESS_DENIED
+            ['signalement' => $signalement, 'partner' => $partner]
         );
         $affectation = $signalement->getAffectationForPartner($partner);
 

--- a/src/Controller/Api/SuiviCreateController.php
+++ b/src/Controller/Api/SuiviCreateController.php
@@ -9,7 +9,6 @@ use App\Entity\File;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
-use App\EventListener\SecurityApiExceptionListener;
 use App\Manager\SuiviManager;
 use App\Security\Voter\Api\ApiSignalementPartnerVoter;
 use App\Service\Sanitizer;
@@ -37,7 +36,7 @@ class SuiviCreateController extends AbstractController
     #[Route('/signalements/{uuid:signalement}/suivis', name: 'api_signalements_suivis_post', methods: ['POST'])]
     #[OA\Post(
         path: '/api/signalements/{uuid}/suivis',
-        description: 'Création d\'un suivi',
+        description: 'Création d\'un suivi<br>⚠️ <a href="#tag/Affectations/operation/patch_api_affectations_update">Condition : l\'affectation du partenaire doit être au statut `EN_COURS`</a>',
         summary: 'Création d\'un suivi',
         security: [['Bearer' => []]],
         tags: ['Suivis']
@@ -140,7 +139,6 @@ class SuiviCreateController extends AbstractController
         $this->denyAccessUnlessGranted(
             ApiSignalementPartnerVoter::API_EDIT_SIGNALEMENT,
             ['signalement' => $signalement, 'partner' => $partner],
-            SecurityApiExceptionListener::ACCESS_DENIED
         );
 
         $errors = $this->validator->validate($suiviRequest);
@@ -158,9 +156,9 @@ class SuiviCreateController extends AbstractController
             description: Sanitizer::sanitize($suiviRequest->getDescription()),
             type: Suivi::TYPE_PARTNER,
             category: SuiviCategory::MESSAGE_PARTNER,
-            isPublic: $suiviRequest->notifyUsager,
             partner: $partner,
             user: $user,
+            isPublic: $suiviRequest->notifyUsager,
             files: $fileToAttach,
         );
 

--- a/src/Controller/Api/VisiteCreateController.php
+++ b/src/Controller/Api/VisiteCreateController.php
@@ -9,7 +9,6 @@ use App\Entity\Partner;
 use App\Entity\Signalement;
 use App\Entity\User;
 use App\Event\InterventionCreatedEvent;
-use App\EventListener\SecurityApiExceptionListener;
 use App\Factory\Api\VisiteFactory;
 use App\Factory\SignalementVisiteRequestFactory;
 use App\Manager\InterventionManager;
@@ -45,7 +44,7 @@ class VisiteCreateController extends AbstractController
      */
     #[OA\Post(
         path: '/api/signalements/{uuid}/visites',
-        description: 'Création d\'une visite',
+        description: 'Création d\'une visite<br>⚠️ <a href="#tag/Affectations/operation/patch_api_affectations_update">Condition : l\'affectation du partenaire doit être au statut `EN_COURS`</a>.',
         summary: 'Création d\'une visite',
         security: [['Bearer' => []]],
         requestBody: new OA\RequestBody(
@@ -183,7 +182,6 @@ class VisiteCreateController extends AbstractController
         $this->denyAccessUnlessGranted(
             ApiSignalementPartnerVoter::API_ADD_INTERVENTION,
             ['signalement' => $signalement, 'partner' => $partner],
-            SecurityApiExceptionListener::ACCESS_DENIED
         );
 
         $errors = $this->validator->validate($visiteRequest);

--- a/src/DataFixtures/Files/Affectation.yml
+++ b/src/DataFixtures/Files/Affectation.yml
@@ -193,6 +193,13 @@ affectations:
     affected_by: "admin-03@signal-logement.fr"
     territory: "Bouches-du-Rhône"
   -
+    signalement: 2023-26
+    partner: "partenaire-13-03@signal-logement.fr"
+    statut: "EN_COURS"
+    answered_by: "admin-03@signal-logement.fr"
+    affected_by: "admin-03@signal-logement.fr"
+    territory: "Bouches-du-Rhône"
+  -
     signalement: 2024-01
     partner: "partenaire-62-01@signal-logement.fr"
     statut: "NOUVEAU"

--- a/src/DataFixtures/Files/UserApiPermission.yml
+++ b/src/DataFixtures/Files/UserApiPermission.yml
@@ -30,5 +30,8 @@ user_api_permissions:
     user: "api-01@signal-logement.fr"
     partner: "Partenaire 13-02"
   -
+    user: "api-01@signal-logement.fr"
+    partner: "Partenaire 13-03"
+  -
     user: "api-02@signal-logement.fr"
     partner: "Alès Agglomération"

--- a/src/EventListener/SecurityApiExceptionListener.php
+++ b/src/EventListener/SecurityApiExceptionListener.php
@@ -38,6 +38,10 @@ class SecurityApiExceptionListener
                 default => 'Une erreur inconnue est survenue.',
             };
 
+            if (str_contains($exception->getMessage(), 'Access Denied')) {
+                $message = $exception->getMessage();
+            }
+
             $response = [
                 'message' => $message,
                 'status' => Response::HTTP_FORBIDDEN,
@@ -50,7 +54,8 @@ class SecurityApiExceptionListener
     {
         return $exception instanceof AccessDeniedHttpException
             && (
-                self::ACCESS_DENIED === $exception->getMessage()
+                str_contains($exception->getMessage(), 'Access Denied')
+                || self::ACCESS_DENIED === $exception->getMessage()
                 || self::ACCESS_DENIED_PARTNER === $exception->getMessage()
                 || self::ACCESS_DENIED_PARTNER_NOT_FOUND === $exception->getMessage()
                 || self::TRANSITION_STATUT_DENIED === $exception->getMessage()

--- a/src/Security/Voter/Api/ApiSignalementPartnerVoter.php
+++ b/src/Security/Voter/Api/ApiSignalementPartnerVoter.php
@@ -82,7 +82,7 @@ class ApiSignalementPartnerVoter extends Voter
     private function canEditSignalement(Signalement $signalement, Partner $partner, ?Vote $vote = null): bool
     {
         if (SignalementStatus::ACTIVE !== $signalement->getStatut()) {
-            $vote->addReason('Le signalement n\'est pas active.');
+            $vote->addReason('Le signalement n\'est pas actif.');
 
             return false;
         }

--- a/src/Security/Voter/Api/ApiSignalementPartnerVoter.php
+++ b/src/Security/Voter/Api/ApiSignalementPartnerVoter.php
@@ -59,34 +59,42 @@ class ApiSignalementPartnerVoter extends Voter
         }
 
         return match ($attribute) {
-            self::API_ADD_INTERVENTION => $this->canAddIntervention($subject['signalement'], $subject['partner']),
-            self::API_EDIT_SIGNALEMENT => $this->canEditSignalement($subject['signalement'], $subject['partner']),
+            self::API_ADD_INTERVENTION => $this->canAddIntervention($subject['signalement'], $subject['partner'], $vote),
+            self::API_EDIT_SIGNALEMENT => $this->canEditSignalement($subject['signalement'], $subject['partner'], $vote),
             default => false,
         };
     }
 
-    private function canAddIntervention(Signalement $signalement, Partner $partner): bool
+    private function canAddIntervention(Signalement $signalement, Partner $partner, ?Vote $vote = null): bool
     {
-        if (!$this->canEditSignalement($signalement, $partner)) {
+        if (!$this->canEditSignalement($signalement, $partner, $vote)) {
             return false;
         }
         if (!\in_array(Qualification::VISITES, $partner->getCompetence())) {
+            $vote->addReason('Le partenaire n\'a pas la compétence visite.');
+
             return false;
         }
 
         return true;
     }
 
-    private function canEditSignalement(Signalement $signalement, Partner $partner): bool
+    private function canEditSignalement(Signalement $signalement, Partner $partner, ?Vote $vote = null): bool
     {
         if (SignalementStatus::ACTIVE !== $signalement->getStatut()) {
+            $vote->addReason('Le signalement n\'est pas active.');
+
             return false;
         }
         $affectation = $signalement->getAffectationForPartner($partner);
         if (!$affectation) {
+            $vote->addReason('Le partenaire n\'est pas affecté au signalement.');
+
             return false;
         }
         if (AffectationStatus::ACCEPTED !== $affectation->getStatut()) {
+            $vote->addReason('L\'affectation doit être au statut EN_COURS.');
+
             return false;
         }
 

--- a/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/ArreteCreateControllerTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional\Controller\Api;
 use App\Entity\Enum\NotificationType;
 use App\Entity\User;
 use App\Repository\NotificationRepository;
+use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -88,6 +89,41 @@ class ArreteCreateControllerTest extends WebTestCase
 
         $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
         $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
+    }
+
+    /**
+     * @dataProvider provideDataFailure403
+     */
+    public function testCreateArretesWithErrors(string $signalementUuid, string $partnerName, string $errorMessage, bool $removeVisiteCompetence = false): void
+    {
+        $partner = self::getContainer()->get(PartnerRepository::class)->findOneBy(['nom' => $partnerName]);
+        $payload = [
+            'date' => '2002-03-11',
+            'numero' => '2023/DD13/00664',
+            'type' => 'Arrêté L.511-11 - Suroccupation',
+            'partenaireUuid' => $partner->getUuid(),
+        ];
+
+        $this->client->request(
+            method: 'POST',
+            uri: $this->router->generate('api_signalements_arretes_post', ['uuid' => $signalementUuid]),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+
+        $this->assertEquals(403, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('Access Denied', $content['message']);
+        $this->assertStringContainsString($errorMessage, $content['message']);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
+    }
+
+    public function provideDataFailure403(): \Generator
+    {
+        yield 'test create arrete with new affectation' => ['00000000-0000-0000-2022-000000000001', 'Partenaire 13-01', 'L\'affectation doit être au statut EN_COURS'];
+        yield 'test create arrete with closed signalement' => ['00000000-0000-0000-2022-000000000003', 'Partenaire 13-01', 'Le signalement n\'est pas actif.'];
+        yield 'test create arrete with partner non affecté' => ['00000000-0000-0000-2022-000000000001', 'Partenaire 13-02', ' Le partenaire n\'est pas affecté au signalement.'];
+        yield 'test create arrete with partner with no competence visite' => ['00000000-0000-0000-2023-000000000026', 'Partenaire 13-03', 'Le partenaire n\'a pas la compétence visite.', true];
     }
 
     public function providePayloadFailure(): \Generator

--- a/tests/Functional/Controller/Api/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementListControllerTest.php
@@ -25,7 +25,7 @@ class SignalementListControllerTest extends WebTestCase
         foreach ($response as $signalement) {
             $this->assertIsArray($signalement['affectations']);
             if ('2023-26' === $signalement['reference']) {
-                $this->assertCount(2, $signalement['affectations']);
+                $this->assertCount(3, $signalement['affectations']);
             }
         }
         $this->assertCount(9, $response);
@@ -71,7 +71,7 @@ class SignalementListControllerTest extends WebTestCase
     public function provideDataSignalementByUuid(): \Generator
     {
         yield 'api-02 user with signalement 2024-12' => ['api-02@signal-logement.fr', '00000000-0000-0000-2024-000000000012', 1, 7];
-        yield 'api-01 user with signalement 2023-26' => ['api-01@signal-logement.fr', '00000000-0000-0000-2023-000000000026', 2, 0];
+        yield 'api-01 user with signalement 2023-26' => ['api-01@signal-logement.fr', '00000000-0000-0000-2023-000000000026', 3, 0];
         yield 'api-01 user with old signalement 2022-03' => ['api-01@signal-logement.fr', '00000000-0000-0000-2022-000000000003', 1, 3];
     }
 

--- a/tests/Functional/Controller/Api/SuiviCreateControllerTest.php
+++ b/tests/Functional/Controller/Api/SuiviCreateControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Functional\Controller\Api;
 
 use App\Entity\Suivi;
 use App\Entity\User;
+use App\Repository\PartnerRepository;
 use App\Repository\SignalementRepository;
 use App\Tests\ApiHelper;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -69,10 +70,42 @@ class SuiviCreateControllerTest extends WebTestCase
         $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
     }
 
+    /**
+     * @dataProvider provideDataFailure403
+     */
+    public function testCreateSuiviWithErrors(string $signalementUuid, string $partnerName, string $errorMessage, bool $removeVisiteCompetence = false): void
+    {
+        $partner = self::getContainer()->get(PartnerRepository::class)->findOneBy(['nom' => $partnerName]);
+        $payload = [
+            'description' => 'lorem ipsum dolor sit <em>amet</em>',
+            'partenaireUuid' => $partner->getUuid(),
+        ];
+
+        $this->client->request(
+            method: 'POST',
+            uri: $this->router->generate('api_signalements_suivis_post', ['uuid' => $signalementUuid]),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode($payload)
+        );
+
+        $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
+        $content = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertStringContainsString('Access Denied', $content['message']);
+        $this->assertStringContainsString($errorMessage, $content['message']);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($this->client);
+    }
+
     public function provideData(): \Generator
     {
         yield 'test create suivi with usager notification' => ['00000000-0000-0000-2022-000000000006', true, 2];
         yield 'test create suivi with no usager notification' => ['00000000-0000-0000-2022-000000000006', false, 1, '00000000-0000-0000-2022-000000000006'];
         yield 'test create suivi with unknown signalement' => ['0000', false, 1];
+    }
+
+    public function provideDataFailure403(): \Generator
+    {
+        yield 'test create suivi with new affectation' => ['00000000-0000-0000-2022-000000000001', 'Partenaire 13-01', 'L\'affectation doit être au statut EN_COURS'];
+        yield 'test create suivi with closed signalement' => ['00000000-0000-0000-2022-000000000003', 'Partenaire 13-01', 'Le signalement n\'est pas actif.'];
+        yield 'test create suivi with partner non affecté' => ['00000000-0000-0000-2022-000000000001', 'Partenaire 13-02', ' Le partenaire n\'est pas affecté au signalement.'];
     }
 }

--- a/tests/Functional/Controller/Api/UserGetMeControllerTest.php
+++ b/tests/Functional/Controller/Api/UserGetMeControllerTest.php
@@ -34,7 +34,7 @@ class UserGetMeControllerTest extends WebTestCase
 
     public function provideUserEmailApi(): \Generator
     {
-        yield 'Partenaire id 2' => ['api-01@signal-logement.fr', 2];
+        yield 'Partenaire id 2' => ['api-01@signal-logement.fr', 3];
         yield 'Partenaire id 84' => ['api-02@signal-logement.fr', 1];
         yield 'Partenaires EPCI de La Réunion' => ['api-reunion-epci@signal-logement.fr', 2];
         yield 'Partenaires COMMUNE_SCHS' => ['api-oilhi@signal-logement.fr', 31];

--- a/tests/Functional/Service/Security/PartnerAuthorizedResolverTest.php
+++ b/tests/Functional/Service/Security/PartnerAuthorizedResolverTest.php
@@ -50,7 +50,8 @@ class PartnerAuthorizedResolverTest extends KernelTestCase
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'api-01@signal-logement.fr']);
         $partnerOK = $this->entityManager->getRepository(Partner::class)->findOneBy(['nom' => 'Partenaire 13-01']);
         $partner2OK = $this->entityManager->getRepository(Partner::class)->findOneBy(['nom' => 'Partenaire 13-02']);
-        $partnerKO = $this->entityManager->getRepository(Partner::class)->findOneBy(['nom' => 'Partenaire 13-03']);
+        $partner3OK = $this->entityManager->getRepository(Partner::class)->findOneBy(['nom' => 'Partenaire 13-03']);
+        $partnerKO = $this->entityManager->getRepository(Partner::class)->findOneBy(['nom' => 'Partenaire 13-04']);
 
         $this->assertInstanceOf(Partner::class, $partnerOK);
         $this->assertTrue($this->partnerAuthorizedResolver->hasPermissionOnPartner($user, $partnerOK));
@@ -136,7 +137,7 @@ class PartnerAuthorizedResolverTest extends KernelTestCase
     {
         yield 'api-01@signal-logement.fr' => [
             'email' => 'api-01@signal-logement.fr',
-            'countExpectedPartner' => 2,
+            'countExpectedPartner' => 3,
         ];
 
         yield 'api-02@signal-logement.fr' => [


### PR DESCRIPTION
## Ticket

#4682    

## Description
La territoire réunion ne comprenait pas pourquoi le message `'Vous n\'avez pas l\'autorisation d\'accéder à cette ressource.',`  lors d'une création de suivi

## Changements apportés
* Mise à jour de la documentation
* Expliquer la décision du voter https://symfony.com/blog/new-in-symfony-7-3-explaining-security-voter-decisions
* Utiliser la raison du voter au lieu du message générique `ACCESS_DENIED`

## Pré-requis

Tests à appliquer sur la création de suivi/visite et arrêtés
## Tests

- [ ] Créer un suivi, visite et arrêté avec un signalement fermé et vérifier que le message le message d'erreur que le message d'erreur est explicite
- [ ] Créer un suivi, visite et arrêté avec une affectation au statut nouveau et vérifier que le message le message d'erreur est explicite
- [ ] Créer un suivi, visite et arrêté avec une affectation avec un partenaire qui n'a pas la compétence visite et vérifier que le message est explicite.
