### PR TITLE
[FO - Formulaire service secours] Ajout d'un bouton annuler pour réinitialiser la saisie en cours

### DIFF
--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -1433,7 +1433,6 @@ ul.fr-toggle__list.fr-toggle__list--inline {
     }
 }
 
-
 .form-nav-row-reverse {
     flex-direction: row-reverse;
 }

--- a/assets/styles/histologe.scss
+++ b/assets/styles/histologe.scss
@@ -1432,3 +1432,8 @@ ul.fr-toggle__list.fr-toggle__list--inline {
         justify-content: center;
     }
 }
+
+
+.form-nav-row-reverse {
+    flex-direction: row-reverse;
+}

--- a/src/Controller/ServiceSecours/ServiceSecoursController.php
+++ b/src/Controller/ServiceSecours/ServiceSecoursController.php
@@ -58,21 +58,10 @@ class ServiceSecoursController extends AbstractController
         ServiceSecoursPdfGenerator $serviceSecoursPdfGenerator,
         MessageBusInterface $messageBus,
     ): Response {
-        $session = $request->getSession();
-        $serviceSecours = $session->get('service_secours_data', new FormServiceSecours());
-        $serviceSecours->step2->territoryZip = $serviceSecoursRoute->getTerritory()->getZip();
-
-        if ($request->request->has('step')) {
-            $step = $request->request->get('step');
-            if (in_array($step, ['step1', 'step2', 'step3', 'step4', 'step5']) && $step < $serviceSecours->currentStep) {
-                $serviceSecours->currentStep = $step;
-            }
-        }
+        $serviceSecours = new FormServiceSecours();
         /** @var FormFlowInterface $flow */
         $flow = $this->createForm(ServiceSecoursType::class, $serviceSecours);
         $flow->handleRequest($request);
-        $session->set('service_secours_data', $flow->getData());
-
         if ($flow->isSubmitted() && $flow->isValid() && $flow->isFinished()) {
             $signalement = $signalementFactory->createInstanceFromFormServiceSecours($flow->getData(), $serviceSecoursRoute);
 

--- a/src/Form/ServiceSecours/ServiceSecoursNavigatorType.php
+++ b/src/Form/ServiceSecours/ServiceSecoursNavigatorType.php
@@ -3,10 +3,13 @@
 namespace App\Form\ServiceSecours;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Flow\ButtonFlowInterface;
 use Symfony\Component\Form\Flow\FormFlowCursor;
+use Symfony\Component\Form\Flow\FormFlowInterface;
 use Symfony\Component\Form\Flow\Type\FinishFlowType;
 use Symfony\Component\Form\Flow\Type\NextFlowType;
 use Symfony\Component\Form\Flow\Type\PreviousFlowType;
+use Symfony\Component\Form\Flow\Type\ResetFlowType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -15,6 +18,10 @@ class ServiceSecoursNavigatorType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            ->add('reset', ResetFlowType::class, [
+                'label' => 'Annuler',
+                'attr' => ['class' => 'fr-btn fr-btn--secondary fr-icon-close-line'],
+            ])
             ->add('previous', PreviousFlowType::class, [
                 'label' => 'Précédent',
                 'include_if' => static fn (FormFlowCursor $cursor) => !$cursor->isFirstStep(),
@@ -37,6 +44,50 @@ class ServiceSecoursNavigatorType extends AbstractType
                 'include_if' => static fn (FormFlowCursor $cursor) => $cursor->isLastStep(),
             ])
         ;
+
+        $builder
+            ->add('editStep1', PreviousFlowType::class, $this->createEditButtonOptions(
+                'step1',
+                'Modifier les coordonnées',
+            ))
+            ->add('editStep2', PreviousFlowType::class, $this->createEditButtonOptions(
+                'step2',
+                'Modifier les infos sur le logement',
+            ))
+            ->add('editStep3', PreviousFlowType::class, $this->createEditButtonOptions(
+                'step3',
+                'Modifier l\'occupation du logement',
+            ))
+            ->add('editStep4', PreviousFlowType::class, $this->createEditButtonOptions(
+                'step4',
+                'Modifier les informations propriétaire / syndic',
+            ))
+            ->add('editStep5', PreviousFlowType::class, $this->createEditButtonOptions(
+                'step5',
+                'Modifier les désordres',
+            ));
+    }
+
+    private function createEditButtonOptions(string $step, string $label): array
+    {
+        return [
+            'label' => '<span class="fr-hidden fr-unhidden-md">Modifier</span>',
+            'label_html' => true,
+            'include_if' => static fn (FormFlowCursor $cursor): bool => $cursor->isLastStep(),
+            'validation_groups' => false,
+            'attr' => [
+                'class' => 'fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left',
+                'aria-label' => $label,
+                'title' => $label,
+            ],
+            'handler' => static function (
+                mixed $_data, // NOSONAR - unused, must respect the handler signature
+                ButtonFlowInterface $_button, // NOSONAR - unused, must respect the handler signature
+                FormFlowInterface $flow,
+            ) use ($step): void {
+                $flow->movePrevious($step);
+            },
+        ];
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/ServiceSecours/ServiceSecoursStep2Type.php
+++ b/src/Form/ServiceSecours/ServiceSecoursStep2Type.php
@@ -20,7 +20,6 @@ class ServiceSecoursStep2Type extends AbstractType
             ->add('adresseCompleteOccupant', TextType::class, [
                 'label' => '<span class="fr-h5">Adresse du logement <span class="text-required">*</span></span>',
                 'label_html' => true,
-                'required' => false,
                 'help' => 'Format attendu : Tapez l\'adresse puis sélectionnez-la dans la liste. Si elle n\'apparaît pas, cliquez sur saisir une adresse manuellement.',
                 'mapped' => false,
                 'required' => false,

--- a/src/Form/ServiceSecours/ServiceSecoursStep2Type.php
+++ b/src/Form/ServiceSecours/ServiceSecoursStep2Type.php
@@ -20,6 +20,7 @@ class ServiceSecoursStep2Type extends AbstractType
             ->add('adresseCompleteOccupant', TextType::class, [
                 'label' => '<span class="fr-h5">Adresse du logement <span class="text-required">*</span></span>',
                 'label_html' => true,
+                'required' => false,
                 'help' => 'Format attendu : Tapez l\'adresse puis sélectionnez-la dans la liste. Si elle n\'apparaît pas, cliquez sur saisir une adresse manuellement.',
                 'mapped' => false,
                 'required' => false,

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -366,20 +366,9 @@
                     {{form_row(form.step6.hidden)}}
                 {% endif %}
                 <div class="fr-col-12 fr-col-lg">
-                    <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+                    <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters form-nav-row-reverse">
                         <div class="fr-col-12 fr-col-lg">
-                            {% if form.navigator.reset is defined %}
-                                <ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                    <li>{{ form_widget(form.navigator.reset) }}</li>
-                                </ul>
-                            {% endif %}
-                        </div>
-
-                        <div class="fr-col-12 fr-col-lg">
-                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                {% if form.navigator.previous is defined %}
-                                    <li>{{ form_widget(form.navigator.previous) }}</li>
-                                {% endif %}
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left  fr-btns-group--inline-reverse">
                                 {% if form.navigator.next is defined %}
                                     <li>{{ form_widget(form.navigator.next) }}</li>
                                 {% endif %}
@@ -389,7 +378,17 @@
                                 {% if form.navigator.finish is defined %}
                                     <li>{{ form_widget(form.navigator.finish) }}</li>
                                 {% endif %}
+                                {% if form.navigator.previous is defined %}
+                                    <li>{{ form_widget(form.navigator.previous) }}</li>
+                                {% endif %}
                             </ul>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg">
+                            {% if form.navigator.reset is defined %}
+                                <ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    <li>{{ form_widget(form.navigator.reset) }}</li>
+                                </ul>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -194,14 +194,7 @@
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
                             <h4 class="fr-h6">Vos coordonnées</h4>
-                            <button
-                                type="submit"
-                                name="step"
-                                class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left"
-                                value="step1"
-                                aria-label="Modifier les coordonnées" title="Modifier les coordonnées">
-                                <span class="fr-hidden fr-unhidden-md">Modifier</span>
-                            </button>
+                            {{ form_row(form.navigator.editStep1) }}
                         </div>
                         {% if data.step1.matriculeDeclarant %}
                             Matricule : {{ data.step1.matriculeDeclarant }}<br>
@@ -223,14 +216,7 @@
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
                             <h4 class="fr-h6">Infos sur le logement</h4>
-                            <button
-                                type="submit"
-                                name="step"
-                                class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left"
-                                value="step2"
-                                aria-label="Modifier les infos sur le logement" title="Modifier les infos sur le logement">
-                                <span class="fr-hidden fr-unhidden-md">Modifier</span>
-                            </button>
+                            {{ form_row(form.navigator.editStep2) }}
                         </div>
                         {{ data.step2.adresseOccupant }} <br>
                         {% if data.step2.adresseAutreOccupant %}
@@ -265,14 +251,7 @@
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
                             <h4 class="fr-h6">Occupation du logement</h4>
-                            <button
-                                type="submit"
-                                name="step"
-                                class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left"
-                                value="step3"
-                                aria-label="Modifier l'occupation du logement" title="Modifier l'occupation du logement">
-                                <span class="fr-hidden fr-unhidden-md">Modifier</span>
-                            </button>
+                            {{ form_row(form.navigator.editStep3) }}
                         </div>
                         {% if data.step3.nomOccupant %}
                             {{ data.step3.nomOccupant }} 
@@ -312,14 +291,7 @@
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
                             <h4 class="fr-h6">Propriétaire / Syndic</h4>
-                            <button
-                                type="submit"
-                                name="step"
-                                class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left"
-                                value="step4"
-                                aria-label="Modifier les informations propriétaire / syndic" title="Modifier les informations propriétaire / syndic">
-                                <span class="fr-hidden fr-unhidden-md">Modifier</span>
-                            </button>
+                            {{ form_row(form.navigator.editStep4) }}
                         </div>
                         {% set showBailleur = data.step4.isBailleurAverti or data.step4.denominationProprio or data.step4.nomProprio or data.step4.prenomProprio or data.step4.mailProprio or data.step4.telProprio %}
                         {% set showSyndic = data.step4.denominationSyndic or data.step4.nomSyndic or data.step4.mailSyndic or data.step4.telSyndic or data.step4.telSyndicSecondaire %}
@@ -370,14 +342,7 @@
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
                             <h4 class="fr-h6">Désordres</h4>
-                            <button
-                                type="submit"
-                                name="step"
-                                class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left"
-                                value="step5"
-                                aria-label="Modifier les désordres" title="Modifier les désordres">
-                                <span class="fr-hidden fr-unhidden-md">Modifier</span>
-                            </button>
+                            {{ form_row(form.navigator.editStep5) }}
                         </div>
                         {% if data.step5.autresOccupantsDesordre %}
                             Désordres rencontrés par d'autres occupants de l'immeuble : {{ data.step5.autresOccupantsDesordre|format_answer }}<br>
@@ -400,21 +365,33 @@
 
                     {{form_row(form.step6.hidden)}}
                 {% endif %}
-                <div class="fr-col-12">
-                    <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                        {% if form.navigator.finish is defined %}
-                            <li>{{ form_row(form.navigator.finish) }}</li>
-                        {% endif %}
-                        {% if form.navigator.nextReview is defined %}
-                            <li>{{ form_row(form.navigator.nextReview) }}</li>
-                        {% endif %}
-                        {% if form.navigator.next is defined %}
-                            <li>{{ form_row(form.navigator.next) }}</li>
-                        {% endif %}
-                        {% if form.navigator.previous is defined %}
-                            <li>{{ form_row(form.navigator.previous) }}</li>
-                        {% endif %}
-                    </ul>
+                <div class="fr-col-12 fr-col-lg">
+                    <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+                        <div class="fr-col-12 fr-col-lg">
+                            {% if form.navigator.reset is defined %}
+                                <ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                    <li>{{ form_widget(form.navigator.reset) }}</li>
+                                </ul>
+                            {% endif %}
+                        </div>
+
+                        <div class="fr-col-12 fr-col-lg">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                {% if form.navigator.previous is defined %}
+                                    <li>{{ form_widget(form.navigator.previous) }}</li>
+                                {% endif %}
+                                {% if form.navigator.next is defined %}
+                                    <li>{{ form_widget(form.navigator.next) }}</li>
+                                {% endif %}
+                                {% if form.navigator.nextReview is defined %}
+                                    <li>{{ form_widget(form.navigator.nextReview) }}</li>
+                                {% endif %}
+                                {% if form.navigator.finish is defined %}
+                                    <li>{{ form_widget(form.navigator.finish) }}</li>
+                                {% endif %}
+                            </ul>
+                        </div>
+                    </div>
                 </div>
                 {{ form_end(form) }}
 

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -367,7 +367,7 @@
                 {% endif %}
                 {#
                     Ordre DOM volontaire pour la tabulation : next => previous => reset
-                    L'ordre visuel est géré en CSS via la classe form-nav-row-reverse et fr-btns-group--inline-reverse
+                    L'ordre visuel est géré en CSS via les classes form-nav-row-reverse et fr-btns-group--inline-reverse
                     Ne pas modifier l'ordre HTML sans adapter aussi la navigation clavier.
                 #}
                 <div class="fr-col-12 fr-col-lg">

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -365,6 +365,11 @@
 
                     {{form_row(form.step6.hidden)}}
                 {% endif %}
+                {#
+                    Ordre DOM volontaire pour la tabulation : next => previous => reset
+                    L'ordre visuel est géré en CSS via la classe form-nav-row-reverse et fr-btns-group--inline-reverse
+                    Ne pas modifier l'ordre HTML sans adapter aussi la navigation clavier.
+                #}
                 <div class="fr-col-12 fr-col-lg">
                     <div class="fr-grid-row fr-grid-row--middle fr-grid-row--gutters form-nav-row-reverse">
                         <div class="fr-col-12 fr-col-lg">


### PR DESCRIPTION
## Ticket

#5600    

## Description
Il n’existe actuellement aucun moyen simple de repartir à zéro lors d’une saisie en cours.
Un rafraîchissement de page ou une fermeture d’onglet ne réinitialise pas le formulaire (stocké en session)
L’utilisateur est contraint de revenir en arrière manuellement et effacer chaque donnée ou de fermer complètement son navigateur.

Ajouter un bouton "Annuler" permettant de réinitialiser proprement la saisie en cours.

L’implémentation de la navigation manuelle https://github.com/MTES-MCT/histologe/pull/5591/changes#r2974631786 introduit des effets de bord sur le fonctionnement du bouton Annuler, reprise de la navigation depuis la page récap en utilisation des boutons géré par formFlow

## Changements apportés
* Ajout d'un bouton reset via le flow
* Navigation sur chaque step via le flow ou chaque bouton utilise un handler personnalisé pour rediriger vers le step ciblé
* Suppression de la gestion de la navigation manuelle 

## Pré-requis

## Tests
- [ ] Saisir un formulaire et cliquer sur le bouton annuler et vérifier que vous repartez de zero
- [ ] Aller sur la page de détail et vérifier que vous êtes rediriger vers la bonne step
