### PR TITLE
[BO - Visualisation des modifications] Améliorations

### DIFF
--- a/src/Controller/Back/HistoryEntryController.php
+++ b/src/Controller/Back/HistoryEntryController.php
@@ -2,11 +2,16 @@
 
 namespace App\Controller\Back;
 
+use App\Entity\Signalement;
+use App\Form\SearchHistoryEntryType;
 use App\Manager\HistoryEntryManager;
 use App\Repository\HistoryEntryRepository;
 use App\Repository\SignalementRepository;
 use App\Security\Voter\SignalementVoter;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -34,25 +39,52 @@ class HistoryEntryController extends AbstractController
         return $this->json(['historyEntries' => $historyEntries]);
     }
 
-    #[Route('/diff/{entity_name}/{entity_id}', name: 'back_history_entry_details', methods: ['GET'])]
+    #[Route('/entry-diff', name: 'back_history_entry_diff', methods: ['GET'])]
     #[IsGranted('ROLE_ADMIN')]
     public function historyEntryDetails(
-        string $entity_id,
-        string $entity_name,
         HistoryEntryRepository $historyEntryRepository,
-        SignalementRepository $signalementRepository,
+        EntityManagerInterface $entityManager,
+        Request $request,
     ): Response {
-        $historyEntries = $historyEntryRepository->findBy(['entityId' => $entity_id, 'entityName' => 'App\\Entity\\'.$entity_name], ['createdAt' => 'ASC']);
+        $entity_name = $request->query->get('entity_name', '');
+        $entity_id = $request->query->get('entity_id', '');
+        $orderType = $request->query->get('orderType', 'ASC');
+        $entity = null;
         $entityUrl = null;
-        if ('Signalement' === $entity_name && $signalement = $signalementRepository->find($entity_id)) {
-            $entityUrl = $this->generateUrl('back_signalement_view', ['uuid' => $signalement->getUUid()]);
+        $historyEntries = [];
+        $relatedEntities = [];
+
+        $searchForm = $this->createForm(SearchHistoryEntryType::class, ['entity_name' => $entity_name, 'entity_id' => $entity_id, 'orderType' => $orderType]);
+        $searchForm->handleRequest($request);
+        if ($searchForm->isSubmitted() && $searchForm->isValid()) {
+            $fullEntityName = 'App\\Entity\\'.$entity_name;
+            /** @var class-string $fullEntityName */
+            $historyEntries = $historyEntryRepository->findBy(['entityId' => $entity_id, 'entityName' => $fullEntityName], ['createdAt' => $orderType]);
+            $entity = $entityManager->getRepository($fullEntityName)->find($entity_id);
+            if ($entity instanceof Signalement) {
+                $entityUrl = $this->generateUrl('back_signalement_view', ['uuid' => $entity->getUuid()]);
+            }
+            foreach ($entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
+                foreach ($metadata->getAssociationMappings() as $fieldName => $mapping) {
+                    if ($mapping['targetEntity'] === $fullEntityName && ClassMetadata::MANY_TO_ONE == $mapping['type'] && empty($mapping['mappedBy'])) {
+                        $shortName = $metadata->getReflectionClass()->getShortName();
+                        if ('HistoryEntry' === $shortName) {
+                            continue;
+                        }
+                        $relatedEntities[$shortName] = $entityManager->getRepository($metadata->getName())->findBy([$fieldName => $entity]);
+                    }
+                }
+            }
         }
 
         return $this->render('back/history-entry/details.html.twig', [
             'entityId' => $entity_id,
             'entityName' => $entity_name,
+            'entity' => $entity,
             'entityUrl' => $entityUrl,
             'historyEntries' => $historyEntries,
+            'relatedEntities' => $relatedEntities,
+            'searchForm' => $searchForm,
         ]);
     }
 }

--- a/src/Controller/Back/HistoryEntryController.php
+++ b/src/Controller/Back/HistoryEntryController.php
@@ -2,7 +2,9 @@
 
 namespace App\Controller\Back;
 
+use App\Entity\Partner;
 use App\Entity\Signalement;
+use App\Entity\Zone;
 use App\Form\SearchHistoryEntryType;
 use App\Manager\HistoryEntryManager;
 use App\Repository\HistoryEntryRepository;
@@ -61,9 +63,12 @@ class HistoryEntryController extends AbstractController
             /** @var class-string $fullEntityName */
             $historyEntries = $historyEntryRepository->findBy(['entityId' => $entity_id, 'entityName' => $fullEntityName], ['createdAt' => $orderType]);
             $entity = $entityManager->getRepository($fullEntityName)->find($entity_id);
