### PR TITLE
[BUG - Edition FO] Edition des coordonées du bailleur

### DIFF
--- a/src/Controller/SignalementEditController.php
+++ b/src/Controller/SignalementEditController.php
@@ -203,7 +203,7 @@ class SignalementEditController extends AbstractController
             } else {
                 $signalement->setIsProprioAverti(false);
             }
-            $informationProcedure->setInfoProcedureBailMoyen($formCoordonneesBailleur->get('infoProcedureBailMoyen')->getData() ? $formCoordonneesBailleur->get('infoProcedureBailMoyen')->getData()->value : null);
+            $informationProcedure->setInfoProcedureBailMoyen($formCoordonneesBailleur->get('infoProcedureBailMoyen')->getData() ? mb_strtolower($formCoordonneesBailleur->get('infoProcedureBailMoyen')->getData()->value) : null);
             $informationProcedure->setInfoProcedureBailReponse($formCoordonneesBailleur->get('infoProcedureBailReponse')->getData());
 
             if ($signalement->getIsLogementSocial()) {

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -247,10 +247,10 @@ class SignalementUpdatedListener
                     continue;
                 }
 
-                if ($diffProperty['new']) {
+                if (array_key_exists('new', $diffProperty)) {
                     $fieldChanges[$field] = [
                         'label' => $label,
-                        'new' => $this->dictionaryProvider->translate($diffProperty['new'], 'suivi'),
+                        'new' => null !== $diffProperty['new'] ? $this->dictionaryProvider->translate($diffProperty['new'], 'suivi') : null,
                     ];
                 }
             }

--- a/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
+++ b/src/Form/SignalementeEditFO/CoordonneesBailleurType.php
@@ -127,7 +127,7 @@ class CoordonneesBailleurType extends AbstractType
                     'placeholder' => 'Sélectionner un moyen de contact',
                     'required' => false,
                     'mapped' => false,
-                    'data' => MoyenContact::tryFrom($signalement->getInformationProcedure()?->getInfoProcedureBailMoyen()),
+                    'data' => MoyenContact::tryFromString($signalement->getInformationProcedure()?->getInfoProcedureBailMoyen()),
                 ])
                 ->add('proprioAvertiAt', DateType::class, [
                     'label' => 'Date d\'avertissement du propriétaire',


### PR DESCRIPTION
## Ticket

#5610

## Description
Sur l'édition FO : 
- Le formulaire des coordonnée bailleur ne reprenait pas l'information enregistré dans `informationProcedure.info_procedure_bail_moyen` et se positionnait toujours sur la valeur vide du select. C'est corrigé.
- Le `SignalementUpdatedListener` n'enregistrait pas les changement de valeur pour les champs de type json passant d'une valeur renseigné à `null`, et donc l'information n'était pas reprise dans le suivi de modification généré. C'est corrigé.

## Tests
- [ ] Se connecter à 'édition FO des coordonnée bailleur. Voir que la valeur sélectionnée du champ "Moyen de contact utilisé pour avertir le propriétaire" correspond bien à celle enregistré en base.
- [ ] Voir que si l'on vide cette valeur un suivi de modification l'indiquant est bien généré
