### PR TITLE
[FO] Amélioration création de suivi lors des éditions

### DIFF
--- a/src/Form/SignalementeEditFO/CoordonneesAgenceType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesAgenceType.php
@@ -67,7 +67,6 @@ class CoordonneesAgenceType extends AbstractType
                     'class' => 'manual-address manual-address-input',
                     'data-autocomplete-addresse-agence' => 'true',
                 ],
-                'empty_data' => '',
             ])
             ->add('codePostalAgence', null, [
                 'label' => 'Code postal',
@@ -76,7 +75,6 @@ class CoordonneesAgenceType extends AbstractType
                     'class' => 'manual-address',
                     'data-autocomplete-codepostal-agence' => 'true',
                 ],
-                'empty_data' => '',
             ])
             ->add('villeAgence', null, [
                 'label' => 'Ville',
@@ -85,7 +83,6 @@ class CoordonneesAgenceType extends AbstractType
                     'class' => 'manual-address',
                     'data-autocomplete-ville-agence' => 'true',
                 ],
-                'empty_data' => '',
             ])
             ->add('save', SubmitType::class, [
                 'label' => 'Envoyer',

--- a/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
@@ -52,7 +52,6 @@ class CoordonneesBailleurType extends AbstractType
                         'class' => 'manual-address manual-address-input',
                         'data-autocomplete-addresse-proprio' => 'true',
                     ],
-                    'empty_data' => '',
                 ])
                 ->add('codePostalProprio', null, [
                     'label' => 'Code postal',
@@ -61,7 +60,6 @@ class CoordonneesBailleurType extends AbstractType
                         'class' => 'manual-address',
                         'data-autocomplete-codepostal-proprio' => 'true',
                     ],
-                    'empty_data' => '',
                 ])
                 ->add('villeProprio', null, [
                     'label' => 'Ville',
@@ -70,7 +68,6 @@ class CoordonneesBailleurType extends AbstractType
                         'class' => 'manual-address',
                         'data-autocomplete-ville-proprio' => 'true',
                     ],
-                    'empty_data' => '',
                 ])
                 ->add('telProprio', TextType::class, [
                     'label' => 'Téléphone principal',

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -348,10 +348,14 @@ class SuiviManager extends Manager
         $description .= '<ul>';
 
         foreach ($sectionChanges['fieldChanges'] as $change) {
+            $new = $change['new'];
+            if (null === $new || '' === $new) {
+                $new = '<i>(valeur supprimée)</i>';
+            }
             $description .= sprintf(
                 '<li>%s : %s</li>',
                 $change['label'],
-                $change['new'] ?? '-'
+                $new
             );
         }
 


### PR DESCRIPTION
## Ticket

#5459    

## Description
Les champs adresses possède une option empty_data à vide 
C'est la raison pour la quelle pour un formulaire vide, il détecte une modification car null est stocké en base

Amélioration UI pour la suppression 
<img width="728" height="217" alt="image" src="https://github.com/user-attachments/assets/1db99374-de9e-4cae-b3bb-676285323745" />


## Changements apportés
* Suppression de l'option dans les deux formulaires
* Ajout de la mention valeur supprimé au lieu de chaine vide 

## Pré-requis

## Tests
- [ ] Soumettre un formulaire vide d'agence vérifier qu'aucun suivi n'est crée
- [ ] Supprimer une adresse, vérifier que la mention de suppression sur les champs d'adresses y figure.

