### PR TITLE
[FO - Formulaire service secours] Pouvoir filtrer les adresses de la BAN par département 

### DIFF
--- a/migrations/Version20260323155252.php
+++ b/migrations/Version20260323155252.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260323155252 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add territory_id to service_secours_route';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE service_secours_route ADD territory_id INT DEFAULT NULL AFTER id');
+        $this->addSql('ALTER TABLE service_secours_route ADD CONSTRAINT FK_3121EF1173F74AD4 FOREIGN KEY (territory_id) REFERENCES territory (id)');
+        $this->addSql('CREATE INDEX IDX_3121EF1173F74AD4 ON service_secours_route (territory_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE service_secours_route DROP FOREIGN KEY FK_3121EF1173F74AD4');
+        $this->addSql('DROP INDEX IDX_3121EF1173F74AD4 ON service_secours_route');
+        $this->addSql('ALTER TABLE service_secours_route DROP territory_id');
+    }
+}

--- a/src/Controller/ServiceSecours/ServiceSecoursController.php
+++ b/src/Controller/ServiceSecours/ServiceSecoursController.php
@@ -39,6 +39,7 @@ class ServiceSecoursController extends AbstractController
     ): Response {
         $session = $request->getSession();
         $serviceSecours = $session->get('service_secours_data', new FormServiceSecours());
+        $serviceSecours->step2->territoryZip = $serviceSecoursRoute->getTerritory()->getZip();
 
         if ($request->request->has('step')) {
             $step = $request->request->get('step');

--- a/src/DataFixtures/Files/ServiceSecoursRoute.yml
+++ b/src/DataFixtures/Files/ServiceSecoursRoute.yml
@@ -2,7 +2,9 @@ service_secours_routes:
 -
   name: "PIN PON"
   email: "pin-pon@example.com"
+  territory: "Bouches-du-Rhône"
 -
   name: "WOUIP WOUIP"
   email: "wouip-wouip@example.com"
+  territory: "Bouches-du-Rhône"
 

--- a/src/DataFixtures/Loader/LoadServiceSecoursRouteData.php
+++ b/src/DataFixtures/Loader/LoadServiceSecoursRouteData.php
@@ -3,6 +3,7 @@
 namespace App\DataFixtures\Loader;
 
 use App\Entity\ServiceSecoursRoute;
+use App\Repository\TerritoryRepository;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -10,6 +11,10 @@ use Symfony\Component\Yaml\Yaml;
 
 class LoadServiceSecoursRouteData extends Fixture implements OrderedFixtureInterface
 {
+    public function __construct(private TerritoryRepository $territoryRepository)
+    {
+    }
+
     public function load(ObjectManager $manager): void
     {
         $serviceSecoursRoutes = Yaml::parseFile(__DIR__.'/../Files/ServiceSecoursRoute.yml');
@@ -26,6 +31,7 @@ class LoadServiceSecoursRouteData extends Fixture implements OrderedFixtureInter
     {
         $serviceSecoursRoute = (new ServiceSecoursRoute())->setName($row['name']);
         $serviceSecoursRoute->setEmail($row['email']);
+        $serviceSecoursRoute->setTerritory($this->territoryRepository->findOneBy(['name' => $row['territory']]));
         $manager->persist($serviceSecoursRoute);
     }
 

--- a/src/Dto/ServiceSecours/FormServiceSecoursStep2.php
+++ b/src/Dto/ServiceSecours/FormServiceSecoursStep2.php
@@ -11,6 +11,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[NatureLogementAutreRequired(groups: ['step2'])]
 class FormServiceSecoursStep2
 {
+    public ?string $territoryZip = null;
+
     public ?string $adresseCompleteOccupant = null;
 
     public ?string $adresseOccupant = null;

--- a/src/Entity/ServiceSecoursRoute.php
+++ b/src/Entity/ServiceSecoursRoute.php
@@ -23,6 +23,11 @@ class ServiceSecoursRoute implements EntityHistoryInterface
     #[ORM\Column]
     private ?int $id = null;
 
+    #[ORM\ManyToOne(targetEntity: Territory::class)]
+    #[Assert\NotBlank]
+    #[ORM\JoinColumn]
+    private ?Territory $territory = null;
+
     #[ORM\Column(type: 'uuid', unique: true)]
     private ?Uuid $uuid = null;
 
@@ -58,6 +63,18 @@ class ServiceSecoursRoute implements EntityHistoryInterface
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getTerritory(): ?Territory
+    {
+        return $this->territory;
+    }
+
+    public function setTerritory(?Territory $territory): static
+    {
+        $this->territory = $territory;
+
+        return $this;
     }
 
     public function getUuid(): ?Uuid

--- a/src/Form/ServiceSecoursRouteType.php
+++ b/src/Form/ServiceSecoursRouteType.php
@@ -2,6 +2,7 @@
 
 namespace App\Form;
 
+use App\Form\Type\TerritoryChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -10,6 +11,9 @@ class ServiceSecoursRouteType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $builder->add('territory', TerritoryChoiceType::class, [
+            'placeholder' => 'Sélectionner un territoire',
+        ]);
         $builder->add('name', null, [
             'label' => 'Nom du service de secours',
             'help' => 'Sera enregistré comme structure du déclarant.',

--- a/src/Form/ServiceSecoursRouteType.php
+++ b/src/Form/ServiceSecoursRouteType.php
@@ -25,7 +25,7 @@ class ServiceSecoursRouteType extends AbstractType
             'required' => false,
         ]);
         $builder->add('phone', null, [
-            'label' => 'Téléphone du service de secours',
+            'label' => 'Téléphone du service de secours (facultatif)',
             'help' => 'Sera enregistré comme téléphone du déclarant.',
             'required' => false,
         ]);

--- a/src/Repository/ServiceSecoursRouteRepository.php
+++ b/src/Repository/ServiceSecoursRouteRepository.php
@@ -23,7 +23,9 @@ class ServiceSecoursRouteRepository extends ServiceEntityRepository
      */
     public function findFilteredPaginated(SearchServiceSecoursRoute $searchServiceSecoursRoute, int $maxResult): Paginator
     {
-        $qb = $this->createQueryBuilder('ssr');
+        $qb = $this->createQueryBuilder('ssr')
+            ->leftJoin('ssr.territory', 't')
+            ->addSelect('t');
 
         if (!empty($searchServiceSecoursRoute->getOrderType())) {
             [$orderField, $orderDirection] = explode('-', $searchServiceSecoursRoute->getOrderType());

--- a/src/Validator/AdresseOccupant.php
+++ b/src/Validator/AdresseOccupant.php
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Constraint;
 class AdresseOccupant extends Constraint
 {
     public string $messageAdresse = 'L\'adresse (numéro et voie) est obligatoire.';
-    public string $messageTerritoryMismatch = 'L’adresse ne correspond pas au territoire attendu.';
+    public string $messageTerritoryMismatch = 'L’adresse ne correspond pas au territoire attendu ({{ territory }}).';
     public string $messageCp = 'Le code postal est obligatoire.';
     public string $messageVille = 'La ville est obligatoire.';
     public string $messageInsee = 'Le territoire n\'est pas actif pour le code INSEE "{{ code }}".';

--- a/src/Validator/AdresseOccupant.php
+++ b/src/Validator/AdresseOccupant.php
@@ -8,6 +8,7 @@ use Symfony\Component\Validator\Constraint;
 class AdresseOccupant extends Constraint
 {
     public string $messageAdresse = 'L\'adresse (numéro et voie) est obligatoire.';
+    public string $messageTerritoryMismatch = 'L’adresse ne correspond pas au territoire attendu.';
     public string $messageCp = 'Le code postal est obligatoire.';
     public string $messageVille = 'La ville est obligatoire.';
     public string $messageInsee = 'Le territoire n\'est pas actif pour le code INSEE "{{ code }}".';

--- a/src/Validator/AdresseOccupantValidator.php
+++ b/src/Validator/AdresseOccupantValidator.php
@@ -96,5 +96,13 @@ class AdresseOccupantValidator extends ConstraintValidator
                 ->atPath('adresseCompleteOccupant')
                 ->addViolation();
         }
+
+        $expectedTerritoryZip = $value->territoryZip ?? null;
+        if ($expectedTerritoryZip && $territory->getZip() !== $expectedTerritoryZip) {
+            $this->context
+                ->buildViolation($constraint->messageTerritoryMismatch)
+                ->atPath('adresseCompleteOccupant')
+                ->addViolation();
+        }
     }
 }

--- a/src/Validator/AdresseOccupantValidator.php
+++ b/src/Validator/AdresseOccupantValidator.php
@@ -3,6 +3,7 @@
 namespace App\Validator;
 
 use App\Dto\ServiceSecours\FormServiceSecoursStep2;
+use App\Repository\TerritoryRepository;
 use App\Service\Signalement\ZipcodeProvider;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -12,6 +13,7 @@ class AdresseOccupantValidator extends ConstraintValidator
 {
     public function __construct(
         private readonly ZipcodeProvider $zipcodeProvider,
+        private readonly TerritoryRepository $territoryRepository,
     ) {
     }
 
@@ -99,8 +101,10 @@ class AdresseOccupantValidator extends ConstraintValidator
 
         $expectedTerritoryZip = $value->territoryZip ?? null;
         if ($expectedTerritoryZip && $territory->getZip() !== $expectedTerritoryZip) {
+            $expectedTerritory = $this->territoryRepository->findOneBy(['zip' => $expectedTerritoryZip]);
             $this->context
                 ->buildViolation($constraint->messageTerritoryMismatch)
+                ->setParameter('{{ territory }}', $expectedTerritory->getZipAndName() ?? '')
                 ->atPath('adresseCompleteOccupant')
                 ->addViolation();
         }

--- a/templates/back/config-service-secours-route/_title-and-table-list-results.html.twig
+++ b/templates/back/config-service-secours-route/_title-and-table-list-results.html.twig
@@ -1,6 +1,7 @@
 <section class="fr-col-12" id="table-list-results">
     {% set tableHead %}
         <th scope="col">ID</th>
+        <th scope="col">Territoire</th>
         <th scope="col">Nom</th>
         <th scope="col">E-mail/Téléphone</th>
         <th scope="col">URL</th>
@@ -11,6 +12,7 @@
         {% for serviceSecoursRoute in serviceSecoursRoutes %}
             <tr class="autoaffectationrule-row">
                 <td>{{ serviceSecoursRoute.id }}</td>
+                <td>{{ serviceSecoursRoute.territory ? serviceSecoursRoute.territory.zipAndName : 'aucun' }}</td>
                 <td>{{ serviceSecoursRoute.name }}</td>
                 <td>
                     {{ serviceSecoursRoute.email }}

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -61,6 +61,11 @@
                     {{ form_row(form.step1.ordreMission) }}
                 {% elseif current_step == 'step2' %}
                     {{ form_row(form.step2.adresseCompleteOccupant) }}
+                    <input
+                            type="hidden"
+                            id="signalement_draft_address_filterSearchAddressTerritory"
+                            value="{{ serviceSecoursRoute.territory.zip }}"
+                    />
                     <div id="fo-form-service-secours-adresse">
                         <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">
                         </div>

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -64,7 +64,7 @@
                     <input
                             type="hidden"
                             id="signalement_draft_address_filterSearchAddressTerritory"
-                            value="{{ serviceSecoursRoute.territory.zip }}"
+                            value="{{ serviceSecoursRoute.territory.zip }}|{{ serviceSecoursRoute.territory.name }}"
                     />
                     <div id="fo-form-service-secours-adresse">
                         <div class="fr-grid-row fr-background-alt--blue-france fr-text-label--blue-france fr-address-group">

--- a/tests/Functional/Controller/Back/ConfigServiceSecoursControllerTest.php
+++ b/tests/Functional/Controller/Back/ConfigServiceSecoursControllerTest.php
@@ -66,6 +66,7 @@ class ConfigServiceSecoursControllerTest extends WebTestCase
         $client->request('POST', $route, [
             'service_secours_route' => [
                 'name' => 'TI DU DUT',
+                'territory' => '13',
                 'email' => 'ti-du-dut@example.com',
                 'phone' => '',
                 '_token' => $csrfToken,

--- a/tests/Unit/Validator/AdresseOccupantValidatorTest.php
+++ b/tests/Unit/Validator/AdresseOccupantValidatorTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Tests\Unit\Validator;
+
+use App\Dto\ServiceSecours\FormServiceSecoursStep2;
+use App\Entity\Territory;
+use App\Service\Signalement\ZipcodeProvider;
+use App\Validator\AdresseOccupant;
+use App\Validator\AdresseOccupantValidator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<AdresseOccupantValidator>
+ */
+class AdresseOccupantValidatorTest extends ConstraintValidatorTestCase
+{
+    private ZipcodeProvider&MockObject $zipcodeProvider;
+
+    protected function createValidator(): AdresseOccupantValidator
+    {
+        $this->zipcodeProvider = $this->createMock(ZipcodeProvider::class);
+
+        return new AdresseOccupantValidator($this->zipcodeProvider);
+    }
+
+    /**
+     * @dataProvider provideInvalidTerritoryCases
+     */
+    public function testItAddsViolationWhenTerritoryIsInvalid(
+        ?Territory $territoryFromInsee,
+        ?Territory $territoryFromPostal,
+        string $expectedMessage,
+        string $expectedCode,
+        bool $expectPostalFallback,
+    ): void {
+        $constraint = new AdresseOccupant();
+
+        $form = new FormServiceSecoursStep2();
+        $form->adresseCompleteOccupant = '19 Quai de la Joliette, 13002 Marseille';
+        $form->adresseOccupant = '19 Quai de la Joliette';
+        $form->cpOccupant = '13002';
+        $form->villeOccupant = 'Marseille';
+        $form->inseeOccupant = '13055';
+
+        $this->zipcodeProvider
+            ->expects($this->once())
+            ->method('getTerritoryByInseeCode')
+            ->with('13055')
+            ->willReturn($territoryFromInsee);
+
+        if ($expectPostalFallback) {
+            $this->zipcodeProvider
+                ->expects($this->once())
+                ->method('getTerritoryByPostalCode')
+                ->with('13002')
+                ->willReturn($territoryFromPostal);
+        } else {
+            $this->zipcodeProvider
+                ->expects($this->never())
+                ->method('getTerritoryByPostalCode');
+        }
+
+        $this->validator->validate($form, $constraint);
+
+        $this
+            ->buildViolation($expectedMessage)
+            ->setParameter('{{ code }}', $expectedCode)
+            ->atPath('property.path.adresseCompleteOccupant')
+            ->assertRaised();
+    }
+
+    public function provideInvalidTerritoryCases(): iterable
+    {
+        // territoire inactif via INSEE
+        $inactiveTerritory = $this->createMock(Territory::class);
+        $inactiveTerritory->method('isIsActive')->willReturn(false);
+
+        yield 'territory inactive via insee' => [
+            $inactiveTerritory,
+            null,
+            (new AdresseOccupant())->messageInsee,
+            '13055',
+            false,
+        ];
+
+        yield 'no territory found' => [
+            null,
+            null,
+            (new AdresseOccupant())->messagePostalCode,
+            '13002',
+            true,
+        ];
+    }
+
+    public function testItAddsViolationWhenExpectedTerritoryZipDoesNotMatch(): void
+    {
+        $constraint = new AdresseOccupant();
+
+        $form = new FormServiceSecoursStep2();
+        $form->adresseCompleteOccupant = '19 Quai de la Joliette, 13002 Marseille';
+        $form->adresseOccupant = '19 Quai de la Joliette';
+        $form->cpOccupant = '13002';
+        $form->villeOccupant = 'Marseille';
+        $form->inseeOccupant = '13055';
+        $form->territoryZip = '75001';
+
+        $territory = $this->createMock(Territory::class);
+        $territory->method('isIsActive')->willReturn(true);
+        $territory->method('getZip')->willReturn('13002');
+
+        $this->zipcodeProvider
+            ->expects($this->once())
+            ->method('getTerritoryByInseeCode')
+            ->with('13055')
+            ->willReturn($territory);
+
+        $this->validator->validate($form, $constraint);
+
+        $this
+            ->buildViolation($constraint->messageTerritoryMismatch)
+            ->atPath('property.path.adresseCompleteOccupant')
+            ->assertRaised();
+    }
+}

--- a/tests/Unit/Validator/AdresseOccupantValidatorTest.php
+++ b/tests/Unit/Validator/AdresseOccupantValidatorTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Unit\Validator;
 
 use App\Dto\ServiceSecours\FormServiceSecoursStep2;
 use App\Entity\Territory;
+use App\Repository\TerritoryRepository;
 use App\Service\Signalement\ZipcodeProvider;
 use App\Validator\AdresseOccupant;
 use App\Validator\AdresseOccupantValidator;
@@ -16,12 +17,14 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 class AdresseOccupantValidatorTest extends ConstraintValidatorTestCase
 {
     private ZipcodeProvider&MockObject $zipcodeProvider;
+    private TerritoryRepository&MockObject $territoryRepository;
 
     protected function createValidator(): AdresseOccupantValidator
     {
         $this->zipcodeProvider = $this->createMock(ZipcodeProvider::class);
+        $this->territoryRepository = $this->createMock(TerritoryRepository::class);
 
-        return new AdresseOccupantValidator($this->zipcodeProvider);
+        return new AdresseOccupantValidator($this->zipcodeProvider, $this->territoryRepository);
     }
 
     /**
@@ -109,16 +112,31 @@ class AdresseOccupantValidatorTest extends ConstraintValidatorTestCase
         $territory->method('isIsActive')->willReturn(true);
         $territory->method('getZip')->willReturn('13002');
 
+        $expectedTerritory = $this->createMock(Territory::class);
+        $expectedTerritory->method('getZip')->willReturn('75001');
+        $expectedTerritory->method('getZipAndName')->willReturn('75001 Paris');
+
         $this->zipcodeProvider
             ->expects($this->once())
             ->method('getTerritoryByInseeCode')
             ->with('13055')
             ->willReturn($territory);
 
+        $this->zipcodeProvider
+            ->expects($this->never())
+            ->method('getTerritoryByPostalCode');
+
+        $this->territoryRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['zip' => '75001'])
+            ->willReturn($expectedTerritory);
+
         $this->validator->validate($form, $constraint);
 
         $this
             ->buildViolation($constraint->messageTerritoryMismatch)
+            ->setParameter('{{ territory }}', '75001 Paris')
             ->atPath('property.path.adresseCompleteOccupant')
             ->assertRaised();
     }


### PR DESCRIPTION
## Ticket

#5593    

## Description
Proposer une liste d'adresse correspondant au territoire du service secours

## Changements apportés
* Mise à jour migration
* Ajouter d'un nouveau champs territoire (migration, formulaire et liste)
* Activation du filtre par département via le champ de type hidden
* Mise à jour du validator

## Pré-requis

## Tests
- [ ] Créer un nouveau lien de service secours et vérifier que les adresses proposées correspondent au territoire sélectionné lors de la création 
- [ ] Tester la nouvelle contrainte en commentant le champ caché https://github.com/MTES-MCT/histologe/pull/5599#discussion_r2982434533
<img width="1465" height="211" alt="image" src="https://github.com/user-attachments/assets/ed00c83a-fdfc-46b4-ba45-561f1c1f33d6" />

