### PR TITLE
[BUG - edition FO] mail occupant

### DIFF
--- a/src/Controller/SignalementEditController.php
+++ b/src/Controller/SignalementEditController.php
@@ -144,8 +144,12 @@ class SignalementEditController extends AbstractController
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             $msg = 'Les coordonnées de l\'occupant ont bien été mises à jour.';
-            if ($mailOccupant != $form->get('mailOccupantTemp')->getData()) {
-                $signalement->setMailOccupantTemp($form->get('mailOccupantTemp')->getData());
+            $mailTemp = $form->get('mailOccupantTemp')->getData();
+            if (!$mailTemp) { // email vide possible en cas de signalement tiers déclarant
+                $signalement->setMailOccupant(null);
+                $signalement->setMailOccupantTemp(null);
+            } elseif ($mailOccupant != $mailTemp) {
+                $signalement->setMailOccupantTemp($mailTemp);
                 $notificationMailerRegistry->send(
                     new NotificationMail(
                         type: NotificationMailerType::TYPE_SIGNALEMENT_EDIT_MAIL_OCCUPANT,

--- a/tests/Functional/Controller/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/SignalementEditControllerTest.php
@@ -7,6 +7,7 @@ use App\Entity\Enum\SignalementStatus;
 use App\Entity\Enum\SuiviCategory;
 use App\Entity\Signalement;
 use App\Entity\Suivi;
+use App\Manager\UserManager;
 use App\Repository\SuiviRepository;
 use App\Tests\SessionHelper;
 use App\Tests\UserHelper;
@@ -185,5 +186,46 @@ class SignalementEditControllerTest extends WebTestCase
         $this->assertStringContainsString('Ville', $description);
         $this->assertStringContainsString('Téléphone', $description);
         $this->assertStringContainsString('Téléphone secondaire', $description);
+    }
+
+    public function testSubmitsuiviSignalementCompleteOccupantWithEmptyMailOccupant(): void
+    {
+        $client = static::createClient();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get('doctrine')->getManager();
+        /** @var Signalement $signalement */
+        $signalement = $entityManager->getRepository(Signalement::class)->findOneBy(['reference' => '2022-14']);
+        $signalementUser = $this->getSignalementUser($signalement, UserManager::DECLARANT);
+        $client->loginUser($signalementUser, 'code_suivi');
+
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get(RouterInterface::class);
+        $url = $router->generate('front_suivi_signalement_complete_occupant', ['code' => $signalement->getCodeSuivi()]);
+
+        $crawler = $client->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Envoyer')->form([
+            'coordonnees_occupant[civiliteOccupant]' => 'mr',
+            'coordonnees_occupant[nomOccupant]' => 'NomOccupant',
+            'coordonnees_occupant[prenomOccupant]' => 'PrenomOccupant',
+            'coordonnees_occupant[mailOccupantTemp]' => '',
+            'coordonnees_occupant[telOccupant]' => '',
+            'coordonnees_occupant[telOccupantBis]' => '',
+        ]);
+
+        $client->submit($form);
+        $this->assertResponseRedirects('/suivre-mon-signalement/'.$signalement->getCodeSuivi().'/dossier');
+        $signalement = $entityManager->getRepository(Signalement::class)->find($signalement->getId());
+
+        $this->assertNull($signalement->getMailOccupant());
+        $this->assertNull($signalement->getMailOccupantTemp());
+        $this->assertEmailCount(0);
+
+        /** @var SuiviRepository $suiviRepository */
+        $suiviRepository = $entityManager->getRepository(Suivi::class);
+        $suivi = $suiviRepository->findBy(['signalement' => $signalement, 'category' => SuiviCategory::SIGNALEMENT_EDITED_FO]);
+        $this->assertCount(1, $suivi);
     }
 }


### PR DESCRIPTION
## Ticket

#5645

## Description
BUG Edition FO Coordonnées de l'occupant : Dans les cas d'un signalement déposé par un tiers l'email occupant n'est pas obligatoire. En l'état si on le passait a vide on tentait d'envoyer un email vers la nouvelle adresse vide et cela provoquait un  crash `App\Service\Mailer\NotificationMail::__construct(): Argument #2 ($to) must be of type array|string, null given`
- Correction du cas
- Ajout d'un TU de vérification de ce cas

## Tests
- [ ] Se connecter en tant qu'usager à un signalement déposé par un tiers (ex 2022-14) et modifier l'email occupant pour le passer à vide. Voir qu'il n'y à pas de crash.
