### PR TITLE
[BO - Filtres] Revue des catégories de suivi dans le filtre "Dossiers sans activité partenaire"

### DIFF
--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2066,6 +2066,7 @@ class SignalementRepository extends ServiceEntityRepository
             'INTERVENTION_ARRETE_IS_CREATED',
             'INTERVENTION_ARRETE_IS_RESCHEDULED',
             'NEW_DOCUMENT',
+            'AFFECTATION_IS_CLOSED',
         ];
 
         $paramsToBind = [];


### PR DESCRIPTION
## Ticket

#5400   

## Description
https://bo.signal-logement.beta.gouv.fr/bo/signalements/?territoire=13&partenaires[]=6404&status=en_cours&isImported=oui&isDossiersSansActivite=oui&statusAffectation=cloture_un_partenaire&sortBy=lastSuiviAt&direction=DESC

Des dossiers avec des suivi partenaire de clôtures remonte malgré le filtre  _isDossiersSansActivite_ à oui

## Changements apportés
* Ajouter filtre `AFFECTATION_IS_CLOSED` à la liste des categories à prendre en compte.

## Pré-requis
`make load-data`

## Tests
- [ ] Tester avec les mêmes filtres 
http://localhost:8080/bo/signalements/?territoire=13&partenaires%5B%5D=6404&status=en_cours&isImported=oui&isDossiersSansActivite=oui&statusAffectation=cloture_un_partenaire&sortBy=lastSuiviAt&direction=DESC
