### PR TITLE
[FO - Formulaire police] Finaliser étape 1

### DIFF
--- a/migrations/Version20260217141902.php
+++ b/migrations/Version20260217141902.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260217141902 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout des champs liés à l\'étape 1 du formulaire de service de secours';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE service_secours_route ADD slug VARCHAR(255) NOT NULL, ADD email VARCHAR(255) NOT NULL, ADD phone VARCHAR(20) DEFAULT NULL');
+        $this->addSql('ALTER TABLE signalement ADD service_secours_id INT DEFAULT NULL, ADD matricule_declarant VARCHAR(255) DEFAULT NULL, ADD date_mission DATE DEFAULT NULL COMMENT \'(DC2Type:date_immutable)\', ADD origine_mission VARCHAR(255) DEFAULT NULL, ADD ordre_mission VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B5511465BC0C6B FOREIGN KEY (service_secours_id) REFERENCES service_secours_route (id)');
+        $this->addSql('CREATE INDEX IDX_F4B5511465BC0C6B ON signalement (service_secours_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE service_secours_route DROP slug, DROP email, DROP phone');
+        $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511465BC0C6B');
+        $this->addSql('DROP INDEX IDX_F4B5511465BC0C6B ON signalement');
+        $this->addSql('ALTER TABLE signalement DROP service_secours_id, DROP matricule_declarant, DROP date_mission, DROP origine_mission, DROP ordre_mission');
+    }
+}

--- a/migrations/Version20260217141902.php
+++ b/migrations/Version20260217141902.php
@@ -17,7 +17,7 @@ final class Version20260217141902 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE service_secours_route ADD slug VARCHAR(255) NOT NULL, ADD email VARCHAR(255) NOT NULL, ADD phone VARCHAR(20) DEFAULT NULL');
-        $this->addSql('ALTER TABLE signalement ADD service_secours_id INT DEFAULT NULL, ADD matricule_declarant VARCHAR(255) DEFAULT NULL, ADD date_mission DATE DEFAULT NULL COMMENT \'(DC2Type:date_immutable)\', ADD origine_mission VARCHAR(255) DEFAULT NULL, ADD ordre_mission VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE signalement ADD service_secours_id INT DEFAULT NULL, ADD matricule_declarant VARCHAR(255) DEFAULT NULL, ADD date_mission_service_secours DATE DEFAULT NULL COMMENT \'(DC2Type:date_immutable)\', ADD origine_mission_service_secours VARCHAR(255) DEFAULT NULL, ADD ordre_mission_service_secours VARCHAR(255) DEFAULT NULL');
         $this->addSql('ALTER TABLE signalement ADD CONSTRAINT FK_F4B5511465BC0C6B FOREIGN KEY (service_secours_id) REFERENCES service_secours_route (id)');
         $this->addSql('CREATE INDEX IDX_F4B5511465BC0C6B ON signalement (service_secours_id)');
     }
@@ -27,6 +27,6 @@ final class Version20260217141902 extends AbstractMigration
         $this->addSql('ALTER TABLE service_secours_route DROP slug, DROP email, DROP phone');
         $this->addSql('ALTER TABLE signalement DROP FOREIGN KEY FK_F4B5511465BC0C6B');
         $this->addSql('DROP INDEX IDX_F4B5511465BC0C6B ON signalement');
-        $this->addSql('ALTER TABLE signalement DROP service_secours_id, DROP matricule_declarant, DROP date_mission, DROP origine_mission, DROP ordre_mission');
+        $this->addSql('ALTER TABLE signalement DROP service_secours_id, DROP matricule_declarant, DROP date_mission_service_secours, DROP origine_mission_service_secours, DROP ordre_mission_service_secours');
     }
 }

