### PR TITLE
[BO - Signalement] La modale de suivi garde le contenu précédent

### DIFF
--- a/assets/scripts/vanilla/services/component/component_json_response_handler.js
+++ b/assets/scripts/vanilla/services/component/component_json_response_handler.js
@@ -47,6 +47,10 @@ export function jsonResponseProcess(response) {
       const openModalElement = document.querySelector('.fr-modal--opened');
       if (openModalElement) {
         dsfr(openModalElement).modal.conceal();
+        const formElement = openModalElement.querySelector('form');
+        if (formElement) {
+          formElement.reset();
+        }
       }
     }
     if (response.functions) {


### PR DESCRIPTION
## Ticket

#5429

## Description
Ajout d'un système (générique) de réinitialisation des formulaires, lors d'un retour indiquant que la modal doit être fermé `closeModal`.

Avec le nouveau système de message flash sans rechargement de page, en cas de succès on ferme la modale en cours, dans ce cas les données de son formulaire doivent être réinitialisé. Je pense qu'il faut que ce soit générique, d'autre cas doivent exister.

## Pré-requis
`make npm-watch`

## Tests
- [ ] Soumettre deux suivi d'affilé depuis le BO (sans rechargement de page) et voir que le formulaire est bien réinitialisé entre les deux
