### PR TITLE
[BO - Interconnexion] ARS - Proposer date de reaffectation sur la note de suivi d'un signalement refusé

### DIFF
--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -90,6 +90,10 @@ class EsaboraManager
         }
     }
 
+    /**
+     * @throws \DateInvalidTimeZoneException
+     * @throws \DateMalformedStringException
+     */
     public function updateStatusFor(
         Affectation $affectation,
         User $user,
@@ -142,7 +146,16 @@ class EsaboraManager
                         dispatchAffectationAnsweredEvent: false
                     );
                     if ($this->featureSishRepushMessage) {
-                        $note = '<i>NOTE : vous pourrez, si besoin, renvoyer ce signalement après mise à jour dans les 24 heures</i>';
+                        $timezone = new \DateTimeZone($affectation->getSignalement()->getTimezone());
+                        $dateReaffectation = (new \DateTimeImmutable('now', $timezone))
+                            ->modify('+1 day')
+                            ->format('d/m/Y');
+
+                        $note = \sprintf(
+                            '<i>NOTE : vous pourrez, si besoin, réaffecter ce signalement à partir du : %s</i>',
+                            $dateReaffectation
+                        );
+
                         $description = \sprintf(
                             'refusé via '.$dossierResponse->getNameSI().' pour motif suivant : %s<br>%s',
                             $dossierResponse->getSasCauseRefus(),


### PR DESCRIPTION
## Ticket

#5464   

## Description
Suite aux échanges de mail du jour, mettre à jour le message de suivi


## Changements apportés
* Mise à jour de la note avec la date 

## Pré-requis
Ajouter la var d'env
```
FEATURE_SISH_REPUSH_MESSAGE=1  
```

## Tests
- [ ] Executer make sync-sish
- [ ] Vérifier que que le signalement http://localhost:8080/bo/signalements/00000000-0000-0000-2023-000000000013 possède la note en tant que dossier refusé sur une affectation ARS
- [ ] Repasser la var d'env à 0 puis `make create-db && make sync-sish`, la note ne doit pas s'afficher. 
