### PR TITLE
Suppression des job_event success de plus d'un mois

### DIFF
--- a/src/Entity/JobEvent.php
+++ b/src/Entity/JobEvent.php
@@ -22,7 +22,8 @@ class JobEvent
 
     public const string STATUS_SUCCESS = 'success';
     public const string STATUS_FAILED = 'failed';
-    public const string EXPIRATION_PERIOD = '- 6 months';
+    public const string EXPIRATION_PERIOD_FAILED = '- 6 months';
+    public const string EXPIRATION_PERIOD_DEFAULT = '- 1 month';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Repository/JobEventRepository.php
+++ b/src/Repository/JobEventRepository.php
@@ -217,12 +217,15 @@ class JobEventRepository extends ServiceEntityRepository implements EntityCleane
     /**
      * @throws \Exception
      */
-    public function cleanOlderThan(string $period = JobEvent::EXPIRATION_PERIOD): int
+    public function cleanOlderThan(string $periodFailed = JobEvent::EXPIRATION_PERIOD_FAILED): int
     {
+        $periodDefault = JobEvent::EXPIRATION_PERIOD_DEFAULT;
         $queryBuilder = $this->createQueryBuilder('j');
         $queryBuilder->delete()
-            ->andWhere('DATE(j.createdAt) <= :created_at')
-            ->setParameter('created_at', (new \DateTimeImmutable($period))->format('Y-m-d'));
+            ->andWhere('(DATE(j.createdAt) <= :created_at AND j.status = :status_failed) OR (DATE(j.createdAt) <= :created_at_default AND j.status != :status_failed)')
+            ->setParameter('created_at', (new \DateTimeImmutable($periodFailed))->format('Y-m-d'))
+            ->setParameter('created_at_default', (new \DateTimeImmutable($periodDefault))->format('Y-m-d'))
+            ->setParameter('status_failed', JobEvent::STATUS_FAILED);
 
         return $queryBuilder->getQuery()->execute();
     }


### PR DESCRIPTION
## Ticket

#5509

## Description
- Suppression des job_event de plus d'un mois
- On laisse la limite a 6 mois pour les `failed`

## Pré-requis
- Se mettre sur une copie de la prod

## Tests
- [ ] Lancer la commande `app:clear-entities` (attention la requete sur les jobevent prend plusieurs minutes)