### PR TITLE
[FO - Double affichage de référence] statut INJONCTION_CLOSED

### DIFF
--- a/templates/front/_partials/_suivi_signalement_card.html.twig
+++ b/templates/front/_partials/_suivi_signalement_card.html.twig
@@ -23,7 +23,7 @@
 			<br>
 			<span class="info">
 				#{{ signalement.reference }}
-				{% if signalement.referenceInjonction and signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').INJONCTION_BAILLEUR %}
+				{% if signalement.referenceInjonction and signalement.statut not in enum('App\\Entity\\Enum\\SignalementStatus').injonctionStatuses %}
 					<small>(#{{ signalement.referenceInjonction }})</small>
 				{% endif %}
 			</span>

--- a/templates/front/_partials/_suivi_signalement_card_right.html.twig
+++ b/templates/front/_partials/_suivi_signalement_card_right.html.twig
@@ -16,7 +16,7 @@
 				<br>
 				<span class="info">
 					#{{ signalement.reference }}
-					{% if signalement.referenceInjonction and signalement.statut is not same as enum('App\\Entity\\Enum\\SignalementStatus').INJONCTION_BAILLEUR %}
+					{% if signalement.referenceInjonction and signalement.statut not in enum('App\\Entity\\Enum\\SignalementStatus').injonctionStatuses %}
 						<small>(#{{ signalement.referenceInjonction }})</small>
 					{% endif %}
 				</span>


### PR DESCRIPTION
## Ticket

#5586

## Description
- En statut `INJONCTION_CLOSED` on réaffichait la référence "INJ-XXX" correction en utilisant la méthode `injonctionStatuses` de l'enum.

## Tests
- [ ] Se connecter en usager sur le signalement en `INJONCTION_CLOSED` et vérifier l'affichage de la référence
