### PR TITLE
[BO - Formulaire pro] Correction de la complétion des adresses en cas de retour d'erreur

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -1,4 +1,5 @@
 import { initSearchAndSelectBadges } from '../../services/component/component_search_and_select_badges';
+import { attacheAutocompleteAddressEvents } from '../../services/component/component_search_address';
 
 let boFormSignalementCurrentTabIsDirty = false;
 let boFormNeedRefreshValidationTab = true;
@@ -124,6 +125,7 @@ function saveCurrentTab(event) {
               errorAlertStr +
               document.querySelector('#tabpanel-' + currentTabName + '-panel').innerHTML;
           }
+          attacheAutocompleteAddressEvents();
         }
         initBoFormSignalementSubmit(currentTabName);
       });

--- a/assets/scripts/vanilla/services/component/component_search_address.js
+++ b/assets/scripts/vanilla/services/component/component_search_address.js
@@ -1,9 +1,12 @@
-if (document.querySelector('[data-fr-adresse-autocomplete]')) {
-  attachAutocompleteClickOutsideEvent();
+export function attacheAutocompleteAddressEvents() {
+  if (document.querySelector('[data-fr-adresse-autocomplete]')) {
+    attachAutocompleteClickOutsideEvent();
+  }
+  document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdresse) => {
+    attacheAutocompleteAddressEvent(inputAdresse);
+  });
 }
-document.querySelectorAll('[data-fr-adresse-autocomplete]').forEach((inputAdresse) => {
-  attacheAutocompleteAddressEvent(inputAdresse);
-});
+attacheAutocompleteAddressEvents();
 
 document
   .querySelector('#form-edit-address-adresse')


### PR DESCRIPTION
## Ticket

#4734   

## Description
Dans le formulaire pro, en cas d'erreur (et rechargement d'onglet), la saisie d'adresse avec auto-complétion était bloquée.

## Changements apportés
* Re-déclaration de l'événement pour le champ de saisie d'adresse

## Pré-requis
`npm run watch`

## Tests
- [ ] Saisir une adresse, puis valider l'écran (sans répondre aux autres questions), puis après rechargement saisir une autre adresse
