### PR TITLE
[BO - Liste Signalement] Elargir Recherche si 0 résultat

### DIFF
--- a/assets/scripts/vue/components/signalement-view/TheSignalementAppList.vue
+++ b/assets/scripts/vue/components/signalement-view/TheSignalementAppList.vue
@@ -65,7 +65,7 @@
       <h2 class="fr-text--light" v-if="sharedState.hasErrorLoading">Erreur lors du chargement de la liste.</h2>
       <p v-if="sharedState.hasErrorLoading">Veuillez recharger la page ou nous prévenir <a :href="sharedProps.ajaxurlContact">via le formulaire de contact</a>.</p>
     </section>
-    <section v-else class="fr-col-12 fr-background-alt--blue-france fr-mt-0">
+    <section v-else-if="sharedState.signalements.pagination.total_items > 0" class="fr-col-12 fr-background-alt--blue-france fr-mt-0">
         <div :class="['fr-p-3w', 'fr-container-sml']">
           <SignalementListHeader
               :total="sharedState.signalements.pagination.total_items"
@@ -77,6 +77,21 @@
               :pagination="sharedState.signalements.pagination"
               @changePage="handlePageChange"/>
         </div>
+    </section>
+    <section v-else class="fr-col-12 fr-background-alt--blue-france fr-mt-0">
+      <div :class="['fr-p-3w', 'fr-container-sml']">
+        <div class="fr-grid-row fr-mb-1w">
+          <div class="fr-col fr-col-md-9">
+            <h2>{{ sharedState.selectedSavedSearchId !== undefined ? 'Résultats de la recherche sauvegardée - ' : '' }}{{ sharedState.signalements.pagination.total_items }} signalement{{sharedState.signalements.pagination.total_items > 1 ? 's' : ''}} trouv{{sharedState.signalements.pagination.total_items > 1 ? 'és' : 'é'}}</h2>
+          </div>    
+        </div>
+        <div>
+          Votre recherche n'a donné aucun résultat <span v-if="sharedState.input.filters.showMySignalementsOnly=='oui'">parmi les dossiers auxquels vous êtes abonné</span>. <br>
+        </div>
+        <button v-if="sharedState.input.filters.showMySignalementsOnly=='oui'" class="fr-link fr-link--icon-left fr-icon-add-circle-line" @click="removeMySignalementsOnlyFilter">
+          Cliquez ici pour élargir la recherche à tous les dossiers affectés à votre partenaire.
+        </button>   
+      </div>
     </section>
   </div>
 </template>
@@ -220,6 +235,10 @@ export default defineComponent({
     },
     applySavedSearch(value: string) {
       applySavedSearch(this, value)
+    },
+    removeMySignalementsOnlyFilter() {
+      this.sharedState.input.filters.showMySignalementsOnly = undefined
+      this.handleFilters()
     },
     async deleteItem (item: SignalementItem|null) {
       clearScreen(this)

--- a/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
+++ b/assets/scripts/vue/components/signalement-view/components/SignalementViewFilters.vue
@@ -444,6 +444,9 @@ export default defineComponent({
   watch: {
     'sharedState.filtersApplyKey': function (newList) {
       this.syncToggleStatesWithFilters()
+    },
+    'sharedState.input.filters.showMySignalementsOnly': function (newVal) {
+      this.toggleStates.showMySignalementsOnly = newVal === 'oui'
     }
   },
   methods: {


### PR DESCRIPTION
## Ticket

#5611   

## Description
Lorsqu'un agent fait une recherche de signalement et que le résultat est 0
Afficher un message d'info :
Votre recherche n'a donné aucun résultat parmi les dossiers auxquels vous êtes abonné. Cliquez ici pour élargir la recherche à tous les dossiers affectés à votre partenaire]

-> Si l'agent clique, alors le filtre Afficher uniquement mes dossiers est désélectionné.

<img width="1603" height="633" alt="image" src="https://github.com/user-attachments/assets/8386abc7-6fee-4848-8df0-064060859455" />


## Changements apportés
* Ajout d'un lien avec une fonction dans l'app VueJS

## Pré-requis
 `make npm-watch`
## Tests
- [ ] Tester avec différents utilisateurs et différents contextes
