### PR TITLE
[Tech - Suivi usager] Service de génération des suivi de category SIGNALEMENT_EDITED_FO 

### DIFF
--- a/src/Controller/SignalementEditController.php
+++ b/src/Controller/SignalementEditController.php
@@ -2,19 +2,16 @@
 
 namespace App\Controller;
 
-use App\Entity\Enum\SuiviCategory;
-use App\Entity\Signalement;
-use App\Entity\Suivi;
-use App\Entity\User;
+use App\EventListener\SignalementUpdatedListener;
 use App\Form\CoordonneesAgenceType;
 use App\Form\CoordonneesBailleurType;
 use App\Manager\SuiviManager;
-use App\Manager\UserManager;
 use App\Repository\SignalementRepository;
 use App\Security\User\SignalementUser;
 use App\Security\Voter\SignalementFoVoter;
 use App\Service\Security\CguTiersChecker;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -56,7 +53,13 @@ class SignalementEditController extends AbstractController
             $formCoordonneesBailleur->isSubmitted()
             && $formCoordonneesBailleur->isValid()
         ) {
-            $this->saveChangesAndCreateSuivi($signalement, $signalementUser, 'coordonnees_bailleur');
+            $this->entityManager->flush();
+            $this->suiviManager->createSuiviFromEditUsager(
+                $signalement,
+                $signalementUser,
+                SignalementUpdatedListener::EDIT_COORDONNEES_BAILLEUR
+            );
+
             $this->addFlash('success', ['title' => 'Dossier complété', 'message' => 'Les coordonnées du bailleur ont bien été mises à jour.']);
 
             return $this->redirectToRoute('front_suivi_signalement_dossier', ['code' => $signalement->getCodeSuivi()]);
@@ -68,6 +71,9 @@ class SignalementEditController extends AbstractController
         ]);
     }
 
+    /**
+     * @throws NonUniqueResultException
+     */
     #[Route('/{code}/completer/agence', name: 'front_suivi_signalement_complete_agence', methods: ['GET', 'POST'])]
     public function suiviSignalementCompleteAgence(
         string $code,
@@ -87,7 +93,13 @@ class SignalementEditController extends AbstractController
         $form = $this->createForm(CoordonneesAgenceType::class, $signalement);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->saveChangesAndCreateSuivi($signalement, $signalementUser, 'coordonnees_agence');
+            $this->entityManager->flush();
+            $this->suiviManager->createSuiviFromEditUsager(
+                $signalement,
+                $signalementUser,
+                SignalementUpdatedListener::EDIT_COORDONNEES_AGENCE
+            );
+
             $this->addFlash('success', ['title' => 'Dossier complété', 'message' => 'Les coordonnées de l\'agence ont bien été mises à jour.']);
 
             return $this->redirectToRoute('front_suivi_signalement_dossier', ['code' => $signalement->getCodeSuivi()]);
@@ -97,59 +109,5 @@ class SignalementEditController extends AbstractController
             'signalement' => $signalement,
             'form' => $form,
         ]);
