### PR TITLE
[FO - Espace bailleur] Ajout d'un choix de réponse pour ceux qui ont démarré des travaux

### DIFF
--- a/assets/scripts/vanilla/controllers/front_dossier_bailleur/front_dossier_bailleur.js
+++ b/assets/scripts/vanilla/controllers/front_dossier_bailleur/front_dossier_bailleur.js
@@ -36,6 +36,10 @@ if (reponseInjonctionBailleurDescription) {
           textNode = document.createTextNode(label.getAttribute('data-label-oui-avec-aide'));
           reponseInjonctionBailleurEngagementTravaux.classList.remove('fr-hidden');
           break;
+        case 'REPONSE_OUI_DEMARCHES_COMMENCEES':
+          textNode = document.createTextNode(label.getAttribute('data-label-oui-demarches-commencees'));
+          reponseInjonctionBailleurEngagementTravaux.classList.remove('fr-hidden');
+          break;
         case 'REPONSE_NON':
           textNode = document.createTextNode(label.getAttribute('data-label-non'));
           reponseInjonctionBailleurEngagementTravaux.classList.add('fr-hidden');

--- a/src/Controller/SuiviBailleurController.php
+++ b/src/Controller/SuiviBailleurController.php
@@ -68,7 +68,7 @@ class SuiviBailleurController extends AbstractController
                         return $this->redirectToRoute('front_dossier_bailleur');
                     }
                 }
