### PR TITLE
[FO] Incohérence code postal code insee pour un tiers

### DIFF
--- a/src/Dto/Request/Signalement/SignalementDraftRequest.php
+++ b/src/Dto/Request/Signalement/SignalementDraftRequest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 #[AppAssert\IsTerritoryActive]
+#[AppAssert\PostalCodeInseeCoherence]
 #[AppAssert\ValueLessThanOtherValue(
     property: 'compositionLogementNombreEnfants',
     otherProperty: 'compositionLogementNombrePersonnes',

--- a/src/Validator/IsTerritoryActiveValidator.php
+++ b/src/Validator/IsTerritoryActiveValidator.php
@@ -3,41 +3,32 @@
 namespace App\Validator;
 
 use App\Dto\Request\Signalement\SignalementDraftRequest;
-use App\Entity\Commune;
 use App\Service\Signalement\PostalCodeHomeChecker;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class IsTerritoryActiveValidator extends ConstraintValidator
 {
-    public function __construct(private readonly EntityManagerInterface $em, private readonly PostalCodeHomeChecker $postalCodeHomeChecker)
-    {
+    public function __construct(
+        private readonly PostalCodeHomeChecker $postalCodeHomeChecker,
+    ) {
     }
 
-    public function validate(mixed $obj, Constraint $constraint): void
+    public function validate(mixed $value, Constraint $constraint): void
     {
-        if (!$obj instanceof SignalementDraftRequest) {
-            throw new UnexpectedValueException($obj, SignalementDraftRequest::class);
+        if (!$value instanceof SignalementDraftRequest) {
+            throw new UnexpectedValueException($value, SignalementDraftRequest::class);
         }
 
         if (!$constraint instanceof IsTerritoryActive) {
             throw new UnexpectedValueException($constraint, IsTerritoryActive::class);
         }
 
-        $postalCode = $obj->getAdresseLogementAdresseDetailCodePostal();
-        $inseeCode = $obj->getAdresseLogementAdresseDetailInsee();
+        $postalCode = $value->getAdresseLogementAdresseDetailCodePostal();
+        $inseeCode = $value->getAdresseLogementAdresseDetailInsee();
+        $inseeCode = $this->postalCodeHomeChecker->normalizeInseeCode($postalCode, $inseeCode);
         if ($postalCode && $inseeCode) {
-            $commune = $this->em->getRepository(Commune::class)->findOneBy(['codePostal' => $postalCode, 'codeInsee' => $inseeCode]);
-            if (!$commune) {
-                $message = 'Le code postal "'.$postalCode.'" et le code INSEE "'.$inseeCode.'" ne sont pas cohérents.';
-                $this->context
-                    ->buildViolation($message)
-                    ->atPath('adresseLogementAdresseDetailCodePostal')
-                    ->addViolation();
-            }
-
             if (!$this->postalCodeHomeChecker->isActiveByInseeCode($inseeCode)) {
                 $message = 'Le territoire n\'est pas actif pour le code postal "'.$postalCode.'" et le code INSEE "'.$inseeCode.'".';
                 $this->context

--- a/src/Validator/PostalCodeInseeCoherence.php
+++ b/src/Validator/PostalCodeInseeCoherence.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class PostalCodeInseeCoherence extends Constraint
+{
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Validator/PostalCodeInseeCoherenceValidator.php
+++ b/src/Validator/PostalCodeInseeCoherenceValidator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Validator;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Commune;
+use App\Service\Signalement\PostalCodeHomeChecker;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class PostalCodeInseeCoherenceValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly PostalCodeHomeChecker $postalCodeHomeChecker,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$value instanceof SignalementDraftRequest) {
+            throw new UnexpectedValueException($value, SignalementDraftRequest::class);
+        }
+
+        if (!$constraint instanceof PostalCodeInseeCoherence) {
+            throw new UnexpectedValueException($constraint, PostalCodeInseeCoherence::class);
+        }
+
+        $postalCode = $value->getAdresseLogementAdresseDetailCodePostal();
+        $inseeCode = $value->getAdresseLogementAdresseDetailInsee();
+        $inseeCode = $this->postalCodeHomeChecker->normalizeInseeCode($postalCode, $inseeCode);
+        if (!$postalCode || !$inseeCode) {
+            return;
+        }
+
+        $commune = $this->em->getRepository(Commune::class)->findOneBy([
+            'codePostal' => $postalCode,
+            'codeInsee' => $inseeCode,
+        ]);
+
+        if (!$commune) {
+            \Sentry\captureMessage(sprintf(
+                'Incohérence code postal et code INSEE : Code postal "%s", Code INSEE "%s"',
+                $postalCode,
+                $inseeCode
+            ));
+
+            $message = sprintf(
+                'Le code postal %s et le code INSEE %s ne sont pas cohérents.',
+                $postalCode,
+                $inseeCode
+            );
+
+            $this->context
+                ->buildViolation($message)
+                ->atPath('adresseLogementAdresseDetailCodePostal')
+                ->addViolation();
+        }
+    }
+}

--- a/tests/Unit/Validator/PostalCodeInseeCoherenceValidatorTest.php
+++ b/tests/Unit/Validator/PostalCodeInseeCoherenceValidatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Tests\Unit\Validator;
+
+use App\Dto\Request\Signalement\SignalementDraftRequest;
+use App\Entity\Commune;
+use App\Repository\CommuneRepository;
+use App\Service\Signalement\PostalCodeHomeChecker;
+use App\Validator\PostalCodeInseeCoherence;
+use App\Validator\PostalCodeInseeCoherenceValidator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<PostalCodeInseeCoherenceValidator>
+ */
+class PostalCodeInseeCoherenceValidatorTest extends ConstraintValidatorTestCase
+{
+    private CommuneRepository&MockObject $communeRepository;
+    private PostalCodeHomeChecker&MockObject $postalCodeHomeChecker;
+
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->communeRepository = $this->createMock(CommuneRepository::class);
+        $this->postalCodeHomeChecker = $this->createMock(PostalCodeHomeChecker::class);
+
+        $entityManager
+            ->method('getRepository')
+            ->with(Commune::class)
+            ->willReturn($this->communeRepository);
+
+        return new PostalCodeInseeCoherenceValidator($entityManager, $this->postalCodeHomeChecker);
+    }
+
+    /**
+     * @dataProvider provideCoherenceCases
+     */
+    public function testPostalCodeInseeCoherence(
+        string $postalCode,
+        string $rawInseeCode,
+        string $normalizedInseeCode,
+        bool $communeExists,
+        ?string $expectedViolationMessage,
+    ): void {
+        $request = $this->createMock(SignalementDraftRequest::class);
+        $request->method('getAdresseLogementAdresseDetailCodePostal')->willReturn($postalCode);
+        $request->method('getAdresseLogementAdresseDetailInsee')->willReturn($rawInseeCode);
+
+        $this->postalCodeHomeChecker
+            ->expects($this->once())
+            ->method('normalizeInseeCode')
+            ->with($postalCode, $rawInseeCode)
+            ->willReturn($normalizedInseeCode);
+
+        $this->communeRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with([
+                'codePostal' => $postalCode,
+                'codeInsee' => $normalizedInseeCode,
+            ])
+            ->willReturn($communeExists ? $this->createMock(Commune::class) : null);
+
+        $this->validator->validate($request, new PostalCodeInseeCoherence());
+
+        if (null !== $expectedViolationMessage) {
+            $this->buildViolation($expectedViolationMessage)
+                ->atPath('property.path.adresseLogementAdresseDetailCodePostal')
+                ->assertRaised();
+
+            return;
+        }
+
+        $this->assertNoViolation();
+    }
+
+    public static function provideCoherenceCases(): iterable
+    {
+        yield 'ajoute une violation si aucune commune correspond' => [
+            'postalCode' => '13001',
+            'rawInseeCode' => '13055',
+            'normalizedInseeCode' => '13201',
+            'communeExists' => false,
+            'expectedViolationMessage' => 'Le code postal 13001 et le code INSEE 13201 ne sont pas cohérents.',
+        ];
+
+        yield 'aucune violation si la commune existe' => [
+            'postalCode' => '44000',
+            'rawInseeCode' => '44109',
+            'normalizedInseeCode' => '44109',
+            'communeExists' => true,
+            'expectedViolationMessage' => null,
+        ];
+    }
+
+    public function testThrowsWhenValueIsNotSignalementDraftRequest(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $this->validator->validate('not_a_request', new PostalCodeInseeCoherence());
+    }
+
+    public function testThrowsWhenConstraintIsNotPostalCodeInseeCoherence(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $request = $this->createMock(SignalementDraftRequest::class);
+        $wrongConstraint = $this->createMock(Constraint::class);
+
+        $this->validator->validate($request, $wrongConstraint);
+    }
+}


### PR DESCRIPTION
## Ticket

#5111    

## Description
La normalisation a été appliqué sur le controlleur mais pas sur le validateur
https://github.com/MTES-MCT/histologe/pull/4725/changes

## Changements apportés
* Déplacer la logique de cohérénce code insee et cp dans un validateur spécifique

## Pré-requis

## Tests
  - [ ] Créer un signalement sur le 1er arrondissement de Marseille 29 rue du musée 13001 Marseille et vérifier que le signalement n'est pas bloqué
