### PR TITLE
[FO] Suivi des modifications prises en compte des champs JSON

### DIFF
--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -4,6 +4,8 @@ namespace App\EventListener;
 
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Service\History\EntityComparator;
+use App\Utils\DictionaryProvider;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Events;
@@ -14,7 +16,13 @@ class SignalementUpdatedListener
 {
     public const string EDIT_COORDONNEES_BAILLEUR = 'coordonnees_bailleur';
     public const string EDIT_COORDONNEES_AGENCE = 'coordonnees_agence';
+    public const string EDIT_INFORMATIONS_ASSURANCE = 'informations_assurance';
 
+    /**
+     * Définition des champs suivis.
+     * - Champs simples : "field" => "label"
+     * - Champs JSON : "<jsonField>.<jsonProperty>" => "label".
+     */
     public const array EDIT_SECTIONS = [
         self::EDIT_COORDONNEES_BAILLEUR => [
             'label' => 'Les coordonnées du bailleur',
@@ -43,12 +51,32 @@ class SignalementUpdatedListener
                 'villeAgence' => 'Ville',
             ],
         ],
+        self::EDIT_INFORMATIONS_ASSURANCE => [
+            'label' => 'Les informations d\'assurance',
+            'fields' => [
+                'informationProcedure.info_procedure_reponse_assurance' => 'Réponse de l\'assurance',
+                'informationProcedure.info_procedure_assurance_contactee' => 'Assurance contactée',
+            ],
+        ],
     ];
 
