### PR TITLE
[FO - Service secours] Masquer les champs concernant le bailleur quand le profil est un bailleur occupant

### DIFF
--- a/assets/scripts/vanilla/controllers/front_service_secours/front_service_secours.js
+++ b/assets/scripts/vanilla/controllers/front_service_secours/front_service_secours.js
@@ -1,4 +1,7 @@
-import { attacheAutocompleteAddressEvent, initComponentAddress } from '../../services/component/component_search_address';
+import {
+  attacheAutocompleteAddressEvent,
+  initComponentAddress,
+} from '../../services/component/component_search_address';
 
 attachFormServiceSecoursEvent();
 
@@ -14,12 +17,18 @@ function attachFormServiceSecoursEvent() {
   }
 
   // Si on coche la valeur "appartement" pour la nature du logement (service_secours[step2][natureLogement]), on affiche "type-etage-logement-appartement-container"
-  const natureLogementRadios = document.querySelectorAll('input[name="service_secours[step2][natureLogement]"]');
-  const typeEtageLogementAppartementContainer = document.querySelector('.type-etage-logement-appartement-container');
+  const natureLogementRadios = document.querySelectorAll(
+    'input[name="service_secours[step2][natureLogement]"]'
+  );
+  const typeEtageLogementAppartementContainer = document.querySelector(
+    '.type-etage-logement-appartement-container'
+  );
   const natureLogementAutreContainer = document.querySelector('.nature-logement-autre-container');
 
   // Vérifier l'état initial au chargement de la page
