### PR TITLE
[BO - Espace documentaire] Correction aperçu dans Chrome

### DIFF
--- a/config/app/csp.yaml
+++ b/config/app/csp.yaml
@@ -41,6 +41,7 @@ parameters:
       - "https://fonts.gstatic.com"
     frame-src:
       - "'self'"
+      - "blob:"
     object-src:
       - "'self'"
       - "blob:"


### PR DESCRIPTION
## Ticket

#4781   

## Description
Correction aperçu dans Chrome dans l'espace documentaire

## Changements apportés
* Modification de règle csp pour `frame-src`

## Tests
- [ ] Vérifier l'affichage des aperçus sur différents navigateurs
