### PR TITLE
[QA - API] Call to a member function getId() on null

### DIFF
--- a/src/DataFixtures/Files/Intervention.yml
+++ b/src/DataFixtures/Files/Intervention.yml
@@ -111,3 +111,12 @@ interventions:
     user: "admin-partenaire-13-01@signal-logement.fr"
     scheduled_at: '+2 days'
     status: 'PLANNED'
+  - 
+    signalement: "2024-12"
+    partner: "partenaire-30-01@signal-logement.fr "
+    scheduled_at: '2024-12-12 15:30:00'
+    status: 'DONE'
+    occupant_present: 1
+    proprietaire_present: 0
+    details: "<p>Rapport de visite ajouté au dossier</p>"
+    conclude_procedure: [ 'INSALUBRITE' ]

--- a/src/DataFixtures/Files/NewSignalement.yml
+++ b/src/DataFixtures/Files/NewSignalement.yml
@@ -262,6 +262,10 @@ signalements:
     qualifications:
       - "RSD"
       - "NON_DECENCE"
+    files: 
+      - file: "rapport-de-visite-sans-intervention-id.pdf"
+        titre: "rapport-de-visite-sans-intervention-id.pdf"
+        document_type: "PROCEDURE_RAPPORT_DE_VISITE"
   -
     territory: "Hérault"
     uuid: "00000000-0000-0000-2024-000000000006"

--- a/src/Factory/Api/VisiteFactory.php
+++ b/src/Factory/Api/VisiteFactory.php
@@ -29,9 +29,8 @@ readonly class VisiteFactory
         $signalement = $intervention->getSignalement();
 
         foreach ($signalement->getFiles() as $file) {
-            if (in_array(
-                $file->getDocumentType(),
-                [DocumentType::PHOTO_VISITE, DocumentType::PROCEDURE_RAPPORT_DE_VISITE])
+            if (in_array($file->getDocumentType(), [DocumentType::PHOTO_VISITE, DocumentType::PROCEDURE_RAPPORT_DE_VISITE])
+                && $file->getIntervention()
                 && $file->getIntervention()->getId() == $intervention->getId()
             ) {
                 $visite->files[] = $this->fileFactory->createFrom($file);

--- a/tests/Functional/Controller/Api/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementListControllerTest.php
@@ -33,6 +33,29 @@ class SignalementListControllerTest extends WebTestCase
         $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
+    public function testGetSignalementListUserApi02(): void
+    {
+        $client = static::createClient();
+        $user = self::getContainer()->get('doctrine')->getRepository(User::class)->findOneBy([
+            'email' => 'api-02@signal-logement.fr',
+        ]);
+        $client->loginUser($user, 'api');
+        $client->request('GET', '/api/signalements');
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $response = json_decode((string) $client->getResponse()->getContent(), true);
+
+        foreach ($response as $signalement) {
+            $this->assertIsArray($signalement['affectations']);
+            if ('2024-12' === $signalement['reference']) {
+                $this->assertCount(1, $signalement['files']);
+                $this->assertCount(1, haystack: $signalement['visites']);
+            }
+        }
+        $this->assertCount(1, $response);
+        $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
+    }
+
     public function testGetSignalementListWithLimit(): void
     {
         $client = static::createClient();

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -66,7 +66,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
         yield 'Search by Statut de la visite "Planifié"' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 5];
         yield 'Search by Statut de la visite "Conclusion à renseigner"' => [['visiteStatus' => 'Conclusion à renseigner', 'isImported' => 'oui'], 1];
-        yield 'Search by Statut de la visite "Terminé"' => [['visiteStatus' => 'Terminée', 'isImported' => 'oui'], 6];
+        yield 'Search by Statut de la visite "Terminé"' => [['visiteStatus' => 'Terminée', 'isImported' => 'oui'], 7];
         yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 6];
         yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18', 'isImported' => 'oui'], 2];
         yield 'Search by Statut de l\'affectation' => [['statusAffectation' => 'refuse', 'isImported' => 'oui'], 1];


### PR DESCRIPTION
## Ticket

#5058

## Description
La récupération des signalements via l'API provoquait un crash dans le cas d'un dossier contenant une visite, et un document de type `PROCEDURE_RAPPORT_DE_VISITE` non lié à la visite : 

## Changements apportés
- Correction de l'`API/VisiteFactory` pour gérer le cas.
- Ajout de fixture et tests pour vérifier le fonctionnement de ce cas.

## Pré-requis
`make load-fixtures`

## Tests
- [ ] via postman se connecter avec `api-02@signal-logement.fr` faire un `GET /api/signalements` et voir que ca fonctionne sans erreur.
