### PR TITLE
[BO - Signalement] Laisser le signalement accessible quand la démarche accélérée est terminée

### DIFF
--- a/src/Entity/Enum/SignalementStatus.php
+++ b/src/Entity/Enum/SignalementStatus.php
@@ -65,10 +65,10 @@ enum SignalementStatus: string
             self::ARCHIVED,
             self::DRAFT,
             self::DRAFT_ARCHIVED,
-            self::INJONCTION_CLOSED,
         ];
         if ($includeInjonctionBailleur) {
             $list[] = self::INJONCTION_BAILLEUR;
+            $list[] = self::INJONCTION_CLOSED;
         }
 
         return $list;


### PR DESCRIPTION
## Ticket

#5576   

## Description
Laisser le signalement accessible quand la démarche accélérée est terminée

## Changements apportés
* Ajustement du voter

## Tests
- [ ] Vérifier l'accès pour SA, RT et agents
