### PR TITLE
[QA] Améliorer performance filtres connexions SI externes

### DIFF
--- a/migrations/Version20251014151542.php
+++ b/migrations/Version20251014151542.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251014151542 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout des index composites pour accélérer les requêtes JobEvent / Partner';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_job_event_created_at_partner_id ON job_event (created_at, partner_id)');
+        $this->addSql('CREATE INDEX idx_partner_territory_id ON partner (territory_id)');
+        $this->addSql('CREATE INDEX idx_job_event_status_created_at ON job_event (status, created_at)');
+        $this->addSql('CREATE INDEX idx_job_event_service_action_created_at ON job_event (service, action, created_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_job_event_created_at_partner_id ON job_event');
+        $this->addSql('DROP INDEX idx_partner_territory_id ON partner');
+        $this->addSql('DROP INDEX idx_job_event_status_created_at ON job_event');
+        $this->addSql('DROP INDEX idx_job_event_service_action_created_at ON job_event');
+    }
+}

--- a/src/Entity/JobEvent.php
+++ b/src/Entity/JobEvent.php
@@ -13,6 +13,9 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['created_at'], name: 'idx_job_event_created_at')]
 #[ORM\Index(columns: ['partner_id'], name: 'idx_job_event_partner_id')]
 #[ORM\Index(columns: ['service'], name: 'idx_job_event_service')]
+#[ORM\Index(columns: ['created_at', 'partner_id'], name: 'idx_job_event_created_at_partner_id')]
+#[ORM\Index(columns: ['status', 'created_at'], name: 'idx_job_event_status_created_at')]
+#[ORM\Index(columns: ['service', 'action', 'created_at'], name: 'idx_job_event_service_action_created_at')]
 class JobEvent
 {
     use TimestampableTrait;

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -20,6 +20,7 @@ use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: PartnerRepository::class)]
+#[ORM\Index(columns: ['territory_id'], name: 'idx_partner_territory_id')]
 #[ORM\HasLifecycleCallbacks()]
 #[UniqueEntity(
     fields: ['email', 'territory', 'isArchive'],

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -84,11 +84,19 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
             || !$count;
 
         if ($needsPartnerJoin) {
-            $qb->leftJoin(Partner::class, 'p', 'WITH', 'p.id = j.partnerId');
+            $joinType = ($searchInterconnexion->getTerritory() || $searchInterconnexion->getPartner())
+                ? 'innerJoin'
+                : 'leftJoin';
+
+            $qb->{$joinType}(Partner::class, 'p', 'WITH', 'p.id = j.partnerId');
         }
 
         if ($needsSignalementJoin) {
-            $qb->leftJoin(Signalement::class, 's', 'WITH', 's.id = j.signalementId');
+            $joinType = $searchInterconnexion->getReference()
+                ? 'innerJoin'
+                : 'leftJoin';
+
+            $qb->{$joinType}(Signalement::class, 's', 'WITH', 's.id = j.signalementId');
         }
 
         if ($searchInterconnexion->getTerritory()) {


### PR DESCRIPTION
## Ticket

#4650   

## Description
Ajout d'index et changement de jointures dans la requête pour améliorer les performances des recherches dans la page SA Connexions SI externes


| **Cas de test** | **Avant modifs (ms)** | **Après modifs (ms)** | **Gain / Observation** |
|------------------|------------------------|------------------------|------------------------|
| Sans filtre | 186.98 | 137.73 ms | ~identique |
| Territoire `13` | 5442.56 | **290.62 ms** |  gain grâce à l’`INNER JOIN` partenaire et à l'index |
| Référence `2025-201` | 13125.60 | **8318.54** | amélioration sensible (join signalement) |
| Partenaire `ARS44` | 50.42 | 48.20 | inchangé (filtre très sélectif déjà performant) |
| Statut `success` | 5829.56 | **271.94 ms** |  forte progression grâce à l'index composite status+created_at|
| Action `esabora push_dossier` | 5206.95 | **0.94 ms** |   forte progression grâce à l'index composite action+service+created_at |
| Référence `2025-201` + Statut `failed` | 5888.90 | **133.15 ms** | forte amélioration grâce au `INNER JOIN` signalement et à l'index composite status+created_at|

## Pré-requis
`make load-migrations`

## Tests
- [ ] Sur base de prod, tester la page avec différents filtres
