### PR TITLE
[BO - Signalement] Affichage des infos bailleurs même si le profil occupant n'est pas défini

### DIFF
--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -47,6 +47,7 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('status_to_css', [$this, 'getCssFromStatus']),
             new TwigFilter('signalement_lien_declarant_occupant', [$this, 'getLabelLienDeclarantOccupant']),
             new TwigFilter('display_signalement_info_bailleur', [$this, 'isDisplaySignalementInfoBailleur']),
+            new TwigFilter('display_signalement_info_agence', [$this, 'isDisplaySignalementInfoAgence']),
             new TwigFilter('image64', [ImageBase64Encoder::class, 'encode']),
             new TwigFilter('truncate_filename', [$this, 'getTruncatedFilename']),
             new TwigFilter('clean_tagged_text', [$this, 'cleanTaggedText']),
@@ -143,6 +144,13 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
                     || empty($signalement->getProfileOccupant())
                 )
             );
+    }
+
+    public function isDisplaySignalementInfoAgence(Signalement $signalement): bool
+    {
+        return ProfileDeclarant::BAILLEUR_OCCUPANT !== $signalement->getProfileDeclarant()
+            && ProfileOccupant::BAILLEUR_OCCUPANT !== $signalement->getProfileOccupant()
+        ;
     }
 
     public function getTruncatedFilename(string $fileName, int $maxCharacters = 50): string

--- a/templates/back/signalement/view/tabs/tab-situation.html.twig
+++ b/templates/back/signalement/view/tabs/tab-situation.html.twig
@@ -52,14 +52,14 @@
         {% include 'back/signalement/view/information/information-bailleur.html.twig' %}
     </div>
     <hr class="fr-mt-3w fr-hr">
-
 {% endif %}
 
-<div id="signalement-information-agence-container">
-    {% include 'back/signalement/view/information/information-agence.html.twig' %}
-</div>
-
-<hr class="fr-mt-3w fr-hr">
+{% if signalement|display_signalement_info_agence %}
+    <div id="signalement-information-agence-container">
+        {% include 'back/signalement/view/information/information-agence.html.twig' %}
+    </div>
+    <hr class="fr-mt-3w fr-hr">
+{% endif %}
 
 <div id="signalement-information-procedure-container">
     {% include 'back/signalement/view/information/information-procedure.html.twig' %}

--- a/templates/pdf/signalement.html.twig
+++ b/templates/pdf/signalement.html.twig
@@ -260,6 +260,27 @@
                     </td>
                 </tr>
                 {% endif %}
+
+                {% if signalement|display_signalement_info_agence %}
+                <tr>
+                    <td>
+                        <h3 style="margin-bottom: 0">Informations sur l'agence</h3>
+                        <ul style="list-style:none; margin-left:0px;padding-left:0px;">
+                            <li>
+                                <b>Dénomination :</b> {{ signalement.denominationAgence }}<br>
+                                <b>Nom :</b> {{ signalement.nomAgence ?? 'N/R' }}
+                                - <b>Prénom :</b> {{ signalement.prenomAgence ?? 'N/R' }}
+                            </li>
+                            <li><b>Courriel :</b> {{ signalement.mailAgence ?? 'N/R' }}</li>
+                            <li><b>Tel. :</b> {{ signalement.telAgence ? signalement.telAgenceDecoded|phone : 'N/R' }}</li>
+                            <li><b>Tel. sec. :</b> {{ signalement.telAgenceSecondaire ? signalement.telAgenceSecondaireDecoded|phone : 'N/R' }}</li>
+                            <li><b>Adresse :</b>
+                                {{ signalement.adresseAgence ? signalement.adresseAgence ~ ', ' ~ signalement.codePostalAgence ~ ' ' ~ signalement.villeAgence : 'N/R' }}
+                            </li>
+                        </ul>
+                    </td>
+                </tr>
+                {% endif %}
             </table>
         </section>
         <section>

--- a/tests/Unit/Twig/AppExtensionTest.php
+++ b/tests/Unit/Twig/AppExtensionTest.php
@@ -147,6 +147,7 @@ class AppExtensionTest extends WebTestCase
             'status_to_css',
             'signalement_lien_declarant_occupant',
             'display_signalement_info_bailleur',
+            'display_signalement_info_agence',
             'image64',
             'truncate_filename',
             'clean_tagged_text',


### PR DESCRIPTION
## Ticket

#5536   

## Description
Il y a des signalements dont le profil occupant n'est pas défini mais où les infos bailleurs sont définies.
Dans le doute, si le profil de l'occupant n'est pas défini, il faut y afficher les infos bailleurs.

## Pré-requis
`make worker-stop && make worker-start`

## Tests
- [ ] Fiche signalement : Vérifier sur un signalement donc le profil occupant est `null`, avec un déclarant `service secours`, ou `tiers pro`, ou `tiers particulier`, si les informations bailleur s'affichent (et aussi en export PDF)
- [ ] Vérifier que ça reste masqué si le profil occupant est `BAILLEUR_OCCUPANT`
- [ ] Vérifier que ça reste masqué si le déclarant de type `BAILLEUR` (ça doit apparaitre dans les infos de déclarant)
