### PR TITLE
[BO - esabora] date de suivi /ajout a posteriori

### DIFF
--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -308,11 +308,11 @@ class EsaboraManager
             $dateLabel = $rawDate;
         }
 
-        $description = \sprintf('Date : %s', $dateLabel).\PHP_EOL;
-        $description .= 'Message provenant d\'esabora SCHS :'.\PHP_EOL;
+        $description = \sprintf('Date : %s', $dateLabel).'<br/>';
+        $description .= 'Message provenant d\'esabora SCHS :<br/>';
 
         if (!empty($event->getPresentation())) {
-            $description .= $event->getPresentation().\PHP_EOL;
+            $description .= $event->getPresentation().'<br/>';
         }
 
         if (!empty($event->getLibelle())) {

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -316,7 +316,7 @@ class EsaboraManager
         }
 
         if (!empty($event->getLibelle())) {
-            $description .= $event->getLibelle().\PHP_EOL;
+            $description .= $event->getLibelle();
         }
 
         $suivi = $this->suiviManager->createSuivi(

--- a/src/Service/Interconnection/Esabora/EsaboraManager.php
+++ b/src/Service/Interconnection/Esabora/EsaboraManager.php
@@ -72,12 +72,16 @@ class EsaboraManager
         $this->adminUser = $this->userManager->getSystemUser();
     }
 
+    /**
+     * @throws \DateMalformedStringException
+     * @throws \DateInvalidTimeZoneException
+     */
     public function synchronizeAffectationFrom(
         DossierResponseInterface $dossierResponse,
         Affectation $affectation,
     ): void {
         $signalement = $affectation->getSignalement();
-        $description = $this->updateStatusFor($affectation, $this->adminUser, $dossierResponse);
+        $description = $this->updateStatusAndBuildDescription($affectation, $this->adminUser, $dossierResponse);
         if (!empty($description)) {
             $this->suiviManager->createSuivi(
                 signalement: $signalement,
@@ -94,7 +98,7 @@ class EsaboraManager
      * @throws \DateInvalidTimeZoneException
      * @throws \DateMalformedStringException
      */
-    public function updateStatusFor(
+    public function updateStatusAndBuildDescription(
         Affectation $affectation,
         User $user,
         DossierResponseInterface $dossierResponse,
@@ -296,14 +300,23 @@ class EsaboraManager
      */
     public function createSuiviFromDossierEvent(DossierEventSCHS $event, Affectation $affectation): Suivi
     {
-        $description = 'Message provenant d\'esabora SCHS :'.\PHP_EOL;
+        $rawDate = $event->getDate();
+        $dateLabel = 'inconnue';
+        if (!empty($rawDate)
+            && false !== \DateTimeImmutable::createFromFormat(AbstractEsaboraService::FORMAT_DATE, $rawDate)
+        ) {
+            $dateLabel = $rawDate;
+        }
+
+        $description = \sprintf('Date : %s', $dateLabel).\PHP_EOL;
+        $description .= 'Message provenant d\'esabora SCHS :'.\PHP_EOL;
 
         if (!empty($event->getPresentation())) {
             $description .= $event->getPresentation().\PHP_EOL;
         }
 
         if (!empty($event->getLibelle())) {
-            $description .= $event->getLibelle();
+            $description .= $event->getLibelle().\PHP_EOL;
         }
 
         $suivi = $this->suiviManager->createSuivi(
@@ -316,12 +329,7 @@ class EsaboraManager
             context: Suivi::CONTEXT_SCHS,
             flush: false,
         );
-        $createdAt = \DateTimeImmutable::createFromFormat(AbstractEsaboraService::FORMAT_DATE, $event->getDate());
-        if (false === $createdAt) {
-            throw new \InvalidArgumentException(sprintf('Date invalide "%s" pour le format %s', $event->getDate(), AbstractEsaboraService::FORMAT_DATE));
-        }
 
-        $suivi->setCreatedAt($createdAt);
         $suivi->setOriginalData($event->getOriginalData());
         $this->entityManager->persist($suivi);
 


### PR DESCRIPTION
## Ticket

#5511    

## Description
Date d'enregistrement dans le système devient la date de suivi et date métier est dans la description du suivi

## Changements apportés
* Mise à jour du service EsaboraManager

## Pré-requis
```
make mock-stop && make mock-start
```
Ouvrir le dossier http://localhost:8080/bo/signalements/00000000-0000-0000-2024-000000000010 qui peut recevoir des événements mockés

## Tests
- [ ] Exécuter la commande  `make console app="sync-esabora-schs"`  et vérifier que les suivi sont enregitré à la date de jour et que les dates métier figures dans le suivi 

