### PR TITLE
[QA] Erreur de binding entity Partner via query params

### DIFF
--- a/src/DataFixtures/Files/Intervention.yml
+++ b/src/DataFixtures/Files/Intervention.yml
@@ -120,3 +120,10 @@ interventions:
     proprietaire_present: 0
     details: "<p>Rapport de visite ajouté au dossier</p>"
     conclude_procedure: [ 'INSALUBRITE' ]
+  -
+    signalement: "2025-09"
+    external_operator: true
+    partner: "partenaire externe"
+    user: "admin-territoire-30@signal-logement.fr"
+    scheduled_at: '-2 days'
+    status: 'PLANNED'

--- a/src/DataFixtures/Loader/LoadInterventionData.php
+++ b/src/DataFixtures/Loader/LoadInterventionData.php
@@ -50,13 +50,17 @@ class LoadInterventionData extends Fixture implements OrderedFixtureInterface
         $signalement = $this->signalementRepository->findOneBy(['reference' => $row['signalement']]);
         $intervention = (new Intervention())
             ->setSignalement($signalement)
-            ->setPartner($this->partnerRepository->findOneBy(['email' => $row['partner']]))
             ->setScheduledAt($this->getScheduledAt($row))
             ->setType(isset($row['type']) ? InterventionType::from($row['type']) : InterventionType::VISITE)
             ->setDetails($row['details'] ?? null)
             ->setOccupantPresent($row['occupant_present'] ?? null)
             ->setProprietairePresent($row['proprietaire_present'] ?? null)
             ->setStatus($row['status'] ?? Intervention::STATUS_PLANNED);
+        if (isset($row['external_operator']) && $row['external_operator']) {
+            $intervention->setExternalOperator(externalOperator: $row['partner']);
+        } else {
+            $intervention->setPartner($this->partnerRepository->findOneBy(['email' => $row['partner']]));
+        }
 
         if (isset($row['additional_information'])) {
             $intervention->setAdditionalInformation($row['additional_information']);

--- a/src/Repository/UserSignalementSubscriptionRepository.php
+++ b/src/Repository/UserSignalementSubscriptionRepository.php
@@ -51,6 +51,9 @@ class UserSignalementSubscriptionRepository extends ServiceEntityRepository
      */
     public function findForSignalementAndPartner(Signalement $signalement, Partner $partner, bool $excludeRT = false): array
     {
+        if (!$partner->getId()) {
+            return [];
+        }
         $queryBuilder = $this->createQueryBuilder('s')
             ->select('s', 'u')
             ->innerJoin('s.user', 'u')

--- a/tests/Functional/Controller/Back/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementListControllerTest.php
@@ -69,7 +69,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'Search by Procédure estimée' => [['procedure' => 'rsd', 'isImported' => 'oui'], 7];
         yield 'Search by Partenaires affectés' => [['partenaires' => ['5'], 'isImported' => 'oui'], 2];
         yield 'Search by Statut de la visite "Planifié"' => [['visiteStatus' => 'Planifiée', 'isImported' => 'oui'], 5];
-        yield 'Search by Statut de la visite "Conclusion à renseigner"' => [['visiteStatus' => 'Conclusion à renseigner', 'isImported' => 'oui'], 1];
+        yield 'Search by Statut de la visite "Conclusion à renseigner"' => [['visiteStatus' => 'Conclusion à renseigner', 'isImported' => 'oui'], 2];
         yield 'Search by Statut de la visite "Terminé"' => [['visiteStatus' => 'Terminée', 'isImported' => 'oui'], 7];
         yield 'Search by Type de dernier suivi' => [['typeDernierSuivi' => 'automatique', 'isImported' => 'oui'], 7];
         yield 'Search by Date de dernier suivi' => [['dateDernierSuiviDebut' => '2023-04-01', 'dateDernierSuiviFin' => '2023-04-18', 'isImported' => 'oui'], 2];


### PR DESCRIPTION
## Ticket

#5430

## Description
Correction d'un crash de la commande de notification des visites `app:notify-visits` lors de la tentative de notification d'une visite passé ayant un opérateur externe (donc pas de partenaire)

Erreur sentry
https://sentry.incubateur.net/organizations/betagouv/issues/244810/events/c746125ea25343899d5a23c7d4d53ca2/

- Ajout de fixture pour avoir le cas lorsqu'on lance `app:notify-visits` (et sur les TU)
- Correction de la requête `findForSignalementAndPartner` pour éviter le crash

Sur le fond, le problème viens du choix fait lors de l'jout de la gestion de visites avec opérateur externe pour lequel on retourne un partner "virtuel" (sans id) qui provoquait le crahs lors de la requête. 
https://www.notion.so/1cb9671af8ed80a099b7efbc499c4c11?v=1cb9671af8ed80dd9e7c000c071d093d&p=1cb9671af8ed807ba586fefca15a0283&pm=s
<img width="622" height="230" alt="Capture d’écran 2026-02-17 102029" src="https://github.com/user-attachments/assets/7cb2e100-192c-4668-8edb-bc3e98c66161" />

## Pré-requis
`make load-fixtures`

## Tests
- [ ] Lancer la commande `app:notify-visits` et voir que tout se passe bien.
