### PR TITLE
Accepter les demande de poursuite de procédure à plusieurs reprises

### DIFF
--- a/src/Controller/SignalementController.php
+++ b/src/Controller/SignalementController.php
@@ -449,39 +449,6 @@ class SignalementController extends AbstractController
         return $this->json(['error' => 'Aucun fichier n\'a été téléversé'], 400);
     }
 
-    #[Route('/suivre-ma-procedure/{code}', name: 'front_suivi_procedure', methods: ['GET', 'POST'])]
-    public function suiviProcedure(
-        string $code,
-        SignalementRepository $signalementRepository,
-        Request $request,
-    ): Response {
-        $signalement = $signalementRepository->findOneByCodeForPublic($code);
-        $this->denyAccessUnlessGranted(SignalementFoVoter::SIGN_USAGER_VIEW, $signalement);
-        if (SignalementStatus::ARCHIVED === $signalement->getStatut()) {
-            $this->addFlash('error', 'Le lien utilisé est expiré ou invalide.');
-
-            return $this->redirectToRoute('front_suivi_signalement', ['code' => $signalement->getCodeSuivi()]);
-        }
-        $suiviAuto = $request->query->get('suiviAuto');
-        // TODO : route à supprimer quelques semaines/mois après la suppression du feature flipping featureSuiviAction (aout 2025)
-        // pour ne pas avoir des liens cassés dans les anciens mails
-        if (Suivi::ARRET_PROCEDURE == $suiviAuto) {
-            return $this->redirectToRoute(
-                'front_suivi_signalement_procedure',
-                [
-                    'code' => $signalement->getCodeSuivi(),
-                ]
-            );
-        }
-
-        return $this->redirectToRoute(
-            'front_suivi_signalement_procedure_poursuite',
-            [
-                'code' => $signalement->getCodeSuivi(),
-            ]
-        );
-    }
-
     /**
      * @throws NonUniqueResultException
      */
@@ -830,14 +797,10 @@ class SignalementController extends AbstractController
         SignalementRepository $signalementRepository,
         SignalementManager $signalementManager,
         SuiviManager $suiviManager,
