### PR TITLE
[BUG] Ignorer user system de l'archivage / Corriger statut de draft

### DIFF
--- a/migrations/Version20251105103258.php
+++ b/migrations/Version20251105103258.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251105103258 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set SignalementDraft status to EN_SIGNALEMENT for drafts linked to Signalement';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE signalement_draft d
+            INNER JOIN signalement s ON d.id = s.created_from_id
+            SET d.status = 'EN_SIGNALEMENT'
+            WHERE d.status != 'EN_SIGNALEMENT';
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
@@ -34,6 +35,8 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         private readonly TerritoryRepository $territoryRepository,
         private readonly PartnerRepository $partnerRepository,
         private readonly ClockInterface $clock,
+        #[Autowire(env: 'USER_SYSTEM_EMAIL')]
+        private readonly string $userSystemEmail,
     ) {
         parent::__construct($registry, User::class);
     }
@@ -372,6 +375,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $qb->andWhere('u.statut != :statut')->setParameter('statut', UserStatus::ARCHIVE);
         $qb->andWhere('u.anonymizedAt IS NULL');
         $qb->andWhere('u.archivingScheduledAt IS NULL');
+        $qb->andWhere('u.email != :userSystemEmail')->setParameter('userSystemEmail', $this->userSystemEmail);
 
         return $qb->getQuery()->execute();
     }


### PR DESCRIPTION
## Ticket

#4873
#4870

## Description
#4873 : Exclusion de l'user system de la requête de récupération des utilisateur à archivé sans login depuis X délais.

#4870 : Certains draft de signalement (tous crée à la même date) ayant généré un signalement était resté en statut "EN_COURS" ce qui provoquait un crash de la commande `app:clear-entities ` lorsqu'on essayait de les supprimer car il sont référence dans des signalement. Correction de leur statut via une migration

## Pré-requis
- Se mettre sur une base de prod récente
- Voir que certain draft existant en signalement n'ont pas le bon statut : 
```
SELECT d.id, d.profile_declarant, d.address_complete, d.current_step, d.created_at, d.updated_at, d.status,
s.id, s.uuid, s.statut 
FROM `signalement_draft` d INNER JOIN signalement s ON d.id = s.created_from_id
WHERE (d.status != 'EN_SIGNALEMENT');
```
- Correction de status des draft : `make execute-migration name=Version20251105103258 direction=up`

## Tests
- [ ] `make symfony cmd="app:clear-entities"` : Pas d'erreur
- [ ] `make symfony cmd="app:notify-and-archive-inactive-accounts --force=1"` : Le champ `archiving_scheduled_at` de l'user system doit rester `NULL`
