### PR TITLE
[BO - Modif mail contact] Absence de message erreur

### DIFF
--- a/src/Form/PartnerType.php
+++ b/src/Form/PartnerType.php
@@ -225,7 +225,10 @@ class PartnerType extends AbstractType
             $user = $this->userRepository->findOneBy(['email' => $partner->getEmail()]);
 
             if (!empty($user) && !$user->isUsager()) {
-                $context->addViolation('Un utilisateur existe déjà avec cette adresse e-mail.');
+                $context
+                    ->buildViolation('Un utilisateur existe déjà avec cette adresse e-mail.')
+                    ->atPath('email')
+                    ->addViolation();
             }
         }
     }


### PR DESCRIPTION
## Ticket

#5384   

## Description
Ajout d’un feedback lorsque l’email de contact partenaire est déjà utilisé par un utilisateur

## Changements apportés
* Form - Cibler le champ email sur la contrainte de vérification d'email unique

## Pré-requis

## Tests
- [ ] Ajouter un partenaire avec un mail utilisateur existant, l'erreur doit apparaître
- [ ] Editer un partenaire avec un mail utilisateur existant, l'erreur doit apparaître
