### PR TITLE
[Tech] Créer une factory spécifique pour Service secours et ajout tests fonctionnels

### DIFF
--- a/src/Controller/ServiceSecours/ServiceSecoursController.php
+++ b/src/Controller/ServiceSecours/ServiceSecoursController.php
@@ -6,7 +6,7 @@ use App\Dto\ServiceSecours\FormServiceSecours;
 use App\Entity\Enum\AppContext;
 use App\Entity\ServiceSecoursRoute;
 use App\Entity\Signalement;
-use App\Factory\SignalementFactory;
+use App\Factory\SignalementServiceSecoursFactory;
 use App\Form\ServiceSecours\ServiceSecoursType;
 use App\Manager\UserManager;
 use App\Messenger\Message\SignalementServiceSecoursFileMessage;
@@ -47,7 +47,7 @@ class ServiceSecoursController extends AbstractController
     public function index(
         Request $request,
         ServiceSecoursRoute $serviceSecoursRoute,
-        SignalementFactory $signalementFactory,
+        SignalementServiceSecoursFactory $signalementServiceSecoursFactory,
         DesordreCritereRepository $desordreCritereRepository,
         SignalementRepository $signalementRepository,
         EntityManagerInterface $entityManager,
@@ -63,7 +63,7 @@ class ServiceSecoursController extends AbstractController
         $flow = $this->createForm(ServiceSecoursType::class, $serviceSecours);
         $flow->handleRequest($request);
         if ($flow->isSubmitted() && $flow->isValid() && $flow->isFinished()) {
-            $signalement = $signalementFactory->createInstanceFromFormServiceSecours($flow->getData(), $serviceSecoursRoute);
+            $signalement = $signalementServiceSecoursFactory->create($flow->getData(), $serviceSecoursRoute);
 
             $entityManager->beginTransaction();
             $signalement->setReference($referenceGenerator->generateReference($signalement->getTerritory()));

--- a/src/Factory/SignalementImportFactory.php
+++ b/src/Factory/SignalementImportFactory.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Factory;
+
+use App\Entity\Enum\CreationSource;
+use App\Entity\Enum\MotifCloture;
+use App\Entity\Enum\SignalementStatus;
+use App\Entity\Signalement;
+use App\Entity\Territory;
+
+class SignalementImportFactory
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function create(Territory $territory, array $data): Signalement
+    {
+        if (empty($data['statut'])) {
+            $data['statut'] = SignalementStatus::ACTIVE;
+            if ($data['motifCloture'] || $data['closedAt']) {
+                $data['statut'] = SignalementStatus::CLOSED;
+            }
+        }
+
+        return (new Signalement())
+            ->setIsImported(true)
+            ->setCreationSource(CreationSource::IMPORT)
+            ->setTerritory($territory)
+            ->setDetails($data['details'])
+            ->setIsProprioAverti((bool) $data['isProprioAverti'])
+            ->setNbAdultes($data['nbAdultes'])
+            ->setNbEnfantsM6($data['nbEnfantsM6'])
+            ->setNbEnfantsP6($data['nbEnfantsP6'])
+            ->setIsAllocataire($data['isAllocataire'])
+            ->setNumAllocataire($data['numAllocataire'])
+            ->setNatureLogement($data['natureLogement'])
+            ->setSuperficie($data['superficie'])
+            ->setLoyer($data['loyer'])
+            ->setIsBailEnCours((bool) $data['isBailEnCours'])
+            ->setDateEntree($data['dateEntree'])
+            ->setNomProprio($data['nomProprio'])
+            ->setAdresseProprio($data['adresseProprio'])
+            ->setTelProprio($data['telProprio'])
+            ->setMailProprio($data['mailProprio'])
+            ->setIsLogementSocial((bool) $data['isLogementSocial'])
+            ->setIsPreavisDepart((bool) $data['isPreavisDepart'])
+            ->setIsRelogement((bool) $data['isRelogement'])
+            ->setIsRefusIntervention($data['isRefusIntervention'])
+            ->setRaisonRefusIntervention($data['raisonRefusIntervention'])
+            ->setIsNotOccupant((bool) $data['isNotOccupant'])
+            ->setNomDeclarant($data['nomDeclarant'])
+            ->setPrenomDeclarant($data['prenomDeclarant'])
+            ->setTelDeclarant($data['telDeclarant'])
+            ->setMailDeclarant($data['mailDeclarant'])
+            ->setStructureDeclarant($data['structureDeclarant'])
+            ->setNomOccupant($data['nomOccupant'])
+            ->setPrenomOccupant($data['prenomOccupant'])
+            ->setTelOccupant($data['telOccupant'])
+            ->setMailOccupant($data['mailOccupant'])
+            ->setAdresseOccupant($data['adresseOccupant'])
+            ->setCpOccupant($data['cpOccupant'])
+            ->setVilleOccupant($data['villeOccupant'])
+            ->setIsCguAccepted((bool) $data['isCguAccepted'])
+            ->setCreatedAt($data['createdAt'])
+            ->setModifiedAt($data['modifiedAt'])
+            ->setStatut($data['statut'])
+            ->setValidatedAt(
+                SignalementStatus::ACTIVE === $data['statut'] ? $data['createdAt'] : new \DateTimeImmutable()
+            )
+            ->setReference($data['reference'])
+            ->setMontantAllocation((float) $data['montantAllocation'])
+            ->setCodeProcedure($data['codeProcedure'])
+            ->setEtageOccupant($data['etageOccupant'])
+            ->setEscalierOccupant($data['escalierOccupant'])
+            ->setNumAppartOccupant($data['numAppartOccupant'])
+            ->setAdresseAutreOccupant($data['adresseAutreOccupant'])
+            ->setInseeOccupant($data['inseeOccupant'])
+            ->setLienDeclarantOccupant($data['lienDeclarantOccupant'])
+            ->setIsConsentementTiers((bool) $data['isConsentementTiers'])
+            ->setIsRsa((bool) $data['isRsa'])
+            ->setAnneeConstruction($data['anneeConstruction'])
+            ->setTypeEnergieLogement($data['typeEnergieLogement'])
+            ->setOrigineSignalement($data['origineSignalement'])
+            ->setSituationOccupant($data['situationOccupant'])
+            ->setSituationProOccupant($data['situationProOccupant'])
+            ->setNaissanceOccupants($data['naissanceOccupants'])
+            ->setIsLogementCollectif((bool) $data['isLogementCollectif'])
+            ->setIsConstructionAvant1949((bool) $data['isConstructionAvant1949'])
+            ->setIsRisqueSurOccupation((bool) $data['isRisqueSurOccupation'])
+            ->setProprioAvertiAt($data['prorioAvertiAt'])
+            ->setNomReferentSocial($data['nomReferentSocial'])
+            ->setStructureReferentSocial($data['StructureReferentSocial'])
+            ->setNumeroInvariant($data['numeroInvariant'])
+            ->setNbPiecesLogement((int) $data['nbPiecesLogement'])
+            ->setNbChambresLogement((int) $data['nbChambresLogement'])
+            ->setNbNiveauxLogement((int) $data['nbNiveauxLogement'])
+            ->setNbOccupantsLogement((int) $data['nbOccupantsLogement'])
+            ->setMotifCloture(
+                null !== $data['motifCloture']
+                    ? MotifCloture::tryFrom($data['motifCloture'])
+                    : null)
+            ->setClosedAt($data['closedAt'])
+            ->setIsFondSolidariteLogement((bool) $data['isFondSolidariteLogement']);
+    }
+}

--- a/src/Factory/SignalementServiceSecoursFactory.php
+++ b/src/Factory/SignalementServiceSecoursFactory.php
@@ -7,20 +7,17 @@ use App\Dto\ServiceSecours\FormServiceSecoursStep5;
 use App\Entity\DesordreCritere;
 use App\Entity\Enum\CreationSource;
 use App\Entity\Enum\EtageType;
-use App\Entity\Enum\MotifCloture;
 use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\ProfileOccupant;
-use App\Entity\Enum\SignalementStatus;
 use App\Entity\Model\TypeCompositionLogement;
 use App\Entity\ServiceSecoursRoute;
 use App\Entity\Signalement;
-use App\Entity\Territory;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordreCritereRepository;
 use App\Service\Signalement\SignalementAddressUpdater;
 use App\Service\Signalement\ZipcodeProvider;
 
-class SignalementFactory
+class SignalementServiceSecoursFactory
 {
     public function __construct(
         private readonly ZipcodeProvider $zipcodeProvider,
@@ -30,7 +27,7 @@ class SignalementFactory
     ) {
     }
 
-    public function createInstanceFromFormServiceSecours(
+    public function create(
         FormServiceSecours $formServiceSecours,
         ServiceSecoursRoute $serviceSecoursRoute,
     ): Signalement {
@@ -47,14 +44,29 @@ class SignalementFactory
         $signalement->setMailDeclarant($serviceSecoursRoute->getEmail());
         $signalement->setTelDeclarant($serviceSecoursRoute->getPhone());
 
-        // data from step1
+        $this->handleStep1($formServiceSecours, $signalement);
+        $this->handleStep2($formServiceSecours, $signalement, $typeCompositionLogement);
+        $this->handleStep3($formServiceSecours, $signalement, $typeCompositionLogement);
+        $this->handleStep4($formServiceSecours, $signalement, $typeCompositionLogement);
+        $this->handleStep5($formServiceSecours, $signalement);
+
+        return $signalement;
+    }
+
+    private function handleStep1(FormServiceSecours $formServiceSecours, Signalement $signalement): void
+    {
         $signalement->setMatriculeDeclarant($formServiceSecours->step1->matriculeDeclarant);
         $signalement->setNomDeclarant($formServiceSecours->step1->nomDeclarant);
         $signalement->setDateMissionServiceSecours($formServiceSecours->step1->dateMission);
         $signalement->setOrigineMissionServiceSecours($formServiceSecours->step1->origineMission);
         $signalement->setOrdreMissionServiceSecours($formServiceSecours->step1->ordreMission);
+    }
 
-        // data from step2
+    private function handleStep2(
+        FormServiceSecours $formServiceSecours,
+        Signalement $signalement,
+        TypeCompositionLogement $typeCompositionLogement,
+    ): void {
         $signalement->setAdresseOccupant($formServiceSecours->step2->adresseOccupant)
             ->setCpOccupant($formServiceSecours->step2->cpOccupant)
             ->setVilleOccupant($formServiceSecours->step2->villeOccupant)
@@ -67,14 +79,12 @@ class SignalementFactory
             $signalement->setInseeOccupant($formServiceSecours->step2->inseeOccupant);
         }
 
-        switch ($formServiceSecours->step2->isLogementSocial) {
-            case 'oui':
-                $signalement->setIsLogementSocial(true);
-                break;
-            case 'non':
-                $signalement->setIsLogementSocial(false);
-                break;
-                // case 'nsp' si null, which is the default value of the entity
+        $isLogementSocial = $formServiceSecours->step2->isLogementSocial;
+        // case 'nsp' si null, which is the default value of the entity
+        if ('oui' === $isLogementSocial) {
+            $signalement->setIsLogementSocial(true);
+        } elseif ('non' === $isLogementSocial) {
+            $signalement->setIsLogementSocial(false);
         }
 
         $this->signalementAddressUpdater->updateAddressOccupantFromBanData(signalement: $signalement);
@@ -110,16 +120,25 @@ class SignalementFactory
                         $typeCompositionLogement->setTypeLogementRdc('non')
                             ->setTypeLogementDernierEtage('non');
                         break;
+                    default:
+                        // Alerte sonar - cas théoriquement pas possible
+                        break;
                 }
             }
         } elseif ('autre' === $signalement->getNatureLogement()) {
             $typeCompositionLogement->setTypeLogementNatureAutrePrecision($formServiceSecours->step2->natureLogementAutre);
         }
 
-        $signalement->setNbPiecesLogement((int) $formServiceSecours->step2->nbPiecesLogement)
+        $signalement
+            ->setNbPiecesLogement((int) $formServiceSecours->step2->nbPiecesLogement)
             ->setSuperficie((int) $formServiceSecours->step2->superficie);
+    }
 
