### PR TITLE
[FO - Service secours] Ajout de qualifications liées aux désordres spécifiques

### DIFF
--- a/migrations/Version20260401092031.php
+++ b/migrations/Version20260401092031.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260401092031 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'add qualifications to desordre precisions';
+    }
+
+    private const array QUALIFICATIONS_FOR_DESORDRE_PRECISIONS = [
+        'desordres_service_secours_logement_inadapte_logement_exigu' => ['RSD', 'NON_DECENCE', 'INSALUBRITE'],
+        'desordres_service_secours_humidite_moisissures_fuites' => ['RSD', 'NON_DECENCE', 'INSALUBRITE'],
+        'desordres_service_secours_chauffage_dangereux_logement_calfeutre' => ['is_danger'],
+        'desordres_service_secours_risque_electrique_absence_compteur' => ['is_danger'],
+        'desordres_service_secours_salete_accumulation_dechets_logement_sale' => ['SALETE'],
+        'desordres_service_secours_risque_saturnisme_personne_vulnerable' => ['is_danger', 'INSALUBRITE'],
+        'desordres_service_secours_nuisibles_infestations' => ['NON_DECENCE'],
+    ];
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::QUALIFICATIONS_FOR_DESORDRE_PRECISIONS as $desordrePrecisionSlug => $qualifications) {
+            if (in_array('is_danger', $qualifications)) {
+                $this->addSql('UPDATE desordre_precision SET is_danger = 1 WHERE desordre_precision_slug = :slug', [
+                    'slug' => $desordrePrecisionSlug,
+                ]);
+                // remove first element of array to avoid storing 'is_danger' in qualification field
+                array_shift($qualifications);
+            }
+            if (in_array('INSALUBRITE', $qualifications)) {
+                $this->addSql('UPDATE desordre_precision SET is_insalubrite = 1 WHERE desordre_precision_slug = :slug', [
+                    'slug' => $desordrePrecisionSlug,
+                ]);
+            }
+            $this->addSql('UPDATE desordre_precision SET qualification = :qualification WHERE desordre_precision_slug = :slug', [
+                'qualification' => json_encode($qualifications),
+                'slug' => $desordrePrecisionSlug,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::QUALIFICATIONS_FOR_DESORDRE_PRECISIONS as $desordrePrecisionSlug => $qualifications) {
+            $this->addSql('UPDATE desordre_precision SET qualification = :qualification WHERE desordre_precision_slug = :slug', [
+                'qualification' => json_encode([]),
+                'is_danger' => 0,
+                'is_insalubrite' => 0,
+                'slug' => $desordrePrecisionSlug,
+            ]);
+        }
+    }
+}

--- a/src/DataFixtures/Files/DesordrePrecision.yml
+++ b/src/DataFixtures/Files/DesordrePrecision.yml
@@ -1530,7 +1530,8 @@ desordre_precision:
     coef: 0
     is_danger: 0
     is_suroccupation: 0
-    qualification: []
+    is_insalubrite: 1
+    qualification: ['RSD', 'NON_DECENCE', 'INSALUBRITE']
   -
     desordre_critere_slug: "desordres_service_secours_humidite_moisissures"
     desordre_precision_slug: "desordres_service_secours_humidite_moisissures_fuites"
@@ -1538,13 +1539,14 @@ desordre_precision:
     coef: 0
     is_danger: 0
     is_suroccupation: 0
-    qualification: []
+    is_insalubrite: 1
+    qualification: ['RSD', 'NON_DECENCE', 'INSALUBRITE']
   -
     desordre_critere_slug: "desordres_service_secours_chauffage_dangereux"
     desordre_precision_slug: "desordres_service_secours_chauffage_dangereux_logement_calfeutre"
     label: "Logement calfeutré, sans ventilation, appareil ou conduit en mauvais état, toute situation menant à un risque d’intoxication au monoxyde de carbone."
     coef: 0
-    is_danger: 0
+    is_danger: 1
     is_suroccupation: 0
     qualification: []
   -
@@ -1552,7 +1554,7 @@ desordre_precision:
     desordre_precision_slug: "desordres_service_secours_risque_electrique_absence_compteur"
     label: "Absence de compteur individuel, risques de contact direct avec des fils dénudés, traces d’échauffement, etc."
     coef: 0
-    is_danger: 0
+    is_danger: 1
     is_suroccupation: 0
     qualification: []
   -
@@ -1562,7 +1564,7 @@ desordre_precision:
     coef: 0
     is_danger: 0
     is_suroccupation: 0
-    qualification: []
+    qualification: ['SALETE']
   -
     desordre_critere_slug: "desordres_service_secours_mauvais_etat_batiment"
     desordre_precision_slug: "desordres_service_secours_mauvais_etat_batiment_structure"
@@ -1592,9 +1594,10 @@ desordre_precision:
     desordre_precision_slug: "desordres_service_secours_risque_saturnisme_personne_vulnerable"
     label: "Peintures dégradées, présence d’enfant ou de femme enceinte dans un immeuble ancien"
     coef: 0
-    is_danger: 0
+    is_danger: 1
     is_suroccupation: 0
-    qualification: []
+    is_insalubrite: 1
+    qualification: ['INSALUBRITE']
   -
     desordre_critere_slug: "desordres_service_secours_nuisibles"
     desordre_precision_slug: "desordres_service_secours_nuisibles_infestations"
@@ -1602,7 +1605,7 @@ desordre_precision:
     coef: 0
     is_danger: 0
     is_suroccupation: 0
-    qualification: []
+    qualification: ['NON_DECENCE']
   -
     desordre_critere_slug: "desordres_service_secours_parties_communes_degradees"
     desordre_precision_slug: "desordres_service_secours_parties_communes_degradees_precision"

--- a/src/Factory/SignalementServiceSecoursFactory.php
+++ b/src/Factory/SignalementServiceSecoursFactory.php
@@ -14,6 +14,7 @@ use App\Entity\ServiceSecoursRoute;
 use App\Entity\Signalement;
 use App\Repository\BailleurRepository;
 use App\Repository\DesordreCritereRepository;
+use App\Service\Signalement\Qualification\SignalementQualificationUpdater;
 use App\Service\Signalement\SignalementAddressUpdater;
 use App\Service\Signalement\ZipcodeProvider;
 
@@ -24,6 +25,7 @@ class SignalementServiceSecoursFactory
         private readonly SignalementAddressUpdater $signalementAddressUpdater,
         private readonly BailleurRepository $bailleurRepository,
         private readonly DesordreCritereRepository $desordreCritereRepository,
+        private readonly SignalementQualificationUpdater $signalementQualificationUpdater,
     ) {
     }
 
@@ -50,6 +52,8 @@ class SignalementServiceSecoursFactory
         $this->handleStep4($formServiceSecours, $signalement);
         $this->handleStep5($formServiceSecours, $signalement);
         $signalement->setTypeCompositionLogement($typeCompositionLogement);
+
+        $this->signalementQualificationUpdater->updateQualificationFromScore($signalement);
 
         return $signalement;
     }


### PR DESCRIPTION
## Ticket

#5653   

## Description
Ajout de qualifications liées aux désordres spécifiques au formulaire service secours

## Changements apportés
* Ajout d'une migration
* Ajout des infos dans les fixtures
* Ajout de l'algo de qualification lors de la création

## Tests
- [ ] `make execute-migration name=Version20260401092031 direction=up`
- [ ] Créer un signalement Service secours et vérifier que les tags de pré-qualifications correspondent à ce qui a été coché suite à la migration
- [ ] `make create-db`
- [ ] Tester avec un signalement créé après la mise en place de fixtures
