### PR TITLE
[BO - Visite] Rappel envoyé malgré clôture

### DIFF
--- a/src/DataFixtures/Files/Intervention.yml
+++ b/src/DataFixtures/Files/Intervention.yml
@@ -105,3 +105,9 @@ interventions:
       arrete_date: "2025-01-12"
       arrete_type: "Arrêté L.511-12 - Suroccupation"
       arrete_numero: "123456789"
+  -
+    signalement: "2022-3"
+    partner: "partenaire-13-01@signal-logement.fr"
+    user: "admin-partenaire-13-01@signal-logement.fr"
+    scheduled_at: '+2 days'
+    status: 'PLANNED'

--- a/src/Service/Mailer/Mail/Cron/CronMailer.php
+++ b/src/Service/Mailer/Mail/Cron/CronMailer.php
@@ -41,7 +41,7 @@ class CronMailer extends AbstractNotificationMailer
     {
         $this->mailerSubject = \sprintf(
             self::MAILER_SUBJECT,
-            isset($notificationMail->getParams()['error_messages']) && $notificationMail->getParams()['error_messages'] > 0 ?
+            isset($notificationMail->getParams()['error_messages']) && \count($notificationMail->getParams()['error_messages']) > 0 ?
                 's\'est arrêtée en erreur' :
                 's\'est bien exécutée'
         );

--- a/tests/Functional/Command/NotifyVisitsCommandTest.php
+++ b/tests/Functional/Command/NotifyVisitsCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Command;
 
+use Symfony\Bridge\Twig\Mime\NotificationEmail;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -26,5 +27,13 @@ class NotifyVisitsCommandTest extends KernelTestCase
         $this->assertEmailSubjectContains($this->getMailerMessages()[1], '2024-02');
         $this->assertEmailSubjectContains($this->getMailerMessages()[4], '2022-6');
         $this->assertEmailSubjectContains($this->getMailerMessages()[6], '2023-26');
+        /** @var NotificationEmail $message */
+        foreach ($this->getMailerMessages() as $message) {
+            $subject = $message->getSubject();
+            $body = $message->getHtmlBody();
+
+            $this->assertStringNotContainsString('2022-3', $subject, 'Aucun mail ne doit être envoyé pour le signalement fermé 2022-3');
+            $this->assertStringNotContainsString('2022-3', $body, 'Aucun mail ne doit être envoyé pour le signalement fermé 2022-3');
+        }
     }
 }

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -64,7 +64,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Date de depot' => [['dateDepotDebut' => '2023-03-08', 'dateDepotFin' => '2023-03-16', 'isImported' => 'oui'], 2];
         yield 'Search by Procédure estimée' => [['procedure' => 'rsd', 'isImported' => 'oui'], 7];
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
-        yield 'Search by Statut de la visite "Planifié"' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 4];
+        yield 'Search by Statut de la visite "Planifié"' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 5];
         yield 'Search by Statut de la visite "Conclusion à renseigner"' => [['visiteStatus' => 'Conclusion à renseigner', 'isImported' => 'oui'], 1];
         yield 'Search by Statut de la visite "Terminé"' => [['visiteStatus' => 'Terminée', 'isImported' => 'oui'], 6];
         yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 6];

--- a/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
+++ b/tests/Unit/Command/Cron/SynchronizeInterventionSISHCommandTest.php
@@ -12,6 +12,7 @@ use App\Service\Interconnection\Esabora\Handler\InterventionArreteServiceHandler
 use App\Service\Interconnection\Esabora\Handler\InterventionVisiteServiceHandler;
 use App\Service\Mailer\NotificationMailerRegistry;
 use App\Tests\FixturesHelper;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -27,15 +28,20 @@ class SynchronizeInterventionSISHCommandTest extends KernelTestCase
         $kernel = self::bootKernel();
         $application = new Application($kernel);
 
+        /** @var MockObject&EsaboraManager $esaboraManagerMock */
         $esaboraManagerMock = $this->createMock(EsaboraManager::class);
+        /** @var MockObject&SerializerInterface $serializerMock */
         $serializerMock = $this->createMock(SerializerInterface::class);
+        /** @var MockObject&AffectationRepository $affectationRepositoryMock */
         $affectationRepositoryMock = $this->createMock(AffectationRepository::class);
+        /** @var MockObject&JobEventRepository $jobEventRepositoryMock */
         $jobEventRepositoryMock = $this->createMock(JobEventRepository::class);
         $jobEventRepositoryMock
             ->expects($this->once())
             ->method('getReportEsaboraAction')
             ->willReturn(['success_count' => 4, 'failed_count' => 2]);
 
+        /** @var MockObject&JobEventManager $jobEventManagerMock */
         $jobEventManagerMock = $this->createMock(JobEventManager::class);
         $jobEventManagerMock->expects($this->once())->method('getRepository')->willReturn($jobEventRepositoryMock);
 


### PR DESCRIPTION
## Ticket

#4719   

## Description
Modification de la commande d'envoi des notifications de visites pour n'en envoyer que si le signalement est au statut en cours

## Changements apportés
* LModification de la commande
* Ajout de test

## Pré-requis
`make load-fixtures`

## Tests
- [ ] C/I ok
- [ ] Créer une intervention sur un signalement dans 2 jours
- [ ] Faire la même chose sur un autre signalement
- [ ] Fermer un des 2 signalements
- [ ] Lancer la commande `make console app="notify-visits"` et vérifier que les mails ne sont pas envoyés au signalement fermé, mais bien à celui qui est ouvert
