### PR TITLE
[BUG - Form FO] Clic sur un bouton d'édition dans le récap

### DIFF
--- a/assets/json/Signalement/questions_profile_bailleur.json
+++ b/assets/json/Signalement/questions_profile_bailleur.json
@@ -1608,6 +1608,7 @@
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
           },
           "validate": {
+            "maxLength": 255,
             "message": "Veuillez renseigner la réponse de l'assurance."
           }
         },

--- a/assets/json/Signalement/questions_profile_bailleur_occupant.json
+++ b/assets/json/Signalement/questions_profile_bailleur_occupant.json
@@ -1457,6 +1457,7 @@
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
           },
           "validate": {
+            "maxLength": 255,
             "message": "Veuillez renseigner la réponse de l'assurance."
           }
         },

--- a/assets/json/Signalement/questions_profile_locataire.json
+++ b/assets/json/Signalement/questions_profile_locataire.json
@@ -2118,6 +2118,7 @@
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
           },
           "validate": {
+            "maxLength": 255,
             "message": "Veuillez renseigner la réponse de l'assurance."
           }
         },

--- a/assets/json/Signalement/questions_profile_service_secours.json
+++ b/assets/json/Signalement/questions_profile_service_secours.json
@@ -1650,7 +1650,8 @@
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
           },
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_particulier.json
+++ b/assets/json/Signalement/questions_profile_tiers_particulier.json
@@ -1983,7 +1983,8 @@
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
           },
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {

--- a/assets/json/Signalement/questions_profile_tiers_pro.json
+++ b/assets/json/Signalement/questions_profile_tiers_pro.json
@@ -1978,7 +1978,8 @@
             "show": "formStore.data.info_procedure_assurance_contactee === 'oui'"
           },
           "validate": {
-            "required": false
+            "required": false,
+            "maxLength": 255
           }
         },
         {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormOverview.vue
@@ -180,7 +180,7 @@
           </div>
           <div class="fr-col-12 fr-col-md-4 fr-text--right">
             <button
-              @click="handleEdit('info_procedure')"
+              @click="handleEdit('info_procedure_assurance')"
               class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-edit-line"
               aria-label="Editer la procédure">Editer</button>
           </div>


### PR DESCRIPTION
## Ticket

#5147
#5148

## Description
#5147 il manquait une contrainte (coté client) concernant la longueur du texte à la question "réponse de l'assurance")
-> C'est devenu visible suite à la remonté des log d'erreur de contraintes coté serveur. On pourrait se poser la question de l'utilité de limiter ce champs, je ne vois pas de raison valable de le faire.

#5148 Le bouton sur le bouton d'édition de la procédure dans le formulaire de récap provoquait une boucle infini du fait que le nom de de l'écran n'existait pas. 
-> Je suppose qu'on pourrait revoir la logique de la fonction `changeScreenBySlug` pour être certain que ce la ne se reproduise pas (mais j'ai un peu peur d'y toucher)

## Changements apportés
* Ajout de la contrainte de longueur dans les json
* Correction du nom de l'écran a éditer

## Pré-requis
`make npm-watch`

## Tests
- [ ] Tenter de rentrer un long texte sur le champ "réponse de l'assurance" du formulaire, voir que la validation se fait proprement (coté client) pas via une alert js (provenant de l'erreur serveur)
- [ ] Une fois arrivé à l'écran de récap tenter d'éditer la partie procédure et voir que tout fonctionne.
