### PR TITLE
[BO - Dashboard] Optimiser le compte des mails non déliverables

### DIFF
--- a/migrations/Version20251210101651.php
+++ b/migrations/Version20251210101651.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251210101651 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout des index pour optimiser la jointure sur les emails (user.email, email_delivery_issue.email)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_edi_email ON email_delivery_issue (email)');
+        $this->addSql('CREATE INDEX idx_signalement_mail_occupant ON signalement(mail_occupant)');
+        $this->addSql('CREATE INDEX idx_signalement_mail_declarant ON signalement(mail_declarant)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_edi_email ON email_delivery_issue');
+        $this->addSql('DROP INDEX idx_signalement_mail_occupant ON signalement');
+        $this->addSql('DROP INDEX idx_signalement_mail_declarant ON signalement');
+    }
+}

--- a/src/Entity/EmailDeliveryIssue.php
+++ b/src/Entity/EmailDeliveryIssue.php
@@ -11,6 +11,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 #[ORM\Entity(repositoryClass: EmailDeliveryIssueRepository::class)]
 #[ORM\HasLifecycleCallbacks()]
 #[UniqueEntity('email')]
+#[ORM\Index(columns: ['email'], name: 'idx_edi_email')]
 class EmailDeliveryIssue
 {
     use TimestampableTrait;

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -45,6 +45,8 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Index(columns: ['cp_occupant'], name: 'idx_signalement_cp_occupant')]
 #[ORM\Index(columns: ['statut', 'territory_id'], name: 'idx_signalement_statut_territory')]
 #[ORM\Index(columns: ['statut', 'id'], name: 'idx_signalement_statut_id')]
+#[ORM\Index(columns: ['mail_occupant'], name: 'idx_signalement_mail_occupant')]
+#[ORM\Index(columns: ['mail_declarant'], name: 'idx_signalement_mail_declarant')]
 class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInterface
 {
     #[ORM\Id]


### PR DESCRIPTION
## Ticket

#5066   

## Description
Ajout d'index sur les mail occupant et déclarant et sur le mail de email_delivery_issue
On passe de 3900 ms à 700 ms

## Changements apportés
* Migration + entités pour ajouter 3 index

## Pré-requis

## Tests
- [ ] Tester le dashboard avec des données de prod
