### PR TITLE
[Démarche Accélérée] Demande Arret de procedure

### DIFF
--- a/templates/front/suivi_signalement_cancel_procedure_intro.html.twig
+++ b/templates/front/suivi_signalement_cancel_procedure_intro.html.twig
@@ -60,33 +60,6 @@
 						>Non, annuler</a>
 				</li>
 			</ul>
-
-			{% if is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement) %}
-				<div class="fr-notice fr-notice--warning fr-mt-6w fr-mb-3w">
-					<div class="fr-container">
-						<div class="fr-notice__body">
-						<p>
-							<span class="fr-notice__title">Démarche accélérée</span>
-							<span class="fr-notice__desc">
-								Vous êtes actuellement dans le parcours "Démarche accélérée",
-								vous pouvez si vous le souhaitez basculer dans la procédure administrative classique
-							</span>
-						</p>
-						</div>
-					</div>
-				</div>
-
-				<ul class="fr-btns-group fr-btns-group--inline-lg">
-					<li>
-						<a class="fr-btn" href="{{ path('front_suivi_signalement_procedure_bascule', {code: signalement.codeSuivi}) }}"
-							data-matomo-clickable-event-category="Suivre mon signalement - Arrêter la procédure"
-							data-matomo-clickable-event-action="clickLink"
-							data-matomo-clickable-event-name="Basculer en procédure administrative"
-							>Basculer en procédure administrative</a>
-					</li>
-				</ul>
-			{% endif %}
-
 		</div>
 		{% include 'front/_partials/_suivi_signalement_card_right.html.twig' %}
 	</div>

--- a/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
+++ b/templates/front/suivi_signalement_cancel_procedure_validation.html.twig
@@ -38,8 +38,12 @@
 				<div class="fr-grid-row fr-grid-row--gutters">
 					<div class="fr-col-4 fr-hidden fr-unhidden-md">
 						<ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
-							<li>				
-								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary" href="{{ path('front_suivi_signalement_procedure',{code:signalement.codeSuivi}) }}">
+							<li>	
+								{% set route = is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement)
+									? 'front_suivi_signalement'
+									: 'front_suivi_signalement_procedure'
+								%}	
+								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary" href="{{ path(route,{code:signalement.codeSuivi}) }}">
 									Précédent
 								</a>
 							</li>
@@ -59,8 +63,13 @@
 					</div>
 					<div class="fr-col-12 fr-hidden-md fr-pt-0">
 						<ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
-							<li>				
-								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary" href="{{ path('front_suivi_signalement_procedure',{code:signalement.codeSuivi}) }}">
+							<li>
+								{% set route = is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement)
+									? 'front_suivi_signalement'
+									: 'front_suivi_signalement_procedure'
+								%}
+								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary"
+									href="{{ path(route, { code: signalement.codeSuivi }) }}">
 									Précédent
 								</a>
 							</li>

--- a/templates/front/suivi_signalement_dashboard.html.twig
+++ b/templates/front/suivi_signalement_dashboard.html.twig
@@ -182,7 +182,7 @@
 						data-matomo-clickable-event-name="Gérer les documents / photos"
 						>Gérer les documents / photos</a>
 				</li>
-				{% if signalement.isUsagerAbandonProcedure is not same as true and is_granted('SIGN_USAGER_EDIT', signalement) %}
+				{% if signalement.isUsagerAbandonProcedure is not same as true and is_granted('SIGN_USAGER_EDIT', signalement) and is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement) !== true %}
 					<li>
 						<a href="{{ path('front_suivi_signalement_procedure', {'code': signalement.codeSuivi}) }}" class="fr-btn fr-icon-close-circle-line fr-btn--secondary"
 							data-matomo-clickable-event-category="Suivre mon signalement"
@@ -205,6 +205,45 @@
 					{% include '_partials/_demande-lien-signalement-intro.html.twig' with {motifRefusDoublon: true} %}
 					{% include '_partials/_demande-lien-signalement-container.html.twig' with {formatVertical: true} %}
 				</div>
