### PR TITLE
[QA] Initialiser le profil déclarant des signalements où ce n'est pas fait

### DIFF
--- a/migrations/Version20251210111952.php
+++ b/migrations/Version20251210111952.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251210111952 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update profile_declarant for signalement where created_from_id and profile_declarant IS NULL';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $baseWhere = 'WHERE created_from_id IS NULL AND profile_declarant IS NULL';
+        $this->addSql('UPDATE signalement SET profile_declarant = \'LOCATAIRE\' '.$baseWhere.' AND is_not_occupant = 0');
+        $this->addSql('UPDATE signalement SET profile_declarant = \'TIERS_PRO\' '.$baseWhere.' AND lien_declarant_occupant IN (\'PROFESSIONNEL\', \'pro\', \'assistante sociale\', \'curatrice\')');
+        $this->addSql('UPDATE signalement SET profile_declarant = \'TIERS_PARTICULIER\' '.$baseWhere.'');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Ticket

#5063   

## Description
Migration pour initialiser le profil déclarant des signalements qui n'en ont pas
Reprise de la PR : https://github.com/MTES-MCT/histologe/pull/4044

## Pré-requis
Attendre la fin de l'import avant de merger

## Tests
- [ ] `make execute-migration name=Version20250505092515 direction=up`
