### PR TITLE
[BO - UI] Ne pas afficher l'auto-complete dans les composants avec liste de cases à cocher

### DIFF
--- a/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
+++ b/templates/back/signalement/view/visites/visites-form-confirm-fields.html.twig
@@ -64,7 +64,7 @@
             Quelle est la conclusion de la visite ?
         </legend>
         <div class="search-checkbox-container fr-input-group fr-w-100">
-            <input id="visite-{{ formType }}[concludeProcedure]_input" type="text" placeholder="Sélectionner une ou plusieurs conclusions" class="fr-input">
+            <input id="visite-{{ formType }}[concludeProcedure]_input" type="text" placeholder="Sélectionner une ou plusieurs conclusions" class="fr-input" autocomplete="off">
             <button type="button" class="fr-btn--close fr-btn fr-hidden" style="top:2.5rem;">Fermer</button>
             <div class="search-checkbox" class="fr-hidden">
                 {% set listProceduresTypes = enum('\\App\\Entity\\Enum\\ProcedureType') %}
@@ -128,7 +128,7 @@
             Quelle est la conclusion de la visite ?
         </legend>
         <div class="search-checkbox-container fr-input-group fr-w-100">
-            <input id="visite-{{ formType }}[concludeProcedure]_input" type="text" placeholder="Sélectionner une ou plusieurs conclusions" class="fr-input">
+            <input id="visite-{{ formType }}[concludeProcedure]_input" type="text" placeholder="Sélectionner une ou plusieurs conclusions" class="fr-input" autocomplete="off">
             <button type="button" class="fr-btn--close fr-btn fr-hidden" style="top:2.5rem;">Fermer</button>
             <div class="search-checkbox" class="fr-hidden">
                 {% set listProceduresTypes = enum('\\App\\Entity\\Enum\\ProcedureType') %}

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -190,7 +190,7 @@
             {% if label is not same as(false) %}
                 <label for="{{ id }}_input" class="fr-label">{{ label }} {{form_help(form)}}</label>
             {% endif %}
-            <input id="{{ id }}_input" type="text" placeholder="{{ noselectionlabel }}" class="fr-input">
+            <input id="{{ id }}_input" type="text" placeholder="{{ noselectionlabel }}" class="fr-input" autocomplete="off">
         </div>
         <div class="search-checkbox-badges" {% if not showSelectionAsBadges %}style="display:none"{% endif %}></div>
         <button type="button" class="fr-btn--close fr-btn fr-hidden">Fermer</button>
@@ -205,7 +205,7 @@
             {% if label is not same as(false) %}
                 <label for="{{ id }}_input" class="fr-label">{{ label }} {{form_help(form)}}</label>
             {% endif %}
-            <input id="{{ id }}_input" type="text" placeholder="{{ noselectionlabel }}" class="fr-input">
+            <input id="{{ id }}_input" type="text" placeholder="{{ noselectionlabel }}" class="fr-input" autocomplete="off">
         </div>
         <div class="search-checkbox-badges" {% if not showSelectionAsBadges %}style="display:none"{% endif %}></div>
         <button type="button" class="fr-btn--close fr-btn fr-hidden">Fermer</button>


### PR DESCRIPTION
## Ticket

#5406   

## Description
Ne pas afficher l'auto-complete dans les composants avec liste de cases à cocher

## Tests
- [ ] Tester avec un navigateur qui affiche les suggestions autocomplete (ex : Chrome)
- [ ] Ajouter un suivi avec un fichier et valider le formulaire
- [ ] Ajouter un autre suivi, cliquer sur le champ pour ajouter un fichier : il ne doit pas être marqué "1 élément sélectionné" (mais on peut toujours sélectionner un fichier)
