### PR TITLE
[Tech - Suppression de code] Supprimer les tables signalement_critere et signalement_situation

### DIFF
--- a/migrations/Version20251017140959.php
+++ b/migrations/Version20251017140959.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251017140959 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove signalement_critere and signalement_situation tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE signalement_critere DROP FOREIGN KEY FK_81C2C8A79E5F45AB');
+        $this->addSql('ALTER TABLE signalement_critere DROP FOREIGN KEY FK_81C2C8A765C5E57E');
+        $this->addSql('ALTER TABLE signalement_situation DROP FOREIGN KEY FK_E4FA89793408E8AF');
+        $this->addSql('ALTER TABLE signalement_situation DROP FOREIGN KEY FK_E4FA897965C5E57E');
+        $this->addSql('DROP TABLE signalement_critere');
+        $this->addSql('DROP TABLE signalement_situation');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE signalement_critere (signalement_id INT NOT NULL, critere_id INT NOT NULL, INDEX IDX_81C2C8A765C5E57E (signalement_id), INDEX IDX_81C2C8A79E5F45AB (critere_id), PRIMARY KEY(signalement_id, critere_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        $this->addSql('CREATE TABLE signalement_situation (signalement_id INT NOT NULL, situation_id INT NOT NULL, INDEX IDX_E4FA89793408E8AF (situation_id), INDEX IDX_E4FA897965C5E57E (signalement_id), PRIMARY KEY(signalement_id, situation_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        $this->addSql('ALTER TABLE signalement_critere ADD CONSTRAINT FK_81C2C8A79E5F45AB FOREIGN KEY (critere_id) REFERENCES critere (id) ON UPDATE NO ACTION ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE signalement_critere ADD CONSTRAINT FK_81C2C8A765C5E57E FOREIGN KEY (signalement_id) REFERENCES signalement (id) ON UPDATE NO ACTION ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE signalement_situation ADD CONSTRAINT FK_E4FA89793408E8AF FOREIGN KEY (situation_id) REFERENCES situation (id) ON UPDATE NO ACTION ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE signalement_situation ADD CONSTRAINT FK_E4FA897965C5E57E FOREIGN KEY (signalement_id) REFERENCES signalement (id) ON UPDATE NO ACTION ON DELETE CASCADE');
+    }
+}

--- a/src/DataFixtures/Files/Signalement.yml
+++ b/src/DataFixtures/Files/Signalement.yml
@@ -34,14 +34,6 @@ signalements:
     usager_abandon_procedure: 1
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      -  "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -81,14 +73,6 @@ signalements:
     territory: "Ain"
     tags:
       - "Peril"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -126,14 +110,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -171,14 +147,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -216,14 +184,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -260,14 +220,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -303,14 +255,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -348,14 +292,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -392,14 +328,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -436,14 +364,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -480,14 +400,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -526,14 +438,6 @@ signalements:
     territory: "Ain"
     tags:
       - "Peril"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -572,14 +476,6 @@ signalements:
     territory: "Ain"
     tags:
       - "Peril"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -619,14 +515,6 @@ signalements:
     territory: "Ain"
     tags:
       - "Peril"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -665,8 +553,6 @@ signalements:
     territory: "Ain"
     is_imported: true
     tags: []
-    situations: []
-    criteres: []
     criticites: []
   -
     uuid: "00000000-0000-0000-2023-000000000002"
@@ -701,8 +587,6 @@ signalements:
     nb_occupants_logement: 2
     territory: "Rhône"
     tags: []
-    situations: []
-    criteres: []
     criticites: []
   -
     uuid: "00000000-0000-0000-2023-000000000003"
@@ -736,8 +620,6 @@ signalements:
     nb_occupants_logement: 2
     territory: "Métropole de Lyon"
     tags: []
-    situations: []
-    criteres: []
     criticites: []
   -
     uuid: "00000000-0000-0000-2023-000000000004"
@@ -771,8 +653,6 @@ signalements:
     nb_occupants_logement: 2
     territory: "Métropole de Lyon"
     tags: []
-    situations: []
-    criteres: []
     criticites: []
   -
     uuid: "00000000-0000-0000-2023-000000000005"
@@ -806,8 +686,6 @@ signalements:
     nb_occupants_logement: 2
     territory: "Rhône"
     tags: []
-    situations: []
-    criteres: []
     criticites: []
   -
     uuid: "00000000-0000-0000-2023-000000000006"
@@ -841,14 +719,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -885,12 +755,6 @@ signalements:
     nb_occupants_logement: 2
     territory: "Yonne"
     tags: []
-    situations:
-      - "le confort du logement"
-      - "le confort du logement"
-    criteres:
-      - "Mon logement est mal isolé."
-      - "J’utilise un appareil d'appoint pour le chauffage."
     criticites:
       - "Le DPE indique une étiquette énergie F ou G ou n’a pas été fait. J’ai tout le temps la sensation d'avoir froid en hiver et/ou très chaud en été."
       - "J’utilise plusieurs chauffages d'appoint et/ou des pièces principales ne possèdent pas de moyen de chauffage."
@@ -929,12 +793,6 @@ signalements:
     nb_occupants_logement: 2
     territory: "Puy-de-Dôme"
     tags: []
-    situations:
-      - "le confort du logement"
-      - "le confort du logement"
-    criteres:
-      - "Mon logement est mal isolé."
-      - "J’utilise un appareil d'appoint pour le chauffage."
     criticites:
       - "Le DPE indique une étiquette énergie F ou G ou n’a pas été fait. J’ai tout le temps la sensation d'avoir froid en hiver et/ou très chaud en été."
       - "J’utilise plusieurs chauffages d'appoint et/ou des pièces principales ne possèdent pas de moyen de chauffage."
@@ -973,12 +831,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "l'état du bâtiment"
-      - "le confort du logement"
-    criteres:
-      - "Les murs et plafonds intérieurs sont mal entretenus"
-      - "J'ai un problème de ventilation dans mon logement."
     criticites:
       - "la peinture est sale et non entretenue."
       - "il n’y a pas de ventilation dans au moins deux pièces parmi : les WC, la salle de bain et la cuisine."
@@ -1014,12 +866,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "l'état du bâtiment"
-      - "le confort du logement"
-    criteres:
-      - "Les murs et plafonds intérieurs sont mal entretenus"
-      - "J'ai un problème de ventilation dans mon logement."
     criticites:
       - "la peinture est sale et non entretenue."
       - "il n’y a pas de ventilation dans au moins deux pièces parmi : les WC, la salle de bain et la cuisine."
@@ -1058,12 +904,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "l'état du bâtiment"
-      - "le confort du logement"
-    criteres:
-      - "Les murs et plafonds intérieurs sont mal entretenus"
-      - "J'ai un problème de ventilation dans mon logement."
     criticites:
       - "la peinture est sale et non entretenue."
       - "il n’y a pas de ventilation dans au moins deux pièces parmi : les WC, la salle de bain et la cuisine."
@@ -1103,14 +943,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1151,14 +983,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1200,14 +1024,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1245,14 +1061,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1290,14 +1098,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1336,14 +1136,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1381,14 +1173,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1427,14 +1211,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1474,14 +1250,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-      - "la sécurité des occupants"
-      - "l'état et propreté du logement"
-    criteres:
-      - "Les déchets sont mal stockés."
-      - "La protection incendie n’est pas adaptée."
-      - "Les sols sont humides."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
       - "il n’y a pas de détecteur OU l’évacuation du logement est complexe (une seule sortie étroite, étage élevé, absence de fenêtre, escalier peu praticable…)."
@@ -1522,10 +1290,6 @@ signalements:
     territory: "Bouches-du-Rhône"
     tags:
       - "Urgent"
-    situations:
-      - "la vie commune et le voisinage"
-    criteres:
-      - "Les déchets sont mal stockés."
     criticites:
       - "les déchets ne peuvent être stockés nulle part. Il y a des ordures stockées n’importe où à l'intérieur ou à l'extérieur du bâtiment."
   -
@@ -1713,12 +1477,6 @@ signalements:
     is_rsa: 0
     nb_occupants_logement: 4
     territory: "Pas-de-Calais"
-    situations:
-      - "le confort du logement"
-    criteres:
-      - "De l’air s’infiltre dans mon logement."
-      - "Mes factures de chauffage sont anormalement élevées."
-      - "Mon logement est mal isolé."
     criticites:
       - "Infiltration ou fuite d'air dans plus de deux des éléments suivants : toit, charpente, façades, murs extérieurs. Sensation de courant d'air régulière ou très fréquente."
       - "Ma facture est trop élevée et le chauffage est limité dans le logement."
@@ -1754,12 +1512,6 @@ signalements:
     is_rsa: 0
     nb_occupants_logement: 4
     territory: "Bouches-du-Rhône"
-    situations:
-      - "le confort du logement"
-    criteres:
-      - "De l’air s’infiltre dans mon logement."
-      - "Mes factures de chauffage sont anormalement élevées."
-      - "Mon logement est mal isolé."
     criticites:
       - "Infiltration ou fuite d'air dans plus de deux des éléments suivants : toit, charpente, façades, murs extérieurs. Sensation de courant d'air régulière ou très fréquente."
       - "Ma facture est trop élevée et le chauffage est limité dans le logement."
@@ -1793,12 +1545,6 @@ signalements:
     is_rsa: 0
     nb_occupants_logement: 4
     territory: "Seine-Saint-Denis"
-    situations:
-      - "le confort du logement"
-    criteres:
-      - "De l’air s’infiltre dans mon logement."
-      - "Mes factures de chauffage sont anormalement élevées."
-      - "Mon logement est mal isolé."
     criticites:
       - "Infiltration ou fuite d'air dans plus de deux des éléments suivants : toit, charpente, façades, murs extérieurs. Sensation de courant d'air régulière ou très fréquente."
       - "Ma facture est trop élevée et le chauffage est limité dans le logement."

--- a/src/DataFixtures/Loader/LoadSignalementData.php
+++ b/src/DataFixtures/Loader/LoadSignalementData.php
@@ -23,11 +23,9 @@ use App\Factory\Signalement\SituationFoyerFactory;
 use App\Factory\Signalement\TypeCompositionLogementFactory;
 use App\Manager\UserManager;
 use App\Repository\BailleurRepository;
-use App\Repository\CritereRepository;
 use App\Repository\CriticiteRepository;
 use App\Repository\DesordrePrecisionRepository;
 use App\Repository\SignalementDraftRepository;
-use App\Repository\SituationRepository;
 use App\Repository\TagRepository;
 use App\Repository\TerritoryRepository;
 use App\Repository\UserRepository;
@@ -43,8 +41,6 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
     public function __construct(
         private readonly TerritoryRepository $territoryRepository,
         private readonly BailleurRepository $bailleurRepository,
-        private readonly SituationRepository $situationRepository,
-        private readonly CritereRepository $critereRepository,
         private readonly CriticiteRepository $criticiteRepository,
         private readonly DesordrePrecisionRepository $desordrePrecisionRepository,
         private readonly SignalementDraftRepository $signalementDraftRepository,
@@ -187,18 +183,6 @@ class LoadSignalementData extends Fixture implements OrderedFixtureInterface
         if (isset($row['tags'])) {
             foreach ($row['tags'] as $tag) {
                 $signalement->addTag($this->tagRepository->findOneBy(['label' => $tag, 'territory' => $signalement->getTerritory()]));
-            }
-        }
-
-        if (isset($row['situations'])) {
-            foreach ($row['situations'] as $situation) {
-                $signalement->addSituation($this->situationRepository->findOneBy(['label' => $situation]));
-            }
-        }
-
-        if (isset($row['criteres'])) {
-            foreach ($row['criteres'] as $critere) {
-                $signalement->addCritere($this->critereRepository->findOneBy(['label' => $critere]));
             }
         }
 

--- a/src/Entity/Critere.php
+++ b/src/Entity/Critere.php
@@ -37,9 +37,6 @@ class Critere
     #[ORM\OneToMany(mappedBy: 'critere', targetEntity: Criticite::class, orphanRemoval: true)]
     private Collection $criticites;
 
-    #[ORM\ManyToMany(targetEntity: Signalement::class, mappedBy: 'criteres')]
-    private Collection $signalements;
-
     #[ORM\Column(type: 'boolean')]
     private ?bool $isArchive = null;
 
@@ -59,7 +56,6 @@ class Critere
     {
         $this->createdAt = new \DateTimeImmutable();
         $this->criticites = new ArrayCollection();
-        $this->signalements = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -152,33 +148,6 @@ class Critere
             if ($criticite->getCritere() === $this) {
                 $criticite->setCritere(null);
             }
-        }
-
-        return $this;
-    }
-
-    /**
-     * @return Collection<int, Signalement>
-     */
-    public function getSignalements(): Collection
-    {
-        return $this->signalements;
-    }
-
-    public function addSignalement(Signalement $signalement): self
-    {
-        if (!$this->signalements->contains($signalement)) {
-            $this->signalements[] = $signalement;
-            $signalement->addCritere($this);
-        }
-
-        return $this;
-    }
-
-    public function removeSignalement(Signalement $signalement): self
-    {
-        if ($this->signalements->removeElement($signalement)) {
-            $signalement->removeCritere($this);
         }
 
         return $this;

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -56,14 +56,6 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Column(type: 'string', nullable: true, enumType: ProfileDeclarant::class)]
     private ?ProfileDeclarant $profileDeclarant = null;
 
-    /** @var Collection<int, Situation> $situations */
-    #[ORM\ManyToMany(targetEntity: Situation::class, inversedBy: 'signalements')]
-    private Collection $situations;
-
-    /** @var Collection<int, Critere> $criteres */
-    #[ORM\ManyToMany(targetEntity: Critere::class, inversedBy: 'signalements')]
-    private Collection $criteres;
-
     /** @var Collection<int, Criticite> $criticites */
     #[ORM\ManyToMany(targetEntity: Criticite::class, inversedBy: 'signalements')]
     private Collection $criticites;
@@ -518,8 +510,6 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     public function __construct()
     {
-        $this->situations = new ArrayCollection();
-        $this->criteres = new ArrayCollection();
         $this->criticites = new ArrayCollection();
         $this->createdAt = new \DateTimeImmutable();
         $this->statut = SignalementStatus::NEED_VALIDATION;
@@ -561,54 +551,6 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     public function getId(): ?int
     {
         return $this->id;
-    }
-
-    /**
-     * @return Collection<int, Situation>
-     */
-    public function getSituations(): Collection
-    {
-        return $this->situations;
-    }
-
-    public function addSituation(Situation $situation): self
-    {
-        if (!$this->situations->contains($situation)) {
-            $this->situations[] = $situation;
-        }
-
-        return $this;
-    }
-
-    public function removeSituation(Situation $situation): self
-    {
-        $this->situations->removeElement($situation);
-
-        return $this;
-    }
-
-    /**
-     * @return Collection<int, Critere>
-     */
-    public function getCriteres(): Collection
-    {
-        return $this->criteres;
-    }
-
-    public function addCritere(Critere $critere): self
-    {
-        if (!$this->criteres->contains($critere)) {
-            $this->criteres[] = $critere;
-        }
-
-        return $this;
-    }
-
-    public function removeCritere(Critere $critere): self
-    {
-        $this->criteres->removeElement($critere);
-
-        return $this;
     }
 
     /**

--- a/src/Entity/Situation.php
+++ b/src/Entity/Situation.php
@@ -34,10 +34,6 @@ class Situation
     #[ORM\Column(type: 'boolean')]
     private bool $isActive;
 
-    /** @var Collection<int, Signalement> $signalements */
-    #[ORM\ManyToMany(targetEntity: Signalement::class, mappedBy: 'situations')]
-    private Collection $signalements;
-
     #[ORM\Column(type: 'string', length: 50, nullable: true)]
     private ?string $icon;
 
@@ -48,7 +44,6 @@ class Situation
     {
         $this->isArchive = false;
         $this->criteres = new ArrayCollection();
-        $this->signalements = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -142,33 +137,6 @@ class Situation
     public function setIsActive(bool $isActive): self
     {
         $this->isActive = $isActive;
-
-        return $this;
-    }
-
-    /**
-     * @return Collection<int, Signalement>
-     */
-    public function getSignalements(): Collection
-    {
-        return $this->signalements;
-    }
-
-    public function addSignalement(Signalement $signalement): self
-    {
-        if (!$this->signalements->contains($signalement)) {
-            $this->signalements[] = $signalement;
-            $signalement->addSituation($this);
-        }
-
-        return $this;
-    }
-
-    public function removeSignalement(Signalement $signalement): self
-    {
-        if ($this->signalements->removeElement($signalement)) {
-            $signalement->removeSituation($this);
-        }
 
         return $this;
     }

--- a/src/Repository/Query/SignalementList/ExportIterableQuery.php
+++ b/src/Repository/Query/SignalementList/ExportIterableQuery.php
@@ -81,8 +81,11 @@ class ExportIterableQuery
             MAX(vli.scheduledAt) AS interventionScheduledAt,
             MAX(vli.nbVisites) AS interventionNbVisites
             '
-        )->leftJoin('s.situations', 'situations')
-            ->leftJoin('s.criteres', 'criteres')
+        )
+
+            ->leftJoin('s.criticites', 'criticites')
+            ->leftJoin('criticites.critere', 'criteres')
+            ->leftJoin('criteres.situation', 'situations')
             ->leftJoin('s.desordrePrecisions', 'desordrePrecisions')
             ->leftJoin('desordrePrecisions.desordreCritere', 'desordreCriteres')
             ->leftJoin('desordreCriteres.desordreCategorie', 'desordreCategories')

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -304,7 +304,9 @@ class SignalementRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id) AS count, sit.id, sit.menuLabel')
-            ->leftJoin('s.situations', 'sit')
+            ->leftJoin('s.criticites', 'criticites')
+            ->leftJoin('criticites.critere', 'critere')
+            ->leftJoin('critere.situation', 'sit')
             ->where('s.statut NOT IN (:statutList)')
             ->setParameter('statutList', SignalementStatus::excludedStatuses());
 
