### PR TITLE
[Import CSV] Initialisation du profil déclarant

### DIFF
--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -115,12 +115,14 @@ class SignalementImportLoader
                     $progressBar->advance();
                 }
                 $signalement = $this->signalementManager->createOrUpdateFromArrayForImport($territory, $dataMapped);
-                if (!$signalement->getIsNotOccupant()) {
-                    $signalement->setProfileDeclarant(ProfileDeclarant::LOCATAIRE);
-                } elseif (OccupantLink::PRO->name == mb_strtoupper($signalement->getLienDeclarantOccupant())) {
-                    $signalement->setProfileDeclarant(ProfileDeclarant::TIERS_PRO);
-                } else {
-                    $signalement->setProfileDeclarant(ProfileDeclarant::TIERS_PARTICULIER);
+                if (!$signalement->getProfileDeclarant()) {
+                    if (!$signalement->getIsNotOccupant()) {
+                        $signalement->setProfileDeclarant(ProfileDeclarant::LOCATAIRE);
+                    } elseif (OccupantLink::PRO->name == mb_strtoupper($signalement->getLienDeclarantOccupant())) {
+                        $signalement->setProfileDeclarant(ProfileDeclarant::TIERS_PRO);
+                    } else {
+                        $signalement->setProfileDeclarant(ProfileDeclarant::TIERS_PARTICULIER);
+                    }
                 }
                 $this->signalementManager->persist($signalement);
 


### PR DESCRIPTION
## Ticket

#5064   

## Description
Lors de l'import CSV, il faut initialiser le profil déclarant

## Tests
- [ ] `export BUCKET_URL=` (ajouter l'url du bucket staging)
- [ ] `make console app="import-signalement 32"`
- [ ] Vérifier que les nouveaux signalements sur le Gers (32) sont accessibles