+			{% endif %}
+
+			{% if is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement) %}
+			<h2 class="title-blue-france">Procédure en cours</h2>
+				{# <div class="fr-notice fr-notice--warning fr-mt-6w fr-mb-3w">
+					<div class="fr-container">
+						<div class="fr-notice__body">
+						<p>
+							<span class="fr-notice__title">Démarche accélérée</span>
+							<span class="fr-notice__desc">
+								Vous êtes actuellement dans le parcours "Démarche accélérée",
+								vous pouvez si vous le souhaitez basculer dans la procédure administrative classique
+							</span>
+						</p>
+						</div>
+					</div>
+				</div> #}
+				Vous avez opté pour la démarche accélérée, cette procédure vous permet de trouver un accord avec votre propriétaire pour la mise en conformité de votre logement. <br>
+				A tout moment, vous pouvez sortir de la démarche accélérée et : 
+				<ul>
+					<li>Arrêter la procédure et demander à l'administration de fermer votre dossier. Vous ne pourrez alors plus modifier votre dossier.</li>
+					<li>Basculer sur une procédure administrative ordinaire sans déposer un nouveau signalement. Votre dossier sera alors transmis aux services compétents.</li>
+				</ul>
+				<ul class="fr-btns-group">
+					<li>
+						<a class="fr-btn" href="{{ path('front_suivi_signalement_procedure_abandon', {code: signalement.codeSuivi}) }}"
+							data-matomo-clickable-event-category="Suivre mon signalement - Arrêter la procédure"
+							data-matomo-clickable-event-action="clickLink"
+							data-matomo-clickable-event-name="Arrêter la démarche accélérér"
+							>Arrêter la démarche accélérée</a>
+					</li>
+					<li>
+						<a class="fr-btn fr-btn--secondary" href="{{ path('front_suivi_signalement_procedure_bascule', {code: signalement.codeSuivi}) }}"
+							data-matomo-clickable-event-category="Suivre mon signalement - Arrêter la procédure"
+							data-matomo-clickable-event-action="clickLink"
+							data-matomo-clickable-event-name="Basculer en procédure administrative"
+							>Basculer en procédure administrative</a>
+					</li>
+				</ul>
 			{% endif %}
 
 			<h2 class="title-blue-france">Infos utiles</h2>

--- a/templates/front/suivi_signalement_dashboard.html.twig
+++ b/templates/front/suivi_signalement_dashboard.html.twig
@@ -224,7 +224,7 @@
 							>Arrêter la démarche accélérée</a>
 					</li>
 					<li>
-						<a class="fr-btn fr-btn--secondary fr-icon-folder-transfer-line" href="{{ path('front_suivi_signalement_procedure_bascule', {code: signalement.codeSuivi}) }}"
+						<a class="fr-btn fr-btn--secondary fr-icon-share-forward-line" href="{{ path('front_suivi_signalement_procedure_bascule', {code: signalement.codeSuivi}) }}"
 							data-matomo-clickable-event-category="Suivre mon signalement - Arrêter la procédure"
 							data-matomo-clickable-event-action="clickLink"
 							data-matomo-clickable-event-name="Basculer en procédure administrative"

--- a/templates/front/suivi_signalement_dashboard.html.twig
+++ b/templates/front/suivi_signalement_dashboard.html.twig
@@ -209,35 +209,22 @@
 
 			{% if is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement) %}
 			<h2 class="title-blue-france">Procédure en cours</h2>