-        // data from step3
+    private function handleStep3(
+        FormServiceSecours $formServiceSecours,
+        Signalement $signalement,
+        TypeCompositionLogement $typeCompositionLogement,
+    ): void {
         $profilOccupant = $formServiceSecours->step3->profilOccupant;
         if ('logement_vacant' === $profilOccupant) {
             $signalement->setIsLogementVacant(true);
@@ -138,8 +157,13 @@ class SignalementFactory
         $typeCompositionLogement->setCompositionLogementNombreEnfants($formServiceSecours->step3->nbEnfantsDansLogement);
         $typeCompositionLogement->setCompositionLogementEnfants($formServiceSecours->step3->isEnfantsMoinsSixAnsDansLogement);
         $signalement->setAutreSituationVulnerabilite($formServiceSecours->step3->autreVulnerabilite);
+    }
 
-        // data from step4
+    private function handleStep4(
+        FormServiceSecours $formServiceSecours,
+        Signalement $signalement,
+        TypeCompositionLogement $typeCompositionLogement,
+    ): void {
         if ('oui' === $formServiceSecours->step4->isBailleurAverti) {
             $signalement->setIsProprioAverti(true);
         } elseif ('non' === $formServiceSecours->step4->isBailleurAverti) {
@@ -161,10 +185,6 @@ class SignalementFactory
         $signalement->setTelSyndicSecondaire($formServiceSecours->step4->telSyndicSecondaire);
 
         $signalement->setTypeCompositionLogement($typeCompositionLogement);
-
-        $this->handleStep5($formServiceSecours, $signalement);
-
-        return $signalement;
     }
 
     private function handleStep5(FormServiceSecours $formServiceSecours, Signalement $signalement): void
@@ -196,98 +216,5 @@ class SignalementFactory
         }
         $signalement->setJsonContent($jsonContent);
         $signalement->setAutresOccupantsDesordre($formServiceSecours->step5->autresOccupantsDesordre);
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    public function createInstanceFromArrayForImport(Territory $territory, array $data): Signalement
-    {
-        if (empty($data['statut'])) {
-            $data['statut'] = SignalementStatus::ACTIVE;
-            if ($data['motifCloture'] || $data['closedAt']) {
-                $data['statut'] = SignalementStatus::CLOSED;
-            }
-        }
-
-        return (new Signalement())
-            ->setIsImported(true)
-            ->setCreationSource(CreationSource::IMPORT)
-            ->setTerritory($territory)
-            ->setDetails($data['details'])
-            ->setIsProprioAverti((bool) $data['isProprioAverti'])
-            ->setNbAdultes($data['nbAdultes'])
-            ->setNbEnfantsM6($data['nbEnfantsM6'])
-            ->setNbEnfantsP6($data['nbEnfantsP6'])
-            ->setIsAllocataire($data['isAllocataire'])
-            ->setNumAllocataire($data['numAllocataire'])
-            ->setNatureLogement($data['natureLogement'])
-            ->setSuperficie($data['superficie'])
-            ->setLoyer($data['loyer'])
-            ->setIsBailEnCours((bool) $data['isBailEnCours'])
-            ->setDateEntree($data['dateEntree'])
-            ->setNomProprio($data['nomProprio'])
-            ->setAdresseProprio($data['adresseProprio'])
-            ->setTelProprio($data['telProprio'])
-            ->setMailProprio($data['mailProprio'])
-            ->setIsLogementSocial((bool) $data['isLogementSocial'])
-            ->setIsPreavisDepart((bool) $data['isPreavisDepart'])
-            ->setIsRelogement((bool) $data['isRelogement'])
-            ->setIsRefusIntervention($data['isRefusIntervention'])
-            ->setRaisonRefusIntervention($data['raisonRefusIntervention'])
-            ->setIsNotOccupant((bool) $data['isNotOccupant'])
-            ->setNomDeclarant($data['nomDeclarant'])
-            ->setPrenomDeclarant($data['prenomDeclarant'])
-            ->setTelDeclarant($data['telDeclarant'])
-            ->setMailDeclarant($data['mailDeclarant'])
-            ->setStructureDeclarant($data['structureDeclarant'])
-            ->setNomOccupant($data['nomOccupant'])
-            ->setPrenomOccupant($data['prenomOccupant'])
-            ->setTelOccupant($data['telOccupant'])
-            ->setMailOccupant($data['mailOccupant'])
-            ->setAdresseOccupant($data['adresseOccupant'])
-            ->setCpOccupant($data['cpOccupant'])
-            ->setVilleOccupant($data['villeOccupant'])
-            ->setIsCguAccepted((bool) $data['isCguAccepted'])
-            ->setCreatedAt($data['createdAt'])
-            ->setModifiedAt($data['modifiedAt'])
-            ->setStatut($data['statut'])
-            ->setValidatedAt(
-                SignalementStatus::ACTIVE === $data['statut'] ? $data['createdAt'] : new \DateTimeImmutable()
-            )
-            ->setReference($data['reference'])
-            ->setMontantAllocation((float) $data['montantAllocation'])
-            ->setCodeProcedure($data['codeProcedure'])
-            ->setEtageOccupant($data['etageOccupant'])
-            ->setEscalierOccupant($data['escalierOccupant'])
-            ->setNumAppartOccupant($data['numAppartOccupant'])
-            ->setAdresseAutreOccupant($data['adresseAutreOccupant'])
-            ->setInseeOccupant($data['inseeOccupant'])
-            ->setLienDeclarantOccupant($data['lienDeclarantOccupant'])
-            ->setIsConsentementTiers((bool) $data['isConsentementTiers'])
-            ->setIsRsa((bool) $data['isRsa'])
-            ->setAnneeConstruction($data['anneeConstruction'])
-            ->setTypeEnergieLogement($data['typeEnergieLogement'])
-            ->setOrigineSignalement($data['origineSignalement'])
-            ->setSituationOccupant($data['situationOccupant'])
-            ->setSituationProOccupant($data['situationProOccupant'])
-            ->setNaissanceOccupants($data['naissanceOccupants'])
-            ->setIsLogementCollectif((bool) $data['isLogementCollectif'])
-            ->setIsConstructionAvant1949((bool) $data['isConstructionAvant1949'])
-            ->setIsRisqueSurOccupation((bool) $data['isRisqueSurOccupation'])
-            ->setProprioAvertiAt($data['prorioAvertiAt'])
-            ->setNomReferentSocial($data['nomReferentSocial'])
-            ->setStructureReferentSocial($data['StructureReferentSocial'])
-            ->setNumeroInvariant($data['numeroInvariant'])
-            ->setNbPiecesLogement((int) $data['nbPiecesLogement'])
-            ->setNbChambresLogement((int) $data['nbChambresLogement'])
-            ->setNbNiveauxLogement((int) $data['nbNiveauxLogement'])
-            ->setNbOccupantsLogement((int) $data['nbOccupantsLogement'])
-            ->setMotifCloture(
-                null !== $data['motifCloture']
-                ? MotifCloture::tryFrom($data['motifCloture'])
-                : null)
-            ->setClosedAt($data['closedAt'])
-            ->setIsFondSolidariteLogement((bool) $data['isFondSolidariteLogement']);
     }
 }

