### PR TITLE
[BO - Notifications] Ne pas notifier par e-mail l'adresse générique des partenaires, si un des agent a fait l'action

### DIFF
--- a/src/Repository/PartnerRepository.php
+++ b/src/Repository/PartnerRepository.php
@@ -59,9 +59,11 @@ class PartnerRepository extends ServiceEntityRepository
         SearchPartner $searchPartner,
     ): Paginator {
         $queryBuilder = $this->getPartnersQueryBuilder($searchPartner->getTerritoire());
-        $queryBuilder->select('p', 'z', 'ez')
+        $queryBuilder->select('p', 'z', 'ez', 'up', 'u')
             ->leftJoin('p.zones', 'z')
-            ->leftJoin('p.excludedZones', 'ez');
+            ->leftJoin('p.excludedZones', 'ez')
+            ->leftJoin('p.userPartners', 'up')
+            ->leftJoin('up.user', 'u');
 
         $queryBuilder->addSelect(
             '(CASE

--- a/tests/Functional/Controller/Back/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementControllerTest.php
@@ -342,7 +342,7 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(SignalementStatus::CLOSED, $signalement->getStatut());
 
         $client->enableProfiler();
-        $this->assertEmailCount(1);
+        $this->assertEmailCount(0);
     }
 
     public function testAdminPartnerSubmitClotureSignalementWithEmailSentToRT(): void

--- a/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
@@ -480,7 +480,7 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertEquals('maudcolbert@yopmail.com', $signalementUsager->getOccupant()?->getEmail());
         $this->assertNull($signalementUsager->getDeclarant());
 
-        $this->assertEmailCount(2);
+        $this->assertEmailCount(1);
     }
 
     public function testValidationSignalementWithAutoAffectationWithAgentNotAffected(): void


### PR DESCRIPTION
## Ticket

#4872

## Description
- On bloque les notifications sur l'email générique d'un partenaire quand l'action est faite par un agent de ce même partenaire. Cela impacte 3 cas : 
-> Je crée un suivi sur un signalement : le mail générique de mon partenaire (si il est affecté) n'est plus notifié.
-> Je cloture un signalement pour tous : le mail générique de mon partenaire (si il est affecté) n'est plus notifié.
-> J'affecte un partenaire a un signalement, si il s'agit de mon propre partenaire je mail générique n'est plus notifié.

- Modifications sur la requête `PartnerRepository->getPartners` pour éviter les requêtes N+1 sur la liste des partenaires

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis
Pour faciliter les tests : `FEATURE_EDITION_SUIVI=0`

## Tests
- [ ] Ajouter un suivi sur un signalement pour lequel mon partenaire est affecté, voir que l'email générique de mon partenaire n'est pas notifié.
- [ ] Clôturer un signalement pour tous sur un signalement pour lequel mon partenaire est affecté, voir que l'email générique de mon partenaire n'est pas notifié.
- [ ] Affecter mon propre partenaire a un signalement (ou reproduire via auto-affectation du form pro par exemple) voir que l'email générique de mon partenaire n'est pas notifié.
