### PR TITLE
[BO - Dashboard] Modifier widget Injonction automatisée

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2376,16 +2376,13 @@ class SignalementRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
-    public function countInjonctionsAvecAide(
+    public function countInjonctions(
         User $user,
         ?TabQueryParameters $params,
     ): int {
         $qb = $this->createQueryBuilder('s')
             ->where('s.statut = :statut')
-            ->setParameter('statut', SignalementStatus::INJONCTION_BAILLEUR)
-            ->innerJoin('s.suivis', 'su')
-            ->andWhere('su.category = :aideCategory')
-            ->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE);
+            ->setParameter('statut', SignalementStatus::INJONCTION_BAILLEUR);
 
         $qb->select('COUNT(s.id)');
 

--- a/src/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoader.php
+++ b/src/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoader.php
@@ -34,7 +34,7 @@ class DossiersDernierActionTabBodyLoader extends AbstractTabBodyLoader
                 'partenaires_interfaces' => $this->tabDataManager->countPartenairesInterfaces($this->tabQueryParameters),
             ];
             if ($this->security->isGranted(InjonctionBailleurVoter::SEE)) {
-                $data['data_kpi']['injonctions'] = $this->tabDataManager->countInjonctionsAvecAide($this->tabQueryParameters);
+                $data['data_kpi']['injonctions'] = $this->tabDataManager->countInjonctions($this->tabQueryParameters);
             }
         }
         if ($user->isSuperAdmin()) {

--- a/src/Service/DashboardTabPanel/TabDataManager.php
+++ b/src/Service/DashboardTabPanel/TabDataManager.php
@@ -99,12 +99,12 @@ class TabDataManager
         return $tabDossiers;
     }
 
-    public function countInjonctionsAvecAide(?TabQueryParameters $tabQueryParameters = null): int
+    public function countInjonctions(?TabQueryParameters $tabQueryParameters = null): int
     {
         /** @var User $user */
         $user = $this->security->getUser();
 
-        $injonctions = $this->signalementRepository->countInjonctionsAvecAide($user, $tabQueryParameters);
+        $injonctions = $this->signalementRepository->countInjonctions($user, $tabQueryParameters);
 
         return $injonctions;
     }

--- a/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
+++ b/templates/back/dashboard/tabs/accueil/_body_derniere_action_dossiers.html.twig
@@ -50,7 +50,7 @@
                     <h2 class="fr-mb-8v">Administrer mon territoire</h2>
                 {% endif %}
                 <div class="fr-grid-row fr-grid-row--gutters">
-                    {% set linkInjonction = { injonctionAvecAide: 'oui' } %}
+                    {% set linkInjonction = {} %}
                     {% if is_granted('ROLE_ADMIN') %}
                         {% set linkInjonction = linkInjonction|merge({ territoire: items.territory_id }) %}
                     {% endif %}

--- a/tests/Functional/Repository/SignalementRepositoryTest.php
+++ b/tests/Functional/Repository/SignalementRepositoryTest.php
@@ -296,7 +296,7 @@ class SignalementRepositoryTest extends KernelTestCase
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    public function testCountInjonctionsAvecAide(): void
+    public function testCountInjonctions(): void
     {
         /** @var SignalementRepository $signalementRepository */
         $signalementRepository = $this->entityManager->getRepository(Signalement::class);
@@ -311,12 +311,12 @@ class SignalementRepositoryTest extends KernelTestCase
             orderBy: 'DESC',
         );
 
-        $countInjonctions = $signalementRepository->countInjonctionsAvecAide(
+        $countInjonctions = $signalementRepository->countInjonctions(
             user: $user,
             params: $tabQueryParameter
         );
 
-        $this->assertEquals(1, $countInjonctions);
+        $this->assertEquals(2, $countInjonctions);
     }
 
     /**

--- a/tests/Unit/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoaderTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/TabBodyLoader/DossiersDernierActionTabBodyLoaderTest.php
@@ -45,7 +45,7 @@ class DossiersDernierActionTabBodyLoaderTest extends TestCase
             ->with($tabQueryParameters)
             ->willReturn($expectedData);
         $tabDataManager->expects($this->once())
-            ->method('countInjonctionsAvecAide')
+            ->method('countInjonctions')
             ->with($tabQueryParameters)
             ->willReturn($expectedKpi['injonctions']);
         $tabDataManager->expects($this->once())

--- a/tests/Unit/Service/DashboardTabPanel/TabDataManagerTest.php
+++ b/tests/Unit/Service/DashboardTabPanel/TabDataManagerTest.php
@@ -98,12 +98,12 @@ class TabDataManagerTest extends WebTestCase
         $this->assertSame('uuid-123', $result[0]->uuid);
     }
 
-    public function testCountInjonctionsAvecAide(): void
+    public function testCountInjonctions(): void
     {
         /** @var MockObject&User $user */
         $user = $this->createMock(User::class);
         $this->security->method('getUser')->willReturn($user);
-        $this->signalementRepository->method('countInjonctionsAvecAide')->willReturn(5);
+        $this->signalementRepository->method('countInjonctions')->willReturn(5);
 
         $tabDataManager = new TabDataManager(
             $this->security,
@@ -116,7 +116,7 @@ class TabDataManagerTest extends WebTestCase
             $this->tabCountKpiBuilder,
         );
 
-        $result = $tabDataManager->countInjonctionsAvecAide();
+        $result = $tabDataManager->countInjonctions();
         $this->assertSame(5, $result);
     }
 


### PR DESCRIPTION
## Ticket

#5071   

## Description
Sur le dashboard, le widget injonction automatisée doit afficher le compte de tous les signalements au statut injonction, quelle que soit la réponse du bailleur

## Changements apportés
* Modifier la requête, et les tests associés

## Pré-requis

## Tests
- [ ] Tester le dashboard en SA et le lien vers la liste des signalements en injonction, en filtrant par territoire ou pas, et avec différents RT
