### PR TITLE
[BO - Liste des signalements] Bouton Dossiers importés - Bug d’affichage et disparition du filtre dans l'url

### DIFF
--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
@@ -571,6 +571,8 @@ export default defineComponent({
       this.$emit('changeTerritory', value)
     },
     resetFilters () {
+      const keepIsImported = this.sharedState.input.filters.isImported
+
       this.sharedState.showOptions = false
       this.sharedState.input.filters = {
         territoire: null,
@@ -593,7 +595,7 @@ export default defineComponent({
         situation: null,
         dateDepot: null,
         dateDernierSuivi: null,
-        isImported: null,
+        isImported: keepIsImported,
         isZonesDisplayed: null,
         showMyAffectationOnly: null,
         showMySignalementsOnly: null,
@@ -626,7 +628,10 @@ export default defineComponent({
       }
 
       if (this.$refs.isImportedButton) {
-        (this.$refs.isImportedButton as HTMLElement).setAttribute('aria-pressed', 'false')
+        (this.$refs.isImportedButton as HTMLElement).setAttribute(
+            'aria-pressed',
+            keepIsImported === 'oui' ? 'true' : 'false'
+        )
       }
 
       if (this.$refs.isZonesDisplayedButton) {

--- a/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
+++ b/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
@@ -73,7 +73,11 @@ export function handleSettings (context: any, requestResponse: any): any {
   context.sharedState.user.canSeeScore = isAdminOrAdminTerritoire
   context.sharedState.user.partnerIds = requestResponse.partnerIds
   context.sharedState.hasSignalementImported = requestResponse.hasSignalementImported
-  context.sharedState.input.filters.isImported = null
+  if (context.sharedState.user.isAdmin) {
+      context.sharedState.input.filters.isImported = context.sharedState.hasSignalementImported ? "oui" : null
+  } else {
+      context.sharedState.input.filters.isImported = null
+  }
 
   context.sharedState.territories = []
   for (const id in requestResponse.territories) {

--- a/src/Controller/Back/SignalementListController.php
+++ b/src/Controller/Back/SignalementListController.php
@@ -37,7 +37,6 @@ class SignalementListController extends AbstractController
                 'maxItemsPerPage' => SignalementSearchQuery::MAX_LIST_PAGINATION,
                 'orderBy' => 'DESC',
                 'sortBy' => 'reference',
-                'isImported' => 'oui',
             ];
         $signalements = $signalementManager->findSignalementAffectationList($user, $filters);
 

--- a/src/Service/Signalement/SearchFilterOptionDataProvider.php
+++ b/src/Service/Signalement/SearchFilterOptionDataProvider.php
@@ -65,7 +65,8 @@ class SearchFilterOptionDataProvider
                     'zipcodes' => $this->signalementRepository->findZipcodes($user, $territory),
                     'listQualificationStatus' => $this->qualificationStatusService->getList(),
                     'listVisiteStatus' => VisiteStatus::getLabelList(),
-                    'hasSignalementsImported' => $this->signalementRepository->countImported($territory, $user),
+                    'hasSignalementsImported' => $user->isSuperAdmin() || $user->isTerritoryAdmin()
+                        ? $this->signalementRepository->countImported($territory) : false,
                     'bailleursSociaux' => $this->bailleurRepository->findBailleursByTerritory($user, $territory),
                 ];
             }


### PR DESCRIPTION
## Ticket

#4925

## Description

Les problèmes viennent : 
- du WS de signalement qui initialise `isImported` à true sans queryParameter
- une jointure sur les affectations à ignorer dans la requête de comptage de signalement importé

## Changements apportés
* Ne plus appliquer `isImported` à true par défaut 
* Ne plus écraser systématiquement `filters.isImported` lors de l’initialisation depuis `settings` pour le super admin
* Conserver la valeur de `isImported` lors du reset des filtres si elle était active.

## Pré-requis

(remonté par le 76 entre autre mais le bug est généralisé) 
`make load-data `

`make npm-watch`

## Tests

* Se connecter en tant que RT  (76 et 62 entre autre) et super admin
- [ ] Activer `Afficher les signalements importés` et  vérifier la présence de `isImported=oui` dans l’URL.
- [ ] Modifier un autre filtre et vérifier que `isImported=oui` reste dans l’URL et que l'appel est bien effectué avec le filtre
- [ ] Vérifier la cohérence des compteurs avec et sans filtres `Afficher les signalements importés`
- [ ] Réinitialiser les filtres et vérifier que `isImported` reste actif si attendu.

* TNR agents (ne doit pas s'afficher)