### PR TITLE
[QA] Uniformiser l’affichage du territoire via une fonction dédiée

### DIFF
--- a/src/Controller/Back/AnnuaireController.php
+++ b/src/Controller/Back/AnnuaireController.php
@@ -72,7 +72,7 @@ class AnnuaireController extends AbstractController
             $activeWorksheet->setCellValue('E'.$row, $user->getFonction());
             if ($isMultiTerritory) {
                 $territory = $partner->getTerritory();
-                $territoryName = $territory ? $territory->getZip().' - '.$territory->getName() : '';
+                $territoryName = $territory ? $territory->getZipAndName() : '';
                 $activeWorksheet->setCellValue('F'.$row, $territoryName);
             }
             ++$row;

--- a/src/Form/SignalementDraftAddressType.php
+++ b/src/Form/SignalementDraftAddressType.php
@@ -61,7 +61,7 @@ class SignalementDraftAddressType extends AbstractType
             }
             $choicesTerritories = [];
             foreach ($territories as $territoryItem) {
-                $choicesTerritories[$territoryItem->getZip().' - '.$territoryItem->getName()] = $territoryItem->getZip().'|'.$territoryItem->getName();
+                $choicesTerritories[$territoryItem->getZipAndName()] = $territoryItem->getZip().'|'.$territoryItem->getName();
             }
             $builder->add('filterSearchAddressTerritory', ChoiceType::class, [
                 'mapped' => false,

--- a/src/Form/Type/TerritoryChoiceType.php
+++ b/src/Form/Type/TerritoryChoiceType.php
@@ -21,7 +21,7 @@ class TerritoryChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => Territory::class,
-            'choice_label' => fn (Territory $territory) => $territory->getZip().' - '.$territory->getName(),
+            'choice_label' => fn (Territory $territory) => $territory->getZipAndName(),
             'placeholder' => 'Tous les territoires',
             'required' => false,
             'label' => 'Territoire',

--- a/src/Service/ListFilters/SearchPartner.php
+++ b/src/Service/ListFilters/SearchPartner.php
@@ -117,7 +117,7 @@ class SearchPartner
             $filters['Recherche'] = $this->queryPartner;
         }
         if ($this->territoire && $this->user->isSuperAdmin()) {
-            $filters['Territoire'] = $this->territoire->getZip().' - '.$this->territoire->getName();
+            $filters['Territoire'] = $this->territoire->getZipAndName();
         }
         if (null !== $this->partnerType) {
             $filters['Type de partenaire'] = $this->partnerType->label();

--- a/src/Service/ListFilters/SearchTag.php
+++ b/src/Service/ListFilters/SearchTag.php
@@ -83,7 +83,7 @@ class SearchTag
             $filters['Recherche'] = $this->queryTag;
         }
         if ($this->territory && $this->user->isSuperAdmin()) {
-            $filters['Territoire'] = $this->territory->getZip().' - '.$this->territory->getName();
+            $filters['Territoire'] = $this->territory->getZipAndName();
         }
 
         return $filters;

--- a/src/Service/ListFilters/SearchUser.php
+++ b/src/Service/ListFilters/SearchUser.php
@@ -162,7 +162,7 @@ class SearchUser
             $filters['Recherche'] = $this->queryUser;
         }
         if ($this->territory && $this->user->isSuperAdmin()) {
-            $filters['Territoire'] = $this->territory->getZip().' - '.$this->territory->getName();
+            $filters['Territoire'] = $this->territory->getZipAndName();
         }
         if ($this->partners->count()) {
             $label = '';

--- a/src/Service/Statistics/ListTerritoryStatisticProvider.php
+++ b/src/Service/Statistics/ListTerritoryStatisticProvider.php
@@ -25,7 +25,7 @@ class ListTerritoryStatisticProvider
         }
         /** @var Territory $territory */
         foreach ($territories as $territory) {
-            $data[$territory->getId()] = $territory->getZip().' - '.$territory->getName();
+            $data[$territory->getId()] = $territory->getZipAndName();
         }
 
         return $data;

