### PR TITLE
[FO - Suivi usager] Création de suivi si édition par agent

### DIFF
--- a/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement_editor.js
+++ b/assets/scripts/vanilla/controllers/front_suivi_signalement/front_suivi_signalement_editor.js
@@ -117,13 +117,16 @@ const natureLogementSelect = document?.querySelector('#type_composition_natureLo
 if (natureLogementSelect) {
   const natureAutrePrecisionContainer = document.querySelector('#type_composition_natureAutrePrecision')?.closest('.fr-fieldset__element');
   const etageContainer = document.querySelector('#type_composition_appartementEtage')?.closest('.fr-fieldset__element');
+  const avecFenetresContainer = document.querySelector('#type_composition_appartementAvecFenetres')?.closest('.fr-fieldset__element');
 
   function refreshNatureAutrePrecision() {
     if (natureAutrePrecisionContainer) {
       if (natureLogementSelect.value === 'appartement') {
         etageContainer.classList.remove('fr-hidden');
+        avecFenetresContainer.classList.remove('fr-hidden');
       } else {
         etageContainer.classList.add('fr-hidden');
+        avecFenetresContainer.classList.add('fr-hidden');
       }
       if (natureLogementSelect.value === 'autre') {
         natureAutrePrecisionContainer.classList.remove('fr-hidden');

--- a/src/EventListener/SignalementUpdatedListener.php
+++ b/src/EventListener/SignalementUpdatedListener.php
@@ -4,6 +4,7 @@ namespace App\EventListener;
 
 use App\Entity\Signalement;
 use App\Entity\User;
+use App\Security\User\SignalementUser;
 use App\Service\History\EntityComparator;
 use App\Utils\DictionaryProvider;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
@@ -300,10 +301,6 @@ class SignalementUpdatedListener
         /** @var User $user */
         $user = $this->security->getUser();
 
-        if (!$user) {
-            return false;
-        }
-
-        return in_array('ROLE_USAGER', $user->getRoles(), true);
+        return $user instanceof SignalementUser;
     }
 }

--- a/src/Form/SignalementeEditFO/TypeCompositionType.php
+++ b/src/Form/SignalementeEditFO/TypeCompositionType.php
@@ -93,8 +93,17 @@ class TypeCompositionType extends AbstractType
                 'mapped' => false,
                 'data' => $avecFenetres,
                 'constraints' => [
-                    new Assert\NotNull(
-                        message: 'Veuillez indiquer si le logement a des fenêtres.',
+                    new Assert\Callback(
+                        callback: static function ($value, $context) {
+                            $form = $context->getRoot();
+                            $natureLogement = $form->get('natureLogement')->getData();
+
+                            if ('appartement' === $natureLogement && null === $value) {
+                                $context
+                                    ->buildViolation('Veuillez indiquer si l\'appartement a des fenêtres.')
+                                    ->addViolation();
+                            }
+                        },
                     ),
                 ],
             ])


### PR DESCRIPTION
## Ticket

#5612   

## Description
Correction pour créer des suivis lors de l'édition dans la page de suivi usager, même si la personne connectée a un compte agent

## Changements apportés
* Modification de la fonction `support` de `SignalementUpdatedListener` pour tester si la personne connectée est de type `SignalementUser` (connexion sur la page de suivi)
* Autre correction non-liée : ajustement pour l'édition de "Type et composition du logement" : si on sélectionnait `Maison` comme nature de logement, on devait remplir si il y avait des fenêtres. Alors que le champ ne doit apparaître que pour les `Appartements`

## Tests
- [ ] Faire un signalement avec un mail qui correspond à un agent, puis aller sur la page de suivi et s'identifier avec son compte
- [ ] Faire des éditions et vérifier que des suivis avec la liste des modifications sont créés
- [ ] Editer aussi dans un autre endroit (ex : BO) pour vérifier que le suivi n'est pas créé
- [ ] Dans la page de suivi usager, vérifier l'édition du champ "avec fenêtre"