### PR TITLE
[Accessibilité - BO - Profil] Contraste insuffisant

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -789,8 +789,8 @@ ul + p {
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: #ececfe;
-    color: #e4794a;
+    background-color: var(--blue-france-950-100);
+    color: var(--red-marianne-425-625);
     text-align: center;
     font-family: 'Marianne', sans-serif;
     font-weight: bold;


### PR DESCRIPTION
## Ticket

#5100   

## Description
Les 2 liens ayant un contraste insuffisant sont en fait les liens du menu d'évitement. Après check dans le DSFR, il n'est pas utile de faire une correction. https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/liens-d-evitement/accessibilite-des-liens-d-evitement

<img width="1842" height="375" alt="Image" src="https://github.com/user-attachments/assets/2a9d2a5a-c6cf-44af-b316-e01df079492a" />

Par contre en retestant avec un utilisateur n'ayant pas personnalisé son avatar, le contraste sur l'avatar généré était insuffisant. 

## Changements apportés
* Changement des couleurs de l'avatar généré pour augmenter le contraste

## Pré-requis

## Tests
- [ ] Aller vérifier l'avatar généré