--- a/src/Service/UserExportLoader.php
+++ b/src/Service/UserExportLoader.php
@@ -44,7 +44,7 @@ readonly class UserExportLoader
             foreach ($headers as $key => $unused) {
                 $territories = '';
                 foreach ($user->getPartnersTerritories() as $territory) {
-                    $territories .= $territory->getZip().' - '.$territory->getName().', ';
+                    $territories .= $territory->getZipAndName().', ';
                 }
                 $territories = substr($territories, 0, -2);
                 $partners = '';

--- a/templates/_partials/_modal_user_create_multi.html.twig
+++ b/templates/_partials/_modal_user_create_multi.html.twig
@@ -7,7 +7,7 @@
     Ce compte agent existe déjà dans :
     <ul>
         {% for item in user.partners %}
-            <li>le partenaire {{item.nom}} du territoire {{item.territory.zip}} - {{item.territory.name}}</li>
+            <li>le partenaire {{item.nom}} du territoire {{item.territory.zipAndName}}</li>
         {% endfor %}
     </ul>
     <strong>Vous pouvez ajouter ce compte agent à votre partenaire {{partner.nom}}.</strong> Si vous l'ajoutez :

--- a/templates/back/admin-territory-files/index.html.twig
+++ b/templates/back/admin-territory-files/index.html.twig
@@ -88,7 +88,7 @@
                     {% if is_granted('ROLE_ADMIN') %}
                     <td>
                         {% if file.territory %}
-                            {{ file.territory.zip }} - {{ file.territory.name }}
+                            {{ file.territory.zipAndName }}
                         {% else %}
                             Tous
                         {% endif %}

--- a/templates/back/affectation-without-subscription/index.html.twig
+++ b/templates/back/affectation-without-subscription/index.html.twig
@@ -69,7 +69,7 @@
                         {% endif %}
                     </td>
                     <td><a href="{{ path('back_partner_view', {id: affectation.partner.id}) }}">{{ affectation.partner.nom }}</a></td>
-                    <td>{{affectation.signalement.territory.zip}} - {{affectation.signalement.territory.name}}</td>
+                    <td>{{affectation.signalement.territory.zipAndName}}</td>
                     <td>{{ affectation.createdAt|date('d/m/Y H:i') }}</td>
                 </tr>
             {% endfor %}

--- a/templates/back/annuaire/index.html.twig
+++ b/templates/back/annuaire/index.html.twig
@@ -72,7 +72,7 @@
                                 <h3 class="fr-h4 fr-mb-1v">{{ userPartner.user.nomComplet }}</h3>
                                 <strong>{{ userPartner.partner.nom }}</strong>
                                 {% if isMultiTerritory and userPartner.partner.territory %}
-                                    ({{ userPartner.partner.territory.zip }} - {{ userPartner.partner.territory.name }})
+                                    ({{ userPartner.partner.territory.zipAndName }})
                                 {% endif %}
                                 <br>
                                 Fonction : {{ userPartner.user.fonction ? userPartner.user.fonction : '/' }}

--- a/templates/back/auto-affectation-rule/index.html.twig
+++ b/templates/back/auto-affectation-rule/index.html.twig
@@ -62,7 +62,7 @@
         {% set tableBody %}
             {% for autoaffectationrule in autoAffectationRules %}
                 <tr class="autoaffectationrule-row">
-                    <td>{{ autoaffectationrule.territory.zip}} - {{ autoaffectationrule.territory.name}}</td>
+                    <td>{{ autoaffectationrule.territory.zipAndName}}</td>
                     <td>
                         {% if autoaffectationrule.status is same as constant('App\\Entity\\AutoAffectationRule::STATUS_ACTIVE') %}
                             {% set classe = 'fr-badge--green-emeraude' %}

--- a/templates/back/auto-assigner-simulator/territory.html.twig
+++ b/templates/back/auto-assigner-simulator/territory.html.twig
@@ -22,9 +22,9 @@
                         Auto Assigner Simulator ⚗️ 
                         <br>
                         {% if uuid %}
-                            <small>sur le signalement {{uuid}} du territoire {{territory.zip}} - {{territory.name}}</small>
+                            <small>sur le signalement {{uuid}} du territoire {{territory.zipAndName}}</small>
                         {% else %}
-                            <small>sur les {{limit}} derniers signalements du {{territory.zip}} - {{territory.name}}</small>
+                            <small>sur les {{limit}} derniers signalements du {{territory.zipAndName}}</small>
                         {% endif %}
                     </h1>
                 </div>

--- a/templates/back/bailleur/index.html.twig
+++ b/templates/back/bailleur/index.html.twig
@@ -63,7 +63,7 @@
                     <td>{{ bailleur.name }}</td>
                     <td>
                         {% for bailleurTerritory in bailleur.bailleurTerritories %}
-                            <span class="fr-badge fr-badge--no-icon fr-badge--success">{{bailleurTerritory.territory.zip}} {{bailleurTerritory.territory.name}}</span>
+                            <span class="fr-badge fr-badge--no-icon fr-badge--success">{{bailleurTerritory.territory.zipAndName}}</span>
                         {% endfor %}
                     </td>
                     <td class="fr-text--right fr-ws-nowrap">

--- a/templates/back/partner/index.html.twig
+++ b/templates/back/partner/index.html.twig
@@ -103,7 +103,7 @@
                 <tr class="partner-row">
                     <td>{{ partner.id }}</td>
                     {% if is_granted('ROLE_ADMIN') or (is_granted('ROLE_ADMIN_TERRITORY') and app.user.userPartners|length > 1) %}
-                        <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
+                        <td>{{ partner.territory ? partner.territory.zipAndName : 'aucun' }}</td>
                     {% endif %}
                     <td>{{ partner.nom }}</td>
                     <td>{{ partner.type ? partner.type.label : (partner.isCommune ? 'Commune':'N/A') }}</td>

--- a/templates/back/partner/view.html.twig
+++ b/templates/back/partner/view.html.twig
@@ -27,7 +27,7 @@
             <div class="fr-grid-row"> 
                 <div class="fr-col-12">
                     <h1>{{ partner.nom }}</h1>
-                    <p>Territoire : {{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : ''}}</p>
+                    <p>Territoire : {{ partner.territory ? partner.territory.zipAndName : ''}}</p>
                 </div>
             </div>          
         </header>
@@ -66,7 +66,7 @@
                     <div><b>Nom :</b> {{ partner.nom }}</div>
                 </div>
                 <div class="fr-col-6">
-                    <div><b>Territoire :</b> {{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : ''}}</div>
+                    <div><b>Territoire :</b> {{ partner.territory ? partner.territory.zipAndName : ''}}</div>
                 </div>
                 <div class="fr-col-6">
                     <div>

--- a/templates/back/partner_archived/index.html.twig
+++ b/templates/back/partner_archived/index.html.twig
@@ -71,7 +71,7 @@
                     {% set statut = 'actif' %}
                 {% endif %}
                 <tr class="user-row">
-                    <td>{{ partner.territory ? partner.territory.zip ~ ' - ' ~ partner.territory.name : 'aucun' }}</td>
+                    <td>{{ partner.territory ? partner.territory.zipAndName : 'aucun' }}</td>
                     <td>{{ partner.nom}}</td>
                     <td><span class="fr-badge {{ classe }} fr-badge--no-icon fr-ws-nowrap ">{{ statut|upper }}</span></td>
                     <td>{{ partner.email|clean_tagged_text(constant('App\\Entity\\User::SUFFIXE_ARCHIVED'), 'left') }}</td>

--- a/templates/back/pop-notification/index.html.twig
+++ b/templates/back/pop-notification/index.html.twig
@@ -17,7 +17,7 @@
                             Votre compte a été ajouté :
                             <ul class="fr-mb-2v fr-mt-0">
                                 {% for partner in addedPartners %}
-                                <li>au partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
+                                <li>au partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zipAndName}}</strong></li>
                                 {% endfor %}
                             </ul>
                         {% endif %}
