### PR TITLE
[Matomo] Correction de l'envoi d'événements personnalisés

### DIFF
--- a/assets/scripts/vue/components/signalement-form/matomo.ts
+++ b/assets/scripts/vue/components/signalement-form/matomo.ts
@@ -1,6 +1,6 @@
 export const matomo = {
   pushEvent (eventAction: string, eventName: string) {
-    const _paq = Array.isArray(Object(window)._paq) ? Object(window)._paq : []
+    const _paq = Array.isArray(Object(window)._paq) ? Object(window)._paq : (Object(window)._paq = [])
     const eventCategory = 'Signaler un problème de logement'
     _paq.push(['trackEvent', eventCategory, eventAction, eventName])
   }


### PR DESCRIPTION
## Ticket

#5342   

## Description
En novembre 2024, on avait changé la façon d'aller chercher Matomo. Et du coup on avait arrêté d'initialiser le tableau d'événements.
En attendant d'ajouter les événements de la démarche accélérée, cette PR permet de corriger le souci et vérifier que ça vient bien de là.
Problème des tests : les mises à jour de Matomo ne sont pas en temps réel, on ne voit les résultats que le lendemain.

## Pré-requis
`make npm-watch`

## Tests
- [ ] Sur le formulaire de signalement, vérifier qu'il n'y a pas d'erreur js
