### PR TITLE
[BO - Signalement] Correction pour pouvoir se désabonner des dossiers si le partenaire n'est pas affecté

### DIFF
--- a/src/Controller/Back/SignalementController.php
+++ b/src/Controller/Back/SignalementController.php
@@ -145,7 +145,7 @@ class SignalementController extends AbstractController
         $canReopenAffectation = $affectation && $this->isGranted(AffectationVoter::REOPEN, $affectation);
 
         $isUserSubscribed = false;
-        if ($signalementSubscriptionRepository->findOneBy(['user' => $user, 'signalement' => $signalement]) && $affectation) {
+        if ($signalementSubscriptionRepository->findOneBy(['user' => $user, 'signalement' => $signalement])) {
             $isUserSubscribed = true;
         }
 
@@ -180,7 +180,7 @@ class SignalementController extends AbstractController
         }
 
         $transferSubscriptionForm = null;
-        if ($isUserSubscribed) {
+        if ($isUserSubscribed && $affectation) {
             $transferSubscription = (new AgentSelection())->setAffectation($affectation)->setAgents([$user]);
             $transferSubscriptionFormRoute = $this->generateUrl('back_signalement_unsubscribe', ['uuid' => $signalement->getUuid()]);
             $transferSubscriptionForm = $this->createForm(

--- a/templates/back/signalement/view/header/_main-action.html.twig
+++ b/templates/back/signalement/view/header/_main-action.html.twig
@@ -5,7 +5,7 @@
         {% include '_partials/_modal_accept_affectation.html.twig' %}
     </div>
 {% endif %}
-{% if isUserSubscribed and subscriptionsInMyPartner|length < 2 %}
+{% if isUserSubscribed and subscriptionsInMyPartner|length < 2 and affectation %}
     <div data-ajax-form class="fr-display-inline">
         {% include '_partials/_modal_transfer_subscription.html.twig' %}
     </div>

--- a/templates/back/signalement/view/header/_menu.html.twig
+++ b/templates/back/signalement/view/header/_menu.html.twig
@@ -88,13 +88,13 @@
                 {% if is_granted('SIGN_SUBSCRIBE', signalement) %}
                     {% if isUserSubscribed %}
                             <li>
-                                {% if isAloneInCurrentPartner %}
+                                {% if isAloneInCurrentPartner and affectation %}
                                     <button 
                                         class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line disabled"
                                         aria-disabled="true" tabindex="-1" title="Vous ne pouvez pas quitter le dossier, étant le seul agent de votre partenaire.">
                                         Se retirer du dossier
                                     </button>
-                                {% elseif subscriptionsInMyPartner|length > 1 %}
+                                {% elseif subscriptionsInMyPartner|length > 1 or not affectation %}
                                     <a href="{{ path('back_signalement_unsubscribe', {uuid: signalement.uuid}) }}?_token={{ csrf_token('unsubscribe') }}"
                                         class="fr-nav__link fr-btn--icon-left fr-icon-eye-off-line">
                                         Se retirer du dossier


### PR DESCRIPTION
## Ticket

#4906   

## Description
Les utilisateurs qui s'abonnent sans que le partenaire ne soit affecté au dossier ne pouvaient pas s'en désabonner.

## Tests
- [ ] Tester l'abonnement / désabonnement en SA
- [ ] Tester l'abonnement / désabonnement en RT, avec partenaire affecté
- [ ] Tester l'abonnement / désabonnement en RT, avec partenaire non-affecté
- [ ] Tester l'abonnement / désabonnement en Agent, avec partenaire affecté
