### PR TITLE
[QA - Sentry]Doctrine\ORM\NonUniqueResultException

### DIFF
--- a/src/Controller/Webhook/BrevoWebhookController.php
+++ b/src/Controller/Webhook/BrevoWebhookController.php
@@ -111,14 +111,11 @@ class BrevoWebhookController extends AbstractController
         $emailPrefix = explode($pattern, $email)[0];
 
         $countUser = (int) $userRepository->createQueryBuilder('u')
-    ->select('COUNT(u.id)')
-    ->where('u.email LIKE :emailPrefix')
-    ->setParameter('emailPrefix', $emailPrefix.'%')
-    ->getQuery()
-    ->getSingleScalarResult();
-
-
-
+            ->select('COUNT(u.id)')
+            ->where('u.email LIKE :emailPrefix')
+            ->setParameter('emailPrefix', $emailPrefix.'%')
+            ->getQuery()
+            ->getSingleScalarResult();
 
         if ($countUser > 0) {
             return true;

--- a/src/Controller/Webhook/BrevoWebhookController.php
+++ b/src/Controller/Webhook/BrevoWebhookController.php
@@ -110,23 +110,28 @@ class BrevoWebhookController extends AbstractController
         $pattern = User::SUFFIXE_ARCHIVED;
         $emailPrefix = explode($pattern, $email)[0];
 
-        $user = $userRepository->createQueryBuilder('u')
-            ->where('u.email LIKE :emailPrefix')
-            ->setParameter('emailPrefix', $emailPrefix.'%')
-            ->getQuery()
-            ->getOneOrNullResult();
+        $countUser = (int) $userRepository->createQueryBuilder('u')
+    ->select('COUNT(u.id)')
+    ->where('u.email LIKE :emailPrefix')
+    ->setParameter('emailPrefix', $emailPrefix.'%')
+    ->getQuery()
+    ->getSingleScalarResult();
 
-        if ($user) {
+
+
+
+        if ($countUser > 0) {
             return true;
         }
 
-        $partner = $partnerRepository->createQueryBuilder('p')
+        $countPartner = (int) $partnerRepository->createQueryBuilder('p')
+            ->select('COUNT(p.id)')
             ->where('p.email LIKE :emailPrefix')
             ->setParameter('emailPrefix', $emailPrefix.'%')
             ->getQuery()
-            ->getOneOrNullResult();
+            ->getSingleScalarResult();
 
-        if ($partner) {
+        if ($countPartner > 0) {
             return true;
         }
 

--- a/tests/Functional/Controller/Webhook/BrevoWebhookControllerTest.php
+++ b/tests/Functional/Controller/Webhook/BrevoWebhookControllerTest.php
@@ -2,7 +2,10 @@
 
 namespace App\Tests\Functional\Controller\Webhook;
 
+use App\Entity\Enum\UserStatus;
+use App\Entity\User;
 use App\Repository\EmailDeliveryIssueRepository;
+use App\Service\Sanitizer;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -180,5 +183,59 @@ class BrevoWebhookControllerTest extends WebTestCase
             'expectDeliveryIssue' => false,
             'expectedPayload' => null,
         ];
+    }
+
+    public function testArchivedUsersWithSameEmailPrefixCreatesDeliveryIssue(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
+
+        $emailBase = 'duplicate@test.com';
+
+        $user1 = (new User())
+            ->setRoles([User::ROLE_USER_PARTNER])
+            ->setNom('User 1')
+            ->setPrenom('Test')
+            ->setEmail(Sanitizer::tagArchivedEmail($emailBase))
+            ->setStatut(UserStatus::ARCHIVE)
+            ->setIsMailingActive(false);
+
+        $user2 = (new User())
+            ->setRoles([User::ROLE_USER_PARTNER])
+            ->setNom('User 2')
+            ->setPrenom('Test')
+            ->setEmail(Sanitizer::tagArchivedEmail($emailBase).'9')
+            ->setStatut(UserStatus::ARCHIVE)
+            ->setIsMailingActive(false);
+
+        $em->persist($user1);
+        $em->persist($user2);
+        $em->flush();
+
+        $payload = [
+            'event' => 'hard_bounce',
+            'email' => $emailBase,
+        ];
+
+        $client->request(
+            'POST',
+            '/webhook/brevo',
+            [],
+            [],
+            [
+                'REMOTE_ADDR' => '127.0.0.1',
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            (string) json_encode($payload)
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $repo = $container->get(EmailDeliveryIssueRepository::class);
+        $issue = $repo->findOneBy(['email' => $payload['email']]);
+
+        $this->assertNotNull($issue);
+        $this->assertEquals('hard_bounce', $issue->getEvent()->value);
     }
 }


### PR DESCRIPTION
## Ticket

#5475   

## Description
Origine du pb : un agent a créé 212 signalements (dont 44 encore actifs, et sur ces 44 seuls 3 ont une adresse e-mail occupant).
Cet agent n'est plus sur la plateforme, et a blacklisté signal-logement. (blocked : due to blacklist user)
Comme il a été archivé 2 fois, cela créait des erreurs sql sur sentry -> hotfix pour corriger
Avec la correction, on n'aura plus d'erreur sentry, et dans la fiche des signalements, on verra qu'il y a un pb de réception d'e-mail pour le déclarant... Est-ce que ça suffira pour que les autres agents changent le déclarant, je ne pense pas...

## Changements apportés
* Correction du BrevoWebHookController

## Pré-requis

## Tests
- [ ] CI ok