-				{# <div class="fr-notice fr-notice--warning fr-mt-6w fr-mb-3w">
-					<div class="fr-container">
-						<div class="fr-notice__body">
-						<p>
-							<span class="fr-notice__title">Démarche accélérée</span>
-							<span class="fr-notice__desc">
-								Vous êtes actuellement dans le parcours "Démarche accélérée",
-								vous pouvez si vous le souhaitez basculer dans la procédure administrative classique
-							</span>
-						</p>
-						</div>
-					</div>
-				</div> #}
 				Vous avez opté pour la démarche accélérée, cette procédure vous permet de trouver un accord avec votre propriétaire pour la mise en conformité de votre logement. <br>
 				A tout moment, vous pouvez sortir de la démarche accélérée et : 
 				<ul>
 					<li>Arrêter la procédure et demander à l'administration de fermer votre dossier. Vous ne pourrez alors plus modifier votre dossier.</li>
 					<li>Basculer sur une procédure administrative ordinaire sans déposer un nouveau signalement. Votre dossier sera alors transmis aux services compétents.</li>
 				</ul>
-				<ul class="fr-btns-group">
+				<ul class="fr-btns-group fr-btns-group--center fr-btns-group--icon-left">
 					<li>
-						<a class="fr-btn" href="{{ path('front_suivi_signalement_procedure_abandon', {code: signalement.codeSuivi}) }}"
+						<a class="fr-btn fr-icon-close-circle-line" href="{{ path('front_suivi_signalement_procedure_abandon', {code: signalement.codeSuivi}) }}"
 							data-matomo-clickable-event-category="Suivre mon signalement - Arrêter la procédure"
 							data-matomo-clickable-event-action="clickLink"
 							data-matomo-clickable-event-name="Arrêter la démarche accélérér"
 							>Arrêter la démarche accélérée</a>
 					</li>
 					<li>
-						<a class="fr-btn fr-btn--secondary" href="{{ path('front_suivi_signalement_procedure_bascule', {code: signalement.codeSuivi}) }}"
+						<a class="fr-btn fr-btn--secondary fr-icon-folder-transfer-line" href="{{ path('front_suivi_signalement_procedure_bascule', {code: signalement.codeSuivi}) }}"
 							data-matomo-clickable-event-category="Suivre mon signalement - Arrêter la procédure"
 							data-matomo-clickable-event-action="clickLink"
 							data-matomo-clickable-event-name="Basculer en procédure administrative"

--- a/templates/front/suivi_signalement_poursuivre_procedure_bascule.html.twig
+++ b/templates/front/suivi_signalement_poursuivre_procedure_bascule.html.twig
@@ -25,7 +25,11 @@
 					<div class="fr-col-4 fr-hidden fr-unhidden-md">
 						<ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
 							<li>				
-								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary" href="{{ path('front_suivi_signalement_procedure',{code:signalement.codeSuivi}) }}">
+								{% set route = is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement)
+									? 'front_suivi_signalement'
+									: 'front_suivi_signalement_procedure'
+								%}			
+								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary" href="{{ path(route,{code:signalement.codeSuivi}) }}">
 									Précédent
 								</a>
 							</li>
@@ -46,7 +50,11 @@
 					<div class="fr-col-12 fr-hidden-md fr-pt-0">
 						<ul class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left">
 							<li>				
-								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary" href="{{ path('front_suivi_signalement_procedure',{code:signalement.codeSuivi}) }}">
+								{% set route = is_granted('SIGN_USAGER_BASCULE_PROCEDURE', signalement)
+									? 'front_suivi_signalement'
+									: 'front_suivi_signalement_procedure'
+								%}	
+								<a class="fr-btn fr-icon-arrow-left-line fr-btn--secondary" href="{{ path(route,{code:signalement.codeSuivi}) }}">
 									Précédent
 								</a>
 							</li>


### PR DESCRIPTION
## Ticket

#5562   

## Description
Modification de la page suivi usager en démarche accélérée pour mettre les boutons "arrêter la démarche accélérée" et "Basculer en procédure administrative" sur la page d'accueil du suivi usager : 
<img width="2095" height="1165" alt="image" src="https://github.com/user-attachments/assets/080e0064-9b53-49f5-b76f-36a0cdbd76e2" />


## Changements apportés
* Suppression de la partie démarche accélérée dans templates/front/suivi_signalement_cancel_procedure_intro.html.twig
* Réorganisation de templates/front/suivi_signalement_dashboard.html.twig en cas de démarche accélérée

## Pré-requis

## Tests
- [ ] Tester la page suivi usager en procédure administrative, et en démarche accélérée
- [ ] Tester les deux actions en démarche accélérée