-                if (in_array($suiviReponse->getCategory(), [SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI, SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE], true)) {
+                if (in_array($suiviReponse->getCategory(), [SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI, SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE, SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES], true)) {
                     $engagementTravauxPdf = $fileRepository->findOneBy(['signalement' => $signalement, 'documentType' => DocumentType::ENGAGEMENT_TRAVAUX_BAILLEUR]);
                     $stopProcedure = new StopProcedure();
                     $stopProcedure->setSignalement($signalement);

--- a/src/Dto/ReponseInjonctionBailleur.php
+++ b/src/Dto/ReponseInjonctionBailleur.php
@@ -10,6 +10,7 @@ class ReponseInjonctionBailleur
 {
     public const REPONSE_OUI = 'REPONSE_OUI';
     public const REPONSE_OUI_AVEC_AIDE = 'REPONSE_OUI_AVEC_AIDE';
+    public const REPONSE_OUI_DEMARCHES_COMMENCEES = 'REPONSE_OUI_DEMARCHES_COMMENCEES';
     public const REPONSE_NON = 'REPONSE_NON';
 
     #[Assert\NotBlank()]
@@ -23,7 +24,7 @@ class ReponseInjonctionBailleur
     #[Assert\Callback]
     public function validate(ExecutionContextInterface $context, mixed $payload): void
     {
-        if (in_array($this->reponse, [self::REPONSE_OUI_AVEC_AIDE, self::REPONSE_NON])) {
+        if (in_array($this->reponse, [self::REPONSE_OUI_AVEC_AIDE, self::REPONSE_OUI_DEMARCHES_COMMENCEES, self::REPONSE_NON])) {
             if (empty($this->description)) {
                 $context->buildViolation('Veuillez renseigner un commentaire.')
                     ->atPath('description')

--- a/src/Entity/Enum/SuiviCategory.php
+++ b/src/Entity/Enum/SuiviCategory.php
@@ -37,6 +37,7 @@ enum SuiviCategory: string
     // cas liés à l'injonction bailleur
     case INJONCTION_BAILLEUR_REPONSE_OUI = 'INJONCTION_BAILLEUR_REPONSE_OUI';
     case INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE = 'INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE';
+    case INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES = 'INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES';
     case INJONCTION_BAILLEUR_REPONSE_NON = 'INJONCTION_BAILLEUR_REPONSE_NON';
     case INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE = 'INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE';
     case INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_USAGER = 'INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_USAGER';
@@ -56,6 +57,7 @@ enum SuiviCategory: string
         $reponseList = [
             self::INJONCTION_BAILLEUR_REPONSE_OUI->name => 'Oui',
             self::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE->name => 'Oui avec aide',
+            self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES->name => 'Oui, les démarches ont commencé',
             self::INJONCTION_BAILLEUR_REPONSE_NON->name => 'Non',
         ];
 
@@ -97,6 +99,7 @@ enum SuiviCategory: string
             'MESSAGE_PARTNER' => 'Suivi du partenaire',
             'INJONCTION_BAILLEUR_REPONSE_OUI' => 'Réponse du bailleur : Oui',
             'INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE' => 'Réponse du bailleur : Oui avec aide',
+            'INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES' => 'Réponse du bailleur : Oui, les démarches ont commencé',
             'INJONCTION_BAILLEUR_REPONSE_NON' => 'Réponse du bailleur : Non',
             'INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE' => 'Commentaire du bailleur',
             'INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_USAGER' => 'Bascule en procédure administrative par l\'usager',
@@ -113,6 +116,7 @@ enum SuiviCategory: string
         return [
             self::INJONCTION_BAILLEUR_REPONSE_OUI,
             self::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE,
+            self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES,
             self::INJONCTION_BAILLEUR_REPONSE_NON,
             self::INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE,
             self::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_BAILLEUR,
@@ -126,6 +130,7 @@ enum SuiviCategory: string
         return [
             self::INJONCTION_BAILLEUR_REPONSE_OUI,
             self::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE,
+            self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES,
             self::INJONCTION_BAILLEUR_REPONSE_NON,
             self::INJONCTION_BAILLEUR_REPONSE_COMMENTAIRE,
             self::INJONCTION_BAILLEUR_BASCULE_PROCEDURE_PAR_USAGER,
@@ -143,6 +148,7 @@ enum SuiviCategory: string
         return [
             self::INJONCTION_BAILLEUR_REPONSE_OUI,
             self::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE,
+            self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES,
             self::INJONCTION_BAILLEUR_REPONSE_NON,
         ];
     }

--- a/src/Form/ReponseInjonctionBailleurType.php
+++ b/src/Form/ReponseInjonctionBailleurType.php
@@ -20,6 +20,7 @@ class ReponseInjonctionBailleurType extends AbstractType
                 'choices' => [
                     'Oui' => ReponseInjonctionBailleur::REPONSE_OUI,
                     'Oui avec aide' => ReponseInjonctionBailleur::REPONSE_OUI_AVEC_AIDE,
+                    'Oui, les démarches ont commencé' => ReponseInjonctionBailleur::REPONSE_OUI_DEMARCHES_COMMENCEES,
                     'Non' => ReponseInjonctionBailleur::REPONSE_NON,
                 ],
                 'required' => false,
@@ -36,6 +37,10 @@ class ReponseInjonctionBailleurType extends AbstractType
                             'data-dsfr-label' => 'Oui, je m\'engage à réaliser les travaux nécessaires et j\'ai besoin d\'un accompagnement',
                             'data-dsfr-hint' => 'Les services de l\'ADIL et de France Rénov pourront vous accompagner',
                         ],
+                        ReponseInjonctionBailleur::REPONSE_OUI_DEMARCHES_COMMENCEES => [
+                            'data-dsfr-label' => 'Oui, je m\'engage à réaliser les travaux nécessaires et j\'ai déjà commencé les démarches',
+                            'data-dsfr-hint' => 'Les travaux ont déjà débuté ou les devis sont en cours',
+                        ],
                         ReponseInjonctionBailleur::REPONSE_NON => [
                             'data-dsfr-label' => 'Non, je conteste les désordres déclarés et ne m\'engage pas à réaliser de travaux',
                             'data-dsfr-hint' => 'Le dossier sera transmis aux autorités compétentes.',
@@ -49,6 +54,7 @@ class ReponseInjonctionBailleurType extends AbstractType
                 'label_attr' => [
                     'data-label-oui' => 'Souhaitez-vous apporter des précisions sur la situation ? (facultatif)',
                     'data-label-oui-avec-aide' => 'Précisez votre situation et l\'aide attendue',
+                    'data-label-oui-demarches-commencees' => 'Précisez les démarches que vous avez engagées',
                     'data-label-non' => 'Précisez la raison de votre refus',
                 ],
                 'help' => 'Dix (10) caractères minimum',

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2531,13 +2531,14 @@ class SignalementRepository extends ServiceEntityRepository
                         ->select('1')
                         ->join('s1.suivis', 'su1')
                         ->where('s1 = s')
-                        ->andWhere('su1.category = :ouiCategory OR su1.category = :aideCategory')
+                        ->andWhere('su1.category = :ouiCategory OR su1.category = :aideCategory OR su1.category = :demarchesCategory')
                         ->getDQL()
                 )
             )
         );
         $qb->setParameter('ouiCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI)
-            ->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE);
+            ->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE)
+            ->setParameter('demarchesCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES);
 
         $qb->setParameter('statut', SignalementStatus::INJONCTION_BAILLEUR)
             ->setParameter('date', $beforeDate)
@@ -2563,7 +2564,7 @@ class SignalementRepository extends ServiceEntityRepository
                     ->select('1')
                     ->join('s1.suivis', 'su1')
                     ->where('s1 = s')
-                    ->andWhere('su1.category = :ouiCategory OR su1.category = :aideCategory')
+                    ->andWhere('su1.category = :ouiCategory OR su1.category = :aideCategory OR su1.category = :demarchesCategory')
                     ->andWhere(
                         $qb->expr()->lt('su1.createdAt', ':date')
                     )
@@ -2571,7 +2572,8 @@ class SignalementRepository extends ServiceEntityRepository
             )
         );
         $qb->setParameter('ouiCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI)
-            ->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE);
+            ->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE)
+            ->setParameter('demarchesCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES);
 
         // Soit pas de rappel envoyé, soit un rappel envoyé avant la date
         $qb->andWhere(

--- a/src/Service/InjonctionBailleur/InjonctionBailleurService.php
+++ b/src/Service/InjonctionBailleur/InjonctionBailleurService.php
@@ -67,6 +67,13 @@ class InjonctionBailleurService
                 $this->saveEngagementTravauxBailleurPdf($signalement);
                 $this->assignHelpingPartners($signalement);
                 break;
+            case ReponseInjonctionBailleur::REPONSE_OUI_DEMARCHES_COMMENCEES:
+                $contenu = 'Le bailleur s\'engage à résoudre les désordres signalés, et indique que les démarches ont déjà commencé.';
+                $category = SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES;
+                $this->suiviManager->createSuivi(signalement: $signalement, description: $contenu, type: Suivi::TYPE_AUTO, category: $category, isPublic: true);
+                $this->createInjonctionBailleurCommentaireSuivi($signalement, $description);
+                $this->saveEngagementTravauxBailleurPdf($signalement);
+                break;
             case ReponseInjonctionBailleur::REPONSE_NON:
                 $contenu = 'Le bailleur refuse de résoudre les désordres signalés, le signalement va être pris en charge par les partenaires compétents.';
                 $category = SuiviCategory::INJONCTION_BAILLEUR_REPONSE_NON;

--- a/templates/back/signalement-injonction/index.html.twig
+++ b/templates/back/signalement-injonction/index.html.twig
@@ -86,7 +86,8 @@
                     {% set labelReponseBailleur = signalement.suiviReponseBailleur.category.labelReponseBailleur %}
                     {% if signalement.suiviReponseBailleur.category is same as enum('App\\Entity\\Enum\\SuiviCategory').INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE %}
                         {% set classeBadgeReponseBailleur = 'fr-badge--info' %}
-                    {% elseif signalement.suiviReponseBailleur.category is same as enum('App\\Entity\\Enum\\SuiviCategory').INJONCTION_BAILLEUR_REPONSE_OUI %}
+                    {% elseif signalement.suiviReponseBailleur.category is same as enum('App\\Entity\\Enum\\SuiviCategory').INJONCTION_BAILLEUR_REPONSE_OUI
+                        or signalement.suiviReponseBailleur.category is same as enum('App\\Entity\\Enum\\SuiviCategory').INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES %}
                         {% set classeBadgeReponseBailleur = 'fr-badge--success' %}
                     {% endif %}
                 {% endif %}
@@ -102,7 +103,7 @@
                     <td><span class="fr-badge {{ classeBadgeReponseBailleur }} fr-badge--no-icon fr-ws-nowrap ">{{ labelReponseBailleur }}</span></td>
                     <td>{{ signalement.getCountAffectationsByStatus(enum('App\\Entity\\Enum\\AffectationStatus').ACCEPTED) }} / {{ signalement.affectations|length }}</td>
                     <td>
-                        <a href="{{ path('back_signalement_view', {uuid: signalement.uuid}) }}" class="fr-btn fr-fi-arrow-right-line fr-btn--sm" title="Voir le signalement {{ signalement.reference }}"></a>
+                        <a href="{{ path('back_signalement_view', {uuid: signalement.uuid}) }}" class="fr-btn fr-fi-arrow-right-line fr-btn--sm fr-mb-1v" title="Voir le signalement {{ signalement.reference }}"></a>
                         {% if is_granted('ROLE_ADMIN') %}
                         <a href="{{ path('back_injonction_signalement_courrier_bailleur', { uuid: signalement.uuid }) }}" class="fr-btn fr-icon-mail-line fr-btn--sm" target="_blank" rel="noopener" title="Afficher le courrier (Ouvre une nouvelle fenêtre)">
                             Courrier bailleur


### PR DESCRIPTION
## Ticket

#5269
#5309

## Description
Dans l'espace bailleur, ajout d'un choix de réponse pour ceux qui ont démarré des travaux

## Pré-requis
`make npm-watch`

## Tests
- [ ] Vérifier la présence de la nouvelle réponse
- [ ] Vérifier que le formulaire réagit bien dans l'affichage, l'obligation de commentaire
- [ ] Vérifier les suivis créés
- [ ] Vérifier dans la liste des signalements en injonction
- [ ] Dans la liste des signalements en injonction, vérifier la marge entre les deux boutons
