### PR TITLE
[BUG - Form Pro] Mettre à jour la date created_at à la validation du signalement PRO

### DIFF
--- a/migrations/Version20251017150657.php
+++ b/migrations/Version20251017150657.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251017150657 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set created_at of Signalement from HistoryEntry when created from DRAFT';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE signalement s
+            INNER JOIN history_entry h ON s.id = h.entity_id AND h.entity_name = 'App\\Entity\\Signalement'
+            SET s.created_at = h.created_at
+            WHERE s.statut NOT IN ('DRAFT', 'DRAFT_ARCHIVED')
+            AND s.created_by_id IS NOT NULL
+            AND JSON_EXTRACT(h.changes, '$.statut.old') = 'DRAFT'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -550,6 +550,7 @@ class SignalementCreateController extends AbstractController
                 $params = [];
             }
             $signalement->setReference($referenceGenerator->generate($signalement->getTerritory()));
+            $signalement->setCreatedAt(new \DateTimeImmutable());
             $userManager->createUsagerFromSignalement($signalement, UserManager::OCCUPANT);
             $userManager->createUsagerFromSignalement($signalement, UserManager::DECLARANT);
             $fileRepository->updateIsWaitingSuiviForSignalement($signalement);


### PR DESCRIPTION
## Ticket

#4765

## Description
- Pour garder un ordre chronologique logique, ne pas garder la date de création du brouillons des form PRO mais celle de la soumission.
- Corriger aussi les existants via les informations présente dans l'historique

## Pré-requis
`make execute-migration name=Version20251017150657 direction=up`

## Tests
- [ ] Sur une copie de base de prod regarder la date de création du signalement 2025-284 dans l'ain (01)
- [ ] Lancer la commande `make execute-migration name=Version20251017150657 direction=up` et voir que la date correspond à présent à sa soumission
- [ ] Créer un signalement via le form Pro et voir que la date enregistré et celle de la soumission
