### PR TITLE
[FO - Signalement] Limiter l'accès au sélecteur de bâtiment si on saisit une adresse manuellement

### DIFF
--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -195,18 +195,27 @@ export default defineComponent({
     watch(
       () => this.formStore.data[this.id + '_detail_numero'],
       async () => {
+        if (this.isSearchSkipped) {
+          return
+        }
         this.handleAddressFieldsEdited(false)
       }
     )
     watch(
       () => this.formStore.data[this.id + '_detail_code_postal'],
       async () => {
+        if (this.isSearchSkipped) {
+          return
+        }
         this.handleAddressFieldsEdited(true)
       }
     )
     watch(
       () => this.formStore.data[this.id + '_detail_commune'],
       async () => {
+        if (this.isSearchSkipped) {
+          return
+        }
         this.handleAddressFieldsEdited(true)
       }
     )


### PR DESCRIPTION
## Ticket

#5450   

## Description
Limiter l'accès au sélecteur de bâtiment si on saisit une adresse manuellement

## Pré-requis
`make npm-watch`

## Tests
- [ ] Créer un signalement, saisir une adresse et la choisir dans la liste : le sélecteur ne s'affiche pas
- [ ] Puis modifier un des champs : le sélecteur s'affiche
- [ ] Reprendre de zero et saisir l'adresse : le sélecteur s'affiche
