### PR TITLE
[BO - Formulaire pro] Suppression bouton finir plus tard sur dernier onglet

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -870,7 +870,7 @@ ul + p {
         border: 1px solid var(--border-default-grey);
         border-top: 0;
         padding: 0.5rem;
-        padding-top: 1rem;
+        padding-top: 2rem;
         position: absolute;
         width: 100%;
         z-index: 10;

--- a/templates/back/signalement_create/tabs/tab-validation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-validation.html.twig
@@ -175,9 +175,6 @@
     {% endif %}
 
     <div class="fr-grid-row fr-grid-row--right">
-        <div>
-            <button type="button" id="quit-validation" data-route="{{path('back_signalement_drafts')}}" class="fr-btn fr-icon-arrow-go-forward-line fr-btn--icon-left fr-btn--tertiary-no-outline fr-btn">Finir plus tard</button>
-        </div>
         <div class="fr-ml-2w">
             <button type="submit" class="fr-btn fr-icon-check-line fr-btn--icon-left fr-btn">
                 {% if is_granted('ROLE_ADMIN_TERRITORY') or assignablePartners|length %}


### PR DESCRIPTION
## Ticket

#5282   

## Description
Sur le formulaire pro :
- Suppression bouton finir plus tard sur dernier onglet
- Ajout d'une marge dans les champ de sélection des désordres

## Tests
- [ ] Vérifier la marge en-dessous du bouton Fermer dans les champs de sélection de désordre
- [ ] Vérifier l'absence du bouton "Finir plus tard" sur l'onglet Validation
