### PR TITLE
[Tech - viewSignalement] Simplifier le controller

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -156,12 +156,12 @@ class AffectationController extends AbstractController
     }
 
     #[Route('/affectation/{affectation}/accept', name: 'back_signalement_affectation_accept', methods: 'POST')]
+    #[IsGranted(AffectationVoter::AFFECTATION_ACCEPT_OR_REFUSE, subject: 'affectation')]
     public function affectationResponseSignalement(
         Affectation $affectation,
         Request $request,
         UserSignalementSubscriptionManager $userSignalementSubscriptionManager,
     ): Response {
-        $this->denyAccessUnlessGranted(AffectationVoter::ANSWER, $affectation);
         $signalement = $affectation->getSignalement();
         /** @var User $user */
         $user = $this->getUser();
@@ -218,11 +218,11 @@ class AffectationController extends AbstractController
     }
 
     #[Route('/affectation/{affectation}/deny', name: 'back_signalement_affectation_deny', methods: 'POST')]
+    #[IsGranted(AffectationVoter::AFFECTATION_ACCEPT_OR_REFUSE, subject: 'affectation')]
     public function affectationResponseDenySignalement(
         Affectation $affectation,
         Request $request,
     ): JsonResponse {
-        $this->denyAccessUnlessGranted(AffectationVoter::ANSWER, $affectation);
         $signalement = $affectation->getSignalement();
         /** @var User $user */
         $user = $this->getUser();

--- a/src/Security/Voter/AffectationVoter.php
+++ b/src/Security/Voter/AffectationVoter.php
@@ -16,9 +16,10 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  */
 class AffectationVoter extends Voter
 {
-    public const string ANSWER = 'AFFECTATION_ANSWER';
-    public const string CLOSE = 'AFFECTATION_CLOSE';
-    public const string REOPEN = 'AFFECTATION_REOPEN';
+    public const string AFFECTATION_ACCEPT_OR_REFUSE = 'AFFECTATION_ACCEPT_OR_REFUSE';
+    public const string AFFECTATION_CANCEL_REFUSED = 'AFFECTATION_CANCEL_REFUSED';
+    public const string AFFECTATION_CLOSE = 'AFFECTATION_CLOSE';
+    public const string AFFECTATION_REOPEN = 'AFFECTATION_REOPEN';
     public const string AFFECTATION_REINIT = 'AFFECTATION_REINIT';
 
     public function __construct(
@@ -28,7 +29,7 @@ class AffectationVoter extends Voter
 
     protected function supports(string $attribute, $subject): bool
     {
-        return \in_array($attribute, [self::ANSWER, self::CLOSE, self::REOPEN, self::AFFECTATION_REINIT], true) && ($subject instanceof Affectation);
+        return \in_array($attribute, [self::AFFECTATION_ACCEPT_OR_REFUSE, self::AFFECTATION_CANCEL_REFUSED, self::AFFECTATION_CLOSE, self::AFFECTATION_REOPEN, self::AFFECTATION_REINIT], true) && ($subject instanceof Affectation);
     }
 
     /**
@@ -45,9 +46,10 @@ class AffectationVoter extends Voter
         }
 
         return match ($attribute) {
-            self::ANSWER => $this->canAnswer($subject, $user),
-            self::CLOSE => $this->canClose($subject, $user),
-            self::REOPEN => $this->canReopen($subject, $user),
+            self::AFFECTATION_ACCEPT_OR_REFUSE => $this->canAcceptOrRefuse($subject, $user),
+            self::AFFECTATION_CANCEL_REFUSED => $this->canCancelRefused($subject, $user),
+            self::AFFECTATION_CLOSE => $this->canClose($subject, $user),
+            self::AFFECTATION_REOPEN => $this->canReopen($subject, $user),
             self::AFFECTATION_REINIT => $this->canReinit($subject, $user),
             default => false,
         };
@@ -63,6 +65,16 @@ class AffectationVoter extends Voter
         }
 
         return false;
+    }
+
+    private function canAcceptOrRefuse(Affectation $affectation, User $user): bool
+    {
+        return $this->canAnswer($affectation, $user) && AffectationStatus::WAIT === $affectation->getStatut();
+    }
+
+    private function canCancelRefused(Affectation $affectation, User $user): bool
+    {
+        return $this->canAnswer($affectation, $user) && AffectationStatus::REFUSED === $affectation->getStatut();
     }
 
     private function canClose(Affectation $affectation, User $user): bool

--- a/templates/_partials/_modal_cloture.html.twig
+++ b/templates/_partials/_modal_cloture.html.twig
@@ -38,7 +38,7 @@
                                         Clôturer pour tous les partenaires
                                     </button>
                                 </li>
-                                {% if affectation and isAffectationAccepted %}
+                                {% if affectation and affectation.statut is same as constant('App\\Entity\\Enum\\AffectationStatus::ACCEPTED') %}
                                     <li>
                                         <button class="fr-btn fr-icon-check-line" form="cloture_form" type="submit" data-cloture-type="partner">
                                             Clôturer pour {{ app.user.partnerInTerritoryOrFirstOne(signalement.territory) ? app.user.partnerInTerritoryOrFirstOne(signalement.territory).nom : 'N/A' }}

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -73,21 +73,18 @@
         {% include '_partials/_modal_reopen_signalement.html.twig' with { 'all': '0' } %}
     {% endif %}
 
-    <div class="fr-background--white
-            {{ (isClosedForMe and not is_granted('ROLE_ADMIN_TERRITORY'))
-                or signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED
-                or signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').REFUSED
-            ? 'signalement-invalid'
-            : ''
-            }}">
-        <section id="signalement-{{ signalement.id }}-content"
-            class="fr-p-5v">
-
+    {% set signalementInvalidClass = '' %}
+    {% 
+       if signalement.statut in [enum('App\\Entity\\Enum\\SignalementStatus').CLOSED, enum('App\\Entity\\Enum\\SignalementStatus').REFUSED] 
+       or (not is_granted('ROLE_ADMIN_TERRITORY') and affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').CLOSED)
+     %}
+        {% set signalementInvalidClass = 'signalement-invalid' %}
+    {% endif %}
+    <div class="fr-background--white {{ signalementInvalidClass }}">
+        <section id="signalement-{{ signalement.id }}-content" class="fr-p-5v">
             {% include 'back/signalement/view/photos-album.html.twig' %}
-            
             {% include 'back/signalement/view/header.html.twig' %}
         </section>
-
         {% include 'back/signalement/view/tabs.html.twig' %}
     </div>
 {% endblock %}

--- a/templates/back/signalement/view/header/_main-action.html.twig
+++ b/templates/back/signalement/view/header/_main-action.html.twig
@@ -1,6 +1,6 @@
 {% set currentPartner =  app.user.partnerInTerritoryOrFirstOne(signalement.territory) %}
 {% set isAloneInCurrentPartner = app.user.isAloneInPartner(currentPartner) %}
-{% if (canAnswerAffectation or canCancelRefusedAffectation) and not isAloneInCurrentPartner %}
+{% if (is_granted('AFFECTATION_ACCEPT_OR_REFUSE', affectation) or is_granted('AFFECTATION_CANCEL_REFUSED', affectation)) and not isAloneInCurrentPartner %}
     <div data-ajax-form class="fr-display-inline">
         {% include '_partials/_modal_accept_affectation.html.twig' %}
     </div>
@@ -10,7 +10,7 @@
         {% include '_partials/_modal_transfer_subscription.html.twig' %}
     </div>
 {% endif %}
-{% if canValidateOrRefuseSignalement and not isUniqueRtInCurrentPartner %}
+{% if is_granted('SIGN_VALIDATE', signalement) and not isUniqueRtInCurrentPartner %}
     <div data-ajax-form>
         {% include '_partials/_modal_accept_signalement.html.twig' %}
     </div>
@@ -26,7 +26,7 @@
         </div>
     </div>
 {% endif %}
-{% if canAnswerAffectation %}
+{% if is_granted('AFFECTATION_ACCEPT_OR_REFUSE', affectation) %}
     <div data-ajax-form class="fr-display-inline">
         {% include '_partials/_modal_refus_affectation.html.twig' %}
     </div>
@@ -61,7 +61,7 @@
         aria-controls="refus-affectation-modal">
         Refuser l'affectation
     </a>
-{% elseif canValidateOrRefuseSignalement %}
+{% elseif is_granted('SIGN_VALIDATE', signalement) %}
     <div class="fr-notice fr-notice--info fr-my-4v fr-text--left">
         <div class="fr-pl-3v">
             <div class="fr-notice__body">

--- a/templates/back/signalement/view/header/_menu.html.twig
+++ b/templates/back/signalement/view/header/_menu.html.twig
@@ -1,13 +1,13 @@
 <nav role="navigation" class="fr-translate menu-actions-signalement fr-nav fr-mb-3v fr-mt-3v">
     <div class="fr-nav__item">
-        <button aria-controls="header-menu" aria-expanded="false" type="button" class="fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-settings-5-line keep-when-signalement-closed">
+        <button aria-controls="header-menu" aria-expanded="false" type="button" class="fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-settings-5-line">
             Actions
         </button>
         <div class="fr-collapse fr-translate__menu fr-menu" id="header-menu">
             <ul class="fr-menu__list">
                 {% set currentPartner =  app.user.partnerInTerritoryOrFirstOne(signalement.territory) %}
                 {% set isAloneInCurrentPartner = app.user.isAloneInPartner(currentPartner) %}
-                {% if canCancelRefusedAffectation %}
+                {% if is_granted('AFFECTATION_CANCEL_REFUSED', affectation) %}
                     <li>
                         {% if isAloneInCurrentPartner %}
                             <form id="signalement-affectation-response-form" action="{{ path('back_signalement_affectation_accept',{affectation:affectation.id}) }}" method="POST" class="inline-form">
@@ -28,7 +28,7 @@
                 {% elseif is_granted('SIGN_REOPEN', signalement) %}
                     <li>
                         <button
-                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill keep-when-signalement-closed"
+                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill"
                             aria-controls="reopen-all-signalement-modal" 
                             data-fr-opened="false"
                             >
@@ -38,7 +38,7 @@
                 {% elseif is_granted('AFFECTATION_REOPEN', affectation) %}
                     <li>
                         <button
-                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill keep-when-signalement-closed"
+                            class="fr-nav__link fr-btn--icon-left fr-fi-lock-fill"
                             aria-controls="reopen-signalement-modal" 
                             data-fr-opened="false">
                             Rouvrir pour {{ currentPartner ? currentPartner.nom : 'N/A' }}
@@ -109,7 +109,7 @@
                                     </button>
                                 {% endif %}
                             </li>
-                        {% elseif not canCancelRefusedAffectation %}
+                        {% elseif not is_granted('AFFECTATION_CANCEL_REFUSED', affectation) %}
                             <li>
                                 <a href="{{ path('back_signalement_subscribe', {uuid: signalement.uuid}) }}?_token={{ csrf_token('subscribe') }}"
                                     class="fr-nav__link fr-btn--icon-left fr-icon-eye-line">

--- a/templates/back/signalement/view/header/_tags.html.twig
+++ b/templates/back/signalement/view/header/_tags.html.twig
@@ -2,7 +2,7 @@
     <div class="fr-mt-4v fr-p-4v fr-background-alt--grey">
         <strong>Etiquettes</strong>
         {% if is_granted('SIGN_EDIT_ACTIVE', signalement) or is_granted('SIGN_EDIT_CLOSED', signalement) %}
-            <button class="keep-when-signalement-closed">
+            <button>
                 <a class="fr-btn--icon-left fr-a-edit fr-icon-bookmark-line fr-ml-2v" id="tags_select_tooltip_btn" href="#" data-fr-opened="false" aria-controls="fr-modal-etiquettes">
                     Gérer les étiquettes
                 </a>
@@ -92,12 +92,12 @@
                             <div class="fr-modal__footer">
                                 <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                                     <li>
-                                        <button class="fr-btn fr-icon-check-line keep-when-signalement-closed" form="form-signalement-save-tags" type="submit">
+                                        <button class="fr-btn fr-icon-check-line" form="form-signalement-save-tags" type="submit">
                                             Valider
                                         </button>
                                     </li>
                                     <li>
-                                        <button class="fr-btn fr-btn--secondary fr-icon-close-line keep-when-signalement-closed" type="button" aria-controls="fr-modal-etiquettes">
+                                        <button class="fr-btn fr-btn--secondary fr-icon-close-line" type="button" aria-controls="fr-modal-etiquettes">
                                             Annuler
                                         </button>
                                     </li>

--- a/templates/back/signalement/view/header/_title.html.twig
+++ b/templates/back/signalement/view/header/_title.html.twig
@@ -16,14 +16,14 @@
                 <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Brouillon</span>
             {% endif %}
         {% else %}
-            {% if affectation and not isAffectationAccepted and not isAffectationRefused and not isSignalementClosed and not isClosedForMe %}
-                <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
-            {% elseif isAffectationAccepted %}
-                <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
-            {% elseif isAffectationRefused %}
-                <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
-            {% elseif isClosedForMe %}
+            {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED or affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').CLOSED %}
                 <span class="fr-badge fr-badge--error fr-badge--no-icon"><span class="fr-icon-checkbox-circle-line" aria-hidden="true"></span> Clôturé</span>
+            {% elseif affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').WAIT %}
+                <span class="fr-badge fr-badge--warning fr-badge--no-icon"><span class="fr-icon-warning-line" aria-hidden="true"></span> Nouveau</span>
+            {% elseif affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').ACCEPTED %}
+                <span class="fr-badge fr-badge--success fr-badge--no-icon"><span class="fr-icon-message-2-line" aria-hidden="true"></span> En cours</span>
+            {% elseif affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').REFUSED %}
+                <span class="fr-badge fr-badge--new fr-badge--no-icon"><span class="fr-icon-close-line" aria-hidden="true"></span> Refusé</span>
             {% endif %}
         {% endif %}
     </div>

--- a/templates/back/signalement/view/partners.html.twig
+++ b/templates/back/signalement/view/partners.html.twig
@@ -37,8 +37,10 @@
             </div>
         {% endif %}
     </div>
-
-{% elseif not isClosedForMe and isAffectationAccepted %}
+{% elseif 
+    signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED 
+    and (affectation and affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').ACCEPTED) 
+%}
     <div class="fr-container--fluid">
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12 fr-col-md-6">

--- a/templates/back/signalement/view/photos-album.html.twig
+++ b/templates/back/signalement/view/photos-album.html.twig
@@ -1,11 +1,11 @@
 <div class="photos-album fr-hidden">
     <div class="photos-album-close-button-container">
-        <button class="photos-album-btn-close fr-btn fr-btn--icon-left fr-icon-close-line keep-when-signalement-closed">Fermer</button>
+        <button class="photos-album-btn-close fr-btn fr-btn--icon-left fr-icon-close-line">Fermer</button>
     </div>
     {% set loopLength = allPhotosOrdered|length %}
     <div class="photos-album-navigation-container">
         <div>
-            <button class="fr-btn photos-album-swipe keep-when-signalement-closed" data-direction="-1">&lt;</button>
+            <button class="fr-btn photos-album-swipe" data-direction="-1">&lt;</button>
         </div>
         <div>
             {% for index, photo in allPhotosOrdered %}
@@ -15,17 +15,17 @@
                 </div>
                 <div class="photos-album-flex">
                     <div>
-                        <button class="photos-album-main-btn-edit fr-btn fr-btn--icon-left fr-icon-edit-line keep-when-signalement-closed" data-id="{{ photo.id }}">Modifier l'orientation</button>
+                        <button class="photos-album-main-btn-edit fr-btn fr-btn--icon-left fr-icon-edit-line" data-id="{{ photo.id }}">Modifier l'orientation</button>
                         <ul class="photos-album-list-btn-edit fr-hidden fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left fr-btns-group--center" data-id="{{ photo.id }}">
                             <li>
-                                <button class="photo-album-rotate-left-btn fr-btn fr-icon-arrow-go-back-line keep-when-signalement-closed" data-id="{{ photo.id }}">Pivoter à gauche</button>
+                                <button class="photo-album-rotate-left-btn fr-btn fr-icon-arrow-go-back-line" data-id="{{ photo.id }}">Pivoter à gauche</button>
                             </li>
                             <li>
-                                <button class="photo-album-rotate-right-btn fr-btn fr-btn--icon-right fr-icon-arrow-go-forward-line keep-when-signalement-closed" data-id="{{ photo.id }}">Pivoter à droite</button>
+                                <button class="photo-album-rotate-right-btn fr-btn fr-btn--icon-right fr-icon-arrow-go-forward-line" data-id="{{ photo.id }}">Pivoter à droite</button>
                             </li>
                             <li>
                                 <button 
-                                    class="photo-album-save-rotation fr-btn fr-icon-save-3-line keep-when-signalement-closed" 
+                                    class="photo-album-save-rotation fr-btn fr-icon-save-3-line" 
                                     disabled 
                                     data-action="{{path('back_signalement_file_rotate', {uuid: photo.signalement.uuid, id: photo.id})}}" 
                                     data-id="{{ photo.id }}">Enregistrer
@@ -63,15 +63,15 @@
                         Photo ajoutée par {{ photo.uploadedBy.nomComplet ?? 'l\'usager' }}
                     </div>
                     <div class="fr-grid-row fr-mt-2v fr-grid-row--right" id="zoom">
-                        <button class="photos-album-btn-zoom-out fr-btn fr-btn--icon-center fr-icon-zoom-out-line keep-when-signalement-closed fr-mr-4v" data-id="{{ photo.id }}"></button>
-                        <button class="photos-album-btn-zoom-in fr-btn fr-btn--icon-center fr-icon-zoom-in-line keep-when-signalement-closed" data-id="{{ photo.id }}"></button>
+                        <button class="photos-album-btn-zoom-out fr-btn fr-btn--icon-center fr-icon-zoom-out-line fr-mr-4v" data-id="{{ photo.id }}"></button>
+                        <button class="photos-album-btn-zoom-in fr-btn fr-btn--icon-center fr-icon-zoom-in-line" data-id="{{ photo.id }}"></button>
                     </div>
                 </div>
             </div>
             {% endfor %}
         </div>
         <div>
-            <button class="fr-btn photos-album-swipe keep-when-signalement-closed" data-direction="1">&gt;</button>
+            <button class="fr-btn photos-album-swipe" data-direction="1">&gt;</button>
         </div>
     </div>
     <script type="text/javascript" nonce="{{ app.request.attributes.get('csp_script_nonce') }}">

--- a/templates/back/signalement/view/tabs.html.twig
+++ b/templates/back/signalement/view/tabs.html.twig
@@ -2,12 +2,12 @@
     <ul class="fr-tabs__list" role="tablist" aria-label="Informations du signalement">
         <li role="presentation">
             <button id="tabpanel-activite" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="0" role="tab"
-                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION or canAnswerAffectation %}aria-selected="false"{% else %}aria-selected="true"{% endif %}
+                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION or is_granted('AFFECTATION_ACCEPT_OR_REFUSE', affectation) %}aria-selected="false"{% else %}aria-selected="true"{% endif %}
                 aria-controls="tabpanel-activite-panel">Activité PNLHI ({{ signalement.suivis|length }})</button>
         </li>
         <li role="presentation">
             <button id="tabpanel-situation" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="-1" role="tab"
-                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION or canAnswerAffectation %}aria-selected="true"{% else %}aria-selected="false"{% endif %}
+                {% if signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').NEED_VALIDATION or is_granted('AFFECTATION_ACCEPT_OR_REFUSE', affectation) %}aria-selected="true"{% else %}aria-selected="false"{% endif %}
                 aria-controls="tabpanel-situation-panel">Situation</button>
         </li>
         <li role="presentation">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -146,13 +146,6 @@
     <script src="{{ asset('build/popper/umd/popper.min.js') }}"></script>
     <script src="{{ asset('build/tippy/tippy.umd.min.js') }}"></script>
     <script src="{{ asset('build/tinymce/tinymce.min.js') }}"></script>
-    <script nonce="{{ app.request.attributes.get('csp_script_nonce') }}">
-        {% if isClosedForMe or signalement.statut is same as enum('App\\Entity\\Enum\\SignalementStatus').CLOSED %}
-        document?.querySelector('#signalement-{{ signalement.id }}-content').querySelectorAll('button:not(.reopen,.reaffect,.img-box,.fr-accordion__btn,.keep-when-signalement-closed),.fr-btn:not(.reopen,.reaffect,.img-box,.fr-fi-file-pdf-fill,.keep-when-signalement-closed)').forEach(input => {
-            input.remove()
-        })
-        {% endif %}
-    </script>
 {% endif %}
 
 {% block javascripts %}{% endblock %}


### PR DESCRIPTION
## Ticket

#4850
#5007

## Description
#4850 
- Suppression dans `base.html.twig` du code de suppression des bouton quand le signalement est clôturé. D’après mon analyse il ne masquait plus rien hormis 
-> en mode mobile le bouton permettant d'afficher le fil d'arianne (bug) 
-> les bouton "Voir sur la carte" / "Signalement à la même adresse" du bloc adresse (involontaire je pense)
- Suppression des classe `keep-when-signalement-closed` qui permettait au bouton de ne pas être supprimé.

#5007 
- Quelque simplification dans le `/Back/SignalementController` sur `viewSignalement` afin de réduire le nombre de variables transmis au template
- Adaptation des template en conséquences pour ne plus utiliser les variables mais des comparaison (voter / statut) équivalentes.
- Modification de l'`AffectationVoter` pour une utilisation des constante/valeur comme défini en équipe

## Tests
- [ ] Naviguer sur des fiche de signalements sous différent statuts et statut d'affectation avec les différents rôle utilisateurs.
