### PR TITLE
[BO] Gestion des erreurs - Limiter SecurityApiExceptionListener au contexte API

### DIFF
--- a/src/EventListener/SecurityApiExceptionListener.php
+++ b/src/EventListener/SecurityApiExceptionListener.php
@@ -4,6 +4,7 @@ namespace App\EventListener;
 
 use App\Entity\Affectation;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -19,6 +20,12 @@ class SecurityApiExceptionListener
     public function onKernelException(ExceptionEvent $event): void
     {
         $exception = $event->getThrowable();
+        $request = $event->getRequest();
+
+        if (!$this->isApiRoute($request)) {
+            return;
+        }
+
         if ($this->supports($exception)) {
             $previous = $exception->getPrevious();
             $affectation = null;
@@ -63,5 +70,15 @@ class SecurityApiExceptionListener
                 || self::ACCESS_DENIED_PARTNER_NOT_FOUND === $exception->getMessage()
                 || self::TRANSITION_STATUT_DENIED === $exception->getMessage()
             );
+    }
+
+    private function isApiRoute(Request $request): bool
+    {
+        $pathInfo = $request->getPathInfo();
+        if (str_starts_with($pathInfo, '/api/')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Functional/Controller/Back/ConfigClubEventControllerTest.php
+++ b/tests/Functional/Controller/Back/ConfigClubEventControllerTest.php
@@ -29,6 +29,27 @@ class ConfigClubEventControllerTest extends WebTestCase
         $this->assertSelectorTextContains('h2', '6 événements trouvés');
     }
 
+    public function testIndexForUnauthorizedUser(): void
+    {
+        $client = static::createClient();
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findOneBy(['email' => 'admin-territoire-30@signal-logement.fr']);
+        $client->loginUser($user);
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+
+        $route = $router->generate('back_config_club_event_index');
+        $client->request('GET', $route);
+
+        $this->assertResponseStatusCodeSame(403);
+        $response = $client->getResponse();
+        $contentType = $response->headers->get('Content-Type');
+        $this->assertStringContainsString('text/html', $contentType);
+        $this->assertStringContainsString('Access Denied. The user doesn\'t have ROLE_ADMIN.', (string) $response->getContent());
+    }
+
     public function testEdit(): void
     {
         $client = static::createClient();

--- a/tests/Functional/Controller/Back/SignalementActionControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementActionControllerTest.php
@@ -331,7 +331,6 @@ class SignalementActionControllerTest extends WebTestCase
                 ],
             ]
         );
-        $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $this->assertResponseStatusCodeSame(403);
     }
 
@@ -355,7 +354,6 @@ class SignalementActionControllerTest extends WebTestCase
                 ],
             ]
         );
-        $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $this->assertResponseStatusCodeSame(403);
     }
 


### PR DESCRIPTION
## Ticket

#5183

## Description
- Restriction du fonctionnement de `SecurityApiExceptionListener` aux URLs de l'API
- Ajout et correction de tests vérifiant ce fonctionnement

## Tests
- [ ] Se connecter au BO avec un utilisateur non SA et se rendre sur une page restreinte aux admin (ex http://localhost:8080/bo/config-club-utilisateur) voir que l'erreur retourné est sous la forme d'une page html
- [ ] Se connecter à l'API et mettre à jour une affectation avec une transition incorrecte, voir que le retour est toujours en json 

<img width="551" height="208" alt="Screenshot 2026-01-06 at 16-47-57 Access Denied  The user doesn&#39;t have ROLE_ADMIN  (403 Forbidden)" src="https://github.com/user-attachments/assets/7ea454a2-db3a-4cc2-ba47-ec7390a123ca" />
<img width="641" height="173" alt="Capture d’écran 2026-01-06 161657" src="https://github.com/user-attachments/assets/be58c5b5-bbd9-4114-8424-f5f9eaf6c596" />

