### PR TITLE
[BO - Signalements] Agent - Pbm dossier importé

### DIFF
--- a/src/Service/Signalement/SearchFilterOptionDataProvider.php
+++ b/src/Service/Signalement/SearchFilterOptionDataProvider.php
@@ -66,7 +66,7 @@ class SearchFilterOptionDataProvider
                     'listQualificationStatus' => $this->qualificationStatusService->getList(),
                     'listVisiteStatus' => VisiteStatus::getLabelList(),
                     'hasSignalementsImported' => $user->isSuperAdmin() || $user->isTerritoryAdmin()
-                        ? $this->signalementRepository->countImported($territory) : false,
+                        ? $this->signalementRepository->countImported($territory) : $this->signalementRepository->countImported($territory, $user),
                     'bailleursSociaux' => $this->bailleurRepository->findBailleursByTerritory($user, $territory),
                 ];
             }


### PR DESCRIPTION
## Ticket

#4929   

## Description
Les agents peuvent voir le bouton

## Changements apportés
* Mise à jour du web-service settings

## Pré-requis
```
make load-data
```

Chercher des agents dans des partenaires affectés dans des signalement importés
```sql
select s.uuid, p.nom, p.id, s.reference
from signalement s
inner join affectation a on a.signalement_id = s.id
inner join partner p on p.id = a.partner_id
where s.territory_id = 63 and s.is_imported = 1;
```

## Tests
- [ ] Se connecter en tant qu'agent dans un territoire qui a des signalement importé
