### PR TITLE
[QA] getPath(): Argument #1 ($name) must be of type string, null given

### DIFF
--- a/templates/footer.html.twig
+++ b/templates/footer.html.twig
@@ -42,10 +42,10 @@
                     <a href="{{ sites_faciles_url }}cgu/" class="fr-footer__bottom-link" target="_self">CGU</a>
                 </li>
                 <li class="fr-footer__bottom-item">
-                    {% if app.user and '/bo/' in path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) %}
-                    <a href="{{ path('back_plan_du_site') }}" class="fr-footer__bottom-link" target="_self">Plan du site</a>
+                    {% if app.user and app.request.attributes.get('_route') and '/bo/' in path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) %}
+                        <a href="{{ path('back_plan_du_site') }}" class="fr-footer__bottom-link" target="_self">Plan du site</a>
                     {% else %}
-                    <a href="https://signal-logement.beta.gouv.fr/plan-du-site/" class="fr-footer__bottom-link" target="_self">Plan du site</a>
+                        <a href="https://signal-logement.beta.gouv.fr/plan-du-site/" class="fr-footer__bottom-link" target="_self">Plan du site</a>
                     {% endif %}
                 </li>
                 <li class="fr-footer__bottom-item">


### PR DESCRIPTION
## Ticket

#5147

## Description
Depuis la modification du footer pour ajouter le lien du site BO, quelques erreurs sont remontées dans sentry.
Il s'agit d'erreur provoqué par notre page 403 custom (http://localhost:8080/_error/403) car en environnement de prod ces pages sont géré d'uen façon particulière par symfony et leur paramètre `_route` est null.

Elle sont provoqué par l'appel à des images sans paramètre de signature (ex https://histologe-staging.incubateur.net/show/0ae98a2d-c747-4377-9623-5819af18cfe1). Je n'explique pas pourquoi ces url sont parfois appelé, je vais essayer de creuser dans un  second temps

## Tests
- [ ] C'est assez difficile à tester en local le plus simple étant de se rendre sur  http://localhost:8080/_error/403 et de modifier le template du `footer.html.twig` pour retirer les condition `app.user and app.request.attributes.get('_route')` pour voir l'erreur de prod apparaître.
