### PR TITLE
[BO - Signalement] Ajout document impossible sur dossier fermé

### DIFF
--- a/src/Controller/Back/SignalementFileController.php
+++ b/src/Controller/Back/SignalementFileController.php
@@ -68,7 +68,10 @@ class SignalementFileController extends AbstractController
         EntityManagerInterface $entityManager,
         SignalementFileProcessor $signalementFileProcessor,
     ): Response {
-        if (!$this->isGranted(SignalementVoter::SIGN_EDIT_DRAFT, $signalement) && !$this->isGranted(SignalementVoter::SIGN_EDIT_ACTIVE, $signalement) && !$this->isGranted(SignalementVoter::SIGN_EDIT_INJONCTION, $signalement)) {
+        if (!$this->isGranted(SignalementVoter::SIGN_EDIT_DRAFT, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_ACTIVE, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_CLOSED, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_INJONCTION, $signalement)) {
             throw $this->createAccessDeniedException();
         }
         if (!$this->isCsrfTokenValid('signalement_add_file_'.$signalement->getId(), (string) $request->get('_token')) || !$files = $request->files->get('signalement-add-file')) {
@@ -105,7 +108,10 @@ class SignalementFileController extends AbstractController
         SuiviManager $suiviManager,
         UploadHandlerService $uploadHandlerService,
     ): JsonResponse {
-        if (!$this->isGranted(SignalementVoter::SIGN_EDIT_DRAFT, $signalement) && !$this->isGranted(SignalementVoter::SIGN_EDIT_ACTIVE, $signalement) && !$this->isGranted(SignalementVoter::SIGN_EDIT_INJONCTION, $signalement)) {
+        if (!$this->isGranted(SignalementVoter::SIGN_EDIT_DRAFT, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_ACTIVE, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_CLOSED, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_INJONCTION, $signalement)) {
             throw $this->createAccessDeniedException();
         }
         /** @var FileRepository $fileRepository */
@@ -309,7 +315,9 @@ class SignalementFileController extends AbstractController
         Request $request,
         ImageManipulationHandler $imageManipulationHandler,
     ): Response {
-        if (!$this->isGranted(SignalementVoter::SIGN_EDIT_ACTIVE, $signalement) && !$this->isGranted(SignalementVoter::SIGN_EDIT_INJONCTION, $signalement)) {
+        if (!$this->isGranted(SignalementVoter::SIGN_EDIT_ACTIVE, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_CLOSED, $signalement)
+            && !$this->isGranted(SignalementVoter::SIGN_EDIT_INJONCTION, $signalement)) {
             throw $this->createAccessDeniedException();
         }
         $rotate = (int) $request->get('rotate', 0);

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -43,8 +43,10 @@
     {% if is_granted('SIGN_EDIT_NDE', signalement) %}
         {% include '_partials/_modal_edit_nde.html.twig' %}
     {% endif %}
-    {% if is_granted('SIGN_EDIT_ACTIVE', signalement) or is_granted('SIGN_EDIT_INJONCTION', signalement) %}
+    {% if is_granted('SIGN_EDIT_ACTIVE', signalement) or is_granted('SIGN_EDIT_CLOSED', signalement) or is_granted('SIGN_EDIT_INJONCTION', signalement) %}
         {% include '_partials/_modal_upload_files.html.twig' with {'context': 'form-bo-edit'} %}
+    {% endif %}
+    {% if is_granted('SIGN_EDIT_ACTIVE', signalement) or is_granted('SIGN_EDIT_INJONCTION', signalement) %}
         {% include '_partials/_modal_reinit_affectation.html.twig' %}
     {% endif %}
     {% if signalement.geoloc.lat is defined and signalement.geoloc.lng is defined %}

--- a/templates/back/signalement/view/photos-documents.html.twig
+++ b/templates/back/signalement/view/photos-documents.html.twig
@@ -4,7 +4,7 @@
             <h3 class="fr-h5">{{ zonetitle }}</h3>
         </div>
         <div class="fr-col-3 fr-col-md-6 fr-text--right">
-            {% if (is_granted('SIGN_EDIT_ACTIVE', signalement) or is_granted('SIGN_EDIT_INJONCTION', signalement)) and filesFilter is not same as 'visite' %}
+            {% if (is_granted('SIGN_EDIT_ACTIVE', signalement) or is_granted('SIGN_EDIT_CLOSED', signalement) or is_granted('SIGN_EDIT_INJONCTION', signalement)) and filesFilter is not same as 'visite' %}
                 <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-btns-group--icon-left">
                     <li>
                         <button


### PR DESCRIPTION
## Ticket

#5196

## Description
Suite a une régression due au ticket #4917 les RT ne pouvait plus ajouter de documents sur le signalements fermé.
Correction du problème de voters

## Tests
- [ ] Se connecter en RT sur un signalement fermé et vérifier que l'on peux ajouter/editer des documents
