### PR TITLE
[BO - Fiche signalement] Ajouter nom du partenaire qui a saisi le signalement pro

### DIFF
--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -7,8 +7,8 @@
             {% set noticeDesc = 'Ce signalement a été créé via API par ' ~ signalement.createdBy.email ~ ' pour le partenaire ' ~ signalement.createdByPartner.nom ~ '.' %}
         {% else %}
             {% set noticeTitle = 'Signalement BO' %}
-            {% set partnerName = signalement.createdBy.getPartnerInTerritory(signalement.territory) ? signalement.createdBy.getPartnerInTerritory(signalement.territory).nom : 'N/A' %}
-            {% set noticeDesc = 'Ce signalement a été créé depuis le formulaire pro par ' ~ signalement.createdBy.prenom ~ ' ' ~ signalement.createdBy.nom ~ ', du partenaire ' ~ partnerName ~ '.' %}
+            {% set partnerProvenance = signalement.createdBy.getPartnerInTerritory(signalement.territory) ? ', du partenaire ' ~ signalement.createdBy.getPartnerInTerritory(signalement.territory).nom : '' %}
+            {% set noticeDesc = 'Ce signalement a été créé par ' ~ signalement.createdBy.prenom ~ ' ' ~ signalement.createdBy.nom ~ partnerProvenance ~ ' depuis le formulaire pro.' %}
         {% endif %}
             <div class="fr-notice fr-notice--info">
                 <div class="fr-container">

--- a/templates/back/signalement/view/header/_infos-creation.html.twig
+++ b/templates/back/signalement/view/header/_infos-creation.html.twig
@@ -2,7 +2,7 @@
 <div class="fr-mb-4v">
     Dossier déposé le : {{ signalement.createdAt|date('d/m/Y') }}
     {% if signalement.createdBy and 'ROLE_API_USER' in signalement.createdBy.roles %}
-        Via l'API
+        via API par {{ signalement.createdBy.email }} pour le partenaire {{ signalement.createdByPartner.nom }}.
     {% elseif signalement.createdBy is not null %}
         par {{ signalement.createdBy.prenom }} {{ signalement.createdBy.nom }}{% if signalement.createdBy.getPartnerInTerritory(signalement.territory) %}, du partenaire {{ signalement.createdBy.getPartnerInTerritory(signalement.territory).nom }}{% endif %} depuis le formulaire pro.    
     {% elseif signalement.isImported is same as true %}


### PR DESCRIPTION
## Ticket

#5357    

## Description
Retour territoires : 
-> Il faudrait ajouter le nom de l'agent / du partenaire à l'origine du signalement pro
Ca donnerait `Dossier déposé le {{date}} par {{prenom nom}}, du partenaire {{partenaire}} depuis le formulaire pro.`

<img alt="Image" src="https://github.com/user-attachments/assets/160fcb1d-e25b-42ae-826e-61f64b5d094d" />

## Changements apportés
* Modification du template twig

## Pré-requis

## Tests
- [ ] Vérifier quelques fiches signalement