--- a/src/Controller/ServiceSecours/ServiceSecoursController.php
+++ b/src/Controller/ServiceSecours/ServiceSecoursController.php
@@ -39,7 +39,7 @@ class ServiceSecoursController extends AbstractController
         if ($flow->isSubmitted() && $flow->isValid() && $flow->isFinished()) {
             $signalement = $signalementFactory->createInstanceFromFormServiceSecours($flow->getData(), $serviceSecoursRoute);
 
-            // dump($signalement); for testing purpose
+            // dump($signalement); // for testing purpose
             // TODO : persist and flush
             // voir les traitements fait dans App\Controller\Api\SignalementCreateController.php, création de la référence dans une transaction en particulier)
             return $this->render('service_secours/success.html.twig', ['serviceSecoursRoute' => $serviceSecoursRoute, 'signalement' => $signalement]);

--- a/src/Controller/ServiceSecours/ServiceSecoursController.php
+++ b/src/Controller/ServiceSecours/ServiceSecoursController.php
@@ -4,6 +4,7 @@ namespace App\Controller\ServiceSecours;
 
 use App\Dto\ServiceSecours\FormServiceSecours;
 use App\Entity\ServiceSecoursRoute;
+use App\Factory\SignalementFactory;
 use App\Form\ServiceSecours\ServiceSecoursType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Flow\FormFlowInterface;
@@ -22,22 +23,26 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 ]
 class ServiceSecoursController extends AbstractController
 {
-    #[Route('/services-secours/{name:serviceSecoursRoute}/{uuid:serviceSecoursRoute}',
+    #[Route('/services-secours/{slug:serviceSecoursRoute}/{uuid:serviceSecoursRoute}',
         name: 'service_secours_index',
         methods: ['GET', 'POST'])
     ]
     public function index(
         Request $request,
         ServiceSecoursRoute $serviceSecoursRoute,
+        SignalementFactory $signalementFactory,
     ): Response {
         $serviceSecours = new FormServiceSecours();
         /** @var FormFlowInterface $flow */
         $flow = $this->createForm(ServiceSecoursType::class, $serviceSecours);
         $flow->handleRequest($request);
         if ($flow->isSubmitted() && $flow->isValid() && $flow->isFinished()) {
-            // TODO : voir les traitements fait dans App\Controller\Api\SignalementCreateController.php pour les adapter / refactoriser ici
+            $signalement = $signalementFactory->createInstanceFromFormServiceSecours($flow->getData(), $serviceSecoursRoute);
 
-            return $this->render('service_secours/success.html.twig', ['serviceSecoursRoute' => $serviceSecoursRoute]);
+            // dump($signalement); for testing purpose
+            // TODO : persist and flush
+            // voir les traitements fait dans App\Controller\Api\SignalementCreateController.php, création de la référence dans une transaction en particulier)
+            return $this->render('service_secours/success.html.twig', ['serviceSecoursRoute' => $serviceSecoursRoute, 'signalement' => $signalement]);
         }
 
         return $this->render('service_secours/index.html.twig', [
@@ -46,14 +51,14 @@ class ServiceSecoursController extends AbstractController
         ]);
     }
 
