### PR TITLE
[BO - Signalement] Corrections sur le filtre "afficher les signalements importés"

### DIFF
--- a/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
+++ b/assets/scripts/vue/components/signalement-view/utils/signalementUtils.ts
@@ -72,11 +72,7 @@ export function handleSettings (context: any, requestResponse: any): any {
   context.sharedState.user.canSeeScore = isAdminOrAdminTerritoire
   context.sharedState.user.partnerIds = requestResponse.partnerIds
   context.sharedState.hasSignalementImported = requestResponse.hasSignalementImported
-  if (context.sharedState.user.isAdmin) {
-      context.sharedState.input.filters.isImported = context.sharedState.hasSignalementImported ? "oui" : null
-  } else {
-      context.sharedState.input.filters.isImported = null
-  }
+  context.sharedState.input.filters.isImported = context.sharedState.hasSignalementImported ? "oui" : null
 
   context.sharedState.territories = []
   for (const id in requestResponse.territories) {

--- a/src/Controller/Back/SettingsController.php
+++ b/src/Controller/Back/SettingsController.php
@@ -33,6 +33,8 @@ class SettingsController extends AbstractController
         $territory = null;
         if ($territoryId && ($security->isGranted('ROLE_ADMIN') || isset($authorizedTerritories[$territoryId]))) {
             $territory = $territoryRepository->find($territoryId);
+        } elseif (1 === count($authorizedTerritories)) {
+            $territory = $authorizedTerritories[array_key_first($authorizedTerritories)];
         }
 
         return $this->json(

--- a/src/Service/Menu/MenuBuilder.php
+++ b/src/Service/Menu/MenuBuilder.php
@@ -24,11 +24,11 @@ readonly class MenuBuilder
     {
         /** @var User $user */
         $user = $this->currentRoute->getUser();
-        $listRouteParameters = [];
+        $listRouteParameters = ['isImported' => 'oui'];
         if ($this->currentRoute->isGranted(User::ROLE_ADMIN)) {
-            $listRouteParameters = ['status' => 'nouveau', 'isImported' => 'oui'];
+            $listRouteParameters['status'] = 'nouveau';
         } elseif ($user->isUserPartner()) {
-            $listRouteParameters = ['showMySignalementsOnly' => 'oui'];
+            $listRouteParameters['showMySignalementsOnly'] = 'oui';
         }
         $signalementsSubMenu = (new MenuItem(label: 'Signalements', roleGranted: User::ROLE_USER))
             ->addChild(new MenuItem(label: 'Liste', route: 'back_signalements_index', routeParameters: $listRouteParameters, roleGranted: User::ROLE_USER));

--- a/tests/Functional/Controller/SettingsControllerTest.php
+++ b/tests/Functional/Controller/SettingsControllerTest.php
@@ -26,6 +26,8 @@ class SettingsControllerTest extends WebTestCase
         $this->assertArrayHasKey('lastname', $responseContent);
         $this->assertArrayHasKey('roleLabel', $responseContent);
         $this->assertArrayHasKey('territories', $responseContent);
+        $this->assertArrayHasKey('hasSignalementImported', $responseContent);
+        $this->assertTrue($responseContent['hasSignalementImported']);
     }
 
     public function testSettingsWithTerritory(): void
@@ -47,5 +49,27 @@ class SettingsControllerTest extends WebTestCase
         $this->assertArrayHasKey('partners', $responseContent);
         $this->assertArrayHasKey('epcis', $responseContent);
         $this->assertArrayHasKey('tags', $responseContent);
+    }
+
+    public function testSettingsWithoutImported(): void
+    {
+        $client = static::createClient();
+
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-44-01@signal-logement.fr']);
+        $client->loginUser($user);
+
+        $router = self::getContainer()->get(RouterInterface::class);
+        $client->request('GET', $router->generate('back_settings'));
+
+        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $responseContent = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('firstname', $responseContent);
+        $this->assertArrayHasKey('lastname', $responseContent);
+        $this->assertArrayHasKey('roleLabel', $responseContent);
+        $this->assertArrayHasKey('territories', $responseContent);
+        $this->assertArrayHasKey('hasSignalementImported', $responseContent);
+        $this->assertFalse($responseContent['hasSignalementImported']);
     }
 }


### PR DESCRIPTION
## Ticket

#4990   

## Description
Activer le filtre signalement importé par défaut pour les agents/RT qui en ont

En faisant la demande, je me suis aperçue que le filtre apparaissait aussi pour les RT n'ayant pas de signalements importés

## Changements apportés
* Correction de signalementUtils.ts et du MenuBuilder pour que le filtre 'afficher les signalements importés" soit coché par défaut pour tous les rôles
* Corrections de SettingsController pour vérifier s'il y a des signalements importés sur le territoire du RT et pas sur tous les territoires

## Pré-requis
`make npm-watch`
## Tests
- [ ] Tester la liste des signalements avec tous les rôles dans au moins 2 territoires (un avec signalements importés genre le 13, un sans signalements importés genre le 44)
- [ ] Vérifier que le filtre n'apparait que s'il y a des signalements importés dans le territoire concerné
- [ ] Vérifier qu'il est coché par défaut
