### PR TITLE
[BO - Signalement] Import historique - 79

### DIFF
--- a/src/Command/Temp/RemoveImportedSignalementDeuxSevresCommand.php
+++ b/src/Command/Temp/RemoveImportedSignalementDeuxSevresCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Command\Temp;
+
+use App\Entity\HistoryEntry;
+use App\Entity\Signalement;
+use App\Entity\Territory;
+use App\Manager\HistoryEntryManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:remove-imported-signalement-deux-sevres',
+    description: 'Remove imported signalements for Deux-Sèvres department',
+)]
+class RemoveImportedSignalementDeuxSevresCommand extends Command
+{
+    private const int TERRITORY_ID = 80;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly HistoryEntryManager $historyEntryManager)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $this->historyEntryManager->removeEntityListeners();
+
+        $historyEntryRepository = $this->em->getRepository(HistoryEntry::class);
+        $territoryRepository = $this->em->getRepository(Territory::class);
+        $territory = $territoryRepository->find(self::TERRITORY_ID);
+        $signalementRepository = $this->em->getRepository(Signalement::class);
+        $importedSignalements = $signalementRepository->findBy(['isImported' => true, 'territory' => $territory]);
+        $io->info('Found '.count($importedSignalements).' imported signalements to remove.');
+
+        foreach ($importedSignalements as $signalement) {
+            $historyEntries = $historyEntryRepository->findBy(['signalement' => $signalement]);
+            foreach ($historyEntries as $historyEntry) {
+                $this->em->remove($historyEntry);
+            }
+            $this->em->remove($signalement);
+        }
+        $this->em->flush();
+
+        $io->success('Removed '.count($importedSignalements).' imported signalements.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Manager/AffectationManager.php
+++ b/src/Manager/AffectationManager.php
@@ -84,7 +84,7 @@ class AffectationManager extends Manager
     /**
      * @throws ExceptionInterface
      */
-    public function createAffectationFrom(Signalement $signalement, Partner $partner, ?User $user): Affectation|bool
+    public function createAffectationFrom(Signalement $signalement, Partner $partner, ?User $user, bool $dispatchEvent = true): Affectation|bool
     {
         $hasAffectation = $signalement
             ->getAffectations()
@@ -107,7 +107,7 @@ class AffectationManager extends Manager
             return false;
         }
 
-        return $this->createAffectation($signalement, $partner, $user);
+        return $this->createAffectation($signalement, $partner, $user, $dispatchEvent);
     }
 
     /**
@@ -117,6 +117,7 @@ class AffectationManager extends Manager
         Signalement $signalement,
         Partner $partner,
         ?User $user = null,
+        bool $dispatchEvent = true,
     ): Affectation {
         $affectation = (new Affectation())
             ->setSignalement($signalement)
@@ -124,7 +125,9 @@ class AffectationManager extends Manager
             ->setAffectedBy($user ?? null)
             ->setTerritory($signalement->getTerritory());
 
-        $this->eventDispatcher->dispatch(new AffectationCreatedEvent($affectation), AffectationCreatedEvent::NAME);
+        if ($dispatchEvent) {
+            $this->eventDispatcher->dispatch(new AffectationCreatedEvent($affectation), AffectationCreatedEvent::NAME);
+        }
 
         $this->persist($affectation);
         $this->interconnectionBus->dispatch($affectation);

--- a/src/Service/Import/Signalement/SignalementImportLoader.php
+++ b/src/Service/Import/Signalement/SignalementImportLoader.php
@@ -124,7 +124,7 @@ class SignalementImportLoader
                         $signalement->setProfileDeclarant(ProfileDeclarant::TIERS_PARTICULIER);
                     }
                 }
-                $this->signalementManager->persist($signalement);
+                $this->signalementManager->save($signalement);
 
                 $signalement = $this->loadTags($signalement, $territory, $dataMapped);
                 foreach (self::SITUATIONS as $situation) {
@@ -224,9 +224,10 @@ class SignalementImportLoader
                 }
 
                 $affectation = $this->affectationManager->createAffectationFrom(
-                    $signalement,
-                    $partner,
-                    $partner->getUsers()->isEmpty() ? null : $partner->getUsers()->first(),
+                    signalement: $signalement,
+                    partner: $partner,
+                    user: $partner->getUsers()->isEmpty() ? null : $partner->getUsers()->first(),
+                    dispatchEvent: false
                 );
                 if ($affectation instanceof Affectation) {
                     $affectation


### PR DESCRIPTION
## Ticket

#5080

## Description
- Ajout d'une commande permettant de supprimer les signalement importé du 79
- Modification de l'import des signalement afin qu'aucun e-mail ne soient envoyé lors de l'import.

## Pré-requis
- Se mettre sur une copie base de prod

## Tests
- [ ] Lancer `make console app="remove-imported-signalement-deux-sevres"`
- [ ] Lancer `make console app="import-signalement 79"`