### PR TITLE
[Médiation Bailleur] Création du statut de signalement “EN_MEDIATION”

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -237,7 +237,7 @@ class SignalementController extends AbstractController
         $signalementsOnSameAddress = $signalementRepository->findOnSameAddress(
             signalement: $signalement,
             exclusiveStatus: [],
-            excludedStatus: [SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED, SignalementStatus::ARCHIVED]
+            excludedStatus: SignalementStatus::excludedStatuses(),
         );
         $isUserSubscribed = false;
         if ($featureNewDashboard && $signalementSubscriptionRepository->findOneBy(['user' => $user, 'signalement' => $signalement])) {

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -1133,3 +1133,45 @@ signalements:
     situation_foyer: "[]"
     information_procedure: "[]"
     information_complementaire: "[]"
+  -     
+    territory: "Gard"
+    uuid: "00000000-0000-0000-2025-000000000011"
+    reference: "2025-11"
+    details: "Le toit n'est plus étanche."
+    is_proprio_averti: 1
+    is_allocataire: "0"
+    nature_logement: "maison"
+    superficie: 80
+    loyer: 750
+    date_entree: "2025-12-01"
+    nom_proprio: "Morel"
+    prenom_proprio: "Sylvain"
+    email_proprio: "s.morel@yopmail.com"
+    type_proprio: "PARTICULIER"
+    is_logement_social: 0
+    civilite_occupant: "mr"
+    nom_occupant: "Talau"
+    prenom_occupant: "Clément"
+    tel_occupant: "+330644556677"
+    phone_number: "+330644556677"
+    mail_occupant: "c.talau@yopmail.com"
+    adresse_occupant: "18 Bd du 8 Mai 1945"
+    cp_occupant: "30110"
+    ville_occupant: "La Grand-Combe"
+    statut: "EN_MEDIATION"
+    geoloc: "[]"
+    insee_occupant: ""
+    nb_pieces_logement: 3
+    nb_occupants_logement: 5
+    score: 37
+    score_logement: 22
+    score_batiment: 13
+    created_from_uuid: '00000000-0000-0000-2025-000000000011'
+    profile_declarant: "LOCATAIRE"
+    type_composition_logement: "[]"
+    situation_foyer: "[]"
+    information_procedure: "[]"
+    information_complementaire: "[]"
+    desordre_precision:
+      - "desordres_batiment_isolation_infiltration_eau_maison_individuelle"
+      - "desordres_logement_electricite_installation_dangereuse"

--- a/src/Entity/Enum/SignalementStatus.php
+++ b/src/Entity/Enum/SignalementStatus.php
@@ -15,11 +15,12 @@ enum SignalementStatus: string
     case ARCHIVED = 'ARCHIVED';
     case REFUSED = 'REFUSED';
     case DRAFT_ARCHIVED = 'DRAFT_ARCHIVED';
+    case EN_MEDIATION = 'EN_MEDIATION';
 
     public function mapAffectationStatus(): string
     {
         return match ($this) {
-            self::DRAFT, self::NEED_VALIDATION => AffectationStatus::WAIT->value,
+            self::EN_MEDIATION, self::DRAFT, self::NEED_VALIDATION => AffectationStatus::WAIT->value,
             self::ACTIVE => AffectationStatus::ACCEPTED->value,
             self::REFUSED => AffectationStatus::REFUSED->value,
             self::CLOSED, self::ARCHIVED, self::DRAFT_ARCHIVED => AffectationStatus::CLOSED->value,
@@ -37,6 +38,7 @@ enum SignalementStatus: string
             self::REFUSED->name => 'refusé',
             self::ARCHIVED->name => 'archivé',
             self::DRAFT_ARCHIVED->name => 'brouillon archivé',
+            self::EN_MEDIATION->name => 'en médiation',
         ];
     }
 
@@ -48,7 +50,19 @@ enum SignalementStatus: string
             'en_cours' => SignalementStatus::ACTIVE->value,
             'ferme' => SignalementStatus::CLOSED->value,
             'refuse' => SignalementStatus::REFUSED->value,
+            'en_mediation' => SignalementStatus::EN_MEDIATION->value,
             default => throw new \UnexpectedValueException('Unexpected signalement status : '.$label),
         };
+    }
+
+    /** @return array<SignalementStatus> */
+    public static function excludedStatuses(): array
+    {
+        return [
+            self::ARCHIVED,
+            self::DRAFT,
+            self::DRAFT_ARCHIVED,
+            self::EN_MEDIATION,
+        ];
     }
 }