@@ -337,7 +339,8 @@ class SignalementRepository extends ServiceEntityRepository
             ->addSelect('SUM(CASE WHEN c.type = :logement THEN 1 ELSE 0 END) AS critere_logement_count')
             ->addSelect('SUM(CASE WHEN dc.zoneCategorie = :batimentString THEN 1 ELSE 0 END) AS desordrecritere_batiment_count')
             ->addSelect('SUM(CASE WHEN dc.zoneCategorie = :logementString THEN 1 ELSE 0 END) AS desordrecritere_logement_count')
-            ->leftJoin('s.criteres', 'c')
+            ->leftJoin('s.criticites', 'criticites')
+            ->leftJoin('criticites.critere', 'c')
             ->leftJoin('s.desordrePrecisions', 'dp')
             ->leftJoin('dp.desordreCritere', 'dc')
             ->setParameter('batiment', 1)
@@ -649,7 +652,9 @@ class SignalementRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('s');
         $qb->select('COUNT(s.id) AS count, sit.id, sit.menuLabel');
-        $qb->leftJoin('s.situations', 'sit');
+        $qb->leftJoin('s.criticites', 'criticites');
+        $qb->leftJoin('criticites.critere', 'critere');
+        $qb->leftJoin('critere.situation', 'sit');
 
         $qb = self::addFiltersToQueryBuilder($qb, $statisticsFilters);
 

