### PR TITLE
[BO - Espace documentaire] Ajustements accessibilité

### DIFF
--- a/templates/back/admin-territory-files/add.html.twig
+++ b/templates/back/admin-territory-files/add.html.twig
@@ -49,7 +49,7 @@
                 <div class="fr-col-6">
                     <div id="form-add-file-no-preview" class="fr-hidden">
                         Pas d'aperçu disponible.<br>
-                        <img src="{{ asset('img/picto-dsfr/document.svg') }}">
+                        <img src="{{ asset('img/picto-dsfr/document.svg') }}" alt="">
                     </div>
                     <div id="form-add-file-preview" class="fr-hidden">
                         Aperçu du document :<br>

--- a/templates/back/admin-territory-files/edit.html.twig
+++ b/templates/back/admin-territory-files/edit.html.twig
@@ -64,7 +64,7 @@
                     <div class="fr-col-6">
                         <div id="form-add-file-no-preview" class="fr-hidden">
                             Pas d'aperçu disponible.<br>
-                            <img src="{{ asset('img/picto-dsfr/document.svg') }}">
+                            <img src="{{ asset('img/picto-dsfr/document.svg') }}" alt="">
                         </div>
                         <div id="form-add-file-preview" class="fr-hidden">
                             Aperçu du document :<br>

--- a/templates/back/territory-files/index.html.twig
+++ b/templates/back/territory-files/index.html.twig
@@ -107,7 +107,7 @@
                         </div>
                         <div class="fr-tile__header">
                             <div class="fr-tile__pictogram">
-                                <img class="fr-responsive-img" src="{{ asset('img/picto-dsfr/document.svg') }}">
+                                <img class="fr-responsive-img" src="{{ asset('img/picto-dsfr/document.svg') }}" alt="">
                             </div>
                         </div>
                     </div>

--- a/templates/form/dsfr_theme.html.twig
+++ b/templates/form/dsfr_theme.html.twig
@@ -137,7 +137,7 @@
 {% endblock choice_widget_expanded %}
 
 {% block choice_enum_widget_expanded %}
-    <div {{ block('widget_container_attributes') }}>
+    <fieldset {{ block('widget_container_attributes') }}>
     {% if not form|length and not form.vars.choices|length and nochoiceslabel is defined %}
         {{ nochoiceslabel }}
     {% else %}
@@ -181,7 +181,7 @@
             {% endif %}
         {% endfor %}
     {% endif %}
-    </div>
+    </fieldset>
 {% endblock choice_enum_widget_expanded %}
 
 {% block search_checkbox_row %}


### PR DESCRIPTION
## Ticket

#5677
#5679
#5680   

## Description
Quelques ajustements concernant l'accessibilité dans l'espace documentaire (liste, liste d'un territoire, ajout, édition)

## Changements apportés
* Ajout d'un alt vide sur le picto dans les cartes de la liste
* Ajout d'un alt vide sur le picto quand il n'y a pas de prévisualisation
* Modification de `div` vers `fieldset` pour le composant qui permet de sélectionner plusieurs checkbox

## Pré-requis
Installer WAVE https://wave.webaim.org/extension/

## Tests
- [ ] Ouvrir WAVE et vérifier qu'il n'y a plus d'erreur sur les 4 pages
- [ ] Vérifier les alt
- [ ] Vérifier le fonctionnement des composants de listes de checkbox
