### PR TITLE
[Injonction Automatisée] Les signalements en insalubrité ne doivent pas être éligibles

### DIFF
--- a/src/Service/Signalement/SignalementBuilder.php
+++ b/src/Service/Signalement/SignalementBuilder.php
@@ -351,12 +351,15 @@ class SignalementBuilder
             if (Qualification::DANGER === $qualification->getQualification()) {
                 return $this;
             }
+            if (Qualification::INSALUBRITE === $qualification->getQualification()) {
+                return $this;
+            }
         }
 
         $arrayDepts = json_decode($this->featureInjonctionBailleurDepts, true);
 
         // Pour entrer dans le statut injonction bailleur il faut :
-        // - que le signalement n'ait pas de qualification danger (au-dessus)
+        // - que le signalement n'ait pas de qualification danger ni insalubrité (au-dessus)
         // - que l'usager ait dit ok : injonction_bailleur_choice = 'oui'
         // - que le signalement soit fait par un locataire
         // - que le logement ne soit pas un logement social


### PR DESCRIPTION
## Ticket

#4896   

## Description
Intégrer dans la liste des exclusions au dispositif d'injonction automatisée les signalements taggés insalubrité

## Changements apportés
* Modification du SignalementBuilder
* Ajout de test

## Pré-requis

## Tests
- [ ] Faire quelques signalements en locataire/parc privé, en autorisant l'injonction, et en choisissant des désordres qui créent une qualif insalubrité ou pas. Vérifier qu'on ne passe pas en injonction si on a une qualif insalubrité