-    #[Route('/services-secours/{name:serviceSecoursRoute}/{uuid:serviceSecoursRoute}/site.webmanifest',
+    #[Route('/services-secours/{slug:serviceSecoursRoute}/{uuid:serviceSecoursRoute}/site.webmanifest',
         name: 'service_secours_webmanifest',
         methods: ['GET'])
     ]
     public function webmanifest(ServiceSecoursRoute $serviceSecoursRoute, Request $request): JsonResponse
     {
         $startUrl = $this->generateUrl('service_secours_index', [
-            'name' => $serviceSecoursRoute->getName(),
+            'slug' => $serviceSecoursRoute->getSlug(),
             'uuid' => $serviceSecoursRoute->getUuid(),
             'domain' => $request->attributes->get('domain'),
         ], UrlGeneratorInterface::ABSOLUTE_PATH);

--- a/src/DataFixtures/Files/ServiceSecoursRoute.yml
+++ b/src/DataFixtures/Files/ServiceSecoursRoute.yml
@@ -1,6 +1,8 @@
 service_secours_routes:
 -
-  name: "PIM-PON"
+  name: "PIN PON"
+  email: "pin-pon@example.com"
 -
-  name: "WOUIP-WOUIP"
+  name: "WOUIP WOUIP"
+  email: "wouip-wouip@example.com"
 

--- a/src/DataFixtures/Loader/LoadServiceSecoursRouteData.php
+++ b/src/DataFixtures/Loader/LoadServiceSecoursRouteData.php
@@ -25,6 +25,7 @@ class LoadServiceSecoursRouteData extends Fixture implements OrderedFixtureInter
     public function loadServiceSecoursRoute(ObjectManager $manager, array $row): void
     {
         $serviceSecoursRoute = (new ServiceSecoursRoute())->setName($row['name']);
+        $serviceSecoursRoute->setEmail($row['email']);
         $manager->persist($serviceSecoursRoute);
     }
 

--- a/src/Dto/ServiceSecours/FormServiceSecoursStep1.php
+++ b/src/Dto/ServiceSecours/FormServiceSecoursStep1.php
@@ -13,11 +13,16 @@ class FormServiceSecoursStep1
     #[Assert\Length(max: 50, groups: ['step1'])]
     public ?string $nomDeclarant = null;
 
-    #[Assert\Length(max: 50, groups: ['step1'])]
-    public ?string $origineMission = null;
-
     public ?\DateTimeImmutable $dateMission = null;
 
     #[Assert\Length(max: 50, groups: ['step1'])]
+    public ?string $origineMission = null;
+
+    #[Assert\Length(max: 50, groups: ['step1'])]
     public ?string $ordreMission = null;
+
+    public function __construct()
+    {
+        $this->dateMission = new \DateTimeImmutable();
+    }
 }

--- a/src/Entity/ServiceSecoursRoute.php
+++ b/src/Entity/ServiceSecoursRoute.php
@@ -91,13 +91,6 @@ class ServiceSecoursRoute implements EntityHistoryInterface
         return $this->slug;
     }
 
-    public function setSlug(string $slug): static
-    {
-        $this->slug = $slug;
-
-        return $this;
-    }
-
     public function getEmail(): ?string
     {
         return $this->email;

--- a/src/Entity/ServiceSecoursRoute.php
+++ b/src/Entity/ServiceSecoursRoute.php
@@ -5,9 +5,14 @@ namespace App\Entity;
 use App\Entity\Behaviour\EntityHistoryInterface;
 use App\Entity\Enum\HistoryEntryEvent;
 use App\Repository\ServiceSecoursRouteRepository;
+use App\Validator as AppAssert;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ServiceSecoursRouteRepository::class)]
 #[UniqueEntity('name')]
@@ -22,11 +27,32 @@ class ServiceSecoursRoute implements EntityHistoryInterface
     private ?Uuid $uuid = null;
 
     #[ORM\Column(length: 255, unique: true)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
     private ?string $name = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $slug = null;
