### PR TITLE
[BUG - Modale d'abonnement] Contrainte + doublon d'id

### DIFF
--- a/assets/scripts/vanilla/services/component/component_select_all_checkbox.js
+++ b/assets/scripts/vanilla/services/component/component_select_all_checkbox.js
@@ -9,7 +9,7 @@ document.addEventListener('click', (e) => {
   if (!targetSelector) return;
 
   /** @type {NodeListOf<HTMLInputElement>} */
-  const checkboxes = target.querySelectorAll('input[type="checkbox"]');
+  const checkboxes = Array.from(target.querySelectorAll('input[type="checkbox"]')).filter((cb) => !cb.disabled);
   const allChecked = Array.from(checkboxes).every((cb) => cb.checked);
 
   checkboxes.forEach((cb) => {

--- a/src/Form/AgentSelectionType.php
+++ b/src/Form/AgentSelectionType.php
@@ -57,10 +57,12 @@ class AgentSelectionType extends AbstractType
         $constraints = [];
         if (!$existingSubscriptionsInChoices) {
             $label = 'Veuillez sélectionner au moins un agent.';
+            $groups = ['Default'];
             if ($options['only_rt']) {
                 $label = 'Veuillez sélectionner au moins un responsable de territoire.';
+                $groups = ['only_rt'];
             }
-            $constraints[] = new Assert\Count(['min' => 1, 'minMessage' => $label]);
+            $constraints[] = new Assert\Count(['min' => 1, 'minMessage' => $label, 'groups' => $groups]);
         }
 
         $builder->add('agents', EntityType::class, [

--- a/templates/_partials/_modal_accept_affectation.html.twig
+++ b/templates/_partials/_modal_accept_affectation.html.twig
@@ -20,11 +20,11 @@
                         </div>
                         {{ form_errors(acceptAffectationForm) }}
                         <div class="fr-select-group agent-selection-container">
-                            {{ form_label(acceptAffectationForm.agents, null, {'label_attr': {'class': 'fr-mb-2v', 'name': 'agents_selection[agents]'}}) }}
+                            {{ form_label(acceptAffectationForm.agents, null, {'label_attr': {'class': 'fr-mb-2v', 'name': 'agent_selection[agents]'}}) }}
                             <div class="fr-grid-row">
                                 {% for agent in acceptAffectationForm.agents %}
                                     <div class="fr-checkbox-group fr-col-6">
-                                        {{ form_row(agent) }}
+                                        {{ form_row(agent, {'id': 'accept_affectation_' ~ agent.vars.value}) }}
                                     </div>
                                 {% endfor %}
                             </div>

--- a/templates/_partials/_modal_accept_signalement.html.twig
+++ b/templates/_partials/_modal_accept_signalement.html.twig
@@ -24,11 +24,11 @@
                         </div>
                         {{ form_errors(acceptSignalementForm) }}
                         <div class="fr-select-group rt-selection-container">
-                            {{ form_label(acceptSignalementForm.agents, null, {'label_attr': {'class': 'fr-mb-2v', 'name': 'agents_selection[agents]'}}) }}
+                            {{ form_label(acceptSignalementForm.agents, null, {'label_attr': {'class': 'fr-mb-2v', 'name': 'agent_selection[agents]'}}) }}
                             <div class="fr-grid-row">
                                 {% for agent in acceptSignalementForm.agents %}
                                     <div class="fr-checkbox-group fr-col-6">
-                                        {{ form_row(agent) }}
+                                        {{ form_row(agent, {'id': 'accept_signalement_' ~ agent.vars.value}) }}
                                     </div>
                                 {% endfor %}
                             </div>

--- a/templates/_partials/_modal_agents_subscription.html.twig
+++ b/templates/_partials/_modal_agents_subscription.html.twig
@@ -20,7 +20,7 @@
                             <div class="fr-grid-row">
                                 {% for agent in agentsSubscriptionForm.agents %}
                                     <div class="fr-checkbox-group fr-col-6">
-                                        {{ form_row(agent) }}
+                                        {{ form_row(agent, {'id': 'agents_subscription_' ~ agent.vars.value}) }}
                                     </div>
                                 {% endfor %}
                             </div>

--- a/templates/_partials/_modal_transfer_subscription.html.twig
+++ b/templates/_partials/_modal_transfer_subscription.html.twig
@@ -23,11 +23,11 @@
                         </div>
                         {{ form_errors(transferSubscriptionForm) }}
                         <div class="fr-select-group agent-transfer-container">
-                            {{ form_label(transferSubscriptionForm.agents, null, {'label_attr': {'class': 'fr-mb-2v', 'name': 'agents_selection[agents]'}}) }}
+                            {{ form_label(transferSubscriptionForm.agents, null, {'label_attr': {'class': 'fr-mb-2v', 'name': 'agent_selection[agents]'}}) }}
                             <div class="fr-grid-row">
                                 {% for agent in transferSubscriptionForm.agents %}
                                     <div class="fr-checkbox-group fr-col-6">
-                                        {{ form_row(agent) }}
+                                        {{ form_row(agent, {'id': 'transfer_subscription_' ~ agent.vars.value}) }}
                                     </div>
                                 {% endfor %}
                             </div>


### PR DESCRIPTION
## Ticket

#5094

## Description
- La contrainte rendant obligatoire la sélection d'un RT à la validation du signalement n'était pas appelé (problème de groupe de validation)
- Les modale de transfer / abonnement d'agent pouvait générer des champ avec le même id, et donc les case à cocher ne fonctionnait plus.
- Le bouton "Tout désélectionner" permettait de décocher des agent grisé et coché car déjà abonné (bien que ca n'ai pas d'effet ensuite)

## Pré-requis
`make npm-watch`
`make load-fixtures`

## Tests
- [ ] Se connecter en SA et accepter le signalement 2024-06 sans sélectionner de RT, voir que le blocage apparaît bien.
- [ ] Valider le signalement 2024-06 en sélectionnant un RT, créer une affectation pour CAF34
- [ ] Se connecte en tant que `user-partenaire-34-02@signal-logement.fr` sur le 2024-06 accepter l'affectation (en s'abonnant soi même)
- [ ] Ouvrir le modale avec le bouton "Se retirer du dossier" et "Abonner un agent" et oir que l'on peux cocher les agents disponibles
