### PR TITLE
[BO - Signalement - visite] Corrections de 2 bugs sur l'édition des visites

### DIFF
--- a/src/Controller/Back/SignalementVisitesController.php
+++ b/src/Controller/Back/SignalementVisitesController.php
@@ -389,10 +389,8 @@ class SignalementVisitesController extends AbstractController
         if ($errorMessage) {
             $flashMessages[] = ['type' => 'alert', 'title' => 'Erreur', 'message' => \sprintf('Erreurs lors de la modification de la visite : %s, veuillez réessayer.', $errorMessage)];
         } elseif ($intervention = $interventionManager->rescheduleVisiteFromRequest($signalement, $visiteRequest, $partner)) {
-            if ($intervention->getScheduledAt()->format('Y-m-d') <= (new \DateTimeImmutable())->format('Y-m-d')) {
-                $flashMessages[] = ['type' => 'success', 'title' => 'Modifications enregistrées', 'message' => self::SUCCESS_MSG_CONFIRM];
-            } else {
-                $flashMessages[] = ['type' => 'success', 'title' => 'Modifications enregistrées', 'message' => self::SUCCESS_MSG_ADD];
+            $flashMessages[] = ['type' => 'success', 'title' => 'Modifications enregistrées', 'message' => self::SUCCESS_MSG_CONFIRM];
+            if ($intervention->getScheduledAt()->format('Y-m-d') > (new \DateTimeImmutable())->format('Y-m-d')) {
                 $eventDispatcher->dispatch(
                     new InterventionRescheduledEvent(
                         $intervention,

--- a/templates/back/signalement/view/visites/bloc-visites.html.twig
+++ b/templates/back/signalement/view/visites/bloc-visites.html.twig
@@ -2,7 +2,7 @@
 
 <div class="fr-grid-row" data-territory-timezone="{{ territory_timezone }}">
     <div class="fr-col-12 fr-col-md-6">
-        <h3 class="fr-h5 fr-mb-3v">Visites du logement</h3>
+        <h3 class="fr-h5 fr-mb-3v">Visites du logement ({{ visites|length > 0 ? visites|length : 'aucune'}})</h3>
 
         <p class="fr-text--sm fr-pb-5v">
             Les visites sont gérées par les partenaires ayant la compétence "Visites" et les responsables de territoires.

--- a/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
+++ b/templates/back/signalement/view/visites/modals/visites-modal-reschedule.html.twig
@@ -9,7 +9,7 @@
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-reschedule-visite-modal-{{intervention.id}}" class="fr-modal__title">
-                                Modifier la date du
+                                Modifier la visite du
                                 {{ (intervention.scheduledAt.format('H')) > 0 ? intervention.scheduledAt|date('d/m/Y à H:i') : intervention.scheduledAt.format('d/m/Y') }}
                             </h1>
 

--- a/templates/back/signalement/view/visites/visites-buttons.html.twig
+++ b/templates/back/signalement/view/visites/visites-buttons.html.twig
@@ -7,7 +7,7 @@
                 </button>
             {% endif %}
             <button class="fr-btn fr-btn--secondary fr-fi-edit-line" aria-controls="reschedule-visite-modal-{{intervention.id}}" data-fr-opened="false">
-                Modifier la date
+                Modifier la visite
             </button>
             {% if workflow_can(intervention, 'confirm') %}
                 <button class="fr-btn fr-fi-check-line" aria-controls="confirm-visite-modal-{{intervention.id}}" data-fr-opened="false">

--- a/templates/back/signalement/view/visites/visites-list.html.twig
+++ b/templates/back/signalement/view/visites/visites-list.html.twig
@@ -1,68 +1,20 @@
-<hr class="fr-mt-3w">
-
-<div class="fr-grid-row" data-territory-timezone="{{ territory_timezone }}">
-    <div class="fr-col-12 fr-col-md-6">
-        <h3 class="fr-h5 fr-mb-3v">Visites du logement ({{ visites|length > 0 ? visites|length : 'aucune'}})</h3>
-
-        <p class="fr-text--sm fr-pb-5v">
-            Les visites sont gérées par les partenaires ayant la compétence "Visites" et les responsables de territoires.
-        </p>
-    </div>
-    <div class="fr-col-12 fr-col-md-6">
-        {% if is_granted('SIGN_ADD_VISITE', signalement) %}
-            {% include 'back/signalement/view/visites/modals/visites-modal-add.html.twig' %}
-            {% set displayAddVisiteButton = true %}
-            {% set listPendingVisiteExternalOperatorNames = [] %}
-            {% for pendingVisite in pendingVisites %}
-                {% set partner = app.user.partnerInTerritoryOrFirstOne(signalement.territory) %}
-                {% if pendingVisite.partner and pendingVisite.partner.id is same as partner.id %}
-                    {% set displayAddVisiteButton = false %}
-                {% endif %}
-                {% if pendingVisite.externalOperator and pendingVisite.partner.id is null %}
-                    {% set listPendingVisiteExternalOperatorNames = listPendingVisiteExternalOperatorNames|merge([pendingVisite.externalOperator]) %}
-                {% endif %}
-            {% endfor %}
-            <span id="list-pending-visite-external-operator-names" data-list="{{ listPendingVisiteExternalOperatorNames|json_encode}}"></span>
-
-            <div class="fr-my-5v fr-text--right">
-                {% if linkToVisitGrid %}
-                    <a class="fr-btn fr-btn--secondary fr-icon-article-line fr-btn--icon-left matomo_download" 
-                    title="Télécharger la grille de visite {% if signalement.territory.grilleVisiteFilename %}du territoire{% endif %}"
-                    download href="{{ sign_url(linkToVisitGrid) }}">
-                        Grille de visite
-                    </a>
-                {% endif %}
-                {% if displayAddVisiteButton %}
-                    <button class="fr-btn fr-fi-calendar-line fr-btn--icon-left" aria-controls="add-visite-modal" data-fr-opened="false">
-                        Ajouter une visite
-                    </button>
+{% for intervention in visites %}
+    <div class="fr-background-alt--grey fr-p-5v fr-mb-5v">
+        <div class="fr-grid-row">
+            <div class="fr-col-12 fr-col-md-6 fr-h6 fr-mb-3v">
+                Visite
+                {% if visites is not empty or intervention.scheduledAt is not empty %}
+                    du {{ intervention.scheduledAt|date('d/m/Y') }}
                 {% endif %}
             </div>
-        {% endif %}
-    </div>
-</div>
-
-{% if signalement.interventions is empty %}
-    {% include 'back/signalement/view/visites/visite-item.html.twig' with { 'isForBO': true } %}
-{% else %}
-    {% for intervention in visites %}
-        <div class="fr-background-alt--grey fr-p-5v fr-mb-5v">
-            <div class="fr-grid-row">
-                <div class="fr-col-12 fr-col-md-6 fr-h6 fr-mb-3v">
-                    Visite
-                    {% if visites is not empty or intervention.scheduledAt is not empty %}
-                        du {{ intervention.scheduledAt|date('d/m/Y') }}
-                    {% endif %}
-                </div>
-                <div class="fr-col-12 fr-col-md-6">
-                    {% if is_granted('SIGN_ADD_VISITE', intervention.signalement) %}
-                        {% include 'back/signalement/view/visites/modals/visites-modals.html.twig' %}
-                    {% endif %}
-                    {% include 'back/signalement/view/visites/visites-buttons.html.twig' %}
-                </div>
+            <div class="fr-col-12 fr-col-md-6">
+                {% if is_granted('SIGN_ADD_VISITE', intervention.signalement) %}
+                    {% include 'back/signalement/view/visites/modals/visites-modals.html.twig' %}
+                {% endif %}
+                {% include 'back/signalement/view/visites/visites-buttons.html.twig' %}
             </div>
-            {% include 'back/signalement/view/visites/visite-item.html.twig' with { 'isForBO': true } %}
         </div>
-    {% endfor %}
-{% endif %}
+        {% include 'back/signalement/view/visites/visite-item.html.twig' with { 'isForBO': true } %}
+    </div>
+{% endfor %}
 


### PR DESCRIPTION
## Ticket

#5435
#5434

## Description
- #5435 : changer l'intitulé du bouton (`Modifier la date` -> `Modifier la visite`) et le message de confirmation (`La date de visite a bien été définie` -> `Les informations de la visite ont bien été enregistrées`.)
- #5434 : mauvais résolution de conflit entre le changement des messages flash de visite et l'ajout d'un compteur sur les visites, on avait l'entête de la partie visites 2 fois

## Changements apportés
* Corrections des twig et du controller

## Pré-requis

## Tests
- [ ] Créer successivement 1 visite dans le futur et 1 visite effectuée dans le passé sans remplir tout les champs, vérifier que tout se passe bien (messages d'erreur etc.)
- [ ] Vérifier qu'on a l'entête de la partie visites une seule fois
- [ ] Changer une visite à venir (par exemple l'opérateur), vérifier le message de confirmation