-            if ($entity instanceof Signalement) {
-                $entityUrl = $this->generateUrl('back_signalement_view', ['uuid' => $entity->getUuid()]);
-            }
+            $entityUrl = match (true) {
+                $entity instanceof Signalement => $this->generateUrl('back_signalement_view', ['uuid' => $entity->getUuid()]),
+                $entity instanceof Partner => $this->generateUrl('back_partner_view', ['id' => $entity->getId()]),
+                $entity instanceof Zone => $this->generateUrl('back_territory_management_zone_show', ['zone' => $entity->getId()]),
+                default => null,
+            };
             foreach ($entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
                 foreach ($metadata->getAssociationMappings() as $fieldName => $mapping) {
                     if ($mapping['targetEntity'] === $fullEntityName && ClassMetadata::MANY_TO_ONE == $mapping['type'] && empty($mapping['mappedBy'])) {
@@ -75,6 +80,7 @@ class HistoryEntryController extends AbstractController
                     }
                 }
             }
+            ksort($relatedEntities);
         }
 
         return $this->render('back/history-entry/details.html.twig', [

--- a/src/Entity/Affectation.php
+++ b/src/Entity/Affectation.php
@@ -77,6 +77,11 @@ class Affectation implements EntityHistoryInterface
         $this->uuid = Uuid::v4();
     }
 
+    public function __toString(): string
+    {
+        return $this->createdAt->format('d/m/y H:i').' '.$this->getPartner()->getNom().' - '.$this->getStatut()->value.'';
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -187,6 +187,11 @@ class File implements EntityHistoryInterface
         $this->isStandalone = false;
     }
 
+    public function __toString(): string
+    {
+        return $this->getDisplayFilename();
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -66,6 +66,11 @@ class Notification
         $this->createdAt = new \DateTimeImmutable();
     }
 
+    public function __toString(): string
+    {
+        return $this->createdAt->format('d/m/y H:i').' '.$this->type->value;
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/SignalementQualification.php
+++ b/src/Entity/SignalementQualification.php
@@ -40,6 +40,11 @@ class SignalementQualification
     #[ORM\Column(nullable: true)]
     private ?bool $isPostVisite = null;
 
+    public function __toString(): string
+    {
+        return $this->qualification->value;
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/Suivi.php
+++ b/src/Entity/Suivi.php
@@ -124,6 +124,11 @@ class Suivi implements EntityHistoryInterface
         $this->waitingNotification = false;
     }
 
+    public function __toString(): string
+    {
+        return $this->createdAt->format('d/m/y H:i').' '.$this->category->value;
+    }
+
     public function setSuiviTransformerService(?SuiviTransformerService $suiviTransformerService): void
     {
         $this->suiviTransformerService = $suiviTransformerService;

--- a/src/Entity/UserSignalementSubscription.php
+++ b/src/Entity/UserSignalementSubscription.php
@@ -40,6 +40,11 @@ class UserSignalementSubscription implements EntityHistoryInterface
         $this->isLegacy = false;
     }
 
+    public function __toString(): string
+    {
+        return $this->createdAt->format('d/m/y H:i').' '.$this->getUser()->getNomComplet();
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Form/SearchHistoryEntryType.php
+++ b/src/Form/SearchHistoryEntryType.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Behaviour\EntityHistoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SearchHistoryEntryType extends AbstractType
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('entity_name', ChoiceType::class, [
+                'label' => 'Type d\'entité',
+                'required' => true,
+                'choices' => $this->getEntityChoices(),
+            ])
+            ->add('entity_id', TextType::class, [
+                'label' => 'Id',
+                'required' => true,
+            ])
+            ->add('orderType', ChoiceType::class, [
+                'label' => 'Ordre',
+                'required' => true,
+                'choices' => [
+                    'Chronologique' => 'ASC',
+                    'Antéchronologique' => 'DESC',
+                ],
+            ])
+            ->add('submit', SubmitType::class, [
+                'label' => 'Rechercher',
+                'attr' => ['class' => 'fr-btn fr-btn--primary'],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+            'method' => 'GET',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return '';
+    }
+
+    /** @return array<string, string> */
+    private function getEntityChoices(): array
+    {
+        $choices = [];
+
+        foreach ($this->entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
+            $className = $metadata->getName();
+            if (is_subclass_of($className, EntityHistoryInterface::class)) {
+                $shortName = (new \ReflectionClass($className))->getShortName();
+                $choices[$shortName] = $shortName;
+            }
+        }
+
+        ksort($choices);
+
+        return $choices;
+    }
+}

--- a/src/Service/Menu/MenuBuilder.php
+++ b/src/Service/Menu/MenuBuilder.php
@@ -89,6 +89,7 @@ readonly class MenuBuilder
             ->addChild(new MenuItem(label: 'Services secours', route: 'back_config_service_secours_route_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Bailleurs', route: 'back_bailleur_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Communes', route: 'back_commune_index', roleGranted: User::ROLE_ADMIN))
+            ->addChild(new MenuItem(label: 'Historique des modifications', route: 'back_history_entry_diff', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Résumés de suivis', route: 'back_suivi_summaries_index', roleGranted: User::ROLE_ADMIN))
             ->addChild(new MenuItem(label: 'Outil RIAL par BAN ID', route: 'back_tools_rial', roleGranted: User::ROLE_ADMIN))
         ;

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -54,7 +54,17 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('phone', [$this, 'formatPhone']),
             new TwigFilter('badge_class', [$this, 'getBadgeClass']),
             new TwigFilter('badge_relance_class', [$this, 'getRelanceBadgeClass']),
+            new TwigFilter('entity_label', [$this, 'getEntityLabel']),
         ];
+    }
+
+    public function getEntityLabel(object $entity): ?string
+    {
+        if ($entity instanceof \Stringable) {
+            return (string) $entity;
+        }
+
+        return null;
     }
 
     public function getBadgeClass(?int $days): string

--- a/src/Twig/DiffExtension.php
+++ b/src/Twig/DiffExtension.php
@@ -25,8 +25,8 @@ class DiffExtension extends AbstractExtension
      */
     public function diff(?string $text, ?string $compare, string $mode = 'new'): string
     {
-        $text = $text ?? self::NULL_PLACEHOLDER;
-        $compare = $compare ?? self::NULL_PLACEHOLDER;
+        $text = html_entity_decode($text ?? self::NULL_PLACEHOLDER, \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
+        $compare = html_entity_decode($compare ?? self::NULL_PLACEHOLDER, \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
 
         if ($text === $compare) {
             return self::NULL_PLACEHOLDER === $text ? '<i>null</i>' : htmlspecialchars($text);

--- a/src/Twig/DiffExtension.php
+++ b/src/Twig/DiffExtension.php
@@ -7,6 +7,8 @@ use Twig\TwigFilter;
 
 class DiffExtension extends AbstractExtension
 {
+    private const string NULL_PLACEHOLDER = "\x00NULL\x00";
+
     public function getFilters(): array
     {
         return [
@@ -23,20 +25,11 @@ class DiffExtension extends AbstractExtension
      */
     public function diff(?string $text, ?string $compare, string $mode = 'new'): string
     {
-        if (null === $text && null === $compare) {
-            return '';
-        }
-
-        if (null === $text) {
-            $text = '';
-        }
-
-        if (null === $compare) {
-            $compare = '';
-        }
+        $text = $text ?? self::NULL_PLACEHOLDER;
+        $compare = $compare ?? self::NULL_PLACEHOLDER;
 
         if ($text === $compare) {
-            return htmlspecialchars($text);
+            return self::NULL_PLACEHOLDER === $text ? '<i>null</i>' : htmlspecialchars($text);
         }
 
         $oldWords = $this->tokenize('old' === $mode ? $text : $compare);
@@ -130,7 +123,7 @@ class DiffExtension extends AbstractExtension
         $result = '';
 
         foreach ($diff as $part) {
-            $value = htmlspecialchars($part['value']);
+            $value = self::NULL_PLACEHOLDER === $part['value'] ? '<small><i>null</i></small>' : htmlspecialchars($part['value']);
 
             switch ($part['type']) {
                 case 'equal':

--- a/src/Twig/TestExtension.php
+++ b/src/Twig/TestExtension.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigTest;
+
+class TestExtension extends AbstractExtension
+{
+    public function getTests(): array
+    {
+        return [
+            new TwigTest('numeric', fn ($value) => is_numeric($value)),
+        ];
+    }
+}

--- a/templates/_partials/macros.html.twig
+++ b/templates/_partials/macros.html.twig
@@ -84,15 +84,17 @@
 {% endmacro %}
 
 {% macro formatValue(value) %}
-    {%- if value is iterable -%}
+    {% if value is iterable %}
         {{ value|join(', ') }}
-    {%- elseif value is same as false -%}
+    {% elseif value is same as false %}
         false
-    {%- elseif value is same as true -%}
+    {% elseif value is same as true %}
         true
-    {%- else -%}
+    {% elseif value is numeric %}
+        {{ value|json_encode }}
+    {% else %}
         {{ value }}
-    {%- endif -%}
+    {% endif %}
 {% endmacro %}
 
 {% macro historyEntriesVizualisation(historyEntryChanges, isSubChange = false, parentName = '') %}
@@ -105,8 +107,8 @@
                 <table class="history-diff">
 {% endif %}
                     {% for name, change in historyEntryChanges %}
-                        {% set old = change.old is defined ? macros.formatValue(change.old) : null %}
-                        {% set new = change.new is defined ? macros.formatValue(change.new) : null %}
+                        {% set old = (change.old is defined and change.old is not null) ? macros.formatValue(change.old) : null %}
+                        {% set new = (change.new is defined and change.new is not null) ? macros.formatValue(change.new) : null %}
 
                         {% if old is not null or new is not null %}
                             <tr>
@@ -117,14 +119,10 @@
                                     {% endif %}
                                 </td>
                                 <td class="history-diff-old">
-                                    {% if old is not null %}
-                                        {{ old|diff(new ?? '', 'old') }}
-                                    {% endif %}
+                                    {{ old|diff(new, 'old') }}
                                 </td>
                                 <td class="history-diff-new">
-                                    {% if new is not null %}
-                                        {{ new|diff(old ?? '', 'new') }}
-                                    {% endif %}
+                                    {{ new|diff(old, 'new') }}
                                 </td>
                             </tr>
                         {% else %}

--- a/templates/_partials/macros.html.twig
+++ b/templates/_partials/macros.html.twig
@@ -90,8 +90,10 @@
         false
     {% elseif value is same as true %}
         true
+    {% elseif value is numeric and value is not same as (value ~ '') %}
+        {{ value|json_encode|raw }}
     {% elseif value is numeric %}
-        {{ value|json_encode }}
+        {{ value }}
     {% else %}
         {{ value }}
     {% endif %}

--- a/templates/back/base_bo.html.twig
+++ b/templates/back/base_bo.html.twig
@@ -12,7 +12,7 @@
         {% include "flash-messages.html.twig" %}
         <div id="flash-messages-live-container"></div>
 
-        <div class="{{ app.request.attributes.get('_route') in ['back_cartographie', 'back_signalements_index', 'back_dashboard', 'back_history_entry_details'] ? 'fr-container-fluid' : container_class }}">
+        <div class="{{ app.request.attributes.get('_route') in ['back_cartographie', 'back_signalements_index', 'back_dashboard', 'back_history_entry_diff'] ? 'fr-container-fluid' : container_class }}">
             <div class="fr-grid-row">
                 <div class="fr-col-12" id="content">
                     {% block content %}{% endblock %}

--- a/templates/back/history-entry/details.html.twig
+++ b/templates/back/history-entry/details.html.twig
@@ -16,62 +16,114 @@
         <header>
             <div class="fr-grid-row">
                 <div class="fr-col-12 fr-text--left">
-                    <h1 class="fr-h1 fr-mb-0">Historique des modifications pour 
-                        {% if entityUrl is defined %}
-                            <a href="{{entityUrl}}">{{ entityName }} #{{ entityId }}</a>
-                        {% else %}
-                            {{ entityName }} #{{ entityId }}
-                        {% endif %}
-                    </h1>
+                    {% if entity %}
+                        <h1 class="fr-h1 fr-mb-0">Historique des modifications pour 
+                            {% if entityUrl %}
+                                <a href="{{entityUrl}}">{{ entityName }} #{{ entityId }}</a>
+                            {% else %}
+                                {{ entityName }} #{{ entityId }}
+                            {% endif %}
+                        </h1>
+                    {% else %}
+                        <h1 class="fr-h1 fr-mb-0">Entité "{{entityName}} : {{entityId}}" introuvable</h1>
+                    {% endif %}
                 </div>
             </div>
         </header>
     </section>
 
     <section class="fr-col-12 fr-p-5v">
-        <h2 class="fr-mb-0" id="desc-table">{{ singular_or_plural(historyEntries|length, 'modification trouvée', 'modifications trouvées') }}</h2>
+        <div class="fr-mb-4v">
+            {{ form_start(searchForm) }}
+            {{ form_errors(searchForm) }}
+            <div class="fr-grid-row fr-grid-row--bottom fr-grid-row--gutters">
+                <div class="fr-col-12 fr-col-lg-3">
+                    {{ form_row(searchForm.entity_name) }}
+                </div>
+                <div class="fr-col-12 fr-col-lg-3">
+                    {{ form_row(searchForm.entity_id) }}
+                </div>
+                <div class="fr-col-12 fr-col-lg-3">
+                    {{ form_row(searchForm.orderType) }}
+                </div>
+                <div class="fr-col-12 fr-col-lg-3">
+                    {{ form_row(searchForm.submit) }}
+                </div>
+            </div>
+            {{ form_end(searchForm) }}
+        </div>
+        {% if entity %}
+            <h2 class="fr-mb-0" id="desc-table">{{ singular_or_plural(historyEntries|length, 'modification trouvée', 'modifications trouvées') }}</h2>
+        {% endif %}
     </section>
 
-    <section class="fr-col-12 fr-pt-0 fr-px-4v">
-        {% set tableHead %}
-            <th scope="col">Utilisateur</th>
-            <th scope="col">Type</th>
-            <th scope="col">Date</th>
-            <th scope="col">Modifications</th>
-            <th scope="col">Source</th>
-        {% endset %}
+    {% if entity %}
+        <section class="fr-col-12 fr-pt-0 fr-px-4v">
+            {% set tableHead %}
+                <th scope="col">Utilisateur</th>
+                <th scope="col">Type</th>
+                <th scope="col">Date</th>
+                <th scope="col">Modifications</th>
+                <th scope="col">Source</th>
+            {% endset %}
 
-        {% set tableBody %}
-            {% for entry in historyEntries %}
-                <tr class="user-row">
-                    <td>
-                        {% if entry.user %}
-                            {{ entry.user.email }}
-                            <br>
-                            {{ entry.user.nomComplet(true) }}
-                            <br>
-                            Id {{entry.user.id}}
-                        {% endif %}
-                    </td>
-                    <td>
-                        <span class="fr-badge {% if entry.event.value == 'CREATE' %}fr-badge--success{% elseif entry.event.value == 'UPDATE' %}fr-badge--info{% endif %}">{{ entry.event.value }}</span>
-                    </td>
-                    <td>{{ entry.createdAt|date('d/m/Y H:i') }}</td>
-                    <td>
-                        {% if entry.changes|length > 0 %}
-                            {{ macros.historyEntriesVizualisation(entry.changes) }}
-                        {% endif %}
-                    </td>
-                    <td>{{ entry.source }}</td>
-                </tr>
-            {% else %}
-                <tr>
-                    <td colspan="5">Aucune modification trouvée</td>
-                </tr>
+            {% set tableBody %}
+                {% for entry in historyEntries %}
+                    <tr class="user-row">
+                        <td>
+                            {% if entry.user %}
+                                {{ entry.user.email }}
+                                <br>
+                                {{ entry.user.nomComplet(true) }}
+                                <br>
+                                Id {{entry.user.id}}
+                            {% endif %}
+                        </td>
+                        <td>
+                            <span title="{{ entry.id }}" class="fr-badge {% if entry.event.value == 'CREATE' %}fr-badge--success{% elseif entry.event.value == 'UPDATE' %}fr-badge--info{% endif %}">{{ entry.event.value }}</span>
+                        </td>
+                        <td>{{ entry.createdAt|date('d/m/Y H:i') }}</td>
+                        <td>
+                            {% if entry.changes|length > 0 %}
+                                {{ macros.historyEntriesVizualisation(entry.changes) }}
+                            {% endif %}
+                        </td>
+                        <td>{{ entry.source }}</td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="5">Aucune modification trouvée</td>
+                    </tr>
+                {% endfor %}
+            {% endset %}
+            {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des modifications', 'tableHead': tableHead, 'tableBody': tableBody } %}
+        </section>
+
+        <section class="fr-col-12 fr-pt-0 fr-px-4v">
+            <h2>Relations</h2>
+            <div class="fr-grid-row fr-grid-row--gutters">
+                {% for entityName, records in relatedEntities %}
+                    {% if records|length > 0 %}
+                        <div class="fr-col-4">
+                            <h3>{{ entityName }}</h3>
+                            <ul>
+                                {% for record in records %}
+                                    {% set label = record|entity_label %}
+                                    <li>
+                                        <a href="{{ path('back_history_entry_diff', { 'entity_name': entityName, 'entity_id': record.id }) }}">
+                                            {{ record.id }}{% if label %} - {{ label }}{% endif %}
+                                        </a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
             {% endfor %}
-        {% endset %}
+            </div>
+        </section>
 
-        {% include '_partials/back/table.html.twig' with { 'tableLabel': 'Liste des modifications', 'tableHead': tableHead, 'tableBody': tableBody } %}
-        
-    </section>
+
+
+    {% endif %}
+
 {% endblock %}

--- a/templates/back/history-entry/details.html.twig
+++ b/templates/back/history-entry/details.html.twig
@@ -24,8 +24,10 @@
                                 {{ entityName }} #{{ entityId }}
                             {% endif %}
                         </h1>
-                    {% else %}
+                    {% elseif entityName %}
                         <h1 class="fr-h1 fr-mb-0">Entité "{{entityName}} : {{entityId}}" introuvable</h1>
+                    {% else %}
+                        <h1 class="fr-h1 fr-mb-0">Effectuez une recherche</h1>
                     {% endif %}
                 </div>
             </div>
@@ -107,15 +109,38 @@
                         <div class="fr-col-4">
                             <h3>{{ entityName }}</h3>
                             <ul>
-                                {% for record in records %}
+                                {% for record in records|slice(0, 10) %}
                                     {% set label = record|entity_label %}
                                     <li>
-                                        <a href="{{ path('back_history_entry_diff', { 'entity_name': entityName, 'entity_id': record.id }) }}">
+                                        {% if entityName in searchForm['entity_name'].vars.choices|map(c => c.value) %}
+                                            <a href="{{ path('back_history_entry_diff', { 'entity_name': entityName, 'entity_id': record.id }) }}">
+                                                {{ record.id }}{% if label %} - {{ label }}{% endif %}
+                                            </a>
+                                        {% else %}
                                             {{ record.id }}{% if label %} - {{ label }}{% endif %}
-                                        </a>
+                                        {% endif %}
                                     </li>
                                 {% endfor %}
                             </ul>
+                            {% if records|length > 10 %}
+                                <details>
+                                    <summary>Afficher tout ({{ records|length - 10 }} de plus)</summary>
+                                    <ul>
+                                        {% for record in records|slice(10) %}
+                                            {% set label = record|entity_label %}
+                                            <li>
+                                                {% if entityName in searchForm['entity_name'].vars.choices|map(c => c.value) %}
+                                                    <a href="{{ path('back_history_entry_diff', { 'entity_name': entityName, 'entity_id': record.id }) }}">
+                                                        {{ record.id }}{% if label %} - {{ label }}{% endif %}
+                                                    </a>
+                                                {% else %}
+                                                    {{ record.id }}{% if label %} - {{ label }}{% endif %}
+                                                {% endif %}
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </details>
+                            {% endif %}
                         </div>
                     {% endif %}
             {% endfor %}

--- a/templates/back/signalement/view/header/_menu.html.twig
+++ b/templates/back/signalement/view/header/_menu.html.twig
@@ -97,7 +97,7 @@
                         </li>
                     {% endif %}
                     <li>
-                        <a href="{{ path('back_history_entry_details', {entity_id: signalement.id, entity_name: 'Signalement'}) }}"
+                        <a href="{{ path('back_history_entry_diff', {entity_id: signalement.id, entity_name: 'Signalement'}) }}"
                             class="fr-nav__link fr-btn--icon-left fr-icon-stack-line"
                             title="Voir l'historique des modifications">
                             Historique des modifications

--- a/tests/Unit/Twig/AppExtensionTest.php
+++ b/tests/Unit/Twig/AppExtensionTest.php
@@ -154,6 +154,7 @@ class AppExtensionTest extends WebTestCase
             'phone',
             'badge_class',
             'badge_relance_class',
+            'entity_label',
         ];
 
         $this->assertEqualsCanonicalizing($expectedFilters, $filterNames);


### PR DESCRIPTION
## Ticket

#5471

## Description
- Ajout d'un formulaire de recherche (type d'entité / id / ordre chronologique ou inversé).
- Sous le tableau de l'historique ajout de la liste des entités liés, cliquable vers leur propre page d'historique. En conséquence ajout d'une méthode `__toString` sur une partie des entités.
- Affichage explicite des valeur `null` dans les changements.
- Correction d'une comparaison de nombre a virgule pour l'affichage dans l'historique.

## Tests
- [ ] De préférence sur base de prod, naviguer sur des historique de signalement
