### PR TITLE
[BO - Démarche accélérée] Eviter la bascule automatique vers PNLHI si il y a eu une réponse du bailleur

### DIFF
--- a/src/Command/Cron/ResetInjonctionNoResponseCommand.php
+++ b/src/Command/Cron/ResetInjonctionNoResponseCommand.php
@@ -11,6 +11,7 @@ use App\Service\InjonctionBailleur\InjonctionBailleurService;
 use App\Service\Signalement\AutoAssigner;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -36,6 +37,7 @@ class ResetInjonctionNoResponseCommand extends AbstractCronCommand
         private readonly InjonctionBailleurService $injonctionBailleurService,
         private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
+        private readonly ClockInterface $clock,
     ) {
         parent::__construct($this->parameterBag);
     }
@@ -47,7 +49,8 @@ class ResetInjonctionNoResponseCommand extends AbstractCronCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $signalements = $this->signalementRepository->findInjonctionBeforePeriodWithoutAnswer($this->periodThreshold);
+        $beforeDate = $this->clock->now()->modify('-'.$this->periodThreshold);
+        $signalements = $this->signalementRepository->findInjonctionBeforeDateWithoutAnswer($beforeDate);
         foreach ($signalements as $signalement) {
             $this->entityManager->beginTransaction();
             try {

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2518,7 +2518,7 @@ class SignalementRepository extends ServiceEntityRepository
      *
      * @throws \Exception
      */
-    public function findInjonctionBeforePeriodWithoutAnswer(string $period): array
+    public function findInjonctionBeforeDateWithoutAnswer(\DateTimeImmutable $beforeDate): array
     {
         $qb = $this->createQueryBuilder('s');
         $qb->where('s.statut = :statut')
@@ -2540,7 +2540,7 @@ class SignalementRepository extends ServiceEntityRepository
             ->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE);
 
         $qb->setParameter('statut', SignalementStatus::INJONCTION_BAILLEUR)
-            ->setParameter('date', (new \DateTimeImmutable())->modify('-'.$period))
+            ->setParameter('date', $beforeDate)
             ->orderBy('s.createdAt', 'DESC');
 
         return $qb->getQuery()->getResult();


### PR DESCRIPTION
## Ticket

#5236   

## Description
Dans la démarche accélérée, éviter la bascule automatique vers PNLHI si il y a eu une réponse du bailleur

## Changements apportés
* Modification requête
* Ajout test

## Tests
- [ ] Avoir un signalement en injonction sans réponse, dont la date de création est avant 3 semaines
- [ ] Avoir un signalement en injonction sans réponse, dont la date de création est dans les derniers jours
- [ ] Avoir un signalement en injonction avec réponse  OUI ou OUI AVEC aide, dont la date de création est avant 3 semaines
- [ ] `make console app="reset-injonction-no-response"`
- [ ] Seul le premier signalement doit basculer en procédure classique
