### PR TITLE
[FO - Signalement] Correction de l'enregistrement de l'ancienneté des désordres

### DIFF
--- a/migrations/Version20260303152631.php
+++ b/migrations/Version20260303152631.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260303152631 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Migration pour corriger la colonne debut_desordres de la table signalement';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE signalement s
+            INNER JOIN signalement_draft sd ON s.created_from_id = sd.id
+            SET s.debut_desordres = UPPER(JSON_UNQUOTE(JSON_EXTRACT(sd.payload, '$.zone_concernee_debut_desordres')))
+            WHERE s.debut_desordres IS NULL
+              AND s.created_from_id IS NOT NULL
+              AND JSON_EXTRACT(sd.payload, '$.zone_concernee_debut_desordres') IS NOT NULL
+              AND JSON_EXTRACT(sd.payload, '$.zone_concernee_debut_desordres') != 'null'
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Entity/Enum/DebutDesordres.php
+++ b/src/Entity/Enum/DebutDesordres.php
@@ -9,8 +9,8 @@ enum DebutDesordres: string
     use EnumTrait;
 
     case LESS_1_MONTH = 'LESS_1_MONTH';
-    case MONTHS_1_to_6 = 'MONTHS_1_to_6';
-    case MONTHS_6_to_12 = 'MONTHS_6_to_12';
+    case MONTHS_1_TO_6 = 'MONTHS_1_TO_6';
+    case MONTHS_6_TO_12 = 'MONTHS_6_TO_12';
     case YEARS_1_TO_2 = 'YEARS_1_TO_2';
     case MORE_2_YEARS = 'MORE_2_YEARS';
     case NSP = 'NSP';
@@ -20,8 +20,8 @@ enum DebutDesordres: string
     {
         return [
             'LESS_1_MONTH' => 'Moins d\'un mois',
-            'MONTHS_1_to_6' => 'Entre 1 mois et 6 mois',
-            'MONTHS_6_to_12' => 'Entre 6 mois et 1 an',
+            'MONTHS_1_TO_6' => 'Entre 1 mois et 6 mois',
+            'MONTHS_6_TO_12' => 'Entre 6 mois et 1 an',
             'YEARS_1_TO_2' => 'Entre 1 et 2 ans',
             'MORE_2_YEARS' => 'Plus de 2 ans',
             'NSP' => 'Ne sait pas',


### PR DESCRIPTION
## Ticket

#5514   

## Description
Correction de l'enregistrement de l'ancienneté des désordres

## Changements apportés
* Correction de l'enum
* Ajout d'une migration

## Tests
- [ ] Créer un signalement front avec un début de désordres `Entre 1 mois et 6 mois` ou `Entre 6 mois et 1 an` et vérifier que c'est bien enregistrer

### Sur base de prod
- [ ] Exécuter `SELECT * FROM `signalement` where debut_desordres is null and created_from_id is not null`
- [ ] `make execute-migration name=Version20260303152631 direction=up`
- [ ] Re-faire la requête pour vérifier les corrections
