### PR TITLE
[BO - Formulaire pro] Localisation et étage toujours grisée

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -690,7 +690,6 @@ function initBoFormSignalementAdresse() {
 
 function initBoFormSignalementLogement() {
   const boFormSignalementLogement = document?.querySelector('#bo-form-signalement-logement');
-
   const compositionLogementInputs = boFormSignalementLogement?.querySelectorAll(
     '#signalement_draft_logement_pieceUnique input'
   );


### PR DESCRIPTION
## Ticket

#5085    

## Description
Avec le déplacement du champ nature Logement, apparition d'une régression sur localisation et étage toujours grisée malgré le fait que appartement ai été coché.

## Changements apportés
* Mise à jour JS gérant l'activation et désactivation des champs

## Pré-requis

## Tests
- [ ] Remplir le formulaire pro en cochant appartement et vérifier sur l'onglet suivant que les champs sont dégrisé
- [ ] Remplir le formulaire pro en cochant maison et autre et vérifier sur l'onglet suivant que les champs sont grisé
