### PR TITLE
[API] Liste signalement - Ajoute filtre code insee 

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -3,6 +3,13 @@ nelmio_api_doc:
         info:
             title: '%platform_name%'
             description:  |
+             ## CHANGELOG 1.3.1 - 2026-02
+             Cette version introduit un nouveau filtre pour la liste des signalements.
+             ### AJOUTS
+             - Ajout du filtre `codeInsee` sur `GET /api/signalements`.
+             
+             *Exemple*
+             `GET /api/signalements?codeInsee=13201`
              ## CHANGELOG 1.3.0 - 2026-01
              Cette version introduit un nouvel endpoint permettant la création de signalement.
              ### AJOUTS
@@ -224,7 +231,7 @@ nelmio_api_doc:
                 | 404  | Not Found             | La ressource est introuvable                                                         |
                 | 500  | Internal Server Error | Une erreur serveur s'est produite (l'équipe technique est notifiée automatiquement)  |
 
-            version: 1.3.0
+            version: 1.3.1
         components:
             securitySchemes:
                 Bearer:

--- a/src/Dto/Api/Request/SignalementListQueryParams.php
+++ b/src/Dto/Api/Request/SignalementListQueryParams.php
@@ -56,6 +56,18 @@ readonly class SignalementListQueryParams implements RequestInterface
             nullable: true
         )]
         public ?string $dateAffectationFin = null,
+
+        #[Assert\Length(
+            min: 5,
+            max: 5,
+            exactMessage: 'Le code INSEE doit contenir 5 caractères (exemple: 13201).'
+        )]
+        #[OA\Property(
+            description: 'Code INSEE de la commune (5 chiffres) pour filtrer les signalements.',
+            example: '13201',
+            nullable: true
+        )]
+        public ?int $codeInsee = null,
     ) {
     }
 }

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1268,6 +1268,11 @@ class SignalementRepository extends ServiceEntityRepository
                 ->setParameter('dateAffectationEnd', $dateAffectationEnd);
         }
 
+        if (!empty($signalementListQueryParams->codeInsee)) {
+            $qb->andWhere('s.inseeOccupant = :codeInsee')
+                ->setParameter('codeInsee', $signalementListQueryParams->codeInsee);
+        }
+
         $qb->orderBy('s.createdAt', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit);

--- a/tests/Functional/Controller/Api/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementListControllerTest.php
@@ -56,19 +56,31 @@ class SignalementListControllerTest extends WebTestCase
         $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
     }
 
-    public function testGetSignalementListWithLimit(): void
+    /**
+     * @dataProvider provideGoodQueryParameters
+     */
+    public function testGetSignalementListWithFilters(array $queryParameters, int $count): void
     {
         $client = static::createClient();
         $user = self::getContainer()->get('doctrine')->getRepository(User::class)->findOneBy([
             'email' => 'api-01@signal-logement.fr',
         ]);
+
         $client->loginUser($user, 'api');
-        $client->request('GET', '/api/signalements?limit=2');
+        $client->request('GET', '/api/signalements?'.http_build_query($queryParameters));
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
         $response = json_decode((string) $client->getResponse()->getContent(), true);
-        $this->assertCount(2, $response);
+        $this->assertCount($count, $response);
+
         $this->hasXrequestIdHeaderAndOneApiRequestLog($client);
+    }
+
+    public static function provideGoodQueryParameters(): iterable
+    {
+        yield 'limit=2' => [['limit' => 2], 2];
+        yield 'codeInsee=13213' => [['codeInsee' => 13213], 2];
+        yield 'codeInsee=13203' => [['codeInsee' => 13203], 7];
     }
 
     /**
@@ -142,6 +154,9 @@ class SignalementListControllerTest extends WebTestCase
                 'dateAffectationFin' => 'friend',
             ],
             6,
+        ];
+        yield 'Wrong code insee' => [
+            ['codeInsee' => '1234567890'], 1,
         ];
     }
 


### PR DESCRIPTION
## Ticket

#5467   

## Description
Ajout nouveau filtre code insee sur la route d'api GET `/api/signalements`

<img width="934" height="193" alt="image" src="https://github.com/user-attachments/assets/fb8889a2-2df7-4ac4-80bd-7ad9a54a67f5" />


## Changements apportés
* Ajout nouveau filtre code insee sur le endpoint api 

## Pré-requis

## Tests
- [ ] Se connecter en tant user api et filtrer sur un `codeInsee`