-    }
-
-    private function saveChangesAndCreateSuivi(Signalement $signalement, SignalementUser $signalementUser, string $type): void
-    {
-        $uow = $this->entityManager->getUnitOfWork();
-        $uow->computeChangeSets();
-        $changeSet = $uow->getEntityChangeSet($signalement);
-        if (empty($changeSet)) {
-            return;
-        }
-        $listOfChanges = '';
-        $whatsUpdated = '';
-        switch ($type) {
-            case 'coordonnees_bailleur':
-                $whatsUpdated = 'les coordonnées du bailleur';
-                $listOfChanges .= $signalement->getNomProprio() ? '<li>Nom : '.$signalement->getNomProprio().'</li>' : '';
-                $listOfChanges .= $signalement->getPrenomProprio() ? '<li>Prénom : '.$signalement->getPrenomProprio().'</li>' : '';
-                $listOfChanges .= $signalement->getMailProprio() ? '<li>E-mail : '.$signalement->getMailProprio().'</li>' : '';
-                $listOfChanges .= $signalement->getTelProprio() ? '<li>Téléphone : '.$signalement->getTelProprio().'</li>' : '';
-                $listOfChanges .= $signalement->getTelProprioSecondaire() ? '<li>Téléphone secondaire : '.$signalement->getTelProprioSecondaire().'</li>' : '';
-                $listOfChanges .= $signalement->getAdresseProprio() ? '<li>Adresse : '.$signalement->getAdresseProprio().'</li>' : '';
-                $listOfChanges .= $signalement->getCodePostalProprio() ? '<li>Code postal : '.$signalement->getCodePostalProprio().'</li>' : '';
-                $listOfChanges .= $signalement->getVilleProprio() ? '<li>Ville : '.$signalement->getVilleProprio().'</li>' : '';
-                break;
-            case 'coordonnees_agence':
-                $whatsUpdated = 'les coordonnées de l\'agence';
-                $listOfChanges .= $signalement->getDenominationAgence() ? '<li>Dénomination : '.$signalement->getDenominationAgence().'</li>' : '';
-                $listOfChanges .= $signalement->getNomAgence() ? '<li>Nom : '.$signalement->getNomAgence().'</li>' : '';
-                $listOfChanges .= $signalement->getPrenomAgence() ? '<li>Prénom : '.$signalement->getPrenomAgence().'</li>' : '';
-                $listOfChanges .= $signalement->getMailAgence() ? '<li>E-mail : '.$signalement->getMailAgence().'</li>' : '';
-                $listOfChanges .= $signalement->getTelAgence() ? '<li>Téléphone : '.$signalement->getTelAgence().'</li>' : '';
-                $listOfChanges .= $signalement->getTelAgenceSecondaire() ? '<li>Téléphone secondaire : '.$signalement->getTelAgenceSecondaire().'</li>' : '';
-                $listOfChanges .= $signalement->getAdresseAgence() ? '<li>Adresse : '.$signalement->getAdresseAgence().'</li>' : '';
-                $listOfChanges .= $signalement->getCodePostalAgence() ? '<li>Code postal : '.$signalement->getCodePostalAgence().'</li>' : '';
-                $listOfChanges .= $signalement->getVilleAgence() ? '<li>Ville : '.$signalement->getVilleAgence().'</li>' : '';
-                break;
-        }
-        /** @var User $user */
-        $user = $signalementUser->getUser();
-        $usager = ($user === $signalement->getSignalementUsager()?->getOccupant()) ? ' ('.UserManager::OCCUPANT.')' : ' ('.UserManager::DECLARANT.')';
-        $description = $user->getNomComplet(true).$usager.' a mis à jour '.$whatsUpdated.'.';
-        $description .= '<br>Voici les nouvelles coordonnées :';
-        $description .= '<ul>';
-        $description .= $listOfChanges;
-        $description .= '</ul>';
-
-        $this->suiviManager->createSuivi(
-            signalement: $signalement,
-            description: $description,
-            type: Suivi::TYPE_USAGER,
-            category: SuiviCategory::SIGNALEMENT_EDITED_FO,
-            user: $user,
-            isPublic: true,
-        );
     }
 }

--- a/src/Controller/SignalementEditController.php
+++ b/src/Controller/SignalementEditController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller;
 
-use App\EventListener\SignalementUpdatedListener;
+use App\Entity\Signalement;
 use App\Form\CoordonneesAgenceType;
 use App\Form\CoordonneesBailleurType;
 use App\Manager\SuiviManager;