+        SuiviRepository $suiviRepository,
     ): Response {
         $signalement = $signalementRepository->findOneByCodeForPublic($code);
         $this->denyAccessUnlessGranted(SignalementFoVoter::SIGN_USAGER_VIEW, $signalement);
-        if (false === $signalement->getIsUsagerAbandonProcedure()) {
-            $this->addFlash('error', ['title' => 'Demande déjà enregistrée', 'message' => 'L\'administration a déjà été informée de votre volonté de poursuivre la procédure.']);
-
-            return $this->redirectToRoute('front_suivi_signalement', ['code' => $signalement->getCodeSuivi()]);
-        }
         if (!$this->isGranted(SignalementFoVoter::SIGN_USAGER_EDIT, $signalement)) {
             $this->addFlash('error', ['title' => 'Accès refusé', 'message' => 'Vous n\'avez pas les droits pour effectuer cette action.']);
 
@@ -851,12 +814,18 @@ class SignalementController extends AbstractController
             return $redirect;
         }
 
+        $lastSuiviDemandePoursuite = $suiviRepository->findOneBy(['signalement' => $signalement, 'category' => SuiviCategory::DEMANDE_POURSUITE_PROCEDURE], ['createdAt' => 'DESC']);
+        $hasRecentDemandePoursuite = false;
+        if ($lastSuiviDemandePoursuite && $lastSuiviDemandePoursuite->getCreatedAt() > (new \DateTime('-20 days'))) {
+            $hasRecentDemandePoursuite = true;
+        }
+
         $user = $signalementUser->getUser();
 
         $form = $this->createForm(UsagerPoursuivreProcedureType::class);
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if (!$hasRecentDemandePoursuite && $form->isSubmitted() && $form->isValid()) {
             $signalement->setIsUsagerAbandonProcedure(false);
 
             $description = $user->getNomComplet().' a indiqué vouloir poursuivre la procédure sur '
@@ -881,6 +850,7 @@ class SignalementController extends AbstractController
         return $this->render('front/suivi_signalement_poursuivre_procedure_validation.html.twig', [
             'signalement' => $signalement,
             'form' => $form->createView(),
+            'hasRecentDemandePoursuite' => $hasRecentDemandePoursuite,
         ]);
     }
 

--- a/templates/front/suivi_signalement_poursuivre_procedure_validation.html.twig
+++ b/templates/front/suivi_signalement_poursuivre_procedure_validation.html.twig
@@ -16,29 +16,44 @@
 	</nav>
 	<div class="fr-grid-row fr-grid-row--gutters">
 		<div class="fr-col-12 fr-col-md-8">
-			{{ form_start(form, {'attr': {'id': 'form-poursuivre-procedure'}}) }}
-			{{ form_errors(form) }}
-				<h1 class="title-blue-france">Poursuivre la procédure</h1>
-				<div class="fr-my-3w">
-					Vous souhaitez poursuivre la procédure ?<br>
-					Nous allons informer les services de votre réponse.
-					<br>
-					Attention votre choix pourra avoir un impact sur la poursuite de votre dossier.<br><br>
-					{{ form_row(form.details,{}) }}
-				</div>	
+			{% if hasRecentDemandePoursuite %}
+				<div class="fr-alert fr-alert--info">
+					<p>
+						Vous avez indiqué vouloir poursuivre la procédure récemment. 
+					</p>
+					<p>
+						Nous avons bien pris en compte votre demande et nous vous invitons à patienter pendant que nous traitons votre dossier. 
+					</p>
+					<p>
+						Si vous souhaitez apporter des éléments complémentaires à votre demande, veuillez utilliser la 
+						<a href="{{ path('front_suivi_signalement_messages', {code: signalement.codeSuivi}) }}">messagerie de votre dossier</a>.
+					</p>
+				</div>
+			{% else %}
+				{{ form_start(form, {'attr': {'id': 'form-poursuivre-procedure'}}) }}
+				{{ form_errors(form) }}
+					<h1 class="title-blue-france">Poursuivre la procédure</h1>
+					<div class="fr-my-3w">
+						Vous souhaitez poursuivre la procédure ?<br>
+						Nous allons informer les services de votre réponse.
+						<br>
+						Attention votre choix pourra avoir un impact sur la poursuite de votre dossier.<br><br>
+						{{ form_row(form.details,{}) }}
+					</div>	
 
-				
-				<ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
-					<li>				
-						<button class="fr-btn fr-icon-check-line" type="submit" id="form_finish_submit" form="form-poursuivre-procedure">
-							Valider ma demande
-						</button>
-					</li>
-					<li>					
-						<a class="fr-btn fr-btn--secondary fr-icon-close-line" href="{{ path('front_suivi_signalement',{code:signalement.codeSuivi}) }}" >Annuler</a>
-					</li>
-				</ul>
-			{{ form_end(form) }}
+					
+					<ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
+						<li>				
+							<button class="fr-btn fr-icon-check-line" type="submit" id="form_finish_submit" form="form-poursuivre-procedure">
+								Valider ma demande
+							</button>
+						</li>
+						<li>					
+							<a class="fr-btn fr-btn--secondary fr-icon-close-line" href="{{ path('front_suivi_signalement',{code:signalement.codeSuivi}) }}" >Annuler</a>
+						</li>
+					</ul>
+				{{ form_end(form) }}
+			{% endif %}
 		</div>
 		{% include 'front/_partials/_suivi_signalement_card_right.html.twig' %}
 	</div>

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -55,40 +55,6 @@ class SignalementControllerTest extends WebTestCase
     /**
      * @dataProvider provideStatusSignalement
      */
-    public function testDisplaySuiviProcedure(string $status): void
-    {
-        $client = static::createClient();
-
-        /** @var EntityManagerInterface $entityManager */
-        $entityManager = self::getContainer()->get('doctrine');
-        /** @var Signalement $signalement */
-        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy([
-            'statut' => $status,
-            'isUsagerAbandonProcedure' => null,
-        ]);
-        $signalementUser = $this->getSignalementUser($signalement);
-        $client->loginUser($signalementUser, 'code_suivi');
-
-        /** @var RouterInterface $router */
-        $router = self::getContainer()->get(RouterInterface::class);
-        $urlSuiviProcedureUser = $router->generate('front_suivi_procedure', [
-            'code' => $signalement->getCodeSuivi(),
-        ]).'?suiviAuto='.Suivi::ARRET_PROCEDURE;
-
-        $client->request('GET', $urlSuiviProcedureUser);
-
-        if (in_array($status, [SignalementStatus::DRAFT->value, SignalementStatus::DRAFT_ARCHIVED->value])) {
-            $this->assertResponseRedirects('/authentification/'.$signalement->getCodeSuivi());
-        } elseif (SignalementStatus::ARCHIVED->value === $status) {
-            $this->assertResponseRedirects('/suivre-mon-signalement/'.$signalement->getCodeSuivi());
-        } else {
-            $this->assertResponseRedirects('/suivre-mon-signalement/'.$signalement->getCodeSuivi().'/procedure');
-        }
-    }
-
-    /**
-     * @dataProvider provideStatusSignalement
-     */
     public function testDisplaySuiviSignalement(string $status): void
     {
         $client = static::createClient();
@@ -253,6 +219,9 @@ class SignalementControllerTest extends WebTestCase
         $this->assertStringContainsString($signalementUser->getUser()->getNomComplet(), $lastSuivi->getDescription());
         $this->assertStringContainsString('vouloir poursuivre la procédure', $lastSuivi->getDescription());
         $this->assertStringContainsString('Commentaire : on veut vraiment vivre mieux &lt;b&gt;test&lt;/b&gt;', $lastSuivi->getDescription());
+
+        $crawler = $client->request('GET', $urlSuiviSignalementUserResponse);
+        $this->assertStringContainsString('Vous avez indiqué vouloir poursuivre la procédure récemment.', $crawler->filter('.fr-alert.fr-alert--info p')->text());
     }
 
     public function testSuiviSignalementProcedureBascule(): void


### PR DESCRIPTION
## Ticket

#5426

## Description
Jusqu’à présent si un usager indiqué vouloir poursuivre sa procédure lors de la première suivante, en cliquant sur le bouton poursuite de procédure on le redirigeait sur son dossier avec un message d'erreur
<img width="1221" height="504" alt="Screenshot 2026-02-13 at 17-49-33 Votre dossier #2025-09 - Signal-Logement" src="https://github.com/user-attachments/assets/f33f8fc8-5265-46b5-9441-dd820889e67e" />

J'ai modifié ce comportement pour qu'il puisse effectuer une demande de poursuite de procédure pour chaque relance (donc une fois par mois au départ) 
Pour éviter les abus j'ai remplacé l'erreur par un message explicatif, si une demande de poursuite de moins de 20 jours existe déja
<img width="1249" height="332" alt="Screenshot 2026-02-13 at 17-42-18 Votre dossier #2025-09 - Signal-Logement" src="https://github.com/user-attachments/assets/14f433d3-282f-488c-97f5-e6298374b1c7" />

* Suppression de la route historique `front_suivi_procedure` plus utilisé depuis août 2025

## Tests
- [ ] Tester de faire une demande de poursuite de procédure
- [ ] Essayer d'en refaire une et voir le message explicatif
- [ ] Modifier la date du suivi de type `DEMANDE_POURSUITE_PROCEDURE` a plus de 20 jours et voir que l'on peux renouveler la demande
