### PR TITLE
[QA] L'API retourne le code insee de la ville pour le 1er arrondissement de Marseille et Lyon

### DIFF
--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -321,6 +321,7 @@ class SignalementController extends AbstractController
         CommuneRepository $communeRepository,
     ): JsonResponse {
         $postalCode = $request->get('cp');
+        $inseeCode = $request->get('insee');
         if (empty($postalCode)) {
             return $this->json([
                 'success' => false,
@@ -329,7 +330,8 @@ class SignalementController extends AbstractController
             ]);
         }
 
-        $inseeCode = $request->get('insee');
+        $inseeCode = $postalCodeHomeChecker->normalizeInseeCode($postalCode, $inseeCode);
+
         if (!empty($inseeCode)) {
             $commune = $communeRepository->findOneBy(['codePostal' => $postalCode, 'codeInsee' => $inseeCode]);
             if (!$commune) {

--- a/src/Service/Signalement/PostalCodeHomeChecker.php
+++ b/src/Service/Signalement/PostalCodeHomeChecker.php
@@ -53,4 +53,17 @@ class PostalCodeHomeChecker
 
         return false;
     }
+
+    public function normalizeInseeCode(string $postalCode, string $inseeCode): string
+    {
+        // Exception that returns city code insee for Marseille and Lyon
+        // https://data.geopf.fr/geocodage/search/?q=13001%20Marseille
+        // https://data.geopf.fr/geocodage/search/?q=69001%20Lyon
+        $postalCodeInseeMapping = [
+            '13001' => ['13055' => '13201'],
+            '69001' => ['69123' => '69381'],
+        ];
+
+        return $postalCodeInseeMapping[$postalCode][$inseeCode] ?? $inseeCode;
+    }
 }

--- a/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
+++ b/tests/Functional/Service/Signalement/PostalCodeHomeCheckerTest.php
@@ -69,4 +69,11 @@ class PostalCodeHomeCheckerTest extends KernelTestCase
         $territory->setAuthorizedCodesInsee(['69091']);
         $this->assertFalse($this->postalCodeHomeChecker->isAuthorizedInseeCode($territory, '69092'));
     }
+
+    public function normalizeInseeCode(): void
+    {
+        $this->assertEquals('13201', $this->postalCodeHomeChecker->normalizeInseeCode('13001', '13055'));
+        $this->assertEquals('69381', $this->postalCodeHomeChecker->normalizeInseeCode('69001', '69381'));
+        $this->assertEquals('13202', $this->postalCodeHomeChecker->normalizeInseeCode('13002', '13202'));
+    }
 }


### PR DESCRIPTION
## Ticket

#4690   

## Description
Gérer l'exception pour les 1er arrondissement de Marseille et Lyon

## Changements apportés
* Ajout d'une fonction de normalisation des cas particulier de codes INSEE dans le service  `PostalCodeHomeChecker`

## Pré-requis

## Tests
- [ ] Exécuter le WS http://localhost:8080/checkterritory?cp=13001&insee=13055, doit retourner true
- [ ] Exécuter le WS http://localhost:8080/checkterritory?cp=69001&insee=69123, doit retourner true
- [ ] TNR sur des couples cp/insee valide
- [ ] TNR sur des couples cp/insee non valide