### PR TITLE
[BO - Cartographie] Ajout d'un referrer pour leaflet

### DIFF
--- a/assets/scripts/vanilla/services/component/pick-localisation.js
+++ b/assets/scripts/vanilla/services/component/pick-localisation.js
@@ -13,6 +13,7 @@ if (modalLocalisation) {
       L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        referrerPolicy: "origin"
       }).addTo(map);
     }
     let btn = document.getElementById('fr-modal-localisation-btn');
@@ -27,6 +28,7 @@ if (modalPickLocalisation) {
   L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    referrerPolicy: "origin"
   }).addTo(map);
 
   modalPickLocalisation.addEventListener('dsfr.disclose', () => {

--- a/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
+++ b/assets/scripts/vue/components/signalement-form/components/SignalementFormAddress.vue
@@ -401,7 +401,8 @@ export default defineComponent({
 
             L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
               maxZoom: 19,
-              attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+              attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+              referrerPolicy: "origin"
             }).addTo(this.map)
 
             // Initialiser la couche vectorielle RNB
@@ -433,7 +434,8 @@ export default defineComponent({
 
             L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
               maxZoom: 19,
-              attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+              attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+              referrerPolicy: "origin"
             }).addTo(this.map)
           })
         })

--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewCarto.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewCarto.vue
@@ -74,9 +74,9 @@ export default defineComponent({
         maxBounds: this.bounds,
         minZoom: 2,
         maxZoom: 18,
-        zoom: this.defaultZoom
+        zoom: this.defaultZoom,
       })
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { crossOrigin: true }).addTo(this.map as unknown as L.Map)
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { crossOrigin: true, referrerPolicy: "origin" }).addTo(this.map as unknown as L.Map)
     },
     addMarkers (signalements: any[]) {
       this.markers.clearLayers()

--- a/public/js/zone_map.js
+++ b/public/js/zone_map.js
@@ -1,7 +1,8 @@
 var map = L.map('zone_map').setView([47, 2], 6);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
-    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    referrerPolicy: "origin"
 }).addTo(map);
 
 // Correction des chemins des icônes


### PR DESCRIPTION
## Ticket

#5609

## Description
Ajout de l'option `referrerPolicy: "origin"` sur toute nos carte afin d'éviter l'erreur "Refrer is required"

## Pré-requis
`make npm-watch`

## Tests
- [ ] Tester l'affichage des carte de l'application
