### PR TITLE
[QA - BUG] Call to a member function getLabelCritere() on null

### DIFF
--- a/src/Service/SuiviTransformerService.php
+++ b/src/Service/SuiviTransformerService.php
@@ -7,6 +7,7 @@ use App\Entity\Enum\DocumentType;
 use App\Repository\DesordreCritereRepository;
 use CoopTilleuls\UrlSignerBundle\UrlSigner\UrlSignerInterface;
 use Doctrine\Common\Collections\Collection;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SuiviTransformerService
@@ -15,6 +16,7 @@ class SuiviTransformerService
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly UrlSignerInterface $urlSigner,
         private readonly DesordreCritereRepository $desordreCritereRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -67,7 +69,12 @@ class SuiviTransformerService
                         if (!$desordreCritere) {
                             $desordreCritere = $this->desordreCritereRepository->findOneBy(['slugCategorie' => $suiviFile->getFile()->getDesordreSlug()]);
                         }
-                        $description .= ' <small>('.$suiviFile->getFile()->getDocumentType()->label().' - '.$desordreCritere->getLabelCritere().')</small>';
+                        if ($desordreCritere) {
+                            $description .= ' <small>('.$suiviFile->getFile()->getDocumentType()->label().' - '.$desordreCritere->getLabelCritere().')</small>';
+                        } else {
+                            $this->logger->error(\sprintf('$desordreCritere not found with slugCritere or slugCategorie = %s', $suiviFile->getFile()->getDesordreSlug()));
+                            $description .= ' <small>('.$suiviFile->getFile()->getDocumentType()->label().' - désordre non défini)</small>';
+                        }
                     } else {
                         $description .= ' <small>('.$suiviFile->getFile()->getDocumentType()->label().')</small>';
                     }


### PR DESCRIPTION
## Ticket

#4773

## Description
Dans certains cas le champ `desordreSlug` des `File` contient le `slugCategorie` au lieu du `slugCritere`, il faut donc chercher dans les deux valeur sous peine de provoquer un crash quand `SuiviTransformerService` est appelé 

## Tests
- [ ] Ajouter un suivi a un signalement en y liant un fichier qui a "desordres_logement_humidite" dans `desordreSlug` et voir que tout s'affiche correctement
