### PR TITLE
 [BO - Dashboard] Permettre de retirer un dossier du dashboard pour les messages usagers post clôture

### DIFF
--- a/src/Controller/Back/NotificationController.php
+++ b/src/Controller/Back/NotificationController.php
@@ -7,7 +7,6 @@ use App\Entity\User;
 use App\Form\SearchNotificationType;
 use App\Repository\NotificationRepository;
 use App\Service\ListFilters\SearchNotification;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -92,7 +91,6 @@ class NotificationController extends AbstractController
     #[Route('/notifications/{id}/supprimer', name: 'back_notifications_delete_notification')]
     public function deleteNotification(
         NotificationRepository $notificationRepository,
-        EntityManagerInterface $em,
         Request $request,
     ): Response {
         $notification = $notificationRepository->find($request->get('id'));
@@ -102,8 +100,7 @@ class NotificationController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
         if ($notification->getUser()->getId() === $user->getId() && $this->isCsrfTokenValid('back_delete_notification_'.$notification->getId(), (string) $request->get('_token'))) {
-            $em->remove($notification);
-            $em->flush();
+            $notificationRepository->deleteUserNotifications($user, [$notification->getId()]);
             $this->addFlash('success', 'Notification supprimée avec succès');
         } else {
             $this->addFlash('error', 'Erreur lors de la suppression de la notification.');

--- a/src/Repository/SuiviRepository.php
+++ b/src/Repository/SuiviRepository.php
@@ -595,12 +595,8 @@ class SuiviRepository extends ServiceEntityRepository
 
     private function addFilterNotificationNotSeen(
         QueryBuilder $qb,
-        ?User $user = null,
+        User $user,
     ): QueryBuilder {
-        if (null === $user) {
-            throw new \InvalidArgumentException('User is required to filter unseen notifications.');
-        }
-
         $qb->innerJoin(
             Notification::class,
             'n',
@@ -608,7 +604,9 @@ class SuiviRepository extends ServiceEntityRepository
             'n.suivi = s AND n.user = :currentUser'
         )
             ->andWhere('n.seenAt IS NULL')
-            ->setParameter('currentUser', $user);
+            ->setParameter('currentUser', $user)
+            ->andWhere('n.deleted = :deleted')
+            ->setParameter('deleted', false);
 
         $qb->andWhere('signalement.statut = :statut')
             ->setParameter('statut', SignalementStatus::CLOSED);

--- a/tests/Functional/Repository/SuiviRepositoryTest.php
+++ b/tests/Functional/Repository/SuiviRepositoryTest.php
@@ -189,6 +189,31 @@ class SuiviRepositoryTest extends KernelTestCase
         $this->assertEquals(0, $result);
     }
 
+    public function testCountSuivisPostClotureDeleted(): void
+    {
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => self::USER_ADMIN]);
+        /** @var Signalement $signalementWithSuiviPostCloture */
+        $signalementWithSuiviPostCloture = $this->entityManager->getRepository(Signalement::class)->findOneBy(['reference' => '2022-2']);
+        /** @var Notification $notification */
+        $notification = $this->entityManager->getRepository(Notification::class)->findOneBy([
+            'signalement' => $signalementWithSuiviPostCloture,
+            'user' => $user,
+            'type' => NotificationType::NOUVEAU_SUIVI,
+        ]);
+        $notification->setDeleted(true);
+        $this->entityManager->persist($notification);
+        $this->entityManager->flush();
+
+        $tabQueryParameter = new TabQueryParameters(
+            mesDossiersMessagesUsagers: '0',
+            sortBy: 'createdAt',
+            orderBy: 'DESC',
+        );
+        $result = $this->suiviRepository->countSuivisPostCloture($user, $tabQueryParameter);
+        $this->assertIsInt($result);
+        $this->assertEquals(0, $result);
+    }
+
     public function testCountSuivisPostClotureNoNotification(): void
     {
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => self::USER_ADMIN]);


### PR DESCRIPTION
## Ticket

#4994   

## Description
Contexte : dans certains cas, les messages usagers post clôture n'appellent pas à une action. Les usagers peuvent simplement dire "merci" ou "ok compris". Le problème est que si on ne fait pas d'action suite à un message post clôture, le dossier continue d'apparaître sur le dashboard, onglet Messages usagers.

On choisit donc de filtrer sur l'état de la notification associée à ce suivi. 
Dès que l'utilisateur va sur la fiche signalement, la notification est considérée comme "vue" (donc le suivi aussi). Un champ seenAt est initialisé. 
Si la notification est supprimée, son champ deleted passe à true. 
Pour le dashboard on filtre sur ces champs.

## Changements apportés
* Modification du SuiviRepository pour ajouter une jointure sur les notifications. Un signalement n'apparaitra que s'il existe pour ce suivi post-cloture et l'utilisateur connecté une notification non-vue et non supprimée
* On corrige la suppression unitaire des notifications pour faire également une suppression logique

## Pré-requis

## Tests
- [ ] Se connecter avec un utilisateur qui est affecté à un signalement ayant un suivi post-cloture (2022-2 par exemple)
- [ ] Vérifier sur le dashboard qu'on a le message dans le panel des messages post-cloture
- [ ] Aller sur le signalement, et vérifier qu'il n'est plus sur le dashboard
- [ ] Supprimer la notification et vérifier qu'il n'est toujours plus sur le dashboard
