### PR TITLE
[Gestion par agents - UI] Limiter l'affichage du nombre d'abonnées sur la fiche signalement

### DIFF
--- a/templates/back/signalement/view/affectation/_subscriptions-list.html.twig
+++ b/templates/back/signalement/view/affectation/_subscriptions-list.html.twig
@@ -11,15 +11,14 @@
 </ul>
 
 {% if remainingCount > 0 %}
-    <p>
-        <button
-            class="fr-link"
-            data-fr-opened="false"
-            aria-controls="modal-agents-subscriptions"
-        >
-            + {{ remainingCount }} agent{{ remainingCount > 1 ? 's' }}
-        </button>
-    </p>
+
+    <button
+        class="fr-link"
+        data-fr-opened="false"
+        aria-controls="modal-agents-subscriptions"
+    >
+        + {{ remainingCount }} agent{{ remainingCount > 1 ? 's' }}
+    </button>
 
     <dialog id="modal-agents-subscriptions" class="fr-modal" role="dialog" aria-labelledby="modal-title-agents">
         <div class="fr-container fr-container--fluid fr-container-md">


### PR DESCRIPTION
## Ticket

#4733   

## Description
on en affiche 3 et une info "+ XX autres" cliquable pour que ce soit visible en modale

## Changements apportés
* Changement du twig

## Pré-requis

## Tests
- [ ] Affecter un partenaire avec plus de 3 agents sur un signalement, et un deuxième partenaire
- [ ] Se connecter avec un des agents de ce partenaire, accepter l'affectation en abonnant tous les agents
- [ ] Vérifier l'affichage
- [ ] Se connecter avec un agent du 2è partenaire, et accepter l'affectation en abonnant 3 ou moins agents
- [ ] Vérifier l'affichage (pas de lien et pas de modale)
