### PR TITLE
[FO] Remplacer /login-baillleur par /connexion-bailleur

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -50,7 +50,7 @@ security:
                 target: app_logout_signalement_user_success
                 invalidate_session: false
         login_bailleur:
-            pattern: ^/(login-bailleur|dossier-bailleur|logout-bailleur)
+            pattern: ^/(connexion-bailleur|dossier-bailleur|logout-bailleur)
             provider: app_signalement_bailleur_provider
             custom_authenticator: App\Security\Authenticator\LoginBailleurAuthenticator
             login_throttling:

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -139,7 +139,7 @@ class SecurityController extends AbstractController
         ]);
     }
 
-    #[Route('/login-bailleur', name: 'app_login_bailleur')]
+    #[Route('/connexion-bailleur', name: 'app_login_bailleur')]
     public function loginBailleur(
         AuthenticationUtils $authenticationUtils,
         #[Autowire(env: 'FEATURE_INJONCTION_BAILLEUR')]

--- a/tests/Functional/Controller/SecurityControllerTest.php
+++ b/tests/Functional/Controller/SecurityControllerTest.php
@@ -29,7 +29,7 @@ class SecurityControllerTest extends WebTestCase
             'bailleur_code' => $signalement->getLoginBailleur(),
             '_csrf_token' => $this->generateCsrfToken($client, 'authenticate'),
         ];
-        $client->request('POST', '/login-bailleur', $payload);
+        $client->request('POST', '/connexion-bailleur', $payload);
         $this->assertResponseRedirects('/dossier-bailleur/');
     }
 
@@ -37,7 +37,7 @@ class SecurityControllerTest extends WebTestCase
     {
         $client = static::createClient();
         $signalement = $client->getContainer()->get(SignalementRepository::class)->findOneBy(['uuid' => self::SIGN_2025_11_UUID]);
-        $client->request('GET', '/login-bailleur', [
+        $client->request('GET', '/connexion-bailleur', [
             'bailleur_reference' => $signalement->getReference(),
             'bailleur_code' => $signalement->getLoginBailleur(),
         ]);
@@ -53,9 +53,9 @@ class SecurityControllerTest extends WebTestCase
             'bailleur_code' => 'invalid_code',
             '_csrf_token' => $this->generateCsrfToken($client, 'authenticate'),
         ];
-        $client->request('POST', '/login-bailleur', $payload);
+        $client->request('POST', '/connexion-bailleur', $payload);
         $this->assertResponseStatusCodeSame(Response::HTTP_FOUND);
-        $this->assertResponseRedirects('/login-bailleur');
+        $this->assertResponseRedirects('/connexion-bailleur');
         $client->followRedirect();
         $this->assertSelectorExists('.fr-alert.fr-alert--error');
     }

--- a/tests/e2e/tests/login.spec.ts
+++ b/tests/e2e/tests/login.spec.ts
@@ -30,7 +30,7 @@ test('login for bailleur', async ({page, context}) => {
   await context.clearCookies();
   await context.clearPermissions();
 
-  await page.goto(`${process.env.BASE_URL ?? 'http://localhost:8080'}/login-bailleur`);
+  await page.goto(`${process.env.BASE_URL ?? 'http://localhost:8080'}/connexion-bailleur`);
   await page.waitForLoadState('networkidle');
 
   await page.getByRole('textbox', { name: 'Référence du dossier' }).click();


### PR DESCRIPTION
## Ticket

#5084

## Description
Modification de l'url de la route de login bailleur de `login-bailleur` à `connexion-bailleur`

## Tests
- [ ] Tester la connexion en tant que bailleur
