### PR TITLE
[BO - Liste signalements] Erreur sur le filtre relancesUsager=NO_SUIVI_AFTER_3_RELANCES

### DIFF
--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -325,7 +325,6 @@ class SuiviRepository extends ServiceEntityRepository
 
         $parameters = [
             'category_ask_feedback' => SuiviCategory::ASK_FEEDBACK_SENT->value,
-            'status_need_validation' => SignalementStatus::NEED_VALIDATION->value,
             'status_active' => SignalementStatus::ACTIVE->value,
             'nb_suivi_technical' => 2,
         ];
@@ -349,7 +348,6 @@ class SuiviRepository extends ServiceEntityRepository
         $connection = $this->getEntityManager()->getConnection();
         $parameters = [
             'category_ask_feedback' => SuiviCategory::ASK_FEEDBACK_SENT->value,
-            'status_need_validation' => SignalementStatus::NEED_VALIDATION->value,
             'status_active' => SignalementStatus::ACTIVE->value,
             'nb_suivi_technical' => 3,
         ];

--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -196,9 +196,7 @@ class SearchFilter
             if (\in_array('NO_SUIVI_AFTER_3_RELANCES', $filters['relances_usager'])) {
                 $connection = $this->entityManager->getConnection();
                 $parameters = [
-                    'day_period' => 0,
                     'category_ask_feedback' => SuiviCategory::ASK_FEEDBACK_SENT->value,
-                    'status_need_validation' => SignalementStatus::NEED_VALIDATION->value,
                     'status_active' => SignalementStatus::ACTIVE->value,
                     'nb_suivi_technical' => 3,
                 ];


### PR DESCRIPTION
## Ticket

#4739   

## Description
Erreur sur la liste de signalements si on passe par l'ancien dashboard et le widget "suggestions de clôture"

## Changements apportés
* Correction des paramètres bindés à la requête créée par SuiviRepository->getSignalementsLastAskFeedbackSuivisQuery()

## Pré-requis
`FEATURE_NEW_DASHBOARD=0`
## Tests
- [ ] Avec différents rôles (SA, RT et agent), tester l'affichage de la liste de signalements depuis le widget "suggestions de clôture" de l'ancien dashboard (vérifier le compteur sur le widget et l'affichage de la liste des signalements)
- [ ] TNR sur la commande `ask-feedback-usager`
