### PR TITLE
[Injonction bailleur] Dernières modifications de texte

### DIFF
--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -190,7 +190,7 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false
           },
@@ -563,7 +563,7 @@
         },
         {
           "type": "SignalementFormParagraph",
-          "label": "* Sous réserve de votre éligibilité à ce dispositif.",
+          "label": "* Sous réserve de votre éligibilité à ce dispositif. Vous en serez informés après la validation de votre signalement.",
           "slug": "injonction_bailleur_paragraph_7"
         },
         {
@@ -596,7 +596,7 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false
           },

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -164,7 +164,7 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false
           },
@@ -284,7 +284,7 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false
           },

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -152,7 +152,7 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_occupant_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false
           },
@@ -269,7 +269,7 @@
           "type": "SignalementFormPhonefield",
           "label": "Téléphone (facultatif)",
           "slug": "coordonnees_bailleur_tel",
-          "description": "Format attendu : Veuillez sélectionner votre pays pour obtenir l'indicatif téléphonique, puis saisir votre numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
+          "description": "Format attendu : Veuillez sélectionner le pays pour obtenir l'indicatif téléphonique, puis saisir le numéro de téléphone au format national (sans l'indicatif). Exemple pour la France : 0702030405.",
           "validate": {
             "required": false
           },

--- a/templates/front/dossier_bailleur.html.twig
+++ b/templates/front/dossier_bailleur.html.twig
@@ -224,7 +224,7 @@
 							<p class="fr-mt-5w">{{signalement.prenomProprio}} {{signalement.nomProprio}} le {{ suiviReponse.createdAt|date('d/m/Y') }}</p>
 							<p>Vous optez pour une résolution amiable avant le déclenchement des contrôles et procédures.<br>
 								Par ce choix <strong>vous vous engagez à remédier dans les meilleurs délais aux désordres</strong> déclarés afin de remettre le logement loué aux normes.<br><br>
-								Pour formaliser votre engagement,  <a href="{{ asset('build/files/Engagement_du_bailleur_a_realiser_des_travaux.docx') }}" target="_blank" rel="noopener" title="Modèle de lettre d'engagement - Ouvre une nouvelle fenêtre">merci de compléter le document suivant</a>.<br><br>
+								Pour formaliser votre engagement,  <a href="{{ asset('build/files/Engagement_du_bailleur_a_realiser_des_travaux.docx') }}" target="_blank" rel="noopener" title="Modèle de lettre d'engagement - Ouvre une nouvelle fenêtre">merci de compléter le document suivant</a> et de l'envoyer à l'adresse e-mail <a href="mailto:demarche-acceleree@signal-logement.beta.gouv.fr">demarche-acceleree@signal-logement.beta.gouv.fr</a>.<br><br>
 								Un suivi sera réalisé mensuellement. Nous vous invitons à mettre à jour le dossier régulièrement avec les justificatifs permettant d’attester de l’avancement des démarches engagées.
 							</p>
 						</div>


### PR DESCRIPTION
## Ticket

#5087   

## Description
Pour le courrier d'engagement, je propose d'ajouter temporairement une ligne qui dirait "remplissez le courrier et renvoyez-le nous par mail à telle adresse" et on parle au point dev/ux de comment on améliore ça ?

amélioration texte info sur le bailleur, je modifierais "puis saisir votre numéro de téléphone " par " le numéro de téléphone "
ajouter une phrase qui precise ou se fait la decision

## Changements apportés
* Changement des json du formulaire
* Ajout d'un texte sur l'espace bailleur

## Pré-requis

## Tests
- [ ] Vérifier les textes
