### PR TITLE
[BO - Utilisateurs] Garder les paramètres de recherche et tri quand on archive un utilisateur

### DIFF
--- a/assets/scripts/vanilla/controllers/back_user_index/form_user.js
+++ b/assets/scripts/vanilla/controllers/back_user_index/form_user.js
@@ -10,7 +10,7 @@ function histoUpdateValueFromData(elementName, elementData, target) {
 document.querySelectorAll('.btn-disable-user').forEach((swbtn) => {
   swbtn.addEventListener('click', (evt) => {
     const target = evt.target;
-    document.querySelectorAll('#fr-modal-user-disable_username').forEach((el) => {
+    document.querySelectorAll('.fr-modal-user-disable_username').forEach((el) => {
       el.textContent = target.getAttribute('data-username');
     });
     histoUpdateValueFromData('#fr-modal-user-disable_userid', 'data-userid', target);

--- a/src/Controller/Back/UserController.php
+++ b/src/Controller/Back/UserController.php
@@ -56,7 +56,7 @@ class UserController extends AbstractController
         /** @var User $user */
         $user = $this->getUser();
         $originalMethod = $request->getMethod();
-        $request->setMethod('GET'); // to prevent Symfony ignoring GET data while handlning the form
+        $request->setMethod('GET'); // to prevent Symfony ignoring GET data while handling the form
         [, $searchUser, $paginatedUsers] = $this->handleSearchUser($request, $userRepository, $maxListPagination);
         if ('POST' === $originalMethod) {
             /** @var string $format */
@@ -136,24 +136,31 @@ class UserController extends AbstractController
         UserManager $userManager,
         UserPasswordHasherInterface $passwordHasher,
     ): Response {
+        /** @var User $user */
+        $user = $this->getUser();
+        $request->setMethod('GET'); // to prevent Symfony ignoring GET data while handling the form
+        $searchUser = new SearchUser($user);
+        $form = $this->createForm(SearchUserType::class, $searchUser);
+        $form->handleRequest($request);
+
         /** @var string $userId */
         $userId = $request->request->get('user_id');
         if (!$this->isCsrfTokenValid('user_disable', (string) $request->request->get('_token'))) {
             $this->addFlash('error', 'Token CSRF invalide, merci d\'actualiser la page et réessayer.');
 
-            return $this->redirectToRoute('back_user_index', [], Response::HTTP_SEE_OTHER);
+            return $this->redirectToRoute('back_user_index', $searchUser->getUrlParams(), Response::HTTP_SEE_OTHER);
         }
         /** @var User $user */
         $user = $userManager->find($userId);
         if (!$user) {
             $this->addFlash('error', 'Utilisateur introuvable.');
 
-            return $this->redirectToRoute('back_user_index', [], Response::HTTP_SEE_OTHER);
+            return $this->redirectToRoute('back_user_index', $searchUser->getUrlParams(), Response::HTTP_SEE_OTHER);
         }
         if (!$this->isGranted(UserVoter::USER_DISABLE, $user)) {
             $this->addFlash('error', 'Action non autorisée sur un super administrateur.');
 
-            return $this->redirectToRoute('back_user_index', [], Response::HTTP_SEE_OTHER);
+            return $this->redirectToRoute('back_user_index', $searchUser->getUrlParams(), Response::HTTP_SEE_OTHER);
         }
 
         $user->setStatut(UserStatus::INACTIVE);
@@ -163,7 +170,7 @@ class UserController extends AbstractController
             'message' => 'L\'utilisateur '.$user->getNomComplet(true).' a bien été désactivé.',
         ]);
 
-        return $this->redirectToRoute('back_user_index', [], Response::HTTP_SEE_OTHER);
+        return $this->redirectToRoute('back_user_index', $searchUser->getUrlParams(), Response::HTTP_SEE_OTHER);
     }
 
     /**

--- a/templates/_partials/_modal_user_disable.html.twig
+++ b/templates/_partials/_modal_user_disable.html.twig
@@ -8,12 +8,12 @@
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-user-disable-title" class="fr-modal__title">
-                            Désactiver <span id="fr-modal-user-disable_username"></span>
+                            Désactiver <span class="fr-modal-user-disable_username"></span>
                         </h1>
-                        <form action="{{ path('back_user_disable') }}" name="user_disable"
+                        <form action="{{ path('back_user_disable', searchUser.urlParams) }}" name="user_disable"
                               id="user_disable_form" method="POST">
                             <div class="fr-select-group">
-                                Vous êtes sur le point de désactiver l'utilisateur <b><span id="fr-modal-user-disable_username"></span></b>. <br>
+                                Vous êtes sur le point de désactiver l'utilisateur <b><span class="fr-modal-user-disable_username"></span></b>. <br>
                                 Son statut passera à INACTIVE, et son mot de passe sera réinitialisé à NULL.<br>
                                 Une fois désactivé, l'utilisateur ne pourra plus se connecter à la plateforme ni accéder aux dossiers. <br>
                                 Il devra réactiver son compte et recréer un mot de passe pour pouvoir se reconnecter.
@@ -29,16 +29,14 @@
                         <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                             <li>
                                 <button class="fr-btn fr-icon-check-line" form="user_disable_form"
-                                        id="user_disable_form_submit">
-                                    Désactiver
-                                </button>
+                                    id="user_disable_form_submit"
+                                    >Désactiver</button>
                             </li>
                             <li>
                                 <button type="button"
-                                        class="fr-btn fr-btn--secondary fr-icon-close-line"
-                                        aria-controls="fr-modal-user-disable">
-                                    Annuler
-                                </button>
+                                    class="fr-btn fr-btn--secondary fr-icon-close-line"
+                                    aria-controls="fr-modal-user-disable"
+                                    >Annuler</button>
                             </li>
                         </ul>
                     </div>

--- a/templates/back/user/index.html.twig
+++ b/templates/back/user/index.html.twig
@@ -79,7 +79,7 @@
             <a 
                 href="{% if users|length > 0 %}{{path('back_user_export', searchUser.urlParams)}}{% else %}#{% endif %}" 
                 class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-fill {% if users|length == 0 %}fr-label--disabled{% endif %} fr-btn--block fr-btn--md-inline"
-            > Exporter les résultats </a>
+                >Exporter les résultats</a>
         </div>
     </section>
     


### PR DESCRIPTION
## Ticket

#5420   

## Description
Dans la liste des utilisateurs, si on filtre ou si on trie, puis qu'on désactive un utilisateur, on souhaite garder les résultats de la recherche au rafraichissement. 

## Changements apportés
* J'ai changé un id d'élément html en double en classe, donc il faut recompiler le js pour que la modale fonctionne

## Pré-requis
`make npm-watch`

## Tests
- [ ] Faire une recherche et un tri, puis désactiver un utilisateur, et vérifier que la recherche est conservée
