### PR TITLE
[BO - Signalement] Abonnement dossiers accepte sans suivi d'un agent

### DIFF
--- a/migrations/Version20251110175046.php
+++ b/migrations/Version20251110175046.php
@@ -16,14 +16,13 @@ final class Version20251110175046 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-
         $this->addSql(<<<'SQL'
                 INSERT INTO user_signalement_subscription (user_id, signalement_id, created_by_id, created_at, is_legacy)
                 SELECT
-                    t.user_id,
-                    t.signalement_id,
-                    t.user_id AS created_by_id,
-                    t.created_at AS created_at,
+                    users_to_subscribe_from_affectation.user_id,
+                    users_to_subscribe_from_affectation.signalement_id,
+                    users_to_subscribe_from_affectation.user_id AS created_by_id,
+                    users_to_subscribe_from_affectation.created_at AS created_at,
                     1 AS is_legacy
                 FROM (
                     SELECT
@@ -36,20 +35,18 @@ final class Version20251110175046 extends AbstractMigration
                     WHERE a.statut = 'EN_COURS'
                       AND a.answered_at <= '2025-10-28 12:00:00'
                       AND u.has_done_subscriptions_choice = 1
-                      AND NOT JSON_CONTAINS(u.roles, '"ROLE_USAGER"')
                     GROUP BY u.id, a.signalement_id
-                ) AS t
+                ) AS users_to_subscribe_from_affectation
                 WHERE NOT EXISTS (
                     SELECT 1
                     FROM user_signalement_subscription uss
-                    WHERE uss.user_id = t.user_id
-                      AND uss.signalement_id = t.signalement_id
+                    WHERE uss.user_id = users_to_subscribe_from_affectation.user_id
+                      AND uss.signalement_id = users_to_subscribe_from_affectation.signalement_id
                 );
                 SQL);
     }
 
     public function down(Schema $schema): void
     {
-        return;
     }
 }


### PR DESCRIPTION
## Ticket

#4910   

## Description
Les abonnements ayant aucune activité de suivi mais avec une affectation accepté ont été supprimé par l'agent ayant cliqué sur **Uniquement les dossiers sur lesquels j'ai effectué une action**

## Changements apportés
* Ajout d'une migration pour recréer les abonnements manquants pour les agents ayant accepté leur affectation.
* Exclusion des abonnés ayant une affectation accepté 

## Pré-requis
Avant d'exécute le load-data
<img width="825" height="301" alt="image" src="https://github.com/user-attachments/assets/2e2abce6-bfac-4fde-8007-c3944276eb05" />

```
make load-data
```
Skip la dernière migration pour constater les abonnements à rajouter 

Exécuter la requête et constater les abonnements à rajouter
```sql
                SELECT
                    users_to_subscribe_from_affectation.user_id,
                    users_to_subscribe_from_affectation.signalement_id,
                    users_to_subscribe_from_affectation.user_id AS created_by_id,
                    users_to_subscribe_from_affectation.created_at AS created_at,
                    1 AS is_legacy
                FROM (
                    SELECT
                        u.id               AS user_id,
                        a.signalement_id   AS signalement_id,
                        -- il y\'a quelques affectations (partenaires différents) mènent au même couple (user, signalement)
                        MIN(a.answered_at) AS created_at
                    FROM affectation a
                    JOIN user u ON u.id = a.answered_by_id
                    WHERE a.statut = 'EN_COURS'
                      AND a.answered_at <= '2025-10-28 12:00:00'
                      AND u.has_done_subscriptions_choice = 1
                    GROUP BY u.id, a.signalement_id
                ) AS users_to_subscribe_from_affectation
                WHERE NOT EXISTS (
                    SELECT 1
                    FROM user_signalement_subscription uss
                    WHERE uss.user_id = users_to_subscribe_from_affectation.user_id
                      AND uss.signalement_id = users_to_subscribe_from_affectation.signalement_id
                );
```
## Tests
- [ ] Exécuter la migration `make execute-migration name=Version20251110175046 direction=up` et rejouter la requete SELECT, celle ci doit retourner aucun résultat
- [ ] Choisir un utilisateur via la requête ci dessous et tester la modale de gestion des dossiers par agent sur un agent n'ayant pas fait son choix  (aucun suivi mais affectation accepté)
```sql
SELECT
    s.user_id,
    u.email,
    s.signalement_id,
    a.id AS affectation_id,
    a.partner_id,
    a.statut,
    a.answered_by_id,
    a.answered_at
FROM user_signalement_subscription s
JOIN user u ON u.id = s.user_id
LEFT JOIN suivi ON (
    suivi.signalement_id = s.signalement_id
    AND suivi.created_by_id = s.user_id
)
JOIN affectation a ON (
    a.signalement_id = s.signalement_id
    AND a.answered_by_id = s.user_id
)
WHERE s.is_legacy = 1
  AND suivi.id IS NULL
  AND a.statut = 'EN_COURS'
  AND u.has_done_subscriptions_choice = 0
ORDER BY s.user_id, s.signalement_id;
```
-  [ ] Vérifier que son abonnement est toujours présent

