### PR TITLE
[QA] Suppression de la partie payload quand on log une requête HTTP

### DIFF
--- a/src/Service/Interconnection/JobEventHttpClient.php
+++ b/src/Service/Interconnection/JobEventHttpClient.php
@@ -67,7 +67,6 @@ class JobEventHttpClient implements HttpClientInterface
             'method' => $method,
             'url' => $url,
             'options' => $options,
-            'payload' => $jobEventMetaData->getPayload(),
             'service' => $service,
             'action' => $action,
             'signalement_id' => $jobEventMetaData->getSignalementId(),


### PR DESCRIPTION
## Ticket

#5501   

## Description
Quand on envoie un événement Esabora, on log ce qui se passe.
Depuis novembre, on enregistrait la payload en plus. Mais ce n'est pas utile car elle est stockée en base de données.
On supprime donc cette partie dans les logs.

## Tests
- [ ] CI OK
