### PR TITLE
[BO - Injonction] Faire évoluer le filtre "injonction avec aide"

### DIFF
--- a/src/Form/SearchSignalementInjonctionType.php
+++ b/src/Form/SearchSignalementInjonctionType.php
@@ -2,6 +2,7 @@
 
 namespace App\Form;
 
+use App\Entity\Enum\SuiviCategory;
 use App\Form\Type\TerritoryChoiceType;
 use App\Service\ListFilters\SearchSignalementInjonction;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -32,14 +33,16 @@ class SearchSignalementInjonctionType extends AbstractType
             $builder->add('territoire', TerritoryChoiceType::class);
         }
 
-        $builder->add('injonctionAvecAide', ChoiceType::class, [
+        $builder->add('reponseBailleur', ChoiceType::class, [
             'choices' => [
-                'Oui' => 'oui',
-                'Non' => 'non',
+                SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI->labelReponseBailleur() => SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI->value,
+                SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE->labelReponseBailleur() => SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE->value,
+                SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES->labelReponseBailleur() => SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES->value,
+                'Aucune réponse' => 'aucune',
             ],
             'required' => false,
             'placeholder' => 'Tous',
-            'label' => 'Injonction avec aide',
+            'label' => 'Réponse bailleur',
         ]);
 
         $builder->add('orderType', ChoiceType::class, [

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2477,8 +2477,26 @@ class SignalementRepository extends ServiceEntityRepository
                 ->setParameter('partners', $userPartners->toArray());
         }
 
-        if (!empty($searchSignalementInjonction->getInjonctionAvecAide())) {
-            if ('oui' === $searchSignalementInjonction->getInjonctionAvecAide()) {
+        if (!empty($searchSignalementInjonction->getReponseBailleur())) {
+            if ('aucune' === $searchSignalementInjonction->getReponseBailleur()) {
+                $queryBuilder->andWhere(
+                    $queryBuilder->expr()->not(
+                        $queryBuilder->expr()->exists(
+                            $this->createQueryBuilder('s3')
+                                ->select('1')
+                                ->join('s3.suivis', 'su3')
+                                ->where('s3 = s')
+                                ->andWhere('su3.category IN (:aideCategories)')
+                                ->getDQL()
+                        )
+                    )
+                );
+
+                $queryBuilder->setParameter(
+                    'aideCategories',
+                    SuiviCategory::injonctionBailleurReponseCategories()
+                );
+            } else {
                 $queryBuilder->andWhere(
                     $queryBuilder->expr()->exists(
                         $this->createQueryBuilder('s2')
@@ -2489,22 +2507,8 @@ class SignalementRepository extends ServiceEntityRepository
                             ->getDQL()
                     )
                 );
-            } else {
-                $queryBuilder->andWhere(
-                    $queryBuilder->expr()->not(
-                        $queryBuilder->expr()->exists(
-                            $this->createQueryBuilder('s3')
-                                ->select('1')
-                                ->join('s3.suivis', 'su3')
-                                ->where('s3 = s')
-                                ->andWhere('su3.category = :aideCategory')
-                                ->getDQL()
-                        )
-                    )
-                );
+                $queryBuilder->setParameter('aideCategory', SuiviCategory::tryFrom($searchSignalementInjonction->getReponseBailleur()));
             }
-
-            $queryBuilder->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE);
         }
 
         if (!empty($searchSignalementInjonction->getOrderType())) {

--- a/src/Service/ListFilters/SearchSignalementInjonction.php
+++ b/src/Service/ListFilters/SearchSignalementInjonction.php
@@ -15,7 +15,7 @@ class SearchSignalementInjonction
     private User $user;
     private ?Territory $territoire = null;
     private ?string $orderType = null;
-    private ?string $injonctionAvecAide = null;
+    private ?string $reponseBailleur = null;
 
     public function __construct(User $user)
     {
@@ -40,14 +40,14 @@ class SearchSignalementInjonction
         $this->territoire = $territoire;
     }
 
-    public function getInjonctionAvecAide(): ?string
+    public function getReponseBailleur(): ?string
     {
-        return $this->injonctionAvecAide;
+        return $this->reponseBailleur;
     }
 
-    public function setInjonctionAvecAide(?string $injonctionAvecAide): void
+    public function setReponseBailleur(?string $reponseBailleur): void
     {
-        $this->injonctionAvecAide = $injonctionAvecAide;
+        $this->reponseBailleur = $reponseBailleur;
     }
 
     public function getOrderType(): ?string

--- a/templates/back/signalement-injonction/index.html.twig
+++ b/templates/back/signalement-injonction/index.html.twig
@@ -45,7 +45,7 @@
                 </div>
             {% endif %}
             <div class="fr-col-12 fr-col-lg-4">
-                {{ form_row(form.injonctionAvecAide) }}
+                {{ form_row(form.reponseBailleur) }}
             </div>
             <div class="fr-col-12 fr-col-lg-4">
                 <a href="{{ path('back_injonction_signalement_index') }}" class="fr-link fr-link--icon-left fr-icon-close-circle-line">Réinitialiser les résultats</a>


### PR DESCRIPTION
## Ticket

#5360   

## Description
Dans le BO, sur la liste des signalements en injonction
Pour pouvoir mieux filtrer les dossiers, il faudrait changer le filtre `injonction avec aide` en `Réponse bailleur` avec les options : 
- Oui
- Oui avec aide
- Oui, les démarches ont commencé
- Aucune réponse

## Changements apportés
* Modification du formType et du repo

## Pré-requis

## Tests
- [ ] Tester la page des signalements en injonction (plus simple sur une base de prod)
