### PR TITLE
[FO] Absence de validation sur l'écran Vos coordonnées pour les tiers

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -88,7 +88,7 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
-                "action": "goto:coordonnees_occupant",
+                "action": "goto.checkonly:coordonnees_occupant",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -88,7 +88,7 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
-                "action": "goto:coordonnees_occupant",
+                "action": "goto.checkonly:coordonnees_occupant",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -96,7 +96,7 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
-                "action": "goto:coordonnees_occupant",
+                "action": "goto.checkonly:coordonnees_occupant",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -84,7 +84,7 @@
                 "type": "SignalementFormButton",
                 "label": "Suivant",
                 "slug": "vos_coordonnees_tiers_next",
-                "action": "goto:coordonnees_occupant",
+                "action": "goto.checkonly:coordonnees_occupant",
                 "customCss": "fr-btn--icon-right fr-icon-arrow-right-line"
               },
               {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormScreen.vue
@@ -133,7 +133,7 @@ export default defineComponent({
       } else if (type === 'archive') {
         requests.archiveDraft(this.gotoHomepage)
       } else if (type.includes('goto')) {
-        await this.showScreenBySlug(param, param2, type.includes('save'), type.includes('checkloc'))
+        await this.showScreenBySlug(param, param2, type.includes('save'), type.includes('checkloc'), type.includes('checkonly'))
       } else if (type.includes('resolve')) {
         this.navigateToDisorderScreen(param, param2, type.includes('save'))
       } else if (type.includes('finish')) {
@@ -196,11 +196,11 @@ export default defineComponent({
       }
       return false
     },
-    async showScreenBySlug (slug: string, slugButton:string, isSaveAndCheck:boolean, isCheckLocation:boolean) {
+    async showScreenBySlug (slug: string, slugButton:string, isSaveAndCheck:boolean, isCheckLocation:boolean, isCheckOnly:boolean = false) {
       formStore.data.errorMessage = ''
       formStore.validationErrors = {}
 
-      if (isSaveAndCheck || isCheckLocation) {
+      if (isSaveAndCheck || isCheckLocation || isCheckOnly) {
         if (this.validateAndFocusFirstError()) {
           return
         }

--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -106,6 +106,7 @@ class SignalementController extends AbstractController
         SignalementDraftRequestSerializer $serializer,
         SignalementDraftManager $signalementDraftManager,
         ValidatorInterface $validator,
+        LoggerInterface $logger,
     ): JsonResponse {
         /** @var SignalementDraftRequest $signalementDraftRequest */
         $signalementDraftRequest = $serializer->deserialize(
@@ -126,6 +127,7 @@ class SignalementController extends AbstractController
                 ),
             ]);
         }
+        $logger->error('Erreur de validation du formulaire FO '.(string) $errors);
 
         return $this->json($errors);
     }
@@ -137,6 +139,7 @@ class SignalementController extends AbstractController
         ValidatorInterface $validator,
         SignalementDuplicateChecker $signalementDuplicateChecker,
         SignalementDraftManager $signalementDraftManager,
+        LoggerInterface $logger,
     ): JsonResponse {
         /** @var SignalementDraftRequest $signalementDraftRequest */
         $signalementDraftRequest = $serializer->deserialize(
@@ -174,6 +177,7 @@ class SignalementController extends AbstractController
 
             return $this->json($result);
         }
+        $logger->error('Erreur de validation du formulaire FO '.(string) $errors);
 
         return $this->json($errors);
     }
@@ -185,6 +189,7 @@ class SignalementController extends AbstractController
         SignalementDraftManager $signalementDraftManager,
         ValidatorInterface $validator,
         SignalementDraft $signalementDraft,
+        LoggerInterface $logger,
     ): JsonResponse {
         if (SignalementDraftStatus::ARCHIVE === $signalementDraft->getStatus()) {
             throw $this->createNotFoundException();
@@ -209,6 +214,7 @@ class SignalementController extends AbstractController
 
             return $this->json($result);
         }
+        $logger->error('Erreur de validation du formulaire FO '.(string) $errors);
 
         return $this->json($errors);
     }


### PR DESCRIPTION
## Ticket

#5117

## Description
Les données des champs de l'écran coordonnées tiers su signalement FO n'était plus validé coté client.
- Correction des `question_xxx.json` concernés (avec une nouvelle valeur `checkonly`)
- Modification de la fonction `showScreenBySlug` pour utiliser le  `checkonly` afin de permettre une validation coté client sans nécessairement faire un `save` (soumission des données au serveur)
- Ajout de log lors d'erreur de validations coté serveur lors de soumissions des données du signalement FO

## Pré-requis
`make npm-build`

## Tests
- [ ] Faire un signalement avec un des profil "pour quelqu’un d'autre" et s'assurer que l'on ne peux pas passer à l'écran "Les coordonnées des personnes occupant le logement" sans renseigner l'écran "Vos coordonnées"
