### PR TITLE
[BUG] Blocage des affectation synchronisés sur Oilhi 

### DIFF
--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -280,7 +280,7 @@ class Affectation implements EntityHistoryInterface
         if ((PartnerType::ARS === $this->getPartner()->getType()
             || PartnerType::COMMUNE_SCHS === $this->getPartner()->getType()
             || PartnerType::EPCI == $this->getPartner()->getType()
-        ) && $this->isSynchronized
+        ) && $this->isSynchronized && !$this->getPartner()->canSyncWithOilhi($this->getSignalement())
         ) {
             return true;
         }


### PR DESCRIPTION
## Ticket

#4709 

## Description
L’utilisation du même champ `isSynchronized` des affectations pour esabora et oilhi provoque un blocage des actions de changement de statuts sur celle concernées par oilhi (alors que c'est attendu uniquement pour celles concernant esabora)

## Changements apportés
* Exclusion du blocage pour les affectations concerné par oilhi

## Tests
- [ ] Sur base de prod se connecter avec l'agent cité dans le message https://mattermost.incubateur.net/betagouv/pl/fextshmjgirkxmiw6h7jwumw8c et voir que ses actions sur les affectation ne sont pas bloqué
