### PR TITLE
[QA][Sentry] Réduire le volume journalier des logs envoyés vers Sentry

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -31,7 +31,7 @@ when@prod:
         sentry_logs:
           type: service
           id: Sentry\SentryBundle\Monolog\LogsHandler
-          channels: [ "!event", "!doctrine", "!console" ]   # optionnel
+          channels: [ "!event", "!doctrine", "!console", "!request" ]
 
 
     services:


### PR DESCRIPTION
## Ticket

#5076    

## Description
A la demande de la DINUM, réduire le volume journalier des logs

## Changements apportés
* Exclure le channel `request` dans le handler `sentry_logs`

## Pré-requis

## Tests
- [ ] CI OK