@@ -25,7 +25,7 @@
                             Votre compte a été retiré :
                             <ul class="fr-mb-2v fr-mt-0">
                                 {% for partner in removedPartners %}
-                                <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
+                                <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zipAndName}}</strong></li>
                                 {% endfor %}
                             </ul>
                         {% endif %}
@@ -34,7 +34,7 @@
                         1. Vous avez accès aux signalements :
                         <ul class="fr-mb-2v fr-mt-0 fr-ml-2v">
                             {% for partner in user.partners %}
-                            <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
+                            <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zipAndName}}</strong></li>
                             {% endfor %}
                         </ul>
                         {% set nb = 2 %}
@@ -42,7 +42,7 @@
                             {{nb}}. Vous n'avez plus accès aux signalements :
                             <ul class="fr-mb-2v fr-mt-0 fr-ml-2v">
                                 {% for partner in removedPartners %}
-                                <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zip}} - {{partner.territory.name}}</strong></li>
+                                <li>du partenaire <strong>{{partner.nom}}</strong> du territoire <strong>{{partner.territory.zipAndName}}</strong></li>
                                 {% endfor %}
                             </ul>
                             {% set nb = nb + 1 %}

--- a/templates/back/profil/index.html.twig
+++ b/templates/back/profil/index.html.twig
@@ -62,11 +62,11 @@
                 {% for partner in app.user.partners %}
                     <div class="fr-col-12 fr-col-md-6">
                         <p>
