### PR TITLE
[QA] Dashboard - Ne pas recharger la page en boucle après une erreur 404 sur un panel

### DIFF
--- a/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
+++ b/assets/scripts/vanilla/controllers/back_dashboard/tabs_loader.js
@@ -93,6 +93,12 @@ export default function initTabsLoader() {
             '<div class="fr-text--error">Accès refusé, vos droits sont insuffisants pour accéder à ce contenu. Merci de contacter un administrateur.</div>';
         }
 
+        if (err.message.includes('404')) {
+          loader.innerHTML =
+              '<div class="fr-text--error">Chargement de données impossible.</div>';
+          continue;
+        }
+
         console.error('Erreur chargement:', err);
         Sentry.captureException(err);
         setTimeout(() => {


### PR DESCRIPTION
## Ticket

#5662   

## Description
Vu sur la PR https://github.com/MTES-MCT/histologe/pull/5646 lors d'un test avec une valeur de type string sur le paramètre page.
La correction dépasse le simple cas d’une valeur invalide. 
Il serait préférable de ne plus recharger le dashboard en cas de 404.

## Changements apportés
* Mise à jour tabs_loader.js en interceptant l'erreur 404

## Pré-requis
`make npm-watch
`
## Tests
- [ ] Envoyer de manière volontaire une erreur 404 et vérifier que la plateforme ne se recharge pas en continue.

```php
    #[Route('/tab-panel-body/{tabBodyType}', name: 'back_tab_panel_body', methods: ['GET'])]

       /* ..... */
        return $this->render($tab->getTemplate(), [
            'items' => $tab->getData(),
            'count' => $tab->getCount(),
            'filters' => $tab->getFilters(),
        ], new Response('', 404));
    }
```