-  const natureLogementChecked = document.querySelector('input[name="service_secours[step2][natureLogement]"]:checked');
+  const natureLogementChecked = document.querySelector(
+    'input[name="service_secours[step2][natureLogement]"]:checked'
+  );
   if (natureLogementChecked) {
     if (natureLogementChecked.value === 'appartement') {
       typeEtageLogementAppartementContainer.classList.remove('fr-hidden');
@@ -29,7 +38,7 @@ function attachFormServiceSecoursEvent() {
     }
   }
 
-  natureLogementRadios.forEach(radio => {
+  natureLogementRadios.forEach((radio) => {
     radio.addEventListener('change', (event) => {
       if (event.target.value === 'appartement') {
         typeEtageLogementAppartementContainer.classList.remove('fr-hidden');
@@ -46,16 +55,20 @@ function attachFormServiceSecoursEvent() {
   });
 
   // Si on coche la valeur "autre" pour le type d'étage (service_secours[step2][typeEtageLogement]), on affiche "etage-occupant-container"
-  const typeEtageLogementRadios = document.querySelectorAll('input[name="service_secours[step2][typeEtageLogement]"]');
+  const typeEtageLogementRadios = document.querySelectorAll(
+    'input[name="service_secours[step2][typeEtageLogement]"]'
+  );
   const etageOccupantContainer = document.querySelector('.etage-occupant-container');
 
   // Vérifier l'état initial au chargement de la page
-  const typeEtageLogementChecked = document.querySelector('input[name="service_secours[step2][typeEtageLogement]"]:checked');
+  const typeEtageLogementChecked = document.querySelector(
+    'input[name="service_secours[step2][typeEtageLogement]"]:checked'
+  );
   if (typeEtageLogementChecked && typeEtageLogementChecked.value === 'AUTRE') {
     etageOccupantContainer.classList.remove('fr-hidden');
   }
 
-  typeEtageLogementRadios.forEach(radio => {
+  typeEtageLogementRadios.forEach((radio) => {
     radio.addEventListener('change', (event) => {
       if (event.target.value === 'AUTRE') {
         etageOccupantContainer.classList.remove('fr-hidden');
@@ -66,10 +79,10 @@ function attachFormServiceSecoursEvent() {
   });
 }
 
-
-
 //step4
-const showInformationsSyndicContainer = document.querySelector('#show-informations-syndic-container');
+const showInformationsSyndicContainer = document.querySelector(
+  '#show-informations-syndic-container'
+);
 const informationsSyndicContainer = document.querySelector('#informations-syndic-container');
 if (showInformationsSyndicContainer && informationsSyndicContainer) {
   showInformationsSyndicContainer.addEventListener('click', (event) => {
@@ -81,12 +94,17 @@ if (showInformationsSyndicContainer && informationsSyndicContainer) {
   const nomSyndic = document.querySelector('#service_secours_step4_nomSyndic');
   const mailSyndic = document.querySelector('#service_secours_step4_mailSyndic');
   const telSyndic = document.querySelector('#service_secours_step4_telSyndic_input');
-  const telSyndicSecondaire = document.querySelector('#service_secours_step4_telSyndicSecondaire_input');
-  if (denominationSyndic.value || nomSyndic.value || mailSyndic.value || telSyndic.value || telSyndicSecondaire.value) {
+  const telSyndicSecondaire = document.querySelector(
+    '#service_secours_step4_telSyndicSecondaire_input'
+  );
+  if (
+    denominationSyndic.value ||
+    nomSyndic.value ||
+    mailSyndic.value ||
+    telSyndic.value ||
+    telSyndicSecondaire.value
+  ) {
     informationsSyndicContainer.classList.remove('fr-hidden');
     showInformationsSyndicContainer.classList.add('fr-hidden');
   }
 }
-
-
-

--- a/assets/scripts/vanilla/controllers/front_service_secours/front_service_secours_install.js
+++ b/assets/scripts/vanilla/controllers/front_service_secours/front_service_secours_install.js
@@ -1,6 +1,6 @@
 let deferredPrompt = null;
 const DISMISS_DURATION_DAYS = 30;
-const MILLISECOND_IN_DAY = 1000 * 60 * 60 * 24
+const MILLISECOND_IN_DAY = 1000 * 60 * 60 * 24;
 const STORAGE_KEY = 'pwa-install-prompt-dismissed';
 
 // Vérifier si l'invite a été rejetée récemment

--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement_editor.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement_editor.js
@@ -9,10 +9,18 @@ if (fieldsetAllocataire) {
     });
 
   function refreshCaisseAllocation() {
-    const containerCaisseAllocation = document.querySelector('#usager_situation_foyer_caisseAllocation').closest('.fr-fieldset__element');
-    const containerNumAllocataire = document.querySelector('#usager_situation_foyer_numAllocataire').closest('.fr-fieldset__element');
-    const containerTypeAllocation = document.querySelector('#usager_situation_foyer_typeAllocation').closest('.fr-fieldset__element');
-    const containerMontantAllocation = document.querySelector('#usager_situation_foyer_montantAllocation').closest('.fr-fieldset__element');
+    const containerCaisseAllocation = document
+      .querySelector('#usager_situation_foyer_caisseAllocation')
+      .closest('.fr-fieldset__element');
+    const containerNumAllocataire = document
+      .querySelector('#usager_situation_foyer_numAllocataire')
+      .closest('.fr-fieldset__element');
+    const containerTypeAllocation = document
+      .querySelector('#usager_situation_foyer_typeAllocation')
+      .closest('.fr-fieldset__element');
+    const containerMontantAllocation = document
+      .querySelector('#usager_situation_foyer_montantAllocation')
+      .closest('.fr-fieldset__element');
     if (document.querySelector('#usager_situation_foyer_allocataire_0').checked) {
       containerCaisseAllocation.classList.remove('fr-hidden');
       containerNumAllocataire.classList.remove('fr-hidden');
@@ -28,7 +36,9 @@ if (fieldsetAllocataire) {
   refreshCaisseAllocation();
 }
 
-const fieldsetAccompagnementTravailleurSocial = document?.querySelector('#usager_situation_foyer_accompagnementTravailleurSocial');
+const fieldsetAccompagnementTravailleurSocial = document?.querySelector(
+  '#usager_situation_foyer_accompagnementTravailleurSocial'
+);
 // le nom de la structure d'accompagnement (usager_situation_foyer_accompagnementTravailleurSocialNomStructure) s'affiche que si on a répondu oui
 if (fieldsetAccompagnementTravailleurSocial) {
   document
@@ -40,12 +50,18 @@ if (fieldsetAccompagnementTravailleurSocial) {
     });
 
   function refreshAccompagnementTravailleurSocial() {
-    const containerNomStructure = document.querySelector('#usager_situation_foyer_accompagnementTravailleurSocialNomStructure').closest('.fr-fieldset__element');
-    if (document.querySelector('#usager_situation_foyer_accompagnementTravailleurSocial_0').checked) {
+    const containerNomStructure = document
+      .querySelector('#usager_situation_foyer_accompagnementTravailleurSocialNomStructure')
+      .closest('.fr-fieldset__element');
+    if (
+      document.querySelector('#usager_situation_foyer_accompagnementTravailleurSocial_0').checked
+    ) {
       containerNomStructure.classList.remove('fr-hidden');
     } else {
       containerNomStructure.classList.add('fr-hidden');
-      document.querySelector('#usager_situation_foyer_accompagnementTravailleurSocialNomStructure').value = '';
+      document.querySelector(
+        '#usager_situation_foyer_accompagnementTravailleurSocialNomStructure'
+      ).value = '';
     }
   }
   refreshAccompagnementTravailleurSocial();
@@ -63,7 +79,9 @@ if (fieldsetDpe) {
     });
 
   function refreshClasseEnergetique() {
-    const containerClasseEnergetique = document.querySelector('#informations_generales_classeEnergetique').closest('.fr-fieldset__element');
+    const containerClasseEnergetique = document
+      .querySelector('#informations_generales_classeEnergetique')
+      .closest('.fr-fieldset__element');
     if (document.querySelector('#informations_generales_dpe_0').checked) {
       containerClasseEnergetique.classList.remove('fr-hidden');
     } else {
@@ -74,7 +92,7 @@ if (fieldsetDpe) {
   refreshClasseEnergetique();
 }
 
-const fieldsetNbEnfants= document?.querySelector('#informations_generales_nbEnfantsDansLogement');
+const fieldsetNbEnfants = document?.querySelector('#informations_generales_nbEnfantsDansLogement');
 // le choix de la classe énergétique ne s'affiche que si on a répondu oui au Dpe
 if (fieldsetNbEnfants) {
   fieldsetNbEnfants.addEventListener('input', () => {
@@ -82,7 +100,9 @@ if (fieldsetNbEnfants) {
   });
 
   function refreshEnfantsMoinsSixAns() {
-    const containerEnfantsMoinsSixAns = document.querySelector('#informations_generales_enfantsDansLogementMoinsSixAns').closest('.fr-fieldset__element');
+    const containerEnfantsMoinsSixAns = document
+      .querySelector('#informations_generales_enfantsDansLogementMoinsSixAns')
+      .closest('.fr-fieldset__element');
     if (document.querySelector('#informations_generales_nbEnfantsDansLogement').value > 0) {
       containerEnfantsMoinsSixAns.classList.remove('fr-hidden');
     } else {

--- a/assets/scripts/vanilla/services/component/component_search_address.js
+++ b/assets/scripts/vanilla/services/component/component_search_address.js
@@ -221,7 +221,9 @@ export function initComponentAddress(id) {
   if (addressInput.dataset.suffix !== undefined && addressInput.dataset.suffix !== '') {
     suffix = '-' + addressInput.dataset.suffix;
   }
-  const inseeInput = document?.querySelector('#' + idForm + ' [data-autocomplete-insee' + suffix + ']');
+  const inseeInput = document?.querySelector(
+    '#' + idForm + ' [data-autocomplete-insee' + suffix + ']'
+  );
   const hasInseeCode = inseeInput && inseeInput.value !== '';
 
   manualAddressSwitcher?.addEventListener('click', (event) => {
@@ -256,9 +258,15 @@ export function initComponentAddress(id) {
   // Si le champ autocomplete est vide mais qu'on a une adresse avec code INSEE,
   // reconstruire l'adresse complète dans le champ autocomplete
   if (addressInput.value == '' && hasManualAddressValues && hasInseeCode) {
-    const addressField = document?.querySelector('#' + idForm + ' [data-autocomplete-addresse' + suffix + ']');
-    const postalCodeField = document?.querySelector('#' + idForm + ' [data-autocomplete-codepostal' + suffix + ']');
-    const cityField = document?.querySelector('#' + idForm + ' [data-autocomplete-ville' + suffix + ']');
+    const addressField = document?.querySelector(
+      '#' + idForm + ' [data-autocomplete-addresse' + suffix + ']'
+    );
+    const postalCodeField = document?.querySelector(
+      '#' + idForm + ' [data-autocomplete-codepostal' + suffix + ']'
+    );
+    const cityField = document?.querySelector(
+      '#' + idForm + ' [data-autocomplete-ville' + suffix + ']'
+    );
 
     if (addressField && postalCodeField && cityField) {
       const fullAddress = `${addressField.value}, ${postalCodeField.value} ${cityField.value}`;

--- a/src/Dto/ServiceSecours/FormServiceSecoursStep4.php
+++ b/src/Dto/ServiceSecours/FormServiceSecoursStep4.php
@@ -7,7 +7,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class FormServiceSecoursStep4
 {
-    #[Assert\NotBlank(groups: ['step4'])]
     public ?string $isBailleurAverti = null;
 
     #[Assert\Length(max: 255, groups: ['step4'])]

--- a/src/Form/ServiceSecours/ServiceSecoursStep4Type.php
+++ b/src/Form/ServiceSecours/ServiceSecoursStep4Type.php
@@ -4,6 +4,7 @@ namespace App\Form\ServiceSecours;
 
 use App\Dto\ServiceSecours\FormServiceSecours;
 use App\Dto\ServiceSecours\FormServiceSecoursStep4;
+use App\Entity\Enum\ProfileOccupant;
 use App\Form\Type\PhoneType;
 use App\Validator\TelephoneFormat;
 use Symfony\Component\Form\AbstractType;
@@ -14,6 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class ServiceSecoursStep4Type extends AbstractType
 {
@@ -23,51 +25,62 @@ class ServiceSecoursStep4Type extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('isBailleurAverti', ChoiceType::class, [
-            'label' => 'Bailleur averti <span class="text-required">*</span>',
-            'label_html' => true,
-            'required' => false,
-            'placeholder' => false,
-            'expanded' => true,
-            'choices' => [
-                'Oui' => 'oui',
-                'Non' => 'non',
-                'Indeterminé' => 'indetermine',
-            ],
-        ]);
-
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (PreSetDataEvent $event): void {
             $form = $event->getForm();
             $rootData = $form->getRoot()->getData();
+            $isBailleurOccupant = ProfileOccupant::BAILLEUR_OCCUPANT->value === $rootData->step3->profilOccupant;
 
             if ($rootData instanceof FormServiceSecours) {
-                if ('oui' === $rootData->step2->isLogementSocial) {
-                    $form->add('denominationProprio', null, [
-                        'label' => 'Dénomination du bailleur',
-                        'help' => 'Format attendu : Tappez le nom du bailleur et sélectionnez-le dans la liste.',
-                        'attr' => [
-                            'data-autocomplete-bailleur-url' => $this->urlGenerator->generate('app_bailleur', ['inseecode' => $rootData->step2->inseeOccupant]),
+                if (!$isBailleurOccupant) {
+                    $form->add('isBailleurAverti', ChoiceType::class, [
+                        'label' => 'Bailleur averti <span class="text-required">*</span>',
+                        'label_html' => true,
+                        'required' => false,
+                        'placeholder' => false,
+                        'expanded' => true,
+                        'choices' => [
+                            'Oui' => 'oui',
+                            'Non' => 'non',
+                            'Indeterminé' => 'indetermine',
+                        ],
+                        'constraints' => [
+                            new Assert\NotBlank([
+                                'message' => 'Veuillez indiquer si le bailleur a été averti.',
+                                'groups' => ['step4'],
+                            ]),
                         ],
                     ]);
-                } else {
-                    $form->add('nomProprio', null, ['label' => 'Nom du bailleur']);
-                    $form->add('prenomProprio', null, ['label' => 'Prénom du bailleur']);
+
+                    if ('oui' === $rootData->step2->isLogementSocial) {
+                        $form->add('denominationProprio', null, [
+                            'label' => 'Dénomination du bailleur',
+                            'help' => 'Format attendu : Tappez le nom du bailleur et sélectionnez-le dans la liste.',
+                            'attr' => [
+                                'data-autocomplete-bailleur-url' => $this->urlGenerator->generate('app_bailleur', ['inseecode' => $rootData->step2->inseeOccupant]),
+                            ],
+                        ]);
+                    } else {
+                        $form->add('nomProprio', null, ['label' => 'Nom du bailleur']);
+                        $form->add('prenomProprio', null, ['label' => 'Prénom du bailleur']);
+                    }
+
+                    $form->add('mailProprio', TextType::class, [
+                        'label' => 'Adresse e-mail',
+                        'help' => 'Format attendu : nom@domaine.fr',
+                        'required' => false,
+                    ]);
+                    $form->add('telProprio', PhoneType::class, [
+                        'label' => 'Téléphone',
+                        'constraints' => [
+                            new TelephoneFormat([
+                                'message' => 'Le numéro de téléphone n\'est pas valide.',
+                            ]),
+                        ],
+                    ]);
                 }
             }
         });
-        $builder->add('mailProprio', TextType::class, [
-            'label' => 'Adresse e-mail',
-            'help' => 'Format attendu : nom@domaine.fr',
-            'required' => false,
-        ]);
-        $builder->add('telProprio', PhoneType::class, [
-            'label' => 'Téléphone',
-            'constraints' => [
-                new TelephoneFormat([
-                    'message' => 'Le numéro de téléphone n\'est pas valide.',
-                ]),
-            ],
-        ]);
+
         $builder->add('denominationSyndic', null, ['label' => 'Dénomination du syndic']);
         $builder->add('nomSyndic', null, ['label' => 'Nom du ou de la représentante']);
         $builder->add('mailSyndic', TextType::class, [

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -101,8 +101,10 @@
                     {{ form_row(form.step3.isEnfantsMoinsSixAnsDansLogement, {display_mode: 'block'}) }}
                     {{ form_row(form.step3.autreVulnerabilite) }}
                 {% elseif current_step == 'step4' %}
-                    <h3 class="fr-h5">Informations sur le bailleur</h3>
-                    {{ form_row(form.step4.isBailleurAverti, {display_mode: 'block'}) }}
+                    {% if form.step4.isBailleurAverti is defined %}
+                        <h3 class="fr-h5">Informations sur le bailleur</h3>
+                        {{ form_row(form.step4.isBailleurAverti, {display_mode: 'block'}) }}
+                    {% endif %}
                     {% if form.step4.denominationProprio is defined %}
                         <div class="fr-input-group">
                             {{ form_label(form.step4.denominationProprio) }}
@@ -117,12 +119,18 @@
                     {% if form.step4.prenomProprio is defined %}
                         {{ form_row(form.step4.prenomProprio) }}
                     {% endif %}
-                    {{ form_row(form.step4.mailProprio) }}
-                    {{ form_row(form.step4.telProprio) }}
+                    {% if form.step4.mailProprio is defined %}
+                        {{ form_row(form.step4.mailProprio) }}
+                    {% endif %}
+                    {% if form.step4.telProprio is defined %}
+                        {{ form_row(form.step4.telProprio) }}
+                    {% endif %}
+                    {% if form.step4.isBailleurAverti is defined %}
                     <div class="fr-my-2w">
                         <button type="button" class="fr-link fr-link--icon-left fr-icon-add-line" id="show-informations-syndic-container">Ajouter les coordonnées du syndic</button>
                     </div>
-                    <div class="fr-hidden fr-mb-3w" id="informations-syndic-container">
+                    {% endif %}
+                    <div class="{% if form.step4.isBailleurAverti is defined %}fr-hidden{% endif %} fr-mb-3w" id="informations-syndic-container">
                         <h3 class="fr-h5">Informations sur le syndic</h3>
                         {{ form_row(form.step4.denominationSyndic) }}
                         {{ form_row(form.step4.nomSyndic) }}


### PR DESCRIPTION
## Ticket

#5572   

## Description
Service secours : Masquer les champs concernant le bailleur quand le profil est un bailleur occupant

## Pré-requis
`make npm-watch`

## Tests
- [ ] TNR : Parcourir le formulaire, type locataire, rien n'a changé
- [ ] Parcourir le formulaire, type bailleur occupant, vérifier les champs qui s'affichent et leur validation
