### PR TITLE
[Démarche Accéléré] Date de dépôt

### DIFF
--- a/migrations/Version20260323105455.php
+++ b/migrations/Version20260323105455.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260323105455 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Ajout d\'un suivi "SIGNALEMENT_IS_INJONCTION" à la date de création du signalement pour les signalements ayant une référence injonction';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            INSERT INTO suivi (
+                created_at,
+                created_by_id,
+                description,
+                is_public,
+                type,
+                signalement_id,
+                is_sanitized,
+                category,
+                waiting_notification
+            )
+            SELECT
+                h.created_at,
+                (SELECT u.id FROM user u WHERE u.email = 'admin@signal-logement.beta.gouv.fr' LIMIT 1),
+                'Dossier déposé dans le cadre de la démarche accélérée',
+                0,
+                1,
+                s.id,
+                1,
+                'SIGNALEMENT_IS_INJONCTION',
+                0
+            FROM history_entry h
+            INNER JOIN signalement s ON h.entity_id = s.id
+            LEFT JOIN suivi su ON s.id = su.signalement_id AND su.category = 'SIGNALEMENT_IS_INJONCTION'
+            WHERE h.event = 'CREATE'
+              AND h.entity_name = 'App\\Entity\\Signalement'
+              AND s.reference_injonction IS NOT NULL
+              AND su.id IS NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/DataFixtures/Files/signalement_draft_payload/locataire_injonction.json
+++ b/src/DataFixtures/Files/signalement_draft_payload/locataire_injonction.json
@@ -1,0 +1,156 @@
+{
+  "profil": "locataire",
+  "currentStep": "validation_signalement",
+  "bail_dpe_dpe": "oui",
+  "bail_dpe_classe_energetique": "G",
+  "bail_dpe_bail": "oui",
+  "type_logement_rdc": "non",
+  "categorieDisorders": {
+    "batiment": [
+      "desordres_batiment_bruit",
+      "desordres_batiment_proprete"
+    ],
+    "logement": [
+      "desordres_logement_electricite",
+      "desordres_logement_nuisibles"
+    ]
+  },
+  "bail_dpe_dpe_upload": [
+    {
+      "key": "documents",
+      "file": "Capture-d-ecran-dpe-1.png",
+      "titre": "Capture d’écran DPE 1.png"
+    },
+    {
+      "key": "documents",
+      "file": "Capture-d-ecran-dpe-2.png",
+      "titre": "Capture d’écran DPE 2.png"
+    }
+  ],
+  "bail_dpe_etat_des_lieux_upload": [
+    {
+      "key": "documents",
+      "file": "Capture-d-ecran-dpe-3.png",
+      "titre": "Capture d’écran DPE 3.png"
+    }
+  ],
+  "bail_dpe_bail_upload": [
+    {
+      "key": "documents",
+      "file": "Capture-d-ecran-bail-1.png",
+      "titre": "Capture d’écran BAIL 1.png"
+    },
+    {
+      "key": "documents",
+      "file": "Capture-d-ecran-bail-2.png",
+      "titre": "Capture d’écran BAIL 2.png"
+    }
+  ],
+  "zone_concernee_zone": "batiment_logement",
+  "type_logement_nature": "appartement",
+  "uuidSignalementDraft": "00000000-0000-0000-2023-locataire001",
+  "bail_dpe_etat_des_lieux": "oui",
+  "adresse_logement_adresse": "61 impasse jean cavalier 30360 Vézénobres",
+  "coordonnees_bailleur_nom": "Bargeton",
+  "coordonnees_bailleur_prenom": "Sandrine",
+  "coordonnees_bailleur_email": "sandrine@signal-logement.fr",
+  "coordonnees_bailleur_tel": "0644784516",
+  "coordonnees_bailleur_tel_countrycode": "FR:33",
+  "coordonnees_bailleur_tel_secondaire": "0644784517",
+  "coordonnees_bailleur_tel_secondaire_countrycode": "FR:33",
+  "coordonnees_bailleur_adresse_suggestion": "10 Rue du 14 Juillet",
+  "coordonnees_bailleur_adresse": "10 rue du 14 juillet 64000 Pau",
+  "coordonnees_bailleur_adresse_detail_numero": "10 rue du 14 juillet",
+  "coordonnees_bailleur_adresse_detail_code_postal": "64000",
+  "coordonnees_bailleur_adresse_detail_commune": "Pau",
+  "coordonnees_bailleur_adresse_detail_insee": "64445",
+  "coordonnees_bailleur_adresse_detail_geoloc_lng": -0.378335,
+  "coordonnees_bailleur_adresse_detail_geoloc_lat": 43.292324,
+  "bail_dpe_date_emmenagement": "2020-10-01",
+  "logement_social_allocation": "oui",
+  "signalement_concerne_profil": "logement_occupez",
+  "type_logement_commodites_wc": "oui",
+  "type_logement_dernier_etage": "non",
+  "composition_logement_enfants": "oui",
+  "vos_coordonnees_occupant_nom": "Locataire Nom",
+  "vos_coordonnees_occupant_tel": "0644784515",
+  "vos_coordonnees_occupant_tel_countrycode": "FR:33",
+  "utilisation_service_ok_visite": 1,
+  "composition_logement_nb_pieces": "2",
+  "logement_social_date_naissance": "1970-10-01",
+  "vos_coordonnees_occupant_email": "locataire-01@signal-logement.fr",
+  "composition_logement_superficie": "45",
+  "info_procedure_bailleur_prevenu": "oui",
+  "info_procedure_bail_moyen": "courrier",
+  "info_procedure_bail_date": "11/2024",
+  "info_procedure_bail_reponse": "Réponse du bailleur",
+  "info_procedure_bail_numero": "R-TR45",
+  "injonction_bailleur_choice": "oui",
+  "vos_coordonnees_occupant_prenom": "Locataire Prenom",
+  "type_logement_commodites_cuisine": "oui",
+  "type_logement_commodites_piece_a_vivre_9m": "oui",
+  "composition_logement_piece_unique": "plusieurs_pieces",
+  "logement_social_allocation_caisse": "caf",
+  "travailleur_social_accompagnement": "oui",
+  "vos_coordonnees_occupant_civilite": "mme",
+  "desordres_batiment_bruit_interieur": 1,
+  "info_procedure_assurance_contactee": "oui",
+  "info_procedure_reponse_assurance" : "Dossier reçu",
+  "logement_social_demande_relogement": "oui",
+  "logement_social_montant_allocation": "300",
+  "logement_social_numero_allocataire": "12345678",
+  "travailleur_social_quitte_logement": "non",
+  "adresse_logement_adresse_suggestion": "61 impasse jean cavalier",
+  "info_procedure_depart_apres_travaux": "oui",
+  "type_logement_commodites_wc_cuisine": "non",
+  "type_logement_sous_sol_sans_fenetre": "non",
+  "desordres_logement_nuisibles_cafards": 1,
+  "adresse_logement_adresse_detail_insee": "30348",
+  "composition_logement_nombre_enfants": "1",
+  "composition_logement_nombre_personnes": "3",
+  "desordres_logement_nuisibles_punaises": 1,
+  "adresse_logement_adresse_detail_numero": "61 impasse jean cavalier",
+  "type_logement_commodites_salle_de_bain": "oui",
+  "adresse_logement_adresse_detail_commune": "Vézénobres",
+  "utilisation_service_ok_demande_logement": 1,
+  "vos_coordonnees_occupant_tel_secondaire": "3621161",
+  "vos_coordonnees_occupant_tel_secondaire_countrycode": "KM:269",
+  "utilisation_service_ok_prevenir_bailleur": 1,
+  "utilisation_service_ok_cgu": 1,
+  "adresse_logement_complement_adresse_etage": "5",
+  "adresse_logement_adresse_detail_geoloc_lat": 44.05452,
+  "adresse_logement_adresse_detail_geoloc_lng": 4.138306,
+  "adresse_logement_adresse_detail_code_postal": "30360",
+  "signalement_concerne_profil_detail_occupant": "locataire",
+  "adresse_logement_complement_adresse_escalier": "A",
+  "desordres_logement_electricite_manque_prises": 1,
+  "desordres_logement_chauffage_details_dpe_annee": "post2023",
+  "signalement_concerne_logement_social_autre_tiers": "non",
+  "desordres_logement_nuisibles_cafards_details_date": "after_movein",
+  "type_logement_commodites_salle_de_bain_collective": "oui",
+  "desordres_logement_nuisibles_punaises_details_date": "after_movein",
+  "informations_complementaires_logement_montant_loyer": "500",
+  "informations_complementaires_logement_nombre_etages": "5",
+  "adresse_logement_complement_adresse_numero_appartement": "124",
+  "message_administration": "En tant que locataire responsable, je tiens à garantir la sécurité et le bien-être de ma famille, y compris mon enfant en bas âge, qui est particulièrement vulnérable à ces problèmes.\n\nJ'ai déjà soumis une demande d'intervention pour résoudre ces problèmes, mais malheureusement, il semble que cela n'ait pas été traité dans les délais appropriés. Je tiens à rappeler que ces problèmes sont non seulement inconfortables mais aussi dangereux pour la sécurité et la santé de ma famille.\n\nJe vous implore de prendre des mesures immédiates pour résoudre ces problèmes en envoyant des professionnels qualifiés pour réparer les problèmes électriques et éliminer les infestations d'insectes. La sécurité et le bien-être de ma famille sont ma priorité absolue.\n\nJe vous remercie de votre attention à cette question urgente et j'attends une réponse et une action rapides de votre part. Je suis disposé à coopérer pleinement pour faciliter toute intervention nécessaire.",
+  "informations_complementaires_logement_annee_construction": "1970",
+  "desordres_logement_electricite_manque_prises_details_pieces": 1,
+  "informations_complementaires_situation_occupants_beneficiaire_fsl": "non",
+  "informations_complementaires_situation_occupants_beneficiaire_rsa": "non",
+  "desordres_logement_electricite_manque_prises_details_pieces_cuisine": 1,
+  "desordres_logement_electricite_manque_prises_details_pieces_piece_a_vivre": 1,
+  "desordres_logement_electricite_manque_prises_details_pieces_salle_de_bain": 1,
+  "desordres_batiment_proprete_photos_upload": [
+    {
+      "key": "photos",
+      "file": "Capture-d-ecran-1-desordre.png",
+      "titre": "Capture écran 1.png"
+    },
+    {
+      "key": "photos",
+      "file": "Capture-d-ecran-2-desordre.png",
+      "titre": "Capture écran 2.png"
+    }
+
+  ]
+}

