### PR TITLE
[QA] Nettoyage du contenu de requête dans les emails d’erreur

### DIFF
--- a/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
+++ b/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
@@ -47,7 +47,7 @@ class ErrorSignalementMailer extends AbstractNotificationMailer
         }
 
         return preg_replace(
-            '/"(password|password-current|password-repeat|_token)"\s*:\s*"[^"]*"/i',
+            '/"(password|password-current|password-repeat|[^"]*token[^"]*)"\s*:\s*"[^"]*"/i',
             '"$1": "[Filtered]"',
             $content
         );

--- a/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
+++ b/src/Service/Mailer/Mail/Error/ErrorSignalementMailer.php
@@ -36,7 +36,20 @@ class ErrorSignalementMailer extends AbstractNotificationMailer
             'url' => $_SERVER['SERVER_NAME'] ?? 'non défini',
             'code' => $event->getThrowable()->getCode(),
             'error' => $event->getThrowable()->getMessage(),
-            'req' => $event->getRequest()->getContent(),
+            'req' => $this->sanitizeContent($event->getRequest()->getContent()),
         ];
+    }
+
+    private function sanitizeContent(?string $content): ?string
+    {
+        if (empty($content)) {
+            return null;
+        }
+
+        return preg_replace(
+            '/"(password|password-current|password-repeat|_token)"\s*:\s*"[^"]*"/i',
+            '"$1": "[Filtered]"',
+            $content
+        );
     }
 }

--- a/tests/Unit/Service/Mailer/Error/ErrorSignalementMailerTest.php
+++ b/tests/Unit/Service/Mailer/Error/ErrorSignalementMailerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Tests\Unit\Service\Mailer\Error;
+
+use App\Service\Mailer\Mail\Error\ErrorSignalementMailer;
+use PHPUnit\Framework\TestCase;
+
+class ErrorSignalementMailerTest extends TestCase
+{
+    /**
+     * @throws \ReflectionException
+     */
+    public function testSanitizeFoundContent(): void
+    {
+        $mailer = $this->createMock(ErrorSignalementMailer::class);
+
+        $reflection = new \ReflectionClass($mailer);
+        $method = $reflection->getMethod('sanitizeContent');
+
+        $rawPayload = json_encode([
+            'password' => 'secret',
+            'password-current' => 'secret',
+            'password-repeat' => 'secret',
+        ]);
+
+        $result = json_decode($method->invoke($mailer, $rawPayload), true);
+
+        $countFiltered = array_count_values($result)['[Filtered]'] ?? 0;
+        $countSecret = array_count_values($result)['secret'] ?? 0;
+        $this->assertEquals(0, $countSecret);
+        $this->assertEquals(3, $countFiltered);
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testSanitizeNotFoundContent(): void
+    {
+        $mailer = $this->createMock(ErrorSignalementMailer::class);
+
+        $reflection = new \ReflectionClass($mailer);
+        $method = $reflection->getMethod('sanitizeContent');
+
+        $rawPayload = 'Hello world';
+
+        $result = $method->invoke($mailer, $rawPayload);
+
+        $this->assertStringContainsString('Hello world', $result);
+    }
+}

--- a/tests/Unit/Service/Mailer/Error/ErrorSignalementMailerTest.php
+++ b/tests/Unit/Service/Mailer/Error/ErrorSignalementMailerTest.php
@@ -21,6 +21,7 @@ class ErrorSignalementMailerTest extends TestCase
             'password' => 'secret',
             'password-current' => 'secret',
             'password-repeat' => 'secret',
+            '_token' => 'secret',
         ]);
 
         $result = json_decode($method->invoke($mailer, $rawPayload), true);
@@ -28,7 +29,7 @@ class ErrorSignalementMailerTest extends TestCase
         $countFiltered = array_count_values($result)['[Filtered]'] ?? 0;
         $countSecret = array_count_values($result)['secret'] ?? 0;
         $this->assertEquals(0, $countSecret);
-        $this->assertEquals(3, $countFiltered);
+        $this->assertEquals(4, $countFiltered);
     }
 
     /**


### PR DESCRIPTION
## Ticket

#5506   

## Description
Nettoyer le contenu

## Changements apportés
* Ajout d'une fonction de sanitization

## Pré-requis

## Tests
- [ ] CI OK 
