### PR TITLE
[BO - Bailleur] Permettre de modifier la liste des territoires associés à un bailleur

### DIFF
--- a/src/Controller/Back/BackBailleurController.php
+++ b/src/Controller/Back/BackBailleurController.php
@@ -70,6 +70,23 @@ class BackBailleurController extends AbstractController
         $form = $this->createForm(BailleurType::class, $bailleur);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
+            $selectedTerritories = $form->get('bailleurTerritories')->getData();
+            foreach ($bailleur->getBailleurTerritories() as $bt) {
+                if (!in_array($bt->getTerritory(), $selectedTerritories, true)) {
+                    $bailleur->removeBailleurTerritory($bt);
+                    $em->remove($bt);
+                }
+            }
+            $currentTerritories = $bailleur->getBailleurTerritories()
+                ->map(fn ($bt) => $bt->getTerritory())
+                ->toArray();
+
+            foreach ($selectedTerritories as $territory) {
+                if (!in_array($territory, $currentTerritories, true)) {
+                    $bailleur->addTerritory($territory);
+                }
+            }
+
             $em->flush();
             $this->addFlash('success', ['title' => 'Modifications enregistrées', 'message' => 'Le bailleur a bien été modifié.']);
 

--- a/src/Form/BailleurType.php
+++ b/src/Form/BailleurType.php
@@ -3,6 +3,9 @@
 namespace App\Form;
 
 use App\Entity\Bailleur;
+use App\Entity\Territory;
+use App\Form\Type\SearchCheckboxType;
+use App\Repository\TerritoryRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -10,14 +13,33 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class BailleurType extends AbstractType
 {
+    public function __construct(
+        private readonly TerritoryRepository $territoryRepository,
+    ) {
+    }
+
     /**
      * @param array<string, mixed> $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $bailleur = $builder->getData();
         $builder
             ->add('name', null, [
                 'label' => 'Nom',
+            ])
+            ->add('bailleurTerritories', SearchCheckboxType::class, [
+                'class' => Territory::class,
+                'choice_label' => 'zipAndName',
+                'label' => 'Territoires associés',
+                'noselectionlabel' => 'Sélectionnez un ou plusieurs territoires à associer',
+                'nochoiceslabel' => 'Aucun territoire associable disponible',
+                'mapped' => false,
+                'choices' => $this->territoryRepository->findAllList(),
+                'data' => $bailleur
+                    ->getBailleurTerritories()
+                    ->map(fn ($bt) => $bt->getTerritory())
+                    ->toArray(),
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'Valider',

--- a/tests/Functional/Controller/Back/BackBailleurControllerTest.php
+++ b/tests/Functional/Controller/Back/BackBailleurControllerTest.php
@@ -69,6 +69,40 @@ class BackBailleurControllerTest extends WebTestCase
         $this->assertEquals('Bailleur Test', $bailleur->getName());
     }
 
+    public function testBailleurEditTerritories(): void
+    {
+        /** @var BailleurRepository $bailleurRepository */
+        $bailleurRepository = static::getContainer()->get(BailleurRepository::class);
+        $bailleur = $bailleurRepository->findOneBy(['name' => '13 HABITAT']);
+        $this->assertCount(1, $bailleur->getBailleurTerritories());
+        $firstTerritory = $bailleur->getBailleurTerritories()->first();
+        if ($firstTerritory) {
+            $this->assertEquals('Bouches-du-Rhône', $firstTerritory->getTerritory()->getName());
+        }
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $route = $router->generate('back_bailleur_edit', ['bailleur' => $bailleur->getId()]);
+
+        $csrfToken = $this->generateCsrfToken($this->client, 'bailleur_type');
+        $this->client->request('POST', $route, [
+            '_token' => $csrfToken,
+            'name' => 'Bailleur Test',
+            'bailleurTerritories' => [13, 45],
+        ]);
+
+        $this->assertEquals('Bailleur Test', $bailleur->getName());
+        $this->assertCount(2, $bailleur->getBailleurTerritories());
+        $firstTerritory = $bailleur->getBailleurTerritories()->first();
+        if ($firstTerritory) {
+            $this->assertEquals('Bouches-du-Rhône', $firstTerritory->getTerritory()->getName());
+        }
+        $lastTerritory = $bailleur->getBailleurTerritories()->last();
+        if ($lastTerritory) {
+            $this->assertEquals('Loire-Atlantique', $lastTerritory->getTerritory()->getName());
+        }
+    }
+
     public function testBailleurDeleteKO(): void
     {
         /** @var BailleurRepository $bailleurRepository */


### PR DESCRIPTION
## Ticket

#5477   

## Description
Pour l'instant la partie SA de gestion des bailleurs ne permet que de modifier le nom d'un bailleur.
Cela pose problème quand un bailleur d'un territoire rachète un parc de logement sur un autre territoire à un autre bailleur.
Il faudrait pouvoir modifier la liste des territoires associés au bailleur

## Changements apportés
* Changement du formType, du controlleur et du test

## Pré-requis

## Tests
- [ ] Modifier la liste des territoires de plusieurs bailleurs (en ajouter et en retirer) vérifier que c'est ok
- [ ] Créer un partenaire de type bailleur social dans un territoire nouvellement ajouté à un bailleur, et vérifier qu'on a bien le bailleur dans la liste
