### PR TITLE
[BUG - QA - Régréssion] Crash envoie lien de suivi à la détection de doublon pour les profils locataire/bailleur_occupant

### DIFF
--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -282,7 +282,7 @@ class SignalementController extends AbstractController
                 $profil = $data['profil'] ?? null;
                 $manageFlashMessages = true;
             } else {
-                $profil = $request->request->get('profil');
+                $profil = $request->query->get('profil');
             }
             $success = $notificationMailerRegistry->send(
                 new NotificationMail(


### PR DESCRIPTION
## Ticket

#5336

## Description
Régression depuis la dernière MEP (message flash ajax)

https://sentry.incubateur.net/organizations/betagouv/issues/239716/events/de4f82db64de404e94d556f441e91afe/events/
`App\Service\Mailer\NotificationMail::__construct(): Argument #2 ($to) must be of type array|string, null given`

Suite à une [modification ](https://github.com/MTES-MCT/histologe/pull/4931/changes#diff-2e8573eb7a3492bd92fd016272a889b6b0e4d14b9d3672ed633e804f9630285a) dans la PR #4931 un paramètre GET n'était plus pris en compte, par conséquent on tentait toujours d'envoyer le lien de suivi suite à la détection de doublon au `mail_declarant`, qui était `null` dans le cas des `locataire` ou `bailleur_occupant`

## Changements apportés
* Correction du `$request->request->get` et en `$request->query->get`

## Tests
- [ ] Déclarer un signalement avec détection de doublon pour un type locataire ou bailleur_occupant et vérifie que l'envoi du lien de suivi fonctionne correctement.