+
+    #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    private ?string $email = null;
+
+    #[ORM\Column(length: 20, nullable: true)]
+    #[AppAssert\TelephoneFormat]
+    private ?string $phone = null;
+
+    /**
+     * @var Collection<int, Signalement>
+     */
+    #[ORM\OneToMany(mappedBy: 'serviceSecours', targetEntity: Signalement::class)]
+    private Collection $signalements;
 
     public function __construct()
     {
         $this->uuid = Uuid::v4();
+        $this->signalements = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -54,8 +80,76 @@ class ServiceSecoursRoute implements EntityHistoryInterface
     public function setName(string $name): static
     {
         $this->name = $name;
+        $slugger = new AsciiSlugger();
+        $this->slug = $slugger->slug($name);
 
         return $this;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): static
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): static
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(?string $phone): static
+    {
+        $this->phone = $phone;
+
+        return $this;
+    }
+
+    public function addSignalement(Signalement $signalement): static
+    {
+        if (!$this->signalements->contains($signalement)) {
+            $this->signalements->add($signalement);
+            $signalement->setServiceSecours($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSignalement(Signalement $signalement): static
+    {
+        if ($this->signalements->removeElement($signalement)) {
+            // set the owning side to null (unless already changed)
+            if ($signalement->getServiceSecours() === $this) {
+                $signalement->setServiceSecours(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Signalement>
+     */
+    public function getSignalements(): Collection
+    {
+        return $this->signalements;
     }
 
     /** @return array<HistoryEntryEvent> */

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -533,6 +533,21 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $loginBailleur = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $matriculeDeclarant = null;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $dateMission = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $origineMission = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $ordreMission = null;
+
+    #[ORM\ManyToOne(inversedBy: 'signalements')]
+    private ?ServiceSecoursRoute $serviceSecours = null;
+
     public function __construct()
     {
         $this->criticites = new ArrayCollection();
@@ -2906,5 +2921,65 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         }
 
         return null;
+    }
+
+    public function getMatriculeDeclarant(): ?string
+    {
+        return $this->matriculeDeclarant;
+    }
+
+    public function setMatriculeDeclarant(?string $matriculeDeclarant): static
+    {
+        $this->matriculeDeclarant = $matriculeDeclarant;
+
+        return $this;
+    }
+
+    public function getDateMission(): ?\DateTimeImmutable
+    {
+        return $this->dateMission;
+    }
+
+    public function setDateMission(?\DateTimeImmutable $dateMission): static
+    {
+        $this->dateMission = $dateMission;
+
+        return $this;
+    }
+
+    public function getOrigineMission(): ?string
+    {
+        return $this->origineMission;
+    }
+
+    public function setOrigineMission(?string $origineMission): static
+    {
+        $this->origineMission = $origineMission;
+
+        return $this;
+    }
+
+    public function getOrdreMission(): ?string
+    {
+        return $this->ordreMission;
+    }
+
+    public function setOrdreMission(?string $ordreMission): static
+    {
+        $this->ordreMission = $ordreMission;
+
+        return $this;
+    }
+
+    public function getServiceSecours(): ?ServiceSecoursRoute
+    {
+        return $this->serviceSecours;
+    }
+
+    public function setServiceSecours(?ServiceSecoursRoute $serviceSecours): static
+    {
+        $this->serviceSecours = $serviceSecours;
+
+        return $this;
     }
 }

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -194,6 +194,9 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Column(type: 'string', length: 200, nullable: true)]
     private ?string $structureDeclarant = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $matriculeDeclarant = null;
+
     #[ORM\Column(type: 'string', length: 10, nullable: true)]
     private ?string $civiliteOccupant = null;
 
@@ -533,17 +536,14 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $loginBailleur = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
-    private ?string $matriculeDeclarant = null;
-
     #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
-    private ?\DateTimeImmutable $dateMission = null;
+    private ?\DateTimeImmutable $dateMissionServiceSecours = null;
 
     #[ORM\Column(length: 255, nullable: true)]
-    private ?string $origineMission = null;
+    private ?string $origineMissionServiceSecours = null;
 
     #[ORM\Column(length: 255, nullable: true)]
-    private ?string $ordreMission = null;
+    private ?string $ordreMissionServiceSecours = null;
 
     #[ORM\ManyToOne(inversedBy: 'signalements')]
     private ?ServiceSecoursRoute $serviceSecours = null;
@@ -2935,38 +2935,38 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
         return $this;
     }
 
-    public function getDateMission(): ?\DateTimeImmutable
+    public function getDateMissionServiceSecours(): ?\DateTimeImmutable
     {
-        return $this->dateMission;
+        return $this->dateMissionServiceSecours;
     }
 
-    public function setDateMission(?\DateTimeImmutable $dateMission): static
+    public function setDateMissionServiceSecours(?\DateTimeImmutable $dateMissionServiceSecours): static
     {
-        $this->dateMission = $dateMission;
+        $this->dateMissionServiceSecours = $dateMissionServiceSecours;
 
         return $this;
     }
 
-    public function getOrigineMission(): ?string
+    public function getOrigineMissionServiceSecours(): ?string
     {
-        return $this->origineMission;
+        return $this->origineMissionServiceSecours;
     }
 
-    public function setOrigineMission(?string $origineMission): static
+    public function setOrigineMissionServiceSecours(?string $origineMissionServiceSecours): static
     {
-        $this->origineMission = $origineMission;
+        $this->origineMissionServiceSecours = $origineMissionServiceSecours;
 
         return $this;
     }
 
-    public function getOrdreMission(): ?string
+    public function getOrdreMissionServiceSecours(): ?string
     {
-        return $this->ordreMission;
+        return $this->ordreMissionServiceSecours;
     }
 
-    public function setOrdreMission(?string $ordreMission): static
+    public function setOrdreMissionServiceSecours(?string $ordreMissionServiceSecours): static
     {
-        $this->ordreMission = $ordreMission;
+        $this->ordreMissionServiceSecours = $ordreMissionServiceSecours;
 
         return $this;
     }

--- a/src/Factory/SignalementFactory.php
+++ b/src/Factory/SignalementFactory.php
@@ -19,7 +19,7 @@ class SignalementFactory
         // default data
         $signalement->setProfileDeclarant(ProfileDeclarant::SERVICE_SECOURS);
         $signalement->setIsCguAccepted(true);
-        // TODO : $signalement->setCreationSource(CreationSource::FORM_SERVICE_SECOURS);
+        $signalement->setCreationSource(CreationSource::FORM_SERVICE_SECOURS);
         // data calculated from serviceSecoursRoute
         $signalement->setServiceSecours($serviceSecoursRoute);
         $signalement->setStructureDeclarant($serviceSecoursRoute->getName());

--- a/src/Factory/SignalementFactory.php
+++ b/src/Factory/SignalementFactory.php
@@ -28,9 +28,9 @@ class SignalementFactory
         // data from step1
         $signalement->setMatriculeDeclarant($formServiceSecours->step1->matriculeDeclarant);
         $signalement->setNomDeclarant($formServiceSecours->step1->nomDeclarant);
-        $signalement->setDateMission($formServiceSecours->step1->dateMission);
-        $signalement->setOrigineMission($formServiceSecours->step1->origineMission);
-        $signalement->setOrdreMission($formServiceSecours->step1->ordreMission);
+        $signalement->setDateMissionServiceSecours($formServiceSecours->step1->dateMission);
+        $signalement->setOrigineMissionServiceSecours($formServiceSecours->step1->origineMission);
+        $signalement->setOrdreMissionServiceSecours($formServiceSecours->step1->ordreMission);
 
         // TODO : manage other steps
         //

--- a/src/Factory/SignalementFactory.php
+++ b/src/Factory/SignalementFactory.php
@@ -2,14 +2,42 @@
 
 namespace App\Factory;
 
+use App\Dto\ServiceSecours\FormServiceSecours;
 use App\Entity\Enum\CreationSource;
 use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\ServiceSecoursRoute;
 use App\Entity\Signalement;
 use App\Entity\Territory;
 
 class SignalementFactory
 {
+    public function createInstanceFromFormServiceSecours(FormServiceSecours $formServiceSecours, ServiceSecoursRoute $serviceSecoursRoute): Signalement
+    {
+        $signalement = new Signalement();
+        // default data
+        $signalement->setProfileDeclarant(ProfileDeclarant::SERVICE_SECOURS);
+        $signalement->setIsCguAccepted(true);
+        // TODO : $signalement->setCreationSource(CreationSource::FORM_SERVICE_SECOURS);
+        // data calculated from serviceSecoursRoute
+        $signalement->setServiceSecours($serviceSecoursRoute);
+        $signalement->setStructureDeclarant($serviceSecoursRoute->getName());
+        $signalement->setMailDeclarant($serviceSecoursRoute->getEmail());
+        $signalement->setTelDeclarant($serviceSecoursRoute->getPhone());
+        // data from step1
+        $signalement->setMatriculeDeclarant($formServiceSecours->step1->matriculeDeclarant);
+        $signalement->setNomDeclarant($formServiceSecours->step1->nomDeclarant);
+        $signalement->setDateMission($formServiceSecours->step1->dateMission);
+        $signalement->setOrigineMission($formServiceSecours->step1->origineMission);
+        $signalement->setOrdreMission($formServiceSecours->step1->ordreMission);
+
+        // TODO : manage other steps
+        //
+        //
+        return $signalement;
+    }
+
     /**
      * @param array<string, mixed> $data
      */

--- a/src/Form/SearchServiceSecoursRouteType.php
+++ b/src/Form/SearchServiceSecoursRouteType.php
@@ -19,8 +19,8 @@ class SearchServiceSecoursRouteType extends AbstractType
     {
         $builder->add('queryName', SearchType::class, [
             'required' => false,
-            'label' => 'Nom de l\'événement',
-            'attr' => ['placeholder' => 'Taper une partie du nom de l\'événement'],
+            'label' => 'Nom du service de secours',
+            'attr' => ['placeholder' => 'Taper une partie du nom du service de secours'],
         ]);
         $builder->add('orderType', ChoiceType::class, [
             'choices' => [

--- a/src/Form/ServiceSecours/ServiceSecoursStep1Type.php
+++ b/src/Form/ServiceSecours/ServiceSecoursStep1Type.php
@@ -18,8 +18,8 @@ class ServiceSecoursStep1Type extends AbstractType
             'required' => false,
         ]);
         $builder->add('nomDeclarant', null, ['label' => 'Nom']);
-        $builder->add('origineMission', null, ['label' => 'Engin du BMPM / SDIS à l\'origine du signalement']);
         $builder->add('dateMission', DateType::class, ['label' => 'Date de la mission', 'help' => 'format attendu : JJ/MM/AAAA', 'required' => false]);
+        $builder->add('origineMission', null, ['label' => 'Engin du BMPM / SDIS à l\'origine du signalement']);
         $builder->add('ordreMission', null, ['label' => 'Ordre de mission']);
     }
 

--- a/src/Form/ServiceSecoursRouteType.php
+++ b/src/Form/ServiceSecoursRouteType.php
@@ -11,8 +11,18 @@ class ServiceSecoursRouteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('name', null, [
-            'label' => 'Type de service de secours',
-            'help' => '255 caractères maximum.',
+            'label' => 'Nom du service de secours',
+            'help' => 'Sera enregistré comme structure du déclarant.',
+            'required' => false,
+        ]);
+        $builder->add('email', null, [
+            'label' => 'E-mail du service de secours',
+            'help' => 'Sera enregistré comme e-mail du déclarant.',
+            'required' => false,
+        ]);
+        $builder->add('phone', null, [
+            'label' => 'Téléphone du service de secours',
+            'help' => 'Sera enregistré comme téléphone du déclarant.',
             'required' => false,
         ]);
         $builder->add('submit', SubmitType::class, [

--- a/templates/back/config-service-secours-route/_title-and-table-list-results.html.twig
+++ b/templates/back/config-service-secours-route/_title-and-table-list-results.html.twig
@@ -2,6 +2,7 @@
     {% set tableHead %}
         <th scope="col">ID</th>
         <th scope="col">Nom</th>
+        <th scope="col">E-mail/Téléphone</th>
         <th scope="col">URL</th>
         <th scope="col" class="fr-text--right">Actions</th>
     {% endset %}
@@ -12,7 +13,15 @@
                 <td>{{ serviceSecoursRoute.id }}</td>
                 <td>{{ serviceSecoursRoute.name }}</td>
                 <td>
-                    <a href="{{ path('service_secours_index', {'name': serviceSecoursRoute.name, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)}) }}">{{ serviceSecoursRoute.uuid }}</a>
+                    {{ serviceSecoursRoute.email }}
+                    {% if serviceSecoursRoute.phone %}
+                        <br>{{ serviceSecoursRoute.phone }}
+                    {% endif %}
+                </td>
+                <td>
+                    <a href="{{ path('service_secours_index', {'slug': serviceSecoursRoute.slug, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)}) }}">
+                        {{ url('service_secours_index', {'slug': serviceSecoursRoute.slug, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)}) }}
+                    </a>
                 </td>
                 <td class="fr-text--right">
                     <button class="fr-btn fr-btn--danger fr-btn--sm fr-fi-delete-line fr-mt-3v btn-delete-config-service-secours-route"

--- a/templates/service_secours/_header.html.twig
+++ b/templates/service_secours/_header.html.twig
@@ -5,7 +5,7 @@
                 <div class="fr-header__brand fr-enlarge-link">
                     <div class="fr-header__brand-top">
                         <div class="fr-header__logo">
-                            <a href="{{path('service_secours_index', {'name': serviceSecoursRoute.name, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)})}}" title="Accueil — Ministère de l'Aménagement du territoire et de la Décentralisation">
+                            <a href="{{path('service_secours_index', {'slug': serviceSecoursRoute.slug, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)})}}" title="Accueil — Ministère de l'Aménagement du territoire et de la Décentralisation">
                                 <p class="fr-logo">Ministères<br>aménagement<br>du territoire<br>transition<br>écologique</p>
                             </a>
                         </div>
@@ -14,7 +14,7 @@
                         </div>
                     </div>
                     <div class="fr-header__service">
-                        <a href="{{path('service_secours_index', {'name': serviceSecoursRoute.name, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)})}}" title="Accueil — Lutter contre le mal logement">
+                        <a href="{{path('service_secours_index', {'slug': serviceSecoursRoute.slug, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)})}}" title="Accueil — Lutter contre le mal logement">
                             <p class="fr-header__service-title">
                                 Lutter contre le mal logement
                             </p>

--- a/templates/service_secours/base.html.twig
+++ b/templates/service_secours/base.html.twig
@@ -9,7 +9,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('service-secours/apple-touch-icon.png') }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('service-secours/favicon-32x32.png') }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('service-secours/favicon-16x16.png') }}">
-    <link rel="manifest" href="{{ path('service_secours_webmanifest', {'name': serviceSecoursRoute.name, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)}) }}">
+    <link rel="manifest" href="{{ path('service_secours_webmanifest', {'slug': serviceSecoursRoute.slug, 'uuid': serviceSecoursRoute.uuid, 'domain': root_domain(app.request.host)}) }}">
 
     <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}">
     <link rel="stylesheet" href={{ asset('build/app.css') }}>

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -48,8 +48,8 @@
                 {% if current_step == 'step1' %}
                     {{ form_row(form.step1.matriculeDeclarant) }}
                     {{ form_row(form.step1.nomDeclarant) }}
-                    {{ form_row(form.step1.origineMission) }}
                     {{ form_row(form.step1.dateMission) }}
+                    {{ form_row(form.step1.origineMission) }}
                     {{ form_row(form.step1.ordreMission) }}
                 {% elseif current_step == 'step2' %}
                     {{ form_row(form.step2.adresseComplete) }}

--- a/templates/service_secours/success.html.twig
+++ b/templates/service_secours/success.html.twig
@@ -6,7 +6,11 @@
             <div class="fr-mt-5v fr-col-md-12">
                 <h1>Le signalement a bien été enregistré !</h1>
                 <p>Le signalement a bien été enregistré sous le numéro : #TODO</p>
+<<<<<<< HEAD
                 <p>Il va automatiquement être transmis au pôle départemental de lutte contre l'habitat indigne.</p>
+=======
+                <p>Il va automatiquement être transmis au pôle départemental de lutte contre l'habitat indigne (DDTM13).</p>
+>>>>>>> 9f78a2912 (implement multi-step form for service secours #5396)
             </div>
         </section>
     </main>

--- a/templates/service_secours/success.html.twig
+++ b/templates/service_secours/success.html.twig
@@ -6,11 +6,7 @@
             <div class="fr-mt-5v fr-col-md-12">
                 <h1>Le signalement a bien été enregistré !</h1>
                 <p>Le signalement a bien été enregistré sous le numéro : #TODO</p>
-<<<<<<< HEAD
                 <p>Il va automatiquement être transmis au pôle départemental de lutte contre l'habitat indigne.</p>
-=======
-                <p>Il va automatiquement être transmis au pôle départemental de lutte contre l'habitat indigne (DDTM13).</p>
->>>>>>> 9f78a2912 (implement multi-step form for service secours #5396)
             </div>
         </section>
     </main>

--- a/tests/Functional/Controller/Back/ConfigServiceSecoursControllerTest.php
+++ b/tests/Functional/Controller/Back/ConfigServiceSecoursControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Functional\Controller\Back;
 
+use App\Repository\ServiceSecoursRouteRepository;
 use App\Repository\UserRepository;
 use App\Tests\SessionHelper;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -64,7 +65,9 @@ class ConfigServiceSecoursControllerTest extends WebTestCase
         $csrfToken = $this->generateCsrfToken($client, 'service_secours_route');
         $client->request('POST', $route, [
             'service_secours_route' => [
-                'name' => 'TI-DU-DUT',
+                'name' => 'TI DU DUT',
+                'email' => 'ti-du-dut@example.com',
+                'phone' => '',
                 '_token' => $csrfToken,
             ],
         ]);
@@ -72,5 +75,13 @@ class ConfigServiceSecoursControllerTest extends WebTestCase
         $this->assertResponseRedirects();
         $client->followRedirect();
         $this->assertSelectorTextContains('h2#desc-table', '3 services secours trouvés');
+
+        $serviceSecourRouteRepository = static::getContainer()->get(ServiceSecoursRouteRepository::class);
+        $serviceSecoursRoute = $serviceSecourRouteRepository->findOneBy(['name' => 'TI DU DUT']);
+        $this->assertNotNull($serviceSecoursRoute);
+        $this->assertSame('TI DU DUT', $serviceSecoursRoute->getName());
+        $this->assertSame('TI-DU-DUT', $serviceSecoursRoute->getSlug());
+        $this->assertSame('ti-du-dut@example.com', $serviceSecoursRoute->getEmail());
+        $this->assertNull($serviceSecoursRoute->getPhone());
     }
 }

--- a/tests/Functional/Controller/ServiceSecoursControllerTest.php
+++ b/tests/Functional/Controller/ServiceSecoursControllerTest.php
@@ -22,7 +22,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         foreach ($routes as $route) {
             // OK
             $url = $router->generate('service_secours_index', [
-                'name' => $route->getName(),
+                'slug' => $route->getSlug(),
                 'uuid' => $route->getUuid(),
                 'domain' => 'localhost',
             ]);
@@ -30,7 +30,7 @@ class ServiceSecoursControllerTest extends WebTestCase
             $this->assertResponseIsSuccessful();
 
             $manifestUrl = $router->generate('service_secours_webmanifest', [
-                'name' => $route->getName(),
+                'slug' => $route->getSlug(),
                 'uuid' => $route->getUuid(),
                 'domain' => 'localhost',
             ]);
@@ -42,7 +42,7 @@ class ServiceSecoursControllerTest extends WebTestCase
             $this->assertJson($content);
             // KO
             $url = $router->generate('service_secours_index', [
-                'name' => $route->getName().'1',
+                'slug' => $route->getSlug().'1',
                 'uuid' => $route->getUuid(),
                 'domain' => 'localhost',
             ]);
@@ -50,7 +50,7 @@ class ServiceSecoursControllerTest extends WebTestCase
             $this->assertResponseStatusCodeSame(404);
 
             $url = $router->generate('service_secours_index', [
-                'name' => $route->getName(),
+                'slug' => $route->getSlug(),
                 'uuid' => $route->getUuid().'1',
                 'domain' => 'localhost',
             ]);


### PR DESCRIPTION
## Ticket

#5440

## Description
Finalisation de l'étape 1 du formulaire service secours 
Selon : 
- [maquette](https://xd.adobe.com/view/863726a7-1019-4e04-aeba-0599f378c8ee-d364/screen/920293d8-454e-4118-b1f6-86bec378205f/)
- [Fichier](https://docs.google.com/spreadsheets/d/19ZORZSACPDRojyRFFTSVaH7UemMC8YnX573wcoxzxH0/edit?gid=0#gid=0)

## Changements apportés
* Ajout de champs dans la table `signalement`
* Ajout de champ dans la table `service_secours_route` (pour completer automatiquement les valeur `structure_declarant`, `mail_declarant`, `tel_declarant`)
* Modification de la configuration des routes service secours
* Ajout de contrainte
* Création d'une fonction permettant de créer une signalement à partir des donnée soumise par le formulaire multi step

## Pré-requis
`make execute-migration name=Version20260217141902 direction=up`
`make load-data`

## Tests
- [ ] Compléter le formulaire et vérifier que les information de l'étape 1 sont bien enregistré dans l'object signalement (décommenté le //dump($signalement) pour cela.
