### PR TITLE
[BO - Fiche Signalement] Certains boutons du menu n'apparaissent pas

### DIFF
--- a/templates/back/signalement/view/header/_menu.html.twig
+++ b/templates/back/signalement/view/header/_menu.html.twig
@@ -28,7 +28,7 @@
                 {% elseif is_granted('SIGN_REOPEN', signalement) %}
                     <li>
                         <button
-                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill"
+                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill keep-when-signalement-closed"
                             aria-controls="reopen-all-signalement-modal" 
                             data-fr-opened="false"
                             >
@@ -38,7 +38,7 @@
                 {% elseif canReopenAffectation %}
                     <li>
                         <button
-                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill"
+                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill keep-when-signalement-closed"
                             aria-controls="reopen-signalement-modal" 
                             data-fr-opened="false">
                             Rouvrir pour {{ currentPartner ? currentPartner.nom : 'N/A' }}
@@ -85,36 +85,38 @@
                         </button>
                     </li>
                 {% endif %}
-                {% if isUserSubscribed %}
-                    <li>
-                        {% if isAloneInCurrentPartner %}
-                            <button 
-                                class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line disabled"
-                                aria-disabled="true" tabindex="-1" title="Vous ne pouvez pas quitter le dossier, étant le seul agent de votre partenaire.">
-                                Se retirer du dossier
-                            </button>
-                        {% elseif subscriptionsInMyPartner|length > 1 %}
-                            <a href="{{ path('back_signalement_unsubscribe', {uuid: signalement.uuid}) }}?_token={{ csrf_token('unsubscribe') }}"
-                                class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line">
-                                Se retirer du dossier
+                {% if signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}
+                    {% if isUserSubscribed %}
+                        <li>
+                            {% if isAloneInCurrentPartner %}
+                                <button 
+                                    class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line disabled"
+                                    aria-disabled="true" tabindex="-1" title="Vous ne pouvez pas quitter le dossier, étant le seul agent de votre partenaire.">
+                                    Se retirer du dossier
+                                </button>
+                            {% elseif subscriptionsInMyPartner|length > 1 %}
+                                <a href="{{ path('back_signalement_unsubscribe', {uuid: signalement.uuid}) }}?_token={{ csrf_token('unsubscribe') }}"
+                                    class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line">
+                                    Se retirer du dossier
+                                </a>
+                            {% else %}
+                                <button
+                                    class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line"
+                                    aria-controls="transfer-subscription-modal" 
+                                    data-fr-opened="false"
+                                    >
+                                    Se retirer du dossier
+                                </button>
+                            {% endif %}
+                        </li>
+                    {% elseif not canCancelRefusedAffectation %}
+                        <li>
+                            <a href="{{ path('back_signalement_subscribe', {uuid: signalement.uuid}) }}?_token={{ csrf_token('subscribe') }}"
+                                class="fr-nav__link fr-btn--icon-left fr-icon-eye-line">
+                                Rejoindre le dossier
                             </a>
-                        {% else %}
-                            <button
-                                class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line"
-                                aria-controls="transfer-subscription-modal" 
-                                data-fr-opened="false"
-                                >
-                                Se retirer du dossier
-                            </button>
-                        {% endif %}
-                    </li>
-                {% elseif not canCancelRefusedAffectation %}
-                    <li>
-                        <a href="{{ path('back_signalement_subscribe', {uuid: signalement.uuid}) }}?_token={{ csrf_token('subscribe') }}"
-                            class="fr-nav__link fr-btn--icon-left fr-icon-eye-line">
-                            Rejoindre le dossier
-                        </a>
-                    </li>
+                        </li>
+                    {% endif %}
                 {% endif %}
             </ul>
         </div>


### PR DESCRIPTION
## Ticket

#4846   

## Description
On ne pouvait plus rouvrir un signalement fermé par contre on pouvait rejoindre ou se retirer du dossier

## Changements apportés
* Ajout de la classe css `keep-when-signalement-closed` sur les boutons de réouverture (cf ligne 145 sur base.html.twig
* Ne pas faire apparaitre les boutons Se retirer du dossier ou Rejoindre le dossier si le signalement est fermé

## Pré-requis

## Tests
- [ ] Tester le menu sur un signalement fermé avec différents rôles
