### PR TITLE
[BO - Signalement] Résultat filtre statut affectation incorrect sur partenaire sélectionné

### DIFF
--- a/src/Service/Signalement/SearchFilter.php
+++ b/src/Service/Signalement/SearchFilter.php
@@ -583,7 +583,7 @@ class SearchFilter
             return $qb;
         }
 
-        $status = trim(AffectationStatus::mapFilterStatus($statusAffectation));
+        $status = AffectationStatus::mapFilterStatus($statusAffectation);
         // Besoin de récupérer toutes les jointures en cours
         $joins = $qb->getDQLPart('join');
         $hasAffectationFiltrePartenaireJoin = false;


### PR DESCRIPTION
## Ticket

#4974    

## Description
Correction du filtre statut d’affectation sur la liste des signalements en tant que SA et RT
Lorsqu'un SA filtrait par partenaire, le statut d’affectation était appliqué sur l’agrégat global (affectationStatus) au lieu d’être appliqué uniquement à l’affectation du partenaire sélectionné.

## Changements apportés
* Renommage de l’alias `affectationFiltrePartenaire` de jointure des affectations filtrées par partenaire
* Mise à jour de `addFilterStatusAffectation()` qui applique désormais le statut directement sur `affectationFiltrePartenaire` si cette jointure existe, sinon elle utilise le filtre habituel basé sur `affectationStatus`.

## Pré-requis

`make load-data`

Ouvrir deux sessions une en tant que SA ou/et RT et l'autre en tant qu'agent

## Tests
- [ ] En tant que SA, filtrer la liste des signalements par partenaire et statut d’affectation et vérifier que le partenaire filtré affiche un badge correspondant au statut sélectionné.

_83 signalements trouvés_
http://localhost:8080/bo/signalements/?territoire=13&partenaires[]=777&isImported=oui&statusAffectation=accepte&sortBy=reference&direction=DESC 

- [ ] En tant qu’agent (avec une autre session), filtrer la liste avec le même statut d’affectation et comparer le nombre de résultats : il doit être identique à celui obtenu côté super admin.

_83 signalements trouvés_
http://localhost:8080/bo/signalements/?status=en_cours&sortBy=reference&direction=DESC
