### PR TITLE
[BO - Menu] Modification du lien vers la liste des signalements pour les agents

### DIFF
--- a/src/Service/Menu/MenuBuilder.php
+++ b/src/Service/Menu/MenuBuilder.php
@@ -25,8 +25,6 @@ readonly class MenuBuilder
         $listRouteParameters = [];
         if ($this->currentRoute->isGranted(User::ROLE_ADMIN)) {
             $listRouteParameters = ['status' => 'nouveau', 'isImported' => 'oui'];
-        } elseif ($this->featureNewDashboard && $user->isUserPartner()) {
-            $listRouteParameters = ['showMySignalementsOnly' => 'oui'];
         }
         $signalementsSubMenu = (new MenuItem(label: 'Signalements', roleGranted: User::ROLE_USER))
             ->addChild(new MenuItem(label: 'Liste', route: 'back_signalements_index', routeParameters: $listRouteParameters, roleGranted: User::ROLE_USER));


### PR DESCRIPTION
## Ticket

#4858   

## Description
Pour les agents, le lien vers la liste des signalements doit donner accès à la totalité des signalements, plutôt que juste ceux qui sont assignés, pour avoir accès aux nouveaux.

## Tests
- [ ] Vérifier le lien dans le menu