@@ -53,12 +53,7 @@ class SignalementEditController extends AbstractController
             $formCoordonneesBailleur->isSubmitted()
             && $formCoordonneesBailleur->isValid()
         ) {
-            $this->entityManager->flush();
-            $this->suiviManager->createSuiviFromEditUsager(
-                $signalement,
-                $signalementUser,
-                SignalementUpdatedListener::EDIT_COORDONNEES_BAILLEUR
-            );
+            $this->saveChangesAndCreateSuivi($signalement, $signalementUser);
 
             $this->addFlash('success', ['title' => 'Dossier complété', 'message' => 'Les coordonnées du bailleur ont bien été mises à jour.']);
 
@@ -93,13 +88,7 @@ class SignalementEditController extends AbstractController
         $form = $this->createForm(CoordonneesAgenceType::class, $signalement);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->entityManager->flush();
-            $this->suiviManager->createSuiviFromEditUsager(
-                $signalement,
-                $signalementUser,
-                SignalementUpdatedListener::EDIT_COORDONNEES_AGENCE
-            );
-
+            $this->saveChangesAndCreateSuivi($signalement, $signalementUser);
             $this->addFlash('success', ['title' => 'Dossier complété', 'message' => 'Les coordonnées de l\'agence ont bien été mises à jour.']);
 
             return $this->redirectToRoute('front_suivi_signalement_dossier', ['code' => $signalement->getCodeSuivi()]);
@@ -109,5 +98,16 @@ class SignalementEditController extends AbstractController
             'signalement' => $signalement,
             'form' => $form,
         ]);
+    }
+
+    private function saveChangesAndCreateSuivi(Signalement $signalement, SignalementUser $signalementUser): void
+    {
+        $this->entityManager->wrapInTransaction(function () use ($signalement, $signalementUser): void {
+            $this->entityManager->flush();
+            $this->suiviManager->createSuiviFromEditUsager(
+                $signalement,
+                $signalementUser,
+            );
+        });
     }
 }

