### PR TITLE
[BO - Formulaire pro] Revue des notifications tiers déclarant pro

### DIFF
--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -611,8 +611,8 @@ function initBoFormSignalementAdresse() {
   initRefreshFromRadio(
     'adresse',
     'signalement_draft_address_profileDeclarant',
-    ['#signalement_draft_coordonnees_isProTiersDeclarant_0'],
-    'TIERS_PRO',
+    ['#signalement_draft_coordonnees_isTiersDeclarant_0', '#signalement_draft_coordonnees_isTiersDeclarant_1'],
+      ['TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS', 'BAILLEUR'],
     [],
     'coordonnees'
   );
@@ -868,10 +868,10 @@ function initBoFormSignalementCoordonnees() {
       '#signalement_draft_coordonnees_prenomProprio_help',
     ]
   );
-  const checkIsProTiersDeclarant = document.querySelector(
-    '#signalement_draft_coordonnees_isProTiersDeclarant_0'
+  const checkIsTiersDeclarant = document.querySelector(
+    '#signalement_draft_coordonnees_isTiersDeclarant_0'
   );
-  checkIsProTiersDeclarant.addEventListener('change', (event) => {
+  checkIsTiersDeclarant.addEventListener('change', (event) => {
     const proTiersStructure = document.querySelector(
       '#signalement_draft_coordonnees_structureDeclarant'
     );
@@ -880,13 +880,13 @@ function initBoFormSignalementCoordonnees() {
     const proTiersMail = document.querySelector('#signalement_draft_coordonnees_mailDeclarant');
     if (event.target.checked) {
       proTiersStructure.value =
-        checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userStructure;
+        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userStructure;
       proTiersNom.value =
-        checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userNom;
+        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userNom;
       proTiersPrenom.value =
-        checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userPrenom;
+        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userPrenom;
       proTiersMail.value =
-        checkIsProTiersDeclarant.parentElement.parentElement.parentElement.dataset.userMail;
+        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userMail;
     } else {
       proTiersStructure.value = '';
       proTiersNom.value = '';

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -611,7 +611,7 @@ function initBoFormSignalementAdresse() {
   initRefreshFromRadio(
     'adresse',
     'signalement_draft_address_profileDeclarant',
-    ['#signalement_draft_coordonnees_isTiersDeclarant_0', '#signalement_draft_coordonnees_isTiersDeclarant_1'],
+    ['#signalement_draft_coordonnees_isTiersDeclarant_0'],
       ['TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS', 'BAILLEUR'],
     [],
     'coordonnees'

--- a/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
+++ b/assets/scripts/vanilla/controllers/back_signalement_form/back_signalement_form.js
@@ -611,7 +611,7 @@ function initBoFormSignalementAdresse() {
   initRefreshFromRadio(
     'adresse',
     'signalement_draft_address_profileDeclarant',
-    ['#signalement_draft_coordonnees_isTiersDeclarant_0'],
+    ['#signalement_draft_coordonnees_copyInfoTiersDeclarant_0'],
       ['TIERS_PARTICULIER', 'TIERS_PRO', 'SERVICE_SECOURS', 'BAILLEUR'],
     [],
     'coordonnees'
@@ -868,10 +868,10 @@ function initBoFormSignalementCoordonnees() {
       '#signalement_draft_coordonnees_prenomProprio_help',
     ]
   );
-  const checkIsTiersDeclarant = document.querySelector(
-    '#signalement_draft_coordonnees_isTiersDeclarant_0'
+  const checkcopyInfoTiersDeclarant = document.querySelector(
+    '#signalement_draft_coordonnees_copyInfoTiersDeclarant_0'
   );
-  checkIsTiersDeclarant.addEventListener('change', (event) => {
+  checkcopyInfoTiersDeclarant.addEventListener('change', (event) => {
     const proTiersStructure = document.querySelector(
       '#signalement_draft_coordonnees_structureDeclarant'
     );
@@ -880,13 +880,13 @@ function initBoFormSignalementCoordonnees() {
     const proTiersMail = document.querySelector('#signalement_draft_coordonnees_mailDeclarant');
     if (event.target.checked) {
       proTiersStructure.value =
-        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userStructure;
+        checkcopyInfoTiersDeclarant.parentElement.parentElement.parentElement.dataset.userStructure;
       proTiersNom.value =
-        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userNom;
+        checkcopyInfoTiersDeclarant.parentElement.parentElement.parentElement.dataset.userNom;
       proTiersPrenom.value =
-        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userPrenom;
+        checkcopyInfoTiersDeclarant.parentElement.parentElement.parentElement.dataset.userPrenom;
       proTiersMail.value =
-        checkIsTiersDeclarant.parentElement.parentElement.parentElement.dataset.userMail;
+        checkcopyInfoTiersDeclarant.parentElement.parentElement.parentElement.dataset.userMail;
     } else {
       proTiersStructure.value = '';
       proTiersNom.value = '';

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -574,20 +574,12 @@ class SignalementCreateController extends AbstractController
     {
         $errorMsgs = [];
         if ($signalement->isTiersDeclarant()) {
-            if ('' === trim($signalement->getStructureDeclarant())) {
-                $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner une structure pour le tiers';
-            }
-
             if ('' === trim($signalement->getMailDeclarant())) {
                 $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner un e-mail pour le tiers.';
             }
 
             if ('' === trim($signalement->getNomDeclarant())) {
                 $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner un nom pour le tiers.';
-            }
-
-            if ('' === trim($signalement->getPrenomDeclarant())) {
-                $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner un prénom pour le tiers.';
             }
         }
         if (!$signalement->getAdresseOccupant()) {

--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -573,6 +573,23 @@ class SignalementCreateController extends AbstractController
     private function getErrorMsgsOnValidation(Signalement $signalement): array
     {
         $errorMsgs = [];
+        if ($signalement->isTiersDeclarant()) {
+            if ('' === trim($signalement->getStructureDeclarant())) {
+                $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner une structure pour le tiers';
+            }
+
+            if ('' === trim($signalement->getMailDeclarant())) {
+                $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner un e-mail pour le tiers.';
+            }
+
+            if ('' === trim($signalement->getNomDeclarant())) {
+                $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner un nom pour le tiers.';
+            }
+
+            if ('' === trim($signalement->getPrenomDeclarant())) {
+                $errorMsgs[] = 'En tant que tiers déclarant, vous devez renseigner un prénom pour le tiers.';
+            }
+        }
         if (!$signalement->getAdresseOccupant()) {
             $errorMsgs[] = 'Vous devez renseigner l\'adresse du logement pour pouvoir soumettre le signalement.';
         }
@@ -594,15 +611,6 @@ class SignalementCreateController extends AbstractController
     private function setSignalementDefaultValuesOnValidation(Signalement $signalement, User $user): void
     {
         if ($signalement->isTiersDeclarant()) {
-            if (!$signalement->getMailDeclarant()) {
-                $signalement->setMailDeclarant($user->getEmail());
-            }
-            if (!$signalement->getNomDeclarant()) {
-                $signalement->setNomDeclarant($user->getNom());
-            }
-            if (!$signalement->getPrenomDeclarant()) {
-                $signalement->setPrenomDeclarant($user->getPrenom());
-            }
             $signalement->setIsNotOccupant(true);
         } else {
             if (!$signalement->getMailOccupant()) {

--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -162,7 +162,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 ],
                 'empty_data' => '',
             ])
-            ->add('isTiersDeclarant', ChoiceType::class, [
+            ->add('copyInfoTiersDeclarant', ChoiceType::class, [
                 'label' => 'Utiliser mes coordonnées',
                 'choices' => [
                     'Copier mes coordonnées' => '1',

--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -15,11 +15,10 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class SignalementDraftCoordonneesType extends AbstractType
 {
@@ -164,17 +163,13 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'empty_data' => '',
             ])
             ->add('isTiersDeclarant', ChoiceType::class, [
-                'label' => $signalement->isTiersDeclarant()
-                    ? 'Utiliser mes coordonnées <span class="text-required">*</span>'
-                    : 'Utiliser mes coordonnées',
+                'label' => 'Utiliser mes coordonnées',
                 'choices' => [
-                    'Oui' => true,
-                    'Non' => false,
+                    'Copier mes coordonnées' => '1',
                 ],
-                'label_html' => true,
                 'help' => 'Cochez cette case pour pré-remplir les coordonnées du déclarant avec vos informations. Vous recevrez alors des mises à jour par e-mail au même titre que l\'occupant du logement.',
                 'expanded' => true,
-                'multiple' => false,
+                'multiple' => true,
                 'required' => false,
                 'placeholder' => false,
                 'mapped' => false,
@@ -186,10 +181,7 @@ class SignalementDraftCoordonneesType extends AbstractType
                 ],
             ])
             ->add('structureDeclarant', TextType::class, [
-                'label' => $signalement->isTiersDeclarant()
-                    ? 'Structure <span class="text-required">*</span>'
-                    : 'Structure',
-                'label_html' => true,
+                'label' => 'Structure',
                 'required' => false,
             ])
             ->add('nomDeclarant', TextType::class, [
@@ -198,12 +190,12 @@ class SignalementDraftCoordonneesType extends AbstractType
                     : 'Nom de famille',
                 'label_html' => true,
                 'required' => false,
+                'constraints' => [
+                    new NotBlank(message: 'Veuillez renseigner un nom.', groups: ['bo_step_coordonnees_tiers']),
+                ],
             ])
             ->add('prenomDeclarant', TextType::class, [
-                'label' => $signalement->isTiersDeclarant()
-                    ? 'Prénom <span class="text-required">*</span>'
-                    : 'Prénom',
-                'label_html' => true,
+                'label' => 'Prénom',
                 'required' => false,
             ])
             ->add('mailDeclarant', TextType::class, [
@@ -213,6 +205,9 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'label_html' => true,
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
+                'constraints' => [
+                    new NotBlank(message: 'Veuillez renseigner une adresse e-mail.', groups: ['bo_step_coordonnees_tiers']),
+                ],
             ])
             ->add('telDeclarant', PhoneType::class, [
                 'required' => false,
@@ -309,43 +304,21 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
         ;
-
-        $builder->addEventListener(FormEvents::POST_SUBMIT, static function (FormEvent $event) use ($signalement): void {
-            if (!$signalement->isTiersDeclarant()) {
-                return;
-            }
-
-            $form = $event->getForm();
-            $isTiersDeclarant = $form->get('isTiersDeclarant')->getData();
-
-            $errorMessageTiersDeclarant = 'Veuillez sélectionner une option.';
-            $errorMessageNom = $isTiersDeclarant ? 'Veuillez renseigner votre nom.' : 'Veuillez renseigner un nom.';
-            $errorMessagePrenom = $isTiersDeclarant ? 'Veuillez renseigner votre prénom.' : 'Veuillez renseigner un prénom.';
-            $errorMessageMail = $isTiersDeclarant ? 'Veuillez renseigner votre adresse e-mail.' : 'Veuillez renseigner une adresse e-mail.';
-            $errorMessageStructure = $isTiersDeclarant ? 'Veuillez renseigner votre structure.' : 'Veuillez renseigner une structure.';
-
-            if (null === $form->get('isTiersDeclarant')->getData()) {
-                $form->get('isTiersDeclarant')->addError(new FormError($errorMessageTiersDeclarant));
-            }
-            if ('' === trim((string) $form->get('nomDeclarant')->getData())) {
-                $form->get('nomDeclarant')->addError(new FormError($errorMessageNom));
-            }
-            if ('' === trim((string) $form->get('prenomDeclarant')->getData())) {
-                $form->get('prenomDeclarant')->addError(new FormError($errorMessagePrenom));
-            }
-            if ('' === trim((string) $form->get('mailDeclarant')->getData())) {
-                $form->get('mailDeclarant')->addError(new FormError($errorMessageMail));
-            }
-            if ('' === trim((string) $form->get('structureDeclarant')->getData())) {
-                $form->get('structureDeclarant')->addError(new FormError($errorMessageStructure));
-            }
-        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'validation_groups' => ['bo_step_coordonnees'],
+            'validation_groups' => static function (FormInterface $form): array {
+                $groups = ['bo_step_coordonnees'];
+
+                $data = $form->getData();
+                if ($data instanceof Signalement && $data->isTiersDeclarant()) {
+                    $groups[] = 'bo_step_coordonnees_tiers';
+                }
+
+                return $groups;
+            },
         ]);
     }
 }

--- a/src/Form/SignalementDraftCoordonneesType.php
+++ b/src/Form/SignalementDraftCoordonneesType.php
@@ -2,7 +2,6 @@
 
 namespace App\Form;
 
-use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\ProprioType;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -16,6 +15,9 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -161,14 +163,18 @@ class SignalementDraftCoordonneesType extends AbstractType
                 ],
                 'empty_data' => '',
             ])
-            ->add('isProTiersDeclarant', ChoiceType::class, [
-                'label' => 'Tiers professionnel',
+            ->add('isTiersDeclarant', ChoiceType::class, [
+                'label' => $signalement->isTiersDeclarant()
+                    ? 'Utiliser mes coordonnées <span class="text-required">*</span>'
+                    : 'Utiliser mes coordonnées',
                 'choices' => [
-                    'Utiliser mes coordonnées' => '1',
+                    'Oui' => true,
+                    'Non' => false,
                 ],
-                'help' => 'Cochez cette case pour devenir le tiers déclarant de ce signalement. Vous recevrez alors des mises à jour par e-mail au même titre que l\'occupant du logement.',
+                'label_html' => true,
+                'help' => 'Cochez cette case pour pré-remplir les coordonnées du déclarant avec vos informations. Vous recevrez alors des mises à jour par e-mail au même titre que l\'occupant du logement.',
                 'expanded' => true,
-                'multiple' => true,
+                'multiple' => false,
                 'required' => false,
                 'placeholder' => false,
                 'mapped' => false,
@@ -178,22 +184,33 @@ class SignalementDraftCoordonneesType extends AbstractType
                     'data-user-prenom' => $user->getPrenom(),
                     'data-user-mail' => $user->getEmail(),
                 ],
-                'data' => (!empty($signalement->getMailDeclarant()) && ProfileDeclarant::TIERS_PRO === $signalement->getProfileDeclarant()) ? [$signalement->getMailDeclarant() == $user->getEmail()] : null,
             ])
             ->add('structureDeclarant', TextType::class, [
-                'label' => 'Structure',
+                'label' => $signalement->isTiersDeclarant()
+                    ? 'Structure <span class="text-required">*</span>'
+                    : 'Structure',
+                'label_html' => true,
                 'required' => false,
             ])
             ->add('nomDeclarant', TextType::class, [
-                'label' => 'Nom de famille',
+                'label' => $signalement->isTiersDeclarant()
+                    ? 'Nom de famille <span class="text-required">*</span>'
+                    : 'Nom de famille',
+                'label_html' => true,
                 'required' => false,
             ])
             ->add('prenomDeclarant', TextType::class, [
-                'label' => 'Prénom',
+                'label' => $signalement->isTiersDeclarant()
+                    ? 'Prénom <span class="text-required">*</span>'
+                    : 'Prénom',
+                'label_html' => true,
                 'required' => false,
             ])
             ->add('mailDeclarant', TextType::class, [
-                'label' => 'Adresse e-mail',
+                'label' => $signalement->isTiersDeclarant()
+                    ? 'Adresse e-mail <span class="text-required">*</span>'
+                    : 'Adresse e-mail',
+                'label_html' => true,
                 'help' => 'Format attendu : nom@domaine.fr',
                 'required' => false,
             ])
@@ -292,6 +309,37 @@ class SignalementDraftCoordonneesType extends AbstractType
                 'row_attr' => ['class' => 'fr-ml-2w'],
             ])
         ;
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, static function (FormEvent $event) use ($signalement): void {
+            if (!$signalement->isTiersDeclarant()) {
+                return;
+            }
+
+            $form = $event->getForm();
+            $isTiersDeclarant = $form->get('isTiersDeclarant')->getData();
+
+            $errorMessageTiersDeclarant = 'Veuillez sélectionner une option.';
+            $errorMessageNom = $isTiersDeclarant ? 'Veuillez renseigner votre nom.' : 'Veuillez renseigner un nom.';
+            $errorMessagePrenom = $isTiersDeclarant ? 'Veuillez renseigner votre prénom.' : 'Veuillez renseigner un prénom.';
+            $errorMessageMail = $isTiersDeclarant ? 'Veuillez renseigner votre adresse e-mail.' : 'Veuillez renseigner une adresse e-mail.';
+            $errorMessageStructure = $isTiersDeclarant ? 'Veuillez renseigner votre structure.' : 'Veuillez renseigner une structure.';
+
+            if (null === $form->get('isTiersDeclarant')->getData()) {
+                $form->get('isTiersDeclarant')->addError(new FormError($errorMessageTiersDeclarant));
+            }
+            if ('' === trim((string) $form->get('nomDeclarant')->getData())) {
+                $form->get('nomDeclarant')->addError(new FormError($errorMessageNom));
+            }
+            if ('' === trim((string) $form->get('prenomDeclarant')->getData())) {
+                $form->get('prenomDeclarant')->addError(new FormError($errorMessagePrenom));
+            }
+            if ('' === trim((string) $form->get('mailDeclarant')->getData())) {
+                $form->get('mailDeclarant')->addError(new FormError($errorMessageMail));
+            }
+            if ('' === trim((string) $form->get('structureDeclarant')->getData())) {
+                $form->get('structureDeclarant')->addError(new FormError($errorMessageStructure));
+            }
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -14,6 +14,7 @@ use App\Entity\User;
 use App\Entity\UserSignalementSubscription;
 use App\Factory\NotificationFactory;
 use App\Repository\UserRepository;
+use App\Repository\UserSignalementSubscriptionRepository;
 use App\Service\InjonctionBailleur\CourrierBailleurGenerator;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
@@ -36,6 +37,7 @@ class NotificationAndMailSender
         private readonly NotificationMailerRegistry $notificationMailerRegistry,
         private readonly Security $security,
         private readonly CourrierBailleurGenerator $courrierBailleurGenerator,
+        private readonly UserSignalementSubscriptionRepository $userSignalementSubscriptionRepository,
     ) {
         $this->suivi = null;
         $user = $this->security->getUser();
@@ -299,9 +301,8 @@ class NotificationAndMailSender
         if (!$recipients->isEmpty()) {
             $recipients->removeElement($this->suivi->getCreatedBy()?->getEmail());
             foreach ($recipients as $recipient) {
-                if ($this->signalement->isTiersDeclarant() && $recipient === $this->signalement->getMailDeclarant()) {
-                    $agentExist = $this->userRepository->findAgentByEmail(email: $recipient, userStatus: UserStatus::ACTIVE, acceptRoleApi: false);
-                    if ($agentExist) {
+                if ($this->signalement->isTiersDeclarant()) {
+                    if ($this->isAgentSubscribedToSignalement($recipient)) {
                         continue;
                     }
                 }
@@ -472,5 +473,23 @@ class NotificationAndMailSender
                 isRecipientVisible: false,
             )
         );
+    }
+
+    private function isAgentSubscribedToSignalement(string $recipient): bool
+    {
+        $agent = $this->userRepository->findAgentByEmail(
+            email: $recipient,
+            userStatus: UserStatus::ACTIVE,
+            acceptRoleApi: false
+        );
+
+        if (!$agent) {
+            return false;
+        }
+
+        return null !== $this->userSignalementSubscriptionRepository->findOneBy([
+            'user' => $agent,
+            'signalement' => $this->signalement,
+        ]);
     }
 }

--- a/src/Service/NotificationAndMailSender.php
+++ b/src/Service/NotificationAndMailSender.php
@@ -301,7 +301,7 @@ class NotificationAndMailSender
         if (!$recipients->isEmpty()) {
             $recipients->removeElement($this->suivi->getCreatedBy()?->getEmail());
             foreach ($recipients as $recipient) {
-                if ($this->signalement->isTiersDeclarant()) {
+                if ($this->signalement->isTiersDeclarant() && $recipient === $this->signalement->getMailDeclarant()) {
                     if ($this->isAgentSubscribedToSignalement($recipient)) {
                         continue;
                     }

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -96,7 +96,7 @@
                 <h3 class="fr-h5">Tiers</h3>
             </legend>
             <div class="fr-fieldset__element">
-                {{ form_row(formCoordonnees.isTiersDeclarant) }}
+                {{ form_row(formCoordonnees.copyInfoTiersDeclarant) }}
             </div>
             <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.structureDeclarant) }}

--- a/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
+++ b/templates/back/signalement_create/tabs/tab-coordonnees.html.twig
@@ -2,7 +2,13 @@
 {% include 'back/signalement_create/tabs/_partial_facultative.html.twig' %}
 
 <div class="fr-alert fr-alert--warning fr-alert--sm fr-mb-5v">
-    <p> Renseigner l'adresse e-mail de la personne occupant le logement ou d'un tiers est recommandé pour un meilleur suivi du dossier. Si vous ne renseignez pas de coordonnées, l'adresse e-mail de votre compte sera associée au dossier.</p>
+    {% if signalement.isTiersDeclarant %}
+        <p>Renseigner l'adresse e-mail de la personne occupant le logement ou d'un tiers permet un meilleur suivi du dossier.
+            <br>Pour un déclarant tiers, les coordonnées du tiers sont obligatoires. </p>
+    {% else %}
+        <p> Renseigner l'adresse e-mail de la personne occupant le logement ou d'un tiers est recommandé pour un meilleur suivi du dossier.
+            Si vous ne renseignez pas de coordonnées, l'adresse e-mail de votre compte sera associée au dossier.</p>
+    {% endif %}
 </div>
 
 {{ form_start(formCoordonnees, {'attr': {'id': 'bo-form-signalement-coordonnees'}}) }}
@@ -90,7 +96,7 @@
                 <h3 class="fr-h5">Tiers</h3>
             </legend>
             <div class="fr-fieldset__element">
-                {{ form_row(formCoordonnees.isProTiersDeclarant) }}
+                {{ form_row(formCoordonnees.isTiersDeclarant) }}
             </div>
             <div class="fr-fieldset__element">
                 {{ form_row(formCoordonnees.structureDeclarant) }}

--- a/tests/Functional/Controller/Back/SignalementControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementControllerTest.php
@@ -348,7 +348,7 @@ class SignalementControllerTest extends WebTestCase
         $this->assertEquals(SignalementStatus::CLOSED, $signalement->getStatut());
 
         $client->enableProfiler();
-        $this->assertEmailCount(0);
+        $this->assertEmailCount(1);
     }
 
     public function testAdminPartnerSubmitClotureSignalementWithEmailSentToRT(): void

--- a/tests/Functional/Service/NotificationAndMailSenderTest.php
+++ b/tests/Functional/Service/NotificationAndMailSenderTest.php
@@ -60,6 +60,7 @@ class NotificationAndMailSenderTest extends KernelTestCase
             $this->notificationMailerRegistry,
             $this->security,
             $courrierBailleurGenerator,
+            $this->userSignalementSubscriptionRepository,
         );
     }
 
@@ -213,6 +214,7 @@ class NotificationAndMailSenderTest extends KernelTestCase
             $this->notificationMailerRegistry,
             $this->security,
             $courrierBailleurGenerator,
+            $this->userSignalementSubscriptionRepository,
         );
 
         $notificationAndMailSender->sendDemandeAbandonProcedureToUsager($suivi);
@@ -263,6 +265,7 @@ class NotificationAndMailSenderTest extends KernelTestCase
             $this->notificationMailerRegistry,
             $this->security,
             $courrierBailleurGenerator,
+            $this->userSignalementSubscriptionRepository,
         );
 
         $notificationAndMailSender->sendDemandeAbandonProcedureToAdminsAndPartners($suivi);
@@ -306,6 +309,7 @@ class NotificationAndMailSenderTest extends KernelTestCase
             $this->notificationMailerRegistry,
             $this->security,
             $courrierBailleurGenerator,
+            $this->userSignalementSubscriptionRepository,
         );
 
         $notificationAndMailSender->sendNewSuiviToUsagers($suivi);
@@ -352,6 +356,7 @@ class NotificationAndMailSenderTest extends KernelTestCase
             $this->notificationMailerRegistry,
             $this->security,
             $courrierBailleurGenerator,
+            $this->userSignalementSubscriptionRepository,
         );
 
         $notificationAndMailSender->sendNewSuiviToUsagers($suivi);


### PR DESCRIPTION
## Ticket

#5397    

## Description
Revue de la règle de réception des notifications pour le le tiers pro 
- Les valeurs tiers deviennent explicitement obligatoire pour les profil tiers : On ne le les renseigne jamais automatiquement à la validation
- On affiche un message d'erreur si elle sont manquante.
- Tous les tiers sont notifié (mail FO) a moins que l'adresse email correspondent a un agent abonnées au signalement concerné

## Changements apportés
* Transformer la case à cocher en bouton radio  "Utiliser mes coordonnées" Oui/Non
* Rendre tous les champs obligatoire pour les tiers
* Revue des messages d'informations et nom de champs
* Ajout méthode privée pour savoir si agent est abonné au signalement

## Pré-requis
`make npm-watch`

## Tests
### Cas 1  - En tant que tiers pro "Utiliser mes coordonnées" = Oui

1. Création du dossier

1.1 Oui
- [ ] Se connecter en tant qu’agent  
- [ ] Saisir un formulaire pro en tant que tiers (peu importe)
- [ ] Cocher **“Utiliser mes coordonnées”** Oui 
- [ ] Aucune régression sur la copie des informations vers les champs concernés
- [ ] Soumettez le formulaire

1.2. Non
- [ ] Cette fois ci Cocher Non avec un autre profil tiers 
- [ ] Vérifier que vous ne pouvez pas soumettre le formulaire sans les infos déclarants

3. Validation + suivi public
- [ ] Se connecter en tant qu’admin territoire  
- [ ] Valider le dossier  
- [ ] Ajouter un suivi public  
- [ ] Vérifier que **l’occupant ET l’agent tiers** reçoivent le même email  

### Cas 2 - En tant qu'abonné

4.  Affectation partenaire + nouveau suivi public

- [ ] Affecter le dossier à un partenaire  
- [ ] Se connecter en tant qu’agent du partenaire affecté  
- [ ] Accepter l’affectation  
- [ ] Vérifier que l’agent est bien abonné  
- [ ] Se reconnecter en tant qu’admin territoire  
- [ ] Ajouter un suivi public  
- [ ] Vérifier que **seul l’occupant est notifié**  

ℹ️ Le comportement standard d’abonnement s’applique ensuite  (notification ou email selon les préférences de l’utilisateur).