--- a/src/Entity/Enum/SuiviCategory.php
+++ b/src/Entity/Enum/SuiviCategory.php
@@ -6,6 +6,7 @@ enum SuiviCategory: string
 {
     case ASK_DOCUMENT = 'ASK_DOCUMENT';
     case ASK_FEEDBACK_SENT = 'ASK_FEEDBACK_SENT';
+    case SIGNALEMENT_IS_INJONCTION = 'SIGNALEMENT_IS_INJONCTION';
     case SIGNALEMENT_IS_ACTIVE = 'SIGNALEMENT_IS_ACTIVE';
     case SIGNALEMENT_IS_CLOSED = 'SIGNALEMENT_IS_CLOSED';
     case SIGNALEMENT_IS_REFUSED = 'SIGNALEMENT_IS_REFUSED';
@@ -77,6 +78,7 @@ enum SuiviCategory: string
         return [
             'ASK_DOCUMENT' => 'Demande de document',
             'ASK_FEEDBACK_SENT' => 'Demande de feedback envoyée à l\'usager',
+            'SIGNALEMENT_IS_INJONCTION' => 'Dépôt de dossier en démarche accélérée',
             'SIGNALEMENT_IS_ACTIVE' => 'Validation du dossier',
             'SIGNALEMENT_IS_CLOSED' => 'Fermeture du dossier',
             'SIGNALEMENT_IS_REFUSED' => 'Refus du dossier',
@@ -156,6 +158,7 @@ enum SuiviCategory: string
     public static function injonctionBailleurCategories(): array
     {
         return [
+            self::SIGNALEMENT_IS_INJONCTION,
             self::INJONCTION_BAILLEUR_REPONSE_OUI,
             self::INJONCTION_BAILLEUR_REPONSE_OUI_AVEC_AIDE,
             self::INJONCTION_BAILLEUR_REPONSE_OUI_DEMARCHES_COMMENCEES,

--- a/src/Entity/Signalement.php
+++ b/src/Entity/Signalement.php
@@ -332,6 +332,7 @@ class Signalement implements EntityHistoryInterface, EntityHistoryCollectionInte
 
     /** @var Collection<int, Suivi> $suivis */
     #[ORM\OneToMany(mappedBy: 'signalement', targetEntity: Suivi::class, orphanRemoval: true, cascade: ['persist'])]
+    #[ORM\OrderBy(['createdAt' => 'ASC'])]
     private Collection $suivis;
 
     #[ORM\Column(nullable: true)]

--- a/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
+++ b/src/EventSubscriber/SignalementDraftCompletedSubscriber.php
@@ -4,12 +4,16 @@ namespace App\EventSubscriber;
 
 use App\Entity\Enum\SignalementDraftStatus;
 use App\Entity\Enum\SignalementStatus;
+use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
 use App\Entity\SignalementDraft;
+use App\Entity\Suivi;
 use App\Event\SignalementDraftCompletedEvent;
 use App\Manager\SignalementManager;
+use App\Manager\SuiviManager;
 use App\Messenger\Message\NewSignalementCheckFileMessage;
 use App\Messenger\Message\SignalementDraftProcessMessage;
+use App\Repository\UserRepository;
 use App\Service\Files\DocumentProvider;
 use App\Service\Mailer\NotificationMail;
 use App\Service\Mailer\NotificationMailerRegistry;
@@ -34,6 +38,8 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
         private readonly ParameterBagInterface $parameterBag,
+        private readonly SuiviManager $suiviManager,
+        private readonly UserRepository $userRepository,
     ) {
     }
 
@@ -69,6 +75,7 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                     $signalement->getTerritory()->getName()
                 ));
                 $this->sendNotifications($signalement);
+                $this->createFirstSuivi($signalement);
                 $this->dispatchDraftProcessing($signalementDraft, $signalement);
                 $this->dispatchCheckFiles($signalement);
                 $signalementDraft->setStatus(SignalementDraftStatus::EN_SIGNALEMENT);
@@ -98,6 +105,19 @@ class SignalementDraftCompletedSubscriber implements EventSubscriberInterface
                     signalement: $signalement,
                     attachment: $this->documentProvider->getModeleCourrierPourProprietaire($signalement),
                 )
