### PR TITLE
[QA - Tech] - Optimisations des requêtes chronophages

### DIFF
--- a/migrations/Version20251218111544.php
+++ b/migrations/Version20251218111544.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251218111544 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add indexes to improve query performance on signalement_draft, user, and suivi tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_signalement_draft_uuid ON signalement_draft (uuid)');
+        $this->addSql('CREATE INDEX idx_user_statut ON user (statut)');
+        $this->addSql('CREATE INDEX idx_suivi_waiting_notification ON suivi (waiting_notification)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_signalement_draft_uuid ON signalement_draft');
+        $this->addSql('DROP INDEX idx_user_statut ON user');
+        $this->addSql('DROP INDEX idx_suivi_waiting_notification ON suivi');
+    }
+}

--- a/src/Entity/SignalementDraft.php
+++ b/src/Entity/SignalementDraft.php
@@ -14,6 +14,7 @@ use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: SignalementDraftRepository::class)]
 #[ORM\HasLifecycleCallbacks()]
+#[ORM\Index(columns: ['uuid'], name: 'idx_signalement_draft_uuid')]
 class SignalementDraft
 {
     use TimestampableTrait;

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Index(columns: ['signalement_id', 'is_public', 'created_at', 'category'], name: 'idx_suivi_signalement_is_public_created_at_category')]
 #[ORM\Index(columns: ['is_public', 'signalement_id', 'created_at', 'type'], name: 'idx_suivi_is_public_signalement_created_at_type')]
 #[ORM\Index(columns: ['signalement_id', 'category', 'created_at', 'is_public', 'created_by_id'], name: 'idx_suivi_signid_cat_createdat_ispublic_createdby')]
+#[ORM\Index(columns: ['waiting_notification'], name: 'idx_suivi_waiting_notification')]
 class Suivi implements EntityHistoryInterface
 {
     public const int TYPE_AUTO = 1;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -25,6 +25,7 @@ use Symfony\Component\Validator\Constraints\Email;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[UniqueEntity('email', message: '{{ value }} existe déja, merci de saisir un nouvel e-mail', groups: ['registration', 'Default'])]
+#[ORM\Index(columns: ['statut'], name: 'idx_user_statut')]
 #[ORM\HasLifecycleCallbacks()]
 #[AppAssert\UserPartnerEmailMulti(groups: ['user_partner_mail_multi'])]
 #[AppAssert\UserPartnerEmail(groups: ['user_partner_mail'])]

--- a/src/Repository/Query/SignalementList/QueryBuilderFactory.php
+++ b/src/Repository/Query/SignalementList/QueryBuilderFactory.php
@@ -107,7 +107,7 @@ readonly class QueryBuilderFactory
         $qb = $this->searchFilter->applyFilters($qb, $options, $user);
 
         if (!empty($options['relanceUsagerSansReponse'])) {
-            $signalementIds = $signalementRepository->getSignalementsIdAvecRelancesSansReponse();
+            $signalementIds = $signalementRepository->getSignalementsIdAvecRelancesSansReponse($user);
             $qb->andWhere('s.id IN (:signalement_ids)')
                 ->setParameter('signalement_ids', $signalementIds);
         }


### PR DESCRIPTION
## Ticket

#5125

## Description
Optimisation des 5 requêtes les plus chronophage (selon le[ tableau de bord sentry](https://sentry.incubateur.net/organizations/betagouv/insights/backend/database/?environment=prod&project=61&spansSort=-sum%28span.self_time%29&statsPeriod=7d) au cours des 7 derniers jours)
<img width="435" height="287" alt="Screenshot 2025-12-18 at 16-17-21 Queries — Insights — betagouv — Sentry" src="https://github.com/user-attachments/assets/309a4946-281e-4d42-8aec-a22fa6a09cb1" />

1.  Modification de la requête généré par la fonction `getBaseSignalementsAvecRelancesSansReponseSql` pour toujours filtrer sur les territoires de l'user en cours (hors SA). Jusqu’à présent pour les simple agent le filtre était en aval, ce qui impliquait pour eux une requete aussi lourde que les SA sur ce point.
-> En local sur base de prod passage de 1 sec en moyenne a 0.200 sec en moyenne (temps pris dans le profiler)

2. Ajout d’un index sur le champ `uuid` de `signalement_draft`. 
-> En local sur base de prod passage de 0.300 sec en moyenne a < 0.001 sec (temps pris en SQL direct) pour : 
`SELECT * FROM signalement_draft WHERE uuid = '[UUID]'`

3. Ajout d’un index sur le champ `statut` de `user`.
-> En local sur base de prod passage de 0.130 sec en moyenne a  0.07 sec en moyenne (temps pris en SQL direct) pour : 
`SELECT * FROM `user` WHERE JSON_CONTAINS(roles, '"ROLE_ADMIN"') = 1 AND statut = 'ACTIVE'; `

4. Modification de la requête `countNouveauxDossiersKpi` afin d'éviter un leftJoin inutile
-> En local sur les gros territoire (ex agent CAF13) passage de 2 sec a 0.5 sec
-> Sur petit territoire pas de différence (en moyenne < 0.02 sec.)

5. Ajout d’un index sur le champ `waiting_notification` de `suivi`
-> En local sur base de prod passage de 3 seconde en moyenne a 0.0003 seconde en moyenne (temps pris SQL direct) pour : 
`SELECT * FROM suivi WHERE created_at < '2025-12-18 14:41:04' AND waiting_notification = 1;`

## Changements apportés
* Liste des changements techniques apportés

## Pré-requis
`make load-data`
`make execute-migration name=Version20251218111544 direction=up`

## Tests
- [ ] Se connecter au tableau de bord avec différents roles (SA / RT / Agent)
