### PR TITLE
[BO - Régle auto-affectation] Augmenter la taille du champ contenenant a liste des code insee

### DIFF
--- a/migrations/Version20260108101547.php
+++ b/migrations/Version20260108101547.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260108101547 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increase length of insee_to_include field in auto_affectation_rule table to 500 characters';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auto_affectation_rule CHANGE insee_to_include insee_to_include VARCHAR(500) NOT NULL COMMENT \'Value possible empty or an array of code insee\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE auto_affectation_rule CHANGE insee_to_include insee_to_include VARCHAR(255) NOT NULL COMMENT \'Value possible empty or an array of code insee\'');
+    }
+}

--- a/src/Entity/AutoAffectationRule.php
+++ b/src/Entity/AutoAffectationRule.php
@@ -53,8 +53,8 @@ class AutoAffectationRule implements EntityHistoryInterface
     #[AppAssert\ValidProfileDeclarant()]
     private ?string $profileDeclarant = null;
 
-    #[ORM\Column(length: 255, options: ['comment' => 'Value possible empty or an array of code insee'])]
-    #[Assert\Length(max: 255)]
+    #[ORM\Column(length: 500, options: ['comment' => 'Value possible empty or an array of code insee'])]
+    #[Assert\Length(max: 500)]
     #[AppAssert\InseeToInclude()]
     private string $inseeToInclude;
 


### PR DESCRIPTION
## Ticket

#5217

## Description
Le champ "Code insee à inclure" du formulaire d'ajout / edition des règle d'auto-affectation, basé sur un champ limité a 255 caractère en base n'était plus suffisant. On passe la limite a 500 caractères. 

## Pré-requis
`make execute-migration name=Version20260108101547 direction=up`

## Tests
- [ ] Vérifier que le champ n'est plus limité a 255 caractère mais à 500
