### PR TITLE
[Suivi usager] Correction de l'accès pour les usagers sans adresse e-mail

### DIFF
--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -1106,7 +1106,7 @@ class SignalementController extends AbstractController
         ]);
     }
 
-    private function redirectIfTiersNeedsToAcceptCgu(Signalement $signalement, string $userEmail): ?Response
+    private function redirectIfTiersNeedsToAcceptCgu(Signalement $signalement, ?string $userEmail): ?Response
     {
         if ($userEmail !== $signalement->getMailDeclarant()) {
             return null;


### PR DESCRIPTION
## Ticket

#5092   

## Description
Les usagers dont l'adresse e-mail est null ont une erreur à cause de la future validation des CGU.

## Tests
- [ ] Mettre une adresse mail null et vérifier que l'accès est ok
