### PR TITLE
[Bug] Commande pour corriger le lastLoginAt en fonction de l'historique

### DIFF
--- a/src/Command/UpdateLastLoginAtCommand.php
+++ b/src/Command/UpdateLastLoginAtCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:user-update-last-login-at',
+    description: 'Met à jour lastLoginAt selon le dernier LOGIN trouvé dans history_entry',
+)]
+class UpdateLastLoginAtCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'Afficher les utilisateurs concernés sans mettre à jour la base'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = $input->getOption('dry-run');
+        $conn = $this->entityManager->getConnection();
+
+        $sql = <<<SQL
+            SELECT u.id, u.email, u.last_login_at, MAX(h.created_at) AS last_login_event
+            FROM user u
+            JOIN history_entry h ON h.user_id = u.id
+            WHERE h.event = 'LOGIN'
+            GROUP BY u.id, u.email, u.last_login_at
+            HAVING u.last_login_at IS NULL OR u.last_login_at < MAX(h.created_at)
+        SQL;
+
+        $rows = $conn->fetchAllAssociative($sql);
+
+        if (empty($rows)) {
+            $io->success('Aucune mise à jour nécessaire 🎉');
+
+            return Command::SUCCESS;
+        }
+
+        $io->section(sprintf('%d utilisateurs à mettre à jour', count($rows)));
+
+        if ($dryRun) {
+            $io->table(['ID', 'Email', 'Ancien lastLoginAt', 'Dernier LOGIN'], array_map(static fn ($row) => [
+                $row['id'],
+                $row['email'],
+                $row['last_login_at'],
+                $row['last_login_event'],
+            ], $rows));
+
+            $io->success('Mode dry-run : aucune donnée modifiée');
+
+            return Command::SUCCESS;
+        }
+
+        $updated = 0;
+        foreach ($rows as $row) {
+            $user = $this->entityManager->getRepository(User::class)->find($row['id']);
+            if ($user) {
+                $user->setLastLoginAt(new \DateTimeImmutable($row['last_login_event']));
+                ++$updated;
+            }
+        }
+
+        $this->entityManager->flush();
+
+        $io->success(sprintf('%d utilisateurs mis à jour ✅', $updated));
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Functional/Command/UpdateLastLoginAtCommandTest.php
+++ b/tests/Functional/Command/UpdateLastLoginAtCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Tests\Functional\Command;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UpdateLastLoginAtCommandTest extends KernelTestCase
+{
+    private ?EntityManagerInterface $entityManager;
+    private ?CommandTester $commandTester;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+
+        $application = new Application($kernel);
+        $command = $application->find('app:user-update-last-login-at');
+        $this->commandTester = new CommandTester($command);
+        $this->user = new User();
+        $this->user->setEmail('test-update@example.com');
+        $this->user->setPassword('dummy');
+        $this->user->setLastLoginAt(new \DateTimeImmutable('2025-05-09'));
+        $this->entityManager->persist($this->user);
+        $this->entityManager->flush();
+
+        $this->entityManager->getConnection()->insert('history_entry', [
+            'user_id' => $this->user->getId(),
+            'event' => 'LOGIN',
+            'entity_name' => 'App\Entity\User',
+            'created_at' => (new \DateTimeImmutable('2025-10-01'))->format('Y-m-d H:i:s'),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->entityManager->close();
+        $this->entityManager = null;
+    }
+
+    public function testDryRunShowsUsersWithoutUpdating(): void
+    {
+        $oldDate = $this->user->getLastLoginAt();
+
+        $this->commandTester->execute(['--dry-run' => true]);
+        $output = $this->commandTester->getDisplay();
+
+        $this->assertStringContainsString('Mode dry-run', $output);
+        $this->assertEquals(0, $this->commandTester->getStatusCode());
+
+        $this->entityManager->refresh($this->user);
+        $this->assertEquals($oldDate, $this->user->getLastLoginAt(), 'Aucune mise à jour en dry-run');
+    }
+
+    public function testCommandUpdatesUsersWhenNeeded(): void
+    {
+        $this->commandTester->execute([]);
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('utilisateurs mis à jour', $output);
+        $this->assertEquals(0, $this->commandTester->getStatusCode());
+
+        $this->entityManager->clear();
+        $updatedUser = $this->entityManager->getRepository(User::class)->find($this->user->getId());
+
+        $this->assertEquals(
+            new \DateTimeImmutable('2025-10-01'),
+            $updatedUser->getLastLoginAt(),
+            'lastLoginAt doit être mis à jour avec la dernière date de LOGIN'
+        );
+    }
+}


### PR DESCRIPTION
## Ticket

#4823   

## Description
Ajout d'une commande qui permet de mettre à jour le lastLoginAt des user s'il y a une entrée LOGIN plus récente pour cet user dans la table history_entry

## Changements apportés
* Ajout d'une commande avec une option` --dry-run`
* Création du test associé

## Pré-requis
`make composer`
## Tests
- [ ] Changer le lastLoginAt d'un ou plusieurs utilisateurs en base
- [ ] Lancer la commande en `--dry-run`
- [ ] Lancer la commande pour de vrai
- [ ] Possible de tester sur une base de prod pour se rendre compte