### PR TITLE
[BO - Signalements] Geoloc absente

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -53,6 +53,8 @@ doctrine:
                 FIND_IN_SET: DoctrineExtensions\Query\Mysql\FindInSet
                 CONCAT_WS: DoctrineExtensions\Query\Mysql\ConcatWs
                 REGEXP: DoctrineExtensions\Query\Mysql\Regexp
+            numeric_functions:
+                JSON_LENGTH: DoctrineExtensions\Query\Mysql\JsonLength
 
 when@test:
     doctrine:

--- a/src/Command/UpdateSignalementGeolocalisationCommand.php
+++ b/src/Command/UpdateSignalementGeolocalisationCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Signalement;
+use App\Manager\HistoryEntryManager;
+use App\Repository\SignalementRepository;
+use App\Repository\TerritoryRepository;
+use App\Service\Signalement\SignalementAddressUpdater;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:update-signalement-geolocalisation',
+    description: 'Recompute geolocalisation signalement data for missing code insee signalement',
+)]
+class UpdateSignalementGeolocalisationCommand extends Command
+{
+    public const int BATCH_SIZE = 20;
+
+    public function __construct(
+        private readonly TerritoryRepository $territoryRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly SignalementAddressUpdater $signalementAddressUpdater,
+        private readonly HistoryEntryManager $historyEntryManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('zip', null, InputOption::VALUE_OPTIONAL, 'Territory zip to target')
+            ->addOption('year', null, InputOption::VALUE_OPTIONAL, 'Filter signalements by 4-digit year (ex: 2023)', '2025')
+            ->addOption('empty_geoloc_only', null, InputOption::VALUE_OPTIONAL, 'Update only signalements with empty geoloc', false)
+            ->addOption('uuid', null, InputOption::VALUE_OPTIONAL, 'UUID du signalement')
+            ->addOption('from_created_at', null, InputOption::VALUE_OPTIONAL, 'Get signalements data from created_at to 1 month');
+    }
+
+    /**
+     * @throws \DateMalformedStringException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $zip = $input->getOption('zip');
+        /** @var ?string $year */
+        $year = $input->getOption('year');
+        /** @var ?bool $emptyGeolocOnly */
+        $emptyGeolocOnly = $input->getOption('empty_geoloc_only');
+        $uuid = $input->getOption('uuid');
+        $fromCreatedAt = $input->getOption('from_created_at');
+        $toCreatedAt = null;
+        $signalements = null;
+
+        /** @var SignalementRepository $signalementRepository */
+        $signalementRepository = $this->entityManager->getRepository(Signalement::class);
+        if ($uuid) {
+            $signalements = $signalementRepository->findBy(['uuid' => $uuid]);
+        } elseif (!empty($zip)) {
+            $this->historyEntryManager->removeEntityListeners();
+            $territory = $this->territoryRepository->findOneBy(['zip' => $zip]);
+            $year = null !== $year ? (int) $year : null;
+
+            if (null !== $year && !preg_match('/^\d{4}$/', (string) $year)) {
+                $io->error('Year must be a 4-digit format (ex: 2023)');
+
+                return Command::FAILURE;
+            }
+
+            $signalements = $signalementRepository->findSignalementsByYear(
+                $year,
+                $territory,
+                $emptyGeolocOnly
+            );
+        } elseif (!empty($fromCreatedAt)) {
+            $fromCreatedAt = \DateTimeImmutable::createFromFormat('Y-m-d', $fromCreatedAt);
+            if (false !== $fromCreatedAt) {
+                $toCreatedAt = $fromCreatedAt->modify('+1 month');
+                $signalements = $signalementRepository->findSignalementsBetweenDates(
+                    $fromCreatedAt,
+                    $toCreatedAt
+                );
+                $io->note(\sprintf('Update signalements from %s to %s',
+                    $fromCreatedAt->format('Y-m-d'),
+                    $toCreatedAt->format('Y-m-d'))
+                );
+            }
+        }
+
+        if (empty($signalements)) {
+            $io->warning('No address signalement to compute with BAN API');
+
+            return Command::SUCCESS;
+        }
+
+        $i = 0;
+        $progressBar = new ProgressBar($output, \count($signalements));
+        $progressBar->start();
+        /** @var Signalement $signalement */
+        foreach ($signalements as $signalement) {
+            $this->signalementAddressUpdater->updateAddressOccupantFromBanData($signalement);
+            if (0 === $i % self::BATCH_SIZE) {
+                $this->entityManager->flush();
+            }
+            ++$i;
+            $progressBar->advance();
+        }
+        $this->entityManager->flush();
+        $progressBar->finish();
+        $io->newLine();
+        $io->success(sprintf('%s signalements updated', $i));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -1200,23 +1200,26 @@ class SignalementRepository extends ServiceEntityRepository
     /**
      * @return array<int, Signalement>
      */
-    public function findSignalementsSplittedCreatedBefore(?int $split, Territory $territory): array
+    public function findSignalementsByYear(?int $year, Territory $territory, ?bool $emptyGeolocOnly = false): array
     {
         $qb = $this->createQueryBuilder('s')
             ->where('s.territory = :territory')
             ->setParameter('territory', $territory)
             ->orderBy('s.createdAt', 'ASC');
 
-        if (1 === $split) {
-            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2024-02-01');
-            $qb->andWhere('s.createdAt > :afterDate')->setParameter('afterDate', '2023-01-01');
-        } elseif (2 === $split) {
-            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2023-01-01');
-            $qb->andWhere('s.createdAt > :afterDate')->setParameter('afterDate', '2021-01-01');
-        } elseif (3 === $split) {
-            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2021-01-01');
-        } else {
-            $qb->andWhere('s.createdAt < :beforeDate')->setParameter('beforeDate', '2024-02-01');
+        if ($emptyGeolocOnly) {
+            $qb->andWhere('s.geoloc IS NULL OR JSON_LENGTH(s.geoloc) = 0');
+        }
+
+        if (null !== $year) {
+            $start = new \DateTimeImmutable(sprintf('%d-01-01 00:00:00', $year));
+            $end = $start->modify('+1 year');
+
+            $qb
+                ->andWhere('s.createdAt >= :start')
+                ->andWhere('s.createdAt < :end')
+                ->setParameter('start', $start)
+                ->setParameter('end', $end);
         }
 
         return $qb->getQuery()->getResult();

--- a/tests/Unit/Command/UpdateSignalementGeolocalisationCommandTest.php
+++ b/tests/Unit/Command/UpdateSignalementGeolocalisationCommandTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\UpdateSignalementGeolocalisationCommand;
+use App\Manager\HistoryEntryManager;
+use App\Repository\SignalementRepository;
+use App\Repository\TerritoryRepository;
+use App\Service\Signalement\SignalementAddressUpdater;
+use App\Tests\FixturesHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UpdateSignalementGeolocalisationCommandTest extends TestCase
+{
+    use FixturesHelper;
+
+    private MockObject&TerritoryRepository $territoryRepository;
+    private MockObject&EntityManagerInterface $entityManager;
+    private MockObject&SignalementAddressUpdater $signalementAddressUpdater;
+    private MockObject&HistoryEntryManager $historyEntryManager;
+
+    protected function setUp(): void
+    {
+        $this->territoryRepository = $this->createMock(TerritoryRepository::class);
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->signalementAddressUpdater = $this->createMock(SignalementAddressUpdater::class);
+        $this->historyEntryManager = $this->createMock(HistoryEntryManager::class);
+    }
+
+    public function testExecuteCommandWithoutArgumentAndOption(): void
+    {
+        $command = new UpdateSignalementGeolocalisationCommand(
+            $this->territoryRepository,
+            $this->entityManager,
+            $this->signalementAddressUpdater,
+            $this->historyEntryManager,
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('[WARNING] No address signalement to compute with BAN API', $output);
+    }
+
+    public function testExecuteCommandWithOptionUuid(): void
+    {
+        $signalementRepository = $this->createMock(SignalementRepository::class);
+
+        $signalementRepository
+            ->expects($this->once())
+            ->method('findBy')
+            ->willReturn($this->getSignalements());
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($signalementRepository);
+
+        $this->signalementAddressUpdater
+            ->expects($this->once())
+            ->method('updateAddressOccupantFromBanData');
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('flush');
+
+        $command = new UpdateSignalementGeolocalisationCommand(
+            $this->territoryRepository,
+            $this->entityManager,
+            $this->signalementAddressUpdater,
+            $this->historyEntryManager,
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['--uuid' => '00000000-0000-0000-2022-000000000001']);
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    /**
+     * @dataProvider provideTestCases
+     *
+     * @param array<string, mixed> $option
+     */
+    public function testExecuteCommandWith(string $providerMethod, array $option): void
+    {
+        $signalementRepository = $this->createMock(SignalementRepository::class);
+
+        $this->createMockSignalementRepository($signalementRepository, 2, $providerMethod, $option);
+        $this->entityManager
+            ->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($signalementRepository);
+
+        $this->signalementAddressUpdater
+            ->expects($this->atMost(2))
+            ->method('updateAddressOccupantFromBanData');
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('flush');
+
+        $command = new UpdateSignalementGeolocalisationCommand(
+            $this->territoryRepository,
+            $this->entityManager,
+            $this->signalementAddressUpdater,
+            $this->historyEntryManager,
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute($option);
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function provideTestCases(): \Generator
+    {
+        yield 'With date option' => ['findSignalementsBetweenDates', ['--from_created_at' => '2024-01-01']];
+        yield 'With territory option' => ['findSignalementsByYear', ['--zip' => 1, '--year' => '2024']];
+    }
+
+    private function createMockSignalementRepository(
+        MockObject&SignalementRepository $signalementRepository,
+        int $countSignalements = 0,
+        string $method = 'findSignalementsByYear',
+        array $option = [],
+    ): MockObject&SignalementRepository {
+        if ('findSignalementsByYear' === $method) {
+            $this->territoryRepository
+                ->expects($this->once())
+                ->method('findOneBy')
+                ->willReturn($this->getTerritory());
+            $signalementRepository
+                ->expects($this->once())
+                ->method($method)
+                ->with($option['--year'], $this->getTerritory(), false)
+                ->willReturn($countSignalements > 0 ? $this->getSignalements($countSignalements) : []);
+        } else {
+            $signalementRepository
+                ->expects($this->once())
+                ->method($method)
+
+                ->willReturn($countSignalements > 0 ? $this->getSignalements($countSignalements) : []);
+        }
+
+        return $signalementRepository;
+    }
+}


### PR DESCRIPTION
## Ticket

#5490   

## Description
On remet en place la commande pour mettre à jour les geoloc (avec quelques modifications)

## Changements apportés
* Remise en place de la commande et du test
* Changement des paramètres de la commande pour pouvoir filtrer par année directement, et par geoloc vide (avant c'était un fonctionnement bizarre avec une option split)

## Pré-requis

## Tests
- [ ] Tester la commande sur une base de prod