+            );
+        }
+    }
+
+    private function createFirstSuivi(Signalement $signalement): void
+    {
+        if (SignalementStatus::INJONCTION_BAILLEUR === $signalement->getStatut()) {
+            $this->suiviManager->createSuivi(
+                signalement: $signalement,
+                description: 'Dossier déposé dans le cadre de la démarche accélérée',
+                type: Suivi::TYPE_AUTO,
+                category: SuiviCategory::SIGNALEMENT_IS_INJONCTION,
+                user: $this->userRepository->findOneBy(['email' => $this->parameterBag->get('user_system_email')])
             );
         }
     }

--- a/tests/Functional/Controller/SignalementControllerTest.php
+++ b/tests/Functional/Controller/SignalementControllerTest.php
@@ -556,6 +556,51 @@ class SignalementControllerTest extends WebTestCase
 
         $this->assertEquals(SignalementDraftStatus::EN_SIGNALEMENT, $signalementDraft->getStatus());
         $this->assertEquals(1, $signalementDraft->getSignalements()->count());
+        $firstSignalement = $signalementDraft->getSignalements()->first();
+        $this->assertNotFalse($firstSignalement);
+        $this->assertEquals(0, $firstSignalement->getSuivis()->count());
+    }
+
+    public function testCompleteSignalementDraftToInjonctionBailleur(): void
+    {
+        $client = static::createClient();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $client->getContainer()->get('doctrine')->getManager();
+
+        $payload = json_decode(
+            (string) file_get_contents(__DIR__.'../../../../src/DataFixtures/Files/signalement_draft_payload/locataire_injonction.json'),
+            true
+        );
+        $uuidSignalement = $payload['uuidSignalementDraft'];
+
+        /** @var RouterInterface $router */
+        $router = $client->getContainer()->get(RouterInterface::class);
+        $urlPutSignalement = $router->generate('mise_a_jour_formulaire_signalement_draft', [
+            'uuid' => $uuidSignalement,
+        ]);
+
+        $client->request('PUT', $urlPutSignalement, [], [], [], (string) json_encode($payload));
+
+        $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $arrayResponse = json_decode((string) $client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('uuid', $arrayResponse);
+        $this->assertArrayHasKey('signalementReference', $arrayResponse);
+        $this->assertArrayHasKey('lienSuivi', $arrayResponse);
+
+        /** @var SignalementDraftRepository $signalementDraftRepository */
+        $signalementDraftRepository = $entityManager->getRepository(SignalementDraft::class);
+        $signalementDraft = $signalementDraftRepository->findOneBy(['uuid' => $uuidSignalement]);
+        $this->assertEquals(SignalementDraftStatus::EN_SIGNALEMENT, $signalementDraft->getStatus());
+
+        $this->assertEquals(1, $signalementDraft->getSignalements()->count());
+        $signalement = $signalementDraft->getSignalements()->first();
+        $this->assertNotFalse($signalement);
+        $this->assertEquals(1, $signalement->getSuivis()->count());
+
+        $this->assertEquals(SignalementStatus::INJONCTION_BAILLEUR, $signalement->getStatut());
+        $this->assertStringStartsWith('INJ-', $signalement->getReference());
     }
 
     public function testUpdateSignalementDraftArchived(): void

--- a/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
+++ b/tests/Functional/Manager/Esabora/EsaboraManagerTest.php
@@ -137,8 +137,13 @@ class EsaboraManagerTest extends KernelTestCase
             'reference' => $referenceSignalement,
         ]);
 