--- a/src/Repository/SituationRepository.php
+++ b/src/Repository/SituationRepository.php
@@ -26,8 +26,8 @@ class SituationRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('s')
             ->andWhere('s.isActive = true')
-            ->leftJoin('s.criteres', 'criteres', 'WITH', 'criteres.isArchive != 1')
-            ->leftJoin('criteres.criticites', 'criticites', 'WITH', 'criticites.isArchive != 1')
+            ->leftJoin('s.criticites', 'criticites', 'WITH', 'criticites.isArchive != 1')
+            ->leftJoin('criticites.critere', 'criteres', 'WITH', 'criteres.isArchive != 1')
             ->addSelect('criteres')
             ->addSelect('criticites')
             ->orderBy('s.id', 'ASC')

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -271,9 +271,7 @@ class SignalementImportLoader
 
                     if (null !== $criticite) {
                         $signalement
-                            ->addCriticite($criticite)
-                            ->addSituation($critere->getSituation())
-                            ->addCritere($critere);
+                            ->addCriticite($criticite);
                     }
                 } catch (\Throwable $exception) {
                     $this->logger->error($critereLabel.' - '.$exception->getMessage());


### PR DESCRIPTION
## Ticket

#4759   

## Description
Suppression des tables `signalement_critere` et `signalement_situation` et de leur usage dans le code

## Pré-requis
`make execute-migration name=Version20251017140959 direction=up`

## Tests
- [ ] Sur une base de prod, vérifier l'affichage des désordres sur des vieux signalements (en comparant avec la vraie prod)
- [ ] Vérifier l'affichage des stats
- [ ] C/I ok
