### PR TITLE
[BO - Dashboard - Nouveaux dossiers] Signalements statut "Nouveau" non affichés sur le dashboard RT

### DIFF
--- a/src/Service/DashboardTabPanel/TabDataManager.php
+++ b/src/Service/DashboardTabPanel/TabDataManager.php
@@ -209,10 +209,14 @@ class TabDataManager
         ?TabQueryParameters $tabQueryParameters = null,
         array $territoires = [],
     ): TabDossierResult {
-        $tabQueryParameters = $this->initTabQueryParametersPartenairesId(
-            $tabQueryParameters,
-            $territoires,
-        );
+        /** @var User $user */
+        $user = $this->security->getUser();
+        if (!$user->isSuperAdmin() && !$user->isTerritoryAdmin()) {
+            $tabQueryParameters = $this->initTabQueryParametersPartenairesId(
+                $tabQueryParameters,
+                $territoires,
+            );
+        }
 
         $dossiers = $this->signalementRepository->findNewDossiersFrom(
             signalementStatus: $signalementStatus,


### PR DESCRIPTION
## Ticket

#4763   

## Description
Je suis RT du 06
Je vais sur mon tableau de bord
Sur l'onglet "Nouveaux dossiers", il est indiqué 7 sur l'onglet
Hors, à l'intérieur de l'onglet, je n'ai que 4 dossiers

## Changements apportés
* Correction de `TabDataManager->getNouveauxDossiersWithCount()` pour ajouter un partenaire au TabQueryParameter seulement pour les agents, car cela n'a pas de sens de filtrer sur l'affectation pour les RT et les SA

## Pré-requis

## Tests
- [ ] Tester l'onglet `Nouveaux dossiers` avec différents rôles, et valider l'affichage, les compteurs en fonction de la liste de signalement