--- a/src/Controller/SignalementEditController.php
+++ b/src/Controller/SignalementEditController.php
@@ -102,8 +102,9 @@ class SignalementEditController extends AbstractController
 
     private function saveChangesAndCreateSuivi(Signalement $signalement, SignalementUser $signalementUser): void
     {
+        // Ordre volontaire : createSuiviFromEditUsager() utilise les changements enregistrés sur Signalement en preUpdate.
         $this->entityManager->wrapInTransaction(function () use ($signalement, $signalementUser): void {
-            $this->entityManager->flush();
+            $this->entityManager->flush(); /* @see SignalementUpdatedListener::preUpdate() écoute l'event dispatché par le flush() */
             $this->suiviManager->createSuiviFromEditUsager(
                 $signalement,
                 $signalementUser,

--- a/src/Entity/Behaviour/EntityChangesTrait.php
+++ b/src/Entity/Behaviour/EntityChangesTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Entity\Behaviour;
+
+/**
+ * État temporaire des changements détectés sur l'entité.
+ */
+trait EntityChangesTrait
+{
+    /**
+     * Flag technique indiquant qu'une mise à jour Doctrine a été détecté.
+     */
+    private bool $updateOccurred = false;
+
+    /**
+     * Tableau structuré calculés pendant un flush.
+     *
+     * @var array<string, mixed>
+     */
+    private array $changes = [];
+
+    public function isUpdateOccurred(): bool
+    {
+        return $this->updateOccurred;
+    }
+
+    public function getChanges(): array
+    {
+        return $this->changes;
+    }
+
+    /**
+     * Marque qu'une mise à jour a eu lieu (sans détail).
+     */
+    public function markUpdateOccurred(): void
+    {
+        $this->updateOccurred = true;
+    }
+
+    /**
+     * Enregistre les changements détectés de manière temporaire.
+     */
+    public function registerChanges(array $changes = []): void
+    {
+        $this->updateOccurred = true;
+        $this->changes = $changes;
+    }
+}

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2893,7 +2893,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         return $this->changes;
     }
 
-    public function setChanges(array $changes): self
+    public function setChanges(array $changes): static
     {
         $this->changes = $changes;
 

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -521,6 +521,10 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $loginBailleur = null;
 
+    private bool $updateOccurred = false;
+
+    private array $changes = [];
+
     public function __construct()
     {
         $this->criticites = new ArrayCollection();
@@ -2870,5 +2874,29 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         }
 
         return null;
+    }
+
+    public function isUpdateOccurred(): bool
+    {
+        return $this->updateOccurred;
+    }
+
+    public function setUpdateOccurred(bool $updateOccurred): static
+    {
+        $this->updateOccurred = $updateOccurred;
+
+        return $this;
+    }
+
+    public function getChanges(): array
+    {
+        return $this->changes;
+    }
+
+    public function setChanges(array $changes): self
+    {
+        $this->changes = $changes;
+
+        return $this;
     }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Entity\Behaviour\EntityChangesTrait;
 use App\Entity\Behaviour\EntityHistoryCollectionInterface;
 use App\Entity\Behaviour\EntityHistoryInterface;
 use App\Entity\Enum\AffectationStatus;
@@ -49,6 +50,8 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 #[ORM\Index(columns: ['mail_declarant'], name: 'idx_signalement_mail_declarant')]
 class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInterface
 {
+    use EntityChangesTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
@@ -520,10 +523,6 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $loginBailleur = null;
-
-    private bool $updateOccurred = false;
-
-    private array $changes = [];
 
     public function __construct()
     {
@@ -2874,29 +2873,5 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         }
 
         return null;
-    }
-
-    public function isUpdateOccurred(): bool
-    {
-        return $this->updateOccurred;
-    }
-
-    public function setUpdateOccurred(bool $updateOccurred): static
-    {
-        $this->updateOccurred = $updateOccurred;
-
-        return $this;
-    }
-
-    public function getChanges(): array
-    {
-        return $this->changes;
-    }
-
-    public function setChanges(array $changes): static
-    {
-        $this->changes = $changes;
-
-        return $this;
     }
 }

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -15,9 +15,9 @@ class SignalementUpdatedListener
     public const string EDIT_COORDONNEES_BAILLEUR = 'coordonnees_bailleur';
     public const string EDIT_COORDONNEES_AGENCE = 'coordonnees_agence';
 
-    public const array EDIT_FIELDS = [
+    public const array EDIT_SECTIONS = [
         self::EDIT_COORDONNEES_BAILLEUR => [
-            'label' => 'coordonnées du bailleur',
+            'label' => 'Les coordonnées du bailleur',
             'fields' => [
                 'nomProprio' => 'Nom',
                 'prenomProprio' => 'Prénom',
@@ -30,7 +30,7 @@ class SignalementUpdatedListener
             ],
         ],
         self::EDIT_COORDONNEES_AGENCE => [
-            'label' => 'coordonnées de l\'agence',
+            'label' => 'Les coordonnées de l\'agence',
             'fields' => [
                 'denominationAgence' => 'Dénomination',
                 'nomAgence' => 'Nom',
@@ -51,19 +51,19 @@ class SignalementUpdatedListener
 
     public function preUpdate(Signalement $signalement, PreUpdateEventArgs $event): void
     {
-        if ([] !== $event->getEntityChangeSet()) {
-            $signalement->setUpdateOccurred(true);
-        }
+        // On continue de flagger qu'un changement est détecté.
+        // On le fait AVANT le verrou `supports` pour que le BO puisse afficher l'info même si on ne détaille pas les changements.
+        $signalement->markUpdateOccurred();
 
-        if (!$this->supports()) {
+        if (!$this->supports()) { // On ne traite que les modifications de l'usager
             return;
         }
 
-        $editedForms = [];
-        foreach (self::EDIT_FIELDS as $editFormKey => $editFormMapping) {
+        $changes = [];
+        foreach (self::EDIT_SECTIONS as $sectionKey => $sectionDefinition) {
             $fieldChanges = [];
 
-            foreach ($editFormMapping['fields'] as $fieldName => $label) {
+            foreach ($sectionDefinition['fields'] as $fieldName => $label) {
                 if (!$event->hasChangedField($fieldName)) {
                     continue;
                 }
@@ -82,14 +82,14 @@ class SignalementUpdatedListener
             }
 
             if ([] !== $fieldChanges) {
-                $editedForms[$editFormKey] = [
-                    'label' => $editFormMapping['label'],
+                $changes[$sectionKey] = [
+                    'label' => $sectionDefinition['label'],
                     'fieldChanges' => $fieldChanges,
                 ];
             }
         }
 
-        $signalement->setChanges($editedForms);
+        $signalement->registerChanges($changes);
     }
 
     private function supports(): bool

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -3,29 +3,104 @@
 namespace App\EventListener;
 
 use App\Entity\Signalement;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
-use Doctrine\ORM\Event\PostUpdateEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Events;
+use Symfony\Bundle\SecurityBundle\Security;
 
-#[AsEntityListener(event: Events::postUpdate, method: 'postUpdate', entity: Signalement::class)]
+#[AsEntityListener(event: Events::preUpdate, method: 'preUpdate', entity: Signalement::class)]
 class SignalementUpdatedListener
 {
-    private bool $updateOccurred = false;
+    public const string EDIT_COORDONNEES_BAILLEUR = 'coordonnees_bailleur';
+    public const string EDIT_COORDONNEES_AGENCE = 'coordonnees_agence';
 
-    public function postUpdate(Signalement $signalement, PostUpdateEventArgs $event): void
+    public const array EDIT_FIELDS = [
+        self::EDIT_COORDONNEES_BAILLEUR => [
+            'label' => 'coordonnées du bailleur',
+            'fields' => [
+                'nomProprio' => 'Nom',
+                'prenomProprio' => 'Prénom',
+                'mailProprio' => 'E-mail',
+                'telProprio' => 'Téléphone',
+                'telProprioSecondaire' => 'Téléphone secondaire',
+                'adresseProprio' => 'Adresse',
+                'codePostalProprio' => 'Code postal',
+                'villeProprio' => 'Ville',
+            ],
+        ],
+        self::EDIT_COORDONNEES_AGENCE => [
+            'label' => 'coordonnées de l\'agence',
+            'fields' => [
+                'denominationAgence' => 'Dénomination',
+                'nomAgence' => 'Nom',
+                'prenomAgence' => 'Prénom',
+                'mailAgence' => 'E-mail',
+                'telAgence' => 'Téléphone',
+                'telAgenceSecondaire' => 'Téléphone secondaire',
+                'adresseAgence' => 'Adresse',
+                'codePostalAgence' => 'Code postal',
+                'villeAgence' => 'Ville',
+            ],
+        ],
+    ];
+
+    public function __construct(private readonly Security $security)
     {
-        $unitOfWork = $event->getObjectManager()->getUnitOfWork();
-
-        foreach ($unitOfWork->getEntityChangeSet($signalement) as $change) {
-            if ($change[0] != $change[1]) {
-                $this->updateOccurred = true;
-                break;
-            }
-        }
     }
 
-    public function updateOccurred(): bool
+    public function preUpdate(Signalement $signalement, PreUpdateEventArgs $event): void
     {
-        return $this->updateOccurred;
+        if ([] !== $event->getEntityChangeSet()) {
+            $signalement->setUpdateOccurred(true);
+        }
+
+        if (!$this->supports()) {
+            return;
+        }
+
+        $editedForms = [];
+        foreach (self::EDIT_FIELDS as $editFormKey => $editFormMapping) {
+            $fieldChanges = [];
+
+            foreach ($editFormMapping['fields'] as $fieldName => $label) {
+                if (!$event->hasChangedField($fieldName)) {
+                    continue;
+                }
+
+                $old = $event->getOldValue($fieldName);
+                $new = $event->getNewValue($fieldName);
+
+                if ($old === $new) {
+                    continue;
+                }
+
+                $fieldChanges[$fieldName] = [
+                    'label' => $label,
+                    'new' => $new,
+                ];
+            }
+
+            if ([] !== $fieldChanges) {
+                $editedForms[$editFormKey] = [
+                    'label' => $editFormMapping['label'],
+                    'fieldChanges' => $fieldChanges,
+                ];
+            }
+        }
+
+        $signalement->setChanges($editedForms);
+    }
+
+    private function supports(): bool
+    {
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        if (!$user) {
+            return false;
+        }
+
+        return in_array('ROLE_USAGER', $user->getRoles(), true);
     }
 }

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -321,7 +321,6 @@ class SuiviManager extends Manager
     public function createSuiviFromEditUsager(
         Signalement $signalement,
         SignalementUser $signalementUser,
-        string $editUsagerFormKey,
     ): void {
         $changes = $signalement->getChanges();
 
@@ -332,21 +331,19 @@ class SuiviManager extends Manager
         /** @var User $user */
         $user = $signalementUser->getUser();
 
-        $usagerType = ($user === $signalement->getSignalementUsager()?->getOccupant())
-            ? UserManager::OCCUPANT
-            : UserManager::DECLARANT;
+        /** @var array{label:string, fieldChanges:array} $sectionChanges */
+        // Un seul formulaire est soumis à la fois,
+        // donc un seul bloc de changements est attendu.
+        $sectionChanges = current($changes);
 
-        $editForm = $changes[$editUsagerFormKey];
         $description = sprintf(
-            '%s (%s) a mis à jour les %s.',
+            '%s ont été modifiées par %s.',
+            $sectionChanges['label'],
             $user->getNomComplet(true),
-            $usagerType,
-            $editForm['label']
         );
-        $description .= '<br>Voici les modifications :';
         $description .= '<ul>';
 
-        foreach ($editForm['fieldChanges'] as $change) {
+        foreach ($sectionChanges['fieldChanges'] as $change) {
             $description .= sprintf(
                 '<li>%s : %s</li>',
                 $change['label'],

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -13,7 +13,7 @@ use App\Entity\Suivi;
 use App\Entity\SuiviFile;
 use App\Entity\User;
 use App\Event\SuiviCreatedEvent;
-use App\EventListener\SignalementUpdatedListener;
+use App\Security\User\SignalementUser;
 use App\Service\Sanitizer;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -25,7 +25,6 @@ class SuiviManager extends Manager
 {
     public function __construct(
         protected ManagerRegistry $managerRegistry,
-        private readonly SignalementUpdatedListener $signalementUpdatedListener,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly Security $security,
         #[Autowire(service: 'html_sanitizer.sanitizer.app.message_sanitizer')]
@@ -133,7 +132,7 @@ class SuiviManager extends Manager
         string $description,
     ): bool {
         $subscriptionCreated = false;
-        if ($this->signalementUpdatedListener->updateOccurred()) {
+        if ($signalement->isUpdateOccurred()) {
             /** @var User $user */
             $user = $this->security->getUser();
             $this->createSuivi(
@@ -317,5 +316,52 @@ class SuiviManager extends Manager
         }
 
         return $description;
+    }
+
+    public function createSuiviFromEditUsager(
+        Signalement $signalement,
+        SignalementUser $signalementUser,
+        string $editUsagerFormKey,
+    ): void {
+        $changes = $signalement->getChanges();
+
+        if ([] === $changes) {
+            return;
+        }
+
+        /** @var User $user */
+        $user = $signalementUser->getUser();
+
+        $usagerType = ($user === $signalement->getSignalementUsager()?->getOccupant())
+            ? UserManager::OCCUPANT
+            : UserManager::DECLARANT;
+
+        $editForm = $changes[$editUsagerFormKey];
+        $description = sprintf(
+            '%s (%s) a mis à jour les %s.',
+            $user->getNomComplet(true),
+            $usagerType,
+            $editForm['label']
+        );
+        $description .= '<br>Voici les modifications :';
+        $description .= '<ul>';
+
+        foreach ($editForm['fieldChanges'] as $change) {
+            $description .= sprintf(
+                '<li>%s : %s</li>',
+                $change['label'],
+                $change['new'] ?? '-'
+            );
+        }
+
+        $description .= '</ul>';
+        $this->createSuivi(
+            signalement: $signalement,
+            description: $description,
+            type: Suivi::TYPE_USAGER,
+            category: SuiviCategory::SIGNALEMENT_EDITED_FO,
+            user: $user,
+            isPublic: true,
+        );
     }
 }

--- a/tests/Functional/Controller/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/SignalementEditControllerTest.php
@@ -12,6 +12,7 @@ use App\Tests\SessionHelper;
 use App\Tests\UserHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -175,6 +176,14 @@ class SignalementEditControllerTest extends WebTestCase
         ]);
         $this->assertEquals('nouvel.email@example.org', $signalement->getMailProprio());
         $this->assertNotNull($suivi);
-        $this->assertStringContainsString('a mis à jour les coordonnées', $suivi->getDescription());
+        $this->assertStringContainsString('Les coordonnées du bailleur ont été modifiées par', $description = $suivi->getDescription());
+        $crawler = new Crawler($description);
+        $this->assertEquals(6, $crawler->filter('li')->count());
+        $this->assertStringContainsString('E-mail', $description);
+        $this->assertStringContainsString('Adresse', $description);
+        $this->assertStringContainsString('Code postal', $description);
+        $this->assertStringContainsString('Ville', $description);
+        $this->assertStringContainsString('Téléphone', $description);
+        $this->assertStringContainsString('Téléphone secondaire', $description);
     }
 }

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -7,7 +7,6 @@ use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
 use App\Entity\User;
-use App\EventListener\SignalementUpdatedListener;
 use App\Manager\SuiviManager;
 use App\Manager\UserManager;
 use App\Manager\UserSignalementSubscriptionManager;
@@ -24,7 +23,6 @@ class SuiviManagerTest extends KernelTestCase
 {
     private const string REF_SIGNALEMENT = '2022-8';
     private ManagerRegistry $managerRegistry;
-    private SignalementUpdatedListener $signalementUpdatedListener;
     private EventDispatcherInterface $eventDispatcherInterface;
     private Security $security;
     private HtmlSanitizerInterface $htmlSanitizerInterface;
@@ -38,7 +36,6 @@ class SuiviManagerTest extends KernelTestCase
     {
         self::bootKernel();
         $this->managerRegistry = self::getContainer()->get(ManagerRegistry::class);
-        $this->signalementUpdatedListener = static::getContainer()->get(SignalementUpdatedListener::class);
         $this->eventDispatcherInterface = static::getContainer()->get(EventDispatcherInterface::class);
         $this->security = static::getContainer()->get(Security::class);
         $this->htmlSanitizerInterface = self::getContainer()->get('html_sanitizer.sanitizer.app.message_sanitizer');
@@ -48,7 +45,6 @@ class SuiviManagerTest extends KernelTestCase
         $this->userManager = static::getContainer()->get(UserManager::class);
         $this->suiviManager = new SuiviManager(
             $this->managerRegistry,
-            $this->signalementUpdatedListener,
             $this->eventDispatcherInterface,
             $this->security,
             $this->htmlSanitizerInterface,


### PR DESCRIPTION
## Ticket

#5372    

## Description
Centralisation de la détection des modifications d’un Signalement via le `SignalementUpdatedListener` (déjà existant)
Afficher uniquement les modifications 

Sur les interventions on n'affiche uniquement la nouvelle valeur dans le suivi (diff ancienne et nouvelle valeur était réservé au mail) 

Je n'affiche donc que la nouvelle valeur 
<img width="473" height="201" alt="image" src="https://github.com/user-attachments/assets/4449da31-c212-480e-81fe-21dd3e0a41f5" />


## Changements apportés
- Ajout d’un mapping pour avoir la correspondance (propriété <=> libelle de formulaire)
- Construction du tableaux des changement dans le `preUpdate`
- Ajout d’un verrou `supports()` basé sur le `ROLE_USAGER` afin de ne rien construire si mise à jour coté BO
- Remplacement de la méthode privée par une méthode de service dans `SuiviManager`


## Pré-requis

## Tests
- [ ] Faire des éditions coté FO pour le block agence et bailleur 
- [ ] Vérifier l'affichage des suivi coté FO 
- [ ] Vérifier l'affichage des suivi coté BO
- [ ] TNR - Vérifier qu'aucune regression est présente sur les éditions BO