--- a/src/EventSubscriber/SuiviCreatedSubscriber.php
+++ b/src/EventSubscriber/SuiviCreatedSubscriber.php
@@ -35,10 +35,7 @@ class SuiviCreatedSubscriber implements EventSubscriberInterface
         if (Suivi::CONTEXT_INTERVENTION === $suivi->getContext()) {
             return;
         }
-
-        if (SignalementStatus::DRAFT === $suivi->getSignalement()->getStatut()
-                || SignalementStatus::ARCHIVED === $suivi->getSignalement()->getStatut()
-                || SignalementStatus::DRAFT_ARCHIVED === $suivi->getSignalement()->getStatut()) {
+        if (in_array($suivi->getSignalement()->getStatut(), SignalementStatus::excludedStatuses())) {
             return;
         }
 

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -64,7 +64,7 @@ class AffectationRepository extends ServiceEntityRepository
             ->select('COUNT(a.signalement) as count')
             ->leftJoin('a.signalement', 's', 'WITH', 's = a.signalement')
             ->andWhere('s.statut NOT IN (:signalement_status_list)')
-            ->setParameter('signalement_status_list', [SignalementStatus::DRAFT, SignalementStatus::ARCHIVED, SignalementStatus::DRAFT_ARCHIVED])
+            ->setParameter('signalement_status_list', SignalementStatus::excludedStatuses())
             ->addSelect('a.statut')
             ->andWhere('a.partner IN (:partners)')
             ->setParameter('partners', $user->getPartners());
@@ -127,11 +127,7 @@ class AffectationRepository extends ServiceEntityRepository
             ->innerJoin('a.signalement', 's')
             ->where('p.esaboraUrl IS NOT NULL AND p.esaboraToken IS NOT NULL AND p.isEsaboraActive = 1')
             ->andWhere('s.statut NOT IN (:signalement_status_list)')
-            ->setParameter('signalement_status_list', [
-                SignalementStatus::ARCHIVED,
-                SignalementStatus::DRAFT,
-                SignalementStatus::DRAFT_ARCHIVED,
-            ]);
+            ->setParameter('signalement_status_list', SignalementStatus::excludedStatuses());
 
         if (is_array($partnerType)) {
             $qb->andWhere('p.type IN (:partner_types)')->setParameter('partner_types', $partnerType);
@@ -225,7 +221,7 @@ class AffectationRepository extends ServiceEntityRepository
             ->innerJoin('a.signalement', 's')
             ->where('s.statut NOT IN (:statut_list)')
             ->andWhere('a.partner IN (:partners)')
-            ->setParameter('statut_list', [SignalementStatus::ARCHIVED->value, SignalementStatus::DRAFT->value, SignalementStatus::DRAFT_ARCHIVED->value])
+            ->setParameter('statut_list', SignalementStatus::excludedStatuses())
             ->setParameter('partners', $user->getPartners());
 
         if (\count($territories)) {
@@ -297,7 +293,7 @@ class AffectationRepository extends ServiceEntityRepository
             ->where('p.isIdossActive = 1')
             ->andWhere('p.idossUrl IS NOT NULL')
             ->andWhere('s.statut NOT IN (:signalement_status_list)')
-            ->setParameter('signalement_status_list', [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED])
+            ->setParameter('signalement_status_list', SignalementStatus::excludedStatuses())
             ->andWhere('s.uuid LIKE :uuid_signalement')
             ->setParameter('uuid_signalement', $uuidSignalement);
 

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -49,7 +49,7 @@ class TagRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('t');
         $qb->select('t', 's')
             ->leftJoin('t.signalements', 's', 'WITH', 's.statut NOT IN (:signalement_status_list)')
-            ->setParameter('signalement_status_list', [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED])
+            ->setParameter('signalement_status_list', SignalementStatus::excludedStatuses())
             ->andWhere('t.isArchive != 1');
 
         if (!empty($searchTag->getOrderType())) {

--- a/src/Repository/ZoneRepository.php
+++ b/src/Repository/ZoneRepository.php
@@ -68,11 +68,17 @@ class ZoneRepository extends ServiceEntityRepository
             JOIN zone z ON ST_Contains(ST_GeomFromText(z.area),
             Point(JSON_EXTRACT(s.geoloc, "$.lng"), JSON_EXTRACT(s.geoloc, "$.lat")))
             WHERE z.id = :zone AND s.territory_id = z.territory_id
-            AND s.statut NOT IN (:status_draft, :status_archived)
+            AND s.statut NOT IN (:status_draft, :status_archived, :status_draft_archived, :status_en_mediation)
             ORDER BY s.created_at DESC
             ';
 
-        $resultSet = $conn->executeQuery($sql, ['zone' => $zone->getId(), 'status_draft' => SignalementStatus::DRAFT->value, 'status_archived' => SignalementStatus::ARCHIVED->value, 'status_draft_archived' => SignalementStatus::DRAFT_ARCHIVED->value]);
+        $resultSet = $conn->executeQuery($sql, [
+            'zone' => $zone->getId(),
+            'status_draft' => SignalementStatus::DRAFT->value,
+            'status_archived' => SignalementStatus::ARCHIVED->value,
+            'status_draft_archived' => SignalementStatus::DRAFT_ARCHIVED->value,
+            'status_en_mediation' => SignalementStatus::EN_MEDIATION->value,
+        ]);
         $list = $resultSet->fetchAllAssociative();
         foreach ($list as $key => $value) {
             $list[$key]['geoloc'] = json_decode($value['geoloc'], true);

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -148,13 +148,11 @@ class SignalementVoter extends Voter
 
     private function canView(Signalement $signalement, User $user): bool
     {
-        if ($this->security->isGranted('ROLE_ADMIN') && SignalementStatus::DRAFT !== $signalement->getStatut() && SignalementStatus::DRAFT_ARCHIVED !== $signalement->getStatut()) {
+        if ($this->security->isGranted('ROLE_ADMIN') && !in_array($signalement->getStatut(), [SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED])) {
             return true;
         }
 
-        if (SignalementStatus::ARCHIVED === $signalement->getStatut()
-        || SignalementStatus::DRAFT === $signalement->getStatut()
-        || SignalementStatus::DRAFT_ARCHIVED === $signalement->getStatut()) {
+        if (in_array($signalement->getStatut(), SignalementStatus::excludedStatuses())) {
             return false;
         }
 

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -156,11 +156,12 @@ class SearchFilter
                     ->select('DISTINCT IDENTITY(a.signalement)')
                     ->innerJoin('a.signalement', 's')
                     ->where('a.statut = :statut_affectation_closed')
-                    ->andWhere('s.statut != :status_archived AND s.statut != :statut_closed AND s.statut != :status_draft AND s.statut != :status_draft_archived')
+                    ->andWhere('s.statut != :status_archived AND s.statut != :statut_closed AND s.statut != :status_draft AND s.statut != :status_draft_archived AND s.statut != :status_en_mediation')
                     ->setParameter('status_archived', SignalementStatus::ARCHIVED->value)
                     ->setParameter('statut_closed', SignalementStatus::CLOSED->value)
                     ->setParameter('status_draft', SignalementStatus::DRAFT->value)
                     ->setParameter('status_draft_archived', SignalementStatus::DRAFT_ARCHIVED->value)
+                    ->setParameter('status_en_mediation', SignalementStatus::EN_MEDIATION->value)
                     ->setParameter('statut_affectation_closed', AffectationStatus::CLOSED->value);
 
                 if (!empty($filters['territories'])) {
@@ -207,6 +208,7 @@ class SearchFilter
                     'status_refused' => SignalementStatus::REFUSED->value,
                     'status_draft' => SignalementStatus::DRAFT->value,
                     'status_draft_archived' => SignalementStatus::DRAFT_ARCHIVED->value,
+                    'status_en_mediation' => SignalementStatus::EN_MEDIATION->value,
                     'nb_suivi_technical' => 3,
                 ];
 

--- a/src/Service/Statistics/GlobalAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalAnalyticsProvider.php
@@ -56,12 +56,7 @@ class GlobalAnalyticsProvider
 
     public function getCountSignalementData(): int
     {
-        return $this->signalementRepository->countAll(
-            territory: null,
-            partners: null,
-            removeImported: true,
-            removeArchived: true
-        );
+        return $this->signalementRepository->countAll(territory: null, partners: null);
     }
 
     public function getCountTerritoryData(): int

--- a/src/Service/Statistics/GlobalBackAnalyticsProvider.php
+++ b/src/Service/Statistics/GlobalBackAnalyticsProvider.php
@@ -56,12 +56,7 @@ class GlobalBackAnalyticsProvider
      */
     private function getCountSignalementData(?Territory $territory, ArrayCollection $partners): int
     {
-        return $this->signalementRepository->countAll(
-            territory: $territory,
-            partners: $partners,
-            removeImported: true,
-            removeArchived: true
-        );
+        return $this->signalementRepository->countAll(territory: $territory, partners: $partners);
     }
 
     /**
@@ -69,11 +64,7 @@ class GlobalBackAnalyticsProvider
      */
     private function getAverageCriticiteData(?Territory $territory, ArrayCollection $partners): float
     {
-        return round($this->signalementRepository->getAverageCriticite(
-            territory: $territory,
-            partners: $partners,
-            removeImported: true
-        ) * 10) / 10;
+        return round($this->signalementRepository->getAverageCriticite(territory: $territory, partners: $partners) * 10) / 10;
     }
 
     /**
@@ -81,11 +72,7 @@ class GlobalBackAnalyticsProvider
      */
     private function getAverageDaysValidationData(?Territory $territory, ArrayCollection $partners): float
     {
-        return round($this->signalementRepository->getAverageDaysValidation(
-            territory: $territory,
-            partners: $partners,
-            removeImported: true
-        ) * 10) / 10;
+        return round($this->signalementRepository->getAverageDaysValidation(territory: $territory, partners: $partners) * 10) / 10;
     }
 
     /**
@@ -93,10 +80,6 @@ class GlobalBackAnalyticsProvider
      */
     private function getAverageDaysClosureData(?Territory $territory, ArrayCollection $partners): float
     {
-        return round($this->signalementRepository->getAverageDaysClosure(
-            territory: $territory,
-            partners: $partners,
-            removeImported: true
-        ) * 10) / 10;
+        return round($this->signalementRepository->getAverageDaysClosure(territory: $territory, partners: $partners) * 10) / 10;
     }
 }

--- a/templates/front/suivi_signalement_messages.html.twig
+++ b/templates/front/suivi_signalement_messages.html.twig
@@ -77,6 +77,10 @@
 					<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
 						<p>Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.</p>
 					</div>
+				{% elseif signalement.statut.name == 'EN_MEDIATION' %}
+					<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
+						<p>Votre dossier est en médiation, vous ne pouvez pas envoyer de messages.</p>
+					</div>
 				{% else %}
 					<div role="alert" class="fr-alert fr-alert--error fr-alert--sm">
 						<p>Vous ne pouvez plus envoyer de messages.</p>

--- a/tests/Functional/Controller/BackStatistiquesControllerTest.php
+++ b/tests/Functional/Controller/BackStatistiquesControllerTest.php
@@ -51,11 +51,11 @@ class BackStatistiquesControllerTest extends WebTestCase
     {
         yield 'Super Admin' => ['back_statistiques_filter', [], self::USER_SUPER_ADMIN, [
             ['result' => 51, 'label' => 'count_signalement'],
-            ['result' => 54.7, 'label' => 'average_criticite'],
+            ['result' => 57.3, 'label' => 'average_criticite'],
         ]];
         yield 'Responsable Territoire' => ['back_statistiques_filter', [], self::USER_ADMIN_TERRITOIRE, [
             ['result' => 25, 'label' => 'count_signalement'],
-            ['result' => 88.4, 'label' => 'average_criticite'],
+            ['result' => 92, 'label' => 'average_criticite'],
         ]];
         yield 'Partner' => ['back_statistiques_filter', [], self::USER_PARTNER, [
             ['result' => 3, 'label' => 'count_signalement'],
@@ -69,7 +69,7 @@ class BackStatistiquesControllerTest extends WebTestCase
         ]];
         yield 'RT - filtered with commune Arles' => ['back_statistiques_filter', ['communes' => '["Arles"]'], self::USER_ADMIN_TERRITOIRE, [
             ['result' => 25, 'label' => 'count_signalement'],
-            ['result' => 88.4, 'label' => 'average_criticite'],
+            ['result' => 92, 'label' => 'average_criticite'],
             ['result' => 0, 'label' => 'count_signalement_filtered'],
             ['result' => 0, 'label' => 'average_criticite_filtered'],
         ]];

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -35,6 +35,7 @@ class SignalementControllerTest extends WebTestCase
         yield 'Archivé' => [SignalementStatus::ARCHIVED->value];
         yield 'Brouillon' => [SignalementStatus::DRAFT->value];
         yield 'Brouillon de signalement' => [SignalementStatus::DRAFT_ARCHIVED->value];
+        yield 'En médiation' => [SignalementStatus::EN_MEDIATION->value];
     }
 
     /**
@@ -98,7 +99,7 @@ class SignalementControllerTest extends WebTestCase
                 'Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.',
                 $crawler->filter('.fr-tile__detail')->text()
             );
-        } elseif (SignalementStatus::ACTIVE->value === $status) {
+        } elseif (SignalementStatus::ACTIVE->value === $status || SignalementStatus::EN_MEDIATION->value === $status) {
             $this->assertEquals('Votre dossier', $crawler->filter('h1')->text());
         } elseif (SignalementStatus::CLOSED->value === $status) {
             $this->assertEquals(
@@ -243,6 +244,8 @@ class SignalementControllerTest extends WebTestCase
             $this->assertEquals('Votre signalement a été archivé, vous ne pouvez plus envoyer de messages.', $crawler->filter('.fr-alert p')->text());
         } elseif (SignalementStatus::CLOSED->value === $status) {
             $this->assertEquals('Votre message suite à la clôture de votre dossier a bien été envoyé. Vous ne pouvez désormais plus envoyer de messages.', $crawler->filter('.fr-alert p')->text());
+        } elseif (SignalementStatus::EN_MEDIATION->value === $status) {
+            $this->assertEquals('Votre dossier est en médiation, vous ne pouvez pas envoyer de messages.', $crawler->filter('.fr-alert p')->text());
         } else {
             $this->assertResponseRedirects('/authentification/'.$signalement->getCodeSuivi());
         }

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -254,7 +254,7 @@ class SignalementRepositoryTest extends KernelTestCase
         $signalementsOnSameAddress = $signalementRepository->findOnSameAddress(
             $signalement,
             [],
-            [SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED, SignalementStatus::ARCHIVED]
+            SignalementStatus::excludedStatuses(),
         );
         $this->assertCount(1, $signalementsOnSameAddress);
 
@@ -449,14 +449,14 @@ class SignalementRepositoryTest extends KernelTestCase
                 ['isUserPartner' => true, 'isPartnerAdmin' => false, 'isTerritoryAdmin' => false, 'partners' => [], 'territories' => []],
                 ['statuses' => [SignalementStatus::ACTIVE->value], 'sortBy' => 'reference', 'orderBy' => 'ASC'],
                 ['LEFT JOIN s.affectations', 'LEFT JOIN a.partner', 's.id IN'],
-                ['statusList' => [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED]],
+                ['statusList' => SignalementStatus::excludedStatuses()],
             ],
             'Partner admin with bailleur' => [
                 ['isUserPartner' => false, 'isPartnerAdmin' => true, 'isTerritoryAdmin' => false, 'partners' => [], 'territories' => []],
                 ['bailleurSocial' => 'LOGEMENT1', 'statuses' => [SignalementStatus::ACTIVE->value]],
                 ['AND s.bailleur = :bailleur', 'LEFT JOIN s.affectations', 'DISTINCT IDENTITY(a2.signalement)'],
                 [
-                    'statusList' => [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED],
+                    'statusList' => SignalementStatus::excludedStatuses(),
                     'bailleur' => 'LOGEMENT1',
                     'partners' => new ArrayCollection([]),
                     'statut_affectation' => [SignalementStatus::ACTIVE->mapAffectationStatus()],
@@ -467,7 +467,7 @@ class SignalementRepositoryTest extends KernelTestCase
                 [],
                 ['s.territory IN (:territories)'],
                 [
-                    'statusList' => [SignalementStatus::ARCHIVED, SignalementStatus::DRAFT, SignalementStatus::DRAFT_ARCHIVED],
+                    'statusList' => SignalementStatus::excludedStatuses(),
                     'territories' => [1, 2],
                 ],
             ],


### PR DESCRIPTION
## Ticket

#4696

## Description
- Création d'un statut de signalement "EN_MEDIATION"
- Ajout d'un signalement avec ce statut dans les fixtures, il est ignoré de partout sauf pour la page FO d'accès au suivi du dossier.
- Correction/Simplification de certains appel de requêtes pour les stats ou l'on ignore toujours les signalement "ARCHIVED"
