### PR TITLE
[BO- Dashboard] Dossiers sans activité partenaire, filtrer sur le status de l'affectation pour un agent

### DIFF
--- a/src/Controller/Back/AffectationController.php
+++ b/src/Controller/Back/AffectationController.php
@@ -189,12 +189,15 @@ class AffectationController extends AbstractController
     }
 
     #[Route('/affectation/{affectation}/accept', name: 'back_signalement_affectation_accept', methods: 'POST')]
-    #[IsGranted(AffectationVoter::AFFECTATION_ACCEPT_OR_REFUSE, subject: 'affectation')]
     public function affectationResponseSignalement(
         Affectation $affectation,
         Request $request,
         UserSignalementSubscriptionManager $userSignalementSubscriptionManager,
     ): Response {
+        if (!$this->isGranted(AffectationVoter::AFFECTATION_ACCEPT_OR_REFUSE, subject: $affectation)
+            && !$this->isGranted(AffectationVoter::AFFECTATION_CANCEL_REFUSED, subject: $affectation)) {
+            throw $this->createAccessDeniedException();
+        }
         $signalement = $affectation->getSignalement();
         /** @var User $user */
         $user = $this->getUser();

--- a/src/Security/Voter/AffectationVoter.php
+++ b/src/Security/Voter/AffectationVoter.php
@@ -69,9 +69,7 @@ class AffectationVoter extends Voter
 
     private function canAcceptOrRefuse(Affectation $affectation, User $user): bool
     {
-        return $this->canAnswer($affectation, $user)
-        && (AffectationStatus::WAIT === $affectation->getStatut() || AffectationStatus::REFUSED === $affectation->getStatut())
-        ;
+        return $this->canAnswer($affectation, $user) && AffectationStatus::WAIT === $affectation->getStatut();
     }
 
     private function canCancelRefused(Affectation $affectation, User $user): bool


### PR DESCRIPTION
## Ticket

#5312   

## Description
Sur le tableau de bord, en tant qu'agent, le panel "Dossiers sans activité partenaire" ne doit afficher que des signalements dont l'affectation du partenaire est au statut NOUVEAU ou EN_COURS
+ Correction d'un voter pour qu'un agent puisse annuler le refus de l'affectation (l'option était disponible mais on avait un Access Denied)

## Changements apportés
* Modification du repository
* Modification du voter

## Pré-requis

## Tests
- [ ] En tant qu'agent, sur un signalement dont le dernier suivi est vieux, jouer avec les différents statuts de l'affectation (en prenant soin de supprimer en base les suivis générés à chaque changement de statut), et vérifier le panel sur le dashboard