--- a/src/Factory/SignalementServiceSecoursFactory.php
+++ b/src/Factory/SignalementServiceSecoursFactory.php
@@ -47,8 +47,9 @@ class SignalementServiceSecoursFactory
         $this->handleStep1($formServiceSecours, $signalement);
         $this->handleStep2($formServiceSecours, $signalement, $typeCompositionLogement);
         $this->handleStep3($formServiceSecours, $signalement, $typeCompositionLogement);
-        $this->handleStep4($formServiceSecours, $signalement, $typeCompositionLogement);
+        $this->handleStep4($formServiceSecours, $signalement);
         $this->handleStep5($formServiceSecours, $signalement);
+        $signalement->setTypeCompositionLogement($typeCompositionLogement);
 
         return $signalement;
     }
@@ -162,7 +163,6 @@ class SignalementServiceSecoursFactory
     private function handleStep4(
         FormServiceSecours $formServiceSecours,
         Signalement $signalement,
-        TypeCompositionLogement $typeCompositionLogement,
     ): void {
         if ('oui' === $formServiceSecours->step4->isBailleurAverti) {
             $signalement->setIsProprioAverti(true);
@@ -183,8 +183,6 @@ class SignalementServiceSecoursFactory
         $signalement->setMailSyndic($formServiceSecours->step4->mailSyndic);
         $signalement->setTelSyndic($formServiceSecours->step4->telSyndic);
         $signalement->setTelSyndicSecondaire($formServiceSecours->step4->telSyndicSecondaire);
-
-        $signalement->setTypeCompositionLogement($typeCompositionLogement);
     }
 
     private function handleStep5(FormServiceSecours $formServiceSecours, Signalement $signalement): void

--- a/src/Manager/SignalementManager.php
+++ b/src/Manager/SignalementManager.php
@@ -36,7 +36,7 @@ use App\Entity\TiersInvitation;
 use App\Entity\User;
 use App\Factory\SignalementAffectationListViewFactory;
 use App\Factory\SignalementExportFactory;
-use App\Factory\SignalementFactory;
+use App\Factory\SignalementImportFactory;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordrePrecisionRepository;
 use App\Repository\PartnerRepository;
@@ -62,7 +62,7 @@ class SignalementManager extends AbstractManager
     public function __construct(
         protected ManagerRegistry $managerRegistry,
         private readonly Security $security,
-        private readonly SignalementFactory $signalementFactory,
+        private readonly SignalementImportFactory $signalementImportFactory,
         private readonly QualificationStatusService $qualificationStatusService,
         private readonly SignalementAffectationListViewFactory $signalementAffectationListViewFactory,
         private readonly SignalementExportFactory $signalementExportFactory,
@@ -100,9 +100,7 @@ class SignalementManager extends AbstractManager
             return $this->update($signalement, $data);
         }
 
-        $signalement = $this->signalementFactory->createInstanceFromArrayForImport($territory, $data);
-
-        return $signalement;
+        return $this->signalementImportFactory->create($territory, $data);
     }
 
     /**

--- a/templates/service_secours/index.html.twig
+++ b/templates/service_secours/index.html.twig
@@ -185,13 +185,13 @@
                     </div>
                 {% elseif current_step == 'step6' %}
                     <div class="fr-mt-5v fr-mb-5v">
-                        <h2 class="fr-h5">Récapitulatif et validation</h2>
+                        <h1 class="fr-h5">Récapitulatif et validation</h1>
                         <div>Vérifiez les informations saisies puis validez le signalement.</div>
                     </div>
                     
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
-                            <h4 class="fr-h6">Vos coordonnées</h4>
+                            <h2 class="fr-h6">Vos coordonnées</h2>
                             {{ form_row(form.navigator.editStep1) }}
                         </div>
                         {% if data.step1.matriculeDeclarant %}
@@ -213,7 +213,7 @@
                     
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
-                            <h4 class="fr-h6">Infos sur le logement</h4>
+                            <h2 class="fr-h6">Infos sur le logement</h2>
                             {{ form_row(form.navigator.editStep2) }}
                         </div>
                         {{ data.step2.adresseOccupant }} <br>
@@ -248,7 +248,7 @@
                     
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
-                            <h4 class="fr-h6">Occupation du logement</h4>
+                            <h2 class="fr-h6">Occupation du logement</h2>
                             {{ form_row(form.navigator.editStep3) }}
                         </div>
                         {% if data.step3.nomOccupant %}
@@ -288,7 +288,7 @@
                     
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
-                            <h4 class="fr-h6">Propriétaire / Syndic</h4>
+                            <h2 class="fr-h6">Propriétaire / Syndic</h2>
                             {{ form_row(form.navigator.editStep4) }}
                         </div>
                         {% set showBailleur = data.step4.isBailleurAverti or data.step4.denominationProprio or data.step4.nomProprio or data.step4.prenomProprio or data.step4.mailProprio or data.step4.telProprio %}
@@ -339,7 +339,7 @@
                     
                     <div class="signalement-group-data-card">
                         <div class="fr-display-flex-row fr-justify-content-space-between fr-align-items-center">
-                            <h4 class="fr-h6">Désordres</h4>
+                            <h2 class="fr-h6">Désordres</h2>
                             {{ form_row(form.navigator.editStep5) }}
                         </div>
                         {% if data.step5.autresOccupantsDesordre %}

--- a/tests/Functional/Controller/ServiceSecoursControllerTest.php
+++ b/tests/Functional/Controller/ServiceSecoursControllerTest.php
@@ -2,8 +2,14 @@
 
 namespace App\Tests\Functional\Controller;
 
+use App\Entity\Enum\CreationSource;
+use App\Entity\Enum\EtageType;
+use App\Entity\ServiceSecoursRoute;
 use App\Repository\ServiceSecoursRouteRepository;
+use App\Repository\SignalementRepository;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Routing\RouterInterface;
 
 class ServiceSecoursControllerTest extends WebTestCase
@@ -57,5 +63,239 @@ class ServiceSecoursControllerTest extends WebTestCase
             $client->request('GET', $url);
             $this->assertResponseStatusCodeSame(404);
         }
+    }
+
+    public function testItDisplaysFirstStep(): void
+    {
+        $client = static::createClient();
+        $this->requestStartFlow($client);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorExists('form');
+        self::assertSelectorTextContains('label', 'Matricule');
+    }
+
+    public function testSubmitToStep2(): void
+    {
+        $client = static::createClient();
+        $crawler = $this->requestStartFlow($client);
+        $this->submitStep1($client, $crawler);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('label', 'Adresse du logement');
+    }
+
+    public function testSubmitToStep3(): void
+    {
+        $client = static::createClient();
+        $crawler = $this->requestStartFlow($client);
+        $crawler = $this->submitStep1($client, $crawler);
+        $this->submitStep2($client, $crawler, 'oui');
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('label', 'Profil de l\'occupant');
+    }
+
+    public function testSubmitToStep4(): void
+    {
+        $client = static::createClient();
+        $crawler = $this->requestStartFlow($client);
+        $crawler = $this->submitStep1($client, $crawler);
+        $crawler = $this->submitStep2($client, $crawler, 'oui');
+        $this->submitStep3($client, $crawler);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('label', 'Bailleur averti');
+    }
+
+    public function testSubmitToStep5(): void
+    {
+        $client = static::createClient();
+        $crawler = $this->requestStartFlow($client);
+        $crawler = $this->submitStep1($client, $crawler);
+        $crawler = $this->submitStep2($client, $crawler, 'non');
+        $crawler = $this->submitStep3($client, $crawler);
+
+        $this->submitStep4($client, $crawler);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('label', 'Désordres');
+        self::assertSelectorTextContains('button[data-upload-photos-trigger]', 'Ajouter des photos');
+    }
+
+    public function testSubmitToStep6(): void
+    {
+        $client = static::createClient();
+        $crawler = $this->requestStartFlow($client);
+        $crawler = $this->submitStep1($client, $crawler);
+        $crawler = $this->submitStep2($client, $crawler, 'non');
+        $crawler = $this->submitStep3($client, $crawler);
+        $crawler = $this->submitStep4($client, $crawler);
+
+        $this->submitStep5($client, $crawler);
+
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Récapitulatif et validation');
+        self::assertSelectorCount(1, 'h2:contains("Vos coordonnées")');
+        self::assertSelectorCount(1, 'h2:contains("Infos sur le logement")');
+        self::assertSelectorCount(1, 'h2:contains("Occupation du logement")');
+        self::assertSelectorCount(1, 'h2:contains("Propriétaire / Syndic")');
+        self::assertSelectorCount(1, 'h2:contains("Désordres")');
+    }
+
+    public function testSubmitToFinalStep(): void
+    {
+        $client = static::createClient();
+        $crawler = $this->requestStartFlow($client);
+        $crawler = $this->submitStep1($client, $crawler);
+        $crawler = $this->submitStep2($client, $crawler);
+        $crawler = $this->submitStep3($client, $crawler);
+        $crawler = $this->submitStep4($client, $crawler);
+        $crawler = $this->submitStep5($client, $crawler);
+
+        $this->submitStep6($client, $crawler);
+        self::assertResponseIsSuccessful();
+        self::assertSelectorTextContains('h1', 'Le signalement a bien été enregistré !');
+
+        self::assertSelectorTextContains('a.fr-btn.fr-icon-download-line', 'Télécharger le PDF');
+        self::assertSelectorTextContains('a.fr-btn.fr-btn--secondary', 'Saisir un autre signalement');
+
+        $signalementRepository = static::getContainer()->get(SignalementRepository::class);
+        $signalement = $signalementRepository->findOneBy(['creationSource' => CreationSource::FORM_SERVICE_SECOURS]);
+
+        $this->assertSame('CHARTIER Yohan', $signalement->getNomOccupantComplet());
+        $this->assertSame('PIERRE CHARTIER', $signalement->getNomDeclarantComplet());
+        $this->assertSame('MAT-123', $signalement->getMatriculeDeclarant());
+        $this->assertSame('BMPM', $signalement->getOrigineMissionServiceSecours());
+        $this->assertSame('Ordre de mission', $signalement->getOrdreMissionServiceSecours());
+        $this->assertSame('27/03/2026', $signalement->getDateMissionServiceSecours()->format('d/m/Y'));
+        $this->assertSame('44179', $signalement->getInseeOccupant());
+        $this->assertSame('44850', $signalement->getCpOccupant());
+        $this->assertFalse($signalement->getIsLogementSocial());
+        $this->assertSame('Martin', $signalement->getNomProprio());
+        $this->assertSame('Syndic Bueno SCI', $signalement->getDenominationSyndic());
+        $this->assertSame('Hello world!!!', $signalement->getAutreSituationVulnerabilite());
+        $this->assertCount(12, $signalement->getDesordreCriteres());
+        $this->assertArrayHasKey('desordres_service_secours_autre_precision', $signalement->getJsonContent());
+        $this->assertSame('Lorem ipsum', $signalement->getJsonContent()['desordres_service_secours_autre_precision']);
+        $this->assertSame('oui', $signalement->getAutresOccupantsDesordre());
+    }
+
+    private function requestStartFlow(KernelBrowser $client): Crawler
+    {
+        $serviceSecoursRoute = $this->getServiceSecoursRoute();
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $url = $router->generate('service_secours_index', [
+            'slug' => $serviceSecoursRoute->getSlug(),
+            'uuid' => $serviceSecoursRoute->getUuid(),
+            'domain' => 'localhost',
+        ]);
+
+        return $client->request('GET', $url);
+    }
+
+    private function getServiceSecoursRoute(): ServiceSecoursRoute
+    {
+        return static::getContainer()
+            ->get(ServiceSecoursRouteRepository::class)
+            ->find(1);
+    }
+
+    private function submitStep1(KernelBrowser $client, Crawler $crawler): Crawler
+    {
+        $form = $crawler->selectButton('Suivant')->form([
+            'service_secours[step1][matriculeDeclarant]' => 'MAT-123',
+            'service_secours[step1][nomDeclarant]' => 'Pierre Chartier',
+            'service_secours[step1][dateMission]' => '2026-03-27',
+            'service_secours[step1][origineMission]' => 'BMPM',
+            'service_secours[step1][ordreMission]' => 'Ordre de mission',
+        ]);
+
+        return $client->submit($form);
+    }
+
+    private function submitStep2(KernelBrowser $client, Crawler $crawler, string $isLogementSocial = 'non'): Crawler
+    {
+        $form = $crawler->selectButton('Suivant')->form([
+            'service_secours[step2][adresseOccupant]' => '8 Rue de la tourmentinerie',
+            'service_secours[step2][cpOccupant]' => '44850',
+            'service_secours[step2][villeOccupant]' => 'Saint-Mars-du-Désert',
+            'service_secours[step2][inseeOccupant]' => '44179',
+            'service_secours[step2][adresseAutreOccupant]' => 'Bâtiment A',
+            'service_secours[step2][isLogementSocial]' => $isLogementSocial,
+            'service_secours[step2][natureLogement]' => 'appartement',
+            'service_secours[step2][typeEtageLogement]' => EtageType::AUTRE->value,
+            'service_secours[step2][etageOccupant]' => '2',
+            'service_secours[step2][nbPiecesLogement]' => '3',
+            'service_secours[step2][superficie]' => '65',
+        ]);
+
+        return $client->submit($form);
+    }
+
+    private function submitStep3(KernelBrowser $client, Crawler $crawler, string $profilOccupant = 'LOCATAIRE'): Crawler
+    {
+        $form = $crawler->selectButton('Suivant')->form([
+            'service_secours[step3][profilOccupant]' => $profilOccupant,
+            'service_secours[step3][nomOccupant]' => 'Chartier',
+            'service_secours[step3][prenomOccupant]' => 'Yohan',
+            'service_secours[step3][mailOccupant]' => 'yohan.chartier@example.org',
+            'service_secours[step3][telOccupant]' => '0612345678',
+            'service_secours[step3][nbAdultesDansLogement]' => '2',
+            'service_secours[step3][nbEnfantsDansLogement]' => '1',
+            'service_secours[step3][isEnfantsMoinsSixAnsDansLogement]' => 'non',
+            'service_secours[step3][autreVulnerabilite]' => 'Hello world!!!',
+        ]);
+
+        return $client->submit($form);
+    }
+
+    private function submitStep4(KernelBrowser $client, Crawler $crawler): Crawler
+    {
+        $form = $crawler->selectButton('Suivant')->form([
+            'service_secours[step4][isBailleurAverti]' => 'oui',
+            'service_secours[step4][nomProprio]' => 'Martin',
+            'service_secours[step4][prenomProprio]' => 'Paul',
+            'service_secours[step4][mailProprio]' => 'paul.martin@example.org',
+            'service_secours[step4][telProprio]' => '0611223344',
+            'service_secours[step4][denominationSyndic]' => 'Syndic Bueno SCI',
+            'service_secours[step4][nomSyndic]' => 'Mme Bueno',
+            'service_secours[step4][mailSyndic]' => 'syndic.bueno@example.org',
+            'service_secours[step4][telSyndic]' => '0622334455',
+            'service_secours[step4][telSyndicSecondaire]' => '0633445566',
+        ]);
+
+        return $client->submit($form);
+    }
+
+    public function submitStep5(KernelBrowser $client, Crawler $crawler): Crawler
+    {
+        $form = $crawler->selectButton('Vérifier ma saisie')->form([
+            'service_secours[step5][desordres]' => [
+                'desordres_service_secours_logement_inadapte',
+                'desordres_service_secours_humidite_moisissures',
+                'desordres_service_secours_chauffage_dangereux',
+                'desordres_service_secours_risque_electrique',
+                'desordres_service_secours_salete_accumulation_dechets',
+                'desordres_service_secours_mauvais_etat_batiment',
+                'desordres_service_secours_absence_confort',
+                'desordres_service_secours_securite_personnes',
+                'desordres_service_secours_risque_saturnisme',
+                'desordres_service_secours_nuisibles',
+                'desordres_service_secours_parties_communes_degradees',
+                'desordres_service_secours_autre',
+            ],
+            'service_secours[step5][desordresAutre]' => 'Lorem ipsum',
+            'service_secours[step5][autresOccupantsDesordre]' => 'oui',
+        ]);
+
+        return $client->submit($form);
+    }
+
+    public function submitStep6(KernelBrowser $client, Crawler $crawler): void
+    {
+        $form = $crawler->selectButton('Valider le signalement')->form();
+        $client->submit($form);
     }
 }

--- a/tests/Functional/Controller/ServiceSecoursControllerTest.php
+++ b/tests/Functional/Controller/ServiceSecoursControllerTest.php
@@ -90,7 +90,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $client = static::createClient();
         $crawler = $this->requestStartFlow($client);
         $crawler = $this->submitStep1($client, $crawler);
-        $this->submitStep2($client, $crawler, 'oui');
+        $this->submitStep2($client, $crawler, 'oui', EtageType::RDC->value);
 
         self::assertResponseIsSuccessful();
         self::assertSelectorTextContains('label', 'Profil de l\'occupant');
@@ -101,7 +101,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $client = static::createClient();
         $crawler = $this->requestStartFlow($client);
         $crawler = $this->submitStep1($client, $crawler);
-        $crawler = $this->submitStep2($client, $crawler, 'oui');
+        $crawler = $this->submitStep2($client, $crawler, 'oui', EtageType::SOUSSOL->value);
         $this->submitStep3($client, $crawler);
 
         self::assertResponseIsSuccessful();
@@ -113,7 +113,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $client = static::createClient();
         $crawler = $this->requestStartFlow($client);
         $crawler = $this->submitStep1($client, $crawler);
-        $crawler = $this->submitStep2($client, $crawler, 'non');
+        $crawler = $this->submitStep2($client, $crawler, 'non', EtageType::DERNIER_ETAGE->value);
         $crawler = $this->submitStep3($client, $crawler);
 
         $this->submitStep4($client, $crawler);
@@ -128,7 +128,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $client = static::createClient();
         $crawler = $this->requestStartFlow($client);
         $crawler = $this->submitStep1($client, $crawler);
-        $crawler = $this->submitStep2($client, $crawler, 'non');
+        $crawler = $this->submitStep2($client, $crawler, 'non', EtageType::DERNIER_ETAGE->value);
         $crawler = $this->submitStep3($client, $crawler);
         $crawler = $this->submitStep4($client, $crawler);
 
@@ -172,6 +172,7 @@ class ServiceSecoursControllerTest extends WebTestCase
         $this->assertSame('44179', $signalement->getInseeOccupant());
         $this->assertSame('44850', $signalement->getCpOccupant());
         $this->assertFalse($signalement->getIsLogementSocial());
+        $this->assertSame('2', $signalement->getEtageOccupant());
         $this->assertSame('Martin', $signalement->getNomProprio());
         $this->assertSame('Syndic Bueno SCI', $signalement->getDenominationSyndic());
         $this->assertSame('Hello world!!!', $signalement->getAutreSituationVulnerabilite());
@@ -179,6 +180,11 @@ class ServiceSecoursControllerTest extends WebTestCase
         $this->assertArrayHasKey('desordres_service_secours_autre_precision', $signalement->getJsonContent());
         $this->assertSame('Lorem ipsum', $signalement->getJsonContent()['desordres_service_secours_autre_precision']);
         $this->assertSame('oui', $signalement->getAutresOccupantsDesordre());
+        $this->assertSame('non', $signalement->getTypeCompositionLogement()->getTypeLogementRdc());
+        $this->assertSame('non', $signalement->getTypeCompositionLogement()->getTypeLogementDernierEtage());
+        $this->assertSame('1', $signalement->getTypeCompositionLogement()->getCompositionLogementNombreEnfants());
+        $this->assertSame('non', $signalement->getTypeCompositionLogement()->getCompositionLogementEnfants());
+        $this->assertSame(3, $signalement->getNbOccupantsLogement()); // 2 adultes + 1 enfant
     }
 
     private function requestStartFlow(KernelBrowser $client): Crawler
@@ -215,8 +221,12 @@ class ServiceSecoursControllerTest extends WebTestCase
         return $client->submit($form);
     }
 
-    private function submitStep2(KernelBrowser $client, Crawler $crawler, string $isLogementSocial = 'non'): Crawler
-    {
+    private function submitStep2(
+        KernelBrowser $client,
+        Crawler $crawler,
+        string $isLogementSocial = 'non',
+        string $typeEtageLogement = EtageType::AUTRE->value,
+    ): Crawler {
         $form = $crawler->selectButton('Suivant')->form([
             'service_secours[step2][adresseOccupant]' => '8 Rue de la tourmentinerie',
             'service_secours[step2][cpOccupant]' => '44850',
@@ -225,7 +235,7 @@ class ServiceSecoursControllerTest extends WebTestCase
             'service_secours[step2][adresseAutreOccupant]' => 'Bâtiment A',
             'service_secours[step2][isLogementSocial]' => $isLogementSocial,
             'service_secours[step2][natureLogement]' => 'appartement',
-            'service_secours[step2][typeEtageLogement]' => EtageType::AUTRE->value,
+            'service_secours[step2][typeEtageLogement]' => $typeEtageLogement,
             'service_secours[step2][etageOccupant]' => '2',
             'service_secours[step2][nbPiecesLogement]' => '3',
             'service_secours[step2][superficie]' => '65',

--- a/tests/Functional/Manager/SignalementManagerTest.php
+++ b/tests/Functional/Manager/SignalementManagerTest.php
@@ -15,7 +15,7 @@ use App\Entity\Territory;
 use App\Entity\User;
 use App\Factory\SignalementAffectationListViewFactory;
 use App\Factory\SignalementExportFactory;
-use App\Factory\SignalementFactory;
+use App\Factory\SignalementImportFactory;
 use App\Manager\AffectationManager;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
@@ -49,7 +49,7 @@ class SignalementManagerTest extends WebTestCase
     private EntityManagerInterface $entityManager;
     private Security $security;
     private ManagerRegistry $managerRegistry;
-    private SignalementFactory $signalementFactory;
+    private SignalementImportFactory $signalementImportFactory;
     private QualificationStatusService $qualificationStatusService;
     private SignalementAffectationListViewFactory $signalementAffectationListViewFactory;
     private SignalementExportFactory $signalementExportFactory;
@@ -77,7 +77,7 @@ class SignalementManagerTest extends WebTestCase
         $this->entityManager = $em;
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->security = static::getContainer()->get('security.helper');
-        $this->signalementFactory = static::getContainer()->get(SignalementFactory::class);
+        $this->signalementImportFactory = static::getContainer()->get(SignalementImportFactory::class);
         $this->qualificationStatusService = static::getContainer()->get(QualificationStatusService::class);
         $this->signalementAffectationListViewFactory = static::getContainer()->get(
             SignalementAffectationListViewFactory::class
@@ -101,7 +101,7 @@ class SignalementManagerTest extends WebTestCase
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
             $this->security,
-            $this->signalementFactory,
+            $this->signalementImportFactory,
             $this->qualificationStatusService,
             $this->signalementAffectationListViewFactory,
             $this->signalementExportFactory,

--- a/tests/Functional/Service/Signalement/PhotoHelperTest.php
+++ b/tests/Functional/Service/Signalement/PhotoHelperTest.php
@@ -6,7 +6,7 @@ use App\Entity\Enum\DocumentType;
 use App\Entity\Signalement;
 use App\Factory\SignalementAffectationListViewFactory;
 use App\Factory\SignalementExportFactory;
-use App\Factory\SignalementFactory;
+use App\Factory\SignalementImportFactory;
 use App\Manager\SignalementManager;
 use App\Manager\SuiviManager;
 use App\Manager\UserManager;
@@ -31,7 +31,7 @@ class PhotoHelperTest extends KernelTestCase
 {
     private Security $security;
     private ManagerRegistry $managerRegistry;
-    private SignalementFactory $signalementFactory;
+    private SignalementImportFactory $signalementImportFactory;
     private QualificationStatusService $qualificationStatusService;
     private SignalementAffectationListViewFactory $signalementAffectationListViewFactory;
     private SignalementExportFactory $signalementExportFactory;
@@ -55,7 +55,7 @@ class PhotoHelperTest extends KernelTestCase
     {
         $this->managerRegistry = static::getContainer()->get(ManagerRegistry::class);
         $this->security = static::getContainer()->get('security.helper');
-        $this->signalementFactory = static::getContainer()->get(SignalementFactory::class);
+        $this->signalementImportFactory = static::getContainer()->get(SignalementImportFactory::class);
         $this->qualificationStatusService = static::getContainer()->get(QualificationStatusService::class);
         $this->signalementAffectationListViewFactory = static::getContainer()->get(
             SignalementAffectationListViewFactory::class
@@ -78,7 +78,7 @@ class PhotoHelperTest extends KernelTestCase
         $this->signalementManager = new SignalementManager(
             $this->managerRegistry,
             $this->security,
-            $this->signalementFactory,
+            $this->signalementImportFactory,
             $this->qualificationStatusService,
             $this->signalementAffectationListViewFactory,
             $this->signalementExportFactory,

--- a/tests/Unit/Factory/SignalementFactoryTest.php
+++ b/tests/Unit/Factory/SignalementFactoryTest.php
@@ -4,11 +4,7 @@ namespace App\Tests\Unit\Factory;
 
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Territory;
-use App\Factory\SignalementFactory;
-use App\Repository\BailleurRepository;
-use App\Repository\DesordreCritereRepository;
-use App\Service\Signalement\SignalementAddressUpdater;
-use App\Service\Signalement\ZipcodeProvider;
+use App\Factory\SignalementImportFactory;
 use Faker\Factory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -97,17 +93,8 @@ class SignalementFactoryTest extends KernelTestCase
             ->setZip('01')
             ->setIsActive(true);
 
-        $zipCodeProvider = static::getContainer()->get(ZipcodeProvider::class);
-        $bailleurRepository = static::getContainer()->get(BailleurRepository::class);
-        $signalementAddressUpdater = static::getContainer()->get(SignalementAddressUpdater::class);
-        $desordreCritereRepository = static::getContainer()->get(DesordreCritereRepository::class);
-        $signalementFactory = new SignalementFactory(
-            $zipCodeProvider,
-            $signalementAddressUpdater,
-            $bailleurRepository,
-            $desordreCritereRepository,
-        );
-        $signalement = $signalementFactory->createInstanceFromArrayForImport($territory, $data);
+        $signalementImportFactory = new SignalementImportFactory();
+        $signalement = $signalementImportFactory->create($territory, $data);
 
         $this->assertEquals($data['reference'], $signalement->getReference());
         $this->assertEquals($data['nomDeclarant'], $signalement->getNomDeclarant());


### PR DESCRIPTION
## Ticket

#5570   
#5589 

## Description
Séparer les factory d'import et de service de secours dans des services dédiés + ajout de test fonctionnel


## Changements apportés
* Ajout de tests
* Refacto des services
* Revue hiérarchie des titres sur la page d'aperçu
* Revue des usages switch/case suite aux alertes sonar

## Pré-requis

## Tests
- [ ] Faire un test de soumission de service secours et vérifier que tout soit OK
- [ ] Faire un test d'import de signalement et vérifier que tout soit OK