### PR TITLE
[BO- Signalement] Non abonnement RT si partenaire affecté

### DIFF
--- a/src/Command/FixRtLegacySubscriptionsWhenPartnerAffectedCommand.php
+++ b/src/Command/FixRtLegacySubscriptionsWhenPartnerAffectedCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Command;
+
+use App\Manager\HistoryEntryManager;
+use App\Manager\UserManager;
+use App\Manager\UserSignalementSubscriptionManager;
+use App\Repository\AffectationRepository;
+use App\Repository\SignalementRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:fix-rt-legacy-subscriptions-when-partner-affected',
+    description: 'Initialize user signalement subscriptions for existing signalements and affectations',
+)]
+class FixRtLegacySubscriptionsWhenPartnerAffectedCommand
+{
+    private const int BATCH_SIZE = 1000;
+    private ?\DateTimeImmutable $activationDate = null;
+    /** @var array<int, array<int>> */
+    private array $usersByPartner = [];
+
+    public function __construct(
+        private readonly UserManager $userManager,
+        private readonly UserRepository $userRepository,
+        private readonly AffectationRepository $affectationRepository,
+        private readonly SignalementRepository $signalementRepository,
+        private readonly UserSignalementSubscriptionManager $userSignalementSubscriptionManager,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly HistoryEntryManager $historyEntryManager,
+    ) {
+        $this->activationDate = new \DateTimeImmutable('2025-10-28 12:25:00');
+        $this->historyEntryManager->removeEntityListeners();
+    }
+
+    public function __invoke(SymfonyStyle $io): int
+    {
+        $creationCounter = 0;
+        $userSystem = $this->userManager->getSystemUser();
+        $listAgents = $this->userRepository->findAllUnarchivedRT();
+        foreach ($listAgents as $user) {
+            if (!isset($this->usersByPartner[$user['partner_id']])) {
+                $this->usersByPartner[$user['partner_id']] = [];
+            }
+            $this->usersByPartner[$user['partner_id']][] = $user['id'];
+        }
+        $affectations = $this->affectationRepository->findAllActiveAffectationOnPartnerWithRt($this->activationDate);
+        $io->info(count($affectations).' affectations à traiter.');
+
+        $progressBar = $io->createProgressBar(count($affectations));
+        $i = 0;
+        foreach ($affectations as $affectation) {
+            if (!isset($this->usersByPartner[$affectation['partner_id']])) {
+                continue;
+            }
+            foreach ($this->usersByPartner[$affectation['partner_id']] as $userId) {
+                $user = $this->userRepository->find($userId);
+                $signalement = $this->signalementRepository->find($affectation['signalement_id']);
+                $created = false;
+                $sub = $this->userSignalementSubscriptionManager->createOrGet(
+                    userToSubscribe: $user,
+                    signalement: $signalement,
+                    createdBy: $userSystem,
+                    subscriptionCreated: $created
+                );
+                if ($created) {
+                    $sub->setIsLegacy(true);
+                    ++$creationCounter;
+                }
+            }
+            ++$i;
+            if (($i % self::BATCH_SIZE) === 0) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+                $userSystem = $this->userManager->getSystemUser();
+            }
+            $progressBar->advance();
+        }
+        $this->entityManager->flush();
+        $progressBar->finish();
+        $io->newLine();
+        $io->success($creationCounter.' abonnements RT créés.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/AffectationRepository.php
+++ b/src/Repository/AffectationRepository.php
@@ -283,6 +283,33 @@ class AffectationRepository extends ServiceEntityRepository
         return $stmt->executeQuery()->fetchAllAssociative();
     }
 
+    /**
+     * @return array<array{signalement_id: int, partner_id: int}>
+     */
+    public function findAllActiveAffectationOnPartnerWithRt(\DateTimeImmutable $date): array
+    {
+        $sql = '
+            SELECT DISTINCT a.signalement_id, a.partner_id
+            FROM affectation a
+            INNER JOIN signalement s ON a.signalement_id = s.id
+            INNER JOIN partner p ON a.partner_id = p.id
+            INNER JOIN user_partner up ON p.id = up.partner_id
+            INNER JOIN user u ON up.user_id = u.id
+            WHERE JSON_CONTAINS(u.roles, \'\"ROLE_ADMIN_TERRITORY\"\') = 1
+            AND a.answered_at <= :date
+            AND s.statut = :signalement_status
+            AND a.statut = :affectation_status
+        ';
+
+        $connection = $this->getEntityManager()->getConnection();
+        $stmt = $connection->prepare($sql);
+        $stmt->bindValue('signalement_status', SignalementStatus::ACTIVE->value);
+        $stmt->bindValue('affectation_status', AffectationStatus::ACCEPTED->value);
+        $stmt->bindValue('date', $date->format('Y-m-d H:i:s'));
+
+        return $stmt->executeQuery()->fetchAllAssociative();
+    }
+
     public function findWithoutSubscriptionFilteredPaginated(SearchAffectationWithoutSubscription $searchAffectation, int $maxResult): Paginator
     {
         // Sous-requête pour identifier les affectations avec abonnements

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -119,6 +119,25 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         return $stmt->executeQuery()->fetchAllAssociative();
     }
 
+    /**
+     * @return array<array{id: int, partner_id: int}>
+     */
+    public function findAllUnarchivedRT(): ?array
+    {
+        $sql = "
+            SELECT u.id, up.partner_id
+            FROM user u
+            INNER JOIN user_partner up ON u.id = up.user_id
+            WHERE u.statut != '".UserStatus::ARCHIVE->value."'
+            AND (JSON_CONTAINS(u.roles, '\"ROLE_ADMIN_TERRITORY\"') = 1)
+        ";
+
+        $connection = $this->getEntityManager()->getConnection();
+        $stmt = $connection->prepare($sql);
+
+        return $stmt->executeQuery()->fetchAllAssociative();
+    }
+
     public function findArchivedUserByEmail(string $email): ?User
     {
         $queryBuilder = $this->createQueryBuilder('u');

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -48,6 +48,7 @@
     <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-system/icons-system.min.css') }}">
     <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}">
     <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-weather/icons-weather.min.css') }}">
+    <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-arrows/icons-arrows.min.css') }}">
     <link rel="stylesheet" href={{ asset('build/app.css') }}>
 
     {% if 'back_signalement_view' in app.request.get('_route') %}


### PR DESCRIPTION
## Ticket

#4928
#4926

## Description
#4928
La commande d'initialisation des abonnements avait exclus les RT des partenaires affecté (au lieu d’abonner tous les agents actif du partenaire affecté, on abonné tous les agent à l'eception ds RT). 
Création de la commande `app:fix-rt-legacy-subscriptions-when-partner-affected` qui corrige ca sur l'historique.

#4926
Ajout d'un import css pour corriger les icone de flèche qui ne fonctionne plus

## Pré-requis
`make load-data`

## Tests
- [ ] Regarder les abonnement du signalement `2025-1196` dans le 33. Lancer la commande et voir que les RT des partenair affecté (DDTM33) sont à présent affecté
