### PR TITLE
[BO - Dossier - Visite] Ajouter la date d'édition du commentaire (gérer le cas sans ancienne valeur provenant Esabora)

### DIFF
--- a/src/EventListener/InterventionEditedListener.php
+++ b/src/EventListener/InterventionEditedListener.php
@@ -22,37 +22,32 @@ class InterventionEditedListener
 
         $changes = [];
         if ($event->hasChangedField('details')) {
-            if (!empty($event->getOldValue('details'))) {
-                $before = self::normalizeText($event->getOldValue('details'));
-                $after = self::normalizeText($event->getNewValue('details'));
-
-                if ($before !== $after && !empty($after)) {
-                    $changes['details'] = [
-                        'old' => $before,
-                        'new' => $after,
-                    ];
-                }
+            $before = self::normalizeText($event->getOldValue('details'));
+            $after = self::normalizeText($event->getNewValue('details'));
+            if ($before !== $after && !empty($after)) {
+                $changes['details'] = [
+                    'old' => $before,
+                    'new' => $after,
+                ];
             }
         }
 
         if ($event->hasChangedField('concludeProcedure')) {
             $before = $event->getOldValue('concludeProcedure') ?? [];
             $after = $event->getNewValue('concludeProcedure') ?? [];
-            if (!empty($before)) {
-                $before = is_array($before)
-                    ? array_map(fn (string $procedure) => ProcedureType::tryFrom($procedure)->label(), $before)
-                    : [];
-                $after = is_array($after)
-                    ? array_map(fn (string $procedure) => ProcedureType::tryFrom($procedure)->label(), $after)
-                    : [];
-                sort($before);
-                sort($after);
-                if ($before !== $after && !empty($after)) {
-                    $changes['concludeProcedure'] = [
-                        'old' => implode(', ', $before),
-                        'new' => implode(', ', $after),
-                    ];
-                }
+            $before = is_array($before)
+                ? array_map(fn (string $procedure) => ProcedureType::tryFrom($procedure)->label(), $before)
+                : [];
+            $after = is_array($after)
+                ? array_map(fn (string $procedure) => ProcedureType::tryFrom($procedure)->label(), $after)
+                : [];
+            sort($before);
+            sort($after);
+            if ($before !== $after && !empty($after)) {
+                $changes['concludeProcedure'] = [
+                    'old' => implode(', ', $before),
+                    'new' => implode(', ', $after),
+                ];
             }
         }
 
@@ -65,7 +60,9 @@ class InterventionEditedListener
     public function supports(Intervention $intervention): bool
     {
         return Intervention::STATUS_DONE === $intervention->getStatus()
-            && InterventionType::VISITE === $intervention->getType();
+            && (InterventionType::VISITE === $intervention->getType()
+                || InterventionType::VISITE_CONTROLE === $intervention->getType()
+            );
     }
 
     private function normalizeText(?string $text): string

--- a/tests/Unit/EventListener/InterventionEditedListenerTest.php
+++ b/tests/Unit/EventListener/InterventionEditedListenerTest.php
@@ -173,4 +173,23 @@ class InterventionEditedListenerTest extends TestCase
         $this->assertArrayHasKey('details', $intervention->getChangesForMail());
         $this->assertArrayHasKey('concludeProcedure', $intervention->getChangesForMail());
     }
+
+    public function testDiffNoOldValue(): void
+    {
+        $intervention = (new Intervention())
+            ->setStatus(Intervention::STATUS_DONE)
+            ->setType(InterventionType::VISITE_CONTROLE);
+
+        $args = $this->createPreUpdateArgs($intervention, [
+            'concludeProcedure' => [null, [ProcedureType::RSD->value, ProcedureType::INSALUBRITE->value]],
+            'details' => [null, 'Bonjour, foo bar éés.'],
+        ]);
+
+        $listener = new InterventionEditedListener();
+        $listener->preUpdate($intervention, $args);
+
+        $this->assertNotNull($intervention->getConclusionVisiteEditedAt());
+        $this->assertNotEmpty($intervention->getChangesForMail()['details']['new']);
+        $this->assertNotEmpty($intervention->getChangesForMail()['concludeProcedure']['new']);
+    }
 }


### PR DESCRIPTION
## Ticket

#4914    

## Description
Une visite effectué peut être ajouté sans ancienne valeur (Esabora) et inclure les visite de contrôle

## Changements apportés
* Suppression de la condition qui vérifie l'existence d'ancienne valeur

## Pré-requis
Ajouter des visites d'esabora

```
make sync-sish
```
## Tests
- [ ] Editer des visites sans commentaire et sans conclusion, vérifier que la date d'édition s'affiche. 
