### PR TITLE
[BO - Profil] Déplacement des boutons dans le body de la modale

### DIFF
--- a/templates/back/profil/_modal_profil_infos.html.twig
+++ b/templates/back/profil/_modal_profil_infos.html.twig
@@ -14,7 +14,7 @@
                         {{ form_start(formProfilInfo, {'attr': {'id': 'user_profil_info'}}) }}
                         {{ form_errors(formProfilInfo) }}
                         <div class="fr-display-inline-flex fr-align-items-center fr-grid-row fr-grid-row--gutters">
-                            <div class="fr-display-flex-column fr-align-items-center fr-col-12 fr-col-md-4">
+                            <div class="fr-display-flex-column fr-align-items-center fr-col-12 fr-col-md-5">
                                 {{ user_avatar_or_placeholder(app.user, 124, false) }}
                                 {% if app.user.avatarFilename %}
                                     <br>
@@ -22,7 +22,7 @@
                                     class="fr-link fr-fi-delete-line fr-link--icon-left">Supprimer l'avatar</a>
                                 {% endif %}
                             </div>
-                            <div class="fr-col-12 fr-col-md-8">
+                            <div class="fr-col-12 fr-col-md-7">
                                 {{ form_row(formProfilInfo.avatar) }}
                             </div>
                         </div>


### PR DESCRIPTION
## Ticket

#5098   

## Description
Afin de pouvoir naviguer dans la modale avec la tabulation, on déplace les boutons de la modale d'édition du profil dans le body. Quand il y a un footer, certains champs peuvent passer en-dessous et être invisibles.

## Tests
- [ ] Vérifier l'utilisation de la modale d'édition de profil avec la tabulation
  - en pleine page
  - en taille d'écran réduite 
