### PR TITLE
BUG - Edition FO] edition bloqué pour les profils BAILLEUR/BAILLEUR_OCCUPANT + replace wording "Bailleur occupant"

### DIFF
--- a/assets/scripts/vue/components/signalement-view/store.ts
+++ b/assets/scripts/vue/components/signalement-view/store.ts
@@ -112,7 +112,7 @@ export const store = {
     occupationLogementList: [
       { Id: 'logement_vacant', Text: 'Logement vacant' },
       { Id: 'logement_occupe', Text: 'Logement occupé' },
-      { Id: 'logement_occupe_bailleur_occupant', Text: 'Logement occupé : bailleur occupant' },
+      { Id: 'logement_occupe_bailleur_occupant', Text: 'Logement occupé : propriétaire occupant' },
       { Id: 'logement_occupe_locataire', Text: 'Logement occupé : locataire' },
       { Id: 'non_renseigne', Text: 'Non renseigné' }
     ],

--- a/assets/scripts/vue/components/signalement-view/store.ts
+++ b/assets/scripts/vue/components/signalement-view/store.ts
@@ -145,7 +145,7 @@ export const store = {
     ],
     typeDeclarantList: [
       { Id: 'locataire', Text: 'Occupant' },
-      { Id: 'bailleur_occupant', Text: 'Bailleur occupant' },
+      { Id: 'bailleur_occupant', Text: 'Propriétaire occupant' },
       { Id: 'bailleur', Text: 'Tiers bailleur' },
       { Id: 'tiers_particulier', Text: 'Tiers particulier' },
       { Id: 'tiers_pro', Text: 'Tiers professionnel' },

--- a/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
+++ b/src/Dto/Request/Signalement/CoordonneesFoyerRequest.php
@@ -50,7 +50,7 @@ class CoordonneesFoyerRequest implements RequestInterface
             groups: ['LOCATAIRE', 'BAILLEUR'])]
         #[Assert\EqualTo(
             value: 'BAILLEUR_OCCUPANT',
-            message: 'Le type d\'occupant doit être Propriétaire occupant pour les déclarant de type Bailleur occupant.',
+            message: 'Le type d\'occupant doit être Propriétaire occupant pour les déclarant de type Propriétaire occupant.',
             groups: ['BAILLEUR_OCCUPANT'])]
         private readonly ?string $profileOccupant = null,
     ) {

--- a/src/Security/Voter/SignalementFoVoter.php
+++ b/src/Security/Voter/SignalementFoVoter.php
@@ -2,7 +2,6 @@
 
 namespace App\Security\Voter;
 
-use App\Entity\Enum\ProfileDeclarant;
 use App\Entity\Enum\SignalementStatus;
 use App\Entity\Signalement;
 use App\Entity\User;
@@ -120,15 +119,6 @@ class SignalementFoVoter extends Voter
 
     private function canUsagerCompleteDossier(Signalement $signalement): bool
     {
-        // Pour l'instant, on ne peut compléter que les infos du bailleur, donc on filtre sur le profil
-        if (
-            $this->canUsagerEdit($signalement)
-            && ProfileDeclarant::BAILLEUR !== $signalement->getProfileDeclarant()
-            && ProfileDeclarant::BAILLEUR_OCCUPANT !== $signalement->getProfileDeclarant()
-        ) {
-            return true;
-        }
-
-        return false;
+        return $this->canUsagerEdit($signalement);
     }
 }

--- a/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
+++ b/src/Service/Signalement/Export/SignalementExportFiltersDisplay.php
@@ -61,7 +61,7 @@ class SignalementExportFiltersDisplay
     private const array OCCUPATION_LOGEMENT_LIST = [
         'logement_vacant' => 'Logement vacant',
         'logement_occupe' => 'Logement occupé',
-        'logement_occupe_bailleur_occupant' => 'Logement occupé : bailleur occupant',
+        'logement_occupe_bailleur_occupant' => 'Logement occupé : propriétaire occupant',
         'logement_occupe_locataire' => 'Logement occupé : locataire',
         'non_renseigne' => 'Non renseigné',
     ];

--- a/tests/Functional/Controller/SignalementEditControllerTest.php
+++ b/tests/Functional/Controller/SignalementEditControllerTest.php
@@ -120,16 +120,11 @@ class SignalementEditControllerTest extends WebTestCase
         ]);
 
         $client->request('GET', $url);
-
-        if (in_array($profile, [ProfileDeclarant::BAILLEUR, ProfileDeclarant::BAILLEUR_OCCUPANT])) {
-            $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
-        } else {
-            $this->assertResponseIsSuccessful();
-            $this->assertSelectorExists('form#form-usager-complete-dossier');
-            $this->assertSelectorTextContains('button[type=submit]', 'Envoyer');
-            $this->assertSelectorExists('h1');
-            $this->assertSelectorTextContains('h1', 'Compléter les informations');
-        }
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('form#form-usager-complete-dossier');
+        $this->assertSelectorTextContains('button[type=submit]', 'Envoyer');
+        $this->assertSelectorExists('h1');
+        $this->assertSelectorTextContains('h1', 'Compléter les informations');
     }
 
     public function testSubmitSuiviSignalementComplete(): void


### PR DESCRIPTION
## Ticket

#5638
#5651

## Description
- On remplace les texte "Bailleur occupant"par "Propriétaire occupant"
- On débloque l'édition FO pour les signalement avec profils `BAILLEUR`/`BAILLEUR_OCCUPANT`

## Tests
- [ ] Tester l'édition FO d'un signalement avec profils `BAILLEUR` ou `BAILLEUR_OCCUPANT`
