### PR TITLE
[BO - Signalement] Permettre aux RT de modifier l'adresse quand le signalement n'est pas encore accepté

### DIFF
--- a/src/Controller/Back/SignalementEditController.php
+++ b/src/Controller/Back/SignalementEditController.php
@@ -43,7 +43,7 @@ class SignalementEditController extends AbstractController
     private const string ERROR_MSG = 'Une erreur s\'est produite. Veuillez actualiser la page.';
 
     #[Route('/{uuid:signalement}/edit-address', name: 'back_signalement_edit_address', methods: 'POST')]
-    #[IsGranted(SignalementVoter::SIGN_EDIT_ACTIVE, subject: 'signalement')]
+    #[IsGranted(SignalementVoter::SIGN_EDIT_ADDRESS, subject: 'signalement')]
     public function editAddress(
         Signalement $signalement,
         Request $request,

--- a/src/Security/Voter/SignalementVoter.php
+++ b/src/Security/Voter/SignalementVoter.php
@@ -28,6 +28,7 @@ class SignalementVoter extends Voter
     public const string SIGN_EDIT_INJONCTION = 'SIGN_EDIT_INJONCTION';
     public const string SIGN_EDIT_DRAFT = 'SIGN_EDIT_DRAFT';
     public const string SIGN_EDIT_NEED_VALIDATION = 'SIGN_EDIT_NEED_VALIDATION';
+    public const string SIGN_EDIT_ADDRESS = 'SIGN_EDIT_ADDRESS';
     public const string SIGN_DELETE_DRAFT = 'SIGN_DELETE_DRAFT';
     public const string SIGN_VIEW = 'SIGN_VIEW';
     public const string SIGN_VIEW_INJONCTION_COURRIER = 'SIGN_VIEW_INJONCTION_COURRIER';
@@ -55,6 +56,7 @@ class SignalementVoter extends Voter
                 self::SIGN_EDIT_INJONCTION,
                 self::SIGN_EDIT_DRAFT,
                 self::SIGN_EDIT_NEED_VALIDATION,
+                self::SIGN_EDIT_ADDRESS,
                 self::SIGN_VIEW,
                 self::SIGN_VIEW_INJONCTION_COURRIER,
                 self::SIGN_SEND_MAIL_BAILLEUR,
@@ -107,6 +109,7 @@ class SignalementVoter extends Voter
             self::SIGN_EDIT_CLOSED => $this->canEditClosed($subject, $user),
             self::SIGN_EDIT_INJONCTION => $this->canEditInjonction($subject, $user),
             self::SIGN_EDIT_NEED_VALIDATION => $this->canEditNeedValidation($subject, $user),
+            self::SIGN_EDIT_ADDRESS => $this->canEditActive($subject, $user) || $this->canEditNeedValidation($subject, $user),
             self::SIGN_VIEW => $this->canView($subject, $user),
             self::SIGN_VIEW_INJONCTION_COURRIER => $this->canViewInjonctionCourrier($subject, $user),
             self::SIGN_SEND_MAIL_BAILLEUR => $this->canSendMailBailleur($subject, $user),

--- a/templates/back/signalement/view.html.twig
+++ b/templates/back/signalement/view.html.twig
@@ -25,10 +25,12 @@
 {% endblock %}
 
 {% block content %}
-    {% if is_granted('SIGN_EDIT_ACTIVE', signalement) %}
+    {% if is_granted('SIGN_EDIT_ADDRESS', signalement) %}
         <div data-ajax-form>
             {% include 'back/signalement/view/edit-modals/edit-address.html.twig' %}
         </div>
+    {% endif %}
+    {% if is_granted('SIGN_EDIT_ACTIVE', signalement) %}
         {% if not signalement.isNotOccupant and not signalement.mailDeclarant %}
             <div data-ajax-form>
                 {% include 'back/signalement/view/edit-modals/edit-invite-tiers.html.twig' %}

--- a/templates/back/signalement/view/header/_address.html.twig
+++ b/templates/back/signalement/view/header/_address.html.twig
@@ -2,7 +2,7 @@
     {{ signalement.adresseOccupant }}
     {% if signalement.complementAdresseOccupant %}- {{signalement.complementAdresseOccupant}}{% endif %},
     {{ signalement.cpOccupant ~' '~ signalement.villeOccupant|capitalize }}
-    {% if is_granted('SIGN_EDIT_ACTIVE', signalement) %}
+    {% if is_granted('SIGN_EDIT_ADDRESS', signalement) %}
         <a href="#" data-fr-opened="false" aria-controls="fr-modal-edit-address" class="fr-ml-6v fr-btn--icon-left fr-icon-edit-line fr-a-edit">
             Modifier
         </a>


### PR DESCRIPTION
## Ticket

#5487   

## Description
Permettre aux RT de modifier l'adresse quand le signalement n'est pas encore accepté

## Changements apportés
* Ajout d'un voter

## Tests
- [ ] Se connecter en RT et vérifier l'accès à la modification de l'adresse si signalement en attente de validation OU en cours
- [ ] Vérifier les autre rôles sur les mêmes statuts