-                            <strong>Territoire : {{ partner.territory.zip }} - {{ partner.territory.name }}</strong>
+                            <strong>Territoire : {{ partner.territory.zipAndName }}</strong>
                             <br>
                             J'ai un compte {{ app.user.roleLabel }} dans le partenaire {{ partner.nom }}.
                             <br>
-                            Responsable(s) du territoire {{ partner.territory.zip }} - {{ partner.territory.name }} :
+                            Responsable(s) du territoire {{ partner.territory.zipAndName }} :
                         </p>
                         <ul>
                             {% for userAdmin in activeTerritoryAdminsByTerritory[partner.territory.id] %}

--- a/templates/back/signalement-injonction/index.html.twig
+++ b/templates/back/signalement-injonction/index.html.twig
@@ -92,7 +92,7 @@
                 {% endif %}
                 <tr>
                     {% if is_granted('ROLE_ADMIN') %}
-                        <td>{{ signalement.territory ? signalement.territory.zip ~ ' - ' ~ signalement.territory.name : 'aucun' }}</td>
+                        <td>{{ signalement.territory ? signalement.territory.zipAndName : 'aucun' }}</td>
                     {% endif %}
                     <td>{{ signalement.reference }}</td>
                     <td>{{ signalement.createdAt.format('d/m/Y') }}</td>

--- a/templates/back/signalement_archived/index.html.twig
+++ b/templates/back/signalement_archived/index.html.twig
@@ -67,7 +67,7 @@
                         <a href="{{ path('back_signalement_view',{uuid:signalement.uuid}) }}"
                         class="fr-ws-nowrap">{{ signalement.reference }}</a>
                     </td>
-                    <td>{{ signalement.territory.zip}} - {{ signalement.territory.name}} </td>
+                    <td>{{ signalement.territory.zipAndName}}</td>
                     <td>{{ signalement.createdAt|date('d/m/Y') }}</td>
                     <td>
                         {{ signalement.nomOccupant|upper }}<br>{{ signalement.prenomOccupant|capitalize }}

