### PR TITLE
[FO - espace bailleur] ref du dossier insensible à la casse

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2361,7 +2361,7 @@ class SignalementRepository extends ServiceEntityRepository
      */
     public function findOneForLoginBailleur(string $referenceInjonction, string $loginBailleur): ?Signalement
     {
-        $referenceInjonction = str_replace(InjonctionBailleurService::REFERENCE_PREFIX, '', $referenceInjonction);
+        $referenceInjonction = str_replace(InjonctionBailleurService::REFERENCE_PREFIX, '', strtoupper($referenceInjonction));
 
         return $this->createQueryBuilder('s')
             ->leftJoin('s.suivis', 'su')

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -406,4 +406,25 @@ class SignalementRepositoryTest extends KernelTestCase
             $this->assertStringContainsStringIgnoringCase('Marseille', $row['adresse']);
         }
     }
+
+    public function testFindOneForLoginBailleur(): void
+    {
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+
+        $referenceInjonction = 'INJ-2364';
+        $loginBailleur = 'XXXX-XXXX-XXXX-XXXX';
+        $signalement = $signalementRepository->findOneForLoginBailleur($referenceInjonction, $loginBailleur);
+        $this->assertInstanceOf(Signalement::class, $signalement);
+
+        $referenceInjonction = 'inj-2364';
+        $loginBailleur = 'XXXX-XXXX-XXXX-XXXX';
+        $signalement = $signalementRepository->findOneForLoginBailleur($referenceInjonction, $loginBailleur);
+        $this->assertInstanceOf(Signalement::class, $signalement);
+
+        $referenceInjonction = 'PLOP-2364';
+        $loginBailleur = 'XXXX-XXXX-XXXX-XXXX';
+        $signalement = $signalementRepository->findOneForLoginBailleur($referenceInjonction, $loginBailleur);
+        $this->assertNull($signalement);
+    }
 }


### PR DESCRIPTION
## Ticket

#5073   

## Description
la reference du dossier à rentrer sur la page de connexion pour le bailleur est sensible à la casse (si pas majuscule ca marche pas)

## Changements apportés
* chgt de la requête findOneForLoginBailleur() pour mettre en majuscule la réf donnée par l'usager
* ajout de test

## Pré-requis

## Tests
- [ ] Tester le login bailleur en mettant la réf en minuscule
