### PR TITLE
[TECH] Mise à jour image docker scalingo-sync-silo-metabase

### DIFF
--- a/.docker/scalingo-job/sync-db.sh
+++ b/.docker/scalingo-job/sync-db.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-IMAGE_VERSION="1.0.1"
+IMAGE_VERSION="1.0.2"
 
 log() {
   level="$1"

--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,7 @@ run-concurrency-request: ## Run concurrency request based postman collection ex:
 scalingo-job-build: ## Build Scalingo sync job container
 	@echo "\033[33mBuilding Scalingo job image...\033[0m"
 	docker build \
+		--no-cache \
 		-f $(METABASE_SYNC_SCALINGO_JOB_DOCKERFILE) \
 		-t $(METABASE_SYNC_IMAGE_NAME):local \
 		.
@@ -308,7 +309,7 @@ scalingo-job-run: ## Run Scalingo sync job locally
 	docker run --rm \
 		-e SCALINGO_API_TOKEN=$(METABASE_SYNC_SCALINGO_API_TOKEN) \
 		-e METABASE_SYNC_SCALINGO_APP=$(METABASE_SYNC_SCALINGO_APP) \
-		-e METABASE_SYNC_LOCAL_MODE=0 \
+		-e METABASE_SYNC_LOCAL_MODE=1 \
 		$(METABASE_SYNC_IMAGE_NAME):local
 
 scalingo-job-tag: ## Tag the local image with a version for Scaleway registry - make scalingo-job-tag IMAGE_VERSION=1.0.x


### PR DESCRIPTION
## Ticket

#5605    

> Je vais attendre pour l'ajout de log car le job que j'ai lancé manuellement hier a mis plus d'une heure, du coup mon hypothèse tombe à l'eau ou le kill de scalingo à 1h est un peu aléatoire

<img width="961" height="369" alt="image" src="https://github.com/user-attachments/assets/3fbb1bff-5d74-4e7c-a46a-c85e30af8cb2" />



## Description
Mise à jour de l'image en 1.0.2
  - Comprend la derniere version de la scalingo cli 

Image déjà envoyé dans le registry
<img width="957" height="105" alt="image" src="https://github.com/user-attachments/assets/53629386-a6ba-46a2-9e9f-05388b980255" />


## Changements apportés
* Mise à jour de l'image avec un tag 1.0.2

## Pré-requis

## Tests
- [ ] Test en local et vérifier que l'image est rebuildé avec la dernière version scalingo cli

```
$ make scalingo-job-run
Running Scalingo job locally...
2026-03-25T11:15:11Z [INFO] Image version: 1.0.2
2026-03-25T11:15:11Z [INFO] Starting Scalingo job
2026-03-25T11:15:11Z [INFO] Remote command: sh /app/scripts/sync-db.sh
2026-03-25T11:15:11Z [INFO] Version installée : scalingo version 1.43.3
``
