### PR TITLE
[BO - Dossier - Suivi] Afficher les docs par ordre alphabetique

### DIFF
--- a/src/Service/FileListService.php
+++ b/src/Service/FileListService.php
@@ -53,14 +53,22 @@ class FileListService
         $situationFiles = $signalement->getFiles()->filter(function (File $file) {
             return !$file->getIsSuspicious() && ($file->isSituation() || null === $file->getDocumentType());
         });
-        $choices['Documents de la situation'] = $situationFiles->toArray();
+        $situationFilesSorted = $situationFiles->toArray();
+        usort($situationFilesSorted, function (File $a, File $b) {
+            return strcmp($a->getTitle(), $b->getTitle());
+        });
+        $choices['Documents de la situation'] = $situationFilesSorted;
 
         // 2. Documents liés à la procédure
         $procedureFiles = $signalement->getFiles()->filter(function (File $file) {
             return !$file->getIsSuspicious() && $file->isProcedure();
         });
         if (!$procedureFiles->isEmpty()) {
-            $choices['Documents liés à la procédure'] = $procedureFiles->toArray();
+            $procedureFilesSorted = $procedureFiles->toArray();
+            usort($procedureFilesSorted, function (File $a, File $b) {
+                return strcmp($a->getTitle(), $b->getTitle());
+            });
+            $choices['Documents liés à la procédure'] = $procedureFilesSorted;
         }
 
         // 3. Documents types (fichiers standalone)

--- a/tests/Unit/Service/FileListServiceTest.php
+++ b/tests/Unit/Service/FileListServiceTest.php
@@ -56,6 +56,14 @@ class FileListServiceTest extends WebTestCase
         $this->assertArrayNotHasKey('Documents liés à la procédure', $choices);
         $this->assertArrayHasKey('Documents types', $choices);
         $this->assertCount(6, $choices['Documents de la situation']);
+
+        $files = $choices['Documents de la situation'];
+
+        $titles = array_map(fn ($file) => $file->getTitle(), $files);
+        $sorted = $titles;
+        sort($sorted, \SORT_NATURAL | \SORT_FLAG_CASE);
+
+        $this->assertSame($sorted, $titles, 'Les fichiers ne sont pas triés alphabétiquement');
     }
 
     public function testGetFileChoicesForSignalementNDE(): void
@@ -77,6 +85,14 @@ class FileListServiceTest extends WebTestCase
         $this->assertArrayHasKey('Modèle de courrier', $choices['Documents types']);
         $this->assertCount(6, $choices['Documents de la situation']);
         $this->assertCount(6, $choices['Documents types']['Modèle de courrier']);
+
+        $files = $choices['Documents de la situation'];
+
+        $titles = array_map(fn ($file) => $file->getTitle(), $files);
+        $sorted = $titles;
+        sort($sorted, \SORT_NATURAL | \SORT_FLAG_CASE);
+
+        $this->assertSame($sorted, $titles, 'Les fichiers ne sont pas triés alphabétiquement');
     }
 
     public function testGetFileChoicesForSignalementNonNDEUser(): void
@@ -98,5 +114,13 @@ class FileListServiceTest extends WebTestCase
         $this->assertArrayNotHasKey('Documents liés à la procédure', $choices);
         $this->assertArrayNotHasKey('Documents types', $choices);
         $this->assertCount(6, $choices['Documents de la situation']);
+
+        $files = $choices['Documents de la situation'];
+
+        $titles = array_map(fn ($file) => $file->getTitle(), $files);
+        $sorted = $titles;
+        sort($sorted, \SORT_NATURAL | \SORT_FLAG_CASE);
+
+        $this->assertSame($sorted, $titles, 'Les fichiers ne sont pas triés alphabétiquement');
     }
 }


### PR DESCRIPTION
## Ticket

#4437   

## Description
Dans la modale d'ajout de suivi, dans le menu d ajout des dosuments : afficher les documents de la situation par ordre alphabetique (comme on le fait pour les documents types)

<img width="1582" height="951" alt="Image" src="https://github.com/user-attachments/assets/879579f0-282a-4456-9493-9b6cc47aa9ed" />

## Changements apportés
* Modification du FileListService et du test associé pour trier les fichiers

## Pré-requis

## Tests
- [ ] Ajouter des documents de situation et des documents de procédure sur un signalement
- [ ] Ajouter un suivi et vérifier l'affichage de la liste des fichiers
