### PR TITLE
[FO - Service secours] Problème de conservation des données lors de la navigation dans le formulaire

### DIFF
--- a/src/Form/ServiceSecours/ServiceSecoursNavigatorType.php
+++ b/src/Form/ServiceSecours/ServiceSecoursNavigatorType.php
@@ -19,6 +19,8 @@ class ServiceSecoursNavigatorType extends AbstractType
                 'label' => 'Précédent',
                 'include_if' => fn (FormFlowCursor $cursor) => !$cursor->isFirstStep(),
                 'attr' => ['class' => 'fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line'],
+                'clear_submission' => false,
+                'validation_groups' => false,
             ])
             ->add('next', NextFlowType::class, [
                 'label' => 'Suivant',


### PR DESCRIPTION
## Ticket

#5560

## Description
Modification des paramètres du bouton "Précédent" du formulaire services secours afin que les données des étapes postérieure ne soit pas vidés quand on retourne en arrière.

## Tests
- [ ] Remplir des données dans les étapes 1, 2, 3, 4 et 5 du formulaire. Retourner en arrière via le bouton précédent, puis avancer a nouveau jusqu'a l'étape 5 et s'assurer que les données préalablement saisie sont conservés
