### PR TITLE
[BO - Dashboard] Incohérence onglet A verifier et liste signalements

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2307,9 +2307,13 @@ class SignalementRepository extends ServiceEntityRepository
         }
 
         if ($params->queryCommune) {
-            $query = '%'.$params->queryCommune.'%';
-            $sql .= ' AND (si.cp_occupant LIKE :query OR si.ville_occupant LIKE :query)';
-            $paramsToBind['query'] = $query;
+            $listCity = [$params->queryCommune];
+            if (isset(CommuneHelper::COMMUNES_ARRONDISSEMENTS[$params->queryCommune])) {
+                $listCity = array_merge($listCity, CommuneHelper::COMMUNES_ARRONDISSEMENTS[$params->queryCommune]);
+            }
+            $sql .= ' AND (si.cp_occupant IN (:cities) OR si.ville_occupant IN (:cities))';
+            $paramsToBind['cities'] = $listCity;
+            $types['cities'] = ArrayParameterType::STRING;
         }
 
         if (!empty($excludedIds)) {


### PR DESCRIPTION
## Ticket

#4660   

## Description
Sur le dashbaord, sur une base de prod datant de fin juillet.
En SA, dans l'onglet A vérifier, je filtre sur Lyon, j'ai 170 dossiers

je clique sur Afficher la liste complète, j'ai 163 dossiers

Même problème pour toutes les villes avec arrondissements

## Changements apportés
* Modification de la requête côté dashboard pour utiliser `CommuneHelper::COMMUNES_ARRONDISSEMENTS` comme dans la liste de signalements

## Pré-requis
Se mettre sur une base de prod
## Tests
- [ ] Faire des tests de recherche sur des noms de commune, avec ou sans arrondissements sur le dashboard, et vérifier que le lien vers la liste complète affiche des résultats cohérents