+        $suivis = $signalement->getSuivis();
         /** @var Suivi $suivi */
-        $suivi = $signalement->getSuivis()->last();
+        $suivi = $suivis->last();
+        if ($suivi instanceof Suivi && SuiviCategory::MESSAGE_USAGER_POST_CLOTURE === $suivi->getCategory()) {
+            $suiviArray = $suivis->toArray();
+            $suivi = $suiviArray[\count($suiviArray) - 2] ?? $suivi;
+        }
         $this->assertStringContainsString($suiviDescription, $suivi->getDescription(), $suiviDescription);
         $this->assertFalse($suivi->getIsPublic());
         $this->assertEquals($suiviStatus, $suivi->getType());
@@ -260,8 +265,13 @@ class EsaboraManagerTest extends KernelTestCase
         $esaboraManager->synchronizeAffectationFrom($dossierResponse, $affectation);
         $this->entityManager->refresh($signalement);
 
+        $suivis = $signalement->getSuivis();
         /** @var Suivi $suivi */
-        $suivi = $signalement->getSuivis()->last();
+        $suivi = $suivis->last();
+        if ($suivi instanceof Suivi && SuiviCategory::MESSAGE_USAGER_POST_CLOTURE === $suivi->getCategory()) {
+            $suiviArray = $suivis->toArray();
+            $suivi = $suiviArray[\count($suiviArray) - 2] ?? $suivi;
+        }
         $this->assertEquals(3, \count($signalement->getSuivis()));
         $this->assertStringContainsString($suiviDescription, $suivi->getDescription());
         $this->assertFalse($suivi->getIsPublic());
