### PR TITLE
[BO - Signalement] Améliorer la recherche dans la liste de documents à ajouter à un suivi

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/back_view_signalement.js
@@ -422,7 +422,7 @@ if (submitModalDuplicateAddresses) {
       fetch(form.action, {
         method: 'POST',
         body: formData,
-      }).then((response) => {
+      }).then(() => {
         window.location.href = urlToRedirect;
       });
     } else {

--- a/assets/scripts/vanilla/controllers/back_signalement_view/toggle-suivi-auto.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_view/toggle-suivi-auto.js
@@ -1,7 +1,7 @@
 const allSuivis = document?.querySelectorAll('.suivi-item');
-const items = Array.from(allSuivis).map(item => ({
+const items = Array.from(allSuivis).map((item) => ({
   el: item,
-  isAuto: item.classList.contains('suivi-auto')
+  isAuto: item.classList.contains('suivi-auto'),
 }));
 const btnDisplayAll = document?.querySelector('#btn-display-all-suivis');
 const toggleWrapper = document?.querySelector('#toggle-hide-technical')?.closest('.fr-toggle');
@@ -46,7 +46,6 @@ function applyFilter() {
     btnDisplayAll.classList.add('fr-hidden');
   }
 }
-
 
 applyFilter();
 

--- a/assets/scripts/vanilla/controllers/front_dossier_bailleur/front_dossier_bailleur.js
+++ b/assets/scripts/vanilla/controllers/front_dossier_bailleur/front_dossier_bailleur.js
@@ -1,5 +1,9 @@
-const reponseInjonctionBailleurDescription = document?.querySelector('#reponse_injonction_bailleur_description');
-const reponseInjonctionBailleurEngagementTravaux = document?.querySelector('#reponse_injonction_bailleur_engagement_travaux');
+const reponseInjonctionBailleurDescription = document?.querySelector(
+  '#reponse_injonction_bailleur_description'
+);
+const reponseInjonctionBailleurEngagementTravaux = document?.querySelector(
+  '#reponse_injonction_bailleur_engagement_travaux'
+);
 
 if (reponseInjonctionBailleurDescription) {
   const descriptionContainer = reponseInjonctionBailleurDescription.parentElement;
@@ -24,21 +28,20 @@ if (reponseInjonctionBailleurDescription) {
       const label = descriptionContainer.querySelector('.fr-label');
       var textNode = '';
       switch (value) {
-      case 'REPONSE_OUI':
-        textNode = document.createTextNode(label.getAttribute('data-label-oui'));
-        reponseInjonctionBailleurEngagementTravaux.classList.remove('fr-hidden');
-        break;
-      case 'REPONSE_OUI_AVEC_AIDE':
-        textNode = document.createTextNode(label.getAttribute('data-label-oui-avec-aide'));
-        reponseInjonctionBailleurEngagementTravaux.classList.remove('fr-hidden');
-        break;
-      case 'REPONSE_NON':
-        textNode = document.createTextNode(label.getAttribute('data-label-non'));
-        reponseInjonctionBailleurEngagementTravaux.classList.add('fr-hidden');
-        break;
+        case 'REPONSE_OUI':
+          textNode = document.createTextNode(label.getAttribute('data-label-oui'));
+          reponseInjonctionBailleurEngagementTravaux.classList.remove('fr-hidden');
+          break;
+        case 'REPONSE_OUI_AVEC_AIDE':
+          textNode = document.createTextNode(label.getAttribute('data-label-oui-avec-aide'));
+          reponseInjonctionBailleurEngagementTravaux.classList.remove('fr-hidden');
+          break;
+        case 'REPONSE_NON':
+          textNode = document.createTextNode(label.getAttribute('data-label-non'));
+          reponseInjonctionBailleurEngagementTravaux.classList.add('fr-hidden');
+          break;
       }
       label.replaceChild(textNode, label.firstChild);
-
     } else {
       reponseInjonctionBailleurEngagementTravaux.classList.add('fr-hidden');
       descriptionContainer.classList.add('fr-hidden');

--- a/assets/scripts/vanilla/services/component/component_search_address.js
+++ b/assets/scripts/vanilla/services/component/component_search_address.js
@@ -207,18 +207,10 @@ export function initComponentAdress(id) {
     return;
   }
   const addressInputParent = addressInput.parentElement.parentElement.parentElement;
-  const manualAddressSwitcher = addressInputParent?.querySelector(
-    '.manual-address-switcher'
-  );
-  const manualAddressContainer = addressInputParent?.querySelector(
-    '.manual-address-container'
-  );
-  const manualAddressAddress = addressInputParent?.querySelector(
-    '.manual-address-input'
-  );
-  const manualAddressInputs = addressInputParent?.querySelectorAll(
-    '.manual-address'
-  );
+  const manualAddressSwitcher = addressInputParent?.querySelector('.manual-address-switcher');
+  const manualAddressContainer = addressInputParent?.querySelector('.manual-address-container');
+  const manualAddressAddress = addressInputParent?.querySelector('.manual-address-input');
+  const manualAddressInputs = addressInputParent?.querySelectorAll('.manual-address');
   const hasManualAddressValues = Array.from(manualAddressInputs).some(
     (input) => input.value !== ''
   );

--- a/assets/scripts/vanilla/services/component/component_search_checkbox.js
+++ b/assets/scripts/vanilla/services/component/component_search_checkbox.js
@@ -41,21 +41,60 @@ function initSearchCheckboxWidgets() {
           .normalize('NFD')
           .replace(/[\u0300-\u036f]/g, '')
           .toLowerCase();
-        checkboxesContainer.querySelectorAll('.fr-fieldset__element').forEach((checkbox) => {
-          if (
-            checkbox.classList.contains('optgroup__element') ||
-            checkbox
-              .querySelector('label')
-              .textContent.normalize('NFD')
-              .replace(/[\u0300-\u036f]/g, '')
-              .toLowerCase()
-              .includes(value)
-          ) {
-            checkbox.style.display = '';
-          } else {
-            checkbox.style.display = 'none';
+
+        let mainGroup = null;
+        let mainGroupHasMatch = false;
+
+        let subGroup = null;
+        let subGroupHasMatch = false;
+
+        checkboxesContainer.querySelectorAll('.fr-fieldset__element').forEach((el) => {
+          const label = el.querySelector('label');
+          const isMainGroup = el.classList.contains('optgroup__element');
+
+          // Main title
+          if (isMainGroup) {
+            if (mainGroup) {
+              mainGroup.style.display = mainGroupHasMatch ? '' : 'none';
+            }
+            mainGroup = el;
+            mainGroupHasMatch = false;
+            subGroup = null;
+            return;
+          }
+
+          // Subtitle
+          if (!label) {
+            if (subGroup) {
+              subGroup.style.display = subGroupHasMatch ? '' : 'none';
+            }
+            subGroup = el;
+            subGroupHasMatch = false;
+            return;
+          }
+
+          // option
+          const text = label.textContent
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase();
+
+          const match = text.includes(value);
+          el.style.display = match ? '' : 'none';
+
+          if (match) {
+            mainGroupHasMatch = true;
+            subGroupHasMatch = true;
           }
         });
+
+        // close last groups
+        if (subGroup) {
+          subGroup.style.display = subGroupHasMatch ? '' : 'none';
+        }
+        if (mainGroup) {
+          mainGroup.style.display = mainGroupHasMatch ? '' : 'none';
+        }
       });
       // hide choices on click outside and on close button
       document.addEventListener('click', function (event) {
@@ -66,7 +105,7 @@ function initSearchCheckboxWidgets() {
       element.addEventListener('click', function (event) {
         event.stopPropagation();
       });
-      closeBtn.addEventListener('click', function (event) {
+      closeBtn.addEventListener('click', function () {
         searchCheckboxHideChoices(element, checkboxesContainer, closeBtn, initialValues);
       });
       // reorder on uncheck

--- a/assets/scripts/vanilla/services/component/component_select_all_checkbox.js
+++ b/assets/scripts/vanilla/services/component/component_select_all_checkbox.js
@@ -9,7 +9,9 @@ document.addEventListener('click', (e) => {
   if (!targetSelector) return;
 
   /** @type {NodeListOf<HTMLInputElement>} */
-  const checkboxes = Array.from(target.querySelectorAll('input[type="checkbox"]')).filter((cb) => !cb.disabled);
+  const checkboxes = Array.from(target.querySelectorAll('input[type="checkbox"]')).filter(
+    (cb) => !cb.disabled
+  );
   const allChecked = Array.from(checkboxes).every((cb) => cb.checked);
 
   checkboxes.forEach((cb) => {


### PR DESCRIPTION
## Ticket

#5194   

## Description
Amélioration de la recherche dans la select de document lors de l'ajout de suivi, afin de filtrer aussi dans les documents types qui sont dans des sous-catégories

## Changements apportés
* Changement de l'événement keyup dans le js component_search_checkbox
* make es-js-fix (les autres fichiers modifiés)

## Pré-requis

## Tests
- [ ] Choisir un signalement et ajouter des documents liés à la situation et liés à la procédure
- [ ] Ajouter un suivi et tester la recherche dans la select d'ajout de documents, les docs liés à la situations, les docs de procédures ET les documents types doivent être filtrés
- [ ] Tester la recherche dans des select plus simple (conclusion de visite, compétences de partenaires etc.) et vérifier que rien n'a changé
