### PR TITLE
[API] Filtre code insee bug Corse

### DIFF
--- a/src/Dto/Api/Request/SignalementListQueryParams.php
+++ b/src/Dto/Api/Request/SignalementListQueryParams.php
@@ -57,17 +57,16 @@ readonly class SignalementListQueryParams implements RequestInterface
         )]
         public ?string $dateAffectationFin = null,
 
-        #[Assert\Length(
-            min: 5,
-            max: 5,
-            exactMessage: 'Le code INSEE doit contenir 5 caractères (exemple: 13201).'
+        #[Assert\Regex(
+            pattern: '/^(?:\d{5}|2[AB]\d{3})$/i',
+            message: 'Le code INSEE doit être au format 5 chiffres (ex: 13201) ou 2A/2B + 3 chiffres (ex: 2A004).'
         )]
         #[OA\Property(
-            description: 'Code INSEE de la commune (5 chiffres) pour filtrer les signalements.',
+            description: 'Code INSEE de la commune (5 chiffres ou 2A/2B + 3 chiffres) pour filtrer les signalements.',
             example: '13201',
             nullable: true
         )]
-        public ?int $codeInsee = null,
+        public ?string $codeInsee = null,
     ) {
     }
 }

--- a/tests/Functional/Controller/Api/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementListControllerTest.php
@@ -79,8 +79,12 @@ class SignalementListControllerTest extends WebTestCase
     public static function provideGoodQueryParameters(): iterable
     {
         yield 'limit=2' => [['limit' => 2], 2];
-        yield 'codeInsee=13213' => [['codeInsee' => 13213], 2];
-        yield 'codeInsee=13203' => [['codeInsee' => 13203], 7];
+        yield 'codeInsee=13213' => [['codeInsee' => '13213'], 2];
+        yield 'codeInsee=13203' => [['codeInsee' => '13203'], 7];
+        yield 'codeInsee=2A247' => [['codeInsee' => '2A247'], 0];
+        yield 'codeInsee=2B002' => [['codeInsee' => '2B002'], 0];
+        yield 'codeInsee=2a247' => [['codeInsee' => '2a247'], 0];
+        yield 'codeInsee=2b002' => [['codeInsee' => '2b002'], 0];
     }
 
     /**

--- a/tests/Functional/Controller/Api/SignalementListControllerTest.php
+++ b/tests/Functional/Controller/Api/SignalementListControllerTest.php
@@ -81,6 +81,7 @@ class SignalementListControllerTest extends WebTestCase
         yield 'limit=2' => [['limit' => 2], 2];
         yield 'codeInsee=13213' => [['codeInsee' => '13213'], 2];
         yield 'codeInsee=13203' => [['codeInsee' => '13203'], 7];
+        // Codes INSEE corses : la validation accepte 2A/2B et aussi 2a/2b (regex insensible à la casse via le flag `i`).
         yield 'codeInsee=2A247' => [['codeInsee' => '2A247'], 0];
         yield 'codeInsee=2B002' => [['codeInsee' => '2B002'], 0];
         yield 'codeInsee=2a247' => [['codeInsee' => '2a247'], 0];


### PR DESCRIPTION
## Ticket

#5497    

## Description
Les codes insee de la corse commencent soit par 2A ou 2B

## Changements apportés
* Mise à jour de la contrainte de validation

## Pré-requis
Utilisateur doit avoir des permissions sur les territoires Corse-du-Sud (2A) et Haute-Corse (2B) 

## Tests
- [ ] Vérifier qu'on se fasse pas bloquer par les contraintes de validation avec une recherche code insee de Corse
