### PR TITLE
[BO - Espace documentaire] Corrections sur la taille des textes

### DIFF
--- a/migrations/Version20251219170708.php
+++ b/migrations/Version20251219170708.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251219170708 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change file description column type from TINYTEXT to VARCHAR(250)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file MODIFY description VARCHAR(250) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE file MODIFY description TINYTEXT DEFAULT NULL');
+    }
+}

--- a/src/Controller/Back/AdminTerritoryFilesController.php
+++ b/src/Controller/Back/AdminTerritoryFilesController.php
@@ -109,14 +109,6 @@ class AdminTerritoryFilesController extends AbstractController
         $form = $this->createForm(TerritoryFileType::class, $file, ['action' => $this->generateUrl('back_territory_management_document_add_ajax')]);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $description = $form->get('description')->getData();
-            // In a special case, mb_strlen can return a smaller length than strlen, so we check both, or the database field limit can be exceeded
-            if ($description && (mb_strlen($description) > 255 || strlen($description) > 255)) {
-                $errorMsg = 'La description ne doit pas dépasser 255 caractères';
-
-                return $this->json(['response' => $errorMsg, 'errors' => ['description' => ['errors' => [$errorMsg]]]], Response::HTTP_BAD_REQUEST);
-            }
-
             /** @var UploadedFile $uploadedFile */
             $uploadedFile = $form->get('file')->getData();
 
@@ -184,13 +176,6 @@ class AdminTerritoryFilesController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $flush = true;
-            $description = $form->get('description')->getData();
-            // In a special case, mb_strlen can return a smaller length than strlen, so we check both, or the database field limit can be exceeded
-            if ($description && (mb_strlen($description) > 255 || strlen($description) > 255)) {
-                $errorMsg = 'La description ne doit pas dépasser 255 caractères';
-
-                return $this->json(['response' => $errorMsg, 'errors' => ['description' => ['errors' => [$errorMsg]]]], Response::HTTP_BAD_REQUEST);
-            }
 
             if (!empty($form->get('file')->getData())) {
                 $flush = false;

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -129,8 +129,8 @@ class File implements EntityHistoryInterface
     #[ORM\Column]
     private ?bool $isVariantsGenerated = null;
 
-    #[ORM\Column(type: 'text', length: 250, nullable: true)]
-    #[Assert\Length(max: 250)]
+    #[ORM\Column(length: 255, nullable: true)]
+    #[Assert\Length(max: 255, maxMessage: 'La description ne doit pas dépasser {{ limit }} caractères')]
     private ?string $description = null;
 
     #[ORM\Column]


### PR DESCRIPTION
## Ticket

#5128
#5139

## Description
* Quand un document a un titre sans espace, l'affichage se casse : ajout de css pour revenir à la ligne
* Quand on saisit certains textes en description avec des caractères spéciaux, le max de caractères de la description n'est pas atteint, mais ça fait tout de même sauter la colonne en base de données. Création d'une migration pour corriger le format du champs de texte.

## Pré-requis
`make execute-migration name=Version20251219170708 direction=up`

## Tests
- [ ] Vérifier un long titre de doc sans espace (ex : séparé par des `_`)
- [ ] Vérifier que la migration se fait bien
- [ ] Vérifier qu'on n'a pas d'erreur quand on essaie de saisir le texte de l'erreur Sentry du ticker #5139
- [ ] Vérifier qu'on a une erreur quand on dépasse 250 caractères
