### PR TITLE
[BO - Signalement] Tri des étiquettes par label

### DIFF
--- a/templates/back/signalement/view/header/_tags.html.twig
+++ b/templates/back/signalement/view/header/_tags.html.twig
@@ -9,7 +9,7 @@
     {% endif %}
     <div>
         <div class="fr-my-3v">
-            {% for tag in signalement.tags %}
+            {% for tag in signalement.tags|sort((a, b) => a.label <=> b.label) %}
                 <span class="fr-badge fr-badge--info fr-badge--no-icon fr-m-1v">{{ tag.label }}</span>
             {% else %}
                 <em class="fr-text-default--warning fr-fi-close-line fr-icon--xs">


### PR DESCRIPTION
## Ticket

#4981    

## Description
Afficher sur les fiches de signalements, les étiquettes par ordre alphabétique  (ordre par défaut actuellement = id)

<img width="971" height="432" alt="Image" src="https://github.com/user-attachments/assets/c1c74ae4-dc66-41f9-8fcf-9fca3c81bc77" />

## Changements apportés
* Changement twig

## Pré-requis

## Tests
- [ ] Tester l'affichage des étiquettes sur différentes fiches
