### PR TITLE
[BUG] Partenaire enregistré sur le suivi AFFECTATION_IS_ACCEPTED

### DIFF
--- a/migrations/Version20251006193044.php
+++ b/migrations/Version20251006193044.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251006193044 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set partner_id to NULL for Suivi entries with category AFFECTATION_IS_ACCEPTED';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE suivi SET partner_id = NULL WHERE category = 'AFFECTATION_IS_ACCEPTED'");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/EventSubscriber/AffectationAnsweredSubscriber.php
+++ b/src/EventSubscriber/AffectationAnsweredSubscriber.php
@@ -5,7 +5,6 @@ namespace App\EventSubscriber;
 use App\Entity\Affectation;
 use App\Entity\Enum\AffectationStatus;
 use App\Entity\Enum\SuiviCategory;
-use App\Entity\Partner;
 use App\Entity\Suivi;
 use App\Event\AffectationAnsweredEvent;
 use App\Factory\Interconnection\Idoss\DossierMessageFactory;
@@ -74,14 +73,14 @@ readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
                 isPublic: $affectation->getHasNotificationUsagerToCreate(),
             );
         }
-        $this->createSuiviOnFirstAcceptedAffectation($event->getAffectation(), $event->getPartner());
+        $this->createSuiviOnFirstAcceptedAffectation($event->getAffectation());
 
         if ($this->dossierMessageFactory->supports($affectation)) {
             $this->bus->dispatch($this->dossierMessageFactory->createInstance($affectation));
         }
     }
 
-    private function createSuiviOnFirstAcceptedAffectation(Affectation $affectation, Partner $partner): void
+    private function createSuiviOnFirstAcceptedAffectation(Affectation $affectation): void
     {
         if ($this->firstAcceptedAffectationSpecification->isSatisfiedBy($affectation)) {
             $adminEmail = $this->parameterBag->get('user_system_email');
@@ -91,7 +90,6 @@ readonly class AffectationAnsweredSubscriber implements EventSubscriberInterface
                 description: $this->parameterBag->get('suivi_message')['first_accepted_affectation'],
                 type: Suivi::TYPE_AUTO,
                 category: SuiviCategory::AFFECTATION_IS_ACCEPTED,
-                partner: $partner,
                 user: $adminUser,
                 isPublic: true,
                 context: Suivi::CONTEXT_NOTIFY_USAGER_ONLY,


### PR DESCRIPTION
## Ticket

#4711

## Description
Suite à l'enregistrement des partenaire sur les suivi, on à aussi enregistré celui générant le message de validation de la première affectation. Hors dans ce cas la l'information n'est pas pertinente et l'usager ne doit pas en avoir connaissance.
- Migration pour corriger les suivi de la catégorie AFFECTATION_IS_ACCEPTED
- Modification du code de création des suivi de cette catégorie pour laisse le partner null 

<img width="2868" height="368" alt="Screenshot 2025-10-06 at 21-42-47 #2025-2543 Signalement - Signal-Logement" src="https://github.com/user-attachments/assets/77701383-9355-44f8-9242-926cef7b088f" />

## Tests
- [ ] Jouer la migration sur base de prod et vérifier les suivi de premiere acceptation récent
- [ ] Accepter une premier affectation et vérifier qu'aucun partenaire n'est enregistré
