### PR TITLE
[QA - Form PRO] Gérer les cas d'erreur API BAN

### DIFF
--- a/src/Controller/Back/SignalementCreateController.php
+++ b/src/Controller/Back/SignalementCreateController.php
@@ -99,7 +99,7 @@ class SignalementCreateController extends AbstractController
             && $this->isCsrfTokenValid('draft_delete', (string) $request->request->get('_token'))
         ) {
             $signalement->setStatut(SignalementStatus::DRAFT_ARCHIVED);
-            // $entityManager->flush();
+            $entityManager->flush();
             $this->addFlash('success', ['title' => 'Brouillon supprimé', 'message' => 'Le brouillon a bien été supprimé.']);
 
             return $this->redirectToRoute('back_signalement_drafts', [], Response::HTTP_SEE_OTHER);

--- a/src/Service/Signalement/SignalementBoManager.php
+++ b/src/Service/Signalement/SignalementBoManager.php
@@ -90,7 +90,7 @@ class SignalementBoManager
             $signalement->setAutresOccupantsDesordre(null);
         }
 
-        $territory = $this->postalCodeHomeChecker->getActiveTerritory($signalement->getInseeOccupant());
+        $territory = $this->postalCodeHomeChecker->getActiveTerritory((string) $signalement->getInseeOccupant());
         if (!$territory) {
             $form->get($fieldAddress)->addError(new FormError('L\'adresse renseignée ne correspond pas à un territoire actif.'));
 

--- a/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
+++ b/tests/Functional/Controller/Back/SignalementCreateControllerTest.php
@@ -236,6 +236,27 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertStringContainsString('pas le droit de créer un signalement sur ce territoire.', $response['tabContent']);
     }
 
+    public function testEditAddressWithInvalidAddress(): void
+    {
+        $crawler = $this->getCrawler();
+
+        $form = $crawler->filter('#bo-form-signalement-adresse')->form();
+        $form->setValues([
+            'signalement_draft_address[adresseOccupant]' => 'xrickr jdjerdhjf',
+            'signalement_draft_address[cpOccupant]' => '99999',
+            'signalement_draft_address[villeOccupant]' => 'vlspeotmdmzor',
+            'signalement_draft_address[isLogementSocial]' => '1',
+            'signalement_draft_address[profileDeclarant]' => 'LOCATAIRE',
+            'signalement_draft_address[natureLogement]' => 'appartement',
+        ]);
+        $this->client->submit($form);
+
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+        $response = json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertArrayHasKey('tabContent', $response);
+        $this->assertStringContainsString('L&#039;adresse renseignée ne correspond pas à un territoire actif.', $response['tabContent']);
+    }
+
     public function testEditLogement(): void
     {
         $crawler = $this->getCrawler();
@@ -530,5 +551,21 @@ class SignalementCreateControllerTest extends WebTestCase
         $this->assertNull($signalementUsager->getDeclarant());
 
         $this->assertEmailCount(2);
+    }
+
+    public function testDeleteDraftSignalementSuccess(): void
+    {
+        $user = $this->userRepository->findOneBy(['email' => 'user-44-02@signal-logement.fr']);
+        $this->client->loginUser($user);
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2025-000000000008']);
+
+        $route = $this->router->generate('back_signalement_delete_draft', ['uuid' => $signalement->getUuid()]);
+        $this->client->request('POST', $route, [
+            '_token' => $this->generateCsrfToken($this->client, 'draft_delete'),
+            'draft_id' => $signalement->getId(),
+        ]);
+        $this->assertResponseRedirects($this->router->generate('back_signalement_drafts'));
+        $signalement = $this->signalementRepository->findOneBy(['uuid' => '00000000-0000-0000-2025-000000000008']);
+        $this->assertEquals(SignalementStatus::DRAFT_ARCHIVED, $signalement->getStatut());
     }
 }


### PR DESCRIPTION
## Ticket

#5667

## Description
Deux correction sur le form pro : 
- Possibilité d'archiver un brouillon
- Correction d'un crash en cas de soumission d'une adresse non reconnue (ne retournant pas de code insee)

Ajout des tests unitaire pour vérifier ls deux cas.

## Tests
- [ ] Se connecter avec user-44-02@signal-logement.fr et archiver son brouillon de form pro
- [ ] Soumettre un nouveau form pro avec les champ obligatoire renseigné et une adresse manuelle complètement bidon, voir que l'erreur est géré proprement

<img width="1599" height="709" alt="Screenshot 2026-04-03 at 16-37-09 Créer un signalement - Signal-Logement" src="https://github.com/user-attachments/assets/26a80c21-ad52-4390-a1a8-e0c545479fab" />

