### PR TITLE
[Relances - Injonction] Relance plusieurs jours de suite

### DIFF
--- a/src/Manager/SuiviManager.php
+++ b/src/Manager/SuiviManager.php
@@ -19,6 +19,7 @@ use App\Security\User\SignalementUser;
 use App\Service\Sanitizer;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
@@ -35,6 +36,7 @@ class SuiviManager extends Manager
         private readonly UserManager $userManager,
         #[Autowire(env: 'EDITION_SUIVI_ENABLE')]
         private readonly bool $editionSuiviEnable,
+        private readonly ClockInterface $clock,
         string $entityName = Suivi::class,
     ) {
         parent::__construct($managerRegistry, $entityName);
@@ -75,6 +77,8 @@ class SuiviManager extends Manager
             ->setCategory($category);
         if (!empty($createdAt)) {
             $suivi->setCreatedAt($createdAt);
+        } else {
+            $suivi->setCreatedAt($this->clock->now());
         }
         if (SuiviCategory::MESSAGE_PARTNER === $suivi->getCategory() && $this->editionSuiviEnable) {
             $suivi->setWaitingNotification(true);

--- a/src/Repository/SignalementRepository.php
+++ b/src/Repository/SignalementRepository.php
@@ -2637,27 +2637,17 @@ class SignalementRepository extends ServiceEntityRepository
             ->setParameter('aideCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE)
             ->setParameter('demarchesCategory', SuiviCategory::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES);
 
-        // Soit pas de rappel envoyé, soit un rappel envoyé avant la date
+        // Aucun rappel envoyé après la date limite
         $qb->andWhere(
-            $qb->expr()->orX(
-                $qb->expr()->not(
-                    $qb->expr()->exists(
-                        $this->createQueryBuilder('s2')
-                            ->select('1')
-                            ->join('s2.suivis', 'su2')
-                            ->where('s2 = s')
-                            ->andWhere('su2.category = :reminderCategory')
-                            ->getDQL()
-                    )
-                ),
+            $qb->expr()->not(
                 $qb->expr()->exists(
-                    $this->createQueryBuilder('s3')
+                    $this->createQueryBuilder('s2')
                         ->select('1')
-                        ->join('s3.suivis', 'su3')
-                        ->where('s3 = s')
-                        ->andWhere('su3.category = :reminderCategory')
+                        ->join('s2.suivis', 'su2')
+                        ->where('s2 = s')
+                        ->andWhere('su2.category = :reminderCategory')
                         ->andWhere(
-                            $qb->expr()->lt('su3.createdAt', ':date')
+                            $qb->expr()->gte('su2.createdAt', ':date')
                         )
                         ->getDQL()
                 )

--- a/tests/Functional/Command/Cron/RemindInjonctionSignalementCommandTest.php
+++ b/tests/Functional/Command/Cron/RemindInjonctionSignalementCommandTest.php
@@ -38,6 +38,49 @@ class RemindInjonctionSignalementCommandTest extends KernelTestCase
         $this->assertEmailCount($expectedEmailCount);
     }
 
+    public function testReminderSentAfterSecondRelance(): void
+    {
+        putenv('APP=test');
+
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $container = self::getContainer();
+        $mockClock = new MockClock(new \DateTimeImmutable('+1 months'));
+        $container->set(ClockInterface::class, $mockClock);
+
+        $command = $application->find('app:remind-injonction-signalement');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+        $output = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('1 rappels faits pour des signalements avec suivi travaux.', $output);
+        $this->assertStringContainsString('1 rappels faits pour des signalements sans réponse bailleur.', $output);
+        // On exécute le lendemain, aucun rappel ne doit être envoyé
+        $mockClock->modify('+1 day');
+        $commandTester->execute([]);
+        $commandTester->assertCommandIsSuccessful();
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Aucun rappel n\'a été envoyé pour le suivi.', $output);
+        $this->assertStringContainsString('Aucun rappel n\'a été envoyé pour les bailleurs.', $output);
+        // On exécute un mois plus tard, les rappels sont à nouveau envoyés
+        $mockClock->modify('+1 month');
+        $commandTester->execute([]);
+        $commandTester->assertCommandIsSuccessful();
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('1 rappels faits pour des signalements avec suivi travaux.', $output);
+        $this->assertStringContainsString('Aucun rappel n\'a été envoyé pour les bailleurs.', $output);
+        // Le lendemain, aucun rappel ne doit être envoyé
+        $mockClock->modify('+1 day');
+        $commandTester->execute([]);
+        $commandTester->assertCommandIsSuccessful();
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Aucun rappel n\'a été envoyé pour le suivi.', $output);
+        $this->assertStringContainsString('Aucun rappel n\'a été envoyé pour les bailleurs.', $output);
+    }
+
     public function provideReminderSentData(): \Generator
     {
         yield 'One reminder, no suivi' => [

--- a/tests/Functional/Manager/SuiviManagerTest.php
+++ b/tests/Functional/Manager/SuiviManagerTest.php
@@ -15,6 +15,7 @@ use App\Repository\UserSignalementSubscriptionRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -51,6 +52,7 @@ class SuiviManagerTest extends KernelTestCase
             $this->userSignalementSubscriptionManager,
             $this->userManager,
             true,
+            self::getContainer()->get(ClockInterface::class),
             Suivi::class,
         );
     }


### PR DESCRIPTION
## Ticket

#5558

## Description
La commande `app:remind-injonction-signalement` envoyait des relance "Point d'avancement mensuel" quotidiennement, à partir de la seconde relance (qui arrivait bien le second mois). Vu les dates de mise en place de la feature le problème a commencé le 1er Mars.

En effet la requête recherchait le signalement avec un suivi de type `INJONCTION_BAILLEUR_REMINDER_FOR_USAGER` antérieur a un mois. Hors cette condition est toujours vraie une fois qu'un mois est passé et qu'une première relance a été envoyé. Correction pour n'envoyer la relance uniquement si il n'yà pas de suivi `INJONCTION_BAILLEUR_REMINDER_FOR_USAGER` après la date limite.

Ajout de test unitaire pour vérifier le fonctionnement de la commande et utilisation du `clockInterface `à la création de suivi afin de pouvoir faire fonctionner les tests en modifiant les dates.

## Tests
- [ ] Lancer la commande sur base de prod ou reproduire la situation sur base locale