-    public function __construct(private readonly Security $security)
-    {
+    private const array JSON_FIELDS = [
+        'typeCompositionLogement',
+        'situationFoyer',
+        'informationProcedure',
+        'informationComplementaire',
+    ];
+
+    public function __construct(
+        private readonly Security $security,
+        private readonly EntityComparator $entityComparator,
+        private readonly DictionaryProvider $dictionaryProvider,
+    ) {
     }
 
+    /**
+     * @throws \ReflectionException
+     */
     public function preUpdate(Signalement $signalement, PreUpdateEventArgs $event): void
     {
         // On continue de flagger qu'un changement est détecté.
@@ -63,21 +91,53 @@ class SignalementUpdatedListener
         foreach (self::EDIT_SECTIONS as $sectionKey => $sectionDefinition) {
             $fieldChanges = [];
 
-            foreach ($sectionDefinition['fields'] as $fieldName => $label) {
-                if (!$event->hasChangedField($fieldName)) {
+            foreach ($sectionDefinition['fields'] as $field => $label) {
+                if (!str_contains($field, '.')) {
+                    if (!$event->hasChangedField($field)) {
+                        continue;
+                    }
+
+                    $old = $event->getOldValue($field);
+                    $new = $event->getNewValue($field);
+
+                    if ($old === $new) {
+                        continue;
+                    }
+
+                    $fieldChanges[$field] = [
+                        'label' => $label,
+                        'new' => $new,
+                    ];
+
                     continue;
                 }
 
-                $old = $event->getOldValue($fieldName);
-                $new = $event->getNewValue($fieldName);
-
-                if ($old === $new) {
+                $parsed = $this->parseJsonPath($field); // ex: information_procedure.info_procedure_assurance_contactee
+                if (null === $parsed) {
                     continue;
                 }
 
-                $fieldChanges[$fieldName] = [
+                $jsonField = $parsed['jsonField']; // ex: information_procedure
+                $jsonProperty = $parsed['jsonProperty'];   // ex: info_procedure_assurance_contactee
+
+                if (!$event->hasChangedField($jsonField)) {
+                    continue;
+                }
+
+                $oldValue = $this->entityComparator->processValue($event->getOldValue($jsonField) ?? []);
+                $newValue = $this->entityComparator->processValue($event->getNewValue($jsonField) ?? []);
+                $fieldsChanges = $this->entityComparator->compareValues($oldValue, $newValue, $jsonField);
+
+                // la propriété déclarée n'a pas changé
+                if (!array_key_exists($jsonProperty, $fieldsChanges)
+                    || empty($diffProperty = $fieldsChanges[$jsonProperty])
+                ) {
+                    continue;
+                }
+
+                $fieldChanges[$field] = [
                     'label' => $label,
-                    'new' => $new,
+                    'new' => $diffProperty['new'] ? $this->dictionaryProvider->translate($diffProperty['new']) : null,
                 ];
             }
 
@@ -90,6 +150,35 @@ class SignalementUpdatedListener
         }
 
         $signalement->registerChanges($changes);
+    }
+
+    /**
+     * Parse "<jsonField>.<jsonProperty>".
+     *
+     * @return array{jsonField:string,jsonProperty:string}|null
+     */
+    private function parseJsonPath(string $path): ?array
+    {
+        $parts = explode('.', $path, 2);
+
+        if (2 !== count($parts)) {
+            return null;
+        }
+
+        [$jsonField, $jsonProperty] = $parts;
+
+        if (!in_array($jsonField, self::JSON_FIELDS, true)) {
+            return null;
+        }
+
+        if ('' === $jsonProperty) {
+            return null;
+        }
+
+        return [
+            'jsonField' => $jsonField,
+            'jsonProperty' => $jsonProperty,
+        ];
     }
 
     private function supports(): bool

--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -343,7 +343,7 @@ class SuiviManager extends Manager
         $description = sprintf(
             '%s ont été modifiées par %s.',
             $sectionChanges['label'],
-            $user->getNomComplet(true),
+            htmlentities($user->getNomComplet(true)),
         );
         $description .= '<ul>';
 
@@ -351,7 +351,7 @@ class SuiviManager extends Manager
             $description .= sprintf(
                 '<li>%s : %s</li>',
                 $change['label'],
-                $change['new'] ?? '-'
+                nl2br(htmlentities($change['new'] ?? '-'))
             );
         }
 

--- a/src/Utils/DictionaryProvider.php
+++ b/src/Utils/DictionaryProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Utils;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+readonly class DictionaryProvider
+{
+    public function __construct(
+        #[Autowire('%kernel.project_dir%')]
+        private string $projectDir,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function all(): array
+    {
+        $path = $this->projectDir.'/assets/json/Signalement/dictionary.json';
+
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($path), true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    public function translate(string $slug, string $context = 'default'): string
+    {
+        $dict = $this->all();
+
+        if (!isset($dict[$slug])) {
+            return $slug;
+        }
+
+        if (isset($dict[$slug]['default']) && is_string($dict[$slug]['default']) && 'default' === $context) {
+            return $dict[$slug]['default'];
+        }
+
+        if (isset($dict[$slug][$context]['default']) && is_string($dict[$slug][$context]['default'])) {
+            return $dict[$slug][$context]['default'];
+        }
+
+        if (isset($dict[$slug]['default']) && is_string($dict[$slug]['default'])) {
+            return $dict[$slug]['default'];
+        }
+
+        return $slug;
+    }
+}

--- a/src/Utils/DictionaryProvider.php
+++ b/src/Utils/DictionaryProvider.php
@@ -19,7 +19,7 @@ class DictionaryProvider
      */
     public function all(): array
     {
-        $path = $this->projectDir.'/assets/json/Signalement/dictionary.json';
+        $path = $this->projectDir.'/public/build/json/Signalement/dictionary.json';
 
         if (!is_file($path)) {
             return [];

--- a/src/Utils/DictionaryProvider.php
+++ b/src/Utils/DictionaryProvider.php
@@ -4,8 +4,10 @@ namespace App\Utils;
 
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-readonly class DictionaryProvider
+class DictionaryProvider
 {
+    private ?array $dictionary = null;
+
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
@@ -30,7 +32,10 @@ readonly class DictionaryProvider
 
     public function translate(string $slug, string $context = 'default'): string
     {
-        $dict = $this->all();
+        if (null === $this->dictionary) {
+            $this->dictionary = $this->all();
+        }
+        $dict = $this->dictionary;
 
         if (!isset($dict[$slug])) {
             return $slug;

--- a/tests/Unit/Utils/DictionaryProviderTest.php
+++ b/tests/Unit/Utils/DictionaryProviderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Unit\Utils;
+
+use App\Utils\DictionaryProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DictionaryProviderTest extends TestCase
+{
+    public function testAllLoadsDictionaryFromAssets(): void
+    {
+        $projectDir = \dirname(__DIR__, 3);
+        $provider = new DictionaryProvider($projectDir);
+
+        $dict = $provider->all();
+
+        $this->assertIsArray($dict);
+        $this->assertNotEmpty($dict);
+        $this->assertArrayHasKey('oui', $dict);
+        $this->assertSame('OUI', $dict['oui']['default'] ?? null);
+    }
+
+    public function testTranslateReturnsKnownSlug(): void
+    {
+        $projectDir = \dirname(__DIR__, 3);
+        $provider = new DictionaryProvider($projectDir);
+
+        $this->assertSame('OUI', $provider->translate('oui'));
+        $this->assertSame('NON', $provider->translate('non'));
+        $this->assertSame('Je ne sais pas', $provider->translate('nsp'));
+        $this->assertSame('N\'a pas d\'assurance logement', $provider->translate('pas_assurance_logement'));
+    }
+}


### PR DESCRIPTION
## Ticket

#5463   

## Description
Mise à jour du `SignalementListener` afin de pouvoir traiter les différence sur des champs JSON


## Changements apportés
* Usage du service `EntityComparator` pour traitement json
* Ajout d'un service du dictionnaire (celui utilisé pour le front)

## Pré-requis

## Tests
- [ ] Faire des éditions sur le bloc assurance
- [ ] TNR sur les autres bloc 
