### PR TITLE
[FO - Maintenance] Bloquer la page de demande de lien de signalement

### DIFF
--- a/src/EventListener/MaintenanceListener.php
+++ b/src/EventListener/MaintenanceListener.php
@@ -54,6 +54,7 @@ class MaintenanceListener
                 || str_starts_with($uri, '/suivre-mon-signalement')
                 || str_starts_with($uri, '/mot-de-pass-perdu')
                 || str_starts_with($uri, '/contact')
+                || str_starts_with($uri, '/demande-lien-signalement')
                 || str_starts_with($uri, '/activation'))
             && !$this->authorizationChecker->isGranted(User::ROLE_ADMIN);
     }


### PR DESCRIPTION
## Ticket

#5418   

## Description
En mode maintenance, bloquer la page de demande de lien de signalement

## Tests
- [ ] Sans mode maintenance, aller sur http://localhost:8080/demande-lien-signalement et avoir une réponse `Method not allowed`
- [ ] Avec mode maintenance, rafraichir et avoir une redirection vers la page de connexion
