### PR TITLE
[QA] Stopper les envois d'email pour les exceptions SuspiciousOperationException

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -7,6 +7,7 @@ use App\Service\Mailer\NotificationMailerRegistry;
 use App\Service\Mailer\NotificationMailerType;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -24,6 +25,7 @@ readonly class ExceptionListener
         MethodNotAllowedException::class,
         NotFoundHttpException::class,
         AccessDeniedHttpException::class,
+        SuspiciousOperationException::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
## Ticket

#5048    

## Description
De nombreux spam de tentative d'intrusion (fallback email pas utile pour ce genre d'erreur)
<img width="1006" height="174" alt="image" src="https://github.com/user-attachments/assets/f9f5def7-fe9c-4323-b63c-540b55f8488b" />


## Changements apportés
* Ajouter `SuspiciousOperationException` dans la liste des exception à ignorer

## Pré-requis

## Tests
- [ ] CI OK
