### PR TITLE
[BO - Export PDF] Ignorer les images taggé comme suspect

### DIFF
--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -673,7 +673,7 @@
     <section>
         <div class="page">
         {% set sortedPhotos = signalement.files
-            |filter(photo => photo.isTypeImage)
+            |filter(photo => photo.isTypeImage and (photo.isSuspicious is not same as(true)))
             |sort((a, b) =>
                 (a.documentType.name == 'PHOTO_VISITE' ? 1 : 0) <=> (b.documentType.name == 'PHOTO_VISITE' ? 1 : 0)
                 ?: (a.createdAt <=> b.createdAt)


### PR DESCRIPTION
## Ticket

#5200    

## Description
Ajouter un filtre  pour ne pas afficher les images qui ont été tagué comme suspect

## Changements apportés
* Ajout filtre sur le twig pdf

## Pré-requis
- Ajouter des photos à un signalement
- Passer des photos somme suspect directement en base

## Tests
- [ ]  Faire un premier export et vérifier que les images suspectes ne s'affiche pas dans le PDF