@@ -318,9 +328,12 @@ class EsaboraManagerTest extends KernelTestCase
         $esaboraManager->createOrUpdateVisite($affectation, $dossierVisite);
         $this->entityManager->flush();
         $this->entityManager->refresh($signalement);
-        $suivi = $signalement->getSuivis()->last();
-        if (!$suivi) {
-            $this->fail('No suivi found for the signalement');
+        $suivis = $signalement->getSuivis();
+        /** @var Suivi $suivi */
+        $suivi = $suivis->last();
+        if ($suivi instanceof Suivi && SuiviCategory::MESSAGE_USAGER_POST_CLOTURE === $suivi->getCategory()) {
+            $suiviArray = $suivis->toArray();
+            $suivi = $suiviArray[\count($suiviArray) - 2] ?? $suivi;
         }
         $intervention = $signalement->getInterventions()->first();
         if (!$intervention) {


### PR DESCRIPTION
## Ticket

#5577

## Description
Lors de la création de signalement en statut `INJONCTION_BAILLEUR`, nous n'avions pas obligatoirement de création de suivi initial. Ainsi lord de la bascule en procédure administrative on ne retrouve plus la date de création de signalement sur la fiche.
- Ajout d'un suivi interne "Dossier déposé dans le cadre de la démarche accélérée" (nouvelle catégorie `SIGNALEMENT_IS_INJONCTION`) lors de la création de signalements  `INJONCTION_BAILLEUR`.
- Ajout d'une migration afin que ce suivi soit ajouté sur tous les signalement passé par l'injonction à leur date de création (dans l'historique) et n'ayant pas encore ce suivi `SIGNALEMENT_IS_INJONCTION`.
- Modification de la requête généré de récupération des suivi dans l'entité `Signalement` afin qu'il soit classé par date.
- Ajout de tests permettant de vérifier le fonctionnement de création de ce suivi.

## Tests
- [ ] Déposer un signalement qui rentre dans le parcours injonction et voir que le suivi interne `SIGNALEMENT_IS_INJONCTION` est bien crée.
- [ ] Sur base de prod lancer la migration `Version20260323105455` et voir que les suivi `SIGNALEMENT_IS_INJONCTION` crées apparaissent bien en bas de la liste des suivi sur la fiche BO
