### PR TITLE
[BO - Stats] Désactiver le timeout iFrameResizer

### DIFF
--- a/assets/scripts/vanilla/services/ui/metabase_resizer.js
+++ b/assets/scripts/vanilla/services/ui/metabase_resizer.js
@@ -11,6 +11,8 @@ window.addEventListener('load', () => {
       log: false,
       checkOrigin: false,
       heightCalculationMethod: 'max',
+      // Disable iframe-resizer warning about slow iframe responses to avoid noisy production logs.
+      // Metabase embeds can legitimately take longer to respond; this is intentional, not to hide real issues.
       warningTimeout: 0,
     },
     iframe


### PR DESCRIPTION
## Ticket

#5173    

## Description
Problème d'affichage en prod
> [iFrameSizer][Host page: iFrameResizer] IFrame has not responded within 5 seconds.
Check iFrameResizer.contentWindow.js has been loaded in iFrame.
This message can be ignored if everything is working, or you can set the warningTimeout option to a higher value or zero to suppress this warning.

## Changements apportés
* Appliquer la recommandation de la console

## Pré-requis

## Tests
- [ ] CI OK
