### PR TITLE
[BO - Club utilisateur] Visibilité des club RT

### DIFF
--- a/src/Service/ClubEventService.php
+++ b/src/Service/ClubEventService.php
@@ -21,6 +21,11 @@ class ClubEventService
             if ($user->isSuperAdmin()) {
                 return $clubEvent;
             }
+            // Les RT ont accès à tous les évènements correspondant à leur rôle
+            if ($user->isTerritoryAdmin() && $this->isRoleMatch($clubEvent, $user)) {
+                return $clubEvent;
+            }
+            // Les autres utilisateurs doivent correspondre aux critères de rôle, type et compétence
             if ($this->isRoleMatch($clubEvent, $user) && $this->isPartnerTypeMatch($clubEvent, $user) && $this->isPartnerCompetenceMatch($clubEvent, $user)) {
                 return $clubEvent;
             }

--- a/templates/back/affectation-without-subscription/index.html.twig
+++ b/templates/back/affectation-without-subscription/index.html.twig
@@ -91,7 +91,7 @@
 
         <div id="territory-pagination" class="fr-grid-row fr-mt-2v fr-grid-row--center">
             {% import '_partials/macros.html.twig' as macros %}
-            {{ macros.customPagination(pages, searchAffectation.page, 'back_bailleur_index', searchAffectation.urlParams) }}
+            {{ macros.customPagination(pages, searchAffectation.page, 'back_affectation_without_subscription_index', searchAffectation.urlParams) }}
         </div>
     </section>
 


### PR DESCRIPTION
## Ticket

#5207 
#5210

## Description
- Modification des règle de visibilité des club pour les RT : Ils peuvent voir tous les club à destination des RT, peu importe les condition de type et compétence des partenaires.
- Correction du lien de la pagination de la page http://localhost:8080/bo/affectation-without-subscription/

## Tests
- [ ] En SA modifier le prochain club RT pour le limiter a un type de partenaire. Se connecter en RT et voir que le club est toujours visible.
