### PR TITLE
[BO - Photos / Documents] Tri

### DIFF
--- a/src/Service/Signalement/PhotoHelper.php
+++ b/src/Service/Signalement/PhotoHelper.php
@@ -41,17 +41,7 @@ class PhotoHelper
 
         foreach ($photoListByType as $key => &$photoArray) {
             usort($photoArray, static function (File $fileA, File $fileB) use ($key) {
-                if ('situation' === $key) {
-                    if (DocumentType::PHOTO_SITUATION === $fileA->getDocumentType() && DocumentType::PHOTO_SITUATION === $fileB->getDocumentType()) {
-                        return $fileA->getId() <=> $fileB->getId();
-                    }
-                    if (DocumentType::PHOTO_SITUATION === $fileA->getDocumentType()) {
-                        return -1;
-                    }
-                    if (DocumentType::PHOTO_SITUATION === $fileB->getDocumentType()) {
-                        return 1;
-                    }
-                } elseif ('visite' === $key) {
+                if ('visite' === $key) {
                     $interventionA = $fileA->getIntervention();
                     $interventionB = $fileB->getIntervention();
                     if (null === $interventionA && null === $interventionB) {
@@ -67,7 +57,8 @@ class PhotoHelper
                     return $interventionA->getId() <=> $interventionB->getId();
                 }
 
-                return $fileA->getId() <=> $fileB->getId();
+                // par défaut ordre antéchronologique
+                return $fileB->getCreatedAt() <=> $fileA->getCreatedAt();
             });
         }
         if ($type) {

--- a/tests/Functional/Service/Signalement/PhotoHelperTest.php
+++ b/tests/Functional/Service/Signalement/PhotoHelperTest.php
@@ -124,7 +124,7 @@ class PhotoHelperTest extends KernelTestCase
         $this->assertCount(3, $photos);
         $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[0]->getDocumentType());
         $this->assertEquals('Capture-d-ecran-du-2023-06-13-12-58-43-648b2a6b9730f.png', $photos[0]->getTitle());
-        $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[1]->getDocumentType());
-        $this->assertEquals(DocumentType::AUTRE, $photos[2]->getDocumentType());
+        $this->assertEquals(DocumentType::AUTRE, $photos[1]->getDocumentType());
+        $this->assertEquals(DocumentType::PHOTO_SITUATION, $photos[2]->getDocumentType());
     }
 }


### PR DESCRIPTION
## Ticket

#5602

## Description
Modification de l'ordre d'affichage des photos de signalement dans le BO, pour un ordre de la plus récente à la plus ancienne.

Jusqu’à présent l'ordre mettait en premier les photo de type `PHOTO_SITUATION` et ensuite le classement était par id (soit un ordre chronologique classique)
- Les document (hors photos) sont déjà en ordre antéchronologique.
- Pour les visite je garde l'ordre existant (chronologique) qui me semble approprié

## Tests
- [ ] Ajouter différente type de photo et document sur un signalement et voir que l'ordre d'affichage correspond.
