### PR TITLE
[Accessibilité] Liste signalements archivés - Aucune information n’est véhiculée uniquement par la couleur

### DIFF
--- a/templates/back/signalement_archived/index.html.twig
+++ b/templates/back/signalement_archived/index.html.twig
@@ -75,17 +75,7 @@
                     <td>{{ signalement.villeOccupant|upper }} <br><small>[{{ signalement.adresseOccupant }}]</small></td>
                     <td>
                         {% for affectation in signalement.affectations %}
-                            {% set classe = '' %}
-                            {% if affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').WAIT %}
-                                {% set classe = 'fr-badge fr-badge--info' %}
-                            {% elseif affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').ACCEPTED %}
-                                {% set classe = 'fr-badge fr-badge--success' %}
-                            {% elseif affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').REFUSED %}
-                                {% set classe = 'fr-badge fr-text-label--red-marianne fr-background-contrast--red-marianne fr-fi-close-line' %}
-                            {% elseif affectation.statut is same as enum('App\\Entity\\Enum\\AffectationStatus').CLOSED %}
-                                {% set classe = 'fr-badge fr-fi-close-circle-fill' %}
-                            {% endif %}
-                            <small class="{{ classe }} fr-ws-nowrap fr-badge--sm fr-my-1v fr-text--bold fr-display-block fr-limit-chars"><span
+                            <small class="fr-badge fr-ws-nowrap fr-badge--sm fr-my-1v fr-text--bold fr-display-block fr-limit-chars"><span
                                 > {{ affectation.partner.nom }}</span></small>
                         {% else %}
                             Aucune


### PR DESCRIPTION
## Ticket

#5186   

## Description
Dans la liste des signalements archivés (fonction SA), le statut de l'affectation était disponible seulement par la couleur du badge. 
J'ai commencé par ajouté le statut de l'affectation textuellement à la suite du nom du partenaire, avant de m'apercevoir qu'en prod toutes les affectations sont fermées pour un signalement archivé.
J'ai donc enlevé l'information de couleur du badge

## Changements apportés
* Changement du twig

## Pré-requis

## Tests
- [ ] Vérifier que tous les badges sont gris (plus facile sur base de prod)
