### PR TITLE
[BO - Form Pro] Filtre partenaires affectables périmètre

### DIFF
--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -437,7 +437,9 @@ class SignalementCreateController extends AbstractController
         $partners = [];
         $assignablePartners = $autoAssigner->assign($signalement, true);
         if (!count($assignablePartners)) {
-            $partners = $partnerRepository->findAllList($signalement->getTerritory());
+            $partners = $signalementManager->findAffectablePartners(
+                signalement: $signalement
+            )['not_affected'];
         }
 
         $acceptSignalementForm = null;
@@ -493,8 +495,9 @@ class SignalementCreateController extends AbstractController
             } elseif ($this->isGranted('ROLE_ADMIN_TERRITORY') && !empty($partnerIds)) {
                 $partnersList = explode(',', (string) $partnerIds);
                 foreach ($partnersList as $partnerId) {
-                    if (isset($partners[$partnerId])) {
-                        $affectation = $affectationManager->createAffectation($signalement, $partners[$partnerId], $user);
+                    if (in_array((int) $partnerId, array_column($partners, 'id'))) {
+                        $partner = $partnerRepository->find((int) $partnerId);
+                        $affectation = $affectationManager->createAffectation($signalement, $partner, $user);
                         $signalement->addAffectation($affectation);
                     }
                 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -560,6 +560,9 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
 
     public function getNomComplet(bool $firstNameFirst = false): string
     {
+        if (null === $this->nom && null === $this->prenom && $this->isApiUser()) {
+            return 'Utilisateur API';
+        }
         if ($firstNameFirst) {
             return ucfirst($this->prenom ?? '').' '.mb_strtoupper($this->nom ?? '');
         }
@@ -806,11 +809,6 @@ class User implements UserInterface, EntityHistoryInterface, PasswordAuthenticat
         $this->isActivateAccountNotificationEnabled = $isActivateAccountNotificationEnabled;
 
         return $this;
-    }
-
-    public function getFullname(): string
-    {
-        return $this->prenom.' '.$this->nom;
     }
 
     /** @return Collection<int, SignalementUsager> */

--- a/src/Manager/HistoryEntryManager.php
+++ b/src/Manager/HistoryEntryManager.php
@@ -159,7 +159,7 @@ class HistoryEntryManager extends AbstractManager
     {
         /** @var HistoryEntry $entry */
         foreach ($entries as $entry) {
-            $userName = $entry->getUser() ? $entry->getUser()->getFullName() : 'Système (automatique)';
+            $userName = $entry->getUser() ? $entry->getUser()->getNomComplet(true) : 'Système (automatique)';
             if ('affectation' === $type || 'subscription' === $type) {
                 $partner = $entry->getUser()?->getPartnerInTerritoryOrFirstOne($entry->getSignalement()->getTerritory());
             } else {

--- a/templates/back/admin-territory-files/_table-list-results.html.twig
+++ b/templates/back/admin-territory-files/_table-list-results.html.twig
@@ -43,7 +43,7 @@
                     aria-controls="fr-modal-document-view"
                     data-url="{{ path('back_territory_management_document_edit', { file: file.id }) }}"
                     data-createdat="{{ file.createdAt|date('d/m/Y') }}"
-                    data-createdby="{{ file.uploadedBy ? file.uploadedBy.fullName : 'Admin' }}"
+                    data-createdby="{{ file.uploadedBy ? file.uploadedBy.nomComplet(true) : 'Admin' }}"
                     data-title="{{ file.title }}"
                     data-description="{{ file.description ?? '/' }}"
                     data-partnertype="Type de partenaire :

--- a/templates/back/history-entry/details.html.twig
+++ b/templates/back/history-entry/details.html.twig
@@ -48,7 +48,7 @@
                         {% if entry.user %}
                             {{ entry.user.email }}
                             <br>
-                            {{ entry.user.fullName }}
+                            {{ entry.user.nomComplet(true) }}
                             <br>
                             Id {{entry.user.id}}
                         {% endif %}

--- a/templates/back/signalement_create/tabs/tab-validation.html.twig
+++ b/templates/back/signalement_create/tabs/tab-validation.html.twig
@@ -131,8 +131,8 @@
                     {% for item in partners %}
                         <span
                             class="fr-badge fr-m-1v search-and-select-badge-add search-and-select-badge-add-{{ item.id }}"
-                            data-badge-id="{{ item.id }}" data-badge-label="{{ item.nom }}"
-                            >{{ item.nom }} <span class="fr-icon-add-line" aria-hidden="true"></span></span>
+                            data-badge-id="{{ item.id }}" data-badge-label="{{ item.name }}"
+                            >{{ item.name }} <span class="fr-icon-add-line" aria-hidden="true"></span></span>
                     {% endfor %}
                 </div>
             </div>

--- a/tests/Functional/Manager/HistoryEntryManagerTest.php
+++ b/tests/Functional/Manager/HistoryEntryManagerTest.php
@@ -98,7 +98,7 @@ class HistoryEntryManagerTest extends WebTestCase
         $this->assertInstanceOf(HistoryEntry::class, $historyEntry);
         $this->assertEquals(HistoryEntryEvent::CREATE, $historyEntry->getEvent());
         $this->assertEquals($affectation->getId(), $historyEntry->getEntityId());
-        $this->assertEquals($affectation->getAffectedBy()->getFullname(), $historyEntry->getUser()->getFullName());
+        $this->assertEquals($affectation->getAffectedBy()->getNomComplet(true), $historyEntry->getUser()->getNomComplet(true));
     }
 
     public function testUpdateAffectationHistoryEntry(): void


### PR DESCRIPTION
## Ticket

#5457   

## Description
Sur un signalement dans la commune Sus-St-Léger, dans le 62, nous avons le partenaire "Beaudricourt" affecté.
Pourtant le périmètre de ce partenaire n'est normalement que la commune Beaudricourt.
Comment la RT a pu l'affecter à ce signalement ? D'autant plus que quand on rouvre la modale d'affectation, on ne voit ce partenaire ni dans la liste des partenaires affectés, ni dans la liste des partenaires affectables.

L'utilisateur API ayant des permissions sur le partenaire Beaudricourt, il a pu créer des suivis sur ce signalement.

De plus, on voit que l'affectation a sans doute été acceptée via API et que ça créé un souci d'affichage qu'il faut corriger

## Changements apportés
* UTilisation de la même requête que sur la fiche signalement dans le form Pro pour trouver les partenaires affectables
* On met "Utilisateur API" dans le getNomComplet() d'un User si pas de prénom/nom et rôle API (pour affichage dans le fiche signalement)

## Pré-requis
Se mettre sur une base de prod

## Tests
- [ ] Créer un signalement via le formPro, et vérifier que les partenaires sont bien filtrés par périmètre (on n'a pas toutes les communes). Affecter quelques partenaires, valider le signalement, et vérifier dans la fiche signalement qu'ils sont bien affectés
- [ ] Aller sur un signalement avec une affectation acceptée par API, vérifier l'affichage dans la fiche signalement et dans l'historique des affectations
