### PR TITLE
[BO - Suivis] Ajustement de l'espace vertical avant des listes à puces

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -677,6 +677,11 @@ p + ul {
 ul + p {
     margin-top: 1.5rem;
 }
+.bloc-suivi-content-row {
+    p + ul {
+        margin-top: 0.5rem;
+    }
+}
 
 .faq-redirection {
     position: fixed;


### PR DESCRIPTION
## Ticket

#4721   

## Description
Quand on avait fait des pages front de contenu FAQ, on avait ajouté une règle générale pour les listes à puces. Cette règle reste  d'actualité pour d'autres parties comme les CGU.
Mais la règle crée un affichage bizarre dans le bo quand on ajoute des puces dans les suivis. 

## Changements apportés
* Ajout d'une règle spécifique pour les suivis

## Tests
- [ ] Vérifier l'affichage des listes dans les CGU
- [ ] Ajouter un suivi avec des puces et vérifier l'affichage