--- a/templates/back/tags/index.html.twig
+++ b/templates/back/tags/index.html.twig
@@ -193,7 +193,7 @@
                     <td>{{ tag.id }}</td>
                     <td><span class="fr-badge fr-badge--blue-ecume fr-badge--no-icon">{{ tag.label }}</span></td>
                     <td>{{ tag.signalements|length }}</td>
-                    <td>{{ tag.territory.name }}</td>
+                    <td>{{ tag.territory.zipAndName }}</td>
                     <td class="fr-text--right fr-ws-nowrap">
                         <button class="fr-btn fr-icon-edit-line"
                             title="Editer l'étiquette {{ tag.label }}"

--- a/templates/back/user/inactive-accounts.html.twig
+++ b/templates/back/user/inactive-accounts.html.twig
@@ -58,7 +58,7 @@
                         <td>
                             {% for partner in user.partners %}
                                 {% if partner.territory %}
-                                    {{ partner.territory.zip ~ ' - ' ~ partner.territory.name }}
+                                    {{ partner.territory.zipAndName }}
                                 {% else %}
                                     N/A
                                 {% endif %}

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -103,7 +103,7 @@
                         <td>
                             {% for partner in user.partners %}
                                 {% if partner.territory %}
-                                    {{ partner.territory.zip ~ ' - ' ~ partner.territory.name }}
+                                    {{ partner.territory.zipAndName }}
                                 {% else %}
                                     N/A
                                 {% endif %}

--- a/templates/back/user_api_permission/index.html.twig
+++ b/templates/back/user_api_permission/index.html.twig
@@ -91,7 +91,7 @@
                                                             {% set currentPermissionDescription %}
                                                             <ul>
                                                                 {% if permission.territory is not null %}
-                                                                    <li><strong>Territoire :</strong> {{ permission.territory.zip ~ ' - ' ~ permission.territory.name }}</li>
+                                                                    <li><strong>Territoire :</strong> {{ permission.territory.zipAndName }}</li>
                                                                 {% endif %}
                                                                 {% if permission.partner is not null %}
                                                                     <li><strong>Partenaire :</strong> <a href="{{ path('back_partner_view', {id: permission.partner.id}) }}">{{ permission.partner.nom }}</a></li>

--- a/templates/back/user_archived/index.html.twig
+++ b/templates/back/user_archived/index.html.twig
@@ -84,7 +84,7 @@
                         {% else %}
                             {% for partner in user.partners %}
                                 {% if partner.territory %}
-                                    {{ partner.territory.zip ~ ' - ' ~ partner.territory.name }}
+                                    {{ partner.territory.zipAndName }}
                                 {% else %}
                                     aucun
                                 {% endif %}

--- a/templates/back/zone/index.html.twig
+++ b/templates/back/zone/index.html.twig
@@ -92,7 +92,7 @@
                     </td>
                     <td>
                         {% if item.territory %}
-                            {{ item.territory.zip }} - {{ item.territory.name }}
+                            {{ item.territory.zipAndName }}
                         {% endif %}
                     </td>
                     <td>{{ item.type.label }}</td>

--- a/templates/back/zone/show.html.twig
+++ b/templates/back/zone/show.html.twig
@@ -27,7 +27,7 @@
                 {% if is_granted('ROLE_ADMIN') %}
                     <div class="fr-col-12">
                         <b>Territoire :</b>
-                        {{ zone.territory.zip }} - {{ zone.territory.name }}
+                        {{ zone.territory.zipAndName }}
                     </div>
                 {% endif %}
                 <div class="fr-col-12">


### PR DESCRIPTION
## Ticket

#4971   

## Description
Utilisation de la fonction de l'entité territoire `getZipAndName()` là où on faisait `getZip() . '-' . getName()` (en twig et en php)

## Changements apportés
* LModification des templates twig et des controller

## Pré-requis

## Tests
- [ ] Vérifier l'affichage sur les pages modifiées (je les ai toutes revérifiées, donc quelques-unes suffiront